### PR TITLE
feat(2.1257): in-session draft recovery after stream loss + L-83 reveal re-pin + comment correction

### DIFF
--- a/src/canvas/components/DraftLoadingAnimation.tsx
+++ b/src/canvas/components/DraftLoadingAnimation.tsx
@@ -272,6 +272,43 @@ export const EARLY_STOP_UNCONFIRMED_NOTICE =
   'You stopped this draft. We could not reach the server to cancel it, so it may still be saved \u2014 reload to see what your canvas holds.'
 
 /**
+ * \u2500\u2500 THE TWO RECOVERY NOTICES (ROADMAP 2.1257) \u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500
+ *
+ * Emitted ONLY after the in-session recovery read has RETURNED a graph and the
+ * merge has APPLIED it (`recoverDraftFromServer` \u2192 `hydrateCanvasFromServer`
+ * \u2192 `'merged'`). Never before the fetch resolves \u2014 a past-tense sentence about
+ * an unmeasured state is a fabrication even when it later proves true, and the
+ * call site is structured so these strings cannot render on any other outcome
+ * (a 404/failure falls through to the standing unsettled notices above).
+ *
+ * TWO strings, not one, per the three-strings-not-one rule the notices above
+ * established: a connection that dropped and a turn that ended in a
+ * server-reported error are different facts, and "the connection dropped"
+ * would be false for the second.
+ *
+ * What each sentence claims, and why the claim is licensed:
+ *   - "this draft had already been saved" \u2014 the scenario-graph read returned a
+ *     graph for THIS scenario whose node identities overlap the GRAPH_READY
+ *     preview (the merge's own acceptance guard), i.e. the server holds this
+ *     draft's committed row. Read back, not inferred.
+ *   - "the saved model is now on your canvas" \u2014 `mergeServerGraphOnHydrate`
+ *     applied the server's values before this string was chosen.
+ *   - No claim the model is finished, fresh, or worth acting on; no verdict,
+ *     no forecast \u2014 the same frame-licence bar as every notice above
+ *     (`narrationHonesty.invariant.spec.ts` governs these the moment they
+ *     exist, via the `*_NOTICE` completeness check).
+ *
+ * Deliberately free of em dashes and bullet glyphs so `safeRichText`'s
+ * house-style substitutions leave them byte-stable in the DOM (same rule as
+ * DRAFT_FAILED_MODEL_KEPT_NOTICE).
+ */
+export const DRAFT_RECOVERED_STREAM_LOSS_NOTICE =
+  'The connection dropped before the reply arrived, but this draft had already been saved. The saved model is now on your canvas, and you can keep working from it.'
+
+export const DRAFT_RECOVERED_TERMINAL_ERROR_NOTICE =
+  'Drafting failed after your model reached the canvas, but the draft itself had already been saved. The saved model is now on your canvas, and you can keep working from it.'
+
+/**
  * Every narration table this module owns, keyed by name.
  *
  * DERIVED, so the cross-surface honesty suite cannot miss one. The suite used

--- a/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
+++ b/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
@@ -59,6 +59,8 @@ import {
   UNSETTLED_DRAFT_NOTICE,
   STOPPED_DRAFT_NOTICE,
   DRAFT_FAILED_MODEL_KEPT_NOTICE,
+  DRAFT_RECOVERED_STREAM_LOSS_NOTICE,
+  DRAFT_RECOVERED_TERMINAL_ERROR_NOTICE,
   EARLY_STOP_NOT_SAVED_NOTICE,
   EARLY_STOP_ALREADY_SAVED_NOTICE,
   EARLY_STOP_UNCONFIRMED_NOTICE,
@@ -294,6 +296,12 @@ const FRAME_LICENSED_STRINGS: ReadonlyArray<readonly [string, string]> = [
   ['UNSETTLED_DRAFT_NOTICE', UNSETTLED_DRAFT_NOTICE],
   ['STOPPED_DRAFT_NOTICE', STOPPED_DRAFT_NOTICE],
   ['DRAFT_FAILED_MODEL_KEPT_NOTICE', DRAFT_FAILED_MODEL_KEPT_NOTICE],
+  // The two recovery notices (ROADMAP 2.1257). Licensed by MORE than a held
+  // frame — a server response whose graph the merge has applied — but held to
+  // the same bar: they may say the saved model is on the canvas, they may not
+  // judge it, call it finished, or forecast anything.
+  ['DRAFT_RECOVERED_STREAM_LOSS_NOTICE', DRAFT_RECOVERED_STREAM_LOSS_NOTICE],
+  ['DRAFT_RECOVERED_TERMINAL_ERROR_NOTICE', DRAFT_RECOVERED_TERMINAL_ERROR_NOTICE],
   // The three explicit-Stop notices (Codex P0 stop-fence). They are shown when
   // drafting has ENDED rather than while it runs, but they are held to the same
   // bar: the frame licence lets them say the canvas is or is not changed, never
@@ -395,6 +403,8 @@ describe('every notice this module exports is governed (trap 12, round 2)', () =
     // And the manifest is named, so a reviewer sees what was actually covered.
     expect(exportedNotices.sort()).toEqual([
       'DRAFT_FAILED_MODEL_KEPT_NOTICE',
+      'DRAFT_RECOVERED_STREAM_LOSS_NOTICE',
+      'DRAFT_RECOVERED_TERMINAL_ERROR_NOTICE',
       'EARLY_STOP_ALREADY_SAVED_NOTICE',
       'EARLY_STOP_NOT_SAVED_NOTICE',
       'EARLY_STOP_UNCONFIRMED_NOTICE',

--- a/src/canvas/conversation/__tests__/ChatThread.revealRepin.spec.tsx
+++ b/src/canvas/conversation/__tests__/ChatThread.revealRepin.spec.tsx
@@ -1,0 +1,180 @@
+/**
+ * L-83 — the reveal re-pin (ISSUE-LEDGER, feedback-2026-08-16).
+ *
+ * THE WITNESSED DEFECT: "Post-timeout Retry button 100% unclickable — 0/121
+ * hit-test points reach it (fully occluded by the chat composer)". Derived at
+ * this tip, the mechanism is NOT z-order: a notice added while the thread is
+ * HIDDEN (minimised floating panel `display:none`; collapsed dock tab) cannot
+ * be scrolled to — `scrollIntoView` on a box-less container is a silent no-op
+ * — and nothing re-pinned when the surface was revealed, so the newest
+ * message and its controls laid out below the visible band, where every
+ * hit-test point resolves to the composer strip that sits under the thread.
+ *
+ * THE FIX under test: `useSmartScroll` observes the scroll container with a
+ * ResizeObserver; a 0 → >0 height transition (hidden boxes have zero size) is
+ * the reveal, and it re-pins to the bottom INSTANTLY unless the user had
+ * deliberately scrolled up.
+ *
+ * TRAP 3 HONESTY: jsdom cannot prove visibility or perform real hit-testing.
+ * These tests pin the MECHANISM — the observer is attached to the real scroll
+ * container (identity-bound via its testid), the reveal transition triggers
+ * an instant bottom pin, and the user's deliberate scroll position is never
+ * stolen. The occlusion itself needs the real-browser witness flagged in the
+ * PR body.
+ *
+ * MUTANT PAIR (rider obligation): removing the reveal re-pin must RED the
+ * first test; removing the scrolled-up guard must RED the second. Neither
+ * alone shows binding — the pair does.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+
+import { ChatThread } from '../zones/ChatThread'
+import type { ConversationMessage } from '../types'
+
+type ROCallback = (entries: Array<{ contentRect: { height: number } }>) => void
+
+/** Capturing ResizeObserver: records observed elements, lets tests drive it. */
+class CapturingResizeObserver {
+  static instances: CapturingResizeObserver[] = []
+  observed: Element[] = []
+  callback: ROCallback
+  constructor(cb: ROCallback) {
+    this.callback = cb
+    CapturingResizeObserver.instances.push(this)
+  }
+  observe(el: Element) {
+    this.observed.push(el)
+  }
+  unobserve() {}
+  disconnect() {}
+}
+
+const savedResizeObserver = global.ResizeObserver
+
+function makeMessages(): ConversationMessage[] {
+  return [
+    {
+      id: 'u1',
+      role: 'user',
+      content: 'Should we build or buy?',
+      timestamp: new Date(),
+    },
+    {
+      id: 'a1',
+      role: 'assistant',
+      synthetic: true,
+      content: 'Drafting ended before your model values arrived.',
+      timestamp: new Date(),
+    },
+  ] as ConversationMessage[]
+}
+
+function renderThread() {
+  return render(
+    <ChatThread
+      messages={makeMessages()}
+      isThinking={false}
+      longRunningHint={null}
+      nodeCount={5}
+      patchBlockStates={new Map()}
+      patchRejections={new Map()}
+      onChipClick={async () => {}}
+      onPatchAccept={() => {}}
+      onPatchDismiss={() => {}}
+      onFeedback={() => {}}
+      onRetry={() => {}}
+    />,
+  )
+}
+
+/** The observer bound to the thread's scroll container — identity, not index. */
+function observerForThread(threadEl: Element): CapturingResizeObserver {
+  const bound = CapturingResizeObserver.instances.filter((i) =>
+    i.observed.includes(threadEl),
+  )
+  // Exactly one owner: a second observer on the same container would mean a
+  // second scroll authority.
+  expect(bound).toHaveLength(1)
+  return bound[0]
+}
+
+beforeEach(() => {
+  CapturingResizeObserver.instances = []
+  global.ResizeObserver = CapturingResizeObserver as unknown as typeof ResizeObserver
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+afterEach(() => {
+  global.ResizeObserver = savedResizeObserver
+})
+
+describe('the reveal re-pin (L-83 mechanism)', () => {
+  it('attaches a ResizeObserver to the scroll container and re-pins INSTANTLY on the hidden→visible transition', () => {
+    renderThread()
+    const threadEl = screen.getByTestId('chat-thread')
+    const observer = observerForThread(threadEl)
+
+    // Mount scrolling has happened (smooth, from the message effect); the
+    // reveal pin must be a NEW, instant call. Reset to isolate it.
+    ;(Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>).mockClear()
+
+    // jsdom boxes are zero-height, which is exactly the hidden state:
+    // lastHeight initialised to 0. Drive the reveal.
+    act(() => {
+      observer.callback([{ contentRect: { height: 420 } }])
+    })
+
+    const calls = (Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>).mock.calls
+    expect(calls).toHaveLength(1)
+    // Instant, never smooth: an animated flight on reveal is surprise motion.
+    expect(calls[0][0]).toEqual({ behavior: 'auto' })
+
+    // A later ordinary resize (visible → visible) must NOT re-pin — the pin
+    // is licensed by the reveal transition only.
+    ;(Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>).mockClear()
+    act(() => {
+      observer.callback([{ contentRect: { height: 500 } }])
+    })
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled()
+  })
+
+  it('never steals the position of a user who deliberately scrolled up (the opposite-direction twin)', () => {
+    renderThread()
+    const threadEl = screen.getByTestId('chat-thread')
+    const observer = observerForThread(threadEl)
+
+    // Make the container report "scrolled up": far from the bottom.
+    Object.defineProperty(threadEl, 'scrollTop', { value: 0, configurable: true })
+    Object.defineProperty(threadEl, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(threadEl, 'clientHeight', { value: 100, configurable: true })
+    fireEvent.scroll(threadEl)
+
+    ;(Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>).mockClear()
+    act(() => {
+      observer.callback([{ contentRect: { height: 420 } }])
+    })
+
+    expect(Element.prototype.scrollIntoView).not.toHaveBeenCalled()
+  })
+
+  it('positive control: without the scrolled-up state the same drive DOES pin — the twin above is not vacuous', () => {
+    renderThread()
+    const threadEl = screen.getByTestId('chat-thread')
+    const observer = observerForThread(threadEl)
+
+    // Same geometry, but NEAR the bottom (within the 60px threshold), so the
+    // scroll event records "not scrolled up".
+    Object.defineProperty(threadEl, 'scrollTop', { value: 940, configurable: true })
+    Object.defineProperty(threadEl, 'scrollHeight', { value: 1000, configurable: true })
+    Object.defineProperty(threadEl, 'clientHeight', { value: 100, configurable: true })
+    fireEvent.scroll(threadEl)
+
+    ;(Element.prototype.scrollIntoView as ReturnType<typeof vi.fn>).mockClear()
+    act(() => {
+      observer.callback([{ contentRect: { height: 420 } }])
+    })
+
+    expect(Element.prototype.scrollIntoView).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/canvas/conversation/__tests__/useConversation.draftRecovery.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.draftRecovery.spec.ts
@@ -321,6 +321,36 @@ describe('stream loss + fallback decline — the server HOLDS the draft', () => 
     expect(chip).toBeDefined()
   })
 
+  it("'unchanged' is NOT a recovery: a token-identical server graph means this draft committed nothing new (reviewer blocker pin)", async () => {
+    // Precondition: a PREVIOUS hydration already applied exactly the graph the
+    // server holds — the identity token matches what the read returns, so
+    // hydrateCanvasFromServer short-circuits to 'unchanged' WITHOUT merging.
+    // Claiming recovery here would present pre-draft state as the recovered
+    // draft ("the saved model is now on your canvas" over the preview's zeroed
+    // values) and open the run gate on unsettled values. The reviewer's mutant
+    // (treat 'unchanged' as recovery) survived the original battery — this pin
+    // is what makes it bite.
+    useCanvasStore.setState({
+      serverGraphIdentity: { value: 'srv-hash-1', projectionVersion: 'p1' },
+    } as never)
+    mockFetchScenarioGraph.mockResolvedValue(serverGraphResult())
+    const result = await driveStreamLossDecline()
+
+    // The read WAS attempted — this test is about the outcome mapping, not
+    // about skipping the fetch (M1 owns that direction).
+    expect(mockFetchScenarioGraph).toHaveBeenCalledTimes(1)
+
+    // Nothing merged: the preview's zeroed values are untouched.
+    expect(canvasEdgeWeight('d1', 'opt_a')).toBe(0)
+
+    // Standing unsettled behaviour, and NO recovery claim in either voice.
+    expect(useDraftStore.getState().draftStreamPhase).toBe('unsettled')
+    const contents = result.current.messages.map((m) => m.content)
+    expect(contents).toContain(UNSETTLED_DRAFT_NOTICE)
+    expect(contents).not.toContain(DRAFT_RECOVERED_STREAM_LOSS_NOTICE)
+    expect(contents).not.toContain(DRAFT_RECOVERED_TERMINAL_ERROR_NOTICE)
+  })
+
   it('a transport-dead recovery read is a failure, not a recovery — same standing behaviour', async () => {
     // The read leg itself can die (the 2.1251 class). `unusable` must route
     // exactly like 404: no claim, standing notice, chip present.

--- a/src/canvas/conversation/__tests__/useConversation.draftRecovery.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.draftRecovery.spec.ts
@@ -1,0 +1,424 @@
+/**
+ * ROADMAP 2.1257 — in-session draft recovery after stream loss.
+ *
+ * THE SEAM. When a draft's SSE stream dies and the buffered fallback cannot
+ * re-draft (CEE's continuation guard declines on a committed scenario), the
+ * server usually HOLDS the drafted graph — and until this change the UI's only
+ * reader of it was boot hydration, so the user was offered "Start a new draft"
+ * for a model one request away. These tests pin the new order: the scenario-
+ * graph read is ATTEMPTED FIRST, and the copy is chosen from its RESULT.
+ *
+ * Harness is streamedDraftTurn.spec.ts's: a real ReadableStream through the
+ * real streamStageFrames → consumeStreamedDraftTurn → fallback → parse chain,
+ * with only the network seams mocked. The recovery read is mocked at the
+ * ADAPTER (`fetchScenarioGraph`) so the REAL ingestion authority runs — the
+ * same `hydrateCanvasFromServer` → `mergeServerGraphOnHydrate` chain boot
+ * hydration uses. Mocking any deeper would let a second ingestion path hide.
+ *
+ * MUTATION OBLIGATIONS (run in a throwaway worktree, per the lane brief):
+ *   M1 — call site skips the recovery fetch (straight to start-new-draft):
+ *        "recovers the committed draft…" and the terminal-error twin RED.
+ *   M2 — recovery claims success on a 404 (`notReadable` → 'recovered'):
+ *        "states the standing truth on 404…" (the honesty pin) REDs.
+ *   M3 — recovery does not release the unsettled phase on success:
+ *        the phase/run-gate assertions in the success tests RED.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+import { useConversation, START_NEW_DRAFT_CHIP_ID } from '../useConversation'
+import { useCanvasStore } from '../../store'
+import { useDraftStore, draftStreamPhaseFor } from '../../stores/draftStore'
+import { canRunAnalysis, DRAFT_VALUES_UNSETTLED_REFUSAL } from '../../utils/canRunAnalysis'
+import {
+  UNSETTLED_DRAFT_NOTICE,
+  DRAFT_FAILED_MODEL_KEPT_NOTICE,
+  DRAFT_RECOVERED_STREAM_LOSS_NOTICE,
+  DRAFT_RECOVERED_TERMINAL_ERROR_NOTICE,
+} from '../../components/DraftLoadingAnimation'
+import type { ScenarioGraphResult } from '../../../adapters/cee/scenarioGraph'
+import wireFixture from './fixtures/cee-draft-goal-constraints-wire.json'
+
+// ---------------------------------------------------------------------------
+// Network seams — the only things mocked
+// ---------------------------------------------------------------------------
+
+const mockOpenStream = vi.fn()
+const mockCallV5Turn = vi.fn()
+const mockFetchScenarioGraph = vi.fn<unknown[], Promise<ScenarioGraphResult>>()
+const mockStopV5Turn = vi.fn((..._args: unknown[]) =>
+  Promise.resolve({ kind: 'not_saved' as const }),
+)
+
+vi.mock('../../../v5/stopTurn', () => ({
+  stopV5Turn: (...args: unknown[]) => mockStopV5Turn(...args),
+  getV5StopEndpoint: () => 'https://cee.test/proxy/v5/turn/stop',
+  STOP_ACK_BUDGET_MS: 5000,
+}))
+
+vi.mock('../../../v5/streamedTurnTransport', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/streamedTurnTransport')>()
+  return {
+    ...actual,
+    openV5TurnStream: (...args: unknown[]) => mockOpenStream(...args),
+  }
+})
+
+vi.mock('../../../v5/v5Adapter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/v5Adapter')>()
+  return {
+    ...actual,
+    callV5Turn: (...args: unknown[]) => mockCallV5Turn(...args),
+    getV5Endpoint: () => 'https://cee.test/proxy/v5/turn',
+  }
+})
+
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  return { ...actual, isV5Eligible: () => ({ eligible: true }) }
+})
+
+vi.mock('../../../lib/supabase', () => ({
+  getUserId: async () => null,
+  getSessionIdentity: async () => ({ userId: null, accessToken: null }),
+}))
+
+vi.mock('../../../services/scenarioService', () => ({ loadScenario: async () => null }))
+
+// The recovery read, mocked at the ADAPTER so hydrateCanvasFromServer and
+// mergeServerGraphOnHydrate — the one ingestion authority — run for real.
+vi.mock('../../../adapters/cee/scenarioGraph', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../adapters/cee/scenarioGraph')>()
+  return {
+    ...actual,
+    fetchScenarioGraph: (...args: unknown[]) => mockFetchScenarioGraph(...args),
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Fixtures — the live 29 Jul wire shape (same provenance as streamedDraftTurn)
+// ---------------------------------------------------------------------------
+
+const TERMINAL_BODY = wireFixture as unknown as Record<string, unknown>
+const TERMINAL_GRAPH = TERMINAL_BODY.draft_graph as {
+  nodes: Array<Record<string, unknown>>
+  edges: Array<Record<string, unknown>>
+}
+
+/**
+ * The GRAPH_READY frame's graph: SAME identities, values zeroed — the frame
+ * contract ("identity is stable, values settle"). Derived from the terminal
+ * graph so the two cannot drift and hollow out the value assertions below.
+ */
+const READY_GRAPH = {
+  nodes: TERMINAL_GRAPH.nodes.map((n) => ({ id: n.id, kind: n.kind, label: n.label })),
+  edges: TERMINAL_GRAPH.edges.map((e) => ({ from: e.from, to: e.to, strength: { mean: 0 } })),
+}
+
+/**
+ * What the SERVER holds after the commit: `scenarios.graph` verbatim — for a
+ * committed draft that is the terminal graph, values included. This is the
+ * body the recovery read returns.
+ */
+function serverGraphResult(): ScenarioGraphResult {
+  return {
+    status: 'graph',
+    graph: { nodes: TERMINAL_GRAPH.nodes, edges: TERMINAL_GRAPH.edges },
+    briefText: null,
+    notModelled: null,
+    identity: { value: 'srv-hash-1', projectionVersion: 'p1' },
+    layoutPresent: false,
+    requestId: 'req-recovery-1',
+  }
+}
+
+function frame(obj: Record<string, unknown>): string {
+  return `event: stage\ndata: ${JSON.stringify(obj)}\n\n`
+}
+const F_DRAFTING = frame({ stage: 'DRAFTING', seq: 0, status: 'in_progress' })
+const F_GRAPH_READY = frame({
+  stage: 'GRAPH_READY',
+  seq: 2,
+  status: 'in_progress',
+  schema_version: 'v3',
+  elapsed_ms: 35_834,
+  graph: READY_GRAPH,
+})
+
+function controllableStream() {
+  const encoder = new TextEncoder()
+  let ctrl!: ReadableStreamDefaultController<Uint8Array>
+  const body = new ReadableStream<Uint8Array>({
+    start(c) {
+      ctrl = c
+    },
+  })
+  const res = new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  })
+  const settle = () =>
+    act(async () => {
+      await new Promise((r) => setTimeout(r, 0))
+      await new Promise((r) => setTimeout(r, 0))
+    })
+  let closed = false
+  return {
+    response: res,
+    async push(text: string) {
+      if (!closed) ctrl.enqueue(encoder.encode(text))
+      await settle()
+    },
+    async fail() {
+      if (!closed) {
+        closed = true
+        try {
+          ctrl.error(new Error('socket hung up'))
+        } catch {
+          /* already closed */
+        }
+      }
+      await settle()
+    },
+  }
+}
+
+const SCENARIO = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
+const BRIEF = 'Should we build or buy a billing system for our new SaaS product?'
+
+/** CEE's decline prose — the buffered fallback on a committed scenario. */
+const DECLINE_RESPONSE = {
+  kind: 'response' as const,
+  response: {
+    response_version: 2,
+    assistant_text: 'Your billing system decision model is already drafted with four options.',
+    blocks: [],
+  },
+}
+
+/**
+ * Drive: stream dies after GRAPH_READY → buffered fallback DECLINES → the
+ * unsettled path, where recovery now runs. Returns the hook handle.
+ */
+async function driveStreamLossDecline() {
+  const stream = controllableStream()
+  mockOpenStream.mockResolvedValue(stream.response)
+  mockCallV5Turn.mockResolvedValue(DECLINE_RESPONSE)
+  const { result } = renderHook(() => useConversation())
+  let sent!: Promise<void>
+  await act(async () => {
+    sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+  })
+  await stream.push(F_DRAFTING + F_GRAPH_READY)
+  await stream.fail()
+  await act(async () => {
+    await sent
+  })
+  return result
+}
+
+function runGate() {
+  const currentScenarioId = useCanvasStore.getState().currentScenarioId
+  return canRunAnalysis({
+    graphHealth: null,
+    readiness: null,
+    hasBlockers: false,
+    nodeCount: useCanvasStore.getState().nodes.length,
+    draftStreamPhase: draftStreamPhaseFor(useDraftStore.getState(), currentScenarioId),
+  })
+}
+
+/** Identity-bound edge lookup (trap 19): endpoint pair, never a value hunt. */
+function canvasEdgeWeight(sourceId: string, targetId: string): number | undefined {
+  const edge = useCanvasStore
+    .getState()
+    .edges.find((e: { source: string; target: string }) => e.source === sourceId && e.target === targetId) as
+    | { data?: { weight?: number } }
+    | undefined
+  expect(edge, `edge ${sourceId}->${targetId} must exist on the canvas`).toBeDefined()
+  return edge?.data?.weight
+}
+
+beforeEach(() => {
+  mockOpenStream.mockReset()
+  mockCallV5Turn.mockReset()
+  mockFetchScenarioGraph.mockReset()
+  useDraftStore.getState().resetDraft()
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO,
+    nodes: [],
+    edges: [],
+    history: { past: [], future: [] },
+    _internal: {
+      ...(useCanvasStore.getState() as unknown as { _internal: object })._internal,
+      lastHistoryHash: null,
+    },
+    ceeAnalysisReady: null,
+    lastAuthoritativeGraph: null,
+    serverGraphIdentity: null,
+    results: { status: 'idle' } as never,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+  } as never)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+
+describe('stream loss + fallback decline — the server HOLDS the draft', () => {
+  it('recovers the committed draft in-session: server values land, phase settles, gate opens, no start-new-draft chip', async () => {
+    mockFetchScenarioGraph.mockResolvedValue(serverGraphResult())
+    const result = await driveStreamLossDecline()
+
+    // The read was attempted, once, for THIS scenario (identity, not luck).
+    expect(mockFetchScenarioGraph).toHaveBeenCalledTimes(1)
+    expect(mockFetchScenarioGraph.mock.calls[0][0]).toBe(SCENARIO)
+
+    // The SERVER's values are on the canvas, through the one ingestion
+    // authority. Identity-bound discriminating pair: two different edges,
+    // two different server values — a merge that wrote one value everywhere,
+    // or matched by index, fails one of the two.
+    expect(canvasEdgeWeight('d1', 'opt_a')).toBe(1)
+    expect(canvasEdgeWeight('opt_a', 'fac_year_budget')).toBe(0.5)
+
+    // The unsettled state is genuinely settled: phase released, gate open.
+    expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+    expect(runGate().allowed).toBe(true)
+
+    // The copy states the recovery — cause-keyed to the dropped connection —
+    // and the failure copy with its chip never renders.
+    const contents = result.current.messages.map((m) => m.content)
+    expect(contents).toContain(DRAFT_RECOVERED_STREAM_LOSS_NOTICE)
+    expect(contents).not.toContain(UNSETTLED_DRAFT_NOTICE)
+    const chips = result.current.messages.flatMap((m) => m.actionChips ?? [])
+    expect(chips.some((c) => c.id === START_NEW_DRAFT_CHIP_ID)).toBe(false)
+  })
+
+  it('states the standing truth on 404: unsettled notice + start-new-draft chip, gate shut, and NO recovery claim (the honesty pin)', async () => {
+    // CEE's 404 is a deliberate "no readable graph" — recovery must not be
+    // claimed, and the pre-existing behaviour must stand byte for byte.
+    mockFetchScenarioGraph.mockResolvedValue({ status: 'notReadable' })
+    const result = await driveStreamLossDecline()
+
+    expect(mockFetchScenarioGraph).toHaveBeenCalledTimes(1)
+
+    // Nothing recovered: the preview's zeroed values are untouched.
+    expect(canvasEdgeWeight('d1', 'opt_a')).toBe(0)
+
+    // The standing unsettled behaviour, unchanged.
+    expect(useDraftStore.getState().draftStreamPhase).toBe('unsettled')
+    expect(runGate().reason).toBe(DRAFT_VALUES_UNSETTLED_REFUSAL)
+    const contents = result.current.messages.map((m) => m.content)
+    expect(contents).toContain(UNSETTLED_DRAFT_NOTICE)
+    // The honesty pin: no sentence claims a recovery that did not happen.
+    expect(contents).not.toContain(DRAFT_RECOVERED_STREAM_LOSS_NOTICE)
+    expect(contents).not.toContain(DRAFT_RECOVERED_TERMINAL_ERROR_NOTICE)
+    const chip = result.current.messages
+      .flatMap((m) => m.actionChips ?? [])
+      .find((c) => c.id === START_NEW_DRAFT_CHIP_ID)
+    expect(chip).toBeDefined()
+  })
+
+  it('a transport-dead recovery read is a failure, not a recovery — same standing behaviour', async () => {
+    // The read leg itself can die (the 2.1251 class). `unusable` must route
+    // exactly like 404: no claim, standing notice, chip present.
+    mockFetchScenarioGraph.mockResolvedValue({ status: 'unusable' })
+    const result = await driveStreamLossDecline()
+
+    expect(useDraftStore.getState().draftStreamPhase).toBe('unsettled')
+    const contents = result.current.messages.map((m) => m.content)
+    expect(contents).toContain(UNSETTLED_DRAFT_NOTICE)
+    expect(contents).not.toContain(DRAFT_RECOVERED_STREAM_LOSS_NOTICE)
+  })
+})
+
+describe('terminal error with kept model — the second unsettled cause', () => {
+  async function driveTerminalErrorKeptModel() {
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    // Terminal COMPLETE with an error status that does NOT prove commit
+    // failure → the model is kept and marked unsettled with the
+    // terminal_error_model_kept cause (F1 reconciliation). Payload is the
+    // 8 Aug measured CEE class, byte-shaped as in
+    // useConversation.streamedDraftTerminalError.spec.tsx.
+    await stream.push(
+      F_DRAFTING +
+        F_GRAPH_READY +
+        frame({
+          stage: 'COMPLETE',
+          seq: 4,
+          status: 'complete',
+          status_code: 504,
+          payload: {
+            error: 'UPSTREAM_TIMEOUT',
+            boundary: 'B1',
+            direction: 'egress',
+            validator: 'draft_graph_pipeline',
+            details: { retryable: true, reason: 'draft_graph_cee_timeout' },
+          },
+        }),
+    )
+    await act(async () => {
+      await sent
+    })
+    return result
+  }
+
+  it('recovers via the same read and keys the copy to the terminal-error cause', async () => {
+    mockFetchScenarioGraph.mockResolvedValue(serverGraphResult())
+    const result = await driveTerminalErrorKeptModel()
+
+    expect(mockFetchScenarioGraph).toHaveBeenCalledTimes(1)
+    expect(canvasEdgeWeight('d1', 'opt_a')).toBe(1)
+    expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+
+    const contents = result.current.messages.map((m) => m.content)
+    // Cause-keyed: "the connection dropped" would be false here.
+    expect(contents).toContain(DRAFT_RECOVERED_TERMINAL_ERROR_NOTICE)
+    expect(contents).not.toContain(DRAFT_RECOVERED_STREAM_LOSS_NOTICE)
+    expect(contents).not.toContain(DRAFT_FAILED_MODEL_KEPT_NOTICE)
+  })
+
+  it('keeps the standing kept-model notice when the read finds nothing', async () => {
+    mockFetchScenarioGraph.mockResolvedValue({ status: 'notReadable' })
+    const result = await driveTerminalErrorKeptModel()
+
+    expect(useDraftStore.getState().draftStreamPhase).toBe('unsettled')
+    const contents = result.current.messages.map((m) => m.content)
+    expect(contents).toContain(DRAFT_FAILED_MODEL_KEPT_NOTICE)
+    expect(contents).not.toContain(DRAFT_RECOVERED_TERMINAL_ERROR_NOTICE)
+  })
+})
+
+describe('recovery is failure-path-only', () => {
+  it('a draft that completes normally never touches the scenario-graph read', async () => {
+    const stream = controllableStream()
+    mockOpenStream.mockResolvedValue(stream.response)
+    const { result } = renderHook(() => useConversation())
+    let sent!: Promise<void>
+    await act(async () => {
+      sent = result.current.sendMessage(BRIEF, { turnType: 'explicit_generate' }) as Promise<void>
+    })
+    await stream.push(
+      F_DRAFTING +
+        F_GRAPH_READY +
+        frame({ stage: 'COMPLETE', seq: 4, status: 'complete', status_code: 200, payload: TERMINAL_BODY }),
+    )
+    await act(async () => {
+      await sent
+    })
+
+    expect(useDraftStore.getState().draftStreamPhase).toBe('idle')
+    expect(mockFetchScenarioGraph).not.toHaveBeenCalled()
+    const contents = result.current.messages.map((m) => m.content)
+    expect(contents).not.toContain(DRAFT_RECOVERED_STREAM_LOSS_NOTICE)
+    expect(contents).not.toContain(DRAFT_RECOVERED_TERMINAL_ERROR_NOTICE)
+  })
+})

--- a/src/canvas/conversation/hooks/useSmartScroll.ts
+++ b/src/canvas/conversation/hooks/useSmartScroll.ts
@@ -45,6 +45,43 @@ export function useSmartScroll({ messageCount, isThinking }: UseSmartScrollDeps)
     }
   }, [messageCount, isThinking, scrollToBottom])
 
+  // ── L-83: re-pin to bottom when the thread is REVEALED ────────────────────
+  //
+  // A message that arrives while the thread is HIDDEN — the floating panel
+  // minimised (`display:none`), or the collapsed dock's Olumi tab — cannot be
+  // scrolled to: `scrollIntoView` on a container with no boxes is a silent
+  // no-op, and nothing here re-ran when the surface came back. So the newest
+  // message (on the witnessed journey, a failure notice whose Retry affordance
+  // is the recovery path) laid out BELOW the visible band, and every
+  // hit-test point of its controls resolved to the composer strip under the
+  // thread — the ISSUE-LEDGER L-83 "0/121 points, fully occluded by the chat
+  // composer" measurement. The z-order was never the defect; the missing
+  // reveal re-pin was.
+  //
+  // A hidden element has zero border-box size, so a ResizeObserver on the
+  // list sees the reveal as a 0 → >0 transition. Re-pin then, INSTANTLY (an
+  // animated flight from scrollTop 0 would be surprise motion the user never
+  // initiated), and only when the user has not deliberately scrolled up —
+  // a reveal must never steal the position of someone reading history (their
+  // "New messages" pill already handles that case).
+  useEffect(() => {
+    const el = listRef.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+    let lastHeight = el.clientHeight
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const height = entry.contentRect.height
+        if (lastHeight === 0 && height > 0 && !userScrolledUpRef.current) {
+          listEndRef.current?.scrollIntoView({ behavior: 'auto' })
+          setShowNewMessageIndicator(false)
+        }
+        lastHeight = height
+      }
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   const handleScroll = useCallback(() => {
     const el = listRef.current
     if (!el) return

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -116,10 +116,13 @@ import {
   UNSETTLED_DRAFT_NOTICE,
   STOPPED_DRAFT_NOTICE,
   DRAFT_FAILED_MODEL_KEPT_NOTICE,
+  DRAFT_RECOVERED_STREAM_LOSS_NOTICE,
+  DRAFT_RECOVERED_TERMINAL_ERROR_NOTICE,
   EARLY_STOP_NOT_SAVED_NOTICE,
   EARLY_STOP_ALREADY_SAVED_NOTICE,
   EARLY_STOP_UNCONFIRMED_NOTICE,
 } from '../components/DraftLoadingAnimation'
+import { recoverDraftFromServer } from '../hydrate/draftRecovery'
 import { stopV5Turn, type TurnStopOutcomeKind } from '../../v5/stopTurn'
 import { reconcileAppliedGraph } from '../utils/mergeAppliedGraph'
 import { getSessionIdentity } from '../../lib/supabase'
@@ -784,9 +787,16 @@ async function runStreamedDraftTurn(args: {
   // 96.981 s; terminal COMPLETE 504 UPSTREAM_TIMEOUT 125.202 s; the next turn
   // reloaded the committed graph — olumi-poc-independent-review-2026-08-09.md).
   // The commit runs server-side around the GRAPH_READY emission and survives
-  // late failures in the common case (CEE 2.709 first-write exemption), and
-  // this client cannot poll server state (no status route; guest RLS). So the
-  // reconciliation is the terminal payload's own commit marker:
+  // late failures in the common case (CEE 2.709 first-write exemption).
+  // ⚠ CORRECTED (ROADMAP 2.1257): this comment used to claim "this client
+  // cannot poll server state (no status route; guest RLS)" — FALSE. The
+  // scenario-graph read exists and is guest-reachable: `fetchScenarioGraph`
+  // (adapters/cee/scenarioGraph.ts) POSTs `/bff/cee/scenarios/{id}/graph` →
+  // CEE `POST /assist/v1/scenarios/:scenario_id/graph`, and the unsettled
+  // path now USES it (`recoverDraftFromServer`, at the notice site). What
+  // remains unpollable is per-TURN commit/delivery status — so the
+  // SYNCHRONOUS reconciliation here still keys on the one thing this
+  // response carries, the terminal payload's own commit marker:
   //   · proof the commit failed (`draft_graph_commit_failed` — the server said
   //     "Nothing was written") → remove the preview; removal states the truth.
   //   · anything else → KEEP the graph. The `previewOwnsCanvas &&
@@ -5296,28 +5306,66 @@ export function useConversation(): UseConversationReturn {
           // duration forecast, no verdict — held to the same bar as the wait
           // narration and pinned by `narrationHonesty.invariant.spec.ts`.
           if (streamedUnsettledCause != null && mode === 'user' && !hidden) {
-            addMessage({
-              id: crypto.randomUUID(),
-              role: 'assistant',
-              synthetic: true,
-              // Cause-keyed copy (the three-strings-not-one rule): a kept
-              // model behind a terminal error is a different fact from a
-              // connection that dropped the values, and each notice states
-              // only its own cause. Both live in DraftLoadingAnimation and are
-              // governed by narrationHonesty.invariant.spec.ts.
-              content:
-                streamedUnsettledCause === 'terminal_error_model_kept'
-                  ? DRAFT_FAILED_MODEL_KEPT_NOTICE
-                  : UNSETTLED_DRAFT_NOTICE,
-              // F3: NOT `retry`. `retryLast` re-sends onto the SAME scenario,
-              // whose canvas is now non-empty, so it is a buffered turn CEE's
-              // continuation guard DECLINES — the old chip could not deliver the
-              // numbers its own copy promised, on any auth tier.
-              actionChips: [
-                { id: START_NEW_DRAFT_CHIP_ID, label: 'Start a new draft', intent: 'primary' },
-              ],
-              timestamp: new Date(),
+            // ═══ ROADMAP 2.1257 — in-session draft recovery, BEFORE the chip ═══
+            //
+            // The server has usually ALREADY persisted the drafted graph when a
+            // stream dies (CEE finishes the turn after the client hangs up;
+            // 2.709 makes the commit the common case), and the scenario-graph
+            // read leg is alive end to end. Until this branch its only caller
+            // was boot hydration — so the user paid a reload for a graph one
+            // request away. Attempt that read HERE, and only then choose copy.
+            //
+            // Honesty ordering is load-bearing: the fetch is AWAITED and the
+            // notice chosen from its RESULT. No sentence below can claim a
+            // recovery before the read has returned (`recoverDraftFromServer`
+            // never throws — hydrateCanvasFromServer's own contract). On
+            // 404/failure the standing unsettled behaviour is untouched:
+            // CEE's 404 means "no readable graph", deliberately.
+            const recovery = await recoverDraftFromServer({
+              scenarioId: scenarioIdAtDispatch,
+              userId: v5UserId,
+              turnClientId,
             })
+            if (recovery === 'recovered') {
+              // The merge applied the server's committed values and released
+              // the unsettled phase (ownership-guarded, in the module). The
+              // reply is still lost — say exactly that, cause-keyed (the
+              // three-strings-not-one rule), with no chip: there is nothing
+              // left for the user to restart.
+              addMessage({
+                id: crypto.randomUUID(),
+                role: 'assistant',
+                synthetic: true,
+                content:
+                  streamedUnsettledCause === 'terminal_error_model_kept'
+                    ? DRAFT_RECOVERED_TERMINAL_ERROR_NOTICE
+                    : DRAFT_RECOVERED_STREAM_LOSS_NOTICE,
+                timestamp: new Date(),
+              })
+            } else {
+              addMessage({
+                id: crypto.randomUUID(),
+                role: 'assistant',
+                synthetic: true,
+                // Cause-keyed copy (the three-strings-not-one rule): a kept
+                // model behind a terminal error is a different fact from a
+                // connection that dropped the values, and each notice states
+                // only its own cause. Both live in DraftLoadingAnimation and are
+                // governed by narrationHonesty.invariant.spec.ts.
+                content:
+                  streamedUnsettledCause === 'terminal_error_model_kept'
+                    ? DRAFT_FAILED_MODEL_KEPT_NOTICE
+                    : UNSETTLED_DRAFT_NOTICE,
+                // F3: NOT `retry`. `retryLast` re-sends onto the SAME scenario,
+                // whose canvas is now non-empty, so it is a buffered turn CEE's
+                // continuation guard DECLINES — the old chip could not deliver the
+                // numbers its own copy promised, on any auth tier.
+                actionChips: [
+                  { id: START_NEW_DRAFT_CHIP_ID, label: 'Start a new draft', intent: 'primary' },
+                ],
+                timestamp: new Date(),
+              })
+            }
           }
         } catch (err) {
           clearLifecycleTimers()

--- a/src/canvas/hydrate/draftRecovery.ts
+++ b/src/canvas/hydrate/draftRecovery.ts
@@ -1,0 +1,89 @@
+/**
+ * draftRecovery — ROADMAP 2.1257: in-session draft recovery after stream loss.
+ *
+ * THE DEFECT THIS CLOSES. When an SSE draft stream dies mid-turn, the server
+ * has usually ALREADY persisted the drafted graph (CEE lets the turn finish
+ * when the client hangs up, and the 2.709 first-write exemption makes the
+ * commit the common case). The scenario-graph read leg is alive end to end
+ * (client `adapters/cee/scenarioGraph.ts` → Netlify edge `/bff/cee` → CEE
+ * `POST /assist/v1/scenarios/:id/graph`) — but until this module its ONLY
+ * caller was boot hydration, so a recoverable persisted draft cost the user a
+ * reload at best and a "start a new draft" at worst.
+ *
+ * ONE AUTHORITY. This module deliberately contains NO graph-ingestion logic of
+ * its own: it delegates to `hydrateCanvasFromServer`, the exact function boot
+ * hydration calls (`useServerGraphHydration` → `serverGraphHydration`), which
+ * owns the adapter call, the scenario-moved guard, the identity token and the
+ * position-preserving merge (`mergeServerGraphOnHydrate`). A second ingestion
+ * path here would be the two-`generateGraphHash`-twins defect all over again.
+ *
+ * WHAT "RECOVERED" MEANS, precisely: `hydrateCanvasFromServer` returned
+ * `'merged'` — the server answered with a graph for this scenario and the
+ * merge APPLIED it (or found the canvas already byte-identical, which is the
+ * same licence: the server's committed values are what is on screen). Every
+ * other outcome is `'notRecovered'`:
+ *   - `'notReadable'` (404) — CEE's deliberate "no readable graph". The
+ *     standing unsettled/start-new-draft behaviour is correct and stands.
+ *   - `'absent'` — the scenario exists with no graph: nothing was committed.
+ *   - `'unchanged'` — the server graph is the one a PREVIOUS hydration already
+ *     applied, i.e. this draft committed nothing new. Claiming recovery on it
+ *     would present pre-draft state as the recovered draft.
+ *   - `'mergeRefused'` / `'refused'` / `'unavailable'` / `'unusable'` /
+ *     `'skipped'` — nothing landed on the canvas, so nothing may be claimed.
+ *
+ * PHASE SETTLEMENT. On `'merged'`, the values on the canvas are the server's
+ * committed ones — the very values the next analysis is computed from — so the
+ * `unsettled` phase is genuinely settled: it is released (run gate opens,
+ * autosave persistence resumes via `shouldPersistGraphForScenario`). Guarded
+ * by ownership: only the turn that marked the draft unsettled may release it,
+ * so a stale recovery can never clear a NEWER draft's phase.
+ */
+
+import { hydrateCanvasFromServer } from './serverGraphHydration'
+import { useDraftStore } from '../stores/draftStore'
+import { logger } from '../../lib/logger'
+
+export type DraftRecoveryOutcome = 'recovered' | 'notRecovered'
+
+export interface RecoverDraftArgs {
+  /** The scenario the failed draft turn was dispatched on. */
+  scenarioId: string | null
+  /** Supabase user id when signed in; null/'guest' handled by the adapter. */
+  userId?: string | null
+  /**
+   * The `client_turn_id` of the turn that marked the draft unsettled. Phase
+   * release is keyed on it — identity, not coincidence.
+   */
+  turnClientId: string
+}
+
+/**
+ * Attempt to recover a stream-lost draft by reading back the scenario's
+ * persisted graph. Never throws (`hydrateCanvasFromServer`'s own contract);
+ * the caller chooses copy strictly from the returned outcome, AFTER it
+ * returns — never before.
+ */
+export async function recoverDraftFromServer(
+  args: RecoverDraftArgs,
+): Promise<DraftRecoveryOutcome> {
+  const hydration = await hydrateCanvasFromServer(args.scenarioId, {
+    userId: args.userId,
+  })
+  logger.debug('draft_recovery.outcome', {
+    scenarioId: args.scenarioId,
+    hydration,
+  })
+  if (hydration !== 'merged') return 'notRecovered'
+
+  // The merge applied the server's committed graph, so the unsettled state is
+  // settled. Ownership-guarded release, same rule as sendTurn's finally: only
+  // the turn that owns the phase may move it.
+  const draft = useDraftStore.getState()
+  if (
+    draft.draftStreamTurnId === args.turnClientId &&
+    draft.draftStreamPhase === 'unsettled'
+  ) {
+    draft.setDraftStreamPhase('idle', null, null)
+  }
+  return 'recovered'
+}


### PR DESCRIPTION
## ROADMAP 2.1257 — in-session draft recovery after stream loss (+ L-83 rider + stale-comment rider)

**Verdict first:** on stream death during a draft turn, the unsettled path now attempts the EXISTING scenario-graph read BEFORE offering start-new-draft; on success the saved model lands on the canvas through the SAME ingestion authority boot hydration uses, with an honest cause-keyed notice; on 404/failure the standing behaviour is byte-for-byte unchanged. Riders: the L-83 occlusion mechanism derived and fixed at `useSmartScroll` (reveal re-pin), and the false "cannot poll server state" comment corrected to name the live route.

### The recovery flow (file:line at this branch)

1. **Trigger** — `useConversation.ts` unsettled-notice block (search `ROADMAP 2.1257 — in-session draft recovery`): fires exactly when `streamedUnsettledCause != null && mode === 'user' && !hidden` — i.e. the two stream-loss unsettled outcomes (buffered-fallback-declined `stream_loss`, and F4/`terminal_error_model_kept`).
2. **Read** — `src/canvas/hydrate/draftRecovery.ts` → `recoverDraftFromServer({scenarioId, userId, turnClientId})` → **`hydrateCanvasFromServer`** (`src/canvas/hydrate/serverGraphHydration.ts:93`) → `fetchScenarioGraph` (`src/adapters/cee/scenarioGraph.ts:230`, POST `/bff/cee/scenarios/{id}/graph`) → `mergeServerGraphOnHydrate` (`src/canvas/utils/mergeServerGraph.ts:182`).
3. **On `'merged'`** — server values are on the canvas; the module releases the `unsettled` phase (ownership-guarded on `turnClientId`), which opens the run gate (`canRunAnalysis`) and resumes autosave persistence (`shouldPersistGraphForScenario`); the call site emits `DRAFT_RECOVERED_STREAM_LOSS_NOTICE` or `DRAFT_RECOVERED_TERMINAL_ERROR_NOTICE` (cause-keyed, three-strings-not-one rule), **no chip**.
4. **On anything else** (`notReadable`/`absent`/`unchanged`/`unavailable`/`refused`/`unusable`/`mergeRefused`/`skipped`) — the pre-existing notice + `Start a new draft` chip render unchanged. CEE's 404 = "no readable graph" is honoured as a deliberate answer.

**Honesty ordering:** the fetch is AWAITED and the copy chosen from its RESULT — no sentence can claim a recovery before the read returns. `'unchanged'` is deliberately NOT a recovery (it means the server graph is one a previous hydration already applied, i.e. this draft committed nothing new).

### One-authority proof

`recoverDraftFromServer` contains **zero graph-ingestion logic**: it delegates to `hydrateCanvasFromServer`, the exact function the boot path calls (`useServerGraphHydration.ts:51` → `serverGraphHydration.ts:101` → `mergeServerGraph`). The new spec mocks at the ADAPTER seam (`fetchScenarioGraph`) precisely so the real hydrate + merge chain executes in-test — a second ingestion path could not hide behind the mock.

### New notices, governed the moment they exist

`DRAFT_RECOVERED_STREAM_LOSS_NOTICE` / `DRAFT_RECOVERED_TERMINAL_ERROR_NOTICE` live in `DraftLoadingAnimation.tsx` beside their siblings; `narrationHonesty.invariant.spec.ts`'s derived `*_NOTICE` completeness check forced them into `FRAME_LICENSED_STRINGS` + the named manifest (both updated here). Both strings pass every retired-fabrication rule and every frame-licence rule (59/59 green). Em-dash-free so `safeRichText` leaves them byte-stable in the DOM.

### Rider 1 — L-83 (post-timeout Retry 100% unclickable)

**Occlusion mechanism derived at this tip:** not z-order. A message added while the thread is HIDDEN — the floating panel minimised (`display:none`, `FloatingOlumiPanel.tsx:920`) or the collapsed dock's Olumi tab (`OlumiTabBody` stays mounted, visibility toggled) — cannot be scrolled to: `useSmartScroll`'s `scrollIntoView` on a box-less container is a silent no-op, and NOTHING re-pinned on reveal (the claimed restore mechanism was already documented as non-existent, `ChatThread.tsx:46-56`). The newest message and its Retry affordance therefore lay out BELOW the visible band, where every hit-test point resolves to the composer strip under the thread — consistent with the witnessed `0/121 points, fully occluded by the chat composer; Send 43/49; Versions 64/64` (ISSUE-LEDGER L-83).

**Fix:** `useSmartScroll.ts` — a ResizeObserver on the scroll container treats the 0 → >0 height transition as the reveal and re-pins to bottom INSTANTLY (`behavior: 'auto'`, no surprise flight), guarded by `!userScrolledUpRef.current` so a reader's position is never stolen.

**Pinned (jsdom, mechanism only — trap 3):** `ChatThread.revealRepin.spec.tsx` binds the observer to the actual scroll container by testid identity, asserts the instant pin on reveal, asserts NO pin on ordinary resizes, and carries the opposite-direction twin (scrolled-up ⇒ no steal) with its own positive control.

**⚠ BROWSER WITNESS STILL NEEDED:** jsdom cannot prove the Retry button becomes clickable. The next real-browser witness should reproduce the post-timeout state, minimise/restore (and collapse/expand the dock), and hit-test `message-action-retry` + the suggested-chip row with `elementFromPoint` — the same instrument that produced the 0/121 figure.

**Epistemic honesty on the mechanism claim:** the original witness artefact (which element, which surface) is not in the estate docs — only the ledger line survives. The mechanism above is derived at the bytes and is consistent with every witnessed number, but it is a derivation, not a reproduction; if the browser witness finds a residual z-order occluder, that is a premise refutation to report against this PR.

### Rider 2 — stale comment corrected

`useConversation.ts` (was :794, now in the F1 terminal-reconciliation block): "this client cannot poll server state (no status route; guest RLS)" → corrected to name `fetchScenarioGraph` / `/bff/cee/scenarios/{id}/graph` → CEE `POST /assist/v1/scenarios/:scenario_id/graph`, and to scope what remains genuinely unpollable (per-TURN commit/delivery status), which is why the synchronous reconciliation still keys on the terminal payload's commit marker. Note: the adjacent timeout-handler comment (~:4474) and `deliveryUnknown.ts` make the narrower turn-status claim, which remains true — deliberately not touched.

### Verification

- **RED-first at pristine call site:** recovery spec 3 failed by name (fetch never attempted / notice absent / phase not settled), 3 standing-behaviour pins green, 6 collected. Reveal spec: 3/3 RED at pristine `useSmartScroll` (no observer attached). Then green: 6/6 and 3/3.
- **Mutation battery** (throwaway worktree OUTSIDE the repo root, detached at the commit, isolation proven by WRITE-TEST + inode compare, applied-check per mutant scoped to `src/`, control zero after each restore, trailing pristine control 9/9):
  - M1 call site skips the fetch → **3 RED** (straight-to-chip mutant bites)
  - M2 recovery claims success on 404 → **3 RED** (the honesty pin bites)
  - M3 phase release removed → **2 RED**
  - M4 reveal re-pin removed → **2 RED**
  - M5 scrolled-up guard removed → **exactly the opposite-direction twin RED, other two GREEN** (discriminating pair — binding proven, not just sensitivity)
- **Adjacent suites green:** `narrationHonesty.invariant` 59 · `draftLossPremise` 6 · `streamedDraftTurn` 44 · `streamedDraftTerminalError` 15 · `terminalNoticeChipRender` + `streamedDraft500Recovery` + `AIInputBar.stopControl` 27.
- **Gates:** see checks on this PR; local `pnpm typecheck` and `pnpm lint` runs recorded in the lane log.

### Reviewer notes / residuals (named, not hidden)

- In the two untouched adjacent suites the recovery read resolves `'unusable'` via Node-fetch's relative-URL rejection (deterministic in jsdom, logged in their output). Their premises are pinned explicitly in the NEW spec's 404/unusable branches; if the vitest environment ever gains a base URL, those two suites should gain an explicit adapter mock.
- Recovery-read latency on the unsettled path is bounded by the adapter's own budget (8 s/attempt; 503 retried ×3 ≈ 25 s worst case) before the failure notice appears. Deliberately reuses the boot budget — one authority — rather than minting a second timeout constant.
- The `outcome 3` shape (fallback declines with an EMPTY canvas — the witnessed "prose about a model you cannot see") is OUT OF SCOPE here by the scope-expansion rule: it has no unsettled marker to key on and overlaps the 2.1251 recovery-fetch-edge-leg lane. Mechanism sketched in the lane report; rowable if wanted.
- File ownership respected: no edits to `OutputsDock.tsx`, `useAnalysisDisplayState`, `useEditConfirmation.ts`, `AnalysisFreshnessNotice.tsx`, or Model Editor files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
