### PR TITLE
Shared model versions in the versions panel — list, named save, confirm-gated restore with undo

### DIFF
--- a/netlify/edge-functions/cee-proxy.ts
+++ b/netlify/edge-functions/cee-proxy.ts
@@ -147,6 +147,15 @@ const ALLOWED_TARGETS: readonly RegExp[] = [
   /^\/assist\/v1\/draft-graph$/,
   /^\/assist\/v1\/scenarios\/[^/]+\/graph$/,
   /^\/assist\/v1\/scenarios\/[^/]+\/graph\/register$/,
+  // Shared model versions (CEE #1001 wiring slice / UI #744): list, named
+  // save, guarded restore. Added WITH their ON-LIST cases in
+  // tests/ci-guards/bffProxyPathAllowlist.spec.ts — the first cut of #744
+  // omitted these and the whole feature died at this seam with 404 while
+  // every unit test above it stayed green (the guard spec is the instrument
+  // that sees this; keep new routes and their cases in the same PR).
+  /^\/assist\/v1\/scenarios\/[^/]+\/versions$/,
+  /^\/assist\/v1\/scenarios\/[^/]+\/versions\/save$/,
+  /^\/assist\/v1\/scenarios\/[^/]+\/versions\/restore$/,
   /^\/assist\/v1\/decision-records\/commit$/,
   /^\/assist\/v1\/decision-records\/[^/]+\/outcome$/,
 ]

--- a/src/adapters/cee/__tests__/modelVersions.spec.ts
+++ b/src/adapters/cee/__tests__/modelVersions.spec.ts
@@ -1,0 +1,359 @@
+/**
+ * modelVersions adapter — the UI's client for CEE's versions wiring slice.
+ *
+ * Server contract (olumi-assistants-service, assist.v1.scenario-versions.ts):
+ *   POST /bff/cee/scenarios/{id}/versions          → model_versions_list.v1
+ *   POST /bff/cee/scenarios/{id}/versions/save     → model_version_save.v1
+ *   POST /bff/cee/scenarios/{id}/versions/restore  → model_version_restore.v1
+ *
+ * What is pinned here:
+ *  - the SAME transport rules as scenarioGraph.ts: literal same-origin
+ *    `/bff/cee` base, POST, identity in the BODY, guest sentinel never sent;
+ *  - typed outcomes for every refusal the server can answer (VERSION_STALE,
+ *    SIGN_IN_REQUIRED, VERSIONS_DISABLED, RESTORE_INCOMPLETE, NOTHING_TO_SAVE,
+ *    VERSION_NOT_FOUND) — a caller must never have to parse HTTP by hand;
+ *  - identity-bound request bodies: restore carries the CHOSEN version_id;
+ *  - writes are NEVER auto-retried (a restore is idempotent-converging
+ *    server-side, but retrying is the USER's call, not the transport's).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import {
+  listModelVersions,
+  restoreModelVersion,
+  saveModelVersion,
+  modelVersionsUrl,
+} from '../modelVersions'
+
+const SCENARIO = 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c'
+const USER = '0f8a1b2c-3d4e-4f50-9a6b-7c8d9e0f1a2b'
+const VERSION_A = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa'
+const HASH_A = 'a'.repeat(64)
+
+function wireSummary(overrides: Record<string, unknown> = {}) {
+  return {
+    id: VERSION_A,
+    scenario_id: SCENARIO,
+    owner_user_id: USER,
+    version_number: 4,
+    graph_identity_hash: HASH_A,
+    hash_algorithm: 'sha256',
+    identity_projection_version: 'identity.v1',
+    identity_normaliser_version: 'normaliser.v1',
+    graph_schema_version: 'graph.v1',
+    label: 'Before pivot',
+    provenance: 'user_save',
+    restored_from_version_id: null,
+    created_at: '2026-08-17T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchSpy = vi.fn()
+  vi.stubGlobal('fetch', fetchSpy)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('modelVersionsUrl', () => {
+  it('builds the same-origin /bff/cee URLs the edge function owns', () => {
+    expect(modelVersionsUrl(SCENARIO)).toBe(`/bff/cee/scenarios/${SCENARIO}/versions`)
+    expect(modelVersionsUrl(SCENARIO, 'restore')).toBe(
+      `/bff/cee/scenarios/${SCENARIO}/versions/restore`,
+    )
+  })
+})
+
+describe('listModelVersions', () => {
+  it('POSTs the user id in the body and parses the list envelope', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, {
+        schema: 'model_versions_list.v1',
+        scenario_id: SCENARIO,
+        versions: [wireSummary()],
+        current_version_id: VERSION_A,
+        request_id: 'req-1',
+      }),
+    )
+
+    const result = await listModelVersions(SCENARIO, { userId: USER })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe(`/bff/cee/scenarios/${SCENARIO}/versions`)
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body).user_id).toBe(USER)
+
+    expect(result.status).toBe('list')
+    if (result.status !== 'list') throw new Error('unreachable')
+    expect(result.versions).toHaveLength(1)
+    expect(result.versions[0]).toMatchObject({
+      id: VERSION_A,
+      versionNumber: 4,
+      label: 'Before pivot',
+      provenance: 'user_save',
+      graphIdentityHash: HASH_A,
+    })
+    expect(result.currentVersionId).toBe(VERSION_A)
+  })
+
+  it('never sends the guest sentinel as a user id', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, {
+        schema: 'model_versions_list.v1',
+        scenario_id: SCENARIO,
+        versions: [],
+        current_version_id: null,
+        request_id: 'req-2',
+      }),
+    )
+
+    await listModelVersions(SCENARIO, { userId: 'guest' })
+    const body = JSON.parse(fetchSpy.mock.calls[0][1].body)
+    expect('user_id' in body).toBe(false)
+  })
+
+  it('maps 404 to notReadable and 503 VERSIONS_DISABLED to disabled', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(404, { schema: 'error.v1', code: 'NOT_FOUND', message: 'no' }),
+    )
+    expect((await listModelVersions(SCENARIO, { userId: USER })).status).toBe('notReadable')
+
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(503, {
+        schema: 'error.v1',
+        code: 'INTERNAL',
+        message: 'off',
+        details: { code: 'VERSIONS_DISABLED' },
+      }),
+    )
+    expect((await listModelVersions(SCENARIO, { userId: USER })).status).toBe('disabled')
+  })
+
+  it('refuses a wrong schema discriminator rather than guessing at the shape', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, { schema: 'something_else.v9', versions: [] }),
+    )
+    expect((await listModelVersions(SCENARIO, { userId: USER })).status).toBe('unusable')
+  })
+
+  it('fails CLOSED on a malformed version row — never a silently shortened list', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, {
+        schema: 'model_versions_list.v1',
+        scenario_id: SCENARIO,
+        versions: [wireSummary({ version_number: 'four' })],
+        current_version_id: null,
+        request_id: 'req-3',
+      }),
+    )
+    expect((await listModelVersions(SCENARIO, { userId: USER })).status).toBe('unusable')
+  })
+})
+
+describe('saveModelVersion', () => {
+  it('sends the label and returns the saved outcome', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, {
+        schema: 'model_version_save.v1',
+        scenario_id: SCENARIO,
+        version: {
+          version_id: VERSION_A,
+          version_number: 4,
+          graph_identity_hash: HASH_A,
+          deduped: false,
+          event_id: 'evt',
+        },
+        request_id: 'req-4',
+      }),
+    )
+
+    const result = await saveModelVersion(SCENARIO, { userId: USER, label: 'Before pivot' })
+
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe(`/bff/cee/scenarios/${SCENARIO}/versions/save`)
+    const body = JSON.parse(init.body)
+    expect(body.label).toBe('Before pivot')
+    expect(body.user_id).toBe(USER)
+    // The adapter NEVER sends a graph: the server versions ITS graph.
+    expect('graph' in body).toBe(false)
+
+    expect(result.status).toBe('saved')
+    if (result.status !== 'saved') throw new Error('unreachable')
+    expect(result.version.versionId).toBe(VERSION_A)
+    expect(result.version.deduped).toBe(false)
+  })
+
+  it('maps SIGN_IN_REQUIRED, VERSION_STALE and NOTHING_TO_SAVE to typed outcomes', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(401, {
+        schema: 'error.v1',
+        code: 'UNAUTHENTICATED',
+        message: 'sign in',
+        details: { code: 'SIGN_IN_REQUIRED' },
+      }),
+    )
+    expect((await saveModelVersion(SCENARIO, {})).status).toBe('signInRequired')
+
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(409, {
+        schema: 'error.v1',
+        code: 'BAD_INPUT',
+        message: 'stale',
+        details: { code: 'VERSION_STALE' },
+      }),
+    )
+    expect((await saveModelVersion(SCENARIO, { userId: USER })).status).toBe('conflict')
+
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(422, {
+        schema: 'error.v1',
+        code: 'BAD_INPUT',
+        message: 'empty',
+        details: { code: 'NOTHING_TO_SAVE' },
+      }),
+    )
+    expect((await saveModelVersion(SCENARIO, { userId: USER })).status).toBe('nothingToSave')
+  })
+
+  it("does NOT auto-retry a 503 — a write retry is the user's call", async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(503, { schema: 'error.v1', code: 'INTERNAL', message: 'down' }),
+    )
+    const result = await saveModelVersion(SCENARIO, { userId: USER })
+    expect(result.status).toBe('unavailable')
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('restoreModelVersion', () => {
+  it('sends the CHOSEN version id and expected hash; returns the restored graph and undo id', async () => {
+    const restoredGraph = {
+      nodes: [{ id: 'n1', label: 'Take the job', kind: 'option' }],
+      edges: [],
+    }
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, {
+        schema: 'model_version_restore.v1',
+        scenario_id: SCENARIO,
+        restored: true,
+        deduped: false,
+        version: {
+          version_id: 'dddddddd-4444-4444-8444-dddddddddddd',
+          version_number: 5,
+          graph_identity_hash: HASH_A,
+          deduped: false,
+          event_id: 'evt',
+          restored_from_version_id: VERSION_A,
+        },
+        undo_version_id: 'cccccccc-3333-4333-8333-cccccccccccc',
+        graph: restoredGraph,
+        graph_identity_hash: { value: HASH_A, projection_version: 'identity.v1' },
+        request_id: 'req-5',
+      }),
+    )
+
+    const result = await restoreModelVersion(SCENARIO, {
+      userId: USER,
+      versionId: VERSION_A,
+      expectedGraphIdentityHash: HASH_A,
+    })
+
+    const [url, init] = fetchSpy.mock.calls[0]
+    expect(url).toBe(`/bff/cee/scenarios/${SCENARIO}/versions/restore`)
+    const body = JSON.parse(init.body)
+    expect(body.version_id).toBe(VERSION_A)
+    expect(body.expected_graph_identity_hash).toBe(HASH_A)
+    // Restore NEVER sends a graph — the server copies the stored version's.
+    expect('graph' in body).toBe(false)
+
+    expect(result.status).toBe('restored')
+    if (result.status !== 'restored') throw new Error('unreachable')
+    expect(result.graph).toEqual(restoredGraph)
+    expect(result.undoVersionId).toBe('cccccccc-3333-4333-8333-cccccccccccc')
+    expect(result.deduped).toBe(false)
+  })
+
+  it('maps VERSION_NOT_FOUND, VERSION_STALE and RESTORE_INCOMPLETE to typed outcomes', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(404, {
+        schema: 'error.v1',
+        code: 'NOT_FOUND',
+        message: 'gone',
+        details: { code: 'VERSION_NOT_FOUND' },
+      }),
+    )
+    expect(
+      (await restoreModelVersion(SCENARIO, { userId: USER, versionId: VERSION_A })).status,
+    ).toBe('versionNotFound')
+
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(409, {
+        schema: 'error.v1',
+        code: 'BAD_INPUT',
+        message: 'stale',
+        details: { code: 'VERSION_STALE' },
+      }),
+    )
+    expect(
+      (await restoreModelVersion(SCENARIO, { userId: USER, versionId: VERSION_A })).status,
+    ).toBe('conflict')
+
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse(503, {
+        schema: 'error.v1',
+        code: 'INTERNAL',
+        message: 'partial',
+        details: { code: 'RESTORE_INCOMPLETE', version_recorded: true },
+      }),
+    )
+    expect(
+      (await restoreModelVersion(SCENARIO, { userId: USER, versionId: VERSION_A })).status,
+    ).toBe('incomplete')
+  })
+
+  it('a restore answer with restored:true but NO graph object is unusable — never applied blind', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, {
+        schema: 'model_version_restore.v1',
+        scenario_id: SCENARIO,
+        restored: true,
+        deduped: false,
+        version: {
+          version_id: VERSION_A,
+          version_number: 5,
+          graph_identity_hash: HASH_A,
+          deduped: false,
+          event_id: null,
+        },
+        undo_version_id: null,
+        graph: null,
+        graph_identity_hash: null,
+        request_id: 'req-6',
+      }),
+    )
+    expect(
+      (await restoreModelVersion(SCENARIO, { userId: USER, versionId: VERSION_A })).status,
+    ).toBe('unusable')
+  })
+
+  it('never auto-retries any failure', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(503, { schema: 'error.v1', code: 'INTERNAL', message: 'down' }),
+    )
+    await restoreModelVersion(SCENARIO, { userId: USER, versionId: VERSION_A })
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/adapters/cee/modelVersions.ts
+++ b/src/adapters/cee/modelVersions.ts
@@ -1,0 +1,400 @@
+/**
+ * modelVersions — the UI's client for CEE's scenario-addressed VERSIONS.
+ *
+ * Server contract: olumi-assistants-service `assist.v1.scenario-versions.ts`
+ * (the Model Management wiring slice):
+ *   POST /assist/v1/scenarios/{id}/versions          → model_versions_list.v1
+ *   POST /assist/v1/scenarios/{id}/versions/save     → model_version_save.v1
+ *   POST /assist/v1/scenarios/{id}/versions/restore  → model_version_restore.v1
+ * reached from the browser as `/bff/cee/scenarios/{id}/versions[...]`.
+ *
+ * THE TRANSPORT RULES ARE scenarioGraph.ts's, INHERITED IN FULL — see that
+ * file's header for why the base is a LITERAL same-origin constant and never
+ * `VITE_CEE_BFF_BASE` (that var is dashboard-baked to an absolute PLoT URL;
+ * resolving from it would leave the edge seam entirely and 404 on a service
+ * that has never heard of versions — CLAUDE.md trap 18 in its live form).
+ * Identity travels in the BODY (`user_id`), never a URL; the guest sentinel
+ * is never sent as a user id.
+ *
+ * WHAT THIS CLIENT NEVER SENDS: a graph. A version is a snapshot of the
+ * SERVER's shared model — save versions `scenarios.graph` server-side, and
+ * restore copies the STORED version's graph server-side. The request schemas
+ * have nowhere to put client bytes, and this client never tries.
+ *
+ * WRITES ARE NEVER AUTO-RETRIED. A restore is idempotent-converging
+ * server-side (the RPC dedupes; the graph write re-runs), so retrying is
+ * SAFE — but it is the USER's decision, surfaced through the typed
+ * `incomplete` / `conflict` outcomes, never the transport's.
+ */
+
+import { logger } from '../../lib/logger'
+
+/** The same-origin Netlify edge path. NOT `VITE_CEE_BFF_BASE` — see header. */
+export const MODEL_VERSIONS_BASE = '/bff/cee'
+
+/** The guest sentinel `AuthContext` mints; never a Supabase user id. */
+const GUEST_USER_ID = 'guest'
+
+/** Per-attempt deadline — same bound and rationale as scenarioGraph.ts. */
+const DEFAULT_TIMEOUT_MS = 8000
+
+export function modelVersionsUrl(
+  scenarioId: string,
+  leaf?: 'save' | 'restore',
+): string {
+  const base = `${MODEL_VERSIONS_BASE}/scenarios/${encodeURIComponent(scenarioId)}/versions`
+  return leaf === undefined ? base : `${base}/${leaf}`
+}
+
+/** One server-side version, as the UI consumes it. */
+export interface ServerModelVersion {
+  id: string
+  versionNumber: number
+  label: string | null
+  /** 'user_save' | 'commit' | 'pre_restore' | 'restore' — rendered, not branched on. */
+  provenance: string | null
+  restoredFromVersionId: string | null
+  /** ISO timestamp from the server row. */
+  createdAt: string
+  /** CEE's opaque identity token for this version — the CAS expectation. */
+  graphIdentityHash: string
+}
+
+export interface ServerVersionWriteOutcome {
+  versionId: string
+  versionNumber: number
+  deduped: boolean
+}
+
+export type ListModelVersionsResult =
+  | {
+      status: 'list'
+      versions: ServerModelVersion[]
+      currentVersionId: string | null
+      requestId: string | null
+    }
+  /** 404 — absent ∪ not-yours ∪ oracle-unresolvable. NEVER deletion. */
+  | { status: 'notReadable' }
+  /** 503 VERSIONS_DISABLED — versioning is off on this service. */
+  | { status: 'disabled' }
+  /** 503 (plain) — unknown, try again. */
+  | { status: 'unavailable' }
+  | { status: 'refused'; httpStatus: number }
+  | { status: 'unusable' }
+
+export type SaveModelVersionResult =
+  | { status: 'saved'; version: ServerVersionWriteOutcome }
+  | { status: 'signInRequired' }
+  | { status: 'conflict' }
+  | { status: 'nothingToSave' }
+  | { status: 'notReadable' }
+  | { status: 'disabled' }
+  | { status: 'unavailable' }
+  | { status: 'refused'; httpStatus: number }
+  | { status: 'unusable' }
+
+export type RestoreModelVersionResult =
+  | {
+      status: 'restored'
+      /** The restored graph EXACTLY as the server persisted it — the input to
+       *  the receipt-class reconcile. Always an object on this arm. */
+      graph: unknown
+      deduped: boolean
+      version: ServerVersionWriteOutcome
+      /** The pre-restore snapshot — restore THIS to undo. Null when the
+       *  server had nothing to snapshot. */
+      undoVersionId: string | null
+      requestId: string | null
+    }
+  | { status: 'signInRequired' }
+  | { status: 'conflict' }
+  | { status: 'versionNotFound' }
+  /** The version row was recorded but the working graph write failed.
+   *  Retrying the same restore CONVERGES server-side. */
+  | { status: 'incomplete' }
+  | { status: 'notReadable' }
+  | { status: 'disabled' }
+  | { status: 'unavailable' }
+  | { status: 'refused'; httpStatus: number }
+  | { status: 'unusable' }
+
+interface CommonOptions {
+  /** Supabase user id. Omitted for guests. */
+  userId?: string | null
+  signal?: AbortSignal
+  timeoutMs?: number
+}
+
+export interface RestoreOptions extends CommonOptions {
+  versionId: string
+  /** The head identity hash the user was shown — the CAS expectation. */
+  expectedGraphIdentityHash?: string
+  label?: string
+}
+
+export interface SaveOptions extends CommonOptions {
+  label?: string
+  expectedGraphIdentityHash?: string
+}
+
+function identityBody(userId: string | null | undefined): Record<string, unknown> {
+  const body: Record<string, unknown> = {}
+  if (typeof userId === 'string' && userId.length > 0 && userId !== GUEST_USER_ID) {
+    body.user_id = userId
+  }
+  return body
+}
+
+function detailsCode(body: unknown): string | null {
+  if (body === null || typeof body !== 'object') return null
+  const details = (body as Record<string, unknown>).details
+  if (details === null || typeof details !== 'object') return null
+  const code = (details as Record<string, unknown>).code
+  return typeof code === 'string' ? code : null
+}
+
+type PostOutcome =
+  | { kind: 'ok'; body: unknown }
+  | { kind: 'http'; status: number; body: unknown }
+  | { kind: 'transportFailure' }
+
+/** One POST, one deadline, no retries. Every failure is a typed outcome. */
+async function postOnce(
+  url: string,
+  payload: Record<string, unknown>,
+  opts: CommonOptions,
+): Promise<PostOutcome> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const controller = new AbortController()
+  const onCallerAbort = () => controller.abort()
+  if (opts.signal) {
+    if (opts.signal.aborted) return { kind: 'transportFailure' }
+    opts.signal.addEventListener('abort', onCallerAbort, { once: true })
+  }
+  const timer = timeoutMs > 0 ? setTimeout(() => controller.abort(), timeoutMs) : null
+
+  let response: Response
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    })
+  } catch (err) {
+    logger.warn('model_versions.transport_failure', {
+      error: (err as Error)?.message ?? 'unknown',
+    })
+    return { kind: 'transportFailure' }
+  } finally {
+    if (timer !== null) clearTimeout(timer)
+    opts.signal?.removeEventListener('abort', onCallerAbort)
+  }
+
+  let body: unknown = null
+  try {
+    body = await response.json()
+  } catch {
+    body = null
+  }
+
+  if (response.ok) return { kind: 'ok', body }
+  return { kind: 'http', status: response.status, body }
+}
+
+/** The refusal statuses shared by all three calls. Returns null for 200s. */
+function sharedRefusal(
+  outcome: PostOutcome,
+):
+  | { status: 'notReadable' }
+  | { status: 'disabled' }
+  | { status: 'unavailable' }
+  | { status: 'refused'; httpStatus: number }
+  | { status: 'unusable' }
+  | null {
+  if (outcome.kind === 'transportFailure') return { status: 'unusable' }
+  if (outcome.kind === 'ok') return null
+  const code = detailsCode(outcome.body)
+  switch (outcome.status) {
+    case 404:
+      return { status: 'notReadable' }
+    case 503:
+      return code === 'VERSIONS_DISABLED' ? { status: 'disabled' } : { status: 'unavailable' }
+    case 401:
+    case 403:
+    case 429:
+      return { status: 'refused', httpStatus: outcome.status }
+    default:
+      return { status: 'unusable' }
+  }
+}
+
+function parseSummary(raw: unknown): ServerModelVersion | null {
+  if (raw === null || typeof raw !== 'object') return null
+  const row = raw as Record<string, unknown>
+  const id = row.id
+  const versionNumber = row.version_number
+  const createdAt = row.created_at
+  const hash = row.graph_identity_hash
+  if (typeof id !== 'string' || id.length === 0) return null
+  if (typeof versionNumber !== 'number' || !Number.isInteger(versionNumber)) return null
+  if (typeof createdAt !== 'string' || createdAt.length === 0) return null
+  if (typeof hash !== 'string' || hash.length === 0) return null
+  return {
+    id,
+    versionNumber,
+    label: typeof row.label === 'string' && row.label.length > 0 ? row.label : null,
+    provenance:
+      typeof row.provenance === 'string' && row.provenance.length > 0 ? row.provenance : null,
+    restoredFromVersionId:
+      typeof row.restored_from_version_id === 'string' &&
+      row.restored_from_version_id.length > 0
+        ? row.restored_from_version_id
+        : null,
+    createdAt,
+    graphIdentityHash: hash,
+  }
+}
+
+function parseWriteOutcome(raw: unknown): ServerVersionWriteOutcome | null {
+  if (raw === null || typeof raw !== 'object') return null
+  const row = raw as Record<string, unknown>
+  if (typeof row.version_id !== 'string' || typeof row.version_number !== 'number') return null
+  return {
+    versionId: row.version_id,
+    versionNumber: row.version_number,
+    deduped: row.deduped === true,
+  }
+}
+
+/** List the scenario's server-side versions. Never throws. */
+export async function listModelVersions(
+  scenarioId: string,
+  opts: CommonOptions & { limit?: number } = {},
+): Promise<ListModelVersionsResult> {
+  const payload = identityBody(opts.userId)
+  if (typeof opts.limit === 'number') payload.limit = opts.limit
+
+  const outcome = await postOnce(modelVersionsUrl(scenarioId), payload, opts)
+  const refusal = sharedRefusal(outcome)
+  if (refusal) return refusal
+  const body = (outcome as { kind: 'ok'; body: unknown }).body
+
+  if (body === null || typeof body !== 'object') return { status: 'unusable' }
+  const b = body as Record<string, unknown>
+  if (b.schema !== 'model_versions_list.v1') {
+    logger.warn('model_versions.unexpected_schema', { schema: String(b.schema) })
+    return { status: 'unusable' }
+  }
+  if (!Array.isArray(b.versions)) return { status: 'unusable' }
+
+  const versions: ServerModelVersion[] = []
+  for (const raw of b.versions) {
+    const parsed = parseSummary(raw)
+    // Fail CLOSED on a malformed row: a silently shortened history would
+    // misrepresent what exists to be restored.
+    if (parsed === null) {
+      logger.warn('model_versions.malformed_row_refused', { scenarioId })
+      return { status: 'unusable' }
+    }
+    versions.push(parsed)
+  }
+
+  return {
+    status: 'list',
+    versions,
+    currentVersionId:
+      typeof b.current_version_id === 'string' && b.current_version_id.length > 0
+        ? b.current_version_id
+        : null,
+    requestId: typeof b.request_id === 'string' ? b.request_id : null,
+  }
+}
+
+/** Save the SERVER's current graph as a named version. Never throws. */
+export async function saveModelVersion(
+  scenarioId: string,
+  opts: SaveOptions = {},
+): Promise<SaveModelVersionResult> {
+  const payload = identityBody(opts.userId)
+  if (typeof opts.label === 'string' && opts.label.trim().length > 0) {
+    payload.label = opts.label.trim().slice(0, 200)
+  }
+  if (opts.expectedGraphIdentityHash !== undefined) {
+    payload.expected_graph_identity_hash = opts.expectedGraphIdentityHash
+  }
+
+  const outcome = await postOnce(modelVersionsUrl(scenarioId, 'save'), payload, opts)
+
+  if (outcome.kind === 'http') {
+    const code = detailsCode(outcome.body)
+    if (outcome.status === 401 && code === 'SIGN_IN_REQUIRED') return { status: 'signInRequired' }
+    if (outcome.status === 409) return { status: 'conflict' }
+    if (outcome.status === 422 && code === 'NOTHING_TO_SAVE') return { status: 'nothingToSave' }
+  }
+  const refusal = sharedRefusal(outcome)
+  if (refusal) return refusal
+  const body = (outcome as { kind: 'ok'; body: unknown }).body
+
+  if (body === null || typeof body !== 'object') return { status: 'unusable' }
+  const b = body as Record<string, unknown>
+  if (b.schema !== 'model_version_save.v1') return { status: 'unusable' }
+  const version = parseWriteOutcome(b.version)
+  if (version === null) return { status: 'unusable' }
+  return { status: 'saved', version }
+}
+
+/** Restore a stored version into the scenario's working graph. Never throws. */
+export async function restoreModelVersion(
+  scenarioId: string,
+  opts: RestoreOptions,
+): Promise<RestoreModelVersionResult> {
+  const payload = identityBody(opts.userId)
+  payload.version_id = opts.versionId
+  if (opts.expectedGraphIdentityHash !== undefined) {
+    payload.expected_graph_identity_hash = opts.expectedGraphIdentityHash
+  }
+  if (typeof opts.label === 'string' && opts.label.trim().length > 0) {
+    payload.label = opts.label.trim().slice(0, 200)
+  }
+
+  const outcome = await postOnce(modelVersionsUrl(scenarioId, 'restore'), payload, opts)
+
+  if (outcome.kind === 'http') {
+    const code = detailsCode(outcome.body)
+    if (outcome.status === 401 && code === 'SIGN_IN_REQUIRED') return { status: 'signInRequired' }
+    if (outcome.status === 409) return { status: 'conflict' }
+    if (outcome.status === 404 && code === 'VERSION_NOT_FOUND') return { status: 'versionNotFound' }
+    if (outcome.status === 503 && code === 'RESTORE_INCOMPLETE') return { status: 'incomplete' }
+  }
+  const refusal = sharedRefusal(outcome)
+  if (refusal) return refusal
+  const body = (outcome as { kind: 'ok'; body: unknown }).body
+
+  if (body === null || typeof body !== 'object') return { status: 'unusable' }
+  const b = body as Record<string, unknown>
+  if (b.schema !== 'model_version_restore.v1') return { status: 'unusable' }
+  if (b.restored !== true) return { status: 'unusable' }
+  const version = parseWriteOutcome(b.version)
+  if (version === null) return { status: 'unusable' }
+
+  // The graph is what the reconcile applies. A restore claim WITHOUT the
+  // graph must never be applied blind — refuse the shape instead.
+  const graph = b.graph
+  if (graph === null || typeof graph !== 'object') {
+    logger.warn('model_versions.restore_without_graph_refused', { scenarioId })
+    return { status: 'unusable' }
+  }
+
+  return {
+    status: 'restored',
+    graph,
+    deduped: b.deduped === true,
+    version,
+    undoVersionId:
+      typeof b.undo_version_id === 'string' && b.undo_version_id.length > 0
+        ? b.undo_version_id
+        : null,
+    requestId: typeof b.request_id === 'string' ? b.request_id : null,
+  }
+}

--- a/src/adapters/cee/modelVersions.ts
+++ b/src/adapters/cee/modelVersions.ts
@@ -21,10 +21,16 @@
  * restore copies the STORED version's graph server-side. The request schemas
  * have nowhere to put client bytes, and this client never tries.
  *
- * WRITES ARE NEVER AUTO-RETRIED. A restore is idempotent-converging
- * server-side (the RPC dedupes; the graph write re-runs), so retrying is
- * SAFE — but it is the USER's decision, surfaced through the typed
- * `incomplete` / `conflict` outcomes, never the transport's.
+ * WRITES ARE NEVER AUTO-RETRIED. Retrying a partial restore is SAFE (no
+ * data loss either way) but it is the USER's decision, surfaced through the
+ * typed `incomplete` / `conflict` outcomes, never the transport's — and the
+ * mechanism matters (measured, review of #744): a retry with the SAME
+ * expected head hash answers 409 (the server's own pre-restore machinery
+ * already moved the head), so a bare transport retry would spin on
+ * conflicts. A retry AFTER re-reading the list (fresh head hash) completes
+ * the restore, at the cost of two more appended version rows per attempt.
+ * The section refreshes the list on `incomplete`/`conflict` for exactly
+ * this reason.
  */
 
 import { logger } from '../../lib/logger'
@@ -109,8 +115,10 @@ export type RestoreModelVersionResult =
   | { status: 'signInRequired' }
   | { status: 'conflict' }
   | { status: 'versionNotFound' }
-  /** The version row was recorded but the working graph write failed.
-   *  Retrying the same restore CONVERGES server-side. */
+  /** The version row was recorded but the working graph write failed. A
+   *  retry completes it ONLY with a re-read head hash (a same-hash retry
+   *  409s; a refreshed retry appends two more version rows and lands the
+   *  graph — no data loss either way). See the header. */
   | { status: 'incomplete' }
   | { status: 'notReadable' }
   | { status: 'disabled' }

--- a/src/canvas/versions/ServerVersionsSection.tsx
+++ b/src/canvas/versions/ServerVersionsSection.tsx
@@ -265,9 +265,13 @@ export function ServerVersionsSection() {
         await refresh()
         return
       case 'incomplete':
+        // Refresh BEFORE inviting a retry: a retry with the stale head hash
+        // answers 409 (the server's pre-restore machinery already moved the
+        // head — measured in review); with the refreshed head it completes.
         setMessage(
-          'The restore did not complete: the version was recorded but the working model was not updated. Try again — it is safe to retry.',
+          'The restore did not complete: the version was recorded but the working model was not updated. The list has been refreshed — restoring the version again will complete it. No work is lost.',
         )
+        await refresh()
         return
       case 'versionNotFound':
         setMessage('That version is no longer available.')

--- a/src/canvas/versions/ServerVersionsSection.tsx
+++ b/src/canvas/versions/ServerVersionsSection.tsx
@@ -1,0 +1,472 @@
+/**
+ * ServerVersionsSection — SHARED versions of this scenario's model.
+ * British English: visualisation, colour, initialise.
+ *
+ * ── WHAT THIS IS, AND HOW IT DIFFERS FROM THE LOCAL HISTORY ─────────────────
+ * The rest of this panel (#739) is BROWSER-LOCAL: capture + compare of the
+ * canvas, localStorage, one device, honest about it. This section is the other
+ * half: versions of the SERVER's shared model (`scenarios.graph` — the graph
+ * every turn and every analysis is computed from), persisted by CEE in
+ * `model_versions`, visible from ANY browser with access to the scenario, and
+ * restorable. Two different objects, deliberately side by side:
+ *   · a LOCAL version answers "what did I change on this canvas?";
+ *   · a SHARED version is a durable state of the team's model itself.
+ *
+ * ── RESTORE, GUARDED TWICE ──────────────────────────────────────────────────
+ * Restore overwrites the working model for everyone with access, so:
+ *   1. the UI arms an explicit CONFIRM before calling the server (a mutant
+ *      that skips the confirm REDs ServerVersionsSection.spec §PIN 1);
+ *   2. the server snapshots the current state FIRST (provenance
+ *      `pre_restore`) and names it in the response — rendered here as UNDO.
+ * The apply path is `reconcileAppliedGraph` — the receipt-class reconcile
+ * with authoritative deletion semantics and layout preservation — never a
+ * second bespoke merge. Restores THEMSELVES are versions (the server appends,
+ * history is never rewritten), which is why undo is just another restore.
+ *
+ * ── GUESTS ──────────────────────────────────────────────────────────────────
+ * Server-side versions require sign-in (DB-level: guest scenarios cannot own
+ * durable rows — CEE's D3 Branch A ruling). Guests see the honest invitation,
+ * and their LOCAL history above keeps working exactly as before. No network
+ * call is spent to learn what we already know.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { UploadCloud, RotateCcw } from 'lucide-react'
+import { PanelSection } from '../panels/_shared/PanelSection'
+import { typography } from '../../styles/typography'
+import { useAuth } from '../../contexts/AuthContext'
+import { useCanvasStore } from '../store'
+import {
+  listModelVersions,
+  restoreModelVersion,
+  saveModelVersion,
+  type ServerModelVersion,
+} from '../../adapters/cee/modelVersions'
+import { reconcileAppliedGraph } from '../utils/mergeAppliedGraph'
+import { logger } from '../../lib/logger'
+
+/** A scenario CEE can address is a UUID (scenarios.id is a uuid column). */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** The guest sentinel AuthContext mints; never a Supabase user id. */
+const GUEST_USER_ID = 'guest'
+
+/** Storage-scope disclosure — the shared counterpart of the local one. */
+export const SERVER_VERSIONS_DISCLOSURE =
+  'Shared versions are stored with the scenario. Anyone who can open this scenario can see and restore them, from any browser.'
+
+export const SERVER_VERSIONS_SIGNIN =
+  'Sign in to save shared versions. Version history for the shared model is available when you are signed in; the local history above still works in this browser.'
+
+/** Provenance, in the user's terms. Unknown values render as themselves. */
+function provenanceLabel(provenance: string | null): string | null {
+  switch (provenance) {
+    case 'user_save':
+      return null // a deliberate save needs no explanation
+    case 'commit':
+      return 'auto — saved on change'
+    case 'pre_restore':
+      return 'auto — before a restore'
+    case 'restore':
+      return 'restored'
+    default:
+      return provenance
+  }
+}
+
+function formatTimestamp(iso: string): string {
+  const parsed = new Date(iso)
+  if (Number.isNaN(parsed.getTime())) return iso
+  try {
+    return parsed.toLocaleString('en-GB', {
+      day: 'numeric',
+      month: 'short',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  } catch {
+    return parsed.toISOString()
+  }
+}
+
+type Phase =
+  | { kind: 'loading' }
+  | { kind: 'ready'; versions: ServerModelVersion[]; currentVersionId: string | null }
+  | { kind: 'disabled' }
+  | { kind: 'failed' }
+
+export function ServerVersionsSection() {
+  const { user } = useAuth()
+  const scenarioId = useCanvasStore((s) => s.currentScenarioId)
+
+  const [phase, setPhase] = useState<Phase>({ kind: 'loading' })
+  /** Row whose confirm is armed (pin 1) — id, never an index. */
+  const [armedVersionId, setArmedVersionId] = useState<string | null>(null)
+  /** One in-flight write at a time; buttons disable on it. */
+  const [busy, setBusy] = useState(false)
+  /** Honest, in-place outcome copy (conflicts, no-ops, partial restores). */
+  const [message, setMessage] = useState<string | null>(null)
+  /** The server-named pre-restore snapshot — restore it to undo. */
+  const [undoVersionId, setUndoVersionId] = useState<string | null>(null)
+  const [draftLabel, setDraftLabel] = useState('')
+  const mountedRef = useRef(true)
+
+  const userId = user?.id ?? null
+  const signedIn =
+    typeof userId === 'string' && userId.length > 0 && userId !== GUEST_USER_ID
+  const addressable = typeof scenarioId === 'string' && UUID_RE.test(scenarioId)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  const refresh = useCallback(async () => {
+    if (!addressable || !signedIn || typeof scenarioId !== 'string') return
+    const result = await listModelVersions(scenarioId, { userId })
+    if (!mountedRef.current) return
+    if (result.status === 'list') {
+      setPhase({
+        kind: 'ready',
+        versions: result.versions,
+        currentVersionId: result.currentVersionId,
+      })
+      return
+    }
+    if (result.status === 'disabled') {
+      setPhase({ kind: 'disabled' })
+      return
+    }
+    // notReadable / unavailable / refused / unusable: one honest retry state.
+    // A failed read must never render as "no versions" — that would be an
+    // empty claim about history we simply could not see.
+    setPhase({ kind: 'failed' })
+  }, [addressable, signedIn, scenarioId, userId])
+
+  useEffect(() => {
+    if (addressable && signedIn) {
+      setPhase({ kind: 'loading' })
+      void refresh()
+    }
+  }, [addressable, signedIn, refresh])
+
+  // No server-addressable scenario ⇒ nothing to offer; the local history
+  // above is the whole story. Rendering a dead section would be an
+  // affordance that cannot keep its promise.
+  if (!addressable) return null
+
+  if (!signedIn) {
+    return (
+      <PanelSection title="Shared versions">
+        <p
+          className={`${typography.panelBody} text-text-light`}
+          data-testid="server-versions-signin"
+        >
+          {SERVER_VERSIONS_SIGNIN}
+        </p>
+      </PanelSection>
+    )
+  }
+
+  const handleSave = async () => {
+    if (typeof scenarioId !== 'string') return
+    setBusy(true)
+    setMessage(null)
+    const label = draftLabel.trim()
+    const result = await saveModelVersion(scenarioId, {
+      userId,
+      ...(label.length > 0 ? { label } : {}),
+    })
+    if (!mountedRef.current) return
+    setBusy(false)
+    switch (result.status) {
+      case 'saved':
+        setDraftLabel('')
+        if (result.version.deduped) {
+          setMessage('This state is already the latest shared version — nothing new to save.')
+        }
+        await refresh()
+        return
+      case 'nothingToSave':
+        setMessage('There is no model content to version yet. Add to your model, then save.')
+        return
+      case 'signInRequired':
+        setMessage('Saving shared versions requires sign-in.')
+        return
+      case 'conflict':
+        setMessage('The model changed since you last loaded it. Refresh and try again.')
+        await refresh()
+        return
+      case 'disabled':
+        setPhase({ kind: 'disabled' })
+        return
+      default:
+        setMessage('The version could not be saved right now. Try again.')
+        return
+    }
+  }
+
+  const handleRestore = async (versionId: string) => {
+    if (typeof scenarioId !== 'string' || phase.kind !== 'ready') return
+    setBusy(true)
+    setMessage(null)
+    setArmedVersionId(null)
+
+    // The CAS expectation is the CURRENT head's identity hash — the state the
+    // list showed the user. The server chains it through its own pre-restore
+    // snapshot, so a concurrent change fails loudly instead of silently losing.
+    const head =
+      phase.versions.find((v) => v.id === phase.currentVersionId) ?? phase.versions[0]
+    const result = await restoreModelVersion(scenarioId, {
+      userId,
+      versionId,
+      ...(head !== undefined ? { expectedGraphIdentityHash: head.graphIdentityHash } : {}),
+    })
+    if (!mountedRef.current) return
+    setBusy(false)
+
+    switch (result.status) {
+      case 'restored': {
+        // The receipt-class apply: adds + updates + deletions in one history
+        // entry, layout preserved, removals gated on acknowledged elements.
+        const applied = reconcileAppliedGraph(
+          // The restore payload carries only `graph`; the reconcile reads
+          // `.graph.nodes/.graph.edges` on exactly this shape.
+          { graph: result.graph } as unknown as Parameters<typeof reconcileAppliedGraph>[0],
+        )
+        const changedNothing =
+          applied.addedNodeCount === 0 &&
+          applied.addedEdgeCount === 0 &&
+          applied.updatedNodeCount === 0 &&
+          applied.updatedEdgeCount === 0 &&
+          applied.removedNodeCount === 0 &&
+          applied.removedEdgeCount === 0
+        setUndoVersionId(result.undoVersionId)
+        if (result.deduped) {
+          setMessage('The model is already at that version — nothing changed.')
+        } else if (changedNothing) {
+          // Honest about ambiguity: the server restored, but the canvas
+          // reconcile reported no change (it may have refused an unrelated
+          // graph, or the canvas already matched). Never claim silently.
+          setMessage(
+            'Restored on the server. If the canvas looks unchanged, reload the page to see the restored model.',
+          )
+          logger.warn('server_versions.restore_applied_no_canvas_change', { scenarioId })
+        } else {
+          setMessage('Restored. The shared model and this canvas now show that version.')
+        }
+        await refresh()
+        return
+      }
+      case 'conflict':
+        setMessage('The model changed since you looked. The list has been refreshed — try again.')
+        await refresh()
+        return
+      case 'incomplete':
+        setMessage(
+          'The restore did not complete: the version was recorded but the working model was not updated. Try again — it is safe to retry.',
+        )
+        return
+      case 'versionNotFound':
+        setMessage('That version is no longer available.')
+        await refresh()
+        return
+      case 'signInRequired':
+        setMessage('Restoring shared versions requires sign-in.')
+        return
+      case 'disabled':
+        setPhase({ kind: 'disabled' })
+        return
+      default:
+        setMessage('The version could not be restored right now. Nothing was changed.')
+        return
+    }
+  }
+
+  return (
+    <PanelSection title="Shared versions">
+      <p className={`${typography.panelMeta} text-text-light`} data-testid="server-versions-disclosure">
+        {SERVER_VERSIONS_DISCLOSURE}
+      </p>
+
+      {phase.kind === 'loading' && (
+        <p className={`${typography.panelBody} text-text-light`}>Loading shared versions…</p>
+      )}
+
+      {phase.kind === 'disabled' && (
+        <p
+          className={`${typography.panelBody} text-text-light`}
+          data-testid="server-versions-unavailable"
+        >
+          Shared version history is not available on this service right now.
+        </p>
+      )}
+
+      {phase.kind === 'failed' && (
+        <div className="space-y-1.5">
+          <p className={`${typography.panelBody} text-text-light`}>
+            Shared versions could not be loaded — this says nothing about whether any exist.
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              setPhase({ kind: 'loading' })
+              void refresh()
+            }}
+            className={`${typography.panelBody} px-3 py-1.5 rounded-md border border-panel-border text-text-body hover:bg-panel-hover`}
+          >
+            Try again
+          </button>
+        </div>
+      )}
+
+      {message !== null && (
+        <p
+          className={`${typography.panelBody} text-text-body`}
+          role="status"
+          data-testid="server-versions-message"
+        >
+          {message}
+        </p>
+      )}
+
+      {undoVersionId !== null && (
+        <button
+          type="button"
+          data-testid="server-restore-undo"
+          disabled={busy}
+          onClick={() => {
+            const target = undoVersionId
+            setUndoVersionId(null)
+            if (target !== null) void handleRestore(target)
+          }}
+          className={`${typography.panelBody} inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border border-panel-border text-text-body hover:bg-panel-hover`}
+        >
+          <RotateCcw className="w-3.5 h-3.5" />
+          Undo restore
+        </button>
+      )}
+
+      {phase.kind === 'ready' && (
+        <>
+          <div className="flex items-center gap-2">
+            <label htmlFor="server-version-name" className="sr-only">
+              Shared version name
+            </label>
+            <input
+              id="server-version-name"
+              type="text"
+              value={draftLabel}
+              disabled={busy}
+              onChange={(event) => setDraftLabel(event.target.value)}
+              placeholder="Name this shared version"
+              className={`${typography.panelBody} flex-1 min-w-0 px-2 py-1.5 rounded-md border border-panel-border bg-panel text-text-body placeholder:text-text-light`}
+            />
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void handleSave()}
+              aria-label="Save shared version"
+              className={`${typography.panelBody} shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-text-on-color disabled:opacity-60`}
+            >
+              <UploadCloud className="w-3.5 h-3.5" />
+              Save shared version
+            </button>
+          </div>
+
+          {phase.versions.length === 0 && (
+            <p className={`${typography.panelBody} text-text-light`} data-testid="server-versions-empty">
+              No shared versions yet. Save one to give the team a restorable state of this model.
+            </p>
+          )}
+
+          {phase.versions.length > 0 && (
+            <ul className="space-y-1">
+              {phase.versions.map((version) => {
+                const isCurrent = version.id === phase.currentVersionId
+                const origin = provenanceLabel(version.provenance)
+                const armed = armedVersionId === version.id
+                return (
+                  <li
+                    key={version.id}
+                    className="space-y-1"
+                    data-testid="server-version-row"
+                    data-version-id={version.id}
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="min-w-0 flex-1">
+                        <span className={`${typography.panelBody} text-text-body`}>
+                          v{version.versionNumber}
+                          {version.label !== null ? ` · ${version.label}` : ''}
+                        </span>
+                        <span className={`${typography.panelMeta} text-text-light ml-2`}>
+                          {formatTimestamp(version.createdAt)}
+                        </span>
+                        {origin !== null && (
+                          <span
+                            className={`${typography.panelMeta} text-text-light ml-2 px-1.5 py-0.5 rounded border border-panel-border`}
+                          >
+                            {origin}
+                          </span>
+                        )}
+                        {isCurrent && (
+                          <span
+                            className={`${typography.panelMeta} text-text-light ml-2 px-1.5 py-0.5 rounded border border-panel-border`}
+                          >
+                            current
+                          </span>
+                        )}
+                      </span>
+                      {!isCurrent && !armed && (
+                        <button
+                          type="button"
+                          disabled={busy}
+                          aria-label={`Restore version ${version.versionNumber}`}
+                          onClick={() => setArmedVersionId(version.id)}
+                          className={`${typography.panelBody} shrink-0 px-2 py-1 rounded-md border border-panel-border text-text-body hover:bg-panel-hover disabled:opacity-60`}
+                        >
+                          Restore
+                        </button>
+                      )}
+                    </div>
+                    {armed && (
+                      <div
+                        className="space-y-1.5 rounded-md border border-panel-border p-2"
+                        data-testid="server-restore-confirm"
+                      >
+                        <p className={`${typography.panelBody} text-text-body`}>
+                          Replace the current shared model with v{version.versionNumber}? The
+                          current state is saved first, so you can undo.
+                        </p>
+                        <div className="flex items-center gap-2">
+                          <button
+                            type="button"
+                            disabled={busy}
+                            onClick={() => void handleRestore(version.id)}
+                            className={`${typography.panelBody} px-3 py-1.5 rounded-md bg-primary text-text-on-color disabled:opacity-60`}
+                          >
+                            Confirm restore
+                          </button>
+                          <button
+                            type="button"
+                            disabled={busy}
+                            onClick={() => setArmedVersionId(null)}
+                            className={`${typography.panelBody} px-3 py-1.5 rounded-md border border-panel-border text-text-body hover:bg-panel-hover`}
+                          >
+                            Cancel
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </li>
+                )
+              })}
+            </ul>
+          )}
+        </>
+      )}
+    </PanelSection>
+  )
+}

--- a/src/canvas/versions/WhatChangedPanel.tsx
+++ b/src/canvas/versions/WhatChangedPanel.tsx
@@ -37,6 +37,7 @@ import { PanelShell } from '../panels/_shared/PanelShell'
 import { PanelSection } from '../panels/_shared/PanelSection'
 import { typography } from '../../styles/typography'
 import { buildVersionLabelIndex, describeChangeset } from './describeChange'
+import { ServerVersionsSection } from './ServerVersionsSection'
 import { useModelVersions } from './useModelVersions'
 import {
   VERSION_STORAGE_DISCLOSURE,
@@ -314,6 +315,14 @@ export function WhatChangedPanel({ isOpen, onClose }: WhatChangedPanelProps) {
             </ul>
           </PanelSection>
         )}
+
+        {/* SHARED (server-side) versions — the durable half. Rendered after
+            the local sections: the local history above answers "what did I
+            change on this canvas?"; this is the team's restorable history of
+            the shared model itself (its own storage disclosure inside;
+            sign-in required, and it says so honestly). Renders nothing when
+            the scenario is not server-addressable. */}
+        <ServerVersionsSection />
       </PanelShell>
     </div>
   )

--- a/src/canvas/versions/__tests__/ServerVersionsSection.spec.tsx
+++ b/src/canvas/versions/__tests__/ServerVersionsSection.spec.tsx
@@ -1,0 +1,309 @@
+/**
+ * ServerVersionsSection — shared (server-side) versions in the versions panel.
+ *
+ * ⚠ SCOPE (CLAUDE.md trap #16): jsdom proves presence, text and call wiring —
+ * never visibility on a deployed canvas. The deployed witness is separate.
+ *
+ * What is pinned here, and why each pin is load-bearing:
+ *
+ *  1. THE CONFIRM GATE. Restore overwrites the working model for EVERYONE with
+ *     access to the scenario. The restore adapter must NOT be called on the
+ *     row's "Restore" click — only on the explicit confirm. A mutant that
+ *     wires the first click straight to the adapter must go RED here.
+ *
+ *  2. IDENTITY-BOUND RESTORE. The confirm calls the adapter with THAT row's
+ *     version id (not the newest, not a constant) and with the CURRENT head's
+ *     identity hash as the CAS expectation — binding by id, not by a value
+ *     predicate another row could satisfy (trap 19).
+ *
+ *  3. THE APPLY IS THE RECEIPT-CLASS RECONCILE. A successful restore hands the
+ *     response graph to `reconcileAppliedGraph` — the one apply path with
+ *     authoritative deletion semantics — never a bespoke second merge.
+ *
+ *  4. UNDO IS REAL. After a restore, the offered undo calls the adapter with
+ *     the server-named `undo_version_id` (the pre-restore snapshot).
+ *
+ *  5. GUESTS GET THE HONEST INVITATION, NOT AN ERROR — and no network call.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const SCENARIO = 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c'
+const USER = '0f8a1b2c-3d4e-4f50-9a6b-7c8d9e0f1a2b'
+const VERSION_HEAD = 'bbbbbbbb-2222-4222-8222-bbbbbbbbbbbb'
+const VERSION_OLD = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa'
+const UNDO_VERSION = 'cccccccc-3333-4333-8333-cccccccccccc'
+const HASH_HEAD = 'b'.repeat(64)
+const HASH_OLD = 'a'.repeat(64)
+
+const listModelVersions = vi.fn()
+const saveModelVersion = vi.fn()
+const restoreModelVersion = vi.fn()
+vi.mock('../../../adapters/cee/modelVersions', () => ({
+  listModelVersions: (...args: unknown[]) => listModelVersions(...args),
+  saveModelVersion: (...args: unknown[]) => saveModelVersion(...args),
+  restoreModelVersion: (...args: unknown[]) => restoreModelVersion(...args),
+}))
+
+const reconcileAppliedGraph = vi.fn()
+vi.mock('../../utils/mergeAppliedGraph', () => ({
+  reconcileAppliedGraph: (...args: unknown[]) => reconcileAppliedGraph(...args),
+}))
+
+const authState: { user: { id: string } | null } = { user: { id: USER } }
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: authState.user }),
+}))
+
+import { ServerVersionsSection } from '../ServerVersionsSection'
+import { useCanvasStore } from '../../store'
+
+function serverVersion(overrides: Record<string, unknown> = {}) {
+  return {
+    id: VERSION_OLD,
+    versionNumber: 1,
+    label: 'First cut',
+    provenance: 'user_save',
+    restoredFromVersionId: null,
+    createdAt: '2026-08-17T10:00:00.000Z',
+    graphIdentityHash: HASH_OLD,
+    ...overrides,
+  }
+}
+
+const TWO_VERSIONS = [
+  serverVersion({
+    id: VERSION_HEAD,
+    versionNumber: 2,
+    label: null,
+    provenance: 'commit',
+    graphIdentityHash: HASH_HEAD,
+  }),
+  serverVersion(),
+]
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  authState.user = { id: USER }
+  useCanvasStore.setState({ currentScenarioId: SCENARIO } as never)
+  listModelVersions.mockResolvedValue({
+    status: 'list',
+    versions: TWO_VERSIONS,
+    currentVersionId: VERSION_HEAD,
+    requestId: 'req-1',
+  })
+  reconcileAppliedGraph.mockReturnValue({
+    addedNodeCount: 1,
+    addedEdgeCount: 0,
+    updatedNodeCount: 0,
+    updatedEdgeCount: 0,
+    removedNodeCount: 0,
+    removedEdgeCount: 0,
+  })
+})
+
+afterEach(() => {
+  useCanvasStore.setState({ currentScenarioId: null } as never)
+})
+
+describe('ServerVersionsSection — list', () => {
+  it('lists the scenario versions with the current one marked', async () => {
+    render(<ServerVersionsSection />)
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('server-version-row')).toHaveLength(2)
+    })
+    expect(listModelVersions).toHaveBeenCalledWith(
+      SCENARIO,
+      expect.objectContaining({ userId: USER }),
+    )
+    const rows = screen.getAllByTestId('server-version-row')
+    expect(rows[0]).toHaveTextContent('v2')
+    expect(rows[0]).toHaveTextContent(/current/i)
+    expect(rows[1]).toHaveTextContent('First cut')
+  })
+
+  it('renders nothing without a server-addressable (UUID) scenario', () => {
+    useCanvasStore.setState({ currentScenarioId: 'local-draft-1' } as never)
+    const { container } = render(<ServerVersionsSection />)
+    expect(container).toBeEmptyDOMElement()
+    expect(listModelVersions).not.toHaveBeenCalled()
+  })
+})
+
+describe('ServerVersionsSection — guests (pin 5)', () => {
+  it('invites sign-in and never calls the network', () => {
+    authState.user = null
+    render(<ServerVersionsSection />)
+
+    expect(screen.getByTestId('server-versions-signin')).toBeInTheDocument()
+    expect(screen.getByTestId('server-versions-signin')).toHaveTextContent(/sign in/i)
+    expect(listModelVersions).not.toHaveBeenCalled()
+    expect(restoreModelVersion).not.toHaveBeenCalled()
+  })
+})
+
+describe('ServerVersionsSection — restore (pins 1–4)', () => {
+  function restoredResponse() {
+    return {
+      status: 'restored',
+      graph: { nodes: [{ id: 'n1', label: 'Take the job', kind: 'option' }], edges: [] },
+      deduped: false,
+      version: { versionId: 'dddddddd-4444-4444-8444-dddddddddddd', versionNumber: 3, deduped: false },
+      undoVersionId: UNDO_VERSION,
+      requestId: 'req-2',
+    }
+  }
+
+  it('PIN 1 — the first click arms a confirm; the adapter is NOT called until confirmed', async () => {
+    restoreModelVersion.mockResolvedValue(restoredResponse())
+    render(<ServerVersionsSection />)
+    await waitFor(() => expect(screen.getAllByTestId('server-version-row')).toHaveLength(2))
+
+    fireEvent.click(screen.getByRole('button', { name: /restore version 1/i }))
+    expect(restoreModelVersion).not.toHaveBeenCalled()
+    expect(screen.getByTestId('server-restore-confirm')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /confirm restore/i }))
+    await waitFor(() => expect(restoreModelVersion).toHaveBeenCalledTimes(1))
+  })
+
+  it('cancel disarms without any call', async () => {
+    render(<ServerVersionsSection />)
+    await waitFor(() => expect(screen.getAllByTestId('server-version-row')).toHaveLength(2))
+
+    fireEvent.click(screen.getByRole('button', { name: /restore version 1/i }))
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(restoreModelVersion).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('server-restore-confirm')).not.toBeInTheDocument()
+  })
+
+  it('PIN 2 — confirms with THAT row\'s id and the CURRENT head hash as the CAS expectation', async () => {
+    restoreModelVersion.mockResolvedValue(restoredResponse())
+    render(<ServerVersionsSection />)
+    await waitFor(() => expect(screen.getAllByTestId('server-version-row')).toHaveLength(2))
+
+    fireEvent.click(screen.getByRole('button', { name: /restore version 1/i }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm restore/i }))
+
+    await waitFor(() => expect(restoreModelVersion).toHaveBeenCalledTimes(1))
+    expect(restoreModelVersion).toHaveBeenCalledWith(
+      SCENARIO,
+      expect.objectContaining({
+        userId: USER,
+        versionId: VERSION_OLD,
+        expectedGraphIdentityHash: HASH_HEAD,
+      }),
+    )
+  })
+
+  it('PIN 3 — applies the restored graph through reconcileAppliedGraph, identity-bound to the response bytes', async () => {
+    const response = restoredResponse()
+    restoreModelVersion.mockResolvedValue(response)
+    render(<ServerVersionsSection />)
+    await waitFor(() => expect(screen.getAllByTestId('server-version-row')).toHaveLength(2))
+
+    fireEvent.click(screen.getByRole('button', { name: /restore version 1/i }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm restore/i }))
+
+    await waitFor(() => expect(reconcileAppliedGraph).toHaveBeenCalledTimes(1))
+    const arg = reconcileAppliedGraph.mock.calls[0][0] as { graph: { nodes: { id: string }[] } }
+    expect(arg.graph.nodes.map((n) => n.id)).toEqual(['n1'])
+  })
+
+  it('PIN 4 — the undo affordance restores the server-named pre-restore snapshot', async () => {
+    restoreModelVersion.mockResolvedValue(restoredResponse())
+    render(<ServerVersionsSection />)
+    await waitFor(() => expect(screen.getAllByTestId('server-version-row')).toHaveLength(2))
+
+    fireEvent.click(screen.getByRole('button', { name: /restore version 1/i }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm restore/i }))
+    await waitFor(() => expect(screen.getByTestId('server-restore-undo')).toBeInTheDocument())
+
+    restoreModelVersion.mockClear()
+    restoreModelVersion.mockResolvedValue({ ...restoredResponse(), undoVersionId: null })
+    fireEvent.click(screen.getByTestId('server-restore-undo'))
+
+    await waitFor(() => expect(restoreModelVersion).toHaveBeenCalledTimes(1))
+    expect(restoreModelVersion.mock.calls[0][1]).toMatchObject({ versionId: UNDO_VERSION })
+  })
+
+  it('a conflict answers with honest copy and a refreshed list, not a silent nothing', async () => {
+    restoreModelVersion.mockResolvedValue({ status: 'conflict' })
+    render(<ServerVersionsSection />)
+    await waitFor(() => expect(screen.getAllByTestId('server-version-row')).toHaveLength(2))
+    listModelVersions.mockClear()
+
+    fireEvent.click(screen.getByRole('button', { name: /restore version 1/i }))
+    fireEvent.click(screen.getByRole('button', { name: /confirm restore/i }))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('server-versions-message')).toHaveTextContent(/changed/i),
+    )
+    expect(listModelVersions).toHaveBeenCalledTimes(1)
+    expect(reconcileAppliedGraph).not.toHaveBeenCalled()
+  })
+})
+
+describe('ServerVersionsSection — save', () => {
+  it('saves a named version and refreshes the list', async () => {
+    saveModelVersion.mockResolvedValue({
+      status: 'saved',
+      version: { versionId: VERSION_HEAD, versionNumber: 3, deduped: false },
+    })
+    render(<ServerVersionsSection />)
+    await waitFor(() => expect(screen.getAllByTestId('server-version-row')).toHaveLength(2))
+    listModelVersions.mockClear()
+
+    fireEvent.change(screen.getByLabelText(/shared version name/i), {
+      target: { value: 'Before pivot' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /save shared version/i }))
+
+    await waitFor(() => expect(saveModelVersion).toHaveBeenCalledTimes(1))
+    expect(saveModelVersion.mock.calls[0][1]).toMatchObject({
+      userId: USER,
+      label: 'Before pivot',
+    })
+    await waitFor(() => expect(listModelVersions).toHaveBeenCalledTimes(1))
+  })
+
+  it('an unchanged model saves as a no-op and says so (deduped)', async () => {
+    saveModelVersion.mockResolvedValue({
+      status: 'saved',
+      version: { versionId: VERSION_HEAD, versionNumber: 2, deduped: true },
+    })
+    render(<ServerVersionsSection />)
+    await waitFor(() => expect(screen.getAllByTestId('server-version-row')).toHaveLength(2))
+
+    fireEvent.click(screen.getByRole('button', { name: /save shared version/i }))
+    await waitFor(() =>
+      expect(screen.getByTestId('server-versions-message')).toHaveTextContent(/already/i),
+    )
+  })
+})
+
+describe('ServerVersionsSection — honest degraded states', () => {
+  it('says when versioning is disabled on the service', async () => {
+    listModelVersions.mockResolvedValue({ status: 'disabled' })
+    render(<ServerVersionsSection />)
+    await waitFor(() =>
+      expect(screen.getByTestId('server-versions-unavailable')).toHaveTextContent(
+        /not available/i,
+      ),
+    )
+  })
+
+  it('offers a retry when the read failed, never an empty claim', async () => {
+    listModelVersions.mockResolvedValueOnce({ status: 'unavailable' })
+    render(<ServerVersionsSection />)
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument(),
+    )
+    expect(screen.queryByTestId('server-version-row')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }))
+    await waitFor(() => expect(screen.getAllByTestId('server-version-row')).toHaveLength(2))
+  })
+})

--- a/tests/ci-guards/bffProxyPathAllowlist.spec.ts
+++ b/tests/ci-guards/bffProxyPathAllowlist.spec.ts
@@ -97,6 +97,44 @@ describe('cee-proxy path allowlist (/bff/cee/* → /assist/v1/*)', () => {
     expect(r.calledUrl).toBe(`https://cee-staging.onrender.com/assist/v1/scenarios/${uuid}/graph`)
   })
 
+  // Shared model versions (UI #744 / CEE #1001). These three cases exist
+  // because the FIRST cut of #744 shipped without the allowlist entries and
+  // every browser call died at this seam with 404 while all 26 unit tests
+  // stayed green — adapter mocked fetch, section mocked the adapter, and
+  // nothing exercised the REAL handler (trap 3b's shape: every instrument
+  // above the seam agreed, and none touched what a user loads). This spec is
+  // the instrument that sees it; any new /bff/cee route needs its ON-LIST
+  // case here IN THE SAME PR.
+  it('ON-LIST /bff/cee/scenarios/{uuid}/versions forwards (versions list)', async () => {
+    const uuid = 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c'
+    const r = await invoke(ceeHandler as Handler, { path: `/bff/cee/scenarios/${uuid}/versions` })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe(`https://cee-staging.onrender.com/assist/v1/scenarios/${uuid}/versions`)
+    expect(r.requestHeaders?.get('X-Olumi-Assist-Key')).toBe(FAKE_KEY)
+  })
+
+  it('ON-LIST /bff/cee/scenarios/{uuid}/versions/save forwards (named save)', async () => {
+    const uuid = 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c'
+    const r = await invoke(ceeHandler as Handler, {
+      path: `/bff/cee/scenarios/${uuid}/versions/save`,
+    })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe(
+      `https://cee-staging.onrender.com/assist/v1/scenarios/${uuid}/versions/save`,
+    )
+  })
+
+  it('ON-LIST /bff/cee/scenarios/{uuid}/versions/restore forwards (guarded restore)', async () => {
+    const uuid = 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c'
+    const r = await invoke(ceeHandler as Handler, {
+      path: `/bff/cee/scenarios/${uuid}/versions/restore`,
+    })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe(
+      `https://cee-staging.onrender.com/assist/v1/scenarios/${uuid}/versions/restore`,
+    )
+  })
+
   it('OFF-LIST /bff/cee/decision-review (a real LLM route the UI never calls) is 404 with NO key sent', async () => {
     const r = await invoke(ceeHandler as Handler, { path: '/bff/cee/decision-review' })
     expect(r.status).toBe(404)


### PR DESCRIPTION
## What this is

The UI half of the versions slice (feedback-wave refill item #1; CEE half: olumi-assistants-service #1001). #739 gave version history ONE home — but browser-local, and its own panel says so. This adds the durable half to the SAME home: versions of the shared model (`scenarios.graph`), persisted by CEE in `model_versions`, visible and restorable from any browser with access to the scenario.

- **`src/adapters/cee/modelVersions.ts`** — list/save/restore client on scenarioGraph.ts's transport rules, inherited in full: literal same-origin `/bff/cee` base (never the PLoT-baked `VITE_CEE_BFF_BASE` — trap 18's live form), POST with identity in the body, guest sentinel never sent, typed outcomes for every server refusal (`VERSION_STALE`, `SIGN_IN_REQUIRED`, `VERSIONS_DISABLED`, `RESTORE_INCOMPLETE`, `NOTHING_TO_SAVE`, `VERSION_NOT_FOUND`), and **writes never auto-retried** — retrying a partial restore is safe (no data loss) but is the user's decision, and the mechanism is: a same-hash retry answers 409 (the server's pre-restore machinery already moved the head — reviewer-measured); a retry after re-reading the list completes it, appending two more version rows. The section refreshes the list on `RESTORE_INCOMPLETE`/`VERSION_STALE` so the user's next attempt carries the fresh head hash.
- **`ServerVersionsSection`** in the versions panel (one import + one mount line in WhatChangedPanel; the #739 local sections are untouched). Rows show v-number, label, time, provenance in user terms (`auto — saved on change`, `auto — before a restore`, `restored`), and mark the current head.
- **Restore, guarded twice**: an explicit CONFIRM must be clicked before any network call (a mutant wiring the first click straight through REDs 6 tests), and the server's pre-restore snapshot comes back as a real **Undo** button. The CAS expectation carries the head hash the user was shown. The apply is `reconcileAppliedGraph` — the receipt-class reconcile with authoritative deletion semantics and layout preservation — never a second bespoke merge. If the reconcile changes nothing after a non-deduped restore, the panel says so honestly (reload guidance) instead of claiming silently.
- **Guests**: the honest sign-in invitation, no network call spent; local history keeps working. **Failed reads never render as 'no versions'** — an unreadable history is an unknown, not an absence.

## User journey (who sees what, from which browser)

Signed-in user saves "Before pricing pivot" on browser A → the same user (or any collaborator with access, once sign-in-shared scenarios exist) opens the scenario on browser B → the panel lists it (plus CEE's auto commit-versions) → Restore (confirm) → the server's working model AND the canvas now show that version; the next turn/analysis is computed from it → Undo restores the pre-restore snapshot. Guests: local-only history + honest sign-in copy.

## Evidence

- RED-first at pristine for both new specs (collection failure before the modules exist); adapter 13/13 + section 13/13 + whole versions module 161/161 + impacted suites (adapters/cee, TopBar.versionHistory, vitestExcludeRegister) 293/293 GREEN.
- **Mutant kit, throwaway worktree outside the repo root, write-test isolation proven, applied-check per mutation (control = exactly 0):** M6 confirm-gate-removed → 6 RED · M7 restore-unbound-from-chosen-row (identity binding, trap 19) → exactly the identity pin RED · M8 reconcile-fed-empty-graph → 1 RED · leading + trailing controls 13/13 GREEN.
- `pnpm typecheck` gate PASSED (ratchet: 2325 → 2308, none added). Scoped eslint clean.

## Fences honoured

No changes to `OutputsDock.tsx` (cockpit #741 owns the panel-header trigger per R4 — this PR mounts nothing new; the existing #739 TopBar trigger + panel host are unchanged), Model Editor files (#742), `useConversation.ts` (#743), or the #737 selector files. `serverGraphHydration.ts` (#727) and `adapters/cee/client.ts` (#682) are not touched — the new adapter is its own file.

## Depends on

CEE #1001 deployed to staging. Until then the section answers its honest failed/disabled states — nothing lies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Fix round (head `20e44ff8`) — the edge seam

The first cut was **dead on the wire**: `cee-proxy.ts`'s `ALLOWED_TARGETS` (the service-key blast-radius allowlist) did not carry the three versions paths, so every browser call 404'd at the edge before reaching CEE — while all 26 unit tests stayed green, because every instrument sat above the seam (adapter mocks fetch, section mocks the adapter; trap 3b's shape). Caught by review executing the real regexes.

Fixed RED-first with the instrument that sees it: three ON-LIST cases added to `tests/ci-guards/bffProxyPathAllowlist.spec.ts` (drives the REAL handler) — **RED at the pristine edge (3 failed), GREEN with the three regexes added** (`…/versions$`, `…/versions/save$`, `…/versions/restore$`). Guard spec 52/52; versions+adapter+guard 213/213; typecheck gate PASSED; scoped lint clean. Also corrected the retry-convergence mechanism above per the reviewer's measurement (same-hash retry 409s; refreshed retry converges at +2 rows; no data loss).
