### PR TITLE
Model Editor v2: mount train — canonical confirm/edit transactions, inline chip confirms (R9)

### DIFF
--- a/docs/Design/MODEL-EDITOR-V2.md
+++ b/docs/Design/MODEL-EDITOR-V2.md
@@ -3,6 +3,18 @@
 **Status:** DESIGN, for Paul's veto — **§7 is the removal review; nothing is removed until he rules.**
 **Lane:** PX-D (design-first). **Derived at:** UI `staging` tip `a3c71513`, 15 Aug 2026.
 
+> **⚠ MOUNT-TRAIN AMENDMENT (16 Aug 2026).** The paragraph below was written when nothing was
+> mounted; that half is now history. `ModelTabV2Panel` mounts the outline + detail region on the
+> Model tab (hosted by `ModelTabBody`, additively — **no §7 removal has been executed; the v1
+> sections are untouched and the removal review still awaits Paul's ruling**). Factor-value edits
+> are LIVE through the canonical `factor_value_edit` transaction
+> (`src/canvas/hooks/useModelEditAuthority.ts` — event build → optimistic undo → sanctioned setter
+> → dispatch, the same path as the v1 chips, with inline Confirm/Discard chips per ruling R9).
+> Edits with no canonical carrier (edge strength/likelihood/direction, option interventions, goal
+> target, factor confirmation) remain disabled with honest labels; the repair queues remain
+> unmounted pending their carriers (§9.1 C7/C9/C12/C15). The raw-write guard is widened and the
+> boundary guard now pins the mount path (§9.1's mount obligations, discharged).
+
 **What exists in code, stated precisely so this header cannot drift into a false claim.** Nothing on
 the Model tab changes, and **nothing in this design is mounted**: no route, no tab registration, no
 import from any live surface. What does exist is an **unmounted component set** under

--- a/src/canvas/components/ModelTabBody.tsx
+++ b/src/canvas/components/ModelTabBody.tsx
@@ -50,6 +50,13 @@ import { buildSynthesisedPriorMap } from './model-tab/synthesisedPriorHelpers'
 import { countFactorsToVerify, mapSourceToDisplay } from './model-tab/utils'
 import { ModelAdjustments } from './model-tab/ModelAdjustments'
 import { resolveRawFactorConfidenceDisplay, type FactorConfidenceDisplay } from '../../components/results/driverConfidenceDisplayPolicy'
+// The Model Editor v2 (16 Aug 2026 mount train). Mounted ON, no flag: the
+// no-dark-launches rule. Its factor-value edits ride the SAME canonical
+// transaction as FactorsSection's chips (`useModelEditAuthority`); everything
+// without a canonical carrier renders honestly disabled. The v1 sections below
+// are retained UNCHANGED — the design's §7 KEEP/CUT removals await Paul's
+// verdict and are deliberately not executed in this train.
+import { ModelTabV2Panel } from '../model-tab-v2/ModelTabV2Panel'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -179,6 +186,9 @@ export const ModelTabBody = memo(function ModelTabBody({
   const selectionEdgeIds = useCanvasStore(s => s.selection?.edgeIds ?? EMPTY_EDGE_IDS)
   const updateEdge = useCanvasStore(s => s.updateEdge)
   const rawV2Response = useCanvasStore(s => s.rawV2Response)
+  // The v2 outline's goal row reads the store scalar (RAW user units — the
+  // single-writer carrier `setGoalThresholdAndUpdateNode` maintains it).
+  const goalThreshold = useCanvasStore(s => s.goalThreshold ?? null)
 
   // ── Scientific enrichment data from PLoT response ───────────────────────────
   // Single-pass extraction of all per-factor enrichment maps from factor_sensitivity.
@@ -745,6 +755,17 @@ export const ModelTabBody = memo(function ModelTabBody({
         isRunning={trust.isRunning}
         startedAt={trust.runStartedAt}
         contentRetained={nodes.length > 0}
+      />
+
+      {/* ── The Model Editor v2 (mounted 16 Aug 2026, no flag) ─────────────── */}
+      {/* One filterable outline of the model, editable in place where the
+          canonical transaction exists. ADDITIVE: the v1 sections below are
+          unchanged — §7's removals await Paul's KEEP/CUT verdict. */}
+      <ModelTabV2Panel
+        nodes={nodes}
+        edges={edges}
+        goalThreshold={goalThreshold}
+        fragileEdgeIds={hasRobustnessData ? fragileEdgeIds : undefined}
       />
 
       {/* ── Header: factor/edge counts + "Show full detail" toggle ─────────── */}

--- a/src/canvas/components/__tests__/ModelTabBody.mountsModelEditorV2.spec.tsx
+++ b/src/canvas/components/__tests__/ModelTabBody.mountsModelEditorV2.spec.tsx
@@ -1,0 +1,108 @@
+/**
+ * The Model Editor v2 is MOUNTED (16 Aug 2026 mount train).
+ *
+ * The PX-D finding this closes: `src/canvas/model-tab-v2/` was a complete,
+ * guarded, render-only editor surface with NO route, NO tab registration and
+ * NO importer — BUILT-UNMOUNTED. This spec pins the mount at the surface a
+ * user actually loads: `ModelTabBody` (the Model tab's container, rendered by
+ * `OutputsDock`) must render the v2 panel, with rows bound to the ids of the
+ * model's own elements.
+ *
+ * ⚠ BOUND TO THE MOUNT PATH, BY IDENTITY (trap 3b). The assertion renders
+ * ModelTabBody itself — not the panel in isolation — so a regression that
+ * unmounts the panel (deleting the import, gating it behind a flag that is
+ * off, or moving it behind a dead branch) goes RED here even while every
+ * panel-level spec stays green. A green panel spec is not evidence about a
+ * component the tab does not render.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+
+vi.mock('../../utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusEdgeById: vi.fn(),
+}))
+
+vi.mock('../../../telemetry/guidanceEvents', () => ({ trackGuidance: vi.fn() }))
+
+const mockGraph: { nodes: unknown[]; edges: unknown[] } = { nodes: [], edges: [] }
+
+function getMockState() {
+  return {
+    nodes: mockGraph.nodes,
+    edges: mockGraph.edges,
+    updateNode: vi.fn(),
+    updateEdge: vi.fn(),
+    ceePipelineTrace: null,
+    highlightedNodes: new Set<string>(),
+    highlightedEdges: new Set<string>(),
+    setHighlightedNodes: vi.fn(),
+    setHighlightedEdges: vi.fn(),
+    currentScenarioId: null,
+    currentStage: null,
+    graphEditedSinceLastRun: false,
+    goalThreshold: null,
+    goalThresholdRepresentation: null,
+  }
+}
+
+vi.mock('../../store', () => ({
+  useCanvasStore: Object.assign(
+    vi.fn((selector: (s: unknown) => unknown) => selector(getMockState())),
+    { getState: getMockState },
+  ),
+}))
+
+vi.mock('../GraphTextView', () => ({
+  SectionErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+import { ModelTabBody } from '../ModelTabBody'
+
+const FACTOR_ID = 'fac_budget'
+
+function factorNode(): Node {
+  return {
+    id: FACTOR_ID,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: {
+      label: 'Budget',
+      category: 'observable',
+      observedState: { value: 0.5, source: 'cee_inference' },
+    },
+  } as unknown as Node
+}
+
+const DEFAULT_PROPS = {
+  showDebug: false,
+  hasDiagnostics: false,
+  diagnostics: null,
+  hasTrim: false,
+  effectiveCorrelationId: null,
+  correlationMismatch: false,
+  correlationIdHeader: null,
+  robustness: null,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGraph.nodes = [factorNode()]
+  mockGraph.edges = []
+})
+
+describe('ModelTabBody mounts the Model Editor v2', () => {
+  it('renders the v2 panel inside the Model tab', () => {
+    render(<ModelTabBody {...DEFAULT_PROPS} nodes={[factorNode()]} edges={[]} />)
+    const tab = screen.getByTestId('model-tab')
+    const panel = screen.getByTestId('model-tab-v2-panel')
+    expect(tab.contains(panel)).toBe(true)
+  })
+
+  it('the mounted panel carries the model, bound by element id', () => {
+    render(<ModelTabBody {...DEFAULT_PROPS} nodes={[factorNode()]} edges={[]} />)
+    expect(screen.getByTestId(`model-row-v2-${FACTOR_ID}`)).toBeInTheDocument()
+  })
+})

--- a/src/canvas/components/__tests__/ModelTabBody.spec.tsx
+++ b/src/canvas/components/__tests__/ModelTabBody.spec.tsx
@@ -14,7 +14,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import { ModelTabBody } from '../ModelTabBody'
 import type { Node, Edge } from '@xyflow/react'
 import { edgeValueSourcePatch } from '../../domain/edgeValueProvenance'
@@ -160,8 +160,10 @@ describe('Goal headline', () => {
         edges={[]}
       />
     )
-    expect(screen.getByTestId('model-goal-section')).toBeInTheDocument()
-    expect(screen.getByText('Pick the right vendor')).toBeInTheDocument()
+    // Scoped by identity: the v2 outline (mounted 16 Aug 2026) also renders
+    // this label, so an unscoped getByText would match two surfaces.
+    const goalSection = screen.getByTestId('model-goal-section')
+    expect(within(goalSection).getByText('Pick the right vendor')).toBeInTheDocument()
   })
 
   it('hides goal section when no goal node', () => {
@@ -180,21 +182,23 @@ describe('Source mapping — canonical value preserved', () => {
   it('shows friendly display label in read mode for cee_inference', () => {
     const nodes = [makeFactorNode('f1', 'Market size', { source: 'cee_inference' })]
     render(<ModelTabBody {...DEFAULT_PROPS} nodes={nodes} edges={[]} />)
-    // Display text shows friendly label
-    expect(screen.getByText('AI estimate')).toBeInTheDocument()
+    // Display text shows friendly label — scoped to the v1 card by identity
+    // (the mounted v2 outline renders its own provenance pill for the row).
+    expect(within(screen.getByTestId('factor-card-f1')).getByText('AI estimate')).toBeInTheDocument()
   })
 
   it('shows friendly display label for brief_extraction', () => {
     const nodes = [makeFactorNode('f1', 'Budget', { source: 'brief_extraction' })]
     render(<ModelTabBody {...DEFAULT_PROPS} nodes={nodes} edges={[]} />)
-    expect(screen.getByText('From brief')).toBeInTheDocument()
+    expect(within(screen.getByTestId('factor-card-f1')).getByText('From brief')).toBeInTheDocument()
   })
 
   it('shows "Not set" pill when source is absent', () => {
     const nodes = [makeFactorNode('f1', 'Cost', { source: undefined })]
     render(<ModelTabBody {...DEFAULT_PROPS} nodes={nodes} edges={[]} />)
-    // P0.5: showWhenAbsent defaults to true — "Not set" is shown to surface missing sources
-    expect(screen.getByText('Not set')).toBeInTheDocument()
+    // P0.5: showWhenAbsent defaults to true — "Not set" is shown to surface missing sources.
+    // Scoped to the v1 card: the v2 row renders its own "Not set" value text.
+    expect(within(screen.getByTestId('factor-card-f1')).getByText('Not set')).toBeInTheDocument()
   })
 })
 
@@ -530,8 +534,9 @@ describe('DS-1: All pills use outlined style (no filled backgrounds)', () => {
       makeEdge('e1', 'f1', 'f2', { direction: 'positive', weight: 0.5, strengthStd: 0.1 }),
     ]
     render(<ModelTabBody {...DEFAULT_PROPS} nodes={nodes} edges={edges} />)
-    // Semantic label for weight=0.5 positive = "Moderate positive effect"
-    expect(screen.getByText('Moderate positive effect')).toBeInTheDocument()
+    // Semantic label for weight=0.5 positive = "Moderate positive effect" —
+    // scoped to the v1 edge summary (the v2 relationship row says it too).
+    expect(within(screen.getByTestId('edge-e1-summary')).getByText('Moderate positive effect')).toBeInTheDocument()
   })
 })
 
@@ -586,7 +591,8 @@ describe('PD-1: Currency prefix formatting', () => {
       },
     }
     render(<ModelTabBody {...DEFAULT_PROPS} nodes={[node]} edges={[]} />)
-    expect(screen.getByText('£49')).toBeInTheDocument()
+    // Scoped to the v1 card: the v2 row renders the same formatted value.
+    expect(within(screen.getByTestId('factor-card-f1')).getByText('£49')).toBeInTheDocument()
   })
 })
 

--- a/src/canvas/components/model-tab/__tests__/modelTabNoRawStoreWrites.sourceScan.spec.ts
+++ b/src/canvas/components/model-tab/__tests__/modelTabNoRawStoreWrites.sourceScan.spec.ts
@@ -22,8 +22,14 @@
  * WHAT IT ASSERTS, precisely
  * --------------------------
  * SCOPE: every non-test `.ts`/`.tsx` file under
- * `src/canvas/components/model-tab/`, **recursively**. That is the complete set
- * of Model-tab section components — enumerated at run time, never quoted here.
+ * `src/canvas/components/model-tab/` AND under `src/canvas/model-tab-v2/`,
+ * **recursively** in both. The second directory was added by the 16 Aug 2026
+ * mount train, discharging the obligation `MODEL-EDITOR-V2.md` §9.1 records:
+ * *"widen this guard in the same PR that mounts anything here"* — a v2 tree
+ * outside the scan was UNGUARDED against raw writes, which is precisely how
+ * the raw-write class was re-opened last time (the inspector was fixed, the
+ * Model tab kept its own hand-rolled writes, and the killed class stayed live
+ * through a different door).
  *
  * The walk was FLAT in the first version of this guard, and the adversarial
  * review proved the hole: a scratch `model-tab/subsections/EvilSection.tsx`
@@ -58,6 +64,8 @@ import { fileURLToPath } from 'node:url'
 import { blankNonCode } from '../../../../../tests/helpers/stripSourceComments'
 
 const MODEL_TAB_DIR = join(dirname(fileURLToPath(import.meta.url)), '..')
+/** The mounted Model Editor v2 — in scope since the mount train (§9.1). */
+const MODEL_TAB_V2_DIR = join(MODEL_TAB_DIR, '..', '..', 'model-tab-v2')
 
 /**
  * The store mutators that take a free-form `data` patch. These are the ones that
@@ -91,7 +99,7 @@ function bannedCallsIn(src: string): string[] {
 }
 
 describe('Model-tab sections never write the canvas store directly (2.121 slice 1)', () => {
-  const files = sourceFilesIn(MODEL_TAB_DIR)
+  const files = [...sourceFilesIn(MODEL_TAB_DIR), ...sourceFilesIn(MODEL_TAB_V2_DIR)]
 
   it('the scan covers the whole model-tab directory (scope is derived, not listed)', () => {
     // Not an exact count — that would be a mirror of its own. The assertion is
@@ -103,6 +111,10 @@ describe('Model-tab sections never write the canvas store directly (2.121 slice 
       'GoalSection.tsx',
       'OptionsSection.tsx',
       'RelationshipsSection.tsx',
+      // The mounted v2 surface — its container and its render components are
+      // in scope from the day of the mount, per §9.1's widening obligation.
+      'ModelTabV2Panel.tsx',
+      'ModelRowView.tsx',
     ]) {
       expect(names).toContain(required)
     }

--- a/src/canvas/components/model-tab/__tests__/utils.spec.ts
+++ b/src/canvas/components/model-tab/__tests__/utils.spec.ts
@@ -11,7 +11,6 @@ import {
   formatValueWithUnit,
   getPrimaryValue,
   isCurrencyUnit,
-  isGenericUnit,
 } from '../utils'
 import { directionFromProducerSignedMean } from '../../../domain/edgeValueProvenance'
 
@@ -143,28 +142,10 @@ describe('isCurrencyUnit', () => {
   })
 })
 
-describe('isGenericUnit', () => {
-  it('recognises generic/dimensionless units', () => {
-    expect(isGenericUnit('scale')).toBe(true)
-    expect(isGenericUnit('index')).toBe(true)
-    expect(isGenericUnit('score')).toBe(true)
-    expect(isGenericUnit('normalised')).toBe(true)
-    expect(isGenericUnit('normalized')).toBe(true)
-    expect(isGenericUnit('norm')).toBe(true)
-  })
-
-  it('is case-insensitive', () => {
-    expect(isGenericUnit('Scale')).toBe(true)
-    expect(isGenericUnit('NORMALISED')).toBe(true)
-  })
-
-  it('rejects specific units', () => {
-    expect(isGenericUnit('months')).toBe(false)
-    expect(isGenericUnit('FTE')).toBe(false)
-    expect(isGenericUnit('%')).toBe(false)
-    expect(isGenericUnit('£')).toBe(false)
-  })
-})
+// `isGenericUnit` removed with its function (16 Aug 2026 mount train, design
+// §7.5 — no production importer). The LIVE generic-unit behaviour is pinned
+// above through `formatValueWithUnit` ('omits generic units …'), which is the
+// path production actually takes.
 
 describe('getPrimaryValue', () => {
   it('returns formatted raw_value with unit when both present', () => {

--- a/src/canvas/components/model-tab/types.ts
+++ b/src/canvas/components/model-tab/types.ts
@@ -1,12 +1,15 @@
 /**
  * Shared types for the model-tab component suite.
+ *
+ * `ModelTabProps` was REMOVED by the 16 Aug 2026 mount train (design §7.5,
+ * F15): it had no importer anywhere in `src/` and had drifted from the live
+ * inline `ModelTabBodyProps` (it declared a `critique` field the body does not
+ * take, and lacked `expertMode` / `onSendMessage`). A stale type nobody uses
+ * is the next session's false map. The live props live inline in
+ * `ModelTabBody.tsx` — read them there.
  */
 
-import type { Node, Edge } from '@xyflow/react'
-import type { MappedRobustness } from '../../../lib/mappers/types'
-import type { CritiqueItemV1 } from '../../../adapters/plot/types'
-import type { CeeQualityDimensions } from '../../store'
-
+/** Factor observed state as the model-tab display readers accept it. */
 export interface ObservedState {
   value?: number
   raw_value?: number
@@ -24,24 +27,4 @@ export type FactorInfluenceMap = Map<string, number>
 /** Context provided by "Show full detail" toggle */
 export interface DetailContext {
   showDetail: boolean
-}
-
-export interface ModelTabProps {
-  showDebug: boolean
-  hasDiagnostics: boolean
-  diagnostics: unknown
-  hasTrim: boolean
-  effectiveCorrelationId: string | null | undefined
-  correlationMismatch: boolean
-  correlationIdHeader: string | null | undefined
-  nodes: Node[]
-  edges: Edge[]
-  robustness: MappedRobustness | null
-  critique?: CritiqueItemV1[] | null
-  /** Factor influence map from PLoT — keyed by node ID, value is 0–1 sensitivity score */
-  factorInfluence?: FactorInfluenceMap
-  /** Trigger analysis re-run (from OutputsDock handleRunAnalysis) */
-  onReanalyse?: () => void
-  /** CEE quality dimensions — from ceeQuality store field */
-  ceeQuality?: CeeQualityDimensions | null
 }

--- a/src/canvas/components/model-tab/utils.ts
+++ b/src/canvas/components/model-tab/utils.ts
@@ -27,11 +27,10 @@ export function isCurrencyUnit(unit: string): boolean {
   return CURRENCY_SYMBOLS.has(trimmed) || ISO_CURRENCY_CODES.has(trimmed)
 }
 
-/** Returns true for units that represent abstract/dimensionless scales.
- *  Source of truth: GENERIC_PLACEHOLDER_UNITS in labelUtils.ts. */
-export function isGenericUnit(unit: string): boolean {
-  return GENERIC_PLACEHOLDER_UNITS.has(unit.trim().toLowerCase())
-}
+// `isGenericUnit` was REMOVED by the 16 Aug 2026 mount train (design §7.5):
+// no production importer — `formatValueWithUnit` below consults
+// GENERIC_PLACEHOLDER_UNITS directly. Contrast control at removal time:
+// `formatValueWithUnit` resolves to 18 importing files.
 
 /** Smart number: integers stay integer, decimals use minimal precision (max 2dp, no trailing zeros) */
 export function formatSmartNumber(n: number): string {
@@ -102,15 +101,8 @@ export function mapSourceToDisplay(source: string | undefined): string | null {
   return cls ? KIND_LABELS[cls.kind] : source
 }
 
-/**
- * The raw literal, for a title attribute. Byte-identical to the map it
- * replaced: every entry in the old `SOURCE_TOOLTIPS` was `Source: <literal>`,
- * i.e. exactly what its own fallback produced (2.638 S2).
- */
-export function mapSourceToTooltip(source: string | undefined): string | undefined {
-  if (!source) return undefined
-  return `Source: ${source}`
-}
+// `mapSourceToTooltip` was REMOVED by the 16 Aug 2026 mount train (design
+// §7.5): no importer anywhere in `src/`, its own declaration aside.
 
 // ── Factor verification ─────────────────────────────────────────────────────
 

--- a/src/canvas/hooks/useModelEditAuthority.ts
+++ b/src/canvas/hooks/useModelEditAuthority.ts
@@ -1,0 +1,121 @@
+/**
+ * useModelEditAuthority — the Model Editor v2's write seam, implemented AS the
+ * canonical transaction path (16 Aug 2026 mount train).
+ *
+ * ⚠ THIS MODULE INVENTS NOTHING. Every step below is the reference factor-value
+ * commit — `FactorsSection.handleValueCommit` (ROADMAP 2.121 slice 1 / #513 /
+ * 2.129(b)) — extracted so the v2 outline and the v1 card commit through ONE
+ * path rather than two that must stay in sync:
+ *
+ *   1. `buildFactorValueEditEvent` owns the scale contract (the node's OWN
+ *      cap/unit decides whether the typed number is a user-unit magnitude);
+ *      it FAILS CLOSED (returns null) on anything the wire cannot carry.
+ *   2. `captureOptimisticFactorEdit` snapshots the undo BEFORE the write, from
+ *      the same pre-write data the event was built from.
+ *   3. `setObservedValue` — the sanctioned setter — writes value + raw_value +
+ *      the provenance stamp in ONE update. Never a raw `updateNode`.
+ *   4. `sendSystemEvent(event, { optimisticFactorEdit })` — the undo travels
+ *      WITH the send: the conversation dispatcher owns the reply (and the
+ *      deferral buffer), so a server REFUSAL reverts the optimistic write and
+ *      an acceptance stamps it, for immediate and deferred dispatch alike.
+ *
+ * WHAT THIS DOES **NOT** PROVIDE, stated so nobody reads more into it: the
+ * receipt-bearing `EditProposalHandle` of `model-tab-v2/contracts.ts` §1
+ * (`applied` reachable only from a receipt). Today's dispatcher resolves
+ * refusal/acceptance CENTRALLY and does not hand the caller a receipt — a
+ * deferred send's promise resolves `SEND_DEFERRED` before the turn exists. An
+ * authority that echoed its own typed value back as an "applied" receipt would
+ * be an optimistic write wearing a confirmation (contracts.ts C11's warning),
+ * so this hook deliberately returns only the DISPATCH outcome and lets the row
+ * render the store, which the central machinery keeps honest. When the
+ * receipt-bearing transaction API lands, this seam is where it plugs in.
+ *
+ * SCOPE AT THIS TIP: `proposeFactorValue` only. The UI's wire vocabulary
+ * (`WIRE_SYSTEM_EVENT_TYPES`) carries exactly three server-authoritative edit
+ * carriers — `factor_value_edit`, `prior_range_edit` (emitted inside the
+ * sanctioned `setPriorRange`) and `edge_adjudication`. Edge strength /
+ * likelihood / direction, option interventions, the goal target and factor
+ * confirmation have NO canonical carrier yet; the v2 surface renders those
+ * affordances DISABLED with an honest label rather than routing them through a
+ * local-only write that would look identical to a server-backed one
+ * (design §2 F6).
+ */
+
+import { useCallback } from 'react'
+import { useCanvasStore } from '../store'
+import { useOptionalConversationContext } from '../conversation/ConversationContext'
+import { useNodeMutations } from '../ui/inspector-v2/useInspectorMutations'
+import { buildFactorValueEditEvent } from '../conversation/factorValueEdit'
+import { captureOptimisticFactorEdit } from '../conversation/optimisticFactorEdit'
+
+/**
+ * How a proposal left this seam.
+ *
+ * - `dispatched`   — local optimistic write landed AND the wire event is with
+ *                    the conversation dispatcher (which owns refusal/revert).
+ * - `local_only`   — local write landed; no ConversationProvider is mounted,
+ *                    so no turn was sent. The same degradation the v1 card has:
+ *                    isolated renders edit locally, never throw.
+ * - `not_encodable`— nothing happened at all: the edit could not be encoded
+ *                    for the wire (no node, non-finite number), so — fail
+ *                    CLOSED — no store write either. A dropped edit is a
+ *                    visible "nothing happened"; a half-committed one is a
+ *                    silent split-brain.
+ */
+export type FactorValueProposalOutcome = 'dispatched' | 'local_only' | 'not_encodable'
+
+export interface ModelEditAuthorityLive {
+  proposeFactorValue: (typedValue: number) => FactorValueProposalOutcome
+}
+
+/**
+ * The authority for ONE node — the node whose edit is currently active.
+ * Hook-parameterised exactly as `useNodeMutations` is; pass `null` when no
+ * edit is active (every proposal is then `not_encodable`).
+ */
+export function useModelEditAuthority(activeNodeId: string | null): ModelEditAuthorityLive {
+  const mutations = useNodeMutations(activeNodeId ?? '')
+  const sendSystemEvent = useOptionalConversationContext()?.sendSystemEvent
+
+  const proposeFactorValue = useCallback(
+    (typedValue: number): FactorValueProposalOutcome => {
+      if (!activeNodeId) return 'not_encodable'
+      const node = useCanvasStore.getState().nodes.find(n => n.id === activeNodeId)
+      if (!node) return 'not_encodable'
+      const data = node.data as Record<string, unknown>
+
+      const event = buildFactorValueEditEvent({
+        nodeId: activeNodeId,
+        typedValue,
+        // The node's data as it is BEFORE the local write — its cap/unit is
+        // what decides the scale of what the user typed.
+        nodeData: data,
+      })
+      if (!event) return 'not_encodable'
+      const { value: modelValue, raw_value: rawMagnitude } = event.payload as {
+        value: number
+        raw_value?: number
+      }
+
+      // Undo BEFORE the write, from the same pre-write data.
+      const undo = captureOptimisticFactorEdit(activeNodeId, modelValue, data)
+
+      // Local write first, in ONE update: value + raw_value + provenance stamp.
+      mutations.setObservedValue(modelValue, rawMagnitude, { source: 'user' })
+
+      if (!sendSystemEvent) return 'local_only'
+      void Promise.resolve(
+        sendSystemEvent(event, undo ? { optimisticFactorEdit: undo } : undefined),
+      ).catch(() => {
+        // Swallowed deliberately — a genuine send failure is recorded by the
+        // conversation's own failure channel, and a server REFUSAL is not a
+        // failure: the dispatcher's central revert handles it. Identical to the
+        // reference surface's catch, for the identical reason.
+      })
+      return 'dispatched'
+    },
+    [activeNodeId, mutations, sendSystemEvent],
+  )
+
+  return { proposeFactorValue }
+}

--- a/src/canvas/model-tab-v2/ModelDetailRegion.tsx
+++ b/src/canvas/model-tab-v2/ModelDetailRegion.tsx
@@ -1,7 +1,8 @@
 /**
  * Model tab v2 — THE DETAIL REGION (design §4.4).
  *
- * ⚠ UNMOUNTED. See `types.ts`.
+ * MOUNTED since the 16 Aug 2026 mount train, via `ModelTabV2Panel`. See
+ * `types.ts`.
  *
  * WHAT IT REPLACES. Today reaching an edge's detail costs THREE nested
  * disclosures — the section accordion, then a per-card `cardExpanded` toggled by

--- a/src/canvas/model-tab-v2/ModelOutline.tsx
+++ b/src/canvas/model-tab-v2/ModelOutline.tsx
@@ -1,7 +1,8 @@
 /**
  * Model tab v2 — THE OUTLINE. Two tiers, seven groups, one scroll (design §4.3).
  *
- * ⚠ UNMOUNTED. See `types.ts`.
+ * MOUNTED since the 16 Aug 2026 mount train, via `ModelTabV2Panel` (hosted by
+ * `ModelTabBody`). The boundary guard pins the mount path.
  *
  * ⚠ THE LOAD-BEARING PROPERTY: THE TIER IS A CONTENT SWITCH, NEVER A LAYOUT
  * SWITCH. Today's `expertMode` drives BOTH the scientific detail AND the
@@ -28,7 +29,13 @@ import { useCallback, useMemo, useState } from 'react'
 import { typography } from '../../styles/typography'
 import { ModelRowView } from './ModelRowView'
 import { GROUP_TITLE } from './rowPresentation'
-import { MODEL_GROUP_IDS, type DetailTier, type ModelGroupId, type ModelRow } from './types'
+import {
+  MODEL_GROUP_IDS,
+  type DetailTier,
+  type EditCommitState,
+  type ModelGroupId,
+  type ModelRow,
+} from './types'
 
 export interface ModelOutlineProps {
   /**
@@ -45,6 +52,24 @@ export interface ModelOutlineProps {
   onFocusOnCanvas?: (id: string) => void
   /** Groups closed at first render. Everything else is open (multi-open always). */
   initiallyClosedGroups?: readonly ModelGroupId[]
+  /**
+   * The host's edit state per row, keyed by row id. Absent entries render idle.
+   * There is deliberately no default map literal here — an absent prop means
+   * "no live editing on this outline", exactly as before the mount.
+   */
+  commitByRowId?: ReadonlyMap<string, EditCommitState>
+  /**
+   * Rows whose edit class has a CANONICAL transaction behind it. When provided,
+   * only these rows get a live editor affordance; everything else renders the
+   * honest disabled control. When absent, presence-of-`onBeginEdit` semantics
+   * are unchanged (back-compatible with render-only callers).
+   */
+  editConnectedIds?: ReadonlySet<string>
+  onBeginEdit?: (id: string) => void
+  onDraftChange?: (id: string, draft: string) => void
+  onProposeEdit?: (id: string) => void
+  onDiscardEdit?: (id: string) => void
+  onConfirmEdit?: (id: string) => void
 }
 
 /**
@@ -89,6 +114,13 @@ export function ModelOutline({
   onSelect,
   onFocusOnCanvas,
   initiallyClosedGroups,
+  commitByRowId,
+  editConnectedIds,
+  onBeginEdit,
+  onDraftChange,
+  onProposeEdit,
+  onDiscardEdit,
+  onConfirmEdit,
 }: ModelOutlineProps) {
   const [closed, setClosed] = useState<ReadonlySet<ModelGroupId>>(
     () => new Set(initiallyClosedGroups ?? []),
@@ -150,8 +182,17 @@ export function ModelOutline({
                     row={row}
                     tier={tier}
                     selected={row.id === selectedId}
+                    commit={commitByRowId?.get(row.id)}
+                    editConnected={
+                      editConnectedIds === undefined ? true : editConnectedIds.has(row.id)
+                    }
                     onSelect={onSelect}
                     onFocusOnCanvas={onFocusOnCanvas}
+                    onBeginEdit={onBeginEdit}
+                    onDraftChange={onDraftChange}
+                    onProposeEdit={onProposeEdit}
+                    onDiscardEdit={onDiscardEdit}
+                    onConfirmEdit={onConfirmEdit}
                   />
                 ))}
               </ul>

--- a/src/canvas/model-tab-v2/ModelRowView.tsx
+++ b/src/canvas/model-tab-v2/ModelRowView.tsx
@@ -231,8 +231,8 @@ function ValueCell({
             <span data-testid={testid} className={typography.tabular}>
               <input
                 data-testid={`${testid}-input`}
-                // eslint-disable-next-line jsx-a11y/no-autofocus -- the input
-                // exists because the user just clicked the value it replaces.
+                // Focus follows the click that opened this input — it replaces
+                // the value control the user just activated.
                 autoFocus
                 inputMode="decimal"
                 value={commit.draft}

--- a/src/canvas/model-tab-v2/ModelRowView.tsx
+++ b/src/canvas/model-tab-v2/ModelRowView.tsx
@@ -1,11 +1,12 @@
 /**
  * Model tab v2 — THE ROW. One anatomy for every element (design §4.2).
  *
- * ⚠ UNMOUNTED. Nothing imports this outside `src/canvas/model-tab-v2/` and its
- * specs; `__tests__/modelTabV2IsUnmounted.sourceScan.spec.ts` proves it.
+ * MOUNTED since the 16 Aug 2026 mount train — `ModelTabV2Panel` hosts this on
+ * the Model tab (via `ModelTabBody`). The boundary guard now pins the mount
+ * path instead of the old unmounted claim.
  *
  * ⚠ THIS COMPONENT NEVER WRITES, AND NEVER DECIDES THAT AN EDIT SUCCEEDED.
- * It renders `commit` — the state the WRITE AUTHORITY reports — and it renders
+ * It renders `commit` — the state the edit host reports — and it renders
  * `row.primaryValue` VERBATIM. It does not re-derive a value, re-format a
  * number, or infer a provenance. The reason is design §2 F6: today an edge
  * strength, an option's intervention value and the goal target are local store
@@ -13,12 +14,17 @@
  * the two are INDISTINGUISHABLE on screen. A row that can only render `applied`
  * from a receipt cannot reproduce that, whatever it is handed.
  *
- * THE DISABLED-AFFORDANCE RULE (the lane boundary, design §8). The write
- * authority is Codex's transactional-edit vertical and it is not frozen yet. So
- * every control here that would CAUSE a transition is rendered DISABLED, with a
- * label saying why, whenever its callback is absent. A disabled affordance with
- * an honest label beats a fake one: a stub that reported success would be the
- * silent-local-write defect re-created inside the component written to kill it.
+ * THE DISABLED-AFFORDANCE RULE (the lane boundary, design §8). An edit control
+ * is live ONLY where the host has a CANONICAL transaction to dispatch on
+ * (`editConnected` + the callbacks). Everywhere else it renders DISABLED, with
+ * a label saying why. A disabled affordance with an honest label beats a fake
+ * one: a stub that reported success would be the silent-local-write defect
+ * re-created inside the component written to kill it.
+ *
+ * THE INLINE-CHIP CONFIRM (ruling R9, 16 Aug 2026). The three-beat renders in
+ * the row itself: an input while `editing`, then Confirm / Discard CHIPS while
+ * `proposed` — never a modal. Until Confirm, the model is unchanged and the
+ * row says so in words.
  */
 
 import { typography } from '../../styles/typography'
@@ -45,10 +51,26 @@ export interface ModelRowViewProps {
   /** Focus this element on the canvas — today's `focusNodeById` behaviour. */
   onFocusOnCanvas?: (id: string) => void
   /**
-   * Begin an edit. ABSENT UNTIL THE WRITE AUTHORITY IS FROZEN, which is why the
-   * editor affordance renders disabled rather than optimistic.
+   * Begin an edit. Presence alone does not enable the editor — see
+   * `editConnected`.
    */
   onBeginEdit?: (id: string) => void
+  /**
+   * Whether THIS row's edit has a canonical transaction behind it. Defaults to
+   * true so presence-of-callback semantics are unchanged for existing callers;
+   * the host passes `false` for rows whose edit class has no wire carrier yet
+   * (edge strength/likelihood/direction, option interventions, goal target),
+   * which keeps their affordances honestly disabled.
+   */
+  editConnected?: boolean
+  /** Live-edit callbacks (the three-beat). Absent ⇒ the static renders below. */
+  onDraftChange?: (id: string, draft: string) => void
+  /** Commit intent: editing → proposed. */
+  onProposeEdit?: (id: string) => void
+  /** Abandon the edit from either the input (Escape) or the proposal chip. */
+  onDiscardEdit?: (id: string) => void
+  /** The inline confirm chip — dispatches the canonical transaction. */
+  onConfirmEdit?: (id: string) => void
 }
 
 /** Why the editor is unavailable. Shown on the disabled control, in words. */
@@ -63,9 +85,14 @@ export function ModelRowView({
   onSelect,
   onFocusOnCanvas,
   onBeginEdit,
+  editConnected = true,
+  onDraftChange,
+  onProposeEdit,
+  onDiscardEdit,
+  onConfirmEdit,
 }: ModelRowViewProps) {
   const phase = commit?.phase ?? 'idle'
-  const editorAvailable = row.editable && typeof onBeginEdit === 'function'
+  const editorAvailable = row.editable && editConnected && typeof onBeginEdit === 'function'
 
   return (
     <li
@@ -105,6 +132,10 @@ export function ModelRowView({
         commit={commit}
         editorAvailable={editorAvailable}
         onBeginEdit={onBeginEdit}
+        onDraftChange={onDraftChange}
+        onProposeEdit={onProposeEdit}
+        onDiscardEdit={onDiscardEdit}
+        onConfirmEdit={onConfirmEdit}
       />
 
       {/*
@@ -174,17 +205,55 @@ function ValueCell({
   commit,
   editorAvailable,
   onBeginEdit,
+  onDraftChange,
+  onProposeEdit,
+  onDiscardEdit,
+  onConfirmEdit,
 }: {
   row: ModelRow
   commit?: EditCommitState
   editorAvailable: boolean
   onBeginEdit?: (id: string) => void
+  onDraftChange?: (id: string, draft: string) => void
+  onProposeEdit?: (id: string) => void
+  onDiscardEdit?: (id: string) => void
+  onConfirmEdit?: (id: string) => void
 }) {
   const testid = `model-row-v2-${row.id}-value`
 
   if (commit && commit.phase !== 'idle') {
     switch (commit.phase) {
       case 'editing':
+        // Live host: a real input. The draft is the HOST's state — this cell
+        // renders it and reports keystrokes; it decides nothing.
+        if (onDraftChange && onProposeEdit && onDiscardEdit) {
+          return (
+            <span data-testid={testid} className={typography.tabular}>
+              <input
+                data-testid={`${testid}-input`}
+                // eslint-disable-next-line jsx-a11y/no-autofocus -- the input
+                // exists because the user just clicked the value it replaces.
+                autoFocus
+                inputMode="decimal"
+                value={commit.draft}
+                aria-label={`New value for ${row.label}`}
+                onClick={e => e.stopPropagation()}
+                onChange={e => onDraftChange(row.id, e.target.value)}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault()
+                    onProposeEdit(row.id)
+                  }
+                  if (e.key === 'Escape') {
+                    e.preventDefault()
+                    onDiscardEdit(row.id)
+                  }
+                }}
+                className={`${typography.tabular} w-24 bg-panel-hover border border-panel-border rounded px-1`}
+              />
+            </span>
+          )
+        }
         return (
           <span data-testid={testid} className={typography.tabular}>
             {commit.draft}
@@ -199,6 +268,37 @@ function ValueCell({
             <span className={`${typography.caption} text-text-light ml-2`}>
               Nothing has changed yet
             </span>
+            {/*
+              R9 — the inline confirm CHIPS. Rendered only when the host can
+              actually dispatch the canonical transaction; a Confirm that could
+              not would be a fake affordance, which is the one thing this
+              surface must never render.
+            */}
+            {onConfirmEdit && onDiscardEdit && (
+              <span
+                className="ml-2 inline-flex gap-1"
+                onClick={e => e.stopPropagation()}
+              >
+                <button
+                  type="button"
+                  data-testid={`model-row-v2-${row.id}-confirm`}
+                  aria-label={`Confirm new value for ${row.label}`}
+                  onClick={() => onConfirmEdit(row.id)}
+                  className={`${typography.buttonSmall} text-info border border-info/50 rounded px-2 py-0.5`}
+                >
+                  Confirm
+                </button>
+                <button
+                  type="button"
+                  data-testid={`model-row-v2-${row.id}-discard`}
+                  aria-label={`Discard new value for ${row.label}`}
+                  onClick={() => onDiscardEdit(row.id)}
+                  className={`${typography.buttonSmall} text-text-light border border-panel-border rounded px-2 py-0.5`}
+                >
+                  Discard
+                </button>
+              </span>
+            )}
           </span>
         )
       case 'inflight':

--- a/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
+++ b/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
@@ -1,0 +1,269 @@
+/**
+ * ModelTabV2Panel — the Model Editor v2's mount host (16 Aug 2026 mount train).
+ *
+ * THE ONE FILE IN THIS DIRECTORY THAT IS ALLOWED TO TOUCH THE LIVE APP. The
+ * render components (`ModelOutline` / `ModelRowView` / `ModelDetailRegion` /
+ * `RepairQueueList`) stay pure projections; this container:
+ *
+ *   · takes the model AS PROPS from `ModelTabBody` (no store subscription of
+ *     its own — the tab already holds nodes/edges/fragility, and a second
+ *     subscription would be a second render authority);
+ *   · builds the row/detail projections through `adapters.ts`;
+ *   · owns the ONE active edit's state machine
+ *     (idle → editing → proposed → dispatched-and-idle);
+ *   · dispatches every write through `useModelEditAuthority` — the canonical
+ *     factor-value transaction (event build → optimistic undo → sanctioned
+ *     setter → `sendSystemEvent` with the undo riding the send). NOTHING here
+ *     writes the store or the wire directly; the boundary guard enforces it.
+ *
+ * WHY THERE IS NO `inflight`/`applied` RENDER THIS TRAIN, stated so nobody
+ * "fixes" it into a lie: the canonical dispatcher resolves refusal/acceptance
+ * CENTRALLY (revert on refusal, stamp on acceptance) and hands back no receipt
+ * — so after Confirm the row returns to rendering the STORE, which is
+ * optimistic-then-authoritative, exactly as the v1 factor chip behaves. A row
+ * that showed "applied" from its own echo would be an optimistic write wearing
+ * a confirmation (contracts.ts §1 C11). When the receipt-bearing transaction
+ * API lands, the three-beat's tail states plug in at `useModelEditAuthority`.
+ *
+ * EDIT COVERAGE AT THIS TIP: factor values (the reference canonical
+ * transaction). Rows whose edit class has NO canonical carrier — edge
+ * strength / likelihood / direction, option interventions, the goal target —
+ * render the honest disabled affordance (`editConnectedIds`). Wiring them
+ * through a local-only write instead would recreate design §2 F6 on the
+ * surface built to kill it.
+ */
+
+import { useCallback, useMemo, useState } from 'react'
+import type { Edge, Node } from '@xyflow/react'
+import { typography } from '../../styles/typography'
+import type { EdgeData } from '../domain/edges'
+import { focusEdgeById, focusNodeById } from '../utils/focusHelpers'
+import { resolveValueInputSeed } from '../conversation/factorValueEdit'
+import { useModelEditAuthority } from '../hooks/useModelEditAuthority'
+import { ModelOutline } from './ModelOutline'
+import { ModelDetailRegion } from './ModelDetailRegion'
+import { toModelRows, toRowDetail, nodeKind, type ModelProjectionInput } from './adapters'
+import type { DetailTier, EditCommitState } from './types'
+
+export interface ModelTabV2PanelProps {
+  nodes: Node[]
+  edges: Edge[]
+  /** RAW user units — the store scalar, never converted here. */
+  goalThreshold: number | null
+  /**
+   * Fragile edge ids from the robustness report. Pass `undefined` when no
+   * analysis has run: nothing is then KNOWN to be fragile, and no row claims
+   * otherwise.
+   */
+  fragileEdgeIds?: ReadonlySet<string>
+}
+
+/** One active edit at a time — the row the user is currently changing. */
+interface ActiveEdit {
+  rowId: string
+  phase: 'editing' | 'proposed'
+  draft: string
+  /** What the row displayed when the edit began — the `from` of the proposal. */
+  from: string
+}
+
+export function ModelTabV2Panel({
+  nodes,
+  edges,
+  goalThreshold,
+  fragileEdgeIds,
+}: ModelTabV2PanelProps) {
+  const [tier, setTier] = useState<DetailTier>('plain')
+  const [filter, setFilter] = useState('')
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [edit, setEdit] = useState<ActiveEdit | null>(null)
+
+  const projection: ModelProjectionInput = useMemo(
+    () => ({
+      nodes,
+      edges: edges as Edge<EdgeData>[],
+      goalThreshold,
+      fragileEdgeIds,
+    }),
+    [nodes, edges, goalThreshold, fragileEdgeIds],
+  )
+
+  const rows = useMemo(() => toModelRows(projection), [projection])
+
+  /**
+   * The rows whose edit has a canonical transaction at this tip: factors.
+   * Derived from the NODES (kind), not from the row's `editable` flag — that
+   * flag states what the design intends to be editable; this set states what
+   * the frozen transaction path can actually carry today.
+   */
+  const editConnectedIds = useMemo(() => {
+    const ids = new Set<string>()
+    for (const node of nodes) if (nodeKind(node) === 'factor') ids.add(node.id)
+    return ids as ReadonlySet<string>
+  }, [nodes])
+
+  const selectedRow = useMemo(
+    () => (selectedId === null ? null : rows.find(r => r.id === selectedId) ?? null),
+    [rows, selectedId],
+  )
+  const selectedDetail = useMemo(
+    () => (selectedId === null ? null : toRowDetail(projection, selectedId)),
+    [projection, selectedId],
+  )
+
+  const authority = useModelEditAuthority(edit?.rowId ?? null)
+
+  /** Rows are nodes OR edges — focus each with the helper that owns its kind. */
+  const focusOnCanvas = useCallback(
+    (id: string) => {
+      if (nodes.some(n => n.id === id)) focusNodeById(id)
+      else focusEdgeById(id)
+    },
+    [nodes],
+  )
+
+  const commitByRowId = useMemo(() => {
+    if (edit === null) return undefined
+    const state: EditCommitState =
+      edit.phase === 'editing'
+        ? { phase: 'editing', draft: edit.draft }
+        : { phase: 'proposed', from: edit.from, to: edit.draft }
+    return new Map<string, EditCommitState>([[edit.rowId, state]])
+  }, [edit])
+
+  const beginEdit = useCallback(
+    (rowId: string) => {
+      const row = rows.find(r => r.id === rowId)
+      if (!row) return
+      const node = nodes.find(n => n.id === rowId)
+      if (!node) return
+      // THE one seed rule (`resolveValueInputSeed`, default `raw_or_value`
+      // basis): the input shows `raw_value ?? value`, exactly as the inspector
+      // panel and the v1 Model-tab chips do. A second copy of that rule is how
+      // the scale ambiguity re-opens, so it is imported, never re-derived.
+      const { seed } = resolveValueInputSeed(node.data)
+      setEdit({
+        rowId,
+        phase: 'editing',
+        draft: seed === undefined ? '' : String(seed),
+        from: row.primaryValue ?? 'Not set',
+      })
+    },
+    [rows, nodes],
+  )
+
+  const changeDraft = useCallback((rowId: string, draft: string) => {
+    setEdit(prev => (prev && prev.rowId === rowId ? { ...prev, draft } : prev))
+  }, [])
+
+  const proposeEdit = useCallback((rowId: string) => {
+    setEdit(prev => {
+      if (!prev || prev.rowId !== rowId) return prev
+      // Intent must parse before it can be proposed. An unparseable draft
+      // stays in `editing` — nothing to confirm, nothing to send.
+      const num = parseFloat(prev.draft)
+      if (!Number.isFinite(num)) return prev
+      return { ...prev, phase: 'proposed' }
+    })
+  }, [])
+
+  const discardEdit = useCallback((rowId: string) => {
+    setEdit(prev => (prev && prev.rowId === rowId ? null : prev))
+  }, [])
+
+  const confirmEdit = useCallback(
+    (rowId: string) => {
+      if (!edit || edit.rowId !== rowId || edit.phase !== 'proposed') return
+      const num = parseFloat(edit.draft)
+      if (!Number.isFinite(num)) return
+      // The canonical transaction. Whatever the outcome, the edit state
+      // clears: on `dispatched`/`local_only` the store now shows the
+      // optimistic value (and the dispatcher owns refusal-revert); on
+      // `not_encodable` nothing was written anywhere — fail closed, and the
+      // row honestly shows the unchanged model.
+      authority.proposeFactorValue(num)
+      setEdit(null)
+    },
+    [edit, authority],
+  )
+
+  return (
+    <section
+      data-testid="model-tab-v2-panel"
+      aria-label="Model outline"
+      className="flex flex-col gap-2 border border-panel-border rounded-lg p-2"
+    >
+      <header className="flex items-center gap-2 flex-wrap">
+        <h3 className={`${typography.h5} text-text-header`}>Model outline</h3>
+        <input
+          data-testid="model-tab-v2-filter"
+          type="search"
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+          placeholder="Filter the model…"
+          aria-label="Filter the model"
+          className={`${typography.bodySmall} flex-1 min-w-[10rem] bg-panel-hover border border-panel-border rounded px-2 py-1`}
+        />
+        {/*
+          The tier control, IN the tab (design §4.3 rule 3). A content switch
+          only: `ModelOutline`'s layout function takes no tier argument, so
+          flipping this cannot reorder, open or close anything.
+        */}
+        <div
+          role="group"
+          aria-label="Detail tier"
+          data-testid="model-tab-v2-tier-toggle"
+          className="inline-flex rounded border border-panel-border overflow-hidden"
+        >
+          <button
+            type="button"
+            data-testid="model-tab-v2-tier-plain"
+            aria-pressed={tier === 'plain'}
+            onClick={() => setTier('plain')}
+            className={`${typography.buttonSmall} px-2 py-0.5 ${
+              tier === 'plain' ? 'bg-panel-hover text-text-header' : 'text-text-light'
+            }`}
+          >
+            Plain
+          </button>
+          <button
+            type="button"
+            data-testid="model-tab-v2-tier-advanced"
+            aria-pressed={tier === 'advanced'}
+            onClick={() => setTier('advanced')}
+            className={`${typography.buttonSmall} px-2 py-0.5 ${
+              tier === 'advanced' ? 'bg-panel-hover text-text-header' : 'text-text-light'
+            }`}
+          >
+            Advanced
+          </button>
+        </div>
+      </header>
+
+      <ModelOutline
+        rows={rows}
+        tier={tier}
+        filter={filter}
+        selectedId={selectedId}
+        onSelect={setSelectedId}
+        onFocusOnCanvas={focusOnCanvas}
+        commitByRowId={commitByRowId}
+        editConnectedIds={editConnectedIds}
+        onBeginEdit={beginEdit}
+        onDraftChange={changeDraft}
+        onProposeEdit={proposeEdit}
+        onDiscardEdit={discardEdit}
+        onConfirmEdit={confirmEdit}
+      />
+
+      {selectedRow !== null && selectedDetail !== null && (
+        <ModelDetailRegion
+          row={selectedRow}
+          detail={selectedDetail}
+          tier={tier}
+          onFocusOnCanvas={focusOnCanvas}
+        />
+      )}
+    </section>
+  )
+}

--- a/src/canvas/model-tab-v2/RepairQueueList.tsx
+++ b/src/canvas/model-tab-v2/RepairQueueList.tsx
@@ -1,10 +1,14 @@
 /**
  * Model tab v2 — THE REPAIR QUEUE LIST, RENDER-ONLY (design §5.3).
  *
- * ⚠ UNMOUNTED, AND DELIBERATELY INERT. This renders the queue. It does not
- * apply anything, and it cannot: applying is a write, writes belong to Codex's
- * transactional-edit vertical, and that API is not frozen. Every Apply, Defer
- * and Resume control here is DISABLED and says why.
+ * ⚠ DELIBERATELY INERT (and still unmounted by the 16 Aug 2026 mount train,
+ * which mounted the outline + detail region only). This renders the queue. It
+ * does not apply anything, and it cannot: applying needs write operations the
+ * canonical wire does not carry yet (`proposeOptionIntervention`,
+ * `proposeFactorConfirmation`, `proposeBatch`, `proposeDeferral` — contracts.ts
+ * §1). Every Apply, Defer and Resume control here is DISABLED and says why.
+ * Mounting an actionless queue would add noise, not capability, so the queues
+ * wait for their carriers.
  *
  * ⚠ WHY NOT STUB THE APPLY. A stub that flipped a row to "applied" would
  * reproduce, inside the component written to kill it, the exact defect this

--- a/src/canvas/model-tab-v2/__tests__/ModelTabV2Panel.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/ModelTabV2Panel.spec.tsx
@@ -1,0 +1,324 @@
+/**
+ * ModelTabV2Panel — the mount train's container spec (16 Aug 2026).
+ *
+ * WHAT THIS PINS, and why each pin exists:
+ *
+ *  1. THE CANONICAL WRITE PATH. A v2 factor-value confirm must commit through
+ *     the SAME transaction the reference surface uses (`FactorsSection`
+ *     `handleValueCommit`, ROADMAP 2.121 slice 1 / #513): build the wire event
+ *     with `buildFactorValueEditEvent`, capture the optimistic undo BEFORE the
+ *     write, write through the sanctioned setter (`setObservedValue` — value +
+ *     raw_value + provenance stamp in ONE update), then dispatch
+ *     `sendSystemEvent(event, { optimisticFactorEdit })`. A mutant that routes
+ *     the write around the dispatch (skips the send, or drops the undo) must
+ *     go RED here — that is this spec's primary job.
+ *
+ *  2. THE INLINE-CHIP CONFIRM (ruling R9). The three-beat is edit → propose
+ *     (nothing has changed yet) → confirm/discard chips in the row. No modal.
+ *     Until Confirm is clicked the store must be UNTOUCHED and nothing may be
+ *     sent — `proposed` is a statement of intent, not a write.
+ *
+ *  3. HONEST NON-CONNECTED AFFORDANCES. Rows whose edits have NO canonical
+ *     wire carrier at this tip (relationships, options, goal) keep the
+ *     disabled affordance with the honest label. Enabling them without a
+ *     carrier would recreate design §2 F6 (a local write indistinguishable
+ *     from a server-backed one) inside the surface built to kill it.
+ *
+ * The store is REAL (the sanctioned setters read the node back out of
+ * `useCanvasStore.getState()` before writing); the conversation context is
+ * mocked at the module seam exactly as `modelTabEditsAreTurns.spec.tsx` does.
+ * Assertions bind by IDENTITY (testids carrying the node id), never by a value
+ * predicate another element could satisfy (trap 19).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, cleanup, fireEvent, screen } from '@testing-library/react'
+import type { Node, Edge } from '@xyflow/react'
+
+const sendSystemEvent = vi.fn()
+
+// Trap 12: spread the real module rather than hand-listing its exports.
+vi.mock('../../conversation/ConversationContext', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    useOptionalConversationContext: () => ({ sendSystemEvent }),
+  }
+})
+
+vi.mock('../../utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusEdgeById: vi.fn(),
+}))
+
+import { ModelTabV2Panel } from '../ModelTabV2Panel'
+import { useCanvasStore } from '../../store'
+import { normaliseRawFactorValue } from '../../utils/observedStateHelpers'
+
+const FACTOR_ID = 'fac_monthly_eng_cost'
+const CAP = 30000
+const COMMITTED_RAW = 30000
+const NEW_RAW = 20000
+const GOAL_ID = 'goal_arr'
+const OPTION_ID = 'opt_premium'
+const EDGE_ID = 'e_cost_to_goal'
+
+function cappedFactorNode(): Node {
+  return {
+    id: FACTOR_ID,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: {
+      label: 'Monthly Engineering Cost',
+      kind: 'factor',
+      category: 'observable',
+      observedState: {
+        value: COMMITTED_RAW / CAP,
+        raw_value: COMMITTED_RAW,
+        cap: CAP,
+        unit: '£',
+        source: 'cee_inference',
+      },
+    },
+  } as unknown as Node
+}
+
+function goalNode(): Node {
+  return {
+    id: GOAL_ID,
+    type: 'goal',
+    position: { x: 0, y: 0 },
+    data: { label: 'Hit ARR target', kind: 'goal' },
+  } as unknown as Node
+}
+
+function optionNode(): Node {
+  return {
+    id: OPTION_ID,
+    type: 'option',
+    position: { x: 0, y: 0 },
+    data: { label: 'Premium-first', kind: 'option', interventions: { [FACTOR_ID]: 0.6 } },
+  } as unknown as Node
+}
+
+function stampedEdge(): Edge {
+  return {
+    id: EDGE_ID,
+    source: FACTOR_ID,
+    target: GOAL_ID,
+    data: {
+      label: 'Cost affects target',
+      weight: 0.4,
+      direction: 'positive',
+      weightSource: 'user',
+      directionSource: 'user',
+    },
+  } as unknown as Edge
+}
+
+function allNodes(): Node[] {
+  return [goalNode(), optionNode(), cappedFactorNode()]
+}
+
+function seedStore() {
+  useCanvasStore.setState(
+    { nodes: allNodes(), edges: [stampedEdge()] } as never,
+    false,
+  )
+}
+
+function observed(id: string): Record<string, unknown> {
+  const n = useCanvasStore.getState().nodes.find(x => x.id === id)
+  return ((n?.data as Record<string, unknown> | undefined)?.observedState ?? {}) as Record<
+    string,
+    unknown
+  >
+}
+
+function renderPanel() {
+  render(
+    <ModelTabV2Panel
+      nodes={allNodes()}
+      edges={[stampedEdge()]}
+      goalThreshold={null}
+    />,
+  )
+}
+
+/** Drive the row to the PROPOSED state: click value → type → Enter. */
+function proposeFactorValue(raw: string) {
+  fireEvent.click(screen.getByTestId(`model-row-v2-${FACTOR_ID}-value`))
+  const input = screen.getByTestId(`model-row-v2-${FACTOR_ID}-value-input`)
+  fireEvent.change(input, { target: { value: raw } })
+  fireEvent.keyDown(input, { key: 'Enter' })
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  seedStore()
+})
+
+afterEach(() => cleanup())
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Rendering + navigation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ModelTabV2Panel — outline, filter, tier, detail', () => {
+  it('renders the outline with one row per element, bound by id', () => {
+    renderPanel()
+    expect(screen.getByTestId('model-tab-v2-panel')).toBeInTheDocument()
+    expect(screen.getByTestId(`model-row-v2-${FACTOR_ID}`)).toBeInTheDocument()
+    expect(screen.getByTestId(`model-row-v2-${GOAL_ID}`)).toBeInTheDocument()
+    expect(screen.getByTestId(`model-row-v2-${OPTION_ID}`)).toBeInTheDocument()
+    expect(screen.getByTestId(`model-row-v2-${EDGE_ID}`)).toBeInTheDocument()
+  })
+
+  it('the filter narrows rows by label — the F3 fix, working on the mounted surface', () => {
+    renderPanel()
+    fireEvent.change(screen.getByTestId('model-tab-v2-filter'), {
+      target: { value: 'Engineering' },
+    })
+    expect(screen.getByTestId(`model-row-v2-${FACTOR_ID}`)).toBeInTheDocument()
+    expect(screen.queryByTestId(`model-row-v2-${OPTION_ID}`)).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`model-row-v2-${EDGE_ID}`)).not.toBeInTheDocument()
+  })
+
+  it('the tier is a content switch: element ids exist only in Advanced', () => {
+    renderPanel()
+    // Plain by default — the id span is ABSENT from the DOM, not hidden.
+    expect(screen.queryByTestId(`model-row-v2-${FACTOR_ID}-id`)).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('model-tab-v2-tier-advanced'))
+    expect(screen.getByTestId(`model-row-v2-${FACTOR_ID}-id`)).toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('model-tab-v2-tier-plain'))
+    expect(screen.queryByTestId(`model-row-v2-${FACTOR_ID}-id`)).not.toBeInTheDocument()
+  })
+
+  it('selecting a row opens the detail region bound to that row id', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTestId(`model-row-v2-${FACTOR_ID}`))
+    const detail = screen.getByTestId('model-detail-v2')
+    expect(detail).toHaveAttribute('data-row-id', FACTOR_ID)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The canonical write path
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ModelTabV2Panel — factor value edits ride the canonical transaction', () => {
+  it('clicking the value opens an input seeded from raw_value (the one seed rule)', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTestId(`model-row-v2-${FACTOR_ID}-value`))
+    const input = screen.getByTestId(
+      `model-row-v2-${FACTOR_ID}-value-input`,
+    ) as HTMLInputElement
+    expect(input.value).toBe(String(COMMITTED_RAW))
+  })
+
+  it('Enter proposes: confirm/discard chips render, the store is untouched, nothing is sent', () => {
+    renderPanel()
+    proposeFactorValue(String(NEW_RAW))
+    expect(screen.getByTestId(`model-row-v2-${FACTOR_ID}-confirm`)).toBeInTheDocument()
+    expect(screen.getByTestId(`model-row-v2-${FACTOR_ID}-discard`)).toBeInTheDocument()
+    // Nothing has changed yet — the design's own words for this beat.
+    expect(observed(FACTOR_ID).raw_value).toBe(COMMITTED_RAW)
+    expect(observed(FACTOR_ID).source).toBe('cee_inference')
+    expect(sendSystemEvent).not.toHaveBeenCalled()
+  })
+
+  it('⭐ Confirm commits through the sanctioned setter AND dispatches the wire event with its undo', () => {
+    renderPanel()
+    proposeFactorValue(String(NEW_RAW))
+    fireEvent.click(screen.getByTestId(`model-row-v2-${FACTOR_ID}-confirm`))
+
+    // The sanctioned-setter write: value + raw_value + stamp, one update.
+    const obs = observed(FACTOR_ID)
+    expect(obs.value).toBe(normaliseRawFactorValue(NEW_RAW, CAP))
+    expect(obs.raw_value).toBe(NEW_RAW)
+    expect(obs.source).toBe('user')
+
+    // The wire event — the SAME shape the reference surface emits.
+    expect(sendSystemEvent).toHaveBeenCalledTimes(1)
+    const [event, opts] = sendSystemEvent.mock.calls[0]
+    expect(event.type).toBe('factor_value_edit')
+    expect(event.payload).toMatchObject({
+      target_id: FACTOR_ID,
+      value: normaliseRawFactorValue(NEW_RAW, CAP),
+      field: 'value',
+      raw_value: NEW_RAW,
+      unit: '£',
+    })
+
+    // The optimistic undo rides WITH the send — the dispatcher owns refusal
+    // resolution (revert) and acceptance (stamp). A confirm without it would
+    // keep a refused number on screen: the 2.129(b) split-brain.
+    expect(opts?.optimisticFactorEdit).toBeDefined()
+    expect(opts.optimisticFactorEdit.nodeId).toBe(FACTOR_ID)
+    expect(opts.optimisticFactorEdit.sentValue).toBe(normaliseRawFactorValue(NEW_RAW, CAP))
+  })
+
+  it('Discard reverts to idle: store untouched, nothing sent, original value shown', () => {
+    renderPanel()
+    proposeFactorValue(String(NEW_RAW))
+    fireEvent.click(screen.getByTestId(`model-row-v2-${FACTOR_ID}-discard`))
+    expect(observed(FACTOR_ID).raw_value).toBe(COMMITTED_RAW)
+    expect(observed(FACTOR_ID).source).toBe('cee_inference')
+    expect(sendSystemEvent).not.toHaveBeenCalled()
+    // Back to the idle affordance, still bound to this row.
+    expect(screen.getByTestId(`model-row-v2-${FACTOR_ID}-value`)).toBeInTheDocument()
+    expect(
+      screen.queryByTestId(`model-row-v2-${FACTOR_ID}-confirm`),
+    ).not.toBeInTheDocument()
+  })
+
+  it('Escape in the input cancels without proposing', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTestId(`model-row-v2-${FACTOR_ID}-value`))
+    const input = screen.getByTestId(`model-row-v2-${FACTOR_ID}-value-input`)
+    fireEvent.change(input, { target: { value: '999' } })
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(
+      screen.queryByTestId(`model-row-v2-${FACTOR_ID}-value-input`),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`model-row-v2-${FACTOR_ID}-confirm`)).not.toBeInTheDocument()
+    expect(sendSystemEvent).not.toHaveBeenCalled()
+  })
+
+  it('a non-numeric draft cannot be proposed: Enter keeps the input open, nothing is sent', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTestId(`model-row-v2-${FACTOR_ID}-value`))
+    const input = screen.getByTestId(`model-row-v2-${FACTOR_ID}-value-input`)
+    fireEvent.change(input, { target: { value: 'not a number' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(screen.getByTestId(`model-row-v2-${FACTOR_ID}-value-input`)).toBeInTheDocument()
+    expect(screen.queryByTestId(`model-row-v2-${FACTOR_ID}-confirm`)).not.toBeInTheDocument()
+    expect(sendSystemEvent).not.toHaveBeenCalled()
+    expect(observed(FACTOR_ID).raw_value).toBe(COMMITTED_RAW)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Honest non-connected affordances
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ModelTabV2Panel — rows with no canonical carrier stay honestly disabled', () => {
+  it.each([
+    ['relationship', EDGE_ID],
+    ['option', OPTION_ID],
+    ['goal', GOAL_ID],
+  ])('the %s row value affordance is disabled and says why', (_kind, id) => {
+    renderPanel()
+    const value = screen.getByTestId(`model-row-v2-${id}-value`)
+    expect(value).toBeDisabled()
+    expect(value).toHaveAttribute(
+      'title',
+      'Editing is not connected yet — this value cannot be changed from here.',
+    )
+  })
+
+  it('POSITIVE CONTROL: the factor row is NOT disabled — the rule above discriminates', () => {
+    renderPanel()
+    expect(screen.getByTestId(`model-row-v2-${FACTOR_ID}-value`)).not.toBeDisabled()
+  })
+})

--- a/src/canvas/model-tab-v2/__tests__/modelTabV2Boundary.sourceScan.spec.ts
+++ b/src/canvas/model-tab-v2/__tests__/modelTabV2Boundary.sourceScan.spec.ts
@@ -344,6 +344,131 @@ describe('⭐ model-tab-v2 NEVER WRITES — the write authority is another lane'
   })
 })
 
+// ── 2b. NO STORE ACCESS AT ALL (review B1, 17 Aug 2026) ──────────────────────
+
+/**
+ * ⚠ ADDED AFTER AN ADVERSARIAL REVIEW EXECUTED TWO EVASIONS OF SECTION 2 AND
+ * EVERY GUARD STAYED GREEN. Both are ordinary idioms in sibling directories, so
+ * an honest future lane would copy them here:
+ *
+ *   E1  `import { useCanvasStore } from '../store'` +
+ *       `useCanvasStore.getState()` / `.setState({ nodes: … })` — the hook scan
+ *       only matches `use[A-Z]\w*(` CALLS, and `BANNED_WRITE` names 12 mutators
+ *       (`setState`, `addNode`, `deleteNodeById`, `applyRepair`,
+ *       `applyAllRepairs` are all unlisted);
+ *   E2  `const { updateNode: patchNode } = canvasState.getState()` —
+ *       destructure-RENAME evades every named token.
+ *
+ * So this scan bans the ACCESS ROUTE rather than enumerating mutators: for
+ * every v2 file INCLUDING the mount host, (a) no import/require/dynamic-import
+ * specifier may resolve to a store module (`…/store`, a `store(s)/` path
+ * segment, or `zustand` itself — path-based, so an alias like `@/canvas/store`
+ * is caught by its tail), and (b) `getState(` / `setState(` may not appear at
+ * all. Zero legitimate occurrences existed when this was written (verified);
+ * the one sanctioned writer remains `useModelEditAuthority`, which lives
+ * OUTSIDE this directory.
+ *
+ * NOTE this deliberately TIGHTENS what an older control in section 2 tolerates:
+ * there, a bare non-invoked store import is "a read, not a subscription" — that
+ * control pins the FOREIGN-HOOK scanner's discrimination and still holds; as
+ * DIRECTORY POLICY, any store import here is now banned outright, because E1
+ * proved a non-hook import is a full write path.
+ *
+ * ⚠ KNOWN LIMITS of source-text scanning (reviewer's riders, recorded so nobody
+ * mistakes this for a semantic guarantee): (i) a SPLIT-TOKEN dynamic import
+ * (`import('../sto' + 're')`) defeats specifier matching; (ii) TRANSITIVE
+ * closure is not scanned — a v2 file importing an out-of-directory helper that
+ * itself writes would pass. Both are visible in review as exactly the
+ * contortions they are; the scans exist to make the HONEST mistake loud, not to
+ * defeat an adversary.
+ */
+const STORE_SPECIFIER = (s: string): boolean =>
+  s === 'zustand' ||
+  s.startsWith('zustand/') ||
+  /(^|\/)store$/.test(s) ||
+  /(^|\/)stores?\//.test(s)
+
+/**
+ * ⚠ `stripComments`, NOT `blankNonCode` — an import specifier IS a string
+ * literal (the same lesson this file has now paid for twice; see the header).
+ */
+function storeAccessIn(src: string, file: string): string[] {
+  const code = stripComments(src, file)
+  const hits: string[] = []
+  const specifiers = [
+    ...code.matchAll(/from\s*['"]([^'"]+)['"]/g),
+    ...code.matchAll(/\bimport\s*\(\s*['"]([^'"]+)['"]/g),
+    ...code.matchAll(/\brequire\s*\(\s*['"]([^'"]+)['"]/g),
+  ].map(m => m[1])
+  for (const s of specifiers) {
+    if (STORE_SPECIFIER(s)) hits.push(`import:${s}`)
+  }
+  for (const m of code.matchAll(/\b(getState|setState)\s*\(/g)) {
+    hits.push(`call:${m[1]}`)
+  }
+  return hits
+}
+
+describe('⭐ model-tab-v2 NEVER TOUCHES THE STORE — the access route is banned, not just the mutator names', () => {
+  it('POSITIVE CONTROL: evasion E1 (store import + getState/setState) is detected in full', () => {
+    // The review's exact executed shape, through the same pipeline as the claim.
+    expect(
+      storeAccessIn(
+        [
+          "import { useCanvasStore } from '../store'",
+          'const s = useCanvasStore.getState()',
+          'useCanvasStore.setState({ nodes: [] })',
+        ].join('\n'),
+        'x.ts',
+      ),
+    ).toEqual(['import:../store', 'call:getState', 'call:setState'])
+  })
+
+  it('POSITIVE CONTROL: evasion E2 (destructure-rename off getState) is detected', () => {
+    expect(
+      storeAccessIn(
+        'const { updateNode: patchNode } = canvasState.getState()\npatchNode(id, { data: {} })',
+        'x.ts',
+      ),
+    ).toEqual(['call:getState'])
+  })
+
+  it('POSITIVE CONTROL: zustand itself, aliased store paths, and a stores/ segment are all caught', () => {
+    expect(storeAccessIn("import { create } from 'zustand'", 'x.ts')).toEqual(['import:zustand'])
+    expect(storeAccessIn("import { useCanvasStore } from '@/canvas/store'", 'x.ts')).toEqual([
+      'import:@/canvas/store',
+    ])
+    expect(storeAccessIn("import { useUIStore } from '../../stores/uiStore'", 'x.ts')).toEqual([
+      'import:../../stores/uiStore',
+    ])
+    expect(storeAccessIn("const m = await import('../store')", 'x.ts')).toEqual(['import:../store'])
+  })
+
+  it('POSITIVE CONTROL: comments and innocent imports are NOT flagged — the scan discriminates', () => {
+    expect(
+      storeAccessIn(
+        "// import { useCanvasStore } from '../store'\n// getState( in prose\nconst x = 1",
+        'x.ts',
+      ),
+    ).toEqual([])
+    expect(
+      storeAccessIn(
+        "import { focusNodeById } from '../utils/focusHelpers'\nfocusNodeById(id)",
+        'x.tsx',
+      ),
+    ).toEqual([])
+  })
+
+  it('no v2 file — the mount host included — imports a store module or calls getState/setState', () => {
+    const offenders: string[] = []
+    for (const file of v2Files) {
+      const found = storeAccessIn(readFileSync(file, 'utf8'), file)
+      if (found.length > 0) offenders.push(`${basename(file)}: ${[...new Set(found)].join(', ')}`)
+    }
+    expect(offenders).toEqual([])
+  })
+})
+
 // ── 3. NO FAKE SUCCESS ───────────────────────────────────────────────────────
 
 /**

--- a/src/canvas/model-tab-v2/__tests__/modelTabV2Boundary.sourceScan.spec.ts
+++ b/src/canvas/model-tab-v2/__tests__/modelTabV2Boundary.sourceScan.spec.ts
@@ -1,20 +1,31 @@
 /**
  * Model tab v2 — THE LANE BOUNDARY, ENFORCED (design §8, §9.1).
  *
- * This lane makes three claims about itself. Each is the kind of claim that is
- * cheap to write in a comment, invisible when it stops being true, and expensive
- * when it does. So each is a test:
+ * ⚠ RESTRUCTURED BY THE 16 Aug 2026 MOUNT TRAIN. The original claim 1 was
+ * "NOTHING IS MOUNTED"; the directory is now mounted deliberately (the PX-D
+ * BUILT-UNMOUNTED finding, closed), so that claim is retired and REPLACED by a
+ * stronger one rather than deleted — the ratified pattern: narrow what is
+ * banned, never stop banning things.
  *
- *   1. NOTHING IS MOUNTED — no file outside this directory references it, so the
- *      whole directory is deletable if Paul vetoes the design.
- *   2. NOTHING WRITES — no file here calls a store mutator or dispatches a turn.
- *      The write authority is Codex's transactional-edit vertical (§9.1), and a
- *      second writer appearing here is exactly how the estate previously ended
- *      up committing one edit through three paths with three provenance stamps.
+ * The three claims now enforced:
+ *
+ *   1. MOUNTED EXACTLY ONCE, FROM THE NAMED HOST — the only file outside this
+ *      directory that references it is `components/ModelTabBody.tsx` (the
+ *      Model tab's container). A second importer is a second mount path and
+ *      must be added HERE, deliberately, or it is a defect.
+ *   2. NOTHING WRITES DIRECTLY — no file here (the mount host included) calls
+ *      a store mutator or dispatches a turn itself. Every write goes through
+ *      `useModelEditAuthority`, the ONE seam that implements the canonical
+ *      transaction — a second writer appearing here is exactly how the estate
+ *      previously ended up committing one edit through three paths with three
+ *      provenance stamps. Corollary: no v2 file except the named mount host
+ *      may invoke a hook from outside this namespace, and the host's foreign
+ *      hooks are pinned to exactly the authority seam.
  *   3. NOTHING FAKES SUCCESS — no runtime module here constructs an `applied`
  *      commit state. `applied` is reachable only from an authority's receipt; a
  *      component that could build one itself would reproduce design §2 F6 inside
- *      the code written to kill it.
+ *      the code written to kill it. (Today's authority returns NO receipt, so
+ *      nothing here may render `applied` at all.)
  *
  * Every scan is DERIVED by walking the directory, never a hand-listed file set —
  * a new component is in scope the moment it exists. Every absence assertion
@@ -79,6 +90,7 @@ describe('model-tab-v2 — the scan sees the directory it claims to cover', () =
       'ModelOutline.tsx',
       'ModelDetailRegion.tsx',
       'RepairQueueList.tsx',
+      'ModelTabV2Panel.tsx',
       'useOutlineKeyboard.ts',
       'types.ts',
       'contracts.ts',
@@ -107,7 +119,15 @@ function referencesV2(src: string, file: string): boolean {
   return V2_PATH_TOKEN.test(stripComments(src, file))
 }
 
-describe('⭐ model-tab-v2 is UNMOUNTED — nothing outside it references it', () => {
+/**
+ * The complete set of files outside this directory that may reference it. ONE
+ * entry: the Model tab's container, which hosts `ModelTabV2Panel`. Adding a
+ * second mount path is a deliberate decision that must be made here, in the
+ * guard, with a reason — never discovered in a diff.
+ */
+const ALLOWED_MOUNT_SITES = ['canvas/components/ModelTabBody.tsx']
+
+describe('⭐ model-tab-v2 is MOUNTED EXACTLY ONCE — from the named host only', () => {
   const outsideFiles = sourceFilesIn(SRC_DIR).filter(
     f => !f.startsWith(V2_DIR + '/') && f !== V2_DIR,
   )
@@ -137,17 +157,17 @@ describe('⭐ model-tab-v2 is UNMOUNTED — nothing outside it references it', (
     expect(referencesV2('// the model-tab-v2 design is unmounted\nconst x = 1', 'x.ts')).toBe(false)
   })
 
-  it('no file outside the directory imports or mentions it', () => {
-    const offenders: string[] = []
+  it('the ONLY outside references are the named mount sites — no second mount path', () => {
+    const referencing: string[] = []
     for (const file of outsideFiles) {
       if (referencesV2(readFileSync(file, 'utf8'), file)) {
-        offenders.push(relative(SRC_DIR, file))
+        referencing.push(relative(SRC_DIR, file))
       }
     }
-    // If this ever goes red, the directory is MOUNTED and three things become
-    // due at once: widen the raw-write guard (§9.1), re-read the disabled
-    // affordances, and stop describing the design as vetoable-by-deletion.
-    expect(offenders).toEqual([])
+    // Exact equality, both directions: a file DROPPING off this list means the
+    // editor was silently unmounted (the BUILT-UNMOUNTED regression), and a
+    // file APPEARING on it means a second mount path nobody ruled on.
+    expect(referencing.sort()).toEqual([...ALLOWED_MOUNT_SITES].sort())
   })
 })
 
@@ -278,8 +298,25 @@ describe('⭐ model-tab-v2 NEVER WRITES — the write authority is another lane'
       foreignHookCallsIn('export function useMine() { return useCanvasStore() }', 'x.ts'),
     ).toEqual(['useCanvasStore'])
 
+    /*
+     * ⚠ THE MOUNT HOST IS THE ONE EXCEPTION, AND ITS EXCEPTION IS PINNED, not
+     * waived: `ModelTabV2Panel` must reach the write authority, and a hook is
+     * the only sanctioned way to reach it. So the host is excluded from the
+     * blanket rule below and held to an EXACT set instead — its foreign hooks
+     * are `useModelEditAuthority` and nothing else. A store subscription
+     * (`useCanvasStore`), a context, or a second authority appearing there
+     * turns this red just as loudly as it would anywhere else.
+     */
+    const MOUNT_HOST = 'ModelTabV2Panel.tsx'
+    const host = v2Files.find(f => basename(f) === MOUNT_HOST)
+    expect(host).toBeDefined()
+    expect(
+      [...new Set(foreignHookCallsIn(readFileSync(host!, 'utf8'), host!))].sort(),
+    ).toEqual(['useModelEditAuthority'])
+
     const offenders: string[] = []
     for (const file of v2Files) {
+      if (basename(file) === MOUNT_HOST) continue
       const found = foreignHookCallsIn(readFileSync(file, 'utf8'), file)
       if (found.length > 0) offenders.push(`${basename(file)}: ${[...new Set(found)].join(', ')}`)
     }

--- a/src/canvas/model-tab-v2/adapters.ts
+++ b/src/canvas/model-tab-v2/adapters.ts
@@ -1,11 +1,12 @@
 /**
  * Model tab v2 — THE READ-ONLY STORE → PROJECTION ADAPTER.
  *
- * Maps LIVE canvas state onto the typed read projections in `types.ts`, so that
- * mounting this surface later is a wiring job rather than a design job.
+ * Maps LIVE canvas state onto the typed read projections in `types.ts`.
+ * MOUNTED since the 16 Aug 2026 mount train: `ModelTabV2Panel` is the caller
+ * that reads the store at the component boundary and passes the slices in.
  *
  * ─────────────────────────────────────────────────────────────────────────────
- * WHAT MAKES THIS SAFE TO EXIST WHILE UNMOUNTED
+ * WHAT MAKES THIS SAFE (the same properties that made it safe unmounted)
  *
  * ⚠ IT TAKES STATE AS AN ARGUMENT. It does NOT call `useCanvasStore()`, or any
  * other hook, anywhere. Every function here is a pure function of the slices it
@@ -16,8 +17,9 @@
  * type` and pure imports are allowed.
  *
  * ⚠ THE DIRECTION OF THE DEPENDENCY IS THE INVARIANT. namespace → live reads
- * are fine and are what this file is for. live → namespace imports are what
- * would constitute a mount, and there are none.
+ * are fine and are what this file is for. live → namespace imports are the
+ * mount, and the boundary guard pins them to exactly one site
+ * (`ModelTabBody.tsx`).
  *
  * ⚠ NO WRITES. No store mutator, no dispatch, no system event. Reading is the
  * whole job.

--- a/src/canvas/model-tab-v2/contracts.ts
+++ b/src/canvas/model-tab-v2/contracts.ts
@@ -1,6 +1,14 @@
 /**
  * Model tab v2 — the contracts this surface needs from OTHER lanes.
- * TYPE DECLARATIONS ONLY. No implementations, no runtime values, nothing mounted.
+ * TYPE DECLARATIONS ONLY. No implementations, no runtime values.
+ *
+ * ⚠ MOUNT-TRAIN STATUS (16 Aug 2026): the surface is now mounted, and the
+ * subset of §1 with a live canonical carrier is served by
+ * `src/canvas/hooks/useModelEditAuthority.ts` (factor values; prior range and
+ * edge adjudication remain reachable through their existing sanctioned seams).
+ * The RECEIPT-bearing handle below (`EditProposalHandle`, `applied` only from
+ * a receipt) is still the target API and still unimplemented — the authority
+ * hook documents why it must not be faked from an echo.
  *
  * This file exists so the two owning lanes have a concrete shape to bind to
  * instead of a paragraph in a design document:

--- a/src/canvas/model-tab-v2/types.ts
+++ b/src/canvas/model-tab-v2/types.ts
@@ -1,27 +1,24 @@
 /**
- * Model tab v2 — the structured model editor. TYPE SKELETON ONLY.
+ * Model tab v2 — the structured model editor. The type contracts.
  *
- * ⚠ NOTHING IN THIS DIRECTORY IS MOUNTED. There is no route, no tab
- * registration, no component and no runtime value here — these are type
- * declarations that pin the contracts in `docs/Design/MODEL-EDITOR-V2.md` (capital
- * D — the lowercase path does not exist and resolves only on macOS) so
- * the write-authority lane (Codex) and the dock lane (PX-A) have something
- * concrete to bind to. Integration/mounting is the technical lead's call, and
- * the design is Paul-vetoable before any of it is built.
+ * MOUNTED since the 16 Aug 2026 mount train: `ModelTabV2Panel` hosts the
+ * outline + detail region on the Model tab (via `ModelTabBody`), with factor
+ * value edits riding the canonical `factor_value_edit` transaction through
+ * `useModelEditAuthority`. These declarations pin the contracts in
+ * `docs/Design/MODEL-EDITOR-V2.md` (capital D — the lowercase path does not
+ * exist and resolves only on macOS). The design's §7 KEEP/CUT removal review
+ * still awaits Paul's verdict — the mount is ADDITIVE and removed nothing.
  *
  * WHY TYPES AND NOT PROSE. Three of the twelve defects the design documents are
  * hand-maintained mirrors (a dead search prop, a dead `isContested` prop, a
  * hand-copied band-threshold table). A contract expressed as prose becomes the
  * next one. Expressed as a total union it is a type error instead.
  *
- * ⚠ WHEN THIS DIRECTORY BECOMES LIVE, EXTEND THE RAW-WRITE GUARD.
- * `src/canvas/components/model-tab/__tests__/modelTabNoRawStoreWrites.sourceScan.spec.ts`
- * scans `src/canvas/components/model-tab/` ONLY. A v2 component tree living
- * here is therefore UNGUARDED against raw `updateNode` / `updateEdge` /
- * `updateEdgeData` calls — the exact class that guard exists to prevent, and the
- * exact way it was re-opened last time (the inspector was fixed, the Model tab
- * kept its own hand-rolled writes, and the killed class stayed live through a
- * different door). Widen its scope in the same PR that mounts anything here.
+ * THE RAW-WRITE GUARD IS WIDENED (the obligation the pre-mount header carried):
+ * `modelTabNoRawStoreWrites.sourceScan.spec.ts` now scans this directory too,
+ * and `modelTabV2Boundary.sourceScan.spec.ts` pins the mount path, bans direct
+ * writes in every file here, and pins the mount host's foreign hooks to the
+ * one authority seam.
  */
 
 // NOTE: this module deliberately imports NOTHING. Provenance travels as the raw

--- a/src/canvas/model-tab-v2/useOutlineKeyboard.ts
+++ b/src/canvas/model-tab-v2/useOutlineKeyboard.ts
@@ -1,7 +1,10 @@
 /**
  * Model tab v2 — KEYBOARD NAVIGATION (design §5.2).
  *
- * ⚠ UNMOUNTED. See `types.ts`.
+ * ⚠ NOT YET WIRED by the 16 Aug 2026 mount train (which mounted the outline +
+ * detail region + in-row editing; the input itself handles Enter/Escape).
+ * Tab-through-and-fix remains to be wired to the mounted outline. See
+ * `types.ts`.
  *
  * Enter states an intent · Escape cancels · Tab and Shift+Tab move to the next
  * and previous EDITABLE value in outline order · ⌘/Ctrl+Enter confirms a


### PR DESCRIPTION
## Model Editor v2 — mount train (PX-D BUILT-UNMOUNTED, closed)

**Verdict first:** the Model Editor v2 is now MOUNTED, ON, no flag, with its one live edit class riding the canonical confirm/edit transaction — and nothing user-visible was removed. The design's §7 KEEP/CUT removal review still awaits Paul's ruling; this train is deliberately additive.

### What mounted

`ModelTabV2Panel` (new, `src/canvas/model-tab-v2/ModelTabV2Panel.tsx`) renders at the top of the Model tab, hosted by `ModelTabBody` (`OutputsDock` untouched, per lane file-ownership). It mounts:

- the **outline** — one filterable listing of the whole model (goal, options, factors, outcomes/risks, relationships), seven groups, multi-open always;
- a **working filter** (design F3's fix, on a mounted surface for the first time);
- the **Plain | Advanced tier control, in the tab**, as a content switch only (F1's fix — the layout function takes no tier argument, structurally);
- the **detail region** on row selection, identity-gated (refuses to render a mismatched row's detail);
- **in-row factor-value editing** with the three-beat: input → proposal ("Nothing has changed yet") → **inline Confirm/Discard chips (ruling R9 — no modal)**.

NOT mounted, stated honestly: the repair queues (their write operations have no canonical carrier yet — contracts §1 C7/C9/C12/C15; every action on them is hard-disabled, so mounting them would add noise, not capability) and `useOutlineKeyboard` tab-through-and-fix (not yet wired; the input handles Enter/Escape).

### The write path, proven canonical

**The dispatch is `sendSystemEvent` with the typed `factor_value_edit` wire event, entered through the new `src/canvas/hooks/useModelEditAuthority.ts` — byte-parallel to the reference surface (`FactorsSection.handleValueCommit`, ROADMAP 2.121 slice 1 / #513 / 2.129(b)):**

1. `buildFactorValueEditEvent` (owns the scale contract; fails closed);
2. `captureOptimisticFactorEdit` (undo snapshot BEFORE the write);
3. sanctioned `setObservedValue` (value + raw_value + provenance stamp, one update — never a raw `updateNode`);
4. `sendSystemEvent(event, { optimisticFactorEdit: undo })` — the undo rides the send, so the conversation dispatcher owns refusal-revert and acceptance-stamp for immediate and deferred sends alike.

No second mutation path exists: the v2 boundary guard bans every direct write token in every v2 file (mount host included) and pins the host's foreign hooks to exactly `useModelEditAuthority`. No receipt is fabricated: the authority returns only the dispatch outcome, and the no-fake-`applied` scan still covers the whole directory — after Confirm the row renders the store, which the central machinery keeps honest (identical semantics to the v1 chips).

**Edits with no canonical carrier stay honestly disabled** (edge strength/likelihood/direction, option interventions, goal target, factor confirmation): wiring them through local-only writes would recreate design §2 F6 — a local write indistinguishable on screen from a server-backed one — inside the surface built to kill it.

### Removals

**Done (dead code, zero importers, contrast controls green at `4a337f70`):**
- `ModelTabProps` (`model-tab/types.ts`) — design F15: no importer anywhere in `src/`, drifted from the live inline props.
- `mapSourceToTooltip` (`model-tab/utils.ts`) — no importer.
- `isGenericUnit` (`model-tab/utils.ts`) — no production importer; the live generic-unit behaviour stays pinned through `formatValueWithUnit`'s own spec.

**Proposed, NOT done (user-visible and/or awaiting Paul's §7 ruling):**
- The entire §7.0 removal list (EntityBar, the unmapped-options coaching card, card-expand disclosures, `factor-{id}-refine-range`, the coaching dismiss `×`, the expert framing border, etc.) — **the design says nothing is removed until Paul rules, and this PR honours that.**
- The five local-only edge/option/goal writers in `useInspectorMutations`/sections — they are LIVE v1 editing surfaces; superseding them requires the canonical carriers to exist first.
- The v1 sections themselves (the v2 outline currently renders above them; executing the §7 MERGE/CUT verdicts is the follow-up train once Paul rules).

### Guards (the §9.1 mount obligations, discharged)

- `modelTabNoRawStoreWrites.sourceScan` **widened** to scan `src/canvas/model-tab-v2/` recursively — the exact obligation the design records for whoever mounts first.
- `modelTabV2Boundary.sourceScan` **restructured, not deleted**: the retired "unmounted" claim is replaced by *mounted exactly once, from `ModelTabBody.tsx`* (exact-set equality, red in both directions: silent unmount AND second mount path); the direct-write ban and the fabricated-`applied` ban stay for every v2 file.

### Evidence

- **RED-first at pristine `4a337f70`:** `ModelTabV2Panel.spec.tsx` failed at collect (module absent); `ModelTabBody.mountsModelEditorV2.spec.tsx` failed both tests (`model-tab-v2-panel` not found). Both named before implementation.
- **New specs collect non-zero by name:** 14 (panel) + 2 (mount), all green post-implementation; full v2 directory 174/174.
- **Mutation kit (6 mutants, throwaway worktree outside the repo root, isolation proven by sentinel WRITE-test + inode comparison, applied-check per mutant scoped to `src/`, HEAD-relative restores, leading + trailing pristine controls green):**
  - M1 route-around-dispatch (send deleted) → RED (the brief's named mutant);
  - M2 undo dropped from the send → RED on a different assertion (discriminating pair);
  - M3 raw `updateNode` in the container → widened raw-write guard RED;
  - M4 panel unmounted from render → mount spec RED;
  - M5 fabricated `applied` state in the container → boundary scan RED;
  - M6 propose-commits-early → "nothing changes until Confirm" RED.
- Six pre-existing `ModelTabBody.spec` assertions re-bound by identity (`within(...)`) — the additive mount made their bare `getByText` ambiguous; the v1 surfaces they pin are unchanged.
- Gates at this tip (CI order, derived from the Staging Gate's own jobs):
  - `pnpm run typecheck` — **PASSED** (coverage + ratchet; "17 fixed since baseline, none added" — the `--update-baseline` invitation declined, the shrink is not this lane's to bank);
  - `ci:guard:zustand` / `ci:guard:starters` / `check:vendor` / `ci:guard:schemas-version` — **all PASSED**;
  - targeted suites (all v2 specs, all model-tab specs, every spec that renders `ModelTabBody`/`OutputsDock`): **green** — except `OutputsDock.conversationSingleton.spec.tsx`, which is **pre-existing flaky under load**: 6/12 fail at PRISTINE `4a337f70` (fresh worktree control), 4/12 solo on this branch, count varies with machine contention; no consistent delta attributable to the mount. Reported, not "fixed" (scope rule).
  - full `pnpm run lint` and full `vitest` and `pnpm run build` were still running locally at PR time on a heavily shared machine — the required **Staging Gate** on this PR is the authority and is being polled to conclusion; results will be appended as a comment.

### Premise refinements (deliverables, not blockers)

1. **"The canonical transactional confirm/edit path is frozen" is true at the PATTERN level, not the API level.** The UI wire vocabulary at `4a337f70` carries exactly three server-authoritative edit carriers (`factor_value_edit`, `prior_range_edit` — emitted inside the sanctioned `setPriorRange` — and `edge_adjudication`). There is **no `edge_strength_edit`** in `WIRE_SYSTEM_EVENT_TYPES`, and no receipt-bearing `EditProposalHandle` exists anywhere. The mount therefore wires what is canonical and keeps the rest honestly disabled.
2. **The design's receipt semantics (`applied` only from a receipt) cannot be implemented on today's dispatcher** — a deferred send's promise resolves `SEND_DEFERRED` before the turn exists, and the dispatcher resolves refusal/acceptance centrally without handing back a receipt. Faking it from an echo is exactly what contracts §1 C11 forbids; documented at the authority seam where the real receipt API will plug in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
