### PR TITLE
feat(collab): the cited evidence reaches the factor panel — closing the readback gap

### DIFF
--- a/src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx
@@ -53,6 +53,8 @@ import {
   describeInWordsToggleLabel,
 } from '../../../components/BeliefElicitationField'
 import { useParticipantName } from '../../../../collab/useParticipantName'
+import { useCitedEvidence } from '../../../../collab/citedEvidenceCache'
+import { CitedEvidenceNote } from '../../../../collab/CitedEvidenceNote'
 
 /**
  * Extract a non-empty string intervention value, accepting either a bare
@@ -118,6 +120,12 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
    * both labels below byte-identical to what they rendered before.
    */
   const attributedTo = useParticipantName(obs?.elicited_from as unknown)
+  /**
+   * The CITATION the owner recorded when they applied this value. A no-op for
+   * every value carrying no citation: `no_citation` fetches nothing and renders
+   * nothing, leaving this panel byte-identical to what it rendered before.
+   */
+  const citedEvidence = useCitedEvidence(obs?.elicited_from as unknown)
   // Canonical location is observedState.uncertainty_drivers (per ObservedStateSchema).
   // Fall back to legacy top-level node.data.uncertainty_drivers for in-flight data
   // that predates the schema consolidation.
@@ -542,6 +550,11 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
               <span className={`${typography.panelMeta} text-info`}>{getProvenanceLabel(source, attributedTo)}</span>
             </div>
           )}
+
+          {/* What the owner cited when they applied it. Renders only when a
+              citation resolved; never gated on `source`, because the citation is
+              a fact about the apply and not about the extraction kind. */}
+          <CitedEvidenceNote resolution={citedEvidence} />
           {uncertaintyDrivers && uncertaintyDrivers.length > 0 && (
             <div className="flex gap-1.5 flex-wrap mt-1.5">
               {uncertaintyDrivers.map((d, i) => (

--- a/src/canvas/ui/inspector-v2/panels/FactorExternalPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorExternalPanel.tsx
@@ -33,6 +33,8 @@ import { FactorExternalEditor } from '../editors/FactorExternalEditor'
 import { factorDisplayText } from '../../../../utils/formatFactorDisplayValue'
 import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 import { useParticipantName } from '../../../../collab/useParticipantName'
+import { useCitedEvidence } from '../../../../collab/citedEvidenceCache'
+import { CitedEvidenceNote } from '../../../../collab/CitedEvidenceNote'
 
 // Quick-set presets
 const QUICK_SET = {
@@ -81,6 +83,12 @@ export const FactorExternalPanel = memo(function FactorExternalPanel({
    * both labels below byte-identical to what they rendered before.
    */
   const attributedTo = useParticipantName(obs?.elicited_from as unknown)
+  /**
+   * The CITATION the owner recorded when they applied this value. A no-op for
+   * every value carrying no citation: `no_citation` fetches nothing and renders
+   * nothing, leaving this panel byte-identical to what it rendered before.
+   */
+  const citedEvidence = useCitedEvidence(obs?.elicited_from as unknown)
 
   // Prior range
   const prior = (node?.data as Record<string, unknown>)?.prior as Record<string, unknown> | number | undefined
@@ -188,6 +196,11 @@ export const FactorExternalPanel = memo(function FactorExternalPanel({
             {getExtractionLabel(source, attributedTo)}
           </span>
         </div>
+
+        {/* What the owner cited when they applied it. Renders only when a
+            citation resolved; never gated on `source`, because the citation is a
+            fact about the apply and not about the extraction kind. */}
+        <CitedEvidenceNote resolution={citedEvidence} />
 
         {/* Post-analysis: ImportanceBar + VoI folded in (no separate bordered card) */}
         <StaleGuardBanner hasResults={isResultsMode}>

--- a/src/canvas/ui/inspector-v2/panels/FactorObservablePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorObservablePanel.tsx
@@ -39,6 +39,8 @@ import { resolveCoaching } from '../coachingConfig'
 import { FactorObservableEditor } from '../editors/FactorObservableEditor'
 import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 import { useParticipantName } from '../../../../collab/useParticipantName'
+import { useCitedEvidence } from '../../../../collab/citedEvidenceCache'
+import { CitedEvidenceNote } from '../../../../collab/CitedEvidenceNote'
 
 export const FactorObservablePanel = memo(function FactorObservablePanel({
   nodeId,
@@ -79,6 +81,14 @@ export const FactorObservablePanel = memo(function FactorObservablePanel({
    * both labels below byte-identical to what they rendered before.
    */
   const attributedTo = useParticipantName(obs?.elicited_from)
+  /**
+   * The CITATION the owner recorded when they applied this value — a colleague's
+   * note or link. Called unconditionally (it is a hook) and, like the name
+   * resolution above, a no-op for every value that carries no citation: no
+   * `evidence_event_id` means `no_citation`, which fetches nothing and renders
+   * nothing, leaving this panel byte-identical to what it rendered before.
+   */
+  const citedEvidence = useCitedEvidence(obs?.elicited_from)
 
   // Description — conditional edit state for EmptyDescriptionPrompt pattern
   const [description, setDescription] = useState(String(node?.data?.description ?? ''))
@@ -237,6 +247,11 @@ export const FactorObservablePanel = memo(function FactorObservablePanel({
               <span className={`${typography.panelMeta} text-info`}>{getProvenanceLabel(source, attributedTo)}</span>
             </div>
           )}
+
+          {/* What the owner cited when they applied it. Renders only when a
+              citation resolved; never gated on `source`, because the citation is
+              a fact about the apply and not about the extraction kind. */}
+          <CitedEvidenceNote resolution={citedEvidence} />
         </PrimaryControlCard>
 
         {/* Coaching — within Your input group, below the card */}

--- a/src/collab/CitedEvidenceNote.tsx
+++ b/src/collab/CitedEvidenceNote.tsx
@@ -1,0 +1,86 @@
+/**
+ * COLLAB — the cited-evidence line on a factor panel.
+ *
+ * ── ⭐ WHAT IT MAY SAY, AND THE ONE THING IT MAY NOT ──────────────────────
+ * It says WHO attached a piece of evidence to this round, the stance CEE
+ * recorded for it, and the words they wrote. It does NOT say the citation caused
+ * the change. CEE's verifier checks that the cited evidence exists, belongs to
+ * the round and names the factor — it does not read `stance` and does not read
+ * `about_participant_id` — so "…as the reason for this change" is a causal claim
+ * the server never established. A 15 Aug review found exactly that sentence
+ * shipped, and this component is where it must not come back.
+ *
+ * The rule it inherits is `inspectorStrings.ts`'s, in Paul's words: ATTRIBUTE,
+ * NEVER ENDORSE. "Apply Grace's value" is not "Grace was correct", and citing
+ * Ada's note is not "Ada was right".
+ *
+ * ── EVERY SENTENCE-BEARING STRING IS CEE'S ────────────────────────────────
+ * `stance_phrase` and `author_label` arrive from the server; `body` is the
+ * participant's own words, verbatim. The only copy this file owns is the
+ * connective — deliberately minimal, and deliberately not a claim.
+ *
+ * ── UNRESOLVED RENDERS NOTHING ────────────────────────────────────────────
+ * All four unresolved reasons render `null`. There is no spinner and no "loading
+ * citation" text: three of the four reasons are indistinguishable from "nothing
+ * was cited" to a user who cannot act on the difference, and the fourth
+ * (`view_unavailable`) is transient. An empty line that later fills is honest; a
+ * placeholder asserting a citation exists before one has resolved is not.
+ */
+
+import { FileText, Link2 } from 'lucide-react'
+
+import type { CitedEvidenceResolution } from './citedEvidence'
+
+export const CITED_EVIDENCE_TESTID = 'collab-cited-evidence'
+
+/**
+ * The connective, and the whole of this bundle's authored copy.
+ *
+ * ⚠ IT IS A REPORT OF AN ACT, NOT OF A CONSEQUENCE. "attached" is what happened
+ * and is verifiable from the evidence row itself. Anything in the register of
+ * "because", "which is why", "the reason for", "supports this value" or
+ * "justifies" asserts a link between the citation and the applied number that
+ * nothing upstream has checked.
+ */
+function attributionSentence(authorLabel: string, stancePhrase: string): string {
+  return `${authorLabel} attached this, ${stancePhrase}`
+}
+
+export function CitedEvidenceNote({
+  resolution,
+}: {
+  resolution: CitedEvidenceResolution
+}): JSX.Element | null {
+  if (resolution.state !== 'cited') return null
+
+  const { author_label, stance_phrase, kind, body, url } = resolution.evidence
+  const Icon = kind === 'link' ? Link2 : FileText
+
+  return (
+    <div
+      data-testid={CITED_EVIDENCE_TESTID}
+      className="mt-2 pt-2 border-t border-panel-border"
+    >
+      <div className="flex items-start gap-1.5">
+        <Icon size={12} className="text-info mt-0.5 shrink-0" aria-hidden="true" />
+        <div className="min-w-0">
+          <div className="text-xs text-text-muted">
+            {attributionSentence(author_label, stance_phrase)}
+          </div>
+          {/* The participant's own words. Verbatim, never summarised. */}
+          <div className="text-xs text-text-body mt-0.5 break-words">{body}</div>
+          {url !== null && (
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-info underline break-all mt-0.5 inline-block"
+            >
+              {url}
+            </a>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/collab/CitedEvidenceNote.tsx
+++ b/src/collab/CitedEvidenceNote.tsx
@@ -34,16 +34,44 @@ import type { CitedEvidenceResolution } from './citedEvidence'
 export const CITED_EVIDENCE_TESTID = 'collab-cited-evidence'
 
 /**
- * The connective, and the whole of this bundle's authored copy.
+ * The sentence, composed the way CEE composes it.
  *
- * ⚠ IT IS A REPORT OF AN ACT, NOT OF A CONSEQUENCE. "attached" is what happened
- * and is verifiable from the evidence row itself. Anything in the register of
- * "because", "which is why", "the reason for", "supports this value" or
- * "justifies" asserts a link between the citation and the applied number that
- * nothing upstream has checked.
+ * ⚠⚠ THE FIRST VERSION WAS BROKEN ENGLISH ON EVERY REAL CITATION, and the
+ * reason is worth keeping: it read `${author} attached this, ${stancePhrase}`,
+ * which assumed `stance_phrase` was a fragment like "challenging this". It is
+ * not. CEE's `STANCE_PHRASE` is a BARE VERB — `supports` / `challenges` /
+ * `qualifies` (`disagreement-copy.ts:126-130`) — so production rendered
+ * **"Ada attached this, challenges"**. The fixture that passed carried
+ * "challenging this", a string CEE never emits: the oracle came from this
+ * lane's head instead of from the producer (trap 13c), and a full mutant kit
+ * scored perfectly against it.
+ *
+ * ⭐ SO THE OBJECT IS SUPPLIED, MIRRORING CEE'S OWN RENDER SITE
+ * (`disagreement-read-model.ts:365-366`):
+ *
+ *     const about = e.about_label !== null ? `${e.about_label}'s position` : 'this factor'
+ *     `- Evidence from ${e.author_label}, ${e.stance_phrase} ${about}: "${e.body}"`
+ *
+ * ⚠ THAT MIRROR IS A CROSS-SERVICE HAZARD AND IS ACCEPTED KNOWINGLY. The
+ * `about` composition now exists in two services, so a change to CEE's form
+ * drifts this one silently — the hand-maintained-mirror defect, across a
+ * boundary. It is taken because the alternative is worse: dropping the stance
+ * loses the fact that a colleague CHALLENGED the number, which is the most
+ * valuable thing this line can say. The durable fix is CEE serving a
+ * sentence-form phrase; until then this comment is the marker.
+ *
+ * ⚠ IT REPORTS A STANCE, NEVER A CONSEQUENCE. "Ada challenges Grace's position"
+ * is a fact recorded on the evidence row. Anything in the register of "because",
+ * "which is why", "the reason for" or "justifies" asserts a link between the
+ * citation and the applied number that CEE never checked.
  */
-function attributionSentence(authorLabel: string, stancePhrase: string): string {
-  return `${authorLabel} attached this, ${stancePhrase}`
+function attributionSentence(
+  authorLabel: string,
+  stancePhrase: string,
+  aboutLabel: string | null,
+): string {
+  const about = aboutLabel !== null ? `${aboutLabel}'s position` : 'this factor'
+  return `${authorLabel} ${stancePhrase} ${about}`
 }
 
 export function CitedEvidenceNote({
@@ -53,7 +81,7 @@ export function CitedEvidenceNote({
 }): JSX.Element | null {
   if (resolution.state !== 'cited') return null
 
-  const { author_label, stance_phrase, kind, body, url } = resolution.evidence
+  const { author_label, stance_phrase, about_label, kind, body, url } = resolution.evidence
   const Icon = kind === 'link' ? Link2 : FileText
 
   return (
@@ -65,7 +93,7 @@ export function CitedEvidenceNote({
         <Icon size={12} className="text-info mt-0.5 shrink-0" aria-hidden="true" />
         <div className="min-w-0">
           <div className="text-xs text-text-muted">
-            {attributionSentence(author_label, stance_phrase)}
+            {attributionSentence(author_label, stance_phrase, about_label)}
           </div>
           {/* The participant's own words. Verbatim, never summarised. */}
           <div className="text-xs text-text-body mt-0.5 break-words">{body}</div>

--- a/src/collab/__tests__/citedEvidenceMount.spec.ts
+++ b/src/collab/__tests__/citedEvidenceMount.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * COLLAB — IS THE CITATION MOUNTED, on the surfaces the deployed flags render.
+ *
+ * ── WHY THIS SUITE IS A SOURCE ASSERTION AND NOT A RENDER TEST ────────────
+ * `citedEvidenceReadback.spec.tsx` proves the resolution and the copy. It cannot
+ * prove the component has a PRODUCT CALL SITE — and that is the failure mode this
+ * whole slice exists to reverse: CEE has written `evidence_event_id` since
+ * 0.41.0, the write path is wire-witnessed, and it reached no user because
+ * nothing read it back. A green resolution suite over a component with zero call
+ * sites is exactly the shape of "we build more than we plug in".
+ *
+ * The estate has shipped this defect twice in one feature already (row 2.466's
+ * grounding badge, then its negative twin at 2.491): every render test and every
+ * mutant passed while pointing at a component the deployed flags do not mount.
+ * So this asserts the MOUNT PATH itself, by name, in the files a DOM census of
+ * real captures shows are live.
+ *
+ * ── THE THREE PANELS ARE THE MOUNTED SURFACES ─────────────────────────────
+ * `FactorObservablePanel`, `FactorControllablePanel` and `FactorExternalPanel`
+ * are where `useParticipantName` was mounted for D1 and where the attribution
+ * pill renders today. They are named in the row that diagnosed this gap
+ * (`FactorExternalPanel.tsx:83`, `FactorControllablePanel.tsx:119`,
+ * `FactorObservablePanel.tsx:81`). The citation must reach the same three, or it
+ * is dark on whichever one it misses.
+ *
+ * ── ⚠ A SOURCE GREP IS A WEAK INSTRUMENT AND IS USED DELIBERATELY NARROWLY ─
+ * It proves a call site EXISTS in a file; it cannot prove that file renders for a
+ * user. It is the right instrument for exactly one claim — "this component is not
+ * orphaned" — and this suite makes no broader one. The rung above it is a browser
+ * witness on the deployed build, which no unit suite can supply.
+ */
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const PANEL_DIR = join(process.cwd(), 'src/canvas/ui/inspector-v2/panels')
+
+const MOUNTED_PANELS = [
+  'FactorObservablePanel.tsx',
+  'FactorControllablePanel.tsx',
+  'FactorExternalPanel.tsx',
+] as const
+
+function panelSource(file: string): string {
+  return readFileSync(join(PANEL_DIR, file), 'utf8')
+}
+
+describe('the citation has a product call site on every mounted factor panel', () => {
+  for (const file of MOUNTED_PANELS) {
+    it(`${file} resolves the citation AND renders the component`, () => {
+      const src = panelSource(file)
+
+      // The positive control for this instrument: the file must contain the D1
+      // name resolution it is already known to carry. If this fails, the grep is
+      // reading the wrong file and every other assertion here is worthless
+      // (trap 13e — a probe needs a contrast that is expected to be PRESENT).
+      expect(src, `${file}: instrument control failed — wrong file?`).toContain(
+        'useParticipantName(',
+      )
+
+      expect(src).toContain('useCitedEvidence(')
+      expect(src).toContain('<CitedEvidenceNote')
+    })
+
+    it(`${file} feeds the citation hook the SAME wire object as the name hook`, () => {
+      const src = panelSource(file)
+
+      /**
+       * ⚠ BOUND TO THE ARGUMENT, NOT JUST THE CALL. Both hooks must read
+       * `observed_state.elicited_from` — the one object CEE stamps. A citation
+       * hook fed anything else (a node id, a target, a hand-built object) would
+       * resolve against the wrong round and render another factor's evidence
+       * here, which is a fabrication rather than an absence.
+       */
+      expect(src).toMatch(/useCitedEvidence\(\s*obs\?\.elicited_from/)
+      expect(src).toMatch(/useParticipantName\(\s*obs\?\.elicited_from/)
+    })
+  }
+
+  it('⭐ the mount list is not silently short — every panel using the name hook also cites', () => {
+    /**
+     * The completeness check a per-file assertion cannot make. Deriving the list
+     * from the directory rather than from the constant above means a FOURTH
+     * factor panel added later, wired for attribution but not for the citation,
+     * turns this red instead of shipping dark — the hand-maintained-mirror
+     * defect, closed by derivation.
+     */
+    const { readdirSync } = require('node:fs') as typeof import('node:fs')
+    const panels = readdirSync(PANEL_DIR).filter((f) => f.endsWith('.tsx'))
+    expect(panels.length).toBeGreaterThan(0)
+
+    const attributing = panels.filter((f) => panelSource(f).includes('useParticipantName('))
+    // Control: the set must be non-empty, or the filter proves nothing.
+    expect(attributing.length).toBeGreaterThanOrEqual(MOUNTED_PANELS.length)
+
+    const missingCitation = attributing.filter((f) => !panelSource(f).includes('useCitedEvidence('))
+    expect(
+      missingCitation,
+      `these panels resolve a panel attribution but never its citation: ${missingCitation.join(', ')}`,
+    ).toEqual([])
+  })
+})

--- a/src/collab/__tests__/citedEvidenceReadback.spec.tsx
+++ b/src/collab/__tests__/citedEvidenceReadback.spec.tsx
@@ -29,11 +29,23 @@
  *
  * ── ASSERTIONS BIND BY IDENTITY ───────────────────────────────────────────
  * The fixture holds THREE evidence rows across TWO targets, with distinct
- * bodies, distinct authors and distinct stances, so no assertion can pass on the
- * wrong row (trap 19). The cited row is deliberately on a DIFFERENT target from
- * the factor under the cursor, and is authored by a DIFFERENT person from the
- * applied value — both are real product paths and both would be hidden by a
- * narrower lookup.
+ * bodies and distinct authors, so no assertion can pass on the wrong row
+ * (trap 19).
+ *
+ * ⚠⚠ THE CROSS-TARGET PLACEMENT IS A GROUPING-ROBUSTNESS FIXTURE AND IS A
+ * PRODUCER-IMPOSSIBLE WIRE STATE. An earlier version of this header claimed CEE
+ * admits a citation on a neighbouring factor. IT DOES NOT: binding (f) at
+ * `apply-verification.ts:282-287` requires the cited row's `target.kind ===
+ * 'factor'` AND `target.id === target_id`, refusing with "That evidence is not
+ * on this round for this factor." So the citation is ALWAYS on the same factor.
+ * The fixture stays because the resolver must not encode an assumption about
+ * which `per_target` row CEE groups an evidence row under — a search wider than
+ * the producer cannot report a false absence, while a narrower one can. It
+ * proves grouping-independence, NOT verifier scope.
+ *
+ * ⭐ WHAT *IS* GENUINELY UNSCOPED IS THE AUTHOR, and CEE says so in that same
+ * region: applying Grace's number BECAUSE ADA CHALLENGED IT "is the most
+ * valuable case this whole feature has".
  */
 
 import { render, screen, waitFor } from '@testing-library/react'
@@ -54,7 +66,19 @@ const GRACE_ID = '55555555-5555-4555-8555-555555555555'
 const ADA_EVIDENCE_ID = '88888888-8888-4888-8888-888888888888'
 const ADA_BODY = 'Q3 cohort held at 12% after the last rise, so 0.85 looks high'
 const ADA_LABEL = 'Ada'
-const ADA_STANCE_PHRASE = 'challenging this'
+/**
+ * ⭐ CEE'S REAL VOCABULARY, derived from the producer at
+ * `disagreement-copy.ts:126-130` — `STANCE_PHRASE` is a BARE VERB, identical at
+ * both service tips.
+ *
+ * ⚠ THIS FIXTURE PREVIOUSLY SAID 'challenging this', WHICH CEE NEVER EMITS. The
+ * suite was green and a 9-mutant kit scored perfectly while production rendered
+ * "Ada attached this, challenges" — a perfect score against an oracle written
+ * from this lane's head rather than from the producer (trap 13c).
+ */
+const ADA_STANCE_PHRASE = 'challenges'
+/** The object of the verb. `null` here means "about the factor, not a person". */
+const ADA_ABOUT_LABEL = 'Grace'
 
 /** A decoy on the SAME target as the cursor. Never cited. */
 const DECOY_EVIDENCE_ID = '99999999-9999-4999-8999-999999999999'
@@ -73,6 +97,7 @@ function evidenceRow(o: {
   author_label: string
   body: string
   stance_phrase?: string
+  about_label?: string | null
   kind?: 'note' | 'link'
   url?: string | null
 }) {
@@ -82,11 +107,11 @@ function evidenceRow(o: {
     author_label: o.author_label,
     stance: 'challenges' as const,
     stance_phrase: o.stance_phrase ?? ADA_STANCE_PHRASE,
+    about_label: o.about_label === undefined ? null : o.about_label,
     kind: o.kind ?? ('note' as const),
     body: o.body,
     url: o.url ?? null,
     about_participant_id: null,
-    about_label: null,
     created_at: '2026-08-14T11:00:00.000Z',
   }
 }
@@ -132,7 +157,12 @@ function disagreementView(overrides: Partial<DisagreementView> = {}): Disagreeme
         // The CITED row lives on the NEIGHBOUR, which is legitimate: CEE's
         // verifier requires only that the evidence belong to the same ROUND.
         evidence: [
-          evidenceRow({ event_id: ADA_EVIDENCE_ID, author_label: ADA_LABEL, body: ADA_BODY }),
+          evidenceRow({
+            event_id: ADA_EVIDENCE_ID,
+            author_label: ADA_LABEL,
+            body: ADA_BODY,
+            about_label: ADA_ABOUT_LABEL,
+          }),
         ],
         headline: 'They agree on this.',
         question: null,
@@ -195,7 +225,7 @@ describe('the reader gate carries the citation without costing the attribution',
 })
 
 describe('resolution binds to the cited row by id, across every target', () => {
-  it('⭐ resolves a row on a DIFFERENT target from the cursor, by id', () => {
+  it('⭐ resolves by id regardless of which per_target row groups it', () => {
     const res = resolveCitedEvidence(citedElicitedFrom, disagreementView())
     expect(res.state).toBe('cited')
     if (res.state !== 'cited') return
@@ -324,14 +354,29 @@ describe('⭐ PROVENANCE IS NEVER FABRICATED: no citation, no line', () => {
 })
 
 describe('⭐ THE COPY REPORTS AN ACT, NEVER A CONSEQUENCE', () => {
-  it('renders the author, the stance and the words', () => {
+  it('⭐ renders GRAMMATICAL English from CEE\'s bare verb, with an object', () => {
     const res = resolveCitedEvidence(citedElicitedFrom, disagreementView())
     render(<CitedEvidenceNote resolution={res} />)
 
     const node = screen.getByTestId(CITED_EVIDENCE_TESTID)
-    expect(node.textContent).toContain(ADA_LABEL)
-    expect(node.textContent).toContain(ADA_STANCE_PHRASE)
+    // The whole sentence, asserted exactly — mirroring CEE's own composition at
+    // `disagreement-read-model.ts:365-366`. A bare-verb regression renders
+    // "Ada attached this, challenges", which this cannot pass.
+    expect(node.textContent).toContain(`${ADA_LABEL} ${ADA_STANCE_PHRASE} ${ADA_ABOUT_LABEL}'s position`)
     expect(node.textContent).toContain(ADA_BODY)
+    // and the broken form is asserted ABSENT by name.
+    expect(node.textContent).not.toContain('attached this,')
+  })
+
+  it('falls back to CEE\'s own object when the evidence is about the factor', () => {
+    const aboutFactor = disagreementView()
+    aboutFactor.per_target[1].evidence[0].about_label = null
+    const res = resolveCitedEvidence(citedElicitedFrom, aboutFactor)
+    render(<CitedEvidenceNote resolution={res} />)
+    // CEE's fallback is the literal 'this factor' — same string, same place.
+    expect(screen.getByTestId(CITED_EVIDENCE_TESTID).textContent).toContain(
+      `${ADA_LABEL} ${ADA_STANCE_PHRASE} this factor`,
+    )
   })
 
   it('asserts NO causal link between the citation and the applied value', () => {
@@ -351,6 +396,9 @@ describe('⭐ THE COPY REPORTS AN ACT, NEVER A CONSEQUENCE', () => {
       'which is why',
       'justifies',
       'justified',
+      // ⚠ 'supports this value' stays banned — that is a claim about the NUMBER.
+      // CEE's own 'supports this factor' is the stance it recorded and is fine;
+      // the two differ by one word and only one of them is a verdict.
       'supports this value',
       'confirms',
       'verified by',
@@ -382,6 +430,109 @@ describe('⭐ THE COPY REPORTS AN ACT, NEVER A CONSEQUENCE', () => {
 
     render(<CitedEvidenceNote resolution={resolveCitedEvidence(citedElicitedFrom, disagreementView())} />)
     expect(screen.queryByRole('link')).toBeNull()
+  })
+})
+
+describe('⭐⭐ B1 — A MALFORMED VIEW MUST NOT CRASH THE INSPECTOR', () => {
+  /**
+   * `fetchOwnerDisagreement` returns `(await res.json()) as DisagreementView` —
+   * a CAST, never validated. So a 200 with a body this bundle did not expect
+   * reaches the resolver intact, and an unguarded iteration THROWS DURING
+   * RENDER, taking the whole inspector subtree — including the participant's
+   * NAME — off the screen.
+   *
+   * That is this feature's own claim ("malformity costs the citation, never the
+   * attribution") failing one seam past the reader gate. Schema skew is this
+   * estate's hazard #1 and is exactly the trigger, so every one of these shapes
+   * is a real deploy state, not a hypothetical.
+   */
+  const MALFORMED: ReadonlyArray<readonly [string, unknown]> = [
+    ['empty object (an older CEE, or a proxy error page)', {}],
+    ['per_target absent', { round_id: ROUND_ID, graph_version_ref: 'mv-1', standing_note: null }],
+    ['per_target null', { per_target: null }],
+    ['per_target an object, not an array', { per_target: { 0: {} } }],
+    ['per_target a string', { per_target: 'nope' }],
+    ['a target whose evidence is absent', { per_target: [{ target: { kind: 'factor', id: 'x' } }] }],
+    ['a target whose evidence is null', { per_target: [{ evidence: null }] }],
+    ['a target that is null', { per_target: [null] }],
+    ['an evidence row that is null', { per_target: [{ evidence: [null] }] }],
+  ]
+
+  for (const [name, body] of MALFORMED) {
+    it(`does not throw and reports view_unavailable or evidence_not_found: ${name}`, () => {
+      // The load-bearing half is that it RETURNS rather than throws.
+      const res = resolveCitedEvidence(citedElicitedFrom, body as DisagreementView)
+      expect(res.state).toBe('unresolved')
+      if (res.state !== 'unresolved') return
+      expect(['view_unavailable', 'evidence_not_found']).toContain(res.reason)
+    })
+  }
+
+  it('⭐ the ATTRIBUTION SURVIVES a malformed view — the claim this PR makes', () => {
+    // The reader gate still answers, so the name pill still renders. This is the
+    // assertion that would have caught B1: the citation degrades, the identity
+    // does not.
+    const ref = readElicitedFrom(citedElicitedFrom)
+    expect(ref?.participant_id).toBe(GRACE_ID)
+    const res = resolveCitedEvidence(citedElicitedFrom, {} as DisagreementView)
+    expect(res).toEqual({ state: 'unresolved', reason: 'view_unavailable' })
+    const { container } = render(<CitedEvidenceNote resolution={res} />)
+    expect(container.innerHTML).toBe('')
+  })
+})
+
+describe('⭐ B1 rider — the url feeds an href and is re-checked here', () => {
+  function withUrl(url: unknown) {
+    const v = disagreementView()
+    v.per_target[1].evidence[0].kind = 'link'
+    ;(v.per_target[1].evidence[0] as { url: unknown }).url = url
+    return resolveCitedEvidence(citedElicitedFrom, v)
+  }
+
+  it('admits http and https', () => {
+    for (const ok of ['https://example.test/a', 'http://example.test/b']) {
+      const res = withUrl(ok)
+      if (res.state !== 'cited') throw new Error('expected cited')
+      expect(res.evidence.url).toBe(ok)
+    }
+  })
+
+  it('⭐ drops every non-http(s) scheme, and the citation still renders', () => {
+    /**
+     * "Validated server-side at append time" is a claim about the PRODUCER, not
+     * about the bytes that arrived through an unvalidated cast. `javascript:` in
+     * an href is where a skewed or hostile payload becomes script execution.
+     *
+     * The prefix-test defeaters are deliberate: a `startsWith('https://')` check
+     * passes the fragment form, and a naive scheme split passes the tab form.
+     */
+    for (const bad of [
+      'javascript:alert(1)',
+      'JaVaScRiPt:alert(1)',
+      'javascript:alert(1)#https://example.test',
+      'data:text/html;base64,PHNjcmlwdD4=',
+      'vbscript:msgbox(1)',
+      'file:///etc/passwd',
+      'not a url at all',
+      '',
+      42,
+      null,
+    ]) {
+      const res = withUrl(bad)
+      // The citation is NOT lost — only the link is. A dangerous url must not
+      // cost the user the note's words.
+      expect(res.state, `url=${String(bad)}`).toBe('cited')
+      if (res.state !== 'cited') continue
+      expect(res.evidence.url, `url=${String(bad)}`).toBeNull()
+      expect(res.evidence.body).toBe(ADA_BODY)
+    }
+  })
+
+  it('renders NO anchor for a dropped url', () => {
+    render(<CitedEvidenceNote resolution={withUrl('javascript:alert(1)')} />)
+    expect(screen.queryByRole('link')).toBeNull()
+    // and the body is still on screen.
+    expect(screen.getByTestId(CITED_EVIDENCE_TESTID).textContent).toContain(ADA_BODY)
   })
 })
 

--- a/src/collab/__tests__/citedEvidenceReadback.spec.tsx
+++ b/src/collab/__tests__/citedEvidenceReadback.spec.tsx
@@ -1,0 +1,464 @@
+/**
+ * COLLAB — THE CITATION READBACK. Does the evidence the owner cited reach a
+ * surface a user looks at.
+ *
+ * ── THE DEFECT ────────────────────────────────────────────────────────────
+ * From 0.41.0 CEE stamps `observed_state.elicited_from.evidence_event_id` when
+ * the owner applies a panellist's value while citing a colleague's note
+ * (`factor-value-edit.ts:362-384`), and the contract carries it — `.strict()`
+ * with `evidence_event_id: z.ZodOptional<z.ZodString>` on the graph's
+ * `elicited_from`. The write path is wire-witnessed.
+ *
+ * It reached no user, because `readElicitedFrom` returned a type with no such
+ * member and EVERY mounted attribution surface goes through that one function.
+ * The product recorded why a value was adopted and showed nobody.
+ *
+ * ── THE LOAD-BEARING BLOCKS ARE THE THIRD AND FOURTH, NOT THE HAPPY PATH ──
+ * Block 3 is the one that must never regress: a manual edit, or an apply with no
+ * citation, MUST NOT produce a citation line. Provenance that can be fabricated
+ * by the client is worse than provenance that is missing, and the mutant kit
+ * below includes a mutation that stamps a citation on an uncited value — it must
+ * go RED.
+ *
+ * Block 4 pins the copy. A 15 Aug review found this feature's own sentence
+ * asserting a causality the server never verified: CEE checks that the evidence
+ * exists, belongs to the round and names the factor, and reads neither `stance`
+ * nor `about_participant_id`. So the surface may report the ACT of attaching and
+ * must never report a CONSEQUENCE. The assertion is over the rendered text, not
+ * over a constant, so a future rewording is caught wherever it is written.
+ *
+ * ── ASSERTIONS BIND BY IDENTITY ───────────────────────────────────────────
+ * The fixture holds THREE evidence rows across TWO targets, with distinct
+ * bodies, distinct authors and distinct stances, so no assertion can pass on the
+ * wrong row (trap 19). The cited row is deliberately on a DIFFERENT target from
+ * the factor under the cursor, and is authored by a DIFFERENT person from the
+ * applied value — both are real product paths and both would be hidden by a
+ * narrower lookup.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { CITED_EVIDENCE_TESTID, CitedEvidenceNote } from '../CitedEvidenceNote'
+import { readCitation, resolveCitedEvidence } from '../citedEvidence'
+import { readElicitedFrom } from '../participantNames'
+import type { DisagreementView } from '../collabService'
+
+/* ── fixtures ─────────────────────────────────────────────────────────────── */
+
+const ROUND_ID = '33333333-3333-4333-8333-333333333333'
+/** Grace's value is the one applied. */
+const GRACE_ID = '55555555-5555-4555-8555-555555555555'
+
+/** The CITED row — Ada's challenge, on the NEIGHBOURING target. */
+const ADA_EVIDENCE_ID = '88888888-8888-4888-8888-888888888888'
+const ADA_BODY = 'Q3 cohort held at 12% after the last rise, so 0.85 looks high'
+const ADA_LABEL = 'Ada'
+const ADA_STANCE_PHRASE = 'challenging this'
+
+/** A decoy on the SAME target as the cursor. Never cited. */
+const DECOY_EVIDENCE_ID = '99999999-9999-4999-8999-999999999999'
+const DECOY_BODY = 'Pricing deck slide 14 supports a steep response'
+const DECOY_LABEL = 'Ruth'
+
+/** A second decoy, same author as the cited row, different id. */
+const SECOND_DECOY_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const SECOND_DECOY_BODY = 'Renewal desk thinks churn is already priced in'
+
+const CURSOR_TARGET_ID = 'fac_churn_risk'
+const NEIGHBOUR_TARGET_ID = 'fac_lead_time'
+
+function evidenceRow(o: {
+  event_id: string
+  author_label: string
+  body: string
+  stance_phrase?: string
+  kind?: 'note' | 'link'
+  url?: string | null
+}) {
+  return {
+    event_id: o.event_id,
+    authored_by: 'server-stamped-id',
+    author_label: o.author_label,
+    stance: 'challenges' as const,
+    stance_phrase: o.stance_phrase ?? ADA_STANCE_PHRASE,
+    kind: o.kind ?? ('note' as const),
+    body: o.body,
+    url: o.url ?? null,
+    about_participant_id: null,
+    about_label: null,
+    created_at: '2026-08-14T11:00:00.000Z',
+  }
+}
+
+function disagreementView(overrides: Partial<DisagreementView> = {}): DisagreementView {
+  return {
+    round_id: ROUND_ID,
+    graph_version_ref: 'mv-1',
+    standing_note: null,
+    per_target: [
+      {
+        target: { kind: 'factor', id: CURSOR_TARGET_ID },
+        label: 'Churn risk after a price rise',
+        model_value_at_version: 0.5,
+        shape: 'split',
+        answering_participants: 2,
+        distinct_values: 2,
+        spread: { low: 0.2, high: 0.85, width: 0.65 },
+        positions: [],
+        positions_with_stated_basis: 2,
+        // The decoys live HERE, on the target under the cursor.
+        evidence: [
+          evidenceRow({ event_id: DECOY_EVIDENCE_ID, author_label: DECOY_LABEL, body: DECOY_BODY }),
+          evidenceRow({
+            event_id: SECOND_DECOY_ID,
+            author_label: ADA_LABEL,
+            body: SECOND_DECOY_BODY,
+          }),
+        ],
+        headline: 'Two people differ on this.',
+        question: 'What would settle it?',
+      },
+      {
+        target: { kind: 'factor', id: NEIGHBOUR_TARGET_ID },
+        label: 'Supplier lead time in weeks',
+        model_value_at_version: 3,
+        shape: 'aligned',
+        answering_participants: 2,
+        distinct_values: 1,
+        spread: null,
+        positions: [],
+        positions_with_stated_basis: 1,
+        // The CITED row lives on the NEIGHBOUR, which is legitimate: CEE's
+        // verifier requires only that the evidence belong to the same ROUND.
+        evidence: [
+          evidenceRow({ event_id: ADA_EVIDENCE_ID, author_label: ADA_LABEL, body: ADA_BODY }),
+        ],
+        headline: 'They agree on this.',
+        question: null,
+      },
+    ],
+    ...overrides,
+  }
+}
+
+/** A cited apply: Grace's value, citing Ada's evidence. */
+const citedElicitedFrom = {
+  round_id: ROUND_ID,
+  participant_id: GRACE_ID,
+  evidence_event_id: ADA_EVIDENCE_ID,
+}
+
+/** An uncited apply. The key is ABSENT, which is how CEE writes it. */
+const uncitedElicitedFrom = { round_id: ROUND_ID, participant_id: GRACE_ID }
+
+/* ══════════════════════════════════════════════════════════════════════════ */
+
+describe('the reader gate carries the citation without costing the attribution', () => {
+  it('readElicitedFrom carries evidence_event_id when the wire has one', () => {
+    const ref = readElicitedFrom(citedElicitedFrom)
+    expect(ref).not.toBeNull()
+    expect(ref?.evidence_event_id).toBe(ADA_EVIDENCE_ID)
+    // The attribution members are untouched.
+    expect(ref?.round_id).toBe(ROUND_ID)
+    expect(ref?.participant_id).toBe(GRACE_ID)
+  })
+
+  it('OMITS the key — not undefined — on an uncited apply, matching the write path', () => {
+    const ref = readElicitedFrom(uncitedElicitedFrom)
+    expect(ref).not.toBeNull()
+    // `'x' in obj` is the presence test `panelApplyHandoff.ts` and
+    // `buildPayload.ts` already use. A key set to `undefined` would pass a
+    // `=== undefined` check and fail this one.
+    expect('evidence_event_id' in (ref as object)).toBe(false)
+  })
+
+  it('⭐ a MALFORMED citation costs the citation and NEVER the attribution', () => {
+    // The inverse of this is the defect that matters: returning null for the
+    // whole reference would take a NAME off the screen because a THIRD field was
+    // junk, and the contract's absence semantics say attribution is intact.
+    for (const junk of ['', '   ', 42, null, {}, []]) {
+      const ref = readElicitedFrom({ ...uncitedElicitedFrom, evidence_event_id: junk })
+      expect(ref, `junk=${JSON.stringify(junk)}`).not.toBeNull()
+      expect(ref?.participant_id).toBe(GRACE_ID)
+      expect(ref?.evidence_event_id).toBeUndefined()
+    }
+  })
+
+  it('readCitation answers null when there is no citation, and the ref when there is', () => {
+    expect(readCitation(uncitedElicitedFrom)).toBeNull()
+    expect(readCitation(citedElicitedFrom)).toEqual({
+      round_id: ROUND_ID,
+      evidence_event_id: ADA_EVIDENCE_ID,
+    })
+  })
+})
+
+describe('resolution binds to the cited row by id, across every target', () => {
+  it('⭐ resolves a row on a DIFFERENT target from the cursor, by id', () => {
+    const res = resolveCitedEvidence(citedElicitedFrom, disagreementView())
+    expect(res.state).toBe('cited')
+    if (res.state !== 'cited') return
+    // Bound by id. The decoys on the cursor's own target must not win.
+    expect(res.evidence.body).toBe(ADA_BODY)
+    expect(res.evidence.body).not.toBe(DECOY_BODY)
+    expect(res.evidence.body).not.toBe(SECOND_DECOY_BODY)
+  })
+
+  it('⭐ names the EVIDENCE author, who is not the applied value\'s author', () => {
+    const res = resolveCitedEvidence(citedElicitedFrom, disagreementView())
+    if (res.state !== 'cited') throw new Error('fixture: expected cited')
+    // The asymmetry IS the feature: Grace's number, Ada's challenge. Collapsing
+    // them, or asserting they must match, destroys the case this exists for.
+    expect(res.evidence.author_label).toBe(ADA_LABEL)
+    expect(res.evidence.author_label).not.toBe(DECOY_LABEL)
+  })
+
+  it('renders CEE\'s stance phrase, not a locally composed one', () => {
+    const res = resolveCitedEvidence(citedElicitedFrom, disagreementView())
+    if (res.state !== 'cited') throw new Error('fixture: expected cited')
+    expect(res.evidence.stance_phrase).toBe(ADA_STANCE_PHRASE)
+  })
+
+  it('distinguishes all four unresolved reasons', () => {
+    // no_citation — the ordinary case for almost every factor.
+    expect(resolveCitedEvidence(uncitedElicitedFrom, disagreementView())).toEqual({
+      state: 'unresolved',
+      reason: 'no_citation',
+    })
+    // view_unavailable — transient. `undefined` (never asked) and `null`
+    // (asked, failed) are both this, and neither is "nothing was cited".
+    expect(resolveCitedEvidence(citedElicitedFrom, undefined)).toEqual({
+      state: 'unresolved',
+      reason: 'view_unavailable',
+    })
+    expect(resolveCitedEvidence(citedElicitedFrom, null)).toEqual({
+      state: 'unresolved',
+      reason: 'view_unavailable',
+    })
+    // evidence_not_found — the view loaded and holds no such row.
+    expect(
+      resolveCitedEvidence(
+        { ...citedElicitedFrom, evidence_event_id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb' },
+        disagreementView(),
+      ),
+    ).toEqual({ state: 'unresolved', reason: 'evidence_not_found' })
+    // body_unusable — a row exists and has nothing to show.
+    const blankBody = disagreementView()
+    blankBody.per_target[1].evidence[0].body = '   '
+    expect(resolveCitedEvidence(citedElicitedFrom, blankBody)).toEqual({
+      state: 'unresolved',
+      reason: 'body_unusable',
+    })
+  })
+
+  it('⭐ refuses to substitute for an absent author label or stance phrase', () => {
+    // Both are CEE's, and a UI default for either is a second authority: an
+    // unattributed quotation, or a stance this bundle invented.
+    const noLabel = disagreementView()
+    noLabel.per_target[1].evidence[0].author_label = ''
+    expect(resolveCitedEvidence(citedElicitedFrom, noLabel)).toEqual({
+      state: 'unresolved',
+      reason: 'body_unusable',
+    })
+
+    const noStance = disagreementView()
+    noStance.per_target[1].evidence[0].stance_phrase = '  '
+    expect(resolveCitedEvidence(citedElicitedFrom, noStance)).toEqual({
+      state: 'unresolved',
+      reason: 'body_unusable',
+    })
+  })
+
+  it('carries no identifier into the resolved result', () => {
+    const res = resolveCitedEvidence(citedElicitedFrom, disagreementView())
+    const serialised = JSON.stringify(res)
+    // A uuid in a sentence position reads to the user as content. Same
+    // invariant `participantNames.ts` holds for names, asserted the same way.
+    for (const id of [ADA_EVIDENCE_ID, GRACE_ID, ROUND_ID, 'server-stamped-id']) {
+      expect(serialised).not.toContain(id)
+    }
+    // Positive control: the assertion above is over a string that DOES contain
+    // the body, so it is proven capable of finding something (trap 13).
+    expect(serialised).toContain(ADA_BODY)
+  })
+})
+
+describe('⭐ PROVENANCE IS NEVER FABRICATED: no citation, no line', () => {
+  it('renders NOTHING for every unresolved reason', () => {
+    for (const reason of [
+      'no_citation',
+      'view_unavailable',
+      'evidence_not_found',
+      'body_unusable',
+    ] as const) {
+      const { container, unmount } = render(
+        <CitedEvidenceNote resolution={{ state: 'unresolved', reason }} />,
+      )
+      expect(container.innerHTML, `reason=${reason}`).toBe('')
+      expect(screen.queryByTestId(CITED_EVIDENCE_TESTID)).toBeNull()
+      unmount()
+    }
+  })
+
+  it('an uncited apply resolves to no_citation against a view FULL of evidence', () => {
+    // The strongest form: the round has three evidence rows and this value cites
+    // none of them. A resolver that fell back to "any evidence on this round"
+    // would render somebody else's note as this value's citation.
+    const res = resolveCitedEvidence(uncitedElicitedFrom, disagreementView())
+    expect(res).toEqual({ state: 'unresolved', reason: 'no_citation' })
+    const { container } = render(<CitedEvidenceNote resolution={res} />)
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('a manual retype — no elicited_from at all — resolves to no_citation', () => {
+    // CEE-1: a manual edit writes `source: 'user_override'` and no
+    // `elicited_from`. Nothing here may invent one.
+    for (const manual of [undefined, null, {}, { source: 'user_override' }]) {
+      expect(resolveCitedEvidence(manual, disagreementView())).toEqual({
+        state: 'unresolved',
+        reason: 'no_citation',
+      })
+    }
+  })
+})
+
+describe('⭐ THE COPY REPORTS AN ACT, NEVER A CONSEQUENCE', () => {
+  it('renders the author, the stance and the words', () => {
+    const res = resolveCitedEvidence(citedElicitedFrom, disagreementView())
+    render(<CitedEvidenceNote resolution={res} />)
+
+    const node = screen.getByTestId(CITED_EVIDENCE_TESTID)
+    expect(node.textContent).toContain(ADA_LABEL)
+    expect(node.textContent).toContain(ADA_STANCE_PHRASE)
+    expect(node.textContent).toContain(ADA_BODY)
+  })
+
+  it('asserts NO causal link between the citation and the applied value', () => {
+    const res = resolveCitedEvidence(citedElicitedFrom, disagreementView())
+    render(<CitedEvidenceNote resolution={res} />)
+    const text = screen.getByTestId(CITED_EVIDENCE_TESTID).textContent?.toLowerCase() ?? ''
+
+    /**
+     * The banned register. CEE verified existence, round and factor — never
+     * that the citation motivated the change. The exact sentence a 15 Aug
+     * review caught is the first entry.
+     */
+    for (const banned of [
+      'as the reason',
+      'the reason for',
+      'because',
+      'which is why',
+      'justifies',
+      'justified',
+      'supports this value',
+      'confirms',
+      'verified by',
+      'proves',
+      // and the endorsement register `inspectorStrings.ts` already bans
+      'was correct',
+      'is correct',
+      'was right',
+      'agreed',
+      'consensus',
+      'resolved',
+      'winner',
+      'recommended',
+    ]) {
+      expect(text, `banned phrase present: ${banned}`).not.toContain(banned)
+    }
+  })
+
+  it('renders a link row\'s url as a real link, and omits it when absent', () => {
+    const withUrl = disagreementView()
+    withUrl.per_target[1].evidence[0].kind = 'link'
+    withUrl.per_target[1].evidence[0].url = 'https://example.test/cohort-report'
+    const cited = resolveCitedEvidence(citedElicitedFrom, withUrl)
+    const { unmount } = render(<CitedEvidenceNote resolution={cited} />)
+    const anchor = screen.getByRole('link', { name: 'https://example.test/cohort-report' })
+    expect(anchor.getAttribute('href')).toBe('https://example.test/cohort-report')
+    expect(anchor.getAttribute('rel')).toContain('noopener')
+    unmount()
+
+    render(<CitedEvidenceNote resolution={resolveCitedEvidence(citedElicitedFrom, disagreementView())} />)
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+})
+
+describe('the cache asks the network only when a citation exists', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('⭐ an UNCITED value triggers no disagreement request at all', async () => {
+    const fetchSpy = vi.fn()
+    vi.doMock('../collabService', async () => ({
+      ...(await vi.importActual<typeof import('../collabService')>('../collabService')),
+      fetchOwnerDisagreement: fetchSpy,
+    }))
+    vi.doMock('../ownerAccessToken', () => ({
+      requireOwnerAccessToken: async () => 'owner-token',
+    }))
+
+    const { ensureDisagreement, __resetCitedEvidenceCacheForTests } = await import(
+      '../citedEvidenceCache'
+    )
+    __resetCitedEvidenceCacheForTests()
+
+    // `useCitedEvidence` derives its round id from `readCitation`, which is null
+    // for an uncited value — so the empty round id must short-circuit.
+    await ensureDisagreement('')
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('dedups concurrent requests for one round to a single fetch', async () => {
+    const fetchSpy = vi.fn(async () => disagreementView())
+    vi.doMock('../collabService', async () => ({
+      ...(await vi.importActual<typeof import('../collabService')>('../collabService')),
+      fetchOwnerDisagreement: fetchSpy,
+    }))
+    vi.doMock('../ownerAccessToken', () => ({
+      requireOwnerAccessToken: async () => 'owner-token',
+    }))
+
+    const { ensureDisagreement, __resetCitedEvidenceCacheForTests } = await import(
+      '../citedEvidenceCache'
+    )
+    __resetCitedEvidenceCacheForTests()
+
+    await Promise.all([
+      ensureDisagreement(ROUND_ID),
+      ensureDisagreement(ROUND_ID),
+      ensureDisagreement(ROUND_ID),
+    ])
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1))
+  })
+
+  it('caches a FAILURE as null rather than retrying on every render', async () => {
+    const fetchSpy = vi.fn(async () => {
+      throw new Error('signed out')
+    })
+    vi.doMock('../collabService', async () => ({
+      ...(await vi.importActual<typeof import('../collabService')>('../collabService')),
+      fetchOwnerDisagreement: fetchSpy,
+    }))
+    vi.doMock('../ownerAccessToken', () => ({
+      requireOwnerAccessToken: async () => 'owner-token',
+    }))
+
+    const { ensureDisagreement, peekDisagreement, __resetCitedEvidenceCacheForTests } =
+      await import('../citedEvidenceCache')
+    __resetCitedEvidenceCacheForTests()
+
+    expect(await ensureDisagreement(ROUND_ID)).toBeNull()
+    expect(await ensureDisagreement(ROUND_ID)).toBeNull()
+    // One attempt, and the cached null is a FACT the surface can read
+    // synchronously — distinct from `undefined`, which means never asked.
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+    expect(peekDisagreement(ROUND_ID)).toBeNull()
+    expect(peekDisagreement('some-other-round')).toBeUndefined()
+  })
+})

--- a/src/collab/citedEvidence.ts
+++ b/src/collab/citedEvidence.ts
@@ -1,0 +1,181 @@
+/**
+ * COLLAB — resolving a persisted CITATION to the piece of panel evidence it
+ * names, at render time.
+ *
+ * ── THE GAP THIS CLOSES ───────────────────────────────────────────────────
+ * From 0.41.0 CEE stamps `observed_state.elicited_from.evidence_event_id` when
+ * the owner applies a panellist's value AND cites a colleague's note or link as
+ * part of that decision (`system-events/factor-value-edit.ts:362-384`). The
+ * write path is complete and wire-witnessed. **No mounted surface read it back**,
+ * because `participantNames.readElicitedFrom` dropped the member and every
+ * attribution surface goes through that one function. So the product recorded
+ * why a value was adopted and then showed nobody — chronic failure #1, on the
+ * attribution family.
+ *
+ * ── WHY THIS IS A SEPARATE MODULE FROM `participantNames.ts` ──────────────
+ * Two questions, two sources, two failure modes. "Whose number is this" is
+ * answered from the ROSTER (`/rounds/:id/preview`, ids → names). "What did the
+ * owner cite" is answered from the OWNER DISAGREEMENT VIEW, the only projection
+ * that carries evidence rows. Folding them would put a heavier fetch behind
+ * every name pill, which is exactly the trade `fetchRoundRoster`'s header
+ * rejected — the name lookup must stay on `/preview`.
+ *
+ * ── ⭐ THE COPY IS CEE'S, AND THAT IS A CORRECTNESS PROPERTY ──────────────
+ * This module returns the SERVER'S OWN `stance_phrase` and `author_label` and
+ * composes no sentence of its own. That is not deference for its own sake: a
+ * review on 15 Aug found the citation copy asserting a causality the server had
+ * never verified — "…as the reason for this change" — when the verifier checks
+ * only that the evidence EXISTS, belongs to the round and names the factor. It
+ * does not read `stance` and it does not read `about_participant_id`. So this
+ * surface may say WHAT was cited and WHO wrote it, and must never say the
+ * citation CAUSED the change.
+ *
+ * The stance phrase is CEE-authored and pinned by CEE's own copy guard, which
+ * asserts over every string that module can emit that none of them resolves the
+ * disagreement. A phrase composed in this bundle would sit outside that proof.
+ *
+ * ── ⭐ THE ASYMMETRY IS THE FEATURE, NOT A BUG TO NORMALISE ───────────────
+ * The cited evidence is frequently authored by a DIFFERENT person from the value
+ * that was applied: the designed path applies Grace's number while citing Ada's
+ * challenge to it. So `author_label` here is resolved and rendered
+ * INDEPENDENTLY of the value's attributed author, and the two must never be
+ * collapsed or assumed equal. An author-equality check would destroy the case
+ * the feature exists for.
+ *
+ * ── WHY THE REASONS ARE DISTINCT ──────────────────────────────────────────
+ *   · `no_citation`        — the owner applied without citing. The ordinary case.
+ *   · `view_unavailable`   — the disagreement view is not loaded YET, or could
+ *                            not be loaded (signed out, another scenario's
+ *                            round). TRANSIENT; a later render may resolve.
+ *   · `evidence_not_found` — the view loaded and holds no row with that id.
+ *   · `body_unusable`      — a row exists and its body is empty.
+ * A surface that collapsed these would render the same thing for "nothing was
+ * cited" and "something WAS cited and I cannot show it", and the second is a
+ * fact the owner needs.
+ */
+
+import type { DisagreementView } from './collabService'
+import { readElicitedFrom } from './participantNames'
+
+/** A citation reference: which round, and which evidence row within it. */
+export interface CitationRef {
+  round_id: string
+  evidence_event_id: string
+}
+
+/**
+ * The resolved citation, as a surface renders it.
+ *
+ * ⚠ NO IDENTIFIER RIDES ALONG, deliberately — the same invariant
+ * `participantNames.ts` holds for names. `event_id` is not carried here and
+ * neither is `authored_by`: a uuid in a sentence position reads to the user as
+ * content, and `author_label` is the only name-shaped thing that has been
+ * through CEE's R-2 pseudonym resolution.
+ */
+export interface CitedEvidence {
+  /** The R-2-resolved label of whoever ATTACHED the evidence. */
+  readonly author_label: string
+  /** CEE's fixed word for the stance. Rendered verbatim, never re-worded. */
+  readonly stance_phrase: string
+  readonly kind: 'note' | 'link'
+  /** The participant's own words. Verbatim. */
+  readonly body: string
+  /** http/https only, normalised server-side at append time. */
+  readonly url: string | null
+}
+
+export type CitationUnresolvedReason =
+  | 'no_citation'
+  | 'view_unavailable'
+  | 'evidence_not_found'
+  | 'body_unusable'
+
+export type CitedEvidenceResolution =
+  | { readonly state: 'cited'; readonly evidence: CitedEvidence }
+  | { readonly state: 'unresolved'; readonly reason: CitationUnresolvedReason }
+
+/**
+ * Read a citation reference off a value that came through a `.passthrough()`
+ * schema.
+ *
+ * Delegates the wire-shape decision to `readElicitedFrom` rather than
+ * re-validating `round_id` here. That is deliberate: two functions deciding
+ * independently what a valid `elicited_from` looks like is the
+ * hand-maintained-mirror defect, and this estate has paid for it before with two
+ * same-named hash functions. One gate, one answer.
+ */
+export function readCitation(elicitedFrom: unknown): CitationRef | null {
+  const ref = readElicitedFrom(elicitedFrom)
+  if (ref === null) return null
+  if (ref.evidence_event_id === undefined) return null
+  return { round_id: ref.round_id, evidence_event_id: ref.evidence_event_id }
+}
+
+/**
+ * Resolve one citation against one round's disagreement view.
+ *
+ * `view === null` means "not available" (not loaded yet, or the load failed) and
+ * is DISTINCT from a view that loaded and holds no matching row — the first is
+ * transient, the second is a fact about the round.
+ */
+export function resolveCitedEvidence(
+  elicitedFrom: unknown,
+  view: DisagreementView | null | undefined,
+): CitedEvidenceResolution {
+  const ref = readCitation(elicitedFrom)
+  if (ref === null) return { state: 'unresolved', reason: 'no_citation' }
+
+  if (view === null || view === undefined) {
+    return { state: 'unresolved', reason: 'view_unavailable' }
+  }
+
+  /**
+   * ⚠ BOUND BY `event_id` ACROSS EVERY TARGET, NOT BY THE TARGET UNDER THE
+   * CURSOR. The citation names an evidence ROW, and CEE's verifier requires only
+   * that the row belong to the same ROUND — a note attached to a neighbouring
+   * factor is a legitimate citation. Scoping this search to one target would
+   * silently render `evidence_not_found` for a citation the server verified and
+   * accepted, and the surface would report an absence that is not real.
+   *
+   * The match is by id, never by a predicate another row could satisfy — no
+   * "the first note", no "the one from this author" (trap 19).
+   */
+  for (const target of view.per_target) {
+    for (const row of target.evidence) {
+      if (row.event_id !== ref.evidence_event_id) continue
+
+      // A row can exist with an unusable body. `body` is the participant's own
+      // words and is the whole content of the citation; an empty one has nothing
+      // to show, and that is a distinct state from "no row".
+      const body = typeof row.body === 'string' ? row.body.trim() : ''
+      if (body === '') return { state: 'unresolved', reason: 'body_unusable' }
+
+      const authorLabel = typeof row.author_label === 'string' ? row.author_label.trim() : ''
+      const stancePhrase = typeof row.stance_phrase === 'string' ? row.stance_phrase.trim() : ''
+
+      /**
+       * ⚠ AN ABSENT LABEL OR STANCE PHRASE IS `body_unusable`, NOT A LOCAL
+       * SUBSTITUTE. Both come from CEE, and both are exactly the fields a
+       * UI-side default would turn into a second authority — an unattributed
+       * quotation, or a stance this bundle invented. The honest outcome when
+       * CEE has not supplied them is to render no citation at all.
+       */
+      if (authorLabel === '' || stancePhrase === '') {
+        return { state: 'unresolved', reason: 'body_unusable' }
+      }
+
+      return {
+        state: 'cited',
+        evidence: {
+          author_label: authorLabel,
+          stance_phrase: stancePhrase,
+          kind: row.kind,
+          body,
+          url: typeof row.url === 'string' && row.url.trim() !== '' ? row.url : null,
+        },
+      }
+    }
+  }
+
+  return { state: 'unresolved', reason: 'evidence_not_found' }
+}

--- a/src/collab/citedEvidence.ts
+++ b/src/collab/citedEvidence.ts
@@ -30,9 +30,17 @@
  * surface may say WHAT was cited and WHO wrote it, and must never say the
  * citation CAUSED the change.
  *
- * The stance phrase is CEE-authored and pinned by CEE's own copy guard, which
- * asserts over every string that module can emit that none of them resolves the
- * disagreement. A phrase composed in this bundle would sit outside that proof.
+ * The stance phrase is CEE-authored, which keeps ONE authority for the word.
+ *
+ * ⚠ AND IT IS NOT COVERED BY CEE'S COPY GUARD — an earlier version of this
+ * header claimed it was, and that was overstated. `disagreement-copy.ts`'s
+ * `everyString()` derives from `STANDING_SENTENCES` plus the headlines and
+ * questions; `STANCE_PHRASE` is NOT in it. So a causal phrase shipped in
+ * `STANCE_PHRASE` would pass this bundle's banned-register assertion unseen,
+ * because that assertion runs over what CEE SERVED and CEE is trusted for this
+ * field. Deferring to CEE is still right — two authorities on one user-facing
+ * word is worse — but it is deference, not a proof, and it must not be cited as
+ * a backstop it is not.
  *
  * ── ⭐ THE ASYMMETRY IS THE FEATURE, NOT A BUG TO NORMALISE ───────────────
  * The cited evidence is frequently authored by a DIFFERENT person from the value
@@ -75,12 +83,36 @@ export interface CitationRef {
 export interface CitedEvidence {
   /** The R-2-resolved label of whoever ATTACHED the evidence. */
   readonly author_label: string
-  /** CEE's fixed word for the stance. Rendered verbatim, never re-worded. */
+  /**
+   * CEE's fixed word for the stance — a BARE VERB (`supports` / `challenges` /
+   * `qualifies`, `disagreement-copy.ts:126-130`), not a sentence fragment.
+   *
+   * ⚠ IT NEEDS AN OBJECT TO READ AS ENGLISH, and CEE supplies one at its own
+   * render site. A surface that drops it in after a comma emits "Ada attached
+   * this, challenges".
+   */
   readonly stance_phrase: string
+  /**
+   * WHOSE position the evidence is about, R-2-resolved by CEE, or null when it
+   * is about the factor rather than a person. The object of `stance_phrase`.
+   *
+   * ⚠ The LABEL only. `about_participant_id` is deliberately not carried — the
+   * same no-identifier rule the author id follows.
+   */
+  readonly about_label: string | null
   readonly kind: 'note' | 'link'
   /** The participant's own words. Verbatim. */
   readonly body: string
-  /** http/https only, normalised server-side at append time. */
+  /**
+   * An http/https URL, or null.
+   *
+   * ⚠ RE-CHECKED HERE EVEN THOUGH CEE NORMALISES AT APPEND TIME. The view
+   * arrives through an unvalidated `as DisagreementView` cast
+   * (`collabService.ts:446`), so "validated server-side" is a claim about the
+   * producer and not about the bytes this function received. This value feeds an
+   * `href`, and `javascript:` in an href is the one place a skewed or hostile
+   * payload becomes script execution.
+   */
   readonly url: string | null
 }
 
@@ -130,19 +162,57 @@ export function resolveCitedEvidence(
   }
 
   /**
-   * ⚠ BOUND BY `event_id` ACROSS EVERY TARGET, NOT BY THE TARGET UNDER THE
-   * CURSOR. The citation names an evidence ROW, and CEE's verifier requires only
-   * that the row belong to the same ROUND — a note attached to a neighbouring
-   * factor is a legitimate citation. Scoping this search to one target would
-   * silently render `evidence_not_found` for a citation the server verified and
-   * accepted, and the surface would report an absence that is not real.
+   * ⭐⭐ THE SHAPE GUARD, AND IT IS NOT DEFENSIVE PADDING — IT WAS A CRASH.
+   *
+   * `fetchOwnerDisagreement` returns `(await res.json()) as DisagreementView` —
+   * a CAST, with no validation anywhere. A 200 whose body is `{}` (an older CEE,
+   * a schema skew, a proxy error page) therefore reaches here with
+   * `per_target === undefined`, and iterating it THROWS DURING RENDER. Because
+   * this hook is called from the factor panels, the throw takes down the whole
+   * inspector subtree — so the participant's NAME leaves the screen too.
+   *
+   * That is this feature's central claim failing one seam past the reader gate:
+   * "malformity costs the citation, never the attribution" was TRUE of
+   * `readElicitedFrom` and FALSE here. Schema skew is this estate's hazard #1
+   * and it is precisely the trigger.
+   *
+   * A malformed view is `view_unavailable` — the same state as a failed load,
+   * which is what it is.
+   */
+  if (!Array.isArray(view.per_target)) {
+    return { state: 'unresolved', reason: 'view_unavailable' }
+  }
+
+  /**
+   * ⚠ BOUND BY `event_id` ACROSS EVERY TARGET IN THE VIEW — and the reason is
+   * ROBUSTNESS TO GROUPING, not the verifier's scope.
+   *
+   * ⚠⚠ AN EARLIER VERSION OF THIS COMMENT SAID CEE "requires only that the row
+   * belong to the same ROUND". THAT IS FALSE, and it was refuted at CEE's bytes:
+   * `apply-verification.ts:282-287` binding (f) requires `evidence_attached` AND
+   * the same round AND `cited.target.kind === 'factor' && cited.target.id ===
+   * target_id`, refusing with "That evidence is not on this round for this
+   * factor." So a citation is always on the SAME FACTOR as the value.
+   *
+   * The wide search STAYS, because the two directions are not symmetric: a
+   * search wider than the producer can never report a FALSE ABSENCE, whereas a
+   * search narrower than the view's grouping can. This function must not encode
+   * an assumption about which `per_target` row CEE files an evidence row under.
+   *
+   * ⭐ WHAT IS *NOT* SCOPED BY THE VERIFIER IS THE AUTHOR — deliberately, and
+   * CEE says so in the same region: applying Grace's number BECAUSE ADA
+   * CHALLENGED IT "is the most valuable case this whole feature has". Never add
+   * an author-equality check.
    *
    * The match is by id, never by a predicate another row could satisfy — no
    * "the first note", no "the one from this author" (trap 19).
    */
   for (const target of view.per_target) {
+    // Same cast, same hazard, one level down: a row whose `evidence` is absent
+    // must skip, never throw.
+    if (!Array.isArray(target?.evidence)) continue
     for (const row of target.evidence) {
-      if (row.event_id !== ref.evidence_event_id) continue
+      if (row?.event_id !== ref.evidence_event_id) continue
 
       // A row can exist with an unusable body. `body` is the participant's own
       // words and is the whole content of the citation; an empty one has nothing
@@ -164,14 +234,36 @@ export function resolveCitedEvidence(
         return { state: 'unresolved', reason: 'body_unusable' }
       }
 
+      /**
+       * The scheme allowlist. `http:`/`https:` only, decided by the URL PARSER
+       * rather than by a string prefix test — `javascript:alert(1)#https://x`
+       * defeats a `startsWith`, and a malformed string must be dropped rather
+       * than thrown on.
+       */
+      let url: string | null = null
+      if (typeof row.url === 'string' && row.url.trim() !== '') {
+        try {
+          const parsed = new URL(row.url.trim())
+          if (parsed.protocol === 'http:' || parsed.protocol === 'https:') url = row.url.trim()
+        } catch {
+          url = null
+        }
+      }
+
+      const aboutLabel =
+        typeof row.about_label === 'string' && row.about_label.trim() !== ''
+          ? row.about_label.trim()
+          : null
+
       return {
         state: 'cited',
         evidence: {
           author_label: authorLabel,
           stance_phrase: stancePhrase,
+          about_label: aboutLabel,
           kind: row.kind,
           body,
-          url: typeof row.url === 'string' && row.url.trim() !== '' ? row.url : null,
+          url,
         },
       }
     }

--- a/src/collab/citedEvidenceCache.ts
+++ b/src/collab/citedEvidenceCache.ts
@@ -1,0 +1,170 @@
+/**
+ * COLLAB — the cache and hook behind render-time citation resolution.
+ *
+ * Deliberately the same shape as `roundRosterCache.ts`: three states, a short
+ * absolute TTL, in-flight dedup, a subscription so instances that did not
+ * initiate the fetch still re-render, and a failure that is CACHED rather than
+ * retried on sight. Those decisions were argued out for the roster and every
+ * reason holds here; a second cache written to a different pattern is how two
+ * surfaces start disagreeing about the same round.
+ *
+ * ── ⭐ WHY THIS FETCH IS NOT FOLDED INTO THE ROSTER CACHE ──────────────────
+ * `fetchRoundRoster`'s header rejected `/reveal` for NAME resolution on data
+ * minimisation: pulling every participant's number and verbatim wording into the
+ * canvas to render one person's name is disproportionate, and `/preview` returns
+ * the roster and nothing else. That reasoning is correct and it is why the roster
+ * cache must keep using `/preview`.
+ *
+ * It does NOT forbid this fetch, and the distinction is the purpose. Here the
+ * evidence content IS the thing being rendered — the owner asked to see what was
+ * cited — so the projection that carries evidence is the proportionate one, not
+ * an overreach. And it costs nothing in disclosure: the caller is the round's
+ * OWNER, who already reads this exact view in full on `/scenario/:id/panel`.
+ *
+ * ── ⚠ IT IS FETCHED ONLY WHEN A CITATION EXISTS ───────────────────────────
+ * The hook returns `no_citation` without touching the network for every value
+ * that was not applied with a citation — which is almost every value on almost
+ * every graph. So the heavier request is bought only by the factors that have
+ * something to show, and an ordinary graph makes zero of them.
+ *
+ * ── FRESHNESS IS AN R-2 CONCERN, SAME AS THE ROSTER ───────────────────────
+ * A cached citation carries `author_label`, which is CEE's `pseudonym ??
+ * display_name`. When the owner redacts a participant, CEE starts serving the
+ * pseudonym, and a cache without an expiry would keep rendering the detached
+ * name for the life of the tab. The TTL bounds that window and is deliberately
+ * not "cache for the session".
+ */
+
+import { useEffect, useState } from 'react'
+
+import { fetchOwnerDisagreement, type DisagreementView } from './collabService'
+import { readCitation, resolveCitedEvidence, type CitedEvidenceResolution } from './citedEvidence'
+import { requireOwnerAccessToken } from './ownerAccessToken'
+
+/**
+ * How long a disagreement answer (success OR failure) is reused.
+ *
+ * Five minutes, matching `ROSTER_TTL_MS`. The two caches hold R-2-sensitive
+ * labels from the same round and a redaction must reach both on the same
+ * schedule; different windows would let one surface name somebody the other had
+ * already stopped naming.
+ */
+export const CITED_EVIDENCE_TTL_MS = 5 * 60 * 1000
+
+interface CacheEntry {
+  /** null = asked and could not answer. */
+  view: DisagreementView | null
+  storedAt: number
+}
+
+const cache = new Map<string, CacheEntry>()
+const inFlight = new Map<string, Promise<DisagreementView | null>>()
+const subscribers = new Set<() => void>()
+
+function notify(): void {
+  // A copy, because a subscriber may unsubscribe itself while being called.
+  for (const fn of [...subscribers]) fn()
+}
+
+export function subscribeToCitedEvidence(fn: () => void): () => void {
+  subscribers.add(fn)
+  return () => {
+    subscribers.delete(fn)
+  }
+}
+
+function fresh(entry: CacheEntry | undefined): entry is CacheEntry {
+  return entry !== undefined && Date.now() - entry.storedAt < CITED_EVIDENCE_TTL_MS
+}
+
+/**
+ * The synchronous read a render uses.
+ *
+ * `undefined` means "nothing known yet", which resolves to `view_unavailable` —
+ * a transient state whose honest rendering is no citation line, never an
+ * assertion that nothing was cited.
+ */
+export function peekDisagreement(roundId: string): DisagreementView | null | undefined {
+  const entry = cache.get(roundId)
+  return fresh(entry) ? entry.view : undefined
+}
+
+/**
+ * Ensure a round's disagreement view is being fetched, and return it when it
+ * lands.
+ *
+ * Never rejects: a failure is a cached `null`. A surface that cannot resolve a
+ * citation must keep rendering the value and its attribution, and a thrown
+ * promise inside a render is how a missing citation becomes a blank panel.
+ */
+export function ensureDisagreement(roundId: string): Promise<DisagreementView | null> {
+  if (roundId === '') return Promise.resolve(null)
+
+  const entry = cache.get(roundId)
+  if (fresh(entry)) return Promise.resolve(entry.view)
+
+  const existing = inFlight.get(roundId)
+  if (existing !== undefined) return existing
+
+  const request = (async (): Promise<DisagreementView | null> => {
+    try {
+      const accessToken = await requireOwnerAccessToken()
+      const view = await fetchOwnerDisagreement(accessToken, roundId)
+      cache.set(roundId, { view, storedAt: Date.now() })
+      return view
+    } catch {
+      // Signed out, a round the caller does not own, a round still open (CEE
+      // refuses `collab_round_open` and it is RIGHT to), a network failure. All
+      // are "cannot show the citation" at the surface, and none is worth
+      // distinguishing there.
+      cache.set(roundId, { view: null, storedAt: Date.now() })
+      return null
+    } finally {
+      inFlight.delete(roundId)
+      notify()
+    }
+  })()
+
+  inFlight.set(roundId, request)
+  return request
+}
+
+/**
+ * The React half of render-time citation resolution.
+ *
+ * Never suspends and never throws, for the same reason `useParticipantName`
+ * does not: the first paint of a cited factor happens before any view can have
+ * arrived, so the FIRST answer is always `view_unavailable` and the surface must
+ * already be truthful in that state. A citation appearing a moment later ADDS a
+ * line; it never replaces a placeholder, because there is no placeholder.
+ */
+export function useCitedEvidence(elicitedFrom: unknown): CitedEvidenceResolution {
+  const ref = readCitation(elicitedFrom)
+  const roundId = ref?.round_id ?? ''
+
+  // A revision counter, not the view itself: the cache owns the data, and
+  // duplicating it into component state is how two copies start disagreeing.
+  const [, bumpRevision] = useState(0)
+
+  useEffect(() => {
+    if (roundId === '') return
+    const unsubscribe = subscribeToCitedEvidence(() => bumpRevision((n) => n + 1))
+    void ensureDisagreement(roundId)
+    return unsubscribe
+  }, [roundId])
+
+  // Resolution happens during RENDER from the cache's current answer, so a view
+  // that was already warm renders the citation on the FIRST paint with no
+  // intermediate frame.
+  return resolveCitedEvidence(
+    elicitedFrom,
+    roundId === '' ? undefined : peekDisagreement(roundId),
+  )
+}
+
+/** Test seam. Never called by product code. */
+export function __resetCitedEvidenceCacheForTests(): void {
+  cache.clear()
+  inFlight.clear()
+  subscribers.clear()
+}

--- a/src/collab/participantNames.ts
+++ b/src/collab/participantNames.ts
@@ -67,6 +67,26 @@
 export interface RoundParticipantRef {
   round_id: string
   participant_id: string
+  /**
+   * 0.41.0 — WHICH piece of panel evidence the owner cited when they applied
+   * this value. Optional in the contract (`evidence_event_id: z.ZodOptional`
+   * inside a `.strict()` object), and the key is OMITTED rather than nulled when
+   * the owner cited nothing.
+   *
+   * ⚠ IT IS CARRIED HERE, NOT RESOLVED HERE. This module answers "whose number
+   * is this"; the citation is a different question with a different source (the
+   * owner disagreement view, not the roster) and lives in `citedEvidence.ts`.
+   * It rides on this reference because THIS is the one gate every mounted
+   * attribution surface passes through — the field was written by CEE from
+   * 0.41.0 onward and reached no surface for three days precisely because this
+   * function dropped it, so a second reader for the same wire object is how a
+   * future field goes dark the same way.
+   *
+   * ⚠ ABSENCE IS NOT AN ERROR AND NOT "CITATION LOST". Absent means the owner
+   * applied a value without citing evidence — the ordinary case, and the only
+   * case for every value written before 0.41.0.
+   */
+  evidence_event_id?: string
 }
 
 /**
@@ -104,10 +124,38 @@ export type ParticipantNameResolution =
  */
 export function readElicitedFrom(value: unknown): RoundParticipantRef | null {
   if (typeof value !== 'object' || value === null) return null
-  const ref = value as { round_id?: unknown; participant_id?: unknown }
+  const ref = value as {
+    round_id?: unknown
+    participant_id?: unknown
+    evidence_event_id?: unknown
+  }
   if (typeof ref.round_id !== 'string' || ref.round_id.trim() === '') return null
   if (typeof ref.participant_id !== 'string' || ref.participant_id.trim() === '') return null
-  return { round_id: ref.round_id, participant_id: ref.participant_id }
+
+  /**
+   * The citation is admitted on its OWN validity, and its absence or malformity
+   * NEVER costs the attribution.
+   *
+   * ⚠ THE ORDER MATTERS AND IS THE POINT. A reference is usable as attribution
+   * the moment its two required members are strings; a junk `evidence_event_id`
+   * is a citation problem, not an attribution problem, and returning `null` for
+   * the whole reference would take a NAME off the screen because a THIRD field
+   * was wrong. That inverts the absence semantics the contract states.
+   *
+   * The key is omitted rather than set to `undefined`, so `'evidence_event_id'
+   * in ref` is false for an uncited apply — the same presence test the write
+   * path already uses (`panelApplyHandoff.ts:169`, `buildPayload.ts:715`).
+   */
+  const citation =
+    typeof ref.evidence_event_id === 'string' && ref.evidence_event_id.trim() !== ''
+      ? ref.evidence_event_id
+      : undefined
+
+  return {
+    round_id: ref.round_id,
+    participant_id: ref.participant_id,
+    ...(citation !== undefined ? { evidence_event_id: citation } : {}),
+  }
 }
 
 /**


### PR DESCRIPTION
## The gap

CEE has stamped `observed_state.elicited_from.evidence_event_id` since **0.41.0** — when the owner applies a panellist's value while citing a colleague's note (`system-events/factor-value-edit.ts:362-384`). The contract carries it (`.strict()`, `evidence_event_id: z.ZodOptional<z.ZodString>` on the graph's `elicited_from`). The write path is wire-witnessed.

**It reached no user.** `participantNames.readElicitedFrom` returned a type with no such member, and **every mounted attribution surface goes through that one function** — so the product recorded *why* a value was adopted and showed nobody. Chronic failure #1, on the attribution family.

Verified at the bytes at `37f626b6`: **zero** occurrences of `evidence_event_id` in `participantNames.ts`.

## What this adds

| File | Job |
|---|---|
| `participantNames.ts` | The reader gate carries the citation. Its absence or malformity costs the **citation** and never the **attribution**. |
| `citedEvidence.ts` (new) | Pure resolution against the owner disagreement view — the only projection carrying evidence rows. Shape-guarded; http/https allowlist on `url`. |
| `citedEvidenceCache.ts` (new) | Same three-state / TTL / dedup discipline as `roundRosterCache`. Fetched **only when a citation exists**. |
| `CitedEvidenceNote.tsx` (new) | The rendered line, on all three mounted factor panels. |

### Why the search spans every `per_target` row
**Robustness to grouping — not the verifier's scope.** CEE's binding (f) at `apply-verification.ts:282-287` requires `evidence_attached` AND the same round AND `cited.target.kind === 'factor' && cited.target.id === target_id`, refusing with *"That evidence is not on this round for this factor."* **A citation is always on the same factor.** The wide search stays because the directions are asymmetric: a search wider than the producer can never report a **false absence**, while one narrower than the view's grouping can — so the resolver must not encode an assumption about which row CEE files evidence under. The cross-target fixture is labelled as grouping-robustness and encodes a **producer-impossible** wire state.

What **is** genuinely unscoped is the **author** — CEE says so in that same region: applying Grace's number *because Ada challenged it* "is the most valuable case this whole feature has". **No author-equality check.**

### Why this fetch does not contradict `fetchRoundRoster`'s data-minimisation header
That header rejected `/reveal` for resolving a **name**; the roster keeps using `/preview`. Here the evidence content **is** what is rendered, so the projection carrying evidence is proportionate. It discloses nothing new: the caller is the round's **owner**, who already reads this view in full on `/scenario/:id/panel`.

## The sentence mirrors CEE's own composition

CEE's `STANCE_PHRASE` is a **bare verb** — `supports` / `challenges` / `qualifies` (`disagreement-copy.ts:126-130`) — and CEE supplies an object at its render site (`disagreement-read-model.ts:365-366`):

```
const about = e.about_label !== null ? `${e.about_label}'s position` : 'this factor'
`- Evidence from ${e.author_label}, ${e.stance_phrase} ${about}: "${e.body}"`
```

So this renders **"Ada challenges Grace's position"**. ⚠ That `about` composition now exists in two services — a **cross-service mirror hazard**, accepted knowingly and marked in the code; the durable fix is CEE serving a sentence-form phrase.

It reports a **stance**, never a **consequence**. CEE verifies existence, round and factor, and reads neither `stance` nor `about_participant_id`, so *"…as the reason for this change"* is a causality nothing established. The banned causal and endorsement registers are asserted over the **rendered DOM**, and the broken bare-verb form is asserted absent **by name**.

⚠ **`STANCE_PHRASE` is NOT covered by CEE's copy guard.** `everyString()` derives from `STANDING_SENTENCES` plus headlines and questions only. A CEE-shipped causal phrase would pass this bundle's assertion unseen. Deferring to CEE is still right — two authorities on one user-facing word is worse — but it is **deference, not a proof**, and is not cited here as a backstop.

## Review blockers fixed (B1–B3)

**B1 — an execution-proven crash that defeated this PR's own central claim.** `fetchOwnerDisagreement` returns `(await res.json()) as DisagreementView` — a cast, never validated — and the resolver iterated `view.per_target` unguarded **during render**. A 200 with body `{}` (older CEE, schema skew, proxy error page) threw `TypeError: view.per_target is not iterable`, and because the hook runs in the factor panels the throw took the **whole inspector subtree — including the participant's name**. "Malformity costs the citation, never the attribution" was true of the reader gate and **false one seam past it**, with schema skew (hazard #1) as the trigger. Now two `Array.isArray` guards + null-safe row access → `view_unavailable`. **Flip proven by execution:** guard removed → `TypeError` at `citedEvidence.ts:208`; guard present → `view_unavailable`.

**B1 rider —** http/https allowlist on `url`, decided by the **URL parser** not a prefix test (`javascript:alert(1)#https://x` defeats `startsWith`). A dropped url costs the **link**, never the note's words.

**B2 —** my round-scope rationale was **false at CEE's bytes** and the PR contradicted itself. Code stays (safe direction); both comment blocks, the fixture label and this narrative corrected.

**B3 —** the sentence was **broken English on every real citation**: it rendered *"Ada attached this, challenges"*, and the fixture's `'challenging this'` is a string **CEE never emits** — the oracle came from the lane's head, not the producer (trap 13c), and a 9-mutant kit scored perfectly against it. Fixture now carries CEE's real vocabulary.

## Evidence

- **RED at pristine:** 11/19 fail with `participantNames.ts` at `HEAD`, in a worktree outside the repo root whose isolation was proven by a **write test** (sentinel did not reach the source; inodes differ).
- **Mutant kit — 13 RED + 1 GREEN discrimination control**, pristine-archive restores, applied-check scoped to `src/`, trailing control green and tree clean:

| Mutant | Expected | Got |
|---|---|---|
| M1 reader gate drops `evidence_event_id` (the historical defect) | RED | RED |
| M2 junk citation costs the attribution | RED | RED |
| **M3 FABRICATES a citation on an UNCITED apply** | RED | RED |
| M4 citation searched on one `per_target` row only | RED | RED |
| M5 renders a line when nothing was cited | RED | RED |
| M6 copy asserts the citation *caused* the change | RED | RED |
| M7 invents a local stance phrase when CEE sent none | RED | RED |
| M8 citation unmounted from one panel | RED | RED |
| **M10 B1 `per_target` guard removed** | RED | RED |
| **M11 B1 per-row `evidence` guard removed** | RED | RED |
| **M12 B1 rider: url allowlist weakened to substring** | RED | RED |
| **M13 B3 sentence reverted to bare-verb form** | RED | RED |
| **M14 B3 about-object fallback dropped** | RED | RED |
| M9 TTL 5min→7min (**control**) | GREEN | GREEN |

M6's original anchor went stale with the B3 rewrite and the kit reported **MUTATION DID NOT APPLY** rather than a false survivor — the applied-check working as intended. Re-targeted and RED.

- **Regression:** 66 files / **738 tests** green across `src/collab` + `src/canvas/ui/inspector-v2`, including the pre-existing D1 suites (`panelAttributionNaming` 14, `participantNames` 29).
- **Named gates:** `scripts/ci/typecheck-gate.sh` **PASSED** (none added; `--update-baseline` deliberately **not** taken — the 18-diagnostic shrink is unverified churn, per recorded precedent). eslint **0 problems** on the changed files. rules-of-hooks ratchet **exactly matching baseline**. **All 13 CI checks green** on `3a98130b`.

## Status ladder

**TESTED** (unit + mutants). Not deployed, not wire-witnessed, **not journey-witnessed** — the mount assertion is a source grep proving the component is not orphaned, and makes no claim a user saw it. The rung above needs a two-person browser witness on the deployed build.

## Scope

No CEE change, no schema change, no new orchestration path — the field and the endpoint both already exist. No workspace-membership / invite / tenancy work. Zero overlap with any open PR on `src/collab/**`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
