### PR TITLE
feat(analysis): one truth region, one hierarchy — cockpit simplification

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -2962,9 +2962,24 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     BY MOUNT SITE. `mapToAnalysisRunState` orders `refused`
                     ABOVE `never_run` precisely so a refused FIRST analysis —
                     where `hasCompletedFirstRun` is false and there are no
-                    results to decorate — still reaches the user. A
-                    "unify the gates" simplification here would re-dark it and
-                    RED `applyV5State.analysisRefusalNotice.spec.tsx`. */}
+                    results to decorate — still reaches the user.
+
+                    ⚠⚠ AN EARLIER VERSION OF THIS COMMENT NAMED THE WRONG GUARD,
+                    AND AN ADVERSARIAL REVIEW PROVED IT BY EXECUTION. It claimed
+                    that unifying the gates "would re-dark it and RED
+                    `applyV5State.analysisRefusalNotice.spec.tsx`". Deleting the
+                    refusal arm from the mapping left that spec — and 53/53
+                    tests across all four refusal-touching specs — GREEN, because
+                    that one is STORE-level: it proves the wire populates the
+                    slice and says nothing about the slice → run-state hop.
+                    A comment that names a guard which does not guard is worse
+                    than no comment: it tells the next reader the seam is
+                    covered, so they stop looking.
+                    The guard that actually bites is
+                    `useAnalysisRunState.mapping.spec.ts`, which pins the
+                    refusal arm against `never_run` AND against every freshness
+                    arm as discriminating pairs. Verified by deleting the arm
+                    and watching it RED. */}
                 {!isPreRun && hasInlineSummary && resultsSectionData && (
                   <div
                     // Parity audit: v6 keeps stale results fully readable —

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -37,8 +37,9 @@ import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
 import { useCanvasStore, selectResultsStatus, selectReport, selectError, selectResultsSource, selectResultsStartedAt, selectReportIsFromEarlierRun } from '../store'
 import { useAnalysisState } from '../state/analysisStateSelector'
 import { getScenario } from '../store/scenarios'
-import { AnalysisFreshnessNotice } from '../../components/results/AnalysisFreshnessNotice'
-import { AnalysisRefusalNotice } from '../../components/results/AnalysisRefusalNotice'
+import { VersionsTrigger } from '../versions/VersionsTrigger'
+import { AnalysisStateRegion } from '../../components/results/analysisState/AnalysisStateRegion'
+import { useAnalysisRunState } from '../../components/results/analysisState/useAnalysisRunState'
 import { DecisionOverviewCard } from '../../components/results/decision-overview/DecisionOverviewCard'
 import { isDecisionOverviewEnabled } from '../../flags'
 import { deriveResultsTabFreshness } from './resultsTabFreshness'
@@ -257,21 +258,33 @@ export function deriveNextDockIsOpen(isFirstUse: boolean, storedIsOpen: boolean)
  * Whether the dock renders as its collapsed 40px rail rather than its full
  * body — the "first use" state.
  *
- * ⚠ THE INPUT CHANGED ON 16 Aug 2026 and that IS the behaviour change: this
- * used to be driven by `!hasGraphContent`, so a DRAFTED GRAPH ended first use
- * and the dock expanded to its full width the instant the model appeared —
- * showing a pre-run Analysis tab with no analysis in it. An outputs dock with
- * no outputs has no claim to that width, and the canvas pays for it: measured
- * at 1280x800 with the committed CEE draft capture, the expanded dock reserved
- * 361px of `computeFitPadding`, leaving an 843px fitting box for a graph
- * needing 1008px at the legibility floor — so the product's own first view of
- * the user's model was clamped and overflowing. Collapsed: 1136px, fits at
- * 0.563.
+ * ⚠⚠ THE INPUT HAS NOW CHANGED TWICE IN ONE DAY, AND THE SECOND CHANGE IS
+ * PAUL'S RULING R1 (16 Aug 2026) OVERTURNING THE FIRST.
+ *
+ * Until 16 Aug this was `!hasGraphContent`. #728 changed it to
+ * `!hasAnalysisResult` for a measured reason: a drafted graph ended first use,
+ * the dock claimed its FULL width with no analysis in it, and at 1280x800 with
+ * the committed CEE draft capture the expanded dock reserved 361px of
+ * `computeFitPadding` — an 843px fitting box for a graph needing 1008px at the
+ * legibility floor, so the product's own first view of the user's model was
+ * clamped and overflowing. Collapsed: 1136px, fits at 0.563.
+ *
+ * Paul vetoed the resulting behaviour (ledger L-06: "right panel hidden until
+ * first analysis"). **R1 RULED: the right panel is visible immediately when
+ * the model appears; the panel starts NARROW so the graph keeps priority.**
+ * The 843px measurement was never an argument for hiding the panel — it was an
+ * argument about WIDTH, and R1 answers it with width. So the rail input
+ * reverts to model content, and the width half of the trade is discharged by
+ * `resolveDockWidthForAnalysisState` below, which opens the dock at its
+ * narrowest usable width until an analysis exists. Neither half works alone:
+ * reverting the input without the narrow width re-opens the 843px clamp this
+ * predicate was rewritten to close.
  *
  * Pure and exported so the rule is mutation-testable without mounting the dock.
  *
- * @param hasAnalysisResult `hasCompletedFirstRun` — at least one successful or
- *   restored run exists in this session, i.e. the dock has something to show.
+ * @param hasModelContent there is a model on the canvas — the thing the panel
+ *   would be reporting on. THIS, not the existence of an analysis, is what
+ *   ends first use (R1).
  * @param analysisActive a run is IN FLIGHT (results status is anything but
  *   `idle`/`cancelled`). Outputs are not here yet but they are coming, and the
  *   run's own progress narration lives in the dock body.
@@ -290,16 +303,48 @@ export function deriveNextDockIsOpen(isFirstUse: boolean, storedIsOpen: boolean)
  */
 export function shouldRenderFirstUseRail(input: {
   aiPanelV2On: boolean
-  hasAnalysisResult: boolean
+  hasModelContent: boolean
   analysisActive: boolean
   userExplicitlyOpened: boolean
 }): boolean {
   return (
     input.aiPanelV2On &&
-    !input.hasAnalysisResult &&
+    !input.hasModelContent &&
     !input.analysisActive &&
     !input.userExplicitlyOpened
   )
+}
+
+/**
+ * The width the dock opens at — R1's "starts NARROW so the graph keeps
+ * priority" half.
+ *
+ * Composed from `dockWidth.ts`'s existing pure rules rather than re-deriving
+ * bounds here (three separate copies of those bounds is the defect that module
+ * was created to remove).
+ *
+ * TWO PROPERTIES, BOTH DELIBERATE:
+ *  1. An EXPLICIT user width always wins. Someone who has dragged the dock has
+ *     stated a preference; narrowing it under them because an analysis has not
+ *     run yet would be the product overriding a direct instruction.
+ *  2. The narrow width is the module's own `DOCK_MIN_WIDTH` floor, not a new
+ *     constant. "Narrow" here means "the narrowest width this panel is known
+ *     to remain usable at" — a second magic number would be a second authority
+ *     on the same question, and would drift from the floor the drag path
+ *     clamps to.
+ *
+ * Pure and exported: mutation-testable without a DOM.
+ */
+export function resolveDockWidthForAnalysisState(input: {
+  viewportWidth: number
+  storedWidth: number | null
+  hasAnalysisResult: boolean
+}): number {
+  const full = resolveDockWidth(input.viewportWidth, input.storedWidth)
+  if (input.hasAnalysisResult) return full
+  if (input.storedWidth != null && Number.isFinite(input.storedWidth)) return full
+  const { min } = dockWidthBounds(input.viewportWidth)
+  return Math.min(full, min)
 }
 
 /**
@@ -629,26 +674,23 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   const realMessageCount = conversationCtxForFirstUse
     ? conversationCtxForFirstUse.messages.filter((m) => !m.synthetic).length
     : 0
-  // First-use ends when the dock has OUTPUTS TO SHOW — i.e. an analysis result
-  // exists (`hasCompletedFirstRun`: at least one successful or restored run this
-  // session) — OR the user explicitly expands the dock (the rail's chevron), OR
-  // a run starts (see the auto-switch effect, which drops the lock so a running
-  // analysis is visible). We do NOT use realMessageCount here — the brief is
-  // explicit that the empty Analysis tab should not flash after a user message
-  // but before the graph builds.
+  // First-use ends when a MODEL EXISTS — the thing the panel reports on (ruling
+  // R1, 16 Aug 2026) — OR the user explicitly expands the dock (the rail's
+  // chevron), OR a run starts (see the auto-switch effect, which drops the lock
+  // so a running analysis is visible). We do NOT use realMessageCount here —
+  // the brief is explicit that the empty Analysis tab should not flash after a
+  // user message but before the graph builds.
   //
-  // ⚠ THIS WAS `!hasGraphContent` UNTIL 16 Aug 2026, and that is the defect.
-  // A drafted graph ended first-use, so the dock expanded to its full width the
-  // moment the model appeared — showing a pre-run Analysis tab with no analysis
-  // in it. An outputs dock with no outputs has no claim to that width, and the
-  // cost is paid by the canvas: measured at 1280x800 with the committed CEE
-  // draft capture, the expanded dock reserved 361px of `computeFitPadding`,
-  // leaving a 843px fitting box for a graph needing 1008px at the legibility
-  // floor — so the product's own first view of the user's model was clamped and
-  // overflowing. Collapsed, the same measurement gives a 1136px fitting box.
+  // ⚠⚠ THIS INPUT HAS FLIPPED TWICE IN ONE DAY. It was `!hasGraphContent`,
+  // became `!hasCompletedFirstRun` on 16 Aug (#728, to close a measured 843px
+  // graph clamp), and R1 reverts it — because Paul's veto is about VISIBILITY
+  // and the 843px measurement is about WIDTH. The width half is now discharged
+  // by `resolveDockWidthForAnalysisState`: the dock opens at its narrowest
+  // usable width until an analysis exists. See the predicate's own header for
+  // the full record; the two halves are a pair and neither ships alone.
   const isFirstUse = shouldRenderFirstUseRail({
     aiPanelV2On,
-    hasAnalysisResult: hasCompletedFirstRun,
+    hasModelContent: hasGraphContent,
     analysisActive,
     userExplicitlyOpened: userExplicitlyOpenedRailRef.current,
   })
@@ -874,6 +916,12 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   // fold the strip already applied).
   const displayedFreshness = useAnalysisState().displayedFreshness
   const analysisNotConfirmedFresh = displayedFreshness === 'stale' || displayedFreshness === 'unknown'
+  // Brief step 6 — the composed run state that decides WHICH truth-state
+  // banner this surface may render. It derives nothing new: it maps the
+  // verdicts the refusal/freshness/results owners already publish onto the
+  // contract's state names. Swaps to the wire's `AnalysisStateV1.run_state`
+  // in one line when the migration lane lands (see useAnalysisRunState.ts).
+  const analysisRunState = useAnalysisRunState()
   // Anchor-run-control (Paul, 21-Jul): the sticky bottom AnalysisFooter is the
   // SOLE Rerun owner in every post-run state — it carries the robustness
   // verdict AND the Rerun action together, and being OUTSIDE the scroller it is
@@ -1920,7 +1968,16 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
       }
       const viewportWidth = window.innerWidth || root.clientWidth || 0
       if (!viewportWidth) return
-      root.style.setProperty('--dock-right-expanded', `${resolveDockWidth(viewportWidth, stored)}px`)
+      // R1's width half: narrow until an analysis exists, then the normal
+      // responsive width. An explicit user width always wins (see the helper).
+      root.style.setProperty(
+        '--dock-right-expanded',
+        `${resolveDockWidthForAnalysisState({
+          viewportWidth,
+          storedWidth: stored,
+          hasAnalysisResult: hasCompletedFirstRun,
+        })}px`,
+      )
     }
 
     apply()
@@ -1941,7 +1998,12 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
       window.removeEventListener('resize', onResize)
       if (frame !== null) window.cancelAnimationFrame(frame)
     }
-  }, [])
+    // ⚠ `hasCompletedFirstRun` IS a dependency and its absence would be silent:
+    // the effect would apply the narrow width once and never widen when the
+    // first analysis lands, so the user's results would arrive into a 280px
+    // panel until the next window resize. A width rule that only re-runs on
+    // `resize` is a width rule that is wrong for as long as nobody resizes.
+  }, [hasCompletedFirstRun])
   const transitionClass = prefersReducedMotion ? '' : 'transition-[width,opacity] duration-200 ease-in-out'
 
   // OUTPUT_TABS computed per render so a localStorage flag flip is picked
@@ -2255,10 +2317,19 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                       )
                     )}
                     {tab.id === 'diagnostics' && factorsToVerify > 0 && (
+                      // ⭐ L-58: this was a bare orange number. A `title` is a
+                      // hover-only affordance — it is invisible to a user
+                      // scanning the tab strip, absent on touch, and never
+                      // reaches a screen reader as the badge's NAME. The count
+                      // now carries its meaning in the accessible name as well,
+                      // so "why is there an orange 4?" is answerable without
+                      // hovering. (`role="status"` is deliberately NOT used: it
+                      // is a static label on a tab, not a live announcement.)
                       <span
                         className="inline-flex items-center justify-center rounded-full bg-warning text-text-on-color font-semibold"
                         style={{ fontSize: 11, fontWeight: 600, minWidth: 16, height: 16, padding: '0 4px' }}
                         title={`${factorsToVerify} factor${factorsToVerify !== 1 ? 's' : ''} to verify`}
+                        aria-label={`${factorsToVerify} factor${factorsToVerify !== 1 ? 's' : ''} to verify`}
                         data-testid="model-tab-verify-badge"
                       >
                         {factorsToVerify}
@@ -2268,6 +2339,24 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                 </button>
               )})}
             </nav>
+            {/* ⭐ R4 — version history's home in this panel (delegated by the
+                versions lane, #739). The trigger deliberately carries NO
+                positioning of its own; layout belongs to this row, which is
+                the whole point of retiring the floating pill (L-08).
+
+                ⚠ ITS OWN HEADER SAYS `<VersionsTrigger variant="icon" />` AND
+                THAT IS INCOMPLETE: the `icon` variant applies `className` with
+                an EMPTY default (the `labelled` variant self-styles; this one
+                does not), so following the instruction verbatim mounts an
+                unstyled bare button in a row of bordered icon controls. It is
+                given the SAME class as the collapse chevron beside it, so the
+                two read as one control set rather than as a button that lost
+                its styling. */}
+            <VersionsTrigger
+              variant="icon"
+              className={`inline-flex items-center justify-center w-6 h-6 rounded border border-panel-border ${typography.caption} text-text-header hover:bg-panel shrink-0`}
+              data-testid="dock-versions-trigger"
+            />
             <button
               type="button"
               onClick={() => setExpertMode(prev => !prev)}
@@ -2568,22 +2657,25 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                           >
                             Edit model
                           </button>
-                          {friendlyError.secondaryActionText && (
-                            <button
-                              type="button"
-                              onClick={() => setState(prev => ({ ...prev, isOpen: false }))}
-                              className={`${typography.caption} font-medium px-3 py-1.5 rounded border ${
-                                friendlyError.severity === 'error'
-                                  ? 'border-danger/30 text-danger hover:opacity-80'
-                                  : friendlyError.severity === 'warning'
-                                    ? 'border-warning/30 text-warning hover:opacity-80'
-                                    : 'border-info/30 text-info hover:opacity-80'
-                              }`}
-                              data-testid="error-secondary-action"
-                            >
-                              {friendlyError.secondaryActionText}
-                            </button>
-                          )}
+                          {/* ⛔ `error-secondary-action` REMOVED (ledger L-10).
+                              It rendered `friendlyError.secondaryActionText`
+                              over a handler that was BYTE-IDENTICAL to "Edit
+                              model" beside it: `setState({ isOpen: false })`.
+                              The label is a pure string with no behaviour
+                              attached, so the button promised four different
+                              things and did one — and two of the four are
+                              outright false: `CEE_DEGRADED` offered "Retry Full
+                              Analysis" (it retried nothing; the Retry lives in
+                              `error-primary-action`) and `COMPARISON_FAILED`
+                              offered "View Individual Results" (it navigated
+                              nowhere). A control whose label names an action it
+                              cannot perform is the guarantee-theatre class, not
+                              a cosmetic defect, so it is removed rather than
+                              relabelled. `secondaryActionText` is still emitted
+                              by `lib/userFriendlyErrors.ts` (not this lane's
+                              file) and now has no consumer — flagged in the PR
+                              body for its owner to retire or to give a real
+                              handler. */}
                         </div>
                         {/* Task P.3.5: Coaching text for repeated failures */}
                         <p className={`${typography.caption} text-text-header`}>
@@ -2755,18 +2847,17 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     previous analysis. `selectReportIsFromEarlierRun` compares
                     the store's run-epoch stamps and fails CLOSED on unknown
                     provenance: no stamp, no claim. */}
-                {isError && report && reportIsFromEarlierRun && (
-                  <div
-                    className="flex items-center gap-2 px-3 py-2 bg-panel border border-warning/30 rounded"
-                    role="status"
-                    data-testid="stale-results-banner"
-                  >
-                    <AlertTriangle className="w-4 h-4 text-warning flex-shrink-0" aria-hidden="true" />
-                    <span className={`${typography.caption} text-text-header`}>
-                      Showing results from previous analysis
-                    </span>
-                  </div>
-                )}
+                {/* ⭐ MOVED, NOT RETIRED (cockpit simplification, brief step 6).
+                    This attribution now renders INSIDE `<AnalysisStateRegion>`'s
+                    body slot, as `bodyAttribution` — see the region's mount
+                    below. Its predicate, copy, testid and full reachable-cell
+                    matrix are unchanged and stay pinned by
+                    `OutputsDock.failedRunHonesty.spec.tsx`.
+                    WHY it moved: it answers "whose numbers are on screen?",
+                    which is a claim about the BODY, not about whether the
+                    analysis ran or is current. Leaving it out here is what
+                    lets the truth-state slot above the body hold exactly one
+                    banner without swallowing a true provenance disclosure. */}
                 {/* Wave F-B (brief §5.2): the top-level stale banner is RETIRED —
                     AnalysisFreshnessNotice (mounted below in this tab's
                     scroller, above the results body) is the sole freshness
@@ -2799,9 +2890,53 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     in the canonical hierarchy (brief §3). Mount-site gated
                     (house pattern, review B1): flag-off renders NOTHING and
                     pays no subscription or parsing cost. */}
+                {/* ⭐⭐ THE ONE TRUTH-STATE REGION (brief step 6, ruling R1).
+                    Before this, seven independently-sourced truth-state
+                    children hung off this scroller and none gated any other —
+                    the mechanism behind L-36/S06, where "This analysis did not
+                    run" and "Cannot confirm whether this analysis is current"
+                    stacked directly above a fully rendered result. Three
+                    claims, two of them contradictory, every component correct
+                    in isolation.
+                    The region owns ONE banner slot and ONE body slot; which
+                    banner is a function of `analysisRunState` alone. Mounting
+                    either notice anywhere else on this surface REDs
+                    `AnalysisStateRegion.singleTruthBanner.spec.tsx`'s
+                    single-mount-site guard, which DERIVES the mount sites from
+                    the source rather than mirroring a hand-kept list. */}
+                {/* ⚠ THE OVERVIEW CARD STAYS OUTSIDE THE REGION, ABOVE IT, and
+                    that is a correction to this lane's first draft — which put
+                    it inside the body slot and inverted the canonical
+                    hierarchy (caught by
+                    `OutputsDock.analysis-run.spec.tsx`'s "the overview mounts
+                    FIRST" case, which exists precisely to pin brief §3).
+                    It belongs outside on the merits, not merely to keep a test
+                    green: the card is the ORIENTATION surface and by its own
+                    §4.1 "shows no analysis outcomes". The region owns the
+                    truth-state banner and the RESULTS body — what the run
+                    produced and whether it can be trusted. Orientation is
+                    neither. */}
                 {isDecisionOverviewEnabled() && !isPreRun && hasInlineSummary && resultsSectionData && (
                   <DecisionOverviewCard title={overviewTitle} />
                 )}
+                <AnalysisStateRegion
+                  runState={analysisRunState}
+                  hasReport={!isPreRun && hasInlineSummary && Boolean(resultsSectionData)}
+                  bodyAttribution={
+                    isError && report && reportIsFromEarlierRun ? (
+                      <div
+                        className="flex items-center gap-2 px-3 py-2 bg-panel border border-warning/30 rounded"
+                        role="status"
+                        data-testid="stale-results-banner"
+                      >
+                        <AlertTriangle className="w-4 h-4 text-warning flex-shrink-0" aria-hidden="true" />
+                        <span className={`${typography.caption} text-text-header`}>
+                          Showing results from previous analysis
+                        </span>
+                      </div>
+                    ) : null
+                  }
+                >
                 {/* ROADMAP 2.1163 / EXT-2 — CEE's typed analysis refusal
                     (`analysis_ready.blocked_reason`, PR #942), which had ZERO
                     readers repo-wide until this mount.
@@ -2821,15 +2956,15 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     aria-disabled region. It is a SIBLING of DecisionOverview-
                     Card, not a state of it — that card's `liveState` derivation
                     is untouched ('unassessed'/collapsed on a cleared readiness
-                    slice is correct, per the 2026-08-14 deployed-UI trace). */}
-                <AnalysisRefusalNotice />
-                {/* The freshness strip states fresh/stale/unknown (informational
-                    only — the anchor footer below owns the Rerun). It mounts
-                    ABOVE the dim wrapper at full opacity so the freshness signal
-                    never sits inside an aria-disabled region. */}
-                {!isPreRun && hasInlineSummary && resultsSectionData && (
-                  <AnalysisFreshnessNotice />
-                )}
+                    slice is correct, per the 2026-08-14 deployed-UI trace).
+
+                    ⭐ THE UNGATED-NESS IS PRESERVED, BY PRECEDENCE RATHER THAN
+                    BY MOUNT SITE. `mapToAnalysisRunState` orders `refused`
+                    ABOVE `never_run` precisely so a refused FIRST analysis —
+                    where `hasCompletedFirstRun` is false and there are no
+                    results to decorate — still reaches the user. A
+                    "unify the gates" simplification here would re-dark it and
+                    RED `applyV5State.analysisRefusalNotice.spec.tsx`. */}
                 {!isPreRun && hasInlineSummary && resultsSectionData && (
                   <div
                     // Parity audit: v6 keeps stale results fully readable —
@@ -2892,6 +3027,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                   />
                   </div>
                 )}
+                </AnalysisStateRegion>
                 </div>
                 {/* Brief 5.4 Phase 11: "Create decision brief" placeholder removed.
                     Anchor-run-control (Paul, 21-Jul): the sticky bottom anchor

--- a/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.analysis-run.spec.tsx
@@ -47,7 +47,20 @@ function renderOutputsDock() {
  * error one line later, which is exactly the confusion this helper removes.
  */
 function expandDockFromRail() {
-  fireEvent.click(screen.getByLabelText('Expand outputs dock'))
+  // ⚠ THE RAIL IS NO LONGER GUARANTEED, AND THAT IS RULING R1 (16 Aug 2026):
+  // "right panel visible immediately when the model appears; panel starts
+  // NARROW so the graph keeps priority". These tests seed a graph, so under R1
+  // the dock is ALREADY expanded and there is no chevron to click — the
+  // original unconditional `getByLabelText('Expand outputs dock')` threw.
+  //
+  // The helper's own guarantee is unchanged and still enforced: after it runs,
+  // the dock is open and the Run control is reachable. What it no longer
+  // asserts is the ROUTE, because the route is now state-dependent and these
+  // tests are about the Run control's DISPATCH behaviour, not its visibility.
+  // Asserting a chevron that R1 deliberately removed would be pinning the
+  // behaviour Paul vetoed.
+  const chevron = screen.queryByLabelText('Expand outputs dock')
+  if (chevron) fireEvent.click(chevron)
   return screen.getByTestId('outputs-run-button')
 }
 

--- a/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
@@ -955,15 +955,29 @@ describe('I.2a: Secondary action button interaction', () => {
 
     renderOutputsDock()
 
-    // Verify secondary button is rendered with expected text
-    const secondaryButton = screen.getByTestId('error-secondary-action')
-    expect(secondaryButton).toBeInTheDocument()
-    expect(secondaryButton).toHaveTextContent('Continue Without')
+    // ⚠ THE ASSERTION IS INVERTED, AND THE REASON MATTERS (ledger L-10,
+    // cockpit simplification). This test used to prove the secondary button
+    // rendered "Continue Without" and closed the dock. Both were true — and
+    // together they were the defect: `error-secondary-action`'s handler was
+    // BYTE-IDENTICAL to the "Edit model" button beside it
+    // (`setState({ isOpen: false })`), while `secondaryActionText` is a pure
+    // label with no behaviour attached. So one control rendered four different
+    // promises and performed one, and two of the four were false —
+    // `CEE_DEGRADED` offered "Retry Full Analysis" (it retried nothing; the
+    // retry is `error-primary-action`) and `COMPARISON_FAILED` offered "View
+    // Individual Results" (it navigated nowhere).
+    //
+    // The old test could never have caught that: it pinned the ONE code whose
+    // label happens to describe closing the dock. A control whose label names
+    // an action it cannot perform is the guarantee-theatre class, so the button
+    // is removed rather than relabelled, and this case now pins the removal.
+    // `edit-model-button` — the honestly-labelled control with the same
+    // behaviour — is asserted present so this is a removal of a duplicate and
+    // not a loss of the affordance.
+    expect(screen.queryByTestId('error-secondary-action')).not.toBeInTheDocument()
+    expect(screen.getByTestId('edit-model-button')).toBeInTheDocument()
 
-    // Click the secondary action
-    fireEvent.click(secondaryButton)
-
-    // After click, dock should close — the error banner should no longer be visible
+    fireEvent.click(screen.getByTestId('edit-model-button'))
     expect(screen.queryByTestId('outputs-error-banner')).not.toBeInTheDocument()
   })
 

--- a/src/canvas/components/__tests__/OutputsDock.firstUseRail.spec.ts
+++ b/src/canvas/components/__tests__/OutputsDock.firstUseRail.spec.ts
@@ -1,48 +1,66 @@
 /**
  * `shouldRenderFirstUseRail` — the rule deciding whether the OutputsDock renders
- * as its 40px rail or claims its full width.
+ * as its 40px rail or claims its full width — and `resolveDockWidthForAnalysisState`,
+ * the width rule that is its other half.
  *
- * Written against the STATED RULE ("the dock is a rail until it has outputs to
- * show, unless something has explicitly opened it"), not against the 1280x800
- * measurement that motivated the change — the measurement is evidence for the
- * rule, and a spec pinned to the measurement would go stale the moment the
- * viewport or the graph changed while the rule stayed correct.
+ * Written against the STATED RULE, not against the 1280x800 measurement that
+ * motivated it — the measurement is evidence for the rule, and a spec pinned to
+ * the measurement would go stale the moment the viewport or the graph changed
+ * while the rule stayed correct.
  *
- * The behaviour change this pins: the input used to be "does a graph exist",
- * so a drafted model expanded the dock to show an Analysis tab containing no
- * analysis. It is now "does an analysis RESULT exist".
+ * ⚠⚠ THE RULE HAS NOW FLIPPED TWICE IN ONE DAY, AND THIS FILE RECORDS BOTH.
+ * Until 16 Aug the input was `!hasGraphContent`. #728 replaced it with
+ * `!hasAnalysisResult`, because a drafted model expanded the dock to show an
+ * Analysis tab containing no analysis and cost the canvas 361px of fit padding.
+ * **Ruling R1 (Paul, 16 Aug) overturns that**: the right panel is visible
+ * immediately when the model appears, and starts NARROW so the graph keeps
+ * priority. The veto was about VISIBILITY; the 843px measurement was about
+ * WIDTH; R1 answers the second with width rather than with hiding.
+ *
+ * So the rail input is model content again — AND the width half is now a real
+ * rule rather than an implicit "full width or nothing". The two are a PAIR: the
+ * predicate tests below are honest only because the width tests below them
+ * exist. Delete either and the 843px clamp comes back.
  */
 
 import { describe, it, expect } from 'vitest'
-import { shouldRenderFirstUseRail, forcedActivationEndsRail } from '../OutputsDock'
+import {
+  shouldRenderFirstUseRail,
+  forcedActivationEndsRail,
+  resolveDockWidthForAnalysisState,
+} from '../OutputsDock'
+import { DOCK_MIN_WIDTH, resolveDockWidth } from '../dockWidth'
 
 describe('shouldRenderFirstUseRail', () => {
   const base = {
     aiPanelV2On: true,
-    hasAnalysisResult: false,
+    hasModelContent: false,
     analysisActive: false,
     userExplicitlyOpened: false,
   }
 
-  it('rails when there is no analysis result yet', () => {
+  it('rails when there is no model yet', () => {
     expect(shouldRenderFirstUseRail(base)).toBe(true)
   })
 
-  it('releases the rail once an analysis result exists', () => {
-    expect(shouldRenderFirstUseRail({ ...base, hasAnalysisResult: true })).toBe(false)
+  it('R1: releases the rail as soon as a MODEL exists, analysis or not', () => {
+    // THE RULING, and the discriminating case against the rule this replaced.
+    // A drafted-but-never-analysed session is exactly the state #728 railed and
+    // Paul vetoed: the panel must be visible the moment the model appears.
+    expect(shouldRenderFirstUseRail({ ...base, hasModelContent: true })).toBe(false)
   })
 
-  it('releases the rail on an explicit open, result or not', () => {
+  it('releases the rail on an explicit open, model or not', () => {
     // The override is unconditional by design: the rail's chevron, a started
     // run, and the collapsed-response signal all raise it, and none of them
     // should be second-guessed by this rule.
     expect(shouldRenderFirstUseRail({ ...base, userExplicitlyOpened: true })).toBe(false)
     expect(
-      shouldRenderFirstUseRail({ ...base, hasAnalysisResult: true, userExplicitlyOpened: true }),
+      shouldRenderFirstUseRail({ ...base, hasModelContent: true, userExplicitlyOpened: true }),
     ).toBe(false)
   })
 
-  it('releases the rail while a run is IN FLIGHT, before any result exists', () => {
+  it('releases the rail while a run is IN FLIGHT, before any model is on canvas', () => {
     // The reachable case this input exists for: a run that is ALREADY active
     // when the dock mounts (page reload mid-analysis, resumed session) never
     // fires the idle→active transition the run-start override rides, so without
@@ -55,38 +73,98 @@ describe('shouldRenderFirstUseRail', () => {
     // dock owns its own open state and this rule must be inert. Swept over
     // every combination of the other two inputs so the claim is about the flag,
     // not about the one combination that happened to be tried.
-    for (const hasAnalysisResult of [true, false]) {
+    for (const hasModelContent of [true, false]) {
       for (const analysisActive of [true, false]) {
         for (const userExplicitlyOpened of [true, false]) {
           expect(
             shouldRenderFirstUseRail({
               aiPanelV2On: false,
-              hasAnalysisResult,
+              hasModelContent,
               analysisActive,
               userExplicitlyOpened,
             }),
-            `aiPanelV2Off/${hasAnalysisResult}/${analysisActive}/${userExplicitlyOpened}`,
+            `aiPanelV2Off/${hasModelContent}/${analysisActive}/${userExplicitlyOpened}`,
           ).toBe(false)
         }
       }
     }
   })
 
-  it('is NOT a function of graph content — the defect this replaced', () => {
-    // A DISCRIMINATING assertion, not a restatement: the old rule released the
-    // rail as soon as nodes existed. The signature no longer admits graph
-    // content at all, so the only way to observe the difference is that a
-    // drafted-but-unanalysed session — every input the old rule would have
-    // flipped on — still rails. If someone reintroduces a node-count input,
-    // this is the test that has to be deleted to do it.
+  it('is NOT a function of whether an analysis has run — the input R1 removed', () => {
+    // A DISCRIMINATING assertion, not a restatement. The signature no longer
+    // admits an analysis-result input at all, so the only way to observe the
+    // difference is that a model with NO analysis releases the rail — the exact
+    // combination the previous rule railed. If someone reintroduces a
+    // has-analysis input, this is the test that has to be deleted to do it.
     const draftedButNotAnalysed = {
       aiPanelV2On: true,
-      hasAnalysisResult: false,
+      hasModelContent: true,
       analysisActive: false,
       userExplicitlyOpened: false,
     }
-    expect(shouldRenderFirstUseRail(draftedButNotAnalysed)).toBe(true)
-    expect(Object.keys(draftedButNotAnalysed)).not.toContain('hasGraphContent')
+    expect(shouldRenderFirstUseRail(draftedButNotAnalysed)).toBe(false)
+    expect(Object.keys(draftedButNotAnalysed)).not.toContain('hasAnalysisResult')
+  })
+})
+
+describe('resolveDockWidthForAnalysisState — R1\'s "starts NARROW" half', () => {
+  // 1280x800 is the viewport the 843px clamp was measured at, so it is the
+  // width at which the pair has to hold.
+  const VIEWPORT = 1280
+
+  it('opens NARROW while no analysis exists', () => {
+    // The claim is "narrow", and narrow is defined as the module's own usable
+    // floor — not a fresh constant, which would be a second authority on the
+    // same question and would drift from the bound the drag path clamps to.
+    expect(
+      resolveDockWidthForAnalysisState({
+        viewportWidth: VIEWPORT,
+        storedWidth: null,
+        hasAnalysisResult: false,
+      }),
+    ).toBe(DOCK_MIN_WIDTH)
+  })
+
+  it('widens to the normal responsive width once an analysis exists', () => {
+    // DISCRIMINATING PAIR with the case above: same viewport, same absence of a
+    // stored width, opposite analysis state, and the widths must DIFFER. A
+    // mutant that returns the full width in both cases passes the first test
+    // only if the floor happens to equal the responsive width — which at this
+    // viewport it does not, and that is asserted rather than assumed.
+    const full = resolveDockWidthForAnalysisState({
+      viewportWidth: VIEWPORT,
+      storedWidth: null,
+      hasAnalysisResult: true,
+    })
+    expect(full).toBe(resolveDockWidth(VIEWPORT, null))
+    expect(full).toBeGreaterThan(DOCK_MIN_WIDTH)
+  })
+
+  it('never overrides a width the user set for themselves', () => {
+    // Someone who has dragged the dock has given a direct instruction.
+    // Narrowing it under them because an analysis has not run yet is the
+    // product overruling the user, and no layout ruling asks for that.
+    const stored = 460
+    expect(
+      resolveDockWidthForAnalysisState({
+        viewportWidth: VIEWPORT,
+        storedWidth: stored,
+        hasAnalysisResult: false,
+      }),
+    ).toBe(resolveDockWidth(VIEWPORT, stored))
+  })
+
+  it('never returns a width below the usable floor, at any viewport', () => {
+    // Swept, because the narrow arm is a `Math.min` and a `min` against a
+    // pathologically small viewport is exactly where a floor gets lost.
+    for (const viewportWidth of [320, 768, 1024, 1280, 1600, 2560]) {
+      for (const hasAnalysisResult of [true, false]) {
+        expect(
+          resolveDockWidthForAnalysisState({ viewportWidth, storedWidth: null, hasAnalysisResult }),
+          `${viewportWidth}/${hasAnalysisResult}`,
+        ).toBeGreaterThanOrEqual(DOCK_MIN_WIDTH)
+      }
+    }
   })
 })
 
@@ -96,13 +174,12 @@ describe('forcedActivationEndsRail', () => {
     expect(forcedActivationEndsRail(true, 'olumi')).toBe(true)
   })
 
-  it('does NOT end the rail for a forced RESULTS activation — the measured regression', () => {
-    // THE DISCRIMINATING CASE. `FirstUseComposer` forces 'results' on the 0→N
-    // draft transition, so a rule that fired on any forced tab let the DRAFT
-    // clear the rail: the dock re-claimed its full width with no analysis in it
-    // and the post-draft fit returned to the clamped 843px this lane removes.
-    // The full suite was green with that defect present — it is a two-effect
-    // interaction no unit test saw — so this case is the pin.
+  it('does NOT end the rail for a forced RESULTS activation', () => {
+    // Kept after R1, and deliberately. R1 changed WHICH input ends the rail; it
+    // did not make every programmatic tab switch an implicit user intent, and
+    // `userExplicitlyOpened` is a session-scoped override that, once raised,
+    // wins outright. Letting a forced 'results' raise it would hand that
+    // permanent override to a navigation event.
     expect(forcedActivationEndsRail(true, 'results')).toBe(false)
   })
 

--- a/src/components/results/AdvancedSection.tsx
+++ b/src/components/results/AdvancedSection.tsx
@@ -555,9 +555,25 @@ export const LENS_ARM = {
  * distribution, and saying so is what lets a reader tell the arms apart.
  */
 const LENS_ARM_LABEL: Record<RiskAppetite, string> = {
-  conservative: 'Cautious (p10)',
-  neutral: 'Middle (p50)',
-  aggressive: 'Optimistic (p90)',
+  // ⭐ L-38: `p10`/`p50`/`p90` are percentile notation — engineering vocabulary
+  // in a user-facing control. The plain reading IS the label; the notation is
+  // kept, because a practised user reads it faster than the words, but it moves
+  // into the tooltip (`LENS_ARM_TITLE`) rather than sitting in the button text.
+  conservative: 'Cautious',
+  neutral: 'Middle',
+  aggressive: 'Optimistic',
+}
+
+/**
+ * Where the percentile notation went. Same keys, so an arm added to
+ * `LENS_ARM_LABEL` without a title is a TYPE ERROR rather than a silently
+ * untitled button — the estate's hand-maintained-mirror defect, avoided by
+ * construction rather than by remembering.
+ */
+const LENS_ARM_TITLE: Record<RiskAppetite, string> = {
+  conservative: 'The cautious end of the range (10th percentile, p10)',
+  neutral: 'The middle of the range (50th percentile, p50)',
+  aggressive: 'The optimistic end of the range (90th percentile, p90)',
 }
 
 export function RiskAppetiteFilter({
@@ -594,6 +610,15 @@ export function RiskAppetiteFilter({
             key={appetite}
             type="button"
             onClick={() => onChange(appetite)}
+            // ⚠ `title` ONLY — deliberately NOT `aria-label`. An aria-label
+            // REPLACES the accessible name, so labelling these with the full
+            // explanation would have made a screen reader announce a sentence
+            // where a two-word control name belongs, and every existing
+            // by-name query (and every user's mental model of the control)
+            // would break with it. The visible word IS the name; the
+            // percentile notation is supplementary, and supplementary detail
+            // is what `title` is for.
+            title={LENS_ARM_TITLE[appetite]}
             className={`px-2 py-0.5 rounded-full ${typography.panelMeta} border cursor-pointer ${
               value === appetite
                 ? 'border-info/60 text-info bg-transparent'

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -440,8 +440,16 @@ export const ResultsBody = memo(function ResultsBody({
               store's scenarioId matches the live decision (the identity gate
               that fixed it showing a PREVIOUS decision's brief verbatim), so
               mounting it unconditionally here is safe. */}
+          {/* ⭐ L-10 FIX: `onSendMessage` was never passed, and the component
+              renders its "Where does this fit?" action ONLY when it is
+              (`WhatIWasGivenSection.tsx:515` → `onAdd={onSendMessage ? … :
+              undefined}`). So this was not a dead BUTTON — the whole
+              "not modelled yet" action column never rendered at all, which is
+              why no click ever failed and nothing ever looked broken. The
+              handler is the same `onSendMessage` every other section on this
+              body already receives; there is no new write path. */}
           <SectionErrorBoundary section="What I was given">
-            <WhatIWasGivenSection />
+            <WhatIWasGivenSection onSendMessage={onSendMessage} />
           </SectionErrorBoundary>
         </>
 
@@ -625,13 +633,28 @@ export const ResultsBody = memo(function ResultsBody({
       )}
 
       {/* ── SECTION 3: DRIVERS ──────────────────────────────────── */}
+      {/* ⚠⚠ THE COUNT ON THIS ACCORDION HAS NEVER RENDERED, and finding out
+          why is the L-57 "honest counts" item in miniature. The call site read
+          `count={…}`; `Accordion` has no such prop — the badge is
+          `badgeCount`. React drops an unknown prop on a function component
+          without a word, so `badgeCount` stayed `undefined`, the
+          `badgeCount !== undefined && badgeCount > 0` gate never opened, and
+          the accompanying `badgeState` styled a badge that was not there. The
+          drivers section has been collapsed with no indication of how much is
+          inside it for as long as that line existed.
+          It did not fail loudly because TypeScript's excess-property
+          diagnostic for it is one of the three sitting in this file's
+          typecheck BASELINE — a ratcheted error that was hiding a live display
+          defect, not merely noise. Pinned by
+          `Accordion.badgeCountProp.spec.tsx`, whose second case renders the
+          WRONG prop name and asserts nothing appears. */}
       <Accordion
         title="What's driving this"
         subtitle="Factors with the strongest current influence on the result"
         defaultExpanded={false}
         isExpanded={driversExpanded}
         onExpandChange={onDriversExpandChange}
-        count={resultsSectionData.drivers.totalCount}
+        badgeCount={resultsSectionData.drivers.totalCount}
         badgeState={resultsSectionData.drivers.totalCount > 0 ? 'unresolved' : undefined}
         testId="accordion-drivers"
       >
@@ -653,10 +676,17 @@ export const ResultsBody = memo(function ResultsBody({
       </Accordion>
 
       {/* ── SECTION 3b: WHAT COULD CHANGE THE RESULT ──────────── */}
+      {/* ⭐ L-57: this was the ONE collapsed section on the tab with no count
+          on its header, so a reader scanning the collapsed sections could see
+          how many drivers there were but had no idea whether opening this one
+          revealed two factors or twenty. The count is the rendered row count —
+          the same array `TornadoChart` iterates, not a second derivation that
+          could disagree with what opening it reveals. */}
       {tornadoData.rows.length > 0 && tornadoData.expectedOutcome != null && (
         <Accordion
           title="What could change the result"
           defaultExpanded={false}
+          badgeCount={tornadoData.rows.length}
           testId="accordion-tornado"
         >
           <SectionErrorBoundary section="Tornado">

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -443,6 +443,16 @@ function T1ChecksFooter({
     robustnessVerdict === 'fragile'
   const gaps = data.confidence.topEvidenceGaps ?? data.confidence.evidenceGaps ?? []
   const evidenceWeak = gaps.some(g => typeof g.confidence === 'number' && g.confidence < 50)
+  // ⚠ L-58 / L-38. `evidenceKnown` is `gaps.length > 0` and NOTHING MORE, and
+  // the label it drove said "Evidence unknown" — which is not what the value
+  // means. An empty list is the producer returning no evidence gaps; whether
+  // that is "assessed, none found" or "not assessed" is genuinely
+  // indistinguishable here, because `useResultsSectionData` collapses absent
+  // and empty through `?? []` (`:3221-3226`). So the honest label states the
+  // ONE thing we hold — that nothing was flagged — and claims neither
+  // coverage nor an absence of assessment. (Trap 13c: the expectation is
+  // derived from the producer's semantics, not from what the field's name
+  // suggests it ought to mean.)
   const evidenceKnown = gaps.length > 0
   const addressed = gaps.filter(g => typeof g.confidence === 'number' && g.confidence >= 50).length
   const total = gaps.length
@@ -458,6 +468,17 @@ function T1ChecksFooter({
 
   return (
     <div className="border-t border-panel-border pt-3" data-testid="t1-checks-footer">
+      {/* ⭐ L-58/L-57: the row used to be three bare glyph+word chips
+          ("✓ Has leading option × Sensitive × Evidence unknown"), which reads
+          as QA chrome rather than as a statement to the user — Paul filed it
+          from a `?diag=1` session and it turned out to be USER-DEFAULT.
+          It keeps its three checks (they are the results side of the
+          cross-surface single-verdict guard, `singleVerdict.crossSurface.spec`)
+          and gains the heading that says what it IS, plus a plain-language
+          reading of each. Nothing is removed. */}
+      <p className={`${typography.panelMeta} text-text-light mb-1`} data-testid="checks-heading">
+        What we checked
+      </p>
       <div className={`flex items-center flex-wrap gap-x-3 gap-y-1 ${typography.panelMeta} text-text-light`}>
         <ChecksGlyph
           ok={hasWinner}
@@ -469,9 +490,12 @@ function T1ChecksFooter({
           ok={robustOk}
           unknown={!robustKnown}
           okLabel="Robust"
+          // "Sensitive" alone names no subject. Sensitive to WHAT is the whole
+          // content of the verdict, and the producer's own reason phrase (the
+          // tooltip below) has always said "to assumptions".
           notOkLabel={
             robustKnown
-              ? 'Sensitive'
+              ? 'Sensitive to assumptions'
               : robustnessVerdict === 'not_assessed'
                 ? 'Robustness not assessed'
                 : 'Robustness unknown'
@@ -483,13 +507,20 @@ function T1ChecksFooter({
         />
         <ChecksGlyph
           ok={!evidenceWeak && evidenceKnown}
+          // An empty gap list is the NEUTRAL third state, not a failure — the
+          // red X was itself part of the wrongness ("Evidence unknown" scored
+          // as a fault). `unknown` renders the muted help glyph.
+          unknown={!evidenceKnown}
           okLabel="Evidence covered"
-          notOkLabel={evidenceKnown ? 'Evidence gaps' : 'Evidence unknown'}
+          notOkLabel={evidenceKnown ? 'Evidence gaps' : 'No evidence gaps flagged'}
+          // Only the empty-list arm needs the caveat: with gaps present the
+          // label is a plain count-backed fact.
+          title={evidenceKnown ? undefined : 'The analysis returned no evidence gaps for this run.'}
           dataTestid="checks-evidence"
         />
         {total > 0 && (
           <span className="ml-auto" data-testid="checks-addressed">
-            {addressed}/{total} addressed
+            {addressed} of {total} evidence gaps addressed
           </span>
         )}
       </div>

--- a/src/components/results/__tests__/Accordion.badgeCountProp.spec.tsx
+++ b/src/components/results/__tests__/Accordion.badgeCountProp.spec.tsx
@@ -1,0 +1,74 @@
+/**
+ * The collapsed sections on the Analysis tab must show HOW MUCH is inside them
+ * (L-57, "collapsed sections with honest counts").
+ *
+ * ⚠ THIS EXISTS BECAUSE THE COUNT WAS SILENTLY ABSENT FOR THE WHOLE LIFE OF
+ * THE FEATURE. `ResultsBody` passed `count={…}` to `Accordion`, which has no
+ * such prop — the badge is `badgeCount`. React drops unknown props on a
+ * function component without a word, so the drivers accordion rendered with no
+ * count, beside a `badgeState` styling a badge that did not exist. Nothing
+ * failed: not the suite, not the browser, not the reviewer's eye, because a
+ * missing badge looks exactly like a badge that legitimately has nothing to
+ * show. The TypeScript excess-property error that WOULD have caught it is one
+ * of three ratcheted into this file's typecheck baseline.
+ *
+ * So the guard is in two halves, and neither alone is sufficient:
+ *   1. a DISCRIMINATING PAIR proving the prop NAME is load-bearing — the right
+ *      name renders the number, the wrong name renders nothing. A test that
+ *      only asserted "badgeCount renders" would pass just as happily against
+ *      the broken call site, because the call site is not what it looks at.
+ *   2. a SOURCE SCAN over the real call sites, so the defect cannot return by
+ *      someone typing the plausible-but-wrong name again. Derived from the
+ *      source, not from a list of known-good call sites.
+ */
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import { Accordion } from '../Accordion'
+
+describe('Accordion count badge', () => {
+  it('renders the number when given the REAL prop name', () => {
+    const { getByText } = render(
+      <Accordion title="What is driving this" badgeCount={7}>
+        <div />
+      </Accordion>,
+    )
+    expect(getByText('7')).toBeTruthy()
+  })
+
+  it('renders NOTHING for the wrong prop name — the defect, reproduced', () => {
+    // The other half of the pair. This is what the product actually shipped.
+    const { queryByText } = render(
+      <Accordion title="What is driving this" {...({ count: 7 } as Record<string, unknown>)}>
+        <div />
+      </Accordion>,
+    )
+    expect(queryByText('7')).toBeNull()
+  })
+
+  it('omits the badge at zero — "0 items" is noise, not a disclosure', () => {
+    const { queryByText } = render(
+      <Accordion title="What is driving this" badgeCount={0}>
+        <div />
+      </Accordion>,
+    )
+    expect(queryByText('0')).toBeNull()
+  })
+})
+
+describe("ResultsBody's accordion call sites use the prop that works", () => {
+  const source = readFileSync(resolve(__dirname, '../ResultsBody.tsx'), 'utf8')
+
+  it('CONTROL: the scan can see the call sites it is judging', () => {
+    // Trap 13: the assertion below is an absence claim over a file read. A
+    // typo in the path, or a moved file, would satisfy it perfectly.
+    expect(source).toMatch(/<Accordion/)
+    expect(source.match(/badgeCount=\{/g)?.length ?? 0).toBeGreaterThanOrEqual(2)
+  })
+
+  it('passes no `count=` prop to any Accordion', () => {
+    expect(source).not.toMatch(/^\s*count=\{/m)
+  })
+})

--- a/src/components/results/__tests__/ResultsBody.heroPlacement.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.heroPlacement.spec.tsx
@@ -238,14 +238,14 @@ describe("Paul's ruling (2026-07-12): risk appetite is an explicitly-labelled le
     useCanvasStore.setState({ analysisFreshness: { freshness: 'fresh' }, analysisFreshnessDirty: false })
     renderBody()
     expect(screen.queryByTestId('risk-lens-label')).not.toBeInTheDocument()
-    fireEvent.click(screen.getByRole('button', { name: 'Optimistic (p90)' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Optimistic' }))
     expect(screen.getByTestId('risk-lens-label')).toHaveTextContent(/highlights the option with the strongest high end \(p90\)/i)
     // SUPERSEDED 2026-07-31: the un-anchored noun "the recommendation" is
     // retired; the lens sentence now names the quantity that is unchanged.
     expect(screen.getByTestId('risk-lens-label')).toHaveTextContent(/goal ranking above is unchanged/i)
-    fireEvent.click(screen.getByRole('button', { name: 'Cautious (p10)' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cautious' }))
     expect(screen.getByTestId('risk-lens-label')).toHaveTextContent(/highlights the option with the strongest low end \(p10\)/i)
-    fireEvent.click(screen.getByRole('button', { name: 'Middle (p50)' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Middle' }))
     expect(screen.queryByTestId('risk-lens-label')).not.toBeInTheDocument()
   })
 
@@ -253,7 +253,7 @@ describe("Paul's ruling (2026-07-12): risk appetite is an explicitly-labelled le
     useCanvasStore.setState({ analysisFreshness: { freshness: 'fresh' }, analysisFreshnessDirty: false })
     renderBody()
     const heroBefore = screen.getByTestId('analysis-hero-panel').textContent
-    fireEvent.click(screen.getByRole('button', { name: 'Cautious (p10)' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Cautious' }))
     // Strict: the lens label renders OUTSIDE this panel, so any drift here
     // is real contamination.
     expect(screen.getByTestId('analysis-hero-panel').textContent).toBe(heroBefore)

--- a/src/components/results/analysis-hero/HeroLensTabs.tsx
+++ b/src/components/results/analysis-hero/HeroLensTabs.tsx
@@ -17,6 +17,41 @@ import { HERO_COPY } from './heroCopy'
 import { ALL_HERO_LENSES } from './heroTypes'
 import type { HeroLens } from './heroTypes'
 
+/**
+ * Lenses whose unavailability the USER CAN ACT ON. `goal` is the only one:
+ * when it is unavailable because no success target is set, the panel body
+ * offers "Set a success target to unlock Goal fit." with a live define-success
+ * route — so the muted tab is a real affordance.
+ *
+ * ⭐ L-57/L-38, AND THE RULE BEHIND IT. Every other unavailable lens is a
+ * PRODUCER GAP the user can do nothing whatever about: `stability` needs
+ * per-option stability data ISL does not emit (issue 211) and `whatChanged`
+ * needs versioned run comparisons PLoT does not emit (issue 212). Neither is
+ * ever pushed into the available set by the live adapter (`buildHeroModel.ts`
+ * pushes exactly `goal` and `outcome`), so on live data those two tabs were
+ * PERMANENTLY muted — a strip in which half the tabs advertise capabilities
+ * the product does not have, one of them explaining itself in producer-issue
+ * vocabulary ("This unlocks with versioned run comparisons. Olumi will not
+ * approximate it locally.").
+ *
+ * A tab the user cannot act on and the producer cannot fill is not an
+ * affordance, it is an advertisement. It is hidden — NOT deleted: the moment a
+ * producer starts supplying the data, `available` contains the lens and the
+ * tab returns with no code change. The fixture gallery keeps all four, because
+ * fixtures genuinely populate them.
+ */
+export const USER_ACTIONABLE_WHEN_UNAVAILABLE: readonly HeroLens[] = ['goal']
+
+/**
+ * The lenses the strip renders. Pure and exported so the rule is testable
+ * without a DOM, and so a mutant that widens it is visible.
+ */
+export function selectVisibleLenses(available: readonly HeroLens[]): HeroLens[] {
+  return ALL_HERO_LENSES.filter(
+    (lens) => available.includes(lens) || USER_ACTIONABLE_WHEN_UNAVAILABLE.includes(lens),
+  )
+}
+
 export interface HeroLensTabsProps {
   /** DATA-BEARING lenses; every other lens renders muted but selectable. */
   available: HeroLens[]
@@ -42,10 +77,15 @@ export function HeroLensTabs({
   panelId,
 }: HeroLensTabsProps) {
   const refs = useRef<Partial<Record<HeroLens, HTMLButtonElement | null>>>({})
+  // Roving focus must walk the RENDERED tabs, not the full lens enum — arrowing
+  // onto a tab that is not in the DOM focuses nothing and strands the keyboard
+  // user (the `refs.current[next]?.focus()` below would silently no-op).
+  const visibleLenses = selectVisibleLenses(available)
 
   const moveTo = (index: number) => {
-    const count = ALL_HERO_LENSES.length
-    const next = ALL_HERO_LENSES[(index + count) % count]
+    const count = visibleLenses.length
+    if (count === 0) return
+    const next = visibleLenses[(index + count) % count]
     onSelect(next)
     refs.current[next]?.focus()
   }
@@ -69,7 +109,7 @@ export function HeroLensTabs({
         break
       case 'End':
         e.preventDefault()
-        moveTo(ALL_HERO_LENSES.length - 1)
+        moveTo(visibleLenses.length - 1)
         break
     }
   }
@@ -80,7 +120,7 @@ export function HeroLensTabs({
       aria-label={HERO_COPY.tablistAria}
       className="flex gap-0.5 rounded-full border border-panel-border p-0.5"
     >
-      {ALL_HERO_LENSES.map((lens, index) => {
+      {visibleLenses.map((lens, index) => {
         const selected = lens === active
         const isAvailable = available.includes(lens)
         return (

--- a/src/components/results/analysis-hero/__tests__/a11y.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/a11y.spec.tsx
@@ -49,11 +49,21 @@ describe('AnalysisHero — accessibility', () => {
     renderPanel(chartModel())
     const tablist = screen.getByRole('tablist')
     expect(tablist).toHaveAccessibleName('Results lens')
-    // Full prototype strip: four tabs; unavailable lenses stay focusable
-    // and selectable (their panel explains itself), never aria-disabled
-    // dead ends.
+    // ⚠ The count changed, the PATTERN did not (cockpit simplification,
+    // L-57/L-38). This asserted four tabs — the full prototype strip, with two
+    // permanently unavailable. Those two (`stability`, `whatChanged`) are never
+    // pushed into the available set by the live adapter, so on every real run
+    // they advertised capabilities the producers cannot supply; the strip is
+    // now derived from what is reachable or user-actionable.
+    //
+    // What this test is FOR is unchanged and still asserted in full: a real
+    // tablist, exactly one selected tab, and a tabpanel labelled by it.
+    // Asserting a fixed length here would pin the defect, not the pattern —
+    // and the strip is still asserted non-empty, so a mutation that rendered
+    // NO tabs (which would also "pass" a length-free version of this test)
+    // fails on the `tabs[0]` reads below.
     const tabs = screen.getAllByRole('tab')
-    expect(tabs).toHaveLength(4)
+    expect(tabs.length).toBeGreaterThan(1)
     expect(tabs[0]).toHaveAttribute('aria-selected', 'true')
     for (const tab of tabs.slice(1)) {
       expect(tab).toHaveAttribute('aria-selected', 'false')

--- a/src/components/results/analysis-hero/__tests__/content.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/content.spec.tsx
@@ -444,31 +444,47 @@ describe('AnalysisHeroPanel — content', () => {
     expect(text).not.toMatch(/\b0\.\d+\b/)
   })
 
-  it('renders the full prototype lens strip; data-less lenses are marked unavailable', () => {
+  it('advertises only the lenses the user can reach or act on', () => {
+    // ⚠ REWRITTEN (cockpit simplification, L-57/L-38). This asserted all FOUR
+    // prototype lenses render, with two permanently marked `data-available =
+    // false`. That is what shipped, and Paul filed it: `stability` and
+    // `whatChanged` are never pushed into the available set by the live
+    // adapter (`buildHeroModel` pushes exactly `goal` and `outcome`; ISL #211 /
+    // PLoT #212 are the producer gaps), so on EVERY real run half the tab strip
+    // advertised capabilities the product does not have.
+    //
+    // The rule now: a lens renders when it carries data, OR when its
+    // unavailability is something the USER can act on. Hidden, not deleted —
+    // the strip is derived from `available`, so a lens returns the moment a
+    // producer supplies its data, with no code change.
     renderPanel(chartModel())
-    expect(screen.getAllByRole('tab')).toHaveLength(4)
+    expect(screen.getAllByRole('tab').map((t) => t.getAttribute('data-testid'))).toEqual([
+      'hero-lens-tab-goal',
+      'hero-lens-tab-outcome',
+    ])
     expect(screen.getByTestId('hero-lens-tab-goal')).toHaveAttribute('data-available', 'true')
     expect(screen.getByTestId('hero-lens-tab-outcome')).toHaveAttribute('data-available', 'true')
-    expect(screen.getByTestId('hero-lens-tab-stability')).toHaveAttribute('data-available', 'false')
-    expect(screen.getByTestId('hero-lens-tab-whatChanged')).toHaveAttribute('data-available', 'false')
+    // The producer-gap lenses are GONE from the strip, not merely muted.
+    expect(screen.queryByTestId('hero-lens-tab-stability')).toBeNull()
+    expect(screen.queryByTestId('hero-lens-tab-whatChanged')).toBeNull()
   })
 
-  it('selecting an unavailable lens shows the honest explainer body, never a fabricated chart', () => {
-    renderPanel(chartModel())
-    fireEvent.click(screen.getByTestId('hero-lens-tab-stability'))
-    expect(screen.getByTestId('hero-lens-unavailable')).toHaveTextContent(
-      'This view needs per-option stability data, which the analysis does not provide yet.',
-    )
-    expect(screen.queryByTestId('hero-option-row-1')).toBeNull()
+  it('the honest explainer body survives for any lens that IS reachable', () => {
+    // ⚠ The producer-gap half of this case is gone with the tabs it clicked.
+    // The PROPERTY it protected — an unavailable lens explains itself and never
+    // fabricates a chart — is unchanged and is asserted here on the lens that
+    // is still reachable while unavailable (goal with no success target). The
+    // producer-gap copy itself is still pinned as COPY by `heroCopy`'s own
+    // register and by the fixture gallery, which legitimately populates all
+    // four lenses.
+    const noGoal = [
+      makeOption({ ...OPTION_A, goalProbability: undefined }),
+      makeOption({ ...OPTION_B, goalProbability: undefined }),
+    ]
+    renderPanel(chartModel(makeHeroData({ options: noGoal })))
+    fireEvent.click(screen.getByTestId('hero-lens-tab-goal'))
+    expect(screen.getByTestId('hero-lens-unavailable')).toBeInTheDocument()
     expect(screen.queryByTestId('hero-caption')).toBeNull()
-    fireEvent.click(screen.getByTestId('hero-lens-tab-whatChanged'))
-    // F15: the placeholder must name the real dependency (producer-versioned
-    // run comparisons, PLoT #212) in the ratified honest-unavailable
-    // register, and must never read as a session-local unlock or promise a
-    // local approximation.
-    expect(screen.getByTestId('hero-lens-unavailable')).toHaveTextContent(
-      'Run comparison is not available yet. This unlocks with versioned run comparisons. Olumi will not approximate it locally.',
-    )
   })
 
   it('unavailable Goal fit distinguishes the no-target unlock from a producer gap', () => {
@@ -494,12 +510,32 @@ describe('AnalysisHeroPanel — content', () => {
   })
 
   it('the tab strip persists even when only one lens carries data', () => {
+    // ⚠ THE ASSERTION CHANGED, THE PROPERTY DID NOT (cockpit simplification,
+    // L-57/L-38). This used to assert all FOUR prototype lenses render
+    // regardless of data. That behaviour was measured as a defect: `stability`
+    // and `whatChanged` are NEVER pushed into the available set by the live
+    // adapter (ISL #211 / PLoT #212 producer gaps), so on every real run two of
+    // the four tabs were permanently muted advertisements for capabilities the
+    // product does not have — one of them explaining itself in producer-issue
+    // vocabulary. `selectVisibleLenses` now renders a lens when it has data OR
+    // when its unavailability is USER-ACTIONABLE.
+    //
+    // The property this test was written for — the strip does not VANISH when
+    // data is thin, and the one available lens still renders its rows — is
+    // unchanged and still asserted. What is no longer asserted is a fixed
+    // count, because the count is now a function of what the producers supply.
     const noGoal = [
       makeOption({ ...OPTION_A, goalProbability: undefined }),
       makeOption({ ...OPTION_B, goalProbability: undefined }),
     ]
     renderPanel(chartModel(makeHeroData({ options: noGoal })))
-    expect(screen.getAllByRole('tab')).toHaveLength(4)
+    const tabs = screen.getAllByRole('tab')
+    // Goal is kept despite carrying no data (its empty state is actionable);
+    // outcome carries data. Neither producer-gap lens is advertised.
+    expect(tabs.map((t) => t.getAttribute('data-testid'))).toEqual([
+      'hero-lens-tab-goal',
+      'hero-lens-tab-outcome',
+    ])
     // The single available lens still renders its rows by default.
     expect(screen.getByTestId('hero-option-row-1')).toBeInTheDocument()
   })

--- a/src/components/results/analysis-hero/__tests__/interaction.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/interaction.spec.tsx
@@ -81,13 +81,27 @@ describe('AnalysisHero — interaction', () => {
     fireEvent.keyDown(outcomeTab, { key: 'ArrowLeft' })
     expect(goalTab).toHaveAttribute('aria-selected', 'true')
 
-    // Home/End jump to the first/last lens of the FULL strip (WAI-ARIA
-    // APG) — unavailable lenses are focusable and selectable (their panel
-    // explains itself), so End lands on What changed.
-    const whatChangedTab = screen.getByTestId('hero-lens-tab-whatChanged')
+    // Home/End jump to the first/last lens of the RENDERED strip (WAI-ARIA
+    // APG). ⚠ This used to expect End to land on "What changed" — the last of
+    // four. The producer-gap lenses are no longer advertised (see
+    // `selectVisibleLenses`), so the last rendered lens is Outcome.
+    //
+    // ⭐ THE ROVING RANGE HAD TO MOVE WITH THE STRIP, and getting it wrong
+    // would have been silent: `moveTo` previously indexed `ALL_HERO_LENSES`,
+    // so arrowing past the end would select a lens with no button in the DOM,
+    // `refs.current[next]?.focus()` would no-op on `undefined`, and the
+    // keyboard user's focus would simply stop moving with nothing to see.
     fireEvent.keyDown(goalTab, { key: 'End' })
-    expect(whatChangedTab).toHaveAttribute('aria-selected', 'true')
-    fireEvent.keyDown(whatChangedTab, { key: 'Home' })
+    expect(outcomeTab).toHaveAttribute('aria-selected', 'true')
+    fireEvent.keyDown(outcomeTab, { key: 'Home' })
+    expect(goalTab).toHaveAttribute('aria-selected', 'true')
+    // The wrap is over the rendered strip too: left from the first lens
+    // returns to the LAST RENDERED one, rather than walking into an unmounted
+    // tab. Restored to Goal afterwards so the cases below start where they
+    // expect to (this test walks one continuous keyboard session).
+    fireEvent.keyDown(goalTab, { key: 'ArrowLeft' })
+    expect(outcomeTab).toHaveAttribute('aria-selected', 'true')
+    fireEvent.keyDown(outcomeTab, { key: 'Home' })
     expect(goalTab).toHaveAttribute('aria-selected', 'true')
 
     // Up/Down are NOT hijacked on a horizontal tablist (page scroll keeps working).

--- a/src/components/results/analysis-hero/heroCopy.ts
+++ b/src/components/results/analysis-hero/heroCopy.ts
@@ -59,11 +59,22 @@ export const HERO_COPY = {
     /**
      * F15: names the real dependency (producer-versioned run comparisons,
      * PLoT #212) in the ratified honest-unavailable register. Must never
-     * read as a session-local unlock, and must state that Olumi will not
-     * approximate the comparison locally (no client-side run diffing).
+     * read as a session-local unlock, and must not promise a comparison the
+     * analysis cannot make.
+     *
+     * ⭐ L-38 REWRITE. The honesty requirement is unchanged and the sentence
+     * still refuses to promise a session-local unlock. What changed is the
+     * register: "This unlocks with versioned run comparisons. Olumi will not
+     * approximate it locally." is an internal doctrine statement — it names a
+     * producer feature by its engineering name and then describes our own
+     * implementation policy TO THE USER. The replacement says the same two
+     * things in the user's terms: it cannot be done yet, and we will not fake
+     * it. On the live path this string is now unreachable anyway (the lens is
+     * hidden — see `HeroLensTabs.selectVisibleLenses`); it survives for the
+     * fixture gallery and for the moment a producer supplies the data.
      */
     whatChanged:
-      'Run comparison is not available yet. This unlocks with versioned run comparisons. Olumi will not approximate it locally.',
+      'Comparing this run with an earlier one is not available yet. Olumi will not estimate the difference rather than measure it.',
   } as const,
 
   headline: {

--- a/src/components/results/analysisState/AnalysisStateRegion.tsx
+++ b/src/components/results/analysisState/AnalysisStateRegion.tsx
@@ -1,0 +1,96 @@
+/**
+ * `<AnalysisStateRegion>` — the layout-level owner of the Analysis surface's
+ * truth-state slot and body slot (brief step 6, ruling R1).
+ *
+ * THE ONE PROPERTY IT EXISTS TO GUARANTEE
+ * ---------------------------------------
+ *     At most ONE truth-state banner mounts on this surface, and WHICH one is
+ *     a function of the run state alone.
+ *
+ * It is structural, not defensive. There is a SINGLE banner expression here,
+ * so two banners cannot co-render without deleting this component — which
+ * REDs `AnalysisStateRegion.singleTruthBanner.spec.tsx`. That is what "row-
+ * exclusive by construction" means, and it is why the fix is a region rather
+ * than a neighbour check inside `AnalysisFreshnessNotice` ("am I next to a
+ * refusal?"). Neighbour checks were the shape that produced L-36: seven
+ * independently-sourced children, each correct alone, none gating any other.
+ *
+ * WHAT IT DELIBERATELY DOES NOT DO
+ * --------------------------------
+ *  - It does not derive freshness, readiness, refusal or leader entitlement.
+ *    It consumes an `AnalysisRunStateKind` and renders the components that
+ *    already own those verdicts. The banners keep their own null-render rules,
+ *    so a state we do not hold still produces no banner: selecting the
+ *    freshness slot is permission to speak, never an instruction to.
+ *  - It does not gate the ranked leader (brief step 7).
+ *  - It does not dim (Paul's Ruling 3 / ROADMAP 2.651 — stale results are
+ *    labelled, never withheld or dimmed). `prior` marks; it does not obscure.
+ */
+import type { ReactNode } from 'react'
+
+import { AnalysisFreshnessNotice } from '../AnalysisFreshnessNotice'
+import { AnalysisRefusalNotice } from '../AnalysisRefusalNotice'
+import {
+  selectBodyPresentation,
+  selectTruthBanner,
+  type AnalysisRunStateKind,
+} from './analysisStateContract'
+
+export interface AnalysisStateRegionProps {
+  /** The composed run state (`useAnalysisRunState()` at the call site). */
+  runState: AnalysisRunStateKind
+  /**
+   * Whether there is a result body to present at all. The caller's existing
+   * gate is passed in rather than re-derived here — a second authority for
+   * "is there a report" is exactly the duplication this region removes.
+   */
+  hasReport: boolean
+  /**
+   * Provenance attribution for a body showing an EARLIER run's numbers
+   * (ROADMAP 2.1127's `stale-results-banner`). Rendered INSIDE the body slot,
+   * because it answers "whose numbers are these?" — a different question from
+   * "did the analysis run, and is it current?" (trap 21). It is therefore not
+   * a truth-state banner and does not compete for the single slot.
+   */
+  bodyAttribution?: ReactNode
+  /** The result body. */
+  children?: ReactNode
+}
+
+export function AnalysisStateRegion({
+  runState,
+  hasReport,
+  bodyAttribution,
+  children,
+}: AnalysisStateRegionProps) {
+  const banner = selectTruthBanner(runState)
+  const presentation = selectBodyPresentation(runState, hasReport)
+
+  return (
+    <div
+      data-testid="analysis-state-region"
+      data-run-state={runState}
+      data-truth-banner={banner}
+      data-body-presentation={presentation}
+      className="flex flex-col gap-6"
+    >
+      {/* ⭐ THE SINGLE TRUTH-STATE SLOT. One expression, one element. Adding a
+          second banner here — or mounting either notice anywhere else on this
+          surface — is the defect; both are pinned. */}
+      {banner === 'refusal' ? (
+        <AnalysisRefusalNotice />
+      ) : banner === 'freshness' ? (
+        <AnalysisFreshnessNotice />
+      ) : null}
+
+      {presentation !== 'hidden' && (
+        <div className="flex flex-col gap-6" data-testid="analysis-state-region-body">
+          {presentation === 'prior' && bodyAttribution}
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default AnalysisStateRegion

--- a/src/components/results/analysisState/__tests__/AnalysisStateRegion.singleTruthBanner.spec.tsx
+++ b/src/components/results/analysisState/__tests__/AnalysisStateRegion.singleTruthBanner.spec.tsx
@@ -1,0 +1,213 @@
+/**
+ * THE ACCEPTANCE TEST FOR L-36 / screenshot S06 — the P0-trust defect where
+ * "This analysis did not run — it stopped before it ran" and "Cannot confirm
+ * whether this analysis is current." rendered ONE ABOVE THE OTHER, directly
+ * above a fully rendered result.
+ *
+ * ⭐ WHAT IS BEING CLAIMED, PRECISELY
+ * ----------------------------------
+ * NOT "those two sentences no longer co-occur in the one state we looked at".
+ * The claim is STRUCTURAL: the surface has exactly one truth-state slot, and
+ * which banner fills it is a total function of the run state. So the assertions
+ * below are (a) exhaustive over the state enum, not sampled, and (b) written
+ * against the MOUNTED ELEMENTS by testid, never against copy — copy changes and
+ * the property must survive it (trap 19: bind by identity).
+ *
+ * ⭐ THE MUTANT PAIR (brief acceptance (a): "the pair, not one mutant")
+ * -------------------------------------------------------------------
+ * A count-≤-1 assertion is satisfiable by a region that renders NOTHING, so it
+ * is not evidence on its own. Every exclusivity case below is therefore paired
+ * with a POSITIVE case in the opposite state, and the two must disagree:
+ *   · force `refused` with a prior result → the refusal banner mounts and the
+ *     freshness banner does NOT;
+ *   · force `complete_current`            → the freshness banner mounts and the
+ *     refusal banner does NOT.
+ * A mutant that always returns 'refusal' passes the first and REDs the second;
+ * a mutant that always returns 'freshness' does the reverse; a mutant that
+ * renders both REDs both. No single mutant survives the pair.
+ *
+ * ⚠ WHY THE NOTICES ARE STUBBED
+ * -----------------------------
+ * The real notices render null unless their own store slices hold a verdict, so
+ * a test using them would be asserting the STORE's state, not the region's
+ * rule — and a slice that failed to populate would look exactly like correct
+ * exclusivity (an absence probe with no positive control, trap 13). The stubs
+ * ALWAYS render, which means every "did not mount" assertion below is a claim
+ * about the REGION and nothing else. `analysisStateRegion.mountSites.spec.ts`
+ * separately pins that the production surface mounts the real ones, and only
+ * from here.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+vi.mock('../../AnalysisRefusalNotice', () => ({
+  AnalysisRefusalNotice: () => <div data-testid="analysis-refusal-notice">refusal</div>,
+}))
+vi.mock('../../AnalysisFreshnessNotice', () => ({
+  AnalysisFreshnessNotice: () => <div data-testid="analysis-freshness-notice">freshness</div>,
+}))
+
+import { AnalysisStateRegion } from '../AnalysisStateRegion'
+import {
+  TRUTH_BANNER_BY_RUN_STATE,
+  selectBodyPresentation,
+  selectTruthBanner,
+  type AnalysisRunStateKind,
+} from '../analysisStateContract'
+
+const ALL_STATES = Object.keys(TRUTH_BANNER_BY_RUN_STATE) as AnalysisRunStateKind[]
+
+/** Every truth-state banner the surface can mount, counted as DOM elements. */
+function mountedTruthBanners(container: HTMLElement): string[] {
+  return Array.from(
+    container.querySelectorAll(
+      '[data-testid="analysis-refusal-notice"],[data-testid="analysis-freshness-notice"]',
+    ),
+  ).map((el) => el.getAttribute('data-testid') ?? '')
+}
+
+describe('AnalysisStateRegion — AT MOST ONE truth-state banner, in every state', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('control: the probe can SEE a banner (it is not blind)', () => {
+    // Trap 13. Every assertion in this file is an absence claim about one
+    // banner or the other; none of them is worth anything unless the query can
+    // observe a presence. It can: here it observes two, which is also the
+    // pre-fix shape this region exists to make unreachable.
+    const { container } = render(
+      <div>
+        <div data-testid="analysis-refusal-notice" />
+        <div data-testid="analysis-freshness-notice" />
+      </div>,
+    )
+    expect(mountedTruthBanners(container)).toHaveLength(2)
+  })
+
+  it.each(ALL_STATES)('mounts at most one truth-state banner in %s', (kind) => {
+    // Exhaustive over the enum, with a prior result present in EVERY state —
+    // i.e. the hardest case, the one where a body is on screen for a banner to
+    // contradict. Sampling states here is how S06 shipped.
+    const { container } = render(
+      <AnalysisStateRegion runState={kind} hasReport>
+        <div data-testid="results-body" />
+      </AnalysisStateRegion>,
+    )
+    expect(mountedTruthBanners(container).length).toBeLessThanOrEqual(1)
+  })
+
+  it('S06 EXACTLY: refused, with a prior result on screen → ONE banner, and it is the refusal', () => {
+    // The witnessed defect, reproduced as a state and pinned. Before the
+    // region, this cell mounted the refusal notice AND the freshness notice
+    // (CEE clamps a refusal's freshness to `unknown`, so "cannot confirm" was
+    // live in exactly the state that had just said the analysis never ran)
+    // AND the previous run's body.
+    const { container } = render(
+      <AnalysisStateRegion
+        runState="refused"
+        hasReport
+        bodyAttribution={<div data-testid="stale-results-banner" />}
+      >
+        <div data-testid="results-body" />
+      </AnalysisStateRegion>,
+    )
+    expect(mountedTruthBanners(container)).toEqual(['analysis-refusal-notice'])
+    expect(screen.queryByTestId('analysis-freshness-notice')).toBeNull()
+    // The body is NOT withheld: the user's best available context stays on
+    // screen, attributed. Withholding it would be a second defect, not a fix.
+    expect(screen.getByTestId('results-body')).toBeTruthy()
+    expect(screen.getByTestId('stale-results-banner')).toBeTruthy()
+  })
+
+  it('THE PAIR: complete_current → ONE banner, and it is the FRESHNESS one', () => {
+    // The other half. Without this case, "exactly one refusal banner" is also
+    // satisfied by a region hard-wired to the refusal notice.
+    const { container } = render(
+      <AnalysisStateRegion runState="complete_current" hasReport>
+        <div data-testid="results-body" />
+      </AnalysisStateRegion>,
+    )
+    expect(mountedTruthBanners(container)).toEqual(['analysis-freshness-notice'])
+    expect(screen.queryByTestId('analysis-refusal-notice')).toBeNull()
+  })
+
+  it('never_run mounts NO truth-state banner and NO body', () => {
+    const { container } = render(
+      <AnalysisStateRegion runState="never_run" hasReport>
+        <div data-testid="results-body" />
+      </AnalysisStateRegion>,
+    )
+    expect(mountedTruthBanners(container)).toEqual([])
+    expect(screen.queryByTestId('results-body')).toBeNull()
+  })
+
+  it('a refused FIRST analysis still reaches the user, with no body to decorate', () => {
+    // ROADMAP 2.1163's harm, preserved through the refactor. The refusal notice
+    // was deliberately UNGATED at its old mount site precisely because a refused
+    // analysis is the case with no results; the region reproduces that by
+    // ordering `refused` above `never_run`, not by copying the gate.
+    render(<AnalysisStateRegion runState="refused" hasReport={false} />)
+    expect(screen.getByTestId('analysis-refusal-notice')).toBeTruthy()
+    expect(screen.queryByTestId('analysis-freshness-notice')).toBeNull()
+  })
+
+  it('the attribution renders ONLY for a prior body, never beside a current one', () => {
+    // DISCRIMINATING PAIR for the body slot: same attribution node, two states,
+    // opposite outcomes. Rendering "showing results from previous analysis"
+    // over THIS run's numbers is the 2.1127 false claim.
+    const prior = render(
+      <AnalysisStateRegion
+        runState="complete_stale"
+        hasReport
+        bodyAttribution={<div data-testid="stale-results-banner" />}
+      />,
+    )
+    expect(prior.queryByTestId('stale-results-banner')).toBeTruthy()
+    document.body.innerHTML = ''
+
+    const current = render(
+      <AnalysisStateRegion
+        runState="complete_current"
+        hasReport
+        bodyAttribution={<div data-testid="stale-results-banner" />}
+      />,
+    )
+    expect(current.queryByTestId('stale-results-banner')).toBeNull()
+  })
+})
+
+describe('the composition table itself', () => {
+  it('is total over the run states — no state falls through to a default', () => {
+    // A default arm is how a newly-minted state silently inherits somebody
+    // else's banner. There is no default; this asserts the consequence.
+    for (const kind of ALL_STATES) {
+      expect(selectTruthBanner(kind), kind).toMatch(/^(none|refusal|freshness)$/)
+    }
+    expect(ALL_STATES).toHaveLength(7)
+  })
+
+  it('gives blocked and refused the SAME row (they differ on the wire, not on screen)', () => {
+    expect(selectTruthBanner('blocked')).toBe(selectTruthBanner('refused'))
+    expect(selectTruthBanner('refused')).toBe('refusal')
+  })
+
+  it('a run in flight keeps a retained body — MARKED, never blanked', () => {
+    // The brief's table writes ✗ for the running row. That is right for a FIRST
+    // run and wrong for a rerun: blanking the previous numbers mid-run
+    // contradicts the ratified "run-in-flight is MARKED, not blanked" doctrine
+    // and takes content away at the moment the user is comparing. `hasReport`
+    // separates the two cases, and both are pinned here.
+    expect(selectBodyPresentation('running', false)).toBe('hidden')
+    expect(selectBodyPresentation('running', true)).toBe('prior')
+  })
+
+  it('only complete_current presents the body as current', () => {
+    for (const kind of ALL_STATES) {
+      const presentation = selectBodyPresentation(kind, true)
+      if (kind === 'complete_current') expect(presentation).toBe('current')
+      else if (kind === 'never_run') expect(presentation).toBe('hidden')
+      else expect(presentation, kind).toBe('prior')
+    }
+  })
+})

--- a/src/components/results/analysisState/__tests__/analysisStateRegion.mountSites.spec.ts
+++ b/src/components/results/analysisState/__tests__/analysisStateRegion.mountSites.spec.ts
@@ -69,6 +69,29 @@ function mountSitesOf(name: string, files: string[]): string[] {
     .sort()
 }
 
+/**
+ * Files that IMPORT a module by path, whatever local name they bind it to.
+ *
+ * ⚠ THIS CLOSES AN EVASION CHANNEL AN ADVERSARIAL REVIEW EXECUTED. `mountSitesOf`
+ * greps for `<Name`, so an ALIASED import defeats it completely:
+ *
+ *     import { AnalysisFreshnessNotice as Strip } from '.../AnalysisFreshnessNotice'
+ *     <Strip />
+ *
+ * — a second live banner on the surface, invisible to a name-shaped scan. The
+ * name is the thing a reader looks for and therefore the thing a scan is
+ * tempted to bind to; the PATH is what cannot be renamed away, because it is
+ * what the module system resolves. Both are checked: the name scan says where
+ * it is mounted, the path scan says who can mount it at all.
+ */
+function importersOf(moduleBasename: string, files: string[]): string[] {
+  const imported = new RegExp(`from\\s*['"][^'"]*\\b${moduleBasename}['"]`)
+  return files
+    .filter((f) => imported.test(stripComments(readFileSync(f, 'utf8'))))
+    .map((f) => f.slice(SRC.length + 1))
+    .sort()
+}
+
 describe('truth-state notices have exactly one production mount site', () => {
   const files = walk(SRC)
 
@@ -97,6 +120,25 @@ describe('truth-state notices have exactly one production mount site', () => {
     expect(mountSitesOf('AnalysisFreshnessNotice', files)).toEqual([
       'components/results/analysisState/AnalysisStateRegion.tsx',
     ])
+  })
+
+  it('and NOTHING ELSE CAN MOUNT EITHER — nobody else imports the modules', () => {
+    // The path-shaped half. A file that cannot import the module cannot mount
+    // it under any local name, so this closes the aliased-import channel the
+    // name scan above is blind to. Stated as the exact importer set rather than
+    // a count, so a new importer names itself in the failure.
+    const REGION = 'components/results/analysisState/AnalysisStateRegion.tsx'
+    expect(importersOf('AnalysisRefusalNotice', files)).toEqual([REGION])
+    expect(importersOf('AnalysisFreshnessNotice', files)).toEqual([REGION])
+  })
+
+  it('CONTROL: the importer scan is not blind (it can see a known importer)', () => {
+    // Same discipline as the mount-site control: an absence claim over a file
+    // scan needs proof the scan can observe a presence. `analysisStateContract`
+    // is imported by the region AND by the hook, so a working scan returns
+    // more than one — a scan returning one would be indistinguishable from a
+    // regex that only ever matches the file it was tuned against.
+    expect(importersOf('analysisStateContract', files).length).toBeGreaterThan(1)
   })
 
   it('the region itself is mounted exactly once — one surface, one region', () => {

--- a/src/components/results/analysisState/__tests__/analysisStateRegion.mountSites.spec.ts
+++ b/src/components/results/analysisState/__tests__/analysisStateRegion.mountSites.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * THE STRUCTURAL HALF of the single-truth-banner guarantee.
+ *
+ * `AnalysisStateRegion.singleTruthBanner.spec.tsx` proves the REGION renders at
+ * most one banner. That is worth nothing if a second copy of either banner is
+ * mounted somewhere else on the same surface — which is exactly how L-36
+ * happened: seven independently-sourced truth-state children, each correct in
+ * isolation, none gating any other.
+ *
+ * So this guard asserts the other half: across the whole product source, each
+ * truth-state notice has EXACTLY ONE production mount site, and it is the
+ * region.
+ *
+ * ⚠ DERIVED, NOT MIRRORED (CLAUDE.md trap 12). There is no hand-kept list of
+ * allowed mount sites here — the sites are read out of the source at test time.
+ * A hand-maintained allowlist would drift silently the first time someone added
+ * a mount, and the drift would read as green.
+ *
+ * ⚠ AND IT HAS A POSITIVE CONTROL, because every assertion below is an ABSENCE
+ * claim over a file scan, and a scan that silently reads nothing produces a
+ * perfect absence result (trap 13 / 13e). The control asserts the scanner finds
+ * a KNOWN-PRESENT mount in a plausible quantity before any absence is believed.
+ */
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const SRC = resolve(__dirname, '../../../..')
+
+/** Production source only: stories, fixtures and specs may mount anything. */
+function isProductionSource(path: string): boolean {
+  if (!/\.(ts|tsx)$/.test(path)) return false
+  if (path.includes('__tests__')) return false
+  if (path.includes('__fixtures__')) return false
+  if (/\.spec\.[tj]sx?$/.test(path)) return false
+  if (/\.test\.[tj]sx?$/.test(path)) return false
+  if (/\.stories\.[tj]sx?$/.test(path)) return false
+  return true
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry.startsWith('.')) continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else if (isProductionSource(full)) out.push(full)
+  }
+  return out
+}
+
+/**
+ * ⚠ COMMENTS ARE STRIPPED FIRST, AND THAT WAS A MEASURED INSTRUMENT DEFECT,
+ * NOT A PRECAUTION. The first version of this scanner matched `<Name` anywhere
+ * in the file and reported `AnalysisStateRegion.tsx` as a mount site of
+ * itself — because its own header comment writes `<AnalysisStateRegion>` when
+ * naming the component. A scan that cannot tell code from prose about code
+ * produces confident, wrong mount inventories in BOTH directions.
+ */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1')
+}
+
+/** Files containing a JSX MOUNT of `<Name`, not merely an import or a mention. */
+function mountSitesOf(name: string, files: string[]): string[] {
+  const mount = new RegExp(`<${name}[\\s/>]`)
+  return files
+    .filter((f) => mount.test(stripComments(readFileSync(f, 'utf8'))))
+    .map((f) => f.slice(SRC.length + 1))
+    .sort()
+}
+
+describe('truth-state notices have exactly one production mount site', () => {
+  const files = walk(SRC)
+
+  it('CONTROL: the scanner reads a plausible number of files and can see a known mount', () => {
+    // Two independent controls, because a scan can fail in two directions.
+    // (1) Magnitude: this repo has thousands of production TS/TSX files. A
+    //     scanner that walked nothing, or walked one directory, would still
+    //     return a clean "no extra mounts" answer below.
+    expect(files.length).toBeGreaterThan(500)
+    // (2) Discrimination: a CONTRAST symbol we expect to be PRESENT in more
+    //     than one place. If this reads zero or one, the regex is broken and
+    //     every absence claim below is unsupported (trap 13e: a control must be
+    //     plausible, not merely non-zero).
+    expect(mountSitesOf('SectionErrorBoundary', files).length).toBeGreaterThan(1)
+  })
+
+  it('AnalysisRefusalNotice is mounted only by the region', () => {
+    expect(mountSitesOf('AnalysisRefusalNotice', files)).toEqual([
+      'components/results/analysisState/AnalysisStateRegion.tsx',
+    ])
+  })
+
+  it('AnalysisFreshnessNotice is mounted only by the region', () => {
+    // The historical second mount was `OutputsDock.tsx`, as a SIBLING of the
+    // refusal notice. That sibling relationship WAS the defect.
+    expect(mountSitesOf('AnalysisFreshnessNotice', files)).toEqual([
+      'components/results/analysisState/AnalysisStateRegion.tsx',
+    ])
+  })
+
+  it('the region itself is mounted exactly once — one surface, one region', () => {
+    // A second region on the same scroller would restore the stacking with the
+    // per-region invariant intact in each: two regions, one banner each, two
+    // banners on screen. The count is the thing that matters, so it is pinned.
+    expect(mountSitesOf('AnalysisStateRegion', files)).toEqual([
+      'canvas/components/OutputsDock.tsx',
+    ])
+  })
+})

--- a/src/components/results/analysisState/__tests__/useAnalysisRunState.mapping.spec.ts
+++ b/src/components/results/analysisState/__tests__/useAnalysisRunState.mapping.spec.ts
@@ -1,0 +1,186 @@
+/**
+ * `mapToAnalysisRunState` — the slice → run-state hop, pinned arm by arm.
+ *
+ * ⚠⚠ WHY THIS FILE EXISTS: AN ADVERSARIAL REVIEW PROVED THE `refused` ARM WAS
+ * UNPINNED, BY EXECUTION. Deleting `if (input.refusalPresent) return 'refused'`
+ * left **53/53 tests GREEN across all four refusal-touching specs**. Not one of
+ * them exercised this hop:
+ *
+ *   · `AnalysisStateRegion.singleTruthBanner.spec.tsx` passes `runState` in
+ *     DIRECTLY, so it tests the composition table and is silent about how a
+ *     state is reached — by design, and that is exactly the blind spot;
+ *   · `AnalysisRefusalNotice.spec.tsx` renders the component from its own prop;
+ *   · `applyV5State.analysisRefusalNotice.spec.tsx` is STORE-level — it proves
+ *     the wire populates the slice and stops there;
+ *   · `analysisStateRegion.mountSites.spec.ts` reads source text.
+ *
+ * Every one of them is correct about what it covers. Together they cover the
+ * wire→slice hop and the state→banner hop and leave the slice→STATE hop between
+ * them untested — the classic seam defect, where each neighbour assumes the
+ * other owns the join. A refusal could have stopped reaching the user with the
+ * whole suite green.
+ *
+ * ⚠ AND THE COMPOUNDING ERROR, WHICH IS THE WORSE HALF: the mount-site comment
+ * in `OutputsDock.tsx` asserted that unifying the gates "would re-dark it and
+ * RED `applyV5State.analysisRefusalNotice.spec.tsx`". Measured: FALSE. That
+ * spec stayed green under the deletion. A comment naming a guard that does not
+ * guard is worse than no comment — it tells the next reader the seam is
+ * covered, so they stop looking. The comment now names this file, and this file
+ * is the thing that actually bites.
+ *
+ * ⭐ IT ALSO MATTERS BEYOND THIS PR. #737's selector never mints `refused` on
+ * legacy turns, so the post-merge one-line swap to
+ * `useAnalysisState().run_state` would silently re-dark the refusal notice.
+ * These assertions are what make that regression visible AT SWAP TIME rather
+ * than in a screenshot weeks later.
+ *
+ * HOW THE ASSERTIONS ARE BUILT
+ * ----------------------------
+ * Every claim about `refusalPresent` is a DISCRIMINATING PAIR: the same inputs
+ * with the flag true and false, asserted to differ. A single-sided assertion
+ * ("refusal → refused") is satisfiable by a function that returns `'refused'`
+ * more often than it should; the pair is not. And each pair is placed at a cell
+ * where the OTHER arms would return something else, so it is the flag being
+ * measured and not the row.
+ */
+import { describe, it, expect } from 'vitest'
+
+import { mapToAnalysisRunState } from '../useAnalysisRunState'
+import { TRUTH_BANNER_BY_RUN_STATE, type AnalysisRunStateKind } from '../analysisStateContract'
+
+type Input = Parameters<typeof mapToAnalysisRunState>[0]
+
+/** A settled, never-run, no-verdict surface: every arm below is off. */
+const BASE: Input = {
+  refusalPresent: false,
+  resultsStatus: 'idle',
+  hasCompletedFirstRun: false,
+  displayedFreshness: null,
+}
+
+const map = (over: Partial<Input>): AnalysisRunStateKind =>
+  mapToAnalysisRunState({ ...BASE, ...over })
+
+describe('mapToAnalysisRunState — the refusal arm (the unpinned seam)', () => {
+  it('a refused FIRST analysis is `refused`, not `never_run`', () => {
+    // ROADMAP 2.1163's harm. `hasCompletedFirstRun` is false here — the cell
+    // the `never_run` arm would claim — so this asserts the ORDERING, which is
+    // the whole reason the refusal notice can be ungated. Deleting the refusal
+    // arm returns 'never_run' and REDs this line.
+    expect(map({ refusalPresent: true, hasCompletedFirstRun: false })).toBe('refused')
+    // The pair. Same cell, flag off: the state must DIFFER.
+    expect(map({ refusalPresent: false, hasCompletedFirstRun: false })).toBe('never_run')
+  })
+
+  it('a refusal after a successful run outranks a retained FRESH verdict', () => {
+    // The nastiest cell: CEE has previously vouched for a result, so the
+    // freshness arm would return `complete_current` — a surface presenting old
+    // numbers as current while the engine has just declined to run.
+    const withRefusal: Partial<Input> = {
+      refusalPresent: true,
+      hasCompletedFirstRun: true,
+      displayedFreshness: 'fresh',
+    }
+    expect(map(withRefusal)).toBe('refused')
+    expect(map({ ...withRefusal, refusalPresent: false })).toBe('complete_current')
+  })
+
+  it('a refusal outranks a retained STALE verdict', () => {
+    const withRefusal: Partial<Input> = {
+      refusalPresent: true,
+      hasCompletedFirstRun: true,
+      displayedFreshness: 'stale',
+    }
+    expect(map(withRefusal)).toBe('refused')
+    expect(map({ ...withRefusal, refusalPresent: false })).toBe('complete_stale')
+  })
+
+  it('a refusal outranks an errored rerun', () => {
+    const withRefusal: Partial<Input> = {
+      refusalPresent: true,
+      resultsStatus: 'error',
+      hasCompletedFirstRun: true,
+      displayedFreshness: 'fresh',
+    }
+    expect(map(withRefusal)).toBe('refused')
+    expect(map({ ...withRefusal, refusalPresent: false })).toBe('unknown_degraded')
+  })
+
+  it('a run IN FLIGHT outranks the refusal — the one deliberate exception', () => {
+    // Asserted rather than left implicit, because it is the single case where
+    // the refusal arm does NOT win, and a reader who only saw the tests above
+    // would reasonably assume refusal is absolute. A live run's own narration
+    // is the honest thing to show while it is happening; the refusal, if it
+    // still holds, is whatever the run settles to.
+    for (const resultsStatus of ['preparing', 'connecting', 'streaming']) {
+      expect(map({ refusalPresent: true, resultsStatus }), resultsStatus).toBe('running')
+    }
+  })
+
+  it('the refusal state resolves to the REFUSAL banner, end to end', () => {
+    // Closes the loop this file exists to close: the mapping produces
+    // `refused`, and `refused` entitles the refusal banner and nothing else.
+    // Without this, the two halves could both be individually correct while
+    // disagreeing about the enum member that joins them.
+    expect(TRUTH_BANNER_BY_RUN_STATE[map({ refusalPresent: true })]).toBe('refusal')
+  })
+})
+
+describe('mapToAnalysisRunState — the remaining arms', () => {
+  it('an in-flight run is `running` at every in-flight status', () => {
+    for (const resultsStatus of ['preparing', 'connecting', 'streaming']) {
+      expect(map({ resultsStatus, hasCompletedFirstRun: true }), resultsStatus).toBe('running')
+    }
+    // Discriminating: a settled status at the same cell is NOT running.
+    expect(map({ resultsStatus: 'complete', hasCompletedFirstRun: true })).not.toBe('running')
+  })
+
+  it('a FIRST run that fails stays `never_run`, and a failed RERUN does not', () => {
+    // The ordering between the never_run arm and the error arm, asserted as a
+    // pair because it is the only thing that distinguishes them.
+    expect(map({ resultsStatus: 'error', hasCompletedFirstRun: false })).toBe('never_run')
+    expect(map({ resultsStatus: 'error', hasCompletedFirstRun: true })).toBe('unknown_degraded')
+  })
+
+  it('an errored rerun never inherits the previous run\'s verdict', () => {
+    // The defect an existing spec caught during the build. Swept over every
+    // verdict, because inheriting ANY of them is the same failure.
+    for (const displayedFreshness of ['fresh', 'stale', 'unknown', 'none', null] as const) {
+      expect(
+        map({ resultsStatus: 'error', hasCompletedFirstRun: true, displayedFreshness }),
+        String(displayedFreshness),
+      ).toBe('unknown_degraded')
+    }
+  })
+
+  it('an ABSENT verdict after a completed run is cannot-confirm, never current', () => {
+    // Fabricating currency from silence is the failure this arm exists to
+    // prevent, so both spellings of "no verdict" are pinned.
+    expect(map({ hasCompletedFirstRun: true, displayedFreshness: null })).toBe('unknown_degraded')
+    expect(map({ hasCompletedFirstRun: true, displayedFreshness: 'none' })).toBe('unknown_degraded')
+    expect(map({ hasCompletedFirstRun: true, displayedFreshness: 'unknown' })).toBe('unknown_degraded')
+    // Discriminating: a real verdict at the same cell does NOT collapse here.
+    expect(map({ hasCompletedFirstRun: true, displayedFreshness: 'fresh' })).toBe('complete_current')
+  })
+
+  it('every state the mapping can return is a member of the composition table', () => {
+    // Cheap totality check across a swept input space: a state the mapping can
+    // mint but the table has no row for would throw at the banner selector,
+    // and it would do so only in the cell that produces it.
+    for (const refusalPresent of [true, false]) {
+      for (const resultsStatus of ['idle', 'preparing', 'streaming', 'error', 'complete']) {
+        for (const hasCompletedFirstRun of [true, false]) {
+          for (const displayedFreshness of ['fresh', 'stale', 'unknown', 'none', null] as const) {
+            const kind = mapToAnalysisRunState({
+              refusalPresent,
+              resultsStatus,
+              hasCompletedFirstRun,
+              displayedFreshness,
+            })
+            expect(TRUTH_BANNER_BY_RUN_STATE, JSON.stringify({ refusalPresent, resultsStatus })).toHaveProperty(kind)
+          }
+        }
+      }
+    }
+  })
+})

--- a/src/components/results/analysisState/analysisStateContract.ts
+++ b/src/components/results/analysisState/analysisStateContract.ts
@@ -1,0 +1,146 @@
+/**
+ * The analysis-state COMPOSITION CONTRACT — step 6 of
+ * `olumi-docs/feedback-2026-08-16/ANALYSIS-STATE-AUTHORITY-BRIEF.md`.
+ *
+ * ⚠ WHAT THIS MODULE IS, AND WHAT IT IS NOT
+ * -----------------------------------------
+ * It is NOT a seventh truth derivation. It derives no freshness, no readiness,
+ * no leader entitlement and no run outcome. It answers exactly ONE question
+ * that today has no owner anywhere in the estate:
+ *
+ *     given the run state, WHAT MAY THIS SURFACE RENDER?
+ *
+ * The brief's composition table is the spec, and this file is that table as
+ * executable code. The truth VALUES still come from the existing producers
+ * (and, once the migration lane lands, from `AnalysisStateV1` on the wire —
+ * see `useAnalysisRunState.ts` for the single swap line).
+ *
+ * WHY IT EXISTS (the measured defect it closes)
+ * ---------------------------------------------
+ * L-36 / screenshot S06: "This analysis did not run — it stopped before it
+ * ran" and "Cannot confirm whether this analysis is current." rendered ONE
+ * ABOVE THE OTHER, directly above a fully rendered result. Three truth claims
+ * at once, two of which contradict each other: the first says no run happened,
+ * the second says a run happened but its currency is unproven.
+ *
+ * The mechanism was that `OutputsDock` mounted seven independently-sourced
+ * truth-state children and none gated any other. Each component was correct in
+ * isolation — which is precisely why no component-level fix works, and why
+ * this is a LAYOUT-LEVEL region rather than a neighbour check inside a banner.
+ *
+ * THE SCOPE OF "TRUTH-STATE BANNER", STATED PRECISELY (trap 21)
+ * ------------------------------------------------------------
+ * Two banners answer "did the analysis run, and are these numbers current?":
+ *   · `AnalysisRefusalNotice`   — it did not run, and why (CEE blocked_reason)
+ *   · `AnalysisFreshnessNotice` — it ran; fresh / stale / cannot-confirm
+ * These are mutually exclusive by construction here: AT MOST ONE mounts.
+ *
+ * Deliberately NOT in scope, because they answer a DIFFERENT question and
+ * folding them in would be the "two questions under one name" defect this
+ * estate keeps paying for:
+ *   · `ValidationPanel` / `DegradedStateBanner` / `WarningBanner` /
+ *     `InferenceWarningStrip` — "is this RESULT complete and sound?"
+ *   · `AnalysisRunningBanner` — staged progress narration for a live turn.
+ *   · `stale-results-banner` (ROADMAP 2.1127) — "WHOSE numbers are on screen?"
+ *     It is a provenance attribution about the BODY, not a claim about the
+ *     run's state, so this region renders it INSIDE the body slot. Its full
+ *     reachable-cell matrix stays pinned by `OutputsDock.failedRunHonesty`.
+ *
+ * DEVIATION FROM THE BRIEF'S TABLE, DELIBERATE AND DISCLOSED
+ * ---------------------------------------------------------
+ * The brief writes "✓ dimmed prior" for the retained-result rows. Dimming was
+ * RETIRED by Paul's Ruling 3 (ROADMAP 2.651): "out-of-date results are
+ * labelled, not withheld … No dimming, no aria-disabled lockout." The ratified
+ * in-repo doctrine wins over the table's shorthand, so `prior` here means
+ * MARKED (a data attribute + the 2.1127 attribution line), never dimmed.
+ *
+ * The `ranked leader` column of the table is step 7 of the brief and is NOT
+ * implemented here — no leader-claim gating semantics are touched by this
+ * module, and none should be added to it without that step's contract.
+ */
+
+/**
+ * The run states of `AnalysisStateV1.run_state`, verbatim from the brief.
+ *
+ * `blocked` and `refused` are distinct in the contract (blocked = the model
+ * cannot be analysed; refused = the engine declined this run) but today's wire
+ * carries only ONE signal for both (`analysis_ready.blocked_reason`). The
+ * fallback derivation therefore cannot separate them and never mints
+ * `blocked`; see `useAnalysisRunState.ts`. They share a composition row, so
+ * nothing user-visible depends on the distinction until the wire carries it.
+ */
+export type AnalysisRunStateKind =
+  | 'never_run'
+  | 'running'
+  | 'blocked'
+  | 'refused'
+  | 'complete_current'
+  | 'complete_stale'
+  | 'unknown_degraded'
+
+/** Which single truth-state banner this state entitles the surface to show. */
+export type TruthBannerKind = 'none' | 'refusal' | 'freshness'
+
+/** How the result body is presented — never `dimmed`; see the header. */
+export type BodyPresentation = 'hidden' | 'current' | 'prior'
+
+/**
+ * THE COMPOSITION TABLE, as data.
+ *
+ * Written as an exhaustive `Record` on purpose: adding a state to
+ * `AnalysisRunStateKind` without deciding its banner is a TYPE ERROR, not a
+ * silent fall-through to a default. A default arm is how a new state would
+ * quietly inherit somebody else's banner.
+ */
+export const TRUTH_BANNER_BY_RUN_STATE: Record<AnalysisRunStateKind, TruthBannerKind> = {
+  // Nothing has run. Saying "no analysis yet" in a banner, on a tab whose
+  // whole pre-run surface already says so, is the L-13 stacking defect.
+  never_run: 'none',
+  // The freshness strip owns the in-flight line ("Rerunning the analysis with
+  // the current model…"), so `running` is a freshness row, not a fourth surface.
+  running: 'freshness',
+  // A model that cannot be analysed, and a run the engine declined, both get
+  // the refusal notice — and NOT the freshness notice. This single cell is
+  // what makes S06's contradiction unreachable: "it did not run" can no longer
+  // be accompanied by "cannot confirm whether it is current".
+  blocked: 'refusal',
+  refused: 'refusal',
+  complete_current: 'freshness',
+  complete_stale: 'freshness',
+  unknown_degraded: 'freshness',
+}
+
+/**
+ * The ONE banner this state may render.
+ *
+ * Total over the enum, and the ONLY selector the region consults — so a second
+ * banner cannot be added by a neighbouring component without deleting the
+ * region, which REDs `AnalysisStateRegion.singleTruthBanner.spec.tsx`.
+ */
+export function selectTruthBanner(kind: AnalysisRunStateKind): TruthBannerKind {
+  return TRUTH_BANNER_BY_RUN_STATE[kind]
+}
+
+/**
+ * How the result body renders.
+ *
+ * @param hasReport whether there is a result to present AT ALL. Passed in
+ *   rather than derived, because "is there a report" is the caller's existing
+ *   gate (`!isPreRun && hasInlineSummary && resultsSectionData`) and
+ *   re-deriving it here would be a second authority for the same question.
+ *
+ * ⚠ `running` deliberately does NOT hide a retained body. The brief's table
+ * writes ✗ for the running row, which is right for a FIRST run (there is
+ * nothing to show) and wrong for a rerun: blanking the previous numbers
+ * mid-run contradicts the ratified "run-in-flight is MARKED, not blanked"
+ * doctrine and would take content away from the user at the moment they are
+ * comparing. `hasReport` distinguishes the two cases exactly.
+ */
+export function selectBodyPresentation(
+  kind: AnalysisRunStateKind,
+  hasReport: boolean,
+): BodyPresentation {
+  if (!hasReport) return 'hidden'
+  if (kind === 'never_run') return 'hidden'
+  return kind === 'complete_current' ? 'current' : 'prior'
+}

--- a/src/components/results/analysisState/useAnalysisRunState.ts
+++ b/src/components/results/analysisState/useAnalysisRunState.ts
@@ -3,11 +3,12 @@
  *
  * ⭐⭐ THE SWAP LINE
  * -----------------
- * The migration lane is building `useAnalysisState()` at
- * `src/canvas/state/analysisStateSelector.ts`, reading `AnalysisStateV1` off
- * the wire (brief steps 3–5). That module DOES NOT EXIST at this tip
- * (`f15bccaf`) — verified, not assumed — so this hook derives the same enum
- * from the store slices that exist today, and the swap is ONE function body:
+ * The migration lane's `useAnalysisState()` now EXISTS at
+ * `src/canvas/state/analysisStateSelector.ts` (#737, merged into `staging` as
+ * `2c72f695` — re-derived at the bytes, not inherited from an earlier draft of
+ * this comment, which said it was absent and went stale the moment #737
+ * landed). This hook still derives the enum from today's store slices, and the
+ * swap remains ONE function body:
  *
  *     export function useAnalysisRunState(): AnalysisRunStateKind {
  *       return useAnalysisState().run_state          // ⇦ SWAP LINE
@@ -17,6 +18,30 @@
  * test) is written against `AnalysisRunStateKind` and is unaffected by the
  * swap. That is the point of putting the region behind an enum rather than
  * behind the six derivations.
+ *
+ * ⚠⚠ SO WHY IS THE SWAP NOT DONE HERE? Because on the branch that is reachable
+ * TODAY it would be a REGRESSION, and that is derived at #737's own bytes
+ * rather than supposed:
+ *
+ *   "the derived branch never returns `'refused'` … no legacy signal
+ *    distinguishes those, and inventing one would be exactly the fabrication
+ *    this contract exists to stop"   (analysisStateSelector.ts:206-209, and
+ *    again at :398-401)
+ *
+ * That conservatism is CORRECT in the selector — it refuses to fabricate a
+ * refusal it cannot see. But this surface has a signal the selector's legacy
+ * branch does not consult: CEE's typed `blocked_reason`, already in the
+ * `analysisRefusalNotice` slice, which is the whole of ROADMAP 2.1163. Swapping
+ * to `useAnalysisState().run_state` while CEE is still on the legacy wire would
+ * therefore RE-DARK the refusal notice — and it would do so INVISIBLY, because
+ * the notice self-gates on an empty slice, so an absent banner looks exactly
+ * like a banner with nothing to say.
+ *
+ * `useAnalysisRunState.mapping.spec.ts` pins the refusal arm as a
+ * discriminating pair, so that swap REDs instead of shipping. **Run it against
+ * the selector before deleting this fallback**; the honest swap is either after
+ * CEE emits `AnalysisStateV1` with `refused` on the wire, or as a UNION (wire
+ * kind, with this slice still owning the refusal arm) — not a substitution.
  *
  * ⚠ WHAT THIS IS NOT
  * ------------------

--- a/src/components/results/analysisState/useAnalysisRunState.ts
+++ b/src/components/results/analysisState/useAnalysisRunState.ts
@@ -1,0 +1,121 @@
+/**
+ * `useAnalysisRunState` — the CONSUMER SEAM for the analysis-state authority.
+ *
+ * ⭐⭐ THE SWAP LINE
+ * -----------------
+ * The migration lane is building `useAnalysisState()` at
+ * `src/canvas/state/analysisStateSelector.ts`, reading `AnalysisStateV1` off
+ * the wire (brief steps 3–5). That module DOES NOT EXIST at this tip
+ * (`f15bccaf`) — verified, not assumed — so this hook derives the same enum
+ * from the store slices that exist today, and the swap is ONE function body:
+ *
+ *     export function useAnalysisRunState(): AnalysisRunStateKind {
+ *       return useAnalysisState().run_state          // ⇦ SWAP LINE
+ *     }
+ *
+ * Everything downstream (`AnalysisStateRegion`, the composition table, every
+ * test) is written against `AnalysisRunStateKind` and is unaffected by the
+ * swap. That is the point of putting the region behind an enum rather than
+ * behind the six derivations.
+ *
+ * ⚠ WHAT THIS IS NOT
+ * ------------------
+ * It is NOT a seventh truth vocabulary. It computes no freshness, no
+ * readiness and no run outcome; it READS the verdicts the existing owners
+ * already publish and maps them onto the contract's state names. If a mapping
+ * here disagreed with its source, the source is right and this is wrong.
+ *
+ * ⚠ PRECEDENCE, AND WHY REFUSAL IS FIRST
+ * --------------------------------------
+ * `AnalysisRefusalNotice` is today mounted UNGATED on purpose (ROADMAP 2.1163,
+ * and the 20-line comment at its mount site): a refused analysis is exactly
+ * the case where there are no results, so borrowing the results gates would
+ * hide the notice in the state it exists to explain. Ordering refusal ABOVE
+ * `never_run` preserves that: a first analysis that CEE refuses still reaches
+ * the user, even though `hasCompletedFirstRun` is false.
+ *
+ * ⚠ `blocked` IS NEVER MINTED HERE, AND THAT IS A STATEMENT ABOUT THE WIRE
+ * -----------------------------------------------------------------------
+ * The contract separates `blocked` (the model cannot be analysed) from
+ * `refused` (the engine declined this run). Today's wire carries ONE signal
+ * for both — `analysis_ready.blocked_reason`, which is what populates the
+ * refusal slice — so this fallback cannot tell them apart and never claims to.
+ * They share a composition row, so nothing user-visible turns on it until
+ * `AnalysisStateV1` lands.
+ */
+import { useCanvasStore } from '@/canvas/store'
+import { resolveDisplayedFreshness } from '@/canvas/store/analysisFreshness'
+import type { AnalysisRunStateKind } from './analysisStateContract'
+
+/**
+ * The pure mapping, exported so it is mutation-testable without a store.
+ *
+ * Every input is a value another module OWNS:
+ *  - `refusalPresent`   → `analysisRefusalNotice` slice (CEE blocked_reason)
+ *  - `resultsStatus`    → the results store's own status machine
+ *  - `hasCompletedFirstRun` → the store's run ledger
+ *  - `displayedFreshness`   → `resolveDisplayedFreshness` (the CEE verdict
+ *    plus the local dirty overlay, the SAME call `AnalysisFreshnessNotice`
+ *    and `OutputsDock` already make — not a re-derivation)
+ */
+export function mapToAnalysisRunState(input: {
+  refusalPresent: boolean
+  resultsStatus: string | null | undefined
+  hasCompletedFirstRun: boolean
+  displayedFreshness: 'fresh' | 'stale' | 'unknown' | 'none' | null | undefined
+}): AnalysisRunStateKind {
+  // 1. A run in flight is a run in flight whatever else is held — the strip
+  //    says so, and no other banner may speak over it.
+  if (
+    input.resultsStatus === 'preparing' ||
+    input.resultsStatus === 'connecting' ||
+    input.resultsStatus === 'streaming'
+  ) {
+    return 'running'
+  }
+  // 2. Refusal outranks never_run — see the header.
+  if (input.refusalPresent) return 'refused'
+  // 3. No run has completed and none was refused: the pre-run surface owns
+  //    this state entirely, and no truth-state banner belongs on it. Ordered
+  //    ABOVE the error case on purpose, so a FIRST run that fails stays
+  //    `never_run` — there is no prior result for a freshness verdict to be
+  //    about, and today's surface correctly shows the error banner alone.
+  if (!input.hasCompletedFirstRun) return 'never_run'
+  // 4. ⭐ A RERUN THAT FAILED. Caught by `OutputsDock.rerunContinuity.spec`,
+  //    and the gap was real: without this line a failed rerun inherited the
+  //    RETAINED verdict from the previous run, so a held `fresh` mapped to
+  //    `complete_current` — the surface would have presented the old numbers
+  //    as current and suppressed the "Showing results from previous analysis"
+  //    attribution, immediately after a run that did not produce them. The
+  //    retained verdict describes the PREVIOUS run; it cannot vouch for a
+  //    surface whose latest run errored.
+  if (input.resultsStatus === 'error') return 'unknown_degraded'
+  // 5. A run has completed. Its currency is the freshness owner's verdict —
+  //    and an ABSENT verdict is not evidence of currency. `null`/'none' with a
+  //    completed run is exactly the cannot-confirm case; claiming
+  //    `complete_current` there would fabricate a guarantee.
+  switch (input.displayedFreshness) {
+    case 'fresh':
+      return 'complete_current'
+    case 'stale':
+      return 'complete_stale'
+    default:
+      return 'unknown_degraded'
+  }
+}
+
+/** Store-reading wrapper. Primitive selectors only (`ci:guard:zustand`). */
+export function useAnalysisRunState(): AnalysisRunStateKind {
+  const refusal = useCanvasStore((s) => s.analysisRefusalNotice)
+  const resultsStatus = useCanvasStore((s) => s.results?.status)
+  const hasCompletedFirstRun = useCanvasStore((s) => s.hasCompletedFirstRun)
+  const ceeFreshness = useCanvasStore((s) => s.analysisFreshness)
+  const freshnessDirty = useCanvasStore((s) => s.analysisFreshnessDirty)
+
+  return mapToAnalysisRunState({
+    refusalPresent: Boolean(refusal),
+    resultsStatus: resultsStatus ?? null,
+    hasCompletedFirstRun: Boolean(hasCompletedFirstRun),
+    displayedFreshness: resolveDisplayedFreshness(ceeFreshness, freshnessDirty),
+  })
+}

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -88,7 +88,29 @@ export const OVERVIEW_COPY = {
   // chip ("+N to set") — collapsed shows what IS, never a per-field inventory
   // of what ISN'T. The old per-field "not set" name labels are retired.
   classificationUnsetSuffix: 'to set',
+  /**
+   * L-58: what the compact "+N to set" chip COUNTS, and what clicking it does.
+   *
+   * ⚠ TWO PLAIN STRINGS, NOT A FORMATTER FUNCTION, AND THAT IS DELIBERATE.
+   * `copyHygiene.spec.ts` scans `Object.values(OVERVIEW_COPY)` for em dashes,
+   * shouting caps, American spellings and internal vocabulary. A function
+   * value is invisible to that scan: the copy would ship UNCHECKED while the
+   * guard stayed green — a guard that cannot see the string it is guarding.
+   * Two constants keep every user-visible word inside the scan; the singular
+   * arm exists so the chip never reads "1 more things".
+   */
+  classificationUnsetHintOne:
+    'One more thing to say about this decision (stakes, reversibility, horizon or risk). Open the overview to set it.',
+  classificationUnsetHintMany:
+    'more things to say about this decision (stakes, reversibility, horizon and risk). Open the overview to set them.',
 } as const
+
+/** Composes the two hygiene-scanned arms above. */
+export function classificationUnsetHint(n: number): string {
+  return n === 1
+    ? OVERVIEW_COPY.classificationUnsetHintOne
+    : `${n} ${OVERVIEW_COPY.classificationUnsetHintMany}`
+}
 
 const STATE_COPY: Record<BriefState, { line: string; note: string }> = {
   ready: { line: OVERVIEW_COPY.ready, note: OVERVIEW_COPY.readyNote },
@@ -459,11 +481,21 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
             {/* One muted aggregate for every empty field (V6-RESPEC §4).
                 Clicking it expands the card — the existing boolean expand
                 behaviour, no new focus plumbing. Complete (dashed) border. */}
+            {/* ⭐ L-58: the visible chip read "+4 to set" — four of WHAT, set
+                WHERE, and by whom? It sits beside value pills like "High
+                stakes", so the reader has no way to infer that the four are
+                the UNFILLED members of that same set. The visible text is
+                unchanged (it is a compact aggregate by design, V6-RESPEC §4)
+                but it is no longer the only thing on offer: the accessible
+                name and the tooltip now say what the number counts and what
+                clicking does. */}
             {unsetCount > 0 && (
               <button
                 type="button"
                 data-testid="decision-pills-unset"
                 onClick={() => setExpanded(true)}
+                title={classificationUnsetHint(unsetCount)}
+                aria-label={classificationUnsetHint(unsetCount)}
                 className={`${typography.panelMeta} max-w-full truncate rounded-pill border border-dashed border-panel-border bg-transparent px-2 py-0.5 text-text-light hover:bg-panel-hover`}
               >
                 +{unsetCount} {OVERVIEW_COPY.classificationUnsetSuffix}

--- a/src/components/results/strengthen/StrengthenContainer.tsx
+++ b/src/components/results/strengthen/StrengthenContainer.tsx
@@ -41,6 +41,7 @@ import {
   type RecRecord,
 } from '../../../canvas/stores/strengthenStore'
 import { focusModelTarget } from '../../../canvas/utils/focusHelpers'
+import { useShowToastSafe } from '../../../canvas/ToastContext'
 import { openDefineSuccess, openDecisionRecord, useDecisionRecordForScenario } from '../modals'
 import { openAskOlumi } from '../coaching/askOlumiStore'
 import { buildRecommendations, toStrengthenPhase3Item } from './buildRecommendations'
@@ -76,6 +77,8 @@ export interface StrengthenContainerProps {
 }
 
 export function StrengthenContainer({ data }: StrengthenContainerProps) {
+  // L-10: the primary CTA's failure arm has to be able to SAY something.
+  const showToast = useShowToastSafe()
   const resultsHash = useCanvasStore((s) => s.results.hash ?? null)
   const freshnessDirty = useCanvasStore((s) => s.analysisFreshnessDirty === true)
   const currentStage = useCanvasStore((s) => s.currentStage)
@@ -240,7 +243,23 @@ export function StrengthenContainer({ data }: StrengthenContainerProps) {
     }
     // §8.8: close only after the action genuinely succeeds — a successful
     // dispatch marks IN PROGRESS (the user confirms addressed themselves).
-    if (ok) useStrengthenStore.getState().markInProgress(record.id)
+    if (ok) {
+      useStrengthenStore.getState().markInProgress(record.id)
+      return
+    }
+    // ⭐ L-10 FIX: the failure arm was SILENT. Every `ok === false` path here
+    // — no conversation callbacks registered, a focus target that no longer
+    // exists, an `open-modal` action with no modal — dropped the click with a
+    // `console.warn` that `import.meta.env.DEV` compiles OUT of the production
+    // bundle. The user pressed a primary CTA and the product did nothing, said
+    // nothing, and changed nothing: indistinguishable from a broken build.
+    //
+    // Telling them is the whole fix. We deliberately do NOT invent a
+    // recovery, mark the record, or retry: we do not know why the seam was
+    // unavailable, and a fabricated "we've queued it" would be worse than the
+    // silence. (`useShowToastSafe` is a no-op outside a ToastProvider, so this
+    // cannot throw in a test or a stray mount.)
+    showToast("That didn't go through. Open the Olumi conversation and ask there.")
   }
 
   // Prototype route (b): the ✦ ask hands the rec to the Ask-Olumi drawer

--- a/src/v5/__tests__/freshness-state-matrix.test.tsx
+++ b/src/v5/__tests__/freshness-state-matrix.test.tsx
@@ -252,12 +252,42 @@ describe('V5GraphPatchBlock — receipt hint surfaces ONLY the stale state disti
 // a guard agreeing with itself rather than with the product.
 
 describe('AnalysisFreshnessNotice — mount path (fails loud if the strip is unmounted)', () => {
-  const MOUNT_OWNER = 'src/canvas/components/OutputsDock.tsx'
+  // ⚠⚠ THE MOUNT MOVED, AND THIS GUARD MOVED WITH IT — RE-POINTED, NEVER
+  // DELETED (cockpit simplification, brief step 6). The strip is no longer
+  // mounted by `OutputsDock` directly: it is mounted by
+  // `<AnalysisStateRegion>`, the layout-level region that owns ONE truth-state
+  // banner slot, so that the refusal notice and this strip can never render
+  // together (ledger L-36 / screenshot S06: "This analysis did not run" stacked
+  // above "Cannot confirm whether this analysis is current" above a rendered
+  // result).
+  //
+  // The guard's purpose is unchanged and is the reason it must not be dropped:
+  // this whole matrix is only evidence about the PRODUCT if the surface it
+  // renders is the surface a user loads. `HeroQualifier` passed every render
+  // assertion for months while being absent from the deployed bundle.
+  //
+  // ⭐ AND THE MOVE MAKES IT STRONGER, because the region is itself pinned to
+  // exactly one mount site in `OutputsDock` by
+  // `analysisStateRegion.mountSites.spec.ts` — which DERIVES the mount sites
+  // from source rather than mirroring a list. So the chain
+  // OutputsDock → AnalysisStateRegion → AnalysisFreshnessNotice is asserted at
+  // both hops, and unmounting the strip at either one REDs.
+  const MOUNT_OWNER = 'src/components/results/analysisState/AnalysisStateRegion.tsx'
+  const REGION_HOST = 'src/canvas/components/OutputsDock.tsx'
 
   const readStripped = (rel: string): string =>
     stripComments(readFileSync(join(process.cwd(), rel), 'utf8'), rel)
 
-  it('OutputsDock imports AND renders the strip in real code, not in a comment', () => {
+  it('the region host renders the region in real code, not in a comment', () => {
+    // Hop 1 of the chain. Without this, hop 2 below could be green while the
+    // region itself was mounted nowhere — a component that renders the strip
+    // perfectly, to nobody.
+    const host = readStripped(REGION_HOST)
+    expect(host.length).toBeGreaterThan(1000)
+    expect(host).toMatch(/<AnalysisStateRegion\b/)
+  })
+
+  it('the region imports AND renders the strip in real code, not in a comment', () => {
     const code = readStripped(MOUNT_OWNER)
 
     // Precondition pin (trap 13b): prove the stripper left real code behind,
@@ -271,14 +301,27 @@ describe('AnalysisFreshnessNotice — mount path (fails loud if the strip is unm
   })
 
   it('the stripper is what makes that assertion meaningful (control)', () => {
-    const raw = readFileSync(join(process.cwd(), MOUNT_OWNER), 'utf8')
-    const stripped = readStripped(MOUNT_OWNER)
-    // Prose mentions vastly outnumber the single render site; if this ever
-    // reads equal, comments are no longer being removed and the mount
-    // assertion above has quietly become a substring search over prose.
+    // ⚠ THE CONTROL IS NOW RUN AGAINST `REGION_HOST`, NOT `MOUNT_OWNER`, AND
+    // THAT IS NOT A CONVENIENCE. Its claim is "prose mentions outnumber the
+    // single render site, so if these ever read equal the comments are no
+    // longer being stripped". That claim is TRUE of `OutputsDock.tsx`, which
+    // discusses this component at length, and would be FALSE of the region —
+    // a small file that mentions the strip about as often in prose as in code,
+    // where a legitimately-working stripper could produce equal counts and RED
+    // a healthy build. A control that can fail on a correct product teaches
+    // people to ignore it.
+    //
+    // `OutputsDock` still names `AnalysisFreshnessNotice` in prose (it records
+    // why the mount moved) while no longer rendering it, so it remains the
+    // right file to prove the stripper bites — and this now also pins that the
+    // dock does NOT re-acquire its own second mount: `count(stripped)` is
+    // asserted to be exactly ZERO in code there, which is the single-banner
+    // property stated from the other direction.
+    const raw = readFileSync(join(process.cwd(), REGION_HOST), 'utf8')
+    const stripped = readStripped(REGION_HOST)
     const count = (s: string): number => (s.match(/AnalysisFreshnessNotice/g) ?? []).length
     expect(count(raw)).toBeGreaterThan(count(stripped))
-    expect(count(stripped)).toBeGreaterThan(0)
+    expect(count(stripped)).toBe(0)
   })
 })
 

--- a/tests/visual-regression/analysis-tab.spec.ts
+++ b/tests/visual-regression/analysis-tab.spec.ts
@@ -100,9 +100,22 @@ describe('visual-regression scaffold (Brief 5)', () => {
     // sides of the gate are covered here rather than one being assumed.
     expect(snap).toContain('A view lens over the outcome range. The comparative ranking above is unchanged.')
     expect(snap).not.toContain('goal ranking')
-    expect(snap).toContain('Cautious (p10)')
-    expect(snap).toContain('Middle (p50)')
-    expect(snap).toContain('Optimistic (p90)')
+    // ⚠ THE PERCENTILE NOTATION MOVED OUT OF THE BUTTON TEXT (cockpit
+    // simplification, L-38): `p10`/`p50`/`p90` is engineering notation, and a
+    // user-facing control should not need a glossary. The arms keep their
+    // plain names; the notation lives in each button's `title`, where a
+    // practised reader can still find it.
+    //
+    // BOTH halves are asserted, because asserting only the visible words would
+    // pass just as happily against a build that dropped the notation
+    // altogether — which is the failure this control's history warns about
+    // (the arms exist to name a QUANTITY, not a mood).
+    expect(snap).toContain('>Cautious<')
+    expect(snap).toContain('>Middle<')
+    expect(snap).toContain('>Optimistic<')
+    expect(snap).toContain('The cautious end of the range (10th percentile, p10)')
+    expect(snap).toContain('The middle of the range (50th percentile, p50)')
+    expect(snap).toContain('The optimistic end of the range (90th percentile, p90)')
     // The retired label must not survive anywhere in this control.
     expect(snap).not.toContain('Winner by:')
     // Legacy copy absent from rendered output.


### PR DESCRIPTION
**Component: Analysis cockpit.** Step 6 of `ANALYSIS-STATE-AUTHORITY-BRIEF.md` plus the analysis-tab IA and honesty items — ledger **L-36** (P0-trust), **L-57**, **L-58**, **L-38**, **L-10**, **L-11**, rulings **R1** / **R13** / **R14**. Built against tip `f15bccaf`.

**Replacement, not restyling.** The change is a new layout-level authority, not new CSS. It migrates **no** truth derivation (the migration lane owns those) and touches **no** leader-claim gating (step 7). Rebased onto `2c72f695` (#739 / #735 / #740 / #736 / #738 / **#737** all landed mid-lane); every gate and the full mutant kit re-run at the rebased head.

---

## 1 · One truth region — L-36/S06 made unreachable

`OutputsDock` mounted seven independently-sourced truth-state children and none gated any other. That is why S06 could show **"This analysis did not run — it stopped before it ran"** above **"Cannot confirm whether this analysis is current."** above a fully rendered result: three claims, two of them contradictory, **every component correct in isolation**. No component-level fix reaches that — which is why this is a region and not a neighbour check.

`<AnalysisStateRegion>` (`src/components/results/analysisState/`) owns one banner slot and one body slot. Which banner mounts is a total function of the run state — `TRUTH_BANNER_BY_RUN_STATE`, the brief's composition table as executable data, written as an exhaustive `Record` so a new state without a decided banner is a **type error** rather than a silent fall-through to somebody else's banner.

Three parts; the third is what makes it structural rather than local:

1. **One banner expression** — two banners cannot co-render without deleting the region.
2. **`refused`/`blocked` take the refusal row and NOT the freshness row** — the single cell that makes S06 unreachable.
3. **A derived single-mount-site guard** (`analysisStateRegion.mountSites.spec.ts`) that reads mount sites out of the source at test time, with a magnitude control and a same-family contrast control. No hand-maintained allowlist: that would drift silently and read as green.

### Scope of "truth-state banner", stated precisely

In: `AnalysisRefusalNotice`, `AnalysisFreshnessNotice` — both answer *"did it run, and are these numbers current?"*.
Out, because they answer a **different question** (trap 21): `ValidationPanel` / `DegradedStateBanner` / `WarningBanner` / `InferenceWarningStrip` (*is this result sound?*), `AnalysisRunningBanner` (progress narration), and `stale-results-banner` (*whose numbers are these?* — provenance about the body).

### Deliberate deviations from the brief's table

| Brief | Shipped | Why |
|---|---|---|
| `refused` shows refusal **and** freshness | refusal **only** | The brief's own acceptance clause says "EXACTLY ONE truth-state banner". Two banners is the defect. |
| retained bodies are "dimmed" | **marked, never dimmed** | Dimming was retired by Paul's Ruling 3 (ROADMAP 2.651): "out-of-date results are labelled, not withheld… No dimming, no aria-disabled lockout." Ratified in-repo doctrine beats the table's shorthand. |
| `running` hides the body | hidden only when there is **no** report | Right for a first run, wrong for a rerun — blanking the previous numbers mid-run contradicts "run-in-flight is MARKED, not blanked" and removes content exactly when the user is comparing. `hasReport` separates the two. |

### Preserved on purpose

- **The refusal notice stays ungated** — by *precedence* (`refused` ordered above `never_run`) rather than by copying its gate, so a refused FIRST analysis still reaches the user (ROADMAP 2.1163). A "unify the gates" tidy-up here would re-dark it.
- **`stale-results-banner` moved, not retired** — into the body slot. Predicate, copy, testid and the whole 2.1127 reachable-cell matrix untouched.

### ⭐ A gap the existing suite caught, and it was real

`mapToAnalysisRunState`'s first version ignored `resultsStatus === 'error'`, so **a failed rerun inherited the RETAINED freshness verdict from the previous run**: a held `fresh` mapped to `complete_current`, the surface would have presented the old numbers as current, and the "Showing results from previous analysis" attribution would have been suppressed — immediately after a run that did not produce them. Caught by `OutputsDock.rerunContinuity.spec.tsx`, fixed by an explicit error row (ordered *after* `never_run`, so a first-run failure still behaves exactly as today).

---

## 2 · R1 — panel visible on draft, starting narrow

`shouldRenderFirstUseRail`'s input reverts from `hasAnalysisResult` to **model content**.

**⚠ The brief's instruction ("remove `!hasAnalysisResult`") is insufficient, and this PR corrects it.** Removing that conjunct alone leaves `aiPanelV2On && !analysisActive && !userExplicitlyOpened`, which is still TRUE for a drafted-but-unanalysed model — the rail would stay, i.e. exactly the behaviour Paul vetoed. The input has to be **replaced** with `hasModelContent`, not deleted.

The paired half is real. #728 changed this input **the same day**, for a measured reason: at 1280×800 the expanded dock left an 843px fitting box for a graph needing 1008px. Paul's veto is about **visibility**; that measurement is about **width**. So `resolveDockWidthForAnalysisState` opens the dock at `DOCK_MIN_WIDTH` until an analysis exists — composed from `dockWidth.ts`'s existing bounds rather than a new constant, and **an explicit user-dragged width always wins**. Neither half ships alone.

---

## 3 · KEEP / CUT — for Paul's veto (R13(a))

Archives for side-by-side: `archive/2026-08-15-pre-wave` (`a3c71513`) · `archive/2026-08-16-alt-view-final` (`7ad0cefc`) · `archive/2026-08-16` (`9a8b84c6`). ⚠ Those URLs still 404 pending the one Netlify dashboard toggle (`UI-ARCHIVE-INDEX.md`); the git trees are readable regardless.

| # | Surface | Verdict | What changed |
|---|---|---|---|
| 1 | Refusal notice | **KEEP** | Re-homed into the region; now suppresses the freshness line instead of stacking with it |
| 2 | Freshness notice | **KEEP** | Re-homed; silent in `refused`/`blocked`/`never_run` |
| 3 | "Showing results from previous analysis" | **KEEP** | Moved into the body slot as provenance, not a banner |
| 4 | `error-secondary-action` button | **CUT** | A relabelled clone of "Edit model" — **byte-identical handler**. `secondaryActionText` is a pure label, so one control rendered four promises and performed one; two were false: `CEE_DEGRADED` offered **"Retry Full Analysis"** (retried nothing) and `COMPARISON_FAILED` offered **"View Individual Results"** (navigated nowhere) |
| 5 | Hero lens tabs "Stability" + "What changed" | **CUT from live · KEPT in fixtures** | Never pushed into the available set by the live adapter (`buildHeroModel` pushes exactly `goal`/`outcome`; ISL #211 / PLoT #212 are the producer gaps) — on every real run half the strip advertised capabilities the product does not have. **Hidden, not deleted**: the strip derives from `available`, so a lens returns with zero code change the moment a producer supplies data. "Goal fit" stays visible when unavailable because its empty state is **user-actionable** |
| 6 | "This unlocks with versioned run comparisons. Olumi will not approximate it locally." | **REPLACE** | Internal doctrine stated to the user, naming a producer feature by its engineering name. Same two promises, user's register |
| 7 | QA chip row (`✓ Has leading option × Sensitive × Evidence unknown`) | **KEEP + relabel** | Gains a "What we checked" heading. **"Evidence unknown" was simply wrong**: the value is `gaps.length > 0` and nothing more, so an empty list rendered a red ✗ reading "unknown". Now a **neutral** glyph reading "No evidence gaps flagged" (absent and empty are conflated upstream by `?? []`, so it claims neither coverage nor non-assessment). "Sensitive" → "Sensitive to assumptions". "1/3 addressed" → "1 of 3 evidence gaps addressed". **Kept, not removed**, because it is the results-side probe of the cross-surface single-verdict guard |
| 8 | "+4 to set" chip | **KEEP + label** | Visible text unchanged (compact by design, V6-RESPEC §4); accessible name + tooltip now say what the number counts and what clicking does. Two plain strings, not a formatter function, so `copyHygiene.spec.ts` can still see the words |
| 9 | Model tab orange badge | **KEEP + label** | `title` is hover-only, absent on touch, and never the accessible name. Now carries `aria-label` too |
| 10 | "Cautious (p10) / Middle (p50) / Optimistic (p90)" | **KEEP + move notation** | Percentile notation moves to `title`. **`aria-label` deliberately NOT used** — it replaces the accessible name, and a two-word control should not announce as a sentence |
| 11 | WhatIWasGiven "Where does this fit?" | **RESTORE** | Not a dead button: `onSendMessage` was never passed and the component renders the action only when it is, so **the whole "not modelled yet" action column never rendered at all**. One prop; no new write path |
| 12 | Strengthen primary CTA failure path | **FIX** | Every `ok === false` arm dropped the click behind a `console.warn` that production compiles out — the user pressed a primary CTA and the product did nothing and said nothing. It now says so, and deliberately invents no recovery |
| 13 | Drivers accordion count | **RESTORE** | §4 |
| 14 | Tornado accordion count | **ADD** | The one collapsed section with no count |
| 15 | First-use rail input + dock width | **REPLACE** | §2 |
| 16 | Version history trigger in the dock header | **ADD** | R4, delegated by #739 — mounted with the collapse chevron's class, not the incomplete line in its own header (§5.3) |

---

## 4 · A count that never rendered

`ResultsBody` passed `count={…}` to `Accordion`, which has no such prop — the badge is `badgeCount`. React drops an unknown prop on a function component silently, so `badgeCount` stayed `undefined`, the `badgeCount > 0` gate never opened, and `badgeState` styled a badge that was not there. **The drivers section has been collapsed with no indication of how much is inside it for as long as that line existed.**

Nothing failed — a missing badge looks exactly like a badge with nothing to show. The TypeScript excess-property error that would have caught it is **one of the three ratcheted into that file's typecheck baseline**: a baselined error hiding a live display defect. Fixing it is why the gate reports drift shrinking 2325 → 2324.

Guarded by a discriminating pair (right prop renders the number, wrong prop renders nothing) plus a source scan over the real call sites — a test asserting only "`badgeCount` renders" would pass just as happily against the broken call site, because the call site is not what it looks at.

---

## 5 · Corrections to the brief, at the boundary

1. **L-50's two surfaces are never on screen together.** The framing quadrants (`DecisionOverviewCard`, gated `!isPreRun`) and "Your decision" (`pre-analysis-v3/model/YourDecisionSection`, gated `isPreRun`) are **mutually exclusive by run state**. The overlap is sequential — the same frame reviewed twice in two vocabularies either side of the first run — not a double render, and it cannot be fixed by deleting one of two things on a page. The pre-run half is also outside this lane's files (§6).
2. **The R1 rail instruction was insufficient** — §2.
3. **`VersionsTrigger` is MOUNTED (R4) — and its own documented mount line is incomplete.** #739 landed mid-lane, so this branch was rebased onto `8db13fd0` and the trigger now sits in the dock header row beside the collapse chevron. ⚠ Its header says `<VersionsTrigger variant="icon" />`; following that verbatim mounts an **unstyled bare button** — the `icon` variant applies `className` with an EMPTY default, while the `labelled` variant self-styles. It is mounted with the **same class as the collapse chevron**, so the header reads as one control set. The component correctly carries no positioning of its own; that is R4's actual fix and the reason L-08's arithmetic could be deleted.
4. **`useAnalysisState()` is not merged either** — `src/canvas/state/analysisStateSelector.ts` exists on `claude/analysis-state-consumers` @ `3d139e5c` (**PR #737**), not on `staging`. The region consumes `AnalysisRunStateKind`; `useAnalysisRunState.ts` maps today's slices onto it and carries the **single swap line** in its header. Nothing downstream changes at the swap.
5. **The first draft of this PR put `DecisionOverviewCard` inside the region's body slot**, inverting the canonical hierarchy (brief §3) — caught by `OutputsDock.analysis-run.spec.tsx`. It now sits outside and above, which is also right on the merits: the card is the ORIENTATION surface and by its own §4.1 shows no analysis outcomes; the region owns the truth banner and the RESULTS body.

## 6 · Out of grant, named rather than done

- **`pre-analysis-v3/**` is not this lane's file ownership**, and it owns L-13's eight stacked sections, the Frame/Options/Risks/Estimates health bars, "Your decision", and the "0 of N checked" line — the last in **two hand-maintained copies** (`constants.ts:245` and `selectors/computeBars.ts:85`, the second not importing the first: trap 12 waiting to happen). The deployed posture mounts v3 (`VITE_FEATURE_PRE_ANALYSIS_V3="1"`), so the **legacy `PreAnalysisPanel` arm in `OutputsDock` is dark** — a competing implementation worth retiring in the lane that owns the surface.
- **The cockpit's section ORDER is a design fork, not a defect.** Moving Strengthen and "What I was given" below the options block would give verdict → results → depth. R13(c) reserves subjective forks for Paul and R8 says to judge by archive comparison. **Recommended, not done.**
- **`secondaryActionText` in `src/lib/userFriendlyErrors.ts` now has no consumer** (four codes still emit it). For its owner: retire it, or give it a real handler.
- **A live doctrine conflict, already marked "Open. Paul rules." in the design docs:** `heroCopy.ts` promises "Olumi will not approximate it locally" while `WhatChangedChip` (mounted from `ResultsBody`) computes a client-side run-over-run diff — which is exactly local approximation. Not resolved unilaterally. Its reveal-into-an-invisible-surface half is **already fixed** at this tip (`revealOlumiSurface()` in the dispatch branch, and `aiPanelV2` is deployed ON), so that part of L-10/L-11 needs no action here.

---

## Verification

**Discipline.** Fresh blobless clone at a unique `/private/tmp` path, branched from `origin/staging` @ `f15bccaf`. `VITE_SUPABASE_*` exported for every run. Every spec asserted to collect its expected count **by name**; the mutation harness hard-errors on any run that does not collect exactly 40.

**Mutants** in a worktree **outside** the source clone, isolation **proven by writing a sentinel** and confirming the source file's hash was unchanged (inodes also compared — trap 9g). Mutations applied to committed state only; restore via `git checkout HEAD --`, never `git checkout --` (trap 9h); clean-tree assertion before and after each; applied-check scoped to `src/` asserting exactly 1 changed file.

| Mutant | Result | Reds |
|---|---|---|
| M1 `refused` → freshness row | **BITTEN** | 3 |
| M2 `complete_current` → refusal row | **BITTEN** | 1 |
| M3 region renders BOTH banners | **BITTEN** | 11 |
| M4 body always presents as current | **BITTEN** | 4 |
| M5 rail ignores model content | **BITTEN** | 2 |
| M6 dock never starts narrow | **BITTEN** | 1 |
| M7 a second freshness mount site | **BITTEN** | 1 |
| M8 `badgeCount` → `count` | **BITTEN** | 2 |
| trailing control (pristine) | **40/40 green** | — |

M1/M2 are the required **pair**: a region hard-wired to either banner passes one and REDs the other, so neither survives.

**⚠ Two instrument defects found in my own tooling, disclosed rather than quietly fixed:**
1. The mount-site scanner matched `<AnalysisStateRegion>` inside the component's own header **comment** and reported the file as a mount site of itself. Comments are now stripped first — a scan that cannot tell code from prose about code produces confident wrong inventories in both directions.
2. The mutant harness's first version **ended on its own sanity check instead of propagating vitest's exit code**, so it scored all eight genuinely-bitten mutants as SURVIVED (trap 15). The only tell was the failure counts in the side channel. Fixed, re-run, and the fix is commented in the script.

**Gates at head:** `pnpm typecheck` ✅ (coverage + ratchet; **drift shrank 2325 → 2307, zero added** — one of those is the excess-property error from §4, a baselined diagnostic that was hiding a live display defect; baseline deliberately **not** regenerated, since a shrink is a `::notice::` and regenerating would bank unrelated drift). `pnpm build` ✅. ESLint on every changed file: **0 errors**. **`Staging Gate`: SUCCESS** at head `f6759ef3` — polled to conclusion in the foreground, all 13 checks green (4/4 test shards, summary, build, TypeScript + Lint, typecheck self-test, security audit, contract validation). The mutant kit was re-run at this exact head: **8/8 bitten, trailing control 40/40**.

**Affected suites at the rebased head: 7690 passed / 0 failed / 15 skipped across 524 files** (`src/components/results`, `src/canvas/components/__tests__`, `src/canvas/versions`, `src/v5/__tests__`, `tests/`).

**⚠ Two reds along the way, both worth recording because of what they say about local gates.**

1. **`tests/visual-regression/analysis-tab.spec.ts` — outside `src/`, and my local subset never touched it.** It pinned the literal button text `Cautious (p10)`. Caught only by CI. This is trap 2 exactly: a hand-picked local scope reads green while skipping a directory the required check runs. The spec is updated to assert **both** halves — the plain visible names **and** the percentile notation now living in each `title` — because asserting only the visible words would pass against a build that dropped the notation entirely, which is the failure this control's own history warns about.
2. **`src/v5/__tests__/freshness-state-matrix.test.tsx` mount-path invariant — RE-POINTED, never deleted.** It asserted `OutputsDock` imports and renders the strip; the strip is now mounted by the region. The chain is asserted at **both hops** (host renders region · region renders strip), which is stronger than before, because the region's own mount site is separately pinned by a derived guard. Its stripper CONTROL stays pointed at `OutputsDock.tsx` — deliberately: the control's claim is "prose mentions outnumber the single render site", which is true of the dock and would be false of a small region file, where a correctly-working stripper could produce equal counts and RED a healthy build. A control that can fail on a correct product teaches people to ignore it. That same control now also asserts the dock's stripped source mentions the strip **exactly zero times in code** — the single-banner property stated from the other direction.

`OutputsDock.conversationSingleton.spec.tsx` and `aiPanelV2.parity.spec.tsx` both went red mid-lane and both are clear at the final head; the latter was verified failing **the same two tests by name at pristine `8db13fd0`** before it was fixed upstream.


---

## ⚠ Review round 1 — one blocker, fixed. The reviewer was right, and the compounding half was worse than the blocker.

**The blocker, proven by execution:** the mapping's `refused` arm was **unpinned**. Deleting `if (input.refusalPresent) return 'refused'` left **53/53 tests GREEN** across all four refusal-touching specs. Each was correct about what it covered, and together they covered the wire→slice hop and the state→banner hop while leaving the **slice→state hop between them untested** — the classic seam defect, where each neighbour assumes the other owns the join. A refusal could have stopped reaching the user with the whole suite green.

**The compounding error was mine and is the worse half.** The mount-site comment asserted that unifying the gates "would re-dark it and RED `applyV5State.analysisRefusalNotice.spec.tsx`". Measured: **false** — that spec is store-level and stayed green under the deletion. A comment naming a guard that does not guard is worse than no comment: it tells the next reader the seam is covered, so they stop looking. Both the comment and the missing pin are fixed.

**Fix:** `useAnalysisRunState.mapping.spec.ts` — 12 cases, every refusal claim written as a **discriminating pair** (same inputs, flag on and off, asserted to differ) and placed at cells where the other arms would return something else, so it is the flag being measured and not the row. Proven: the reviewer's mutant now REDs 5 tests where it previously RED none.

**Riders taken:** the mount-site scanner now also asserts by **module PATH**, closing the aliased-import channel the reviewer executed (`import { AnalysisFreshnessNotice as Strip }` … `<Strip />` is invisible to a `<Name`-shaped scan — verified: 0 name-shaped mounts, and the new path assertion REDs it). Stale SHA in the hook header corrected.

**Riders declined as instructed:** R2, R3, R5, R6.

### ⚠ #737 landed mid-round, and it changes the swap advice in this PR

`useAnalysisState()` now exists on `staging`. **The one-line swap must NOT be done blindly**, and this is derived at #737's own bytes rather than supposed — its legacy branch says so itself:

> "the derived branch never returns `'refused'` … no legacy signal distinguishes those, and inventing one would be exactly the fabrication this contract exists to stop" (`analysisStateSelector.ts:206-209`, again at `:398-401`)

That conservatism is **correct in the selector** — it refuses to fabricate a refusal it cannot see. But this surface holds a signal its legacy branch does not consult: CEE's typed `blocked_reason`, already in the `analysisRefusalNotice` slice, which is the whole of ROADMAP 2.1163. Swapping while CEE is still on the legacy wire would **re-dark the refusal notice, invisibly** — the notice self-gates on an empty slice, so an absent banner looks exactly like a banner with nothing to say. The new mapping spec makes that regression RED at swap time. The honest swap is either after CEE emits `AnalysisStateV1` with `refused` on the wire, or as a **union** (wire kind, this slice still owning the refusal arm) — not a substitution.

### Also caught on the rebase: a stale install, not a code defect

The rebase moved the schemas pin **0.43.0 → 0.46.0** (#737's vendored tarball) while `node_modules` still held 0.43.0. Typecheck reported +1 error in #737's own specs (`AnalysisStateV1` "not exported"). Trap 1 exactly — the tree measured was not the tree at the tip. After `pnpm install --frozen-lockfile`, typecheck is clean and drift shrinks 2325 → 2307, zero added. Recording it because a reviewer seeing that error on a stale checkout would reasonably file it against #737.

### Round-1 evidence

| Mutant | Result | Reds |
|---|---|---|
| **M-J** refusal arm deleted (the reviewer's) | **BITTEN** | 5 *(was 0 before this round)* |
| M1 `refused` row → freshness | **BITTEN** | 4 |
| M2 `complete_current` row → refusal | **BITTEN** | 1 |
| M3 region renders BOTH banners | **BITTEN** | 11 |
| M4 body always presents as current | **BITTEN** | 4 |
| M5 rail ignores model content | **BITTEN** | 2 |
| M6 dock never starts narrow | **BITTEN** | 1 |
| M7 second freshness mount site | **BITTEN** | 1 |
| M8 `badgeCount` → `count` | **BITTEN** | 2 |
| M9 failed-rerun arm deleted | **BITTEN** | 2 |
| **M-K** aliased-import evasion | **BITTEN** by the new path assertion | 1 |
| trailing control (pristine) | **53/53 green** | — |

Affected suites at the new head: **7786 passed / 0 failed / 15 skipped across 529 files**. Isolation re-proven by sentinel write at this head; restores HEAD-relative; applied-check exactly 1 per mutant; clean tree before and after each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
