### PR TITLE
fix(results): conditional winners — bind to producer attestation + identity, withheld neutral arm, no fabricated defaults (V6 S2R)

### DIFF
--- a/src/components/results/ConditionalWinnerCards.tsx
+++ b/src/components/results/ConditionalWinnerCards.tsx
@@ -1,25 +1,40 @@
 /**
- * ConditionalWinnerCards — factor-dependent recommendation splits (ISL).
+ * ConditionalWinnerCards — factor-dependent leadership splits (ISL).
  *
- * Brief 4 Task 10. Post-analysis surfaces where the recommendation flips
- * when a factor crosses a split point. Gated on at least one winner-flip
- * entry being present (entries where high/low buckets share the same
- * winner are not "scenarios" and are filtered out).
+ * V6 Science-to-Reasoning slice: the card binds to the PRODUCER's claims,
+ * never to display-label comparison.
  *
- * Copy derives the direction from which bucket carries the ALTERNATIVE
- * winner relative to the overall recommended option:
- *   - if the flip happens on the HIGH side → "When X exceeds N, ALT leads instead"
- *   - if the flip happens on the LOW side  → "When X falls below N, ALT leads instead"
- * When the recommended option label is unknown, fall back to "exceeds" with
- * the high-bucket winner — this is the most conservative phrasing and matches
- * PLoT's typical monotone interpretation of split values.
+ *   - A scenario is a row the producer ATTESTED with `winner_flips: true`
+ *     (schemas 0.46: "says THAT the winner changes across the split, never
+ *     WHICH option"). Label inequality is not a flip test: two options can
+ *     share one display label (a real flip a label filter cannot see) and a
+ *     label churn is not a flip (trap 19).
+ *
+ *   - Direction binds by IDENTITY: `winner_id` vs `recommendedOptionId`
+ *     (`report.robustness.recommended_option_id`). If the recommended id
+ *     sits in the LOW bucket, the flip happens when the factor EXCEEDS the
+ *     split; in the HIGH bucket, when it FALLS BELOW. Labels are display
+ *     only.
+ *
+ *   - When direction cannot be bound by ID (identity withheld by CEE's
+ *     withheld-claim projection, recommended id absent, or matching neither
+ *     bucket), the card renders the NEUTRAL two-sided arm — the factor and
+ *     the threshold with no option name and no direction — instead of
+ *     guessing or vanishing. CEE ships identity-stripped rows deliberately
+ *     ("dropping the key whole would be the over-suppression failure");
+ *     rendering nothing would drop that claim on the floor.
+ *
+ *   - Absent numerics render as absent. A row without a finite
+ *     `split_value` is not renderable as a threshold claim and is skipped
+ *     (defence in depth — the projection already drops it). An absent
+ *     `win_probability` omits the percentage; it is never minted as 0%.
  */
 
 import { useMemo } from 'react'
 import { GitBranch, Info } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import { focusNodeById } from '../../canvas/utils/focusHelpers'
-import type { ConditionalWinner } from './types'
+import type { ConditionalWinner, ConditionalWinnerBucket } from './types'
 // Canonical glossary check shared with the v17 hero row builders + body
 // sub-components. Used in v17 mode to sanitise user-supplied factor /
 // option labels before they enter generated prose. The raw label still
@@ -30,19 +45,24 @@ const MAX_CONDITIONAL_CARDS = 3
 
 interface ConditionalWinnerCardsProps {
   winners: ConditionalWinner[]
-  /** Label of the overall recommended option (drives direction wording). */
-  recommendedLabel?: string
+  /**
+   * `report.robustness.recommended_option_id` — the backend's own
+   * leading-option identity. Direction wording derives from comparing this
+   * to the buckets' `winner_id`s BY IDENTITY; display labels never decide
+   * direction. Absent (or matching neither bucket) ⇒ the neutral arm.
+   */
+  recommendedOptionId?: string
   onFocusNode?: (nodeId: string) => void
   /**
    * v17 hero mode (Round-7 review). When true:
    *   - The header info tooltip + sr-only text drop the banned word
    *     "recommendation" in favour of "which option leads".
-   *   - All four interpolated user labels (`factor_label`, the chosen
-   *     `alt` winner_label, and the two bucket `winner_label`s in the
-   *     Above/Below footer) route through `safeInterpolatedLabel` so a
-   *     user-named option like "Winning strategy" cannot smuggle a
-   *     banned term into the visible prose. The raw label still appears
-   *     verbatim when `useV17Copy=false`.
+   *   - All interpolated user labels (`factor_label`, the chosen `alt`
+   *     winner_label, and the two bucket `winner_label`s in the Above/Below
+   *     footer) route through `safeInterpolatedLabel` so a user-named
+   *     option like "Winning strategy" cannot smuggle a banned term into
+   *     the visible prose. The raw label still appears verbatim when
+   *     `useV17Copy=false`.
    *
    * Default: false — the copy the legacy panel used before it was deleted,
    * kept so remaining callers and tests are untouched.
@@ -50,14 +70,20 @@ interface ConditionalWinnerCardsProps {
   useV17Copy?: boolean
 }
 
+/** Which direction arm a row can honestly claim. */
+type DirectionArm = 'high-alt' | 'low-alt' | 'neutral'
+
 export function ConditionalWinnerCards({
   winners,
-  recommendedLabel,
+  recommendedOptionId,
   onFocusNode,
   useV17Copy = false,
 }: ConditionalWinnerCardsProps) {
+  // Producer attestation ONLY — label comparison cannot see a same-label
+  // flip and renders label churn as a phantom scenario. A row without a
+  // finite split_value cannot state "flips at N" and is skipped.
   const flipping = useMemo(
-    () => winners.filter(w => w.high_bucket.winner_label !== w.low_bucket.winner_label),
+    () => winners.filter(w => w.winner_flips === true && Number.isFinite(w.split_value)),
     [winners],
   )
   if (flipping.length === 0) return null
@@ -94,47 +120,77 @@ export function ConditionalWinnerCards({
             else focusNodeById(w.factor_id)
           }
         }
-        // Direction: if the recommended option matches the LOW bucket winner,
-        // then the flip happens when the factor EXCEEDS the split (HIGH bucket
-        // is the alternative). If it matches the HIGH bucket, flip happens
-        // when the factor FALLS BELOW the split.
-        const highIsAlt = recommendedLabel != null
-          ? w.low_bucket.winner_label === recommendedLabel
-          : true
-        const direction = highIsAlt ? 'exceeds' : 'falls below'
-        const alt = highIsAlt ? w.high_bucket.winner_label : w.low_bucket.winner_label
-        const splitSuffix = w.split_unit ? w.split_unit : ''
+        // Direction by IDENTITY. The recommended option id must match
+        // exactly one bucket's winner_id; anything else — identity withheld,
+        // recommended absent, or an id the buckets don't carry — is the
+        // neutral arm, never a guess.
+        const highId = w.high_bucket.winner_id
+        const lowId = w.low_bucket.winner_id
+        let arm: DirectionArm = 'neutral'
+        if (recommendedOptionId && highId && lowId && highId !== lowId) {
+          if (lowId === recommendedOptionId) arm = 'high-alt'
+          else if (highId === recommendedOptionId) arm = 'low-alt'
+        }
+        // A directional sentence names the alternative; without its label
+        // there is nothing honest to name — fall back to the neutral arm.
+        const altBucket: ConditionalWinnerBucket | undefined =
+          arm === 'high-alt' ? w.high_bucket : arm === 'low-alt' ? w.low_bucket : undefined
+        if (arm !== 'neutral' && altBucket?.winner_label === undefined) arm = 'neutral'
+
+        const splitDisplay = `${w.split_value.toLocaleString()}${w.split_unit ?? ''}`
         // (Round-7 P1.1) v17 mode: gate every user-supplied label that
         // enters the visible prose through `safeInterpolatedLabel`. The
         // legacy panel keeps the raw labels verbatim (default).
         const factorLabelDisplay = useV17Copy
           ? safeInterpolatedLabel(w.factor_label, 'this factor')
           : w.factor_label
-        const altDisplay = useV17Copy
-          ? safeInterpolatedLabel(alt, 'the other option')
-          : alt
-        const highLabelDisplay = useV17Copy
-          ? safeInterpolatedLabel(w.high_bucket.winner_label, 'the other option')
-          : w.high_bucket.winner_label
-        const lowLabelDisplay = useV17Copy
-          ? safeInterpolatedLabel(w.low_bucket.winner_label, 'the other option')
-          : w.low_bucket.winner_label
+        const altDisplay = altBucket?.winner_label !== undefined
+          ? (useV17Copy ? safeInterpolatedLabel(altBucket.winner_label, 'the other option') : altBucket.winner_label)
+          : undefined
+
+        // Footer sides render exactly what the producer sent: label when
+        // present, percentage when present, neither minted. A side with
+        // nothing to say is omitted; so is an empty footer.
+        const sideText = (bucket: ConditionalWinnerBucket): string | undefined => {
+          const label = bucket.winner_label !== undefined
+            ? (useV17Copy ? safeInterpolatedLabel(bucket.winner_label, 'the other option') : bucket.winner_label)
+            : undefined
+          const pct = bucket.win_probability !== undefined
+            ? `${Math.round(bucket.win_probability * 100)}%`
+            : undefined
+          if (label !== undefined && pct !== undefined) return `${label} (${pct})`
+          if (label !== undefined) return label
+          if (pct !== undefined) return pct
+          return undefined
+        }
+        const aboveText = sideText(w.high_bucket)
+        const belowText = sideText(w.low_bucket)
+
         return (
           <div
             key={`${w.factor_id}-${idx}`}
+            data-cw-arm={arm}
             className={`p-3 bg-panel border border-info/30 rounded-lg ${canFocus ? 'cursor-pointer hover:-translate-y-0.5 hover:shadow-md transition-all' : ''}`}
             onClick={canFocus ? handleFocus : undefined}
             role={canFocus ? 'button' : undefined}
             tabIndex={canFocus ? 0 : undefined}
             onKeyDown={canFocus ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handleFocus() } } : undefined}
           >
-            <p className={`${typography.panelBody} text-text-body`}>
-              When <span className="text-text-header">{factorLabelDisplay}</span> {direction} {w.split_value.toLocaleString()}{splitSuffix}, <span className="text-text-header">{altDisplay}</span> leads instead.
-            </p>
-            <div className={`${typography.panelMeta} text-text-light mt-1 flex gap-4`}>
-              <span>Above: {highLabelDisplay} ({Math.round(w.high_bucket.win_probability * 100)}%)</span>
-              <span>Below: {lowLabelDisplay} ({Math.round(w.low_bucket.win_probability * 100)}%)</span>
-            </div>
+            {arm === 'neutral' ? (
+              <p className={`${typography.panelBody} text-text-body`}>
+                Which option leads depends on <span className="text-text-header">{factorLabelDisplay}</span> — the analysis flips at {splitDisplay}.
+              </p>
+            ) : (
+              <p className={`${typography.panelBody} text-text-body`}>
+                When <span className="text-text-header">{factorLabelDisplay}</span> {arm === 'high-alt' ? 'exceeds' : 'falls below'} {splitDisplay}, <span className="text-text-header">{altDisplay}</span> leads instead.
+              </p>
+            )}
+            {(aboveText !== undefined || belowText !== undefined) && (
+              <div className={`${typography.panelMeta} text-text-light mt-1 flex gap-4`}>
+                {aboveText !== undefined && <span>Above: {aboveText}</span>}
+                {belowText !== undefined && <span>Below: {belowText}</span>}
+              </div>
+            )}
           </div>
         )
       })}

--- a/src/components/results/ConfidenceSection.tsx
+++ b/src/components/results/ConfidenceSection.tsx
@@ -469,6 +469,7 @@ export function ConfidenceSection({
     m2EvidenceEnhancements,
     // New ISL fields (gated on presence)
     conditionalWinners,
+    recommendedOptionId,
     inferenceWarnings,
   } = data
 
@@ -960,7 +961,7 @@ export function ConfidenceSection({
 
       {/* Conditional winners — factor-dependent recommendation splits (ISL) */}
       {conditionalWinners && conditionalWinners.length > 0 && (
-        <ConditionalWinnerCards winners={conditionalWinners} onFocusNode={onFocusNode} />
+        <ConditionalWinnerCards winners={conditionalWinners} recommendedOptionId={recommendedOptionId} onFocusNode={onFocusNode} />
       )}
 
       {/* Inference warnings — model gaps (ISL) */}

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -758,7 +758,7 @@ export const TriageActionCardsBody = memo(function TriageActionCardsBody({
         <div className="border-t border-panel-border pt-3">
           <ConditionalWinnerCards
             winners={data.confidence.conditionalWinners}
-            recommendedLabel={data.recommendation.recommendedOption?.label}
+            recommendedOptionId={data.confidence.recommendedOptionId}
             onFocusNode={onFocusNode}
             useV17Copy={useV17Copy}
           />

--- a/src/components/results/__tests__/ConditionalWinnerCards.direction.spec.tsx
+++ b/src/components/results/__tests__/ConditionalWinnerCards.direction.spec.tsx
@@ -2,10 +2,17 @@
  * ConditionalWinnerCards — direction logic
  *
  * Verifies the "exceeds" vs "falls below" copy derivation against the
- * recommended option label:
- *   - recommended sits in low_bucket  → flip happens on the HIGH side → "exceeds {split}, {high.winner} leads instead"
- *   - recommended sits in high_bucket → flip happens on the LOW side  → "falls below {split}, {low.winner} leads instead"
- *   - recommended label missing       → defaults to "exceeds" / high_bucket.winner_label (safe, monotone assumption)
+ * backend's recommended option IDENTITY (`recommendedOptionId` =
+ * `report.robustness.recommended_option_id`), bound to bucket `winner_id`:
+ *   - recommended id sits in low_bucket  → flip happens on the HIGH side → "exceeds {split}, {high.winner} leads instead"
+ *   - recommended id sits in high_bucket → flip happens on the LOW side  → "falls below {split}, {low.winner} leads instead"
+ *   - recommended id missing (or matching neither bucket) → the NEUTRAL
+ *     two-sided arm — never a guessed direction (the pre-slice behaviour
+ *     guessed "exceeds", which asserted a direction the producer never gave).
+ *
+ * Scenarios are the rows the producer attested with `winner_flips: true`;
+ * label comparison decides nothing (see ConditionalWinnerCards.honesty.spec
+ * for the same-label-flip and label-churn discriminators).
  */
 
 import { describe, it, expect } from 'vitest'
@@ -18,56 +25,60 @@ const makeWinner = (overrides: Partial<ConditionalWinner> = {}): ConditionalWinn
   factor_id: 'fac_market_size',
   split_value: 1000000,
   split_unit: undefined,
-  high_bucket: { winner_label: 'Expand into Europe', win_probability: 0.7 },
-  low_bucket: { winner_label: 'Consolidate current market', win_probability: 0.6 },
+  winner_flips: true,
+  high_bucket: { winner_id: 'opt_expand', winner_label: 'Expand into Europe', win_probability: 0.7 },
+  low_bucket: { winner_id: 'opt_consolidate', winner_label: 'Consolidate current market', win_probability: 0.6 },
   ...overrides,
 })
 
-describe('ConditionalWinnerCards — direction derivation', () => {
-  it('renders "exceeds" + high-bucket winner when recommended sits in low_bucket', () => {
+describe('ConditionalWinnerCards — direction derivation (ID-bound)', () => {
+  it('renders "exceeds" + high-bucket winner when the recommended id sits in low_bucket', () => {
     render(
       <ConditionalWinnerCards
         winners={[makeWinner()]}
-        recommendedLabel="Consolidate current market"
+        recommendedOptionId="opt_consolidate"
       />,
     )
     const body = screen.getByTestId('conditional-winner-cards')
     expect(body.textContent).toMatch(/exceeds/i)
     expect(body.textContent).not.toMatch(/falls below/i)
     // The "leads instead" target should be the high-bucket winner (the alternative)
-    expect(body.textContent).toMatch(/Expand into Europe/)
+    expect(body.textContent).toMatch(/Expand into Europe leads instead/)
   })
 
-  it('renders "falls below" + low-bucket winner when recommended sits in high_bucket', () => {
+  it('renders "falls below" + low-bucket winner when the recommended id sits in high_bucket', () => {
     render(
       <ConditionalWinnerCards
         winners={[makeWinner()]}
-        recommendedLabel="Expand into Europe"
+        recommendedOptionId="opt_expand"
       />,
     )
     const body = screen.getByTestId('conditional-winner-cards')
     expect(body.textContent).toMatch(/falls below/i)
     expect(body.textContent).not.toMatch(/exceeds/i)
     // The "leads instead" target should be the low-bucket winner (the alternative)
-    expect(body.textContent).toMatch(/Consolidate current market/)
+    expect(body.textContent).toMatch(/Consolidate current market leads instead/)
   })
 
-  it('defaults to "exceeds" + high-bucket winner when recommendedLabel is omitted', () => {
+  it('renders the neutral two-sided arm when recommendedOptionId is omitted — never a guessed direction', () => {
     render(<ConditionalWinnerCards winners={[makeWinner()]} />)
     const body = screen.getByTestId('conditional-winner-cards')
-    expect(body.textContent).toMatch(/exceeds/i)
-    expect(body.textContent).toMatch(/Expand into Europe/)
+    expect(body.textContent).toMatch(/Which option leads depends on/)
+    expect(body.textContent).not.toMatch(/exceeds/i)
+    expect(body.textContent).not.toMatch(/falls below/i)
+    expect(body.textContent).not.toMatch(/leads instead/i)
   })
 
-  it('filters out entries where both buckets share the same winner', () => {
+  it('filters out rows the producer did not attest as flips (winner_flips false)', () => {
     const nonFlip = makeWinner({
-      high_bucket: { winner_label: 'Same option', win_probability: 0.6 },
-      low_bucket: { winner_label: 'Same option', win_probability: 0.55 },
+      winner_flips: false,
+      high_bucket: { winner_id: 'opt_same', winner_label: 'Same option', win_probability: 0.6 },
+      low_bucket: { winner_id: 'opt_same', winner_label: 'Same option', win_probability: 0.55 },
     })
     const { container } = render(
       <ConditionalWinnerCards
         winners={[nonFlip]}
-        recommendedLabel="Same option"
+        recommendedOptionId="opt_same"
       />,
     )
     // No card, no container div — the component returns null

--- a/src/components/results/__tests__/ConditionalWinnerCards.honesty.spec.tsx
+++ b/src/components/results/__tests__/ConditionalWinnerCards.honesty.spec.tsx
@@ -1,0 +1,249 @@
+/**
+ * ConditionalWinnerCards — producer-attestation honesty (V6 Science-to-Reasoning slice).
+ *
+ * The card binds to the PRODUCER's claims, never to display-label comparison:
+ *   - a scenario is a row the producer ATTESTED with `winner_flips: true`
+ *     (label inequality is trap 19 — two options can share a label, and a
+ *     label churn is not a flip);
+ *   - direction binds to `winner_id` vs `recommendedOptionId` by IDENTITY;
+ *   - identity-stripped rows (CEE's withheld-claim projection) render the
+ *     NEUTRAL two-sided arm — factor + threshold, no option name — instead
+ *     of silently vanishing (the over-suppression CEE shipped bytes to avoid);
+ *   - absent numerics render as absent. No `?? 0`, no minted percentages.
+ *
+ * Withheld fixture: GENERATED from the full producer row by applying CEE's
+ * published projection rule (strip exactly WITHHELD_DROPPED_CONDITIONAL_BUCKET_MEMBERS
+ * per bucket — olumi-assistants-service
+ * `src/orchestrator-v5/compose/withheld-claim-projection.ts:452,914-937` @ fa8bacc5),
+ * never hand-written member by member. Preconditions are pinned in-test.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ConditionalWinnerCards } from '../ConditionalWinnerCards'
+import type { ConditionalWinner } from '../types'
+
+/**
+ * Mirror of CEE's exported WITHHELD_DROPPED_CONDITIONAL_BUCKET_MEMBERS
+ * (withheld-claim-projection.ts:452 @ fa8bacc5). The fixture below is derived
+ * from the full row by this rule, so the withheld shape under test is the
+ * projection's published output shape, not a hand-authored guess.
+ */
+const WITHHELD_DROPPED_CONDITIONAL_BUCKET_MEMBERS = [
+  'winner_id',
+  'winner_label',
+  'runner_up_id',
+  'runner_up_label',
+] as const
+
+function projectRowForWithheldClaim(row: ConditionalWinner): ConditionalWinner {
+  const strip = (bucket: Record<string, unknown>): Record<string, unknown> => {
+    const out: Record<string, unknown> = {}
+    for (const [k, v] of Object.entries(bucket)) {
+      if ((WITHHELD_DROPPED_CONDITIONAL_BUCKET_MEMBERS as readonly string[]).includes(k)) continue
+      out[k] = v
+    }
+    return out
+  }
+  return {
+    ...row,
+    high_bucket: strip(row.high_bucket as unknown as Record<string, unknown>),
+    low_bucket: strip(row.low_bucket as unknown as Record<string, unknown>),
+  } as ConditionalWinner
+}
+
+const fullRow = (overrides: Partial<ConditionalWinner> = {}): ConditionalWinner => ({
+  factor_label: 'Market growth',
+  factor_id: 'fac_growth',
+  split_value: 42.5,
+  split_unit: '%',
+  winner_flips: true,
+  high_bucket: {
+    winner_id: 'opt_expand',
+    winner_label: 'Expand into Europe',
+    runner_up_id: 'opt_hold',
+    runner_up_label: 'Hold position',
+    win_probability: 0.7,
+  },
+  low_bucket: {
+    winner_id: 'opt_hold',
+    winner_label: 'Hold position',
+    runner_up_id: 'opt_expand',
+    runner_up_label: 'Expand into Europe',
+    win_probability: 0.6,
+  },
+  ...overrides,
+})
+
+describe('ConditionalWinnerCards — attestation binding (winner_flips, not labels)', () => {
+  it('renders a same-label flip: identical display labels, producer attests winner_flips', () => {
+    // Two DIFFERENT options that share one display label — a label-inequality
+    // filter is structurally blind to this row (trap 19).
+    const row = fullRow({
+      high_bucket: { winner_id: 'opt_b', winner_label: 'Rebrand', win_probability: 0.7 },
+      low_bucket: { winner_id: 'opt_a', winner_label: 'Rebrand', win_probability: 0.6 },
+    })
+    // Precondition pin: the labels REALLY are identical and the attestation
+    // REALLY is present — the render below is the code's doing, not the fixture's.
+    expect(row.high_bucket.winner_label).toBe(row.low_bucket.winner_label)
+    expect(row.high_bucket.winner_id).not.toBe(row.low_bucket.winner_id)
+    expect(row.winner_flips).toBe(true)
+
+    render(<ConditionalWinnerCards winners={[row]} recommendedOptionId="opt_a" />)
+    const body = screen.getByTestId('conditional-winner-cards')
+    expect(body.textContent).toMatch(/Market growth/)
+    expect(body.textContent).toMatch(/42\.5/)
+  })
+
+  it('renders exactly the attested rows from a mixed array: label churn without winner_flips is not a scenario', () => {
+    // One genuine attested flip + one label-churn row the producer says did
+    // NOT flip (same winner_id both sides, cosmetically different labels).
+    const flip = fullRow({ factor_label: 'Demand', factor_id: 'fac_demand' })
+    const churn = fullRow({
+      factor_label: 'Churn factor',
+      factor_id: 'fac_churn',
+      winner_flips: false,
+      high_bucket: { winner_id: 'opt_expand', winner_label: 'Expand into Europe', win_probability: 0.7 },
+      low_bucket: { winner_id: 'opt_expand', winner_label: 'European expansion', win_probability: 0.65 },
+    })
+    // Precondition pin: the churn row's labels differ (a label filter WOULD
+    // render it) while its identity does not.
+    expect(churn.high_bucket.winner_label).not.toBe(churn.low_bucket.winner_label)
+    expect(churn.high_bucket.winner_id).toBe(churn.low_bucket.winner_id)
+    expect(churn.winner_flips).toBe(false)
+
+    render(<ConditionalWinnerCards winners={[flip, churn]} recommendedOptionId="opt_hold" />)
+    const body = screen.getByTestId('conditional-winner-cards')
+    // Exactly the attested factor renders; the churn factor does not.
+    expect(body.textContent).toMatch(/Demand/)
+    expect(body.textContent).not.toMatch(/Churn factor/)
+  })
+
+  it('renders nothing when no row carries the winner_flips attestation', () => {
+    const rows = [
+      fullRow({ winner_flips: false }),
+      fullRow({ winner_flips: undefined }),
+    ]
+    const { container } = render(
+      <ConditionalWinnerCards winners={rows} recommendedOptionId="opt_hold" />,
+    )
+    expect(container.querySelector('[data-testid="conditional-winner-cards"]')).toBeNull()
+  })
+})
+
+describe('ConditionalWinnerCards — withheld/neutral arm (CEE projection shape)', () => {
+  it('renders the neutral two-sided line for identity-stripped rows: factor + threshold, no option name', () => {
+    const projected = projectRowForWithheldClaim(fullRow())
+    // Precondition pins (assert the SHAPE before asserting the render —
+    // the fixture must actually be the withheld projection's output):
+    for (const bucket of [projected.high_bucket, projected.low_bucket] as unknown as Record<string, unknown>[]) {
+      for (const member of WITHHELD_DROPPED_CONDITIONAL_BUCKET_MEMBERS) {
+        expect(member in bucket).toBe(false)
+      }
+      expect(bucket.win_probability).toBeDefined()
+    }
+    expect(projected.winner_flips).toBe(true)
+
+    render(<ConditionalWinnerCards winners={[projected]} recommendedOptionId="opt_expand" />)
+    const body = screen.getByTestId('conditional-winner-cards')
+    // Neutral claim: names the factor and the threshold…
+    expect(body.textContent).toMatch(/Which option leads depends on/)
+    expect(body.textContent).toMatch(/Market growth/)
+    expect(body.textContent).toMatch(/42\.5%/)
+    // …and licensed anonymous probabilities…
+    expect(body.textContent).toMatch(/Above: 70%/)
+    expect(body.textContent).toMatch(/Below: 60%/)
+    // …but NO option identity anywhere (the pre-projection fixture carries
+    // both names, so this assertion discriminates).
+    expect(body.textContent).not.toMatch(/Expand into Europe/)
+    expect(body.textContent).not.toMatch(/Hold position/)
+    // And no directional claim — direction is a claim about the withheld leader.
+    expect(body.textContent).not.toMatch(/leads instead/)
+  })
+
+  it('uses the neutral arm, never a guess, when recommendedOptionId matches neither bucket', () => {
+    render(<ConditionalWinnerCards winners={[fullRow()]} recommendedOptionId="opt_unrelated" />)
+    const body = screen.getByTestId('conditional-winner-cards')
+    expect(body.textContent).toMatch(/Which option leads depends on/)
+    expect(body.textContent).not.toMatch(/exceeds/)
+    expect(body.textContent).not.toMatch(/falls below/)
+    expect(body.textContent).not.toMatch(/leads instead/)
+  })
+
+  it('uses the neutral arm, never a guess, when recommendedOptionId is absent', () => {
+    render(<ConditionalWinnerCards winners={[fullRow()]} />)
+    const body = screen.getByTestId('conditional-winner-cards')
+    expect(body.textContent).toMatch(/Which option leads depends on/)
+    expect(body.textContent).not.toMatch(/exceeds/)
+    expect(body.textContent).not.toMatch(/falls below/)
+  })
+})
+
+describe('ConditionalWinnerCards — honest absence (no minted numbers)', () => {
+  it('drops a row with a non-finite split_value; a producer-sent 0 survives (positive control)', () => {
+    const bad = fullRow({ factor_label: 'Broken factor', factor_id: 'fac_bad', split_value: Number.NaN })
+    const zero = fullRow({ factor_label: 'Zero-threshold factor', factor_id: 'fac_zero', split_value: 0 })
+    render(<ConditionalWinnerCards winners={[bad, zero]} recommendedOptionId="opt_hold" />)
+    const body = screen.getByTestId('conditional-winner-cards')
+    expect(body.textContent).not.toMatch(/Broken factor/)
+    expect(body.textContent).not.toMatch(/NaN/)
+    // Positive control: 0 is a real threshold, not an absence.
+    expect(body.textContent).toMatch(/Zero-threshold factor/)
+    expect(body.textContent).toMatch(/0%/) // split 0 with '%' unit renders
+  })
+
+  it('omits the percentage when win_probability is absent — never renders a minted 0%', () => {
+    // The 15 real persisted staging rows (Apr–Jun 2026) carry identity and
+    // winner_flips but NO win_probability — the pre-0.44 wire shape. They must
+    // render their scenario without inventing "(0%)".
+    const historic = fullRow({
+      split_unit: undefined,
+      high_bucket: { winner_id: 'opt_expand', winner_label: 'Expand into Europe' },
+      low_bucket: { winner_id: 'opt_hold', winner_label: 'Hold position' },
+    })
+    expect('win_probability' in (historic.high_bucket as object)).toBe(false)
+
+    render(<ConditionalWinnerCards winners={[historic]} recommendedOptionId="opt_hold" />)
+    const body = screen.getByTestId('conditional-winner-cards')
+    // The scenario renders with its labels…
+    expect(body.textContent).toMatch(/Expand into Europe/)
+    // …and no percentage is fabricated anywhere.
+    expect(body.textContent).not.toMatch(/0%/)
+    expect(body.textContent).not.toMatch(/%\)/)
+  })
+
+  it('renders a producer-sent win_probability of 0 (positive control for absence handling)', () => {
+    const row = fullRow({
+      high_bucket: { winner_id: 'opt_expand', winner_label: 'Expand into Europe', win_probability: 0 },
+      low_bucket: { winner_id: 'opt_hold', winner_label: 'Hold position', win_probability: 1 },
+    })
+    render(<ConditionalWinnerCards winners={[row]} recommendedOptionId="opt_hold" />)
+    const body = screen.getByTestId('conditional-winner-cards')
+    expect(body.textContent).toMatch(/\(0%\)/)
+    expect(body.textContent).toMatch(/\(100%\)/)
+  })
+})
+
+describe('ConditionalWinnerCards — direction binds by identity (trap 19 discriminating fixture)', () => {
+  // Both options share the SAME display label, so any label-based direction
+  // predicate cannot distinguish them; only winner_id can.
+  const sameLabelRow = (): ConditionalWinner =>
+    fullRow({
+      high_bucket: { winner_id: 'opt_b', winner_label: 'Expand', win_probability: 0.7 },
+      low_bucket: { winner_id: 'opt_a', winner_label: 'Expand', win_probability: 0.6 },
+    })
+
+  it('recommended id in the LOW bucket → flip on the HIGH side ("exceeds")', () => {
+    render(<ConditionalWinnerCards winners={[sameLabelRow()]} recommendedOptionId="opt_a" />)
+    const body = screen.getByTestId('conditional-winner-cards')
+    expect(body.textContent).toMatch(/exceeds/)
+    expect(body.textContent).not.toMatch(/falls below/)
+  })
+
+  it('recommended id in the HIGH bucket → flip on the LOW side ("falls below")', () => {
+    render(<ConditionalWinnerCards winners={[sameLabelRow()]} recommendedOptionId="opt_b" />)
+    const body = screen.getByTestId('conditional-winner-cards')
+    expect(body.textContent).toMatch(/falls below/)
+    expect(body.textContent).not.toMatch(/exceeds/)
+  })
+})

--- a/src/components/results/__tests__/useResultsSectionData.conditionalWinnersHonesty.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.conditionalWinnersHonesty.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * useResultsSectionData — conditional-winners projection honesty
+ * (V6 Science-to-Reasoning slice).
+ *
+ * The projection at the report→VM seam must CARRY the producer's contract
+ * (schemas 0.46 EnrichmentConditionalWinnerSchema) instead of stripping it:
+ *   - `winner_id` / `runner_up_id` / `runner_up_label` / `winner_flips` /
+ *     `mean_outcome` travel verbatim;
+ *   - absence is preserved as absence (withheld-projection rows keep their
+ *     identity-stripped shape; nothing is coerced to '' or 0);
+ *   - a row with a non-finite split_value is DROPPED (PLoT's own disposal
+ *     rule, run.ts:681-689 ConditionalWinnerDraft) — never defaulted to 0;
+ *   - a present-but-corrupt win_probability poisons its row (PLoT's
+ *     numeric-egress rule); an ABSENT one stays absent (the pre-0.44
+ *     persisted wire shape carries none, and 0% must not be minted for it);
+ *   - `recommendedOptionId` is the robustness recommended_option_id VERBATIM
+ *     (never the UI's tie-breaker fallback chain) — absent stays absent.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useResultsSectionData } from '../useResultsSectionData'
+import { useCanvasStore } from '../../../canvas/store'
+
+const OPTION_NODES = [
+  { id: 'opt_a', type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'Option A' } },
+  { id: 'opt_b', type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'Option B' } },
+]
+
+const fullWireRow = (overrides: Record<string, unknown> = {}) => ({
+  factor_id: 'fac_growth',
+  factor_label: 'Market growth',
+  split_value: 42.5,
+  split_unit: '%',
+  winner_flips: true,
+  high_bucket: {
+    winner_id: 'opt_b',
+    winner_label: 'Option B',
+    runner_up_id: 'opt_a',
+    runner_up_label: 'Option A',
+    win_probability: 0.7,
+    mean_outcome: 120.5,
+  },
+  low_bucket: {
+    winner_id: 'opt_a',
+    winner_label: 'Option A',
+    runner_up_id: 'opt_b',
+    runner_up_label: 'Option B',
+    win_probability: 0.6,
+    mean_outcome: 88.25,
+  },
+  ...overrides,
+})
+
+function setStoreWithReport(reportOverrides: Record<string, unknown>): void {
+  useCanvasStore.setState({
+    results: {
+      status: 'complete',
+      progress: 100,
+      report: {
+        analysis_status: 'computed',
+        robustness: { fragile_edges: [], robust_edges: [] },
+        ...reportOverrides,
+      },
+    } as any,
+    runMeta: {} as any,
+    nodes: OPTION_NODES as any,
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: null,
+  } as any)
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    results: null,
+    runMeta: null,
+    nodes: [],
+    edges: [],
+    hasCompletedFirstRun: false,
+    rawV2Response: null,
+  } as any)
+})
+
+describe('useResultsSectionData — conditional winners carry the producer contract', () => {
+  it('carries winner_id, runner_up_*, winner_flips and mean_outcome verbatim (identity bound by id, not label)', () => {
+    setStoreWithReport({
+      conditional_winners: [fullWireRow()],
+      robustness: { fragile_edges: [], robust_edges: [], recommended_option_id: 'opt_a' },
+    })
+    const { result } = renderHook(() => useResultsSectionData())
+    const winners = result.current.confidence.conditionalWinners
+    expect(winners).toHaveLength(1)
+    const w = winners![0]
+    // Identity binding: assert by id on the exact row (trap 19).
+    expect(w.factor_id).toBe('fac_growth')
+    expect(w.high_bucket.winner_id).toBe('opt_b')
+    expect(w.high_bucket.runner_up_id).toBe('opt_a')
+    expect(w.high_bucket.runner_up_label).toBe('Option A')
+    expect(w.high_bucket.mean_outcome).toBe(120.5)
+    expect(w.low_bucket.winner_id).toBe('opt_a')
+    expect(w.winner_flips).toBe(true)
+    expect(w.split_value).toBe(42.5)
+    expect(w.high_bucket.win_probability).toBe(0.7)
+  })
+
+  it('preserves the withheld-projection shape: stripped identity stays ABSENT, not ""', () => {
+    // Exactly the shape CEE's projectConditionalWinnersForWithheldClaim emits
+    // (withheld-claim-projection.ts:914-937 @ fa8bacc5): bucket identity
+    // members deleted, probabilities kept, row-level factor fields kept.
+    setStoreWithReport({
+      conditional_winners: [
+        fullWireRow({
+          high_bucket: { win_probability: 0.7 },
+          low_bucket: { win_probability: 0.6 },
+        }),
+      ],
+    })
+    const { result } = renderHook(() => useResultsSectionData())
+    const w = result.current.confidence.conditionalWinners![0]
+    // Absence preserved as absence — the old projection minted '' here.
+    expect('winner_label' in w.high_bucket).toBe(false)
+    expect('winner_id' in w.high_bucket).toBe(false)
+    expect(w.high_bucket.winner_label).toBeUndefined()
+    expect(w.high_bucket.win_probability).toBe(0.7)
+    expect(w.winner_flips).toBe(true)
+  })
+
+  it('drops a row with a non-finite split_value; keeps a producer-sent 0 (positive control)', () => {
+    setStoreWithReport({
+      conditional_winners: [
+        fullWireRow({ factor_id: 'fac_absent', factor_label: 'Absent split' , split_value: undefined }),
+        fullWireRow({ factor_id: 'fac_nan', factor_label: 'NaN split', split_value: Number.NaN }),
+        fullWireRow({ factor_id: 'fac_zero', factor_label: 'Zero split', split_value: 0 }),
+      ],
+    })
+    const { result } = renderHook(() => useResultsSectionData())
+    const winners = result.current.confidence.conditionalWinners
+    // Identity-bound: the surviving row is the zero-split row, by id.
+    expect(winners).toHaveLength(1)
+    expect(winners![0].factor_id).toBe('fac_zero')
+    expect(winners![0].split_value).toBe(0)
+  })
+
+  it('keeps absent win_probability ABSENT (pre-0.44 persisted rows) and drops a present-but-corrupt one', () => {
+    setStoreWithReport({
+      conditional_winners: [
+        // The real persisted staging shape (15 rows, Apr–Jun 2026): identity +
+        // attestation, no probabilities anywhere.
+        fullWireRow({
+          factor_id: 'fac_historic',
+          factor_label: 'Historic shape',
+          high_bucket: { winner_id: 'opt_b', winner_label: 'Option B', runner_up_id: 'opt_a', runner_up_label: 'Option A' },
+          low_bucket: { winner_id: 'opt_a', winner_label: 'Option A', runner_up_id: 'opt_b', runner_up_label: 'Option B' },
+        }),
+        // A corrupt probability poisons its row (PLoT prob01 egress rule).
+        fullWireRow({
+          factor_id: 'fac_corrupt',
+          factor_label: 'Corrupt probability',
+          high_bucket: { winner_id: 'opt_b', winner_label: 'Option B', win_probability: 1.7 },
+          low_bucket: { winner_id: 'opt_a', winner_label: 'Option A', win_probability: 0.6 },
+        }),
+      ],
+    })
+    const { result } = renderHook(() => useResultsSectionData())
+    const winners = result.current.confidence.conditionalWinners
+    expect(winners).toHaveLength(1)
+    const w = winners![0]
+    expect(w.factor_id).toBe('fac_historic')
+    // Absent probability stays absent — no minted 0.
+    expect('win_probability' in w.high_bucket).toBe(false)
+    expect(w.high_bucket.win_probability).toBeUndefined()
+    // Identity still travels.
+    expect(w.high_bucket.winner_id).toBe('opt_b')
+    expect(w.winner_flips).toBe(true)
+  })
+
+  it('exposes recommendedOptionId from robustness.recommended_option_id verbatim; absent stays absent', () => {
+    setStoreWithReport({
+      conditional_winners: [fullWireRow()],
+      robustness: { fragile_edges: [], robust_edges: [], recommended_option_id: 'opt_a' },
+    })
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.confidence.recommendedOptionId).toBe('opt_a')
+  })
+
+  it('leaves recommendedOptionId undefined when robustness carries no recommended_option_id — never the tie-breaker', () => {
+    // The report-level fallback chain (recommendation.option_id etc.) and the
+    // UI tie-breaker must NOT leak into the identity used for direction
+    // binding: a UI-invented recommendation would be a guess wearing an ID.
+    setStoreWithReport({
+      conditional_winners: [fullWireRow()],
+      recommendation: { option_id: 'opt_b' },
+    })
+    const { result } = renderHook(() => useResultsSectionData())
+    expect(result.current.confidence.recommendedOptionId).toBeUndefined()
+  })
+})

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -847,20 +847,56 @@ export interface AssumptionItem {
   target?: string
 }
 
-/** Conditional winner entry from ISL (factor-dependent recommendation splits) */
+/**
+ * One bucket of a conditional-winner split (schemas 0.46
+ * `EnrichmentConditionalBucketSchema`, carried VERBATIM).
+ *
+ * Every identity member is optional BY CONTRACT: CEE's withheld-claim
+ * projection strips exactly `winner_id` / `winner_label` / `runner_up_id` /
+ * `runner_up_label` on claim-withheld turns — absence means the leading
+ * option was withheld on this turn, and the consumer renders the neutral
+ * arm rather than guessing. `win_probability` is contract-required on the
+ * 0.44+ wire but ABSENT on the pre-0.44 persisted rows still replayed from
+ * run history — absence is preserved, never defaulted to 0.
+ */
+export interface ConditionalWinnerBucket {
+  /** Winning option ID in this bucket (absent ⇒ withheld on this turn) */
+  winner_id?: string
+  /** Winning option display label (display only — never bind logic to it) */
+  winner_label?: string
+  /** Runner-up option ID in this bucket */
+  runner_up_id?: string
+  /** Runner-up option display label */
+  runner_up_label?: string
+  /** Win probability of the winner in this bucket (absent stays absent) */
+  win_probability?: number
+  /** Mean outcome for the winner in this bucket */
+  mean_outcome?: number
+}
+
+/** Conditional winner entry from ISL (factor-dependent leadership splits) */
 export interface ConditionalWinner {
   /** Factor label driving the split */
   factor_label: string
   /** Factor node ID */
   factor_id: string
-  /** Split value where winner changes */
+  /** Split value where the leading option changes */
   split_value: number
   /** Unit for display */
   split_unit?: string
-  /** Winner label when factor is above split */
-  high_bucket: { winner_label: string; win_probability: number }
-  /** Winner label when factor is below split */
-  low_bucket: { winner_label: string; win_probability: number }
+  /** Bucket above the split */
+  high_bucket: ConditionalWinnerBucket
+  /** Bucket below the split */
+  low_bucket: ConditionalWinnerBucket
+  /**
+   * Producer attestation that the winning option CHANGES across the split
+   * (schemas 0.46: says THAT the winner changes, never WHICH option). This —
+   * not label comparison — is what makes a row a scenario: two options can
+   * share a display label (a real flip a label filter cannot see) and a
+   * label churn is not a flip. Rows without the attestation are not
+   * rendered as scenarios.
+   */
+  winner_flips?: boolean
 }
 
 /** Inference warning from ISL (model gaps) */
@@ -993,6 +1029,14 @@ export interface ConfidenceSectionData {
 
   /** ISL conditional_winners — factor-dependent recommendation splits */
   conditionalWinners?: ConditionalWinner[]
+  /**
+   * `report.robustness.recommended_option_id` VERBATIM — the backend's own
+   * leading-option identity, used to bind conditional-winner direction by
+   * ID (never by display label). Deliberately NOT the UI's recommendation
+   * fallback chain or tie-breaker: a UI-invented recommendation would be a
+   * guess wearing an ID, and the card's honest fallback is its neutral arm.
+   */
+  recommendedOptionId?: string
   /** ISL inference_warnings — model gap warnings */
   inferenceWarnings?: InferenceWarning[]
   /** ISL edge_e_values — sensitivity measure per edge */

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -3406,45 +3406,53 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       conditionalWinners: (() => {
         const raw = safeArray((report as any)?.conditional_winners ?? (report as any)?.robustness?.conditional_winners)
         if (raw.length === 0) return undefined
-        const probOf = (b: any): { ok: boolean; value?: number } => {
-          if (b == null || typeof b !== 'object' || !('win_probability' in b)) return { ok: true }
-          const p = (b as any).win_probability
+        // Wire rows are narrowed via `unknown` → typeof checks (no `as any`;
+        // the trust-boundary cast budget in wave2-replay-gate.spec.ts is the
+        // enforcement — typed narrowing is the pattern it exists to force).
+        const asRecord = (v: unknown): Record<string, unknown> | null =>
+          v != null && typeof v === 'object' && !Array.isArray(v) ? (v as Record<string, unknown>) : null
+        const probOf = (b: Record<string, unknown>): { ok: boolean; value?: number } => {
+          if (!('win_probability' in b)) return { ok: true }
+          const p = b.win_probability
           if (typeof p === 'number' && Number.isFinite(p) && p >= 0 && p <= 1) return { ok: true, value: p }
           return { ok: false }
         }
-        const toBucket = (b: any, p: number | undefined): ConditionalWinnerBucket => {
+        const toBucket = (b: Record<string, unknown>, p: number | undefined): ConditionalWinnerBucket => {
           const out: ConditionalWinnerBucket = {}
-          if (typeof b?.winner_id === 'string' && b.winner_id) out.winner_id = b.winner_id
-          const label = b?.winner_label ?? b?.label
+          if (typeof b.winner_id === 'string' && b.winner_id) out.winner_id = b.winner_id
+          const label = b.winner_label ?? b.label
           if (typeof label === 'string' && label) out.winner_label = label
-          if (typeof b?.runner_up_id === 'string' && b.runner_up_id) out.runner_up_id = b.runner_up_id
-          if (typeof b?.runner_up_label === 'string' && b.runner_up_label) out.runner_up_label = b.runner_up_label
+          if (typeof b.runner_up_id === 'string' && b.runner_up_id) out.runner_up_id = b.runner_up_id
+          if (typeof b.runner_up_label === 'string' && b.runner_up_label) out.runner_up_label = b.runner_up_label
           if (p !== undefined) out.win_probability = p
-          if (typeof b?.mean_outcome === 'number' && Number.isFinite(b.mean_outcome)) out.mean_outcome = b.mean_outcome
+          if (typeof b.mean_outcome === 'number' && Number.isFinite(b.mean_outcome)) out.mean_outcome = b.mean_outcome
           return out
         }
         const rows: ConditionalWinner[] = []
-        for (const w of raw as any[]) {
-          const split = typeof w?.split_value === 'number' && Number.isFinite(w.split_value) ? w.split_value : undefined
+        for (const item of raw) {
+          const w = asRecord(item)
+          if (!w) continue
+          const split = typeof w.split_value === 'number' && Number.isFinite(w.split_value) ? w.split_value : undefined
           if (split === undefined) continue
-          const factorLabelRaw = w?.factor_label ?? w?.label
-          const factorIdRaw = w?.factor_id ?? w?.node_id
+          const factorLabelRaw = w.factor_label ?? w.label
+          const factorIdRaw = w.factor_id ?? w.node_id
           if (typeof factorLabelRaw !== 'string' || factorLabelRaw.length === 0) continue
           if (typeof factorIdRaw !== 'string' || factorIdRaw.length === 0) continue
-          if (w?.high_bucket == null || typeof w.high_bucket !== 'object') continue
-          if (w?.low_bucket == null || typeof w.low_bucket !== 'object') continue
-          const highProb = probOf(w.high_bucket)
-          const lowProb = probOf(w.low_bucket)
+          const high = asRecord(w.high_bucket)
+          const low = asRecord(w.low_bucket)
+          if (!high || !low) continue
+          const highProb = probOf(high)
+          const lowProb = probOf(low)
           if (!highProb.ok || !lowProb.ok) continue
-          const splitUnit = w?.split_unit ?? w?.unit
+          const splitUnit = w.split_unit ?? w.unit
           rows.push({
             factor_label: factorLabelRaw,
             factor_id: factorIdRaw,
             split_value: split,
             ...(typeof splitUnit === 'string' && splitUnit ? { split_unit: splitUnit } : {}),
-            high_bucket: toBucket(w.high_bucket, highProb.value),
-            low_bucket: toBucket(w.low_bucket, lowProb.value),
-            ...(typeof w?.winner_flips === 'boolean' ? { winner_flips: w.winner_flips } : {}),
+            high_bucket: toBucket(high, highProb.value),
+            low_bucket: toBucket(low, lowProb.value),
+            ...(typeof w.winner_flips === 'boolean' ? { winner_flips: w.winner_flips } : {}),
           })
         }
         return rows.length > 0 ? rows : undefined
@@ -3454,7 +3462,7 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       // (`backendRecommendedId` above deliberately NOT reused — a UI-invented
       // recommendation would be a guess wearing an ID).
       recommendedOptionId: (() => {
-        const raw = (report as any)?.robustness?.recommended_option_id
+        const raw = report?.robustness?.recommended_option_id
         return typeof raw === 'string' && raw.length > 0 ? raw : undefined
       })(),
       inferenceWarnings: (() => {

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -50,6 +50,8 @@ import type {
   ConfidenceCalibrationStatus,
   ConfidenceInputQuality,
   ConfidenceProvenance,
+  ConditionalWinner,
+  ConditionalWinnerBucket,
 } from './types'
 import { normalizeAutoNoiseProvenance, normalizeHeadlineBanded } from './types'
 import {
@@ -3384,23 +3386,76 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       })(),
 
       // New ISL fields (gated on presence)
+      //
+      // V6 Science-to-Reasoning slice: carry the 0.46 contract VERBATIM and
+      // fail closed — never default. The previous projection discarded
+      // `winner_id` / `runner_up_*` / `winner_flips` / `mean_outcome` and
+      // minted `?? 0` / `?? ''` fabrications ("When X exceeds 0", "(0%)" on
+      // every real persisted row). Disposal rules mirror the producer's own
+      // (PLoT run.ts ConditionalWinnerDraft + prob01 egress guard):
+      //   - non-finite `split_value` ⇒ DROP the row (a threshold claim
+      //     without a threshold is nothing; a producer-sent 0 is real);
+      //   - PRESENT-but-corrupt `win_probability` ⇒ DROP the row (a corrupt
+      //     probability poisons the row's measurements);
+      //   - ABSENT `win_probability` ⇒ keep the row, keep the field absent —
+      //     the pre-0.44 persisted rows (the only populated rows on staging,
+      //     Apr–Jun 2026) carry identity + attestation but no probabilities,
+      //     and the flip claim stands without them. Never mint 0%.
+      //   - identity absence (CEE's withheld-claim projection) is PRESERVED,
+      //     so the card can render its neutral arm instead of nothing.
       conditionalWinners: (() => {
         const raw = safeArray((report as any)?.conditional_winners ?? (report as any)?.robustness?.conditional_winners)
         if (raw.length === 0) return undefined
-        return raw.map((w: any) => ({
-          factor_label: String(w.factor_label ?? w.label ?? ''),
-          factor_id: String(w.factor_id ?? w.node_id ?? ''),
-          split_value: Number(w.split_value ?? 0),
-          split_unit: w.split_unit ?? w.unit ?? undefined,
-          high_bucket: {
-            winner_label: String(w.high_bucket?.winner_label ?? w.high_bucket?.label ?? ''),
-            win_probability: Number(w.high_bucket?.win_probability ?? 0),
-          },
-          low_bucket: {
-            winner_label: String(w.low_bucket?.winner_label ?? w.low_bucket?.label ?? ''),
-            win_probability: Number(w.low_bucket?.win_probability ?? 0),
-          },
-        }))
+        const probOf = (b: any): { ok: boolean; value?: number } => {
+          if (b == null || typeof b !== 'object' || !('win_probability' in b)) return { ok: true }
+          const p = (b as any).win_probability
+          if (typeof p === 'number' && Number.isFinite(p) && p >= 0 && p <= 1) return { ok: true, value: p }
+          return { ok: false }
+        }
+        const toBucket = (b: any, p: number | undefined): ConditionalWinnerBucket => {
+          const out: ConditionalWinnerBucket = {}
+          if (typeof b?.winner_id === 'string' && b.winner_id) out.winner_id = b.winner_id
+          const label = b?.winner_label ?? b?.label
+          if (typeof label === 'string' && label) out.winner_label = label
+          if (typeof b?.runner_up_id === 'string' && b.runner_up_id) out.runner_up_id = b.runner_up_id
+          if (typeof b?.runner_up_label === 'string' && b.runner_up_label) out.runner_up_label = b.runner_up_label
+          if (p !== undefined) out.win_probability = p
+          if (typeof b?.mean_outcome === 'number' && Number.isFinite(b.mean_outcome)) out.mean_outcome = b.mean_outcome
+          return out
+        }
+        const rows: ConditionalWinner[] = []
+        for (const w of raw as any[]) {
+          const split = typeof w?.split_value === 'number' && Number.isFinite(w.split_value) ? w.split_value : undefined
+          if (split === undefined) continue
+          const factorLabelRaw = w?.factor_label ?? w?.label
+          const factorIdRaw = w?.factor_id ?? w?.node_id
+          if (typeof factorLabelRaw !== 'string' || factorLabelRaw.length === 0) continue
+          if (typeof factorIdRaw !== 'string' || factorIdRaw.length === 0) continue
+          if (w?.high_bucket == null || typeof w.high_bucket !== 'object') continue
+          if (w?.low_bucket == null || typeof w.low_bucket !== 'object') continue
+          const highProb = probOf(w.high_bucket)
+          const lowProb = probOf(w.low_bucket)
+          if (!highProb.ok || !lowProb.ok) continue
+          const splitUnit = w?.split_unit ?? w?.unit
+          rows.push({
+            factor_label: factorLabelRaw,
+            factor_id: factorIdRaw,
+            split_value: split,
+            ...(typeof splitUnit === 'string' && splitUnit ? { split_unit: splitUnit } : {}),
+            high_bucket: toBucket(w.high_bucket, highProb.value),
+            low_bucket: toBucket(w.low_bucket, lowProb.value),
+            ...(typeof w?.winner_flips === 'boolean' ? { winner_flips: w.winner_flips } : {}),
+          })
+        }
+        return rows.length > 0 ? rows : undefined
+      })(),
+      // Direction identity for the conditional-winner card: the backend's
+      // robustness key VERBATIM, never the UI's fallback chain/tie-breaker
+      // (`backendRecommendedId` above deliberately NOT reused — a UI-invented
+      // recommendation would be a guess wearing an ID).
+      recommendedOptionId: (() => {
+        const raw = (report as any)?.robustness?.recommended_option_id
+        return typeof raw === 'string' && raw.length > 0 ? raw : undefined
       })(),
       inferenceWarnings: (() => {
         const raw = safeArray(readInferenceWarnings(report))


### PR DESCRIPTION
V6 Science-to-Reasoning slice (PR2 · P1/P5): the conditional-winners last hop now renders the producer's claims instead of guesses. Brief: `olumi-docs/feedback-2026-08-16/V6-SCIENCE-TO-REASONING-BRIEF.md`.

## ⭐ PAUL VETO OPEN — neutral-arm copy strings (the only open product-voice call)

Rendered when the leading-option claim is withheld (CEE's projection strips bucket identity) or direction cannot be ID-bound:

> **Card body:** “Which option leads depends on **{factor}** — the analysis flips at {split}{unit}.”
> **Footer (anonymous probabilities, contract-licensed on withheld turns):** “Above: {p}% · Below: {p}%”

No option name, no direction. Everything else in this PR is behaviour the contract already states.

## Honesty deltas (field → old fabrication → new behaviour)

| Field | Old (at `37f626b6`) | New |
|---|---|---|
| `winner_flips` | discarded; flips detected by LABEL inequality — same-label flips invisible, label churn rendered as phantom scenarios | carried verbatim; the card renders exactly the rows the producer attested (`winner_flips === true`) |
| `winner_id` / `runner_up_id` / `runner_up_label` | discarded | carried verbatim; direction binds `winner_id` ↔ `robustness.recommended_option_id` by IDENTITY (labels display-only) |
| Direction when unknown | guessed (“exceeds” + high bucket — the file admitted it) | neutral two-sided arm, never a guess |
| Withheld turns (identity-stripped rows) | `String(… ?? '')` → `'' !== ''` → every row filtered out → silence | neutral arm renders factor + threshold + anonymous probabilities (the exact claim CEE ships bytes for) |
| `split_value` | `Number(… ?? 0)` → “When X exceeds 0” for an absent split | non-finite ⇒ row DROPPED (PLoT’s own `ConditionalWinnerDraft` disposal rule); producer-sent 0 survives |
| `win_probability` | `?? 0` → “(0%)” minted — on EVERY populated row that actually exists on staging | absent stays absent (percentage omitted); present-but-corrupt (∉[0,1]) poisons its row; producer-sent 0 renders |
| `mean_outcome` | discarded | carried verbatim (no new rendering) |
| `recommendedOptionId` (new on `ConfidenceSectionData`) | n/a — card got the recommendation LABEL | `robustness.recommended_option_id` VERBATIM; deliberately NOT the UI fallback chain/tie-breaker |

One scoped deviation from the brief's step-1 letter, derived at the wire: the brief said drop rows with non-finite `win_probability`. The only populated rows that exist on staging (15 facts, Apr–Jun) predate 0.44 and carry NO probabilities at all — row-level drop would blank the only real bytes this surface has. ABSENT probability keeps the row (percentage omitted); PRESENT-but-corrupt drops it. Both arms are pinned by tests + mutants.

## Step-0 probe (brief §4, recorded at `acceptance-evidence/conditional-winners-frequency-census-2026-08-17.md`)

- Census (read-only, 1,570 non-noop `run_analysis` facts): key present 1,570/1,570; **populated 15 (~1%), all ≤ 13 Jun, all `winner_flips: true`, none with `win_probability`**; contrast controls fired (1,570 / 1,231). **1,270 consecutive runs since 14 Jun: zero populated.**
- Three fresh seeded `/v2/run` probes at deployed PLoT (`e0394b8`, ISL `28fe0c9`): all `[]` outbound — **while `_meta.payloads.isl_response` shows ISL EMITTED a populated `winner_flips: true` row**. Attribution at the bytes: ISL's bucket keys for probability/outcome are outside PLoT's contract (digested as unknown by the structure-preserving redactor), so PLoT's numeric-egress guard (`run.ts:793-797`, requires `prob01(win_probability)`) **drops every row**. This is the answer to ROADMAP 1.350-M3's "derive why empty" — and a named-row ask for the ISL/PLoT seat: align the bucket field names and the whole already-built chain lights up.
- STOP rule: not triggered (census ≠ ~0; identity+attestation bytes arrive today via persisted-run replay, where the old code minted "(0%)" on real analyses).

## Evidence

- RED-first at pristine `37f626b6`: 15/17 new cases fail with named signatures; the 2 passes are declared positive controls whose bite mutants M6/M7 prove.
- GREEN: 21/21 across the three specs (collected counts asserted by name: 11 + 6 + 4); affected-directory battery 3,832 passed; `pnpm typecheck` gate PASSED; eslint 0 errors (17 pre-existing warnings, byte-identical at pristine).
- Mutant kit (outside worktree, sentinel-write isolation + inode check, HEAD-relative restores, applied-check 1 / control 0, trailing control green) — **7/7 bit, zero survivors**:
  - M1 label-inequality filter → 7 RED (incl. same-label flip, label churn)
  - M2 delete neutral arm → 4 RED
  - M3 restore `?? 0` on split → 1 RED (positive control discriminates)
  - M4 direction → constant → 5 RED
  - M5 strip `winner_flips` in projection → 3 RED on distinct assertions (deviation from brief's "tests 1+2": the card specs feed the card directly, so the projection mutant is killed at the hook seam)
  - M6 treat 0 probability as absent → 1 RED · M7 recommendedOptionId falls back to chain → 1 RED

## Rungs, fences, tripwires

- **Rung:** CODE EXISTS + TESTED (this PR). Withheld arm is fixture-proven against the 0.46 contract + CEE projection shape (`withheld-claim-projection.ts:452,914-937` @ `fa8bacc5`); **a populated-card wire witness is impossible until the ISL↔PLoT seam fix** — no "live" claim is made. Post-merge witness path: replay a populated-fact scenario (e.g. `2d2d5578`) from run history.
- Files: `types.ts` · `useResultsSectionData.ts` · `ConditionalWinnerCards.tsx` · `TriageActionCardsBody.tsx` + `ConfidenceSection.tsx` (one-line prop pass each) · 3 specs. Zero OutputsDock/route/CEE/PLoT/schemas bytes. #744 merged under this lane (versions files — zero overlap, base rebased to `37f626b6`). #714 (draft) touches `useResultsSectionData.ts` at ~:1183 (interface region) — no hunk overlap with this PR's ~:3387 projection.
- Standing CEE-side tripwire (do not fix here): any lane touching CEE `compose.ts`'s enrichment keep-list darkens this surface; the drift bolt REDs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Commit 2 (`fa06bc2d`):** the first head's only CI red was the trust-boundary cast budget (`wave2-replay-gate.spec.ts` — three new `as any` casts off the allowlist). Fixed by narrowing wire rows via a typed `asRecord`/`unknown` helper and reading `robustness.recommended_option_id` from the typed report — the pattern the gate exists to force, no allowlist widening. Behaviour identical (21/21 specs unchanged); hook-seam mutants M3/M5/M7 re-proven biting at `fa06bc2d`; card files byte-identical so M1/M2/M4/M6 kills carry. All 13 checks green at `fa06bc2d` including Staging Gate.
