### PR TITLE
feat(conversation): the reply says which model elements it was grounded on (CEE hop 4b consumer, supersedes #705)

### DIFF
--- a/src/canvas/conversation/GroundedOnNotice.tsx
+++ b/src/canvas/conversation/GroundedOnNotice.tsx
@@ -43,6 +43,7 @@
 import { memo, useMemo } from 'react'
 import { typo } from '../../styles/typography'
 import { useCanvasStore } from '../store'
+import { resolveElementLabel } from './utils/resolveElementLabel'
 import type { GroundedSelection, GroundedUnresolved } from './groundedSelection'
 
 /** A grounded element this canvas can actually name, bound to its canonical id. */
@@ -51,53 +52,35 @@ export interface NamedGroundedElement {
   label: string
 }
 
-/** The minimal node/edge shape this join needs — narrower than the store's. */
-interface JoinableNode {
-  id: string
-  data?: { label?: unknown } | undefined
-}
-interface JoinableEdge {
-  id: string
-  source: string
-  target: string
-}
-
 /**
  * ID-FIRST, FAIL-CLOSED join from the producer's canonical ids to display
  * labels — the same direction and the same failure posture as CEE's own focus
  * join, which is id-first *precisely because* "labels collide".
  *
- * Label derivation mirrors `useSelectionContext` (the repo's existing authority
- * for naming a canvas element), including its `source → target` form for an
- * edge, so the transcript names an element exactly as the selection pill did
- * when the user picked it. It is NOT re-derived here in a second style.
+ * ⭐ NAMING IS DELEGATED, NOT RE-DERIVED. `resolveElementLabel` is this repo's
+ * existing, tested authority for "what is this canvas element called" (nodes
+ * first, then edges composed from their endpoints, `undefined` when it cannot
+ * say). An earlier draft of this function re-implemented that traversal, which
+ * would have made a SECOND authority on the name of an element — the trap-21
+ * shape this estate has already paid for. Only the id-binding and the
+ * fail-closed dropping below belong to this module.
  *
  * ⚠ AN ID THAT MATCHES NOTHING ON THIS CANVAS CONTRIBUTES NOTHING. That is the
  * fail-closed half: a graph can legitimately be out of step with a turn (an
- * element deleted since the answer, or a hydrated transcript against a
+ * element deleted since the answer, or a hydrated transcript read against a
  * different model), and inventing a name — or echoing a raw uuid at the user —
  * would be a fabrication. Order is preserved as received: it is
  * persisted-graph order and matches the order CEE gave the model.
  */
 export function resolveGroundedLabels(
   elementIds: readonly string[],
-  nodes: readonly JoinableNode[],
-  edges: readonly JoinableEdge[],
+  nodes: Parameters<typeof resolveElementLabel>[1],
+  edges: Parameters<typeof resolveElementLabel>[2],
 ): NamedGroundedElement[] {
   const named: NamedGroundedElement[] = []
   for (const id of elementIds) {
-    const node = nodes.find((n) => n.id === id)
-    if (node) {
-      const label = typeof node.data?.label === 'string' ? node.data.label.trim() : ''
-      if (label.length > 0) named.push({ id, label })
-      continue
-    }
-    const edge = edges.find((e) => e.id === id)
-    if (!edge) continue
-    const sourceLabel = nodes.find((n) => n.id === edge.source)?.data?.label
-    const targetLabel = nodes.find((n) => n.id === edge.target)?.data?.label
-    if (typeof sourceLabel !== 'string' || typeof targetLabel !== 'string') continue
-    const label = `${sourceLabel.trim()} → ${targetLabel.trim()}`
+    const label = resolveElementLabel(id, nodes, edges)?.trim()
+    if (label === undefined || label.length === 0) continue
     named.push({ id, label })
   }
   return named
@@ -133,12 +116,7 @@ export const GroundedOnNotice = memo(function GroundedOnNotice({
   const edges = useCanvasStore((s) => s.edges)
 
   const named = useMemo(
-    () =>
-      resolveGroundedLabels(
-        groundedSelection.element_ids,
-        nodes as unknown as readonly JoinableNode[],
-        edges as unknown as readonly JoinableEdge[],
-      ),
+    () => resolveGroundedLabels(groundedSelection.element_ids, nodes, edges),
     [groundedSelection.element_ids, nodes, edges],
   )
 

--- a/src/canvas/conversation/GroundedOnNotice.tsx
+++ b/src/canvas/conversation/GroundedOnNotice.tsx
@@ -1,0 +1,171 @@
+/**
+ * GroundedOnNotice — "this answer was produced using these elements of your
+ * model", rendered inside the assistant bubble the claim is about.
+ *
+ * THE CONSUMER HALF of CEE's `_grounded_selection` sidecar (hop 4b). The
+ * producer contract, its exact semantics and the fail-closed rules are
+ * documented once, at the wire binding: see `groundedSelection.ts`. Read that
+ * header before changing any copy here — two of the three states in this
+ * component exist to honour a producer ruling, not a design preference.
+ *
+ * ── WHY THIS SURFACE, AND NOT THE CANVAS ───────────────────────────────────
+ * A grounding is a fact about ONE TURN's answer ("which elements was THIS
+ * turn's answer grounded on?"). It therefore belongs with that turn's answer,
+ * and three things follow that a canvas-marking treatment cannot give:
+ *
+ *  1. HISTORY STAYS TRUE. The bubble is per-message, so scrolling back shows
+ *     each answer with its OWN grounding. A canvas mark is global and
+ *     single-slot: the latest turn's marks would sit beside every older answer
+ *     in the transcript, which is a mis-attribution the user cannot detect.
+ *  2. THE TWO UNRESOLVED STATES BECOME VISIBLE AT ALL. `not_in_model` and
+ *     `could_not_check` MUST NOT COLLAPSE (producer ruling). Under node
+ *     marking alone BOTH mark nothing, so the distinction is unrenderable and
+ *     needs a second surface anyway. Here all three states render in ONE place,
+ *     under one authority.
+ *  3. NO SECOND FOCUS AUTHORITY ON THE CANVAS (CLAUDE.md trap 21). The canvas's
+ *     `highlightedNodes` / `highlightedEdges` channel is already read by
+ *     focus-mode and applied-edit treatments; adding a third writer with
+ *     different semantics is how two questions end up under one name. This
+ *     component writes NO store state at all — it is a pure read.
+ *
+ * ── WHAT IT NEVER CLAIMS ───────────────────────────────────────────────────
+ * · Never that the answer's TEXT mentions the elements. The producer refuses to
+ *   make that claim (no code reads the model's output), so the copy is
+ *   "Answered using X" — about the answer's inputs, not its prose.
+ * · Never a COUNT of grounded elements. The id→label join below is fail-closed
+ *   and can legitimately name FEWER elements than the producer sent (an id for
+ *   a node not on this canvas cannot be named without fabricating a label).
+ *   Stating "2 elements" while naming one would be exactly that fabrication, so
+ *   no quantity is ever stated. Do not add one without revisiting the join.
+ * · Never anything at all on a turn that carried no sidecar. `null` in ⇒ this
+ *   component is not rendered (enforced at the call site in MessageBubble).
+ */
+import { memo, useMemo } from 'react'
+import { typo } from '../../styles/typography'
+import { useCanvasStore } from '../store'
+import type { GroundedSelection, GroundedUnresolved } from './groundedSelection'
+
+/** A grounded element this canvas can actually name, bound to its canonical id. */
+export interface NamedGroundedElement {
+  id: string
+  label: string
+}
+
+/** The minimal node/edge shape this join needs — narrower than the store's. */
+interface JoinableNode {
+  id: string
+  data?: { label?: unknown } | undefined
+}
+interface JoinableEdge {
+  id: string
+  source: string
+  target: string
+}
+
+/**
+ * ID-FIRST, FAIL-CLOSED join from the producer's canonical ids to display
+ * labels — the same direction and the same failure posture as CEE's own focus
+ * join, which is id-first *precisely because* "labels collide".
+ *
+ * Label derivation mirrors `useSelectionContext` (the repo's existing authority
+ * for naming a canvas element), including its `source → target` form for an
+ * edge, so the transcript names an element exactly as the selection pill did
+ * when the user picked it. It is NOT re-derived here in a second style.
+ *
+ * ⚠ AN ID THAT MATCHES NOTHING ON THIS CANVAS CONTRIBUTES NOTHING. That is the
+ * fail-closed half: a graph can legitimately be out of step with a turn (an
+ * element deleted since the answer, or a hydrated transcript against a
+ * different model), and inventing a name — or echoing a raw uuid at the user —
+ * would be a fabrication. Order is preserved as received: it is
+ * persisted-graph order and matches the order CEE gave the model.
+ */
+export function resolveGroundedLabels(
+  elementIds: readonly string[],
+  nodes: readonly JoinableNode[],
+  edges: readonly JoinableEdge[],
+): NamedGroundedElement[] {
+  const named: NamedGroundedElement[] = []
+  for (const id of elementIds) {
+    const node = nodes.find((n) => n.id === id)
+    if (node) {
+      const label = typeof node.data?.label === 'string' ? node.data.label.trim() : ''
+      if (label.length > 0) named.push({ id, label })
+      continue
+    }
+    const edge = edges.find((e) => e.id === id)
+    if (!edge) continue
+    const sourceLabel = nodes.find((n) => n.id === edge.source)?.data?.label
+    const targetLabel = nodes.find((n) => n.id === edge.target)?.data?.label
+    if (typeof sourceLabel !== 'string' || typeof targetLabel !== 'string') continue
+    const label = `${sourceLabel.trim()} → ${targetLabel.trim()}`
+    named.push({ id, label })
+  }
+  return named
+}
+
+/**
+ * The disclosure sentence per unresolved state — and the whole reason this is a
+ * lookup rather than a conditional is that the two non-`none` members must
+ * NEVER share copy.
+ *
+ *  · `not_in_model`    — the graph WAS read and does not contain what the turn
+ *                        pointed at. Asserting absence is honest here.
+ *  · `could_not_check` — the graph could NOT be read. This says only that, and
+ *                        claims NOTHING about whether the element exists.
+ *                        Rendering "not found" here is the exact conflation the
+ *                        producer's contract exists to prevent.
+ *  · `none`            — nothing is missing, so there is nothing to disclose.
+ */
+const DISCLOSURE: Readonly<Record<GroundedUnresolved, string | null>> = {
+  none: null,
+  not_in_model: "Something you asked about isn't in this model.",
+  could_not_check: "I couldn't read your model to check what you asked about.",
+}
+
+export const GroundedOnNotice = memo(function GroundedOnNotice({
+  groundedSelection,
+}: {
+  groundedSelection: GroundedSelection
+}) {
+  // Single-field selectors: a bare object selector here would be the React #185
+  // landmine `ci:guard:zustand` exists to catch.
+  const nodes = useCanvasStore((s) => s.nodes)
+  const edges = useCanvasStore((s) => s.edges)
+
+  const named = useMemo(
+    () =>
+      resolveGroundedLabels(
+        groundedSelection.element_ids,
+        nodes as unknown as readonly JoinableNode[],
+        edges as unknown as readonly JoinableEdge[],
+      ),
+    [groundedSelection.element_ids, nodes, edges],
+  )
+
+  const disclosure = DISCLOSURE[groundedSelection.unresolved]
+
+  // Nothing nameable and nothing to disclose ⇒ render nothing. Silence is the
+  // honest output, not an empty container.
+  if (named.length === 0 && disclosure === null) return null
+
+  return (
+    <div
+      className={typo('panelMeta', 'mt-1.5 flex flex-col gap-0.5 text-text-muted')}
+      data-testid="grounded-on-notice"
+      data-unresolved={groundedSelection.unresolved}
+    >
+      {named.length > 0 && (
+        <p data-testid="grounded-on-elements">
+          <span>Answered using </span>
+          {named.map((element, index) => (
+            <span key={element.id} data-testid="grounded-on-element" data-element-id={element.id}>
+              {index > 0 ? ', ' : ''}
+              <span className="text-text-body">{element.label}</span>
+            </span>
+          ))}
+        </p>
+      )}
+      {disclosure !== null && <p data-testid="grounded-on-unresolved">{disclosure}</p>}
+    </div>
+  )
+})

--- a/src/canvas/conversation/MessageBubble.tsx
+++ b/src/canvas/conversation/MessageBubble.tsx
@@ -20,6 +20,7 @@ import { memo, useState, useMemo, useRef } from 'react'
 import { typography } from '../../styles/typography'
 import { safeRichText } from '../utils/safeRichText'
 import { AnswerBody, resolveAnswerBodyText } from './AnswerBody'
+import { GroundedOnNotice } from './GroundedOnNotice'
 import { InlineBlocks } from './InlineBlocks'
 import { AlertCircle, ChevronDown, ChevronUp, ListPlus, AlignLeft, RefreshCw } from 'lucide-react'
 import { FeedbackRow } from './FeedbackRow'
@@ -478,6 +479,17 @@ export const MessageBubble = memo(function MessageBubble({
             </div>
           )}
         </>
+      )}
+      {/* CEE hop 4b — which model elements this answer was grounded on.
+        * NO FLAG (the producer emits unconditionally on the success path), and
+        * the condition is the SIDECAR'S OWN PRESENCE: an ungrounded turn
+        * carries no key, so `message.groundedSelection` is undefined and
+        * nothing renders. Rendering this on a turn without the sidecar would
+        * fabricate a grounding — pinned by the wire spec. Assistant-only: a
+        * grounding is a fact about an ANSWER, and the user's own bubble is not
+        * one. */}
+      {!isUser && message.groundedSelection && (
+        <GroundedOnNotice groundedSelection={message.groundedSelection} />
       )}
       {message.insights && message.insights.length > 0 && isDeterministicCeeEnabled() && (
         <InsightsStrip insights={message.insights} onSendMessage={onArtefactMessage} />

--- a/src/canvas/conversation/__tests__/GroundedOnNotice.spec.tsx
+++ b/src/canvas/conversation/__tests__/GroundedOnNotice.spec.tsx
@@ -281,11 +281,14 @@ describe('GroundedOnNotice — the empty-and-honest producer states', () => {
 })
 
 describe('resolveGroundedLabels — the id-first, fail-closed join', () => {
+  // Naming is DELEGATED to `resolveElementLabel`, the repo's existing authority
+  // (see the component docstring). These cases pin the id-binding and the
+  // fail-closed dropping, which is the part this module owns.
   const nodes = [
     { id: SALARY_ID, data: { label: SALARY_LABEL } },
     { id: MARGIN_ID, data: { label: MARGIN_LABEL } },
-  ]
-  const edges = [{ id: EDGE_ID, source: SALARY_ID, target: MARGIN_ID }]
+  ] as never
+  const edges = [{ id: EDGE_ID, source: SALARY_ID, target: MARGIN_ID }] as never
 
   it('joins a node id to its label, keyed on id', () => {
     expect(resolveGroundedLabels([SALARY_ID], nodes, edges)).toEqual([
@@ -293,10 +296,17 @@ describe('resolveGroundedLabels — the id-first, fail-closed join', () => {
     ])
   })
 
-  it('names an edge as source → target, matching useSelectionContext', () => {
-    expect(resolveGroundedLabels([EDGE_ID], nodes, edges)).toEqual([
-      { id: EDGE_ID, label: `${SALARY_LABEL} → ${MARGIN_LABEL}` },
-    ])
+  it('names an edge from its endpoints, via the delegated label authority', () => {
+    // The composed form is `resolveElementLabel`'s, NOT a second convention
+    // invented here. ⚠ Note it uses an ASCII arrow while `useSelectionContext`
+    // (the SelectionPill the user clicked) uses `→` — a PRE-EXISTING divergence
+    // in the estate, reported rather than silently taken a side on. Pinned here
+    // so the notice cannot drift from whichever authority owns the name.
+    const named = resolveGroundedLabels([EDGE_ID], nodes, edges)
+    expect(named).toHaveLength(1)
+    expect(named[0].id).toBe(EDGE_ID)
+    expect(named[0].label).toContain(SALARY_LABEL)
+    expect(named[0].label).toContain(MARGIN_LABEL)
   })
 
   it('drops an unknown id rather than fabricating a label', () => {
@@ -304,10 +314,10 @@ describe('resolveGroundedLabels — the id-first, fail-closed join', () => {
   })
 
   it('drops a node with no usable label rather than echoing its id at the user', () => {
-    expect(resolveGroundedLabels(['n-blank'], [{ id: 'n-blank', data: { label: '  ' } }], [])).toEqual(
-      [],
-    )
-    expect(resolveGroundedLabels(['n-none'], [{ id: 'n-none' }], [])).toEqual([])
+    expect(
+      resolveGroundedLabels(['n-blank'], [{ id: 'n-blank', data: { label: '  ' } }] as never, []),
+    ).toEqual([])
+    expect(resolveGroundedLabels(['n-none'], [{ id: 'n-none' }] as never, [])).toEqual([])
   })
 
   it('preserves input order and does not sort', () => {

--- a/src/canvas/conversation/__tests__/GroundedOnNotice.spec.tsx
+++ b/src/canvas/conversation/__tests__/GroundedOnNotice.spec.tsx
@@ -1,0 +1,319 @@
+/**
+ * GroundedOnNotice — the rendered consumer of CEE's `_grounded_selection`.
+ *
+ * THREE PROPERTIES CARRY THIS SLICE, and each is pinned in a way that fails for
+ * the right reason:
+ *
+ *  1. FABRICATION IS IMPOSSIBLE. A reply with no sidecar makes NO grounding
+ *     claim. Pinned through the REAL `MessageBubble` (not the notice in
+ *     isolation), because the mount condition is where a fabrication would be
+ *     introduced.
+ *  2. IDENTITY BINDING, proven by a DISCRIMINATING PAIR (CLAUDE.md trap 19).
+ *     The notice names the element the ANSWER WAS GROUNDED ON — asserted via
+ *     `data-element-id`, the canonical id, never via label text another element
+ *     could carry. A single biting mutant proves sensitivity to *something*;
+ *     only the RED/GREEN pair proves sensitivity to the NAMED object.
+ *  3. `not_in_model` AND `could_not_check` DO NOT COLLAPSE — the producer's
+ *     explicit ruling (grounded-selection.ts:71-79). Pinned as a DIFFERENCE
+ *     between the two rendered sentences AND as a ban on absence language in
+ *     the `could_not_check` copy, so a future copy edit that quietly makes them
+ *     synonymous REDs.
+ *
+ * MOUNT (trap 3b — this estate has shipped the same badge dark twice by testing
+ * a component the deployed flags do not mount): every assertion below drives
+ * `MessageBubble`, the post-#736 render authority for an assistant turn, and
+ * NOTHING here sets a flag — because the producer emits unconditionally and
+ * this consumer is deliberately unflagged. A test that rendered
+ * `GroundedOnNotice` directly would pass identically if the mount were deleted.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MessageBubble } from '../MessageBubble'
+import { useCanvasStore } from '../../store'
+import { resolveGroundedLabels } from '../GroundedOnNotice'
+import type { ConversationMessage } from '../types'
+import type { GroundedSelection } from '../groundedSelection'
+
+const noop = async () => {}
+
+/** Canonical ids — non-guessable tokens, so any match is an identity match. */
+const SALARY_ID = 'node-engineer-salary-7c1f'
+const CONTRACTOR_ID = 'node-hire-contractor-93ab'
+const ABSENT_ID = 'node-deleted-since-0000'
+const EDGE_ID = 'edge-salary-to-margin-5d2e'
+const MARGIN_ID = 'node-gross-margin-4f88'
+
+const SALARY_LABEL = 'Engineer salary'
+const CONTRACTOR_LABEL = 'Hire a contractor'
+const MARGIN_LABEL = 'Gross margin'
+
+/** Seed the canvas the label join reads. Two nodes so "a different element" exists. */
+function seedCanvas() {
+  useCanvasStore.setState({
+    nodes: [
+      { id: SALARY_ID, position: { x: 0, y: 0 }, data: { label: SALARY_LABEL } },
+      { id: CONTRACTOR_ID, position: { x: 0, y: 0 }, data: { label: CONTRACTOR_LABEL } },
+      { id: MARGIN_ID, position: { x: 0, y: 0 }, data: { label: MARGIN_LABEL } },
+    ] as never,
+    edges: [{ id: EDGE_ID, source: SALARY_ID, target: MARGIN_ID }] as never,
+  })
+}
+
+function makeMsg(overrides: Partial<ConversationMessage> = {}): ConversationMessage {
+  return {
+    id: 'msg-1',
+    role: 'assistant',
+    content: 'Engineer salary is the biggest cost driver in this model.',
+    timestamp: new Date(),
+    ...overrides,
+  }
+}
+
+const groundedOnSalary: GroundedSelection = {
+  element_ids: [SALARY_ID],
+  unresolved: 'none',
+}
+
+beforeEach(() => {
+  seedCanvas()
+})
+
+describe('GroundedOnNotice — ⭐ fabrication guard (no sidecar ⇒ no claim)', () => {
+  it('a reply with NO groundedSelection renders NO grounding notice at all', () => {
+    render(<MessageBubble message={makeMsg()} onChipClick={noop} />)
+    expect(screen.queryByTestId('grounded-on-notice')).toBeNull()
+    expect(screen.queryByTestId('grounded-on-elements')).toBeNull()
+    expect(screen.queryByTestId('grounded-on-unresolved')).toBeNull()
+  })
+
+  it('the ungrounded reply names NO canvas element anywhere in the bubble', () => {
+    // The strong form: not merely "the testid is absent", but that the element's
+    // label never reaches the DOM. A notice rendered under a different testid
+    // would still be a fabrication and must still fail.
+    render(<MessageBubble message={makeMsg()} onChipClick={noop} />)
+    expect(screen.queryByText(SALARY_LABEL)).toBeNull()
+  })
+
+  it('a USER message never carries a grounding notice, even with a sidecar attached', () => {
+    // A grounding is a fact about an ANSWER. The user's own bubble is not one.
+    render(
+      <MessageBubble
+        message={makeMsg({ role: 'user', groundedSelection: groundedOnSalary })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.queryByTestId('grounded-on-notice')).toBeNull()
+  })
+})
+
+describe('GroundedOnNotice — ⭐ identity binding (the DISCRIMINATING PAIR, trap 19)', () => {
+  it('names the element the answer WAS grounded on, by canonical id', () => {
+    render(
+      <MessageBubble
+        message={makeMsg({ groundedSelection: groundedOnSalary })}
+        onChipClick={noop}
+      />,
+    )
+    const named = screen.getAllByTestId('grounded-on-element')
+    expect(named).toHaveLength(1)
+    expect(named[0].getAttribute('data-element-id')).toBe(SALARY_ID)
+    expect(named[0].textContent).toContain(SALARY_LABEL)
+  })
+
+  it('does NOT name a DIFFERENT element that exists on the same canvas', () => {
+    // The other half of the pair. A fixed-id implementation, or one that named
+    // every node, passes the test above and FAILS here.
+    render(
+      <MessageBubble
+        message={makeMsg({ groundedSelection: groundedOnSalary })}
+        onChipClick={noop}
+      />,
+    )
+    const ids = screen
+      .getAllByTestId('grounded-on-element')
+      .map((el) => el.getAttribute('data-element-id'))
+    expect(ids).not.toContain(CONTRACTOR_ID)
+    expect(screen.queryByText(CONTRACTOR_LABEL)).toBeNull()
+  })
+
+  it('a DIFFERENT grounded id names the OTHER element — the notice tracks the payload', () => {
+    render(
+      <MessageBubble
+        message={makeMsg({
+          groundedSelection: { element_ids: [CONTRACTOR_ID], unresolved: 'none' },
+        })}
+        onChipClick={noop}
+      />,
+    )
+    const named = screen.getAllByTestId('grounded-on-element')
+    expect(named).toHaveLength(1)
+    expect(named[0].getAttribute('data-element-id')).toBe(CONTRACTOR_ID)
+    // ⭐ The discrimination: the two payloads must not render the same thing.
+    expect(named[0].getAttribute('data-element-id')).not.toBe(SALARY_ID)
+  })
+
+  it('names MULTIPLE grounded elements in the order received (persisted-graph order)', () => {
+    render(
+      <MessageBubble
+        message={makeMsg({
+          groundedSelection: { element_ids: [CONTRACTOR_ID, SALARY_ID], unresolved: 'none' },
+        })}
+        onChipClick={noop}
+      />,
+    )
+    expect(
+      screen.getAllByTestId('grounded-on-element').map((el) => el.getAttribute('data-element-id')),
+    ).toEqual([CONTRACTOR_ID, SALARY_ID])
+  })
+})
+
+describe('GroundedOnNotice — ⭐⭐ not_in_model and could_not_check MUST NOT COLLAPSE', () => {
+  function renderWith(unresolved: GroundedSelection['unresolved'], element_ids: string[] = []) {
+    const { unmount } = render(
+      <MessageBubble
+        message={makeMsg({ groundedSelection: { element_ids, unresolved } })}
+        onChipClick={noop}
+      />,
+    )
+    const text = screen.getByTestId('grounded-on-unresolved').textContent ?? ''
+    unmount()
+    return text
+  }
+
+  it('renders DIFFERENT sentences for the two states', () => {
+    const notInModel = renderWith('not_in_model')
+    const couldNotCheck = renderWith('could_not_check')
+    expect(notInModel.length).toBeGreaterThan(0)
+    expect(couldNotCheck.length).toBeGreaterThan(0)
+    expect(notInModel).not.toBe(couldNotCheck)
+  })
+
+  it('`not_in_model` asserts the absence — the graph WAS read', () => {
+    expect(renderWith('not_in_model').toLowerCase()).toContain("isn't in this model")
+  })
+
+  it('⭐ `could_not_check` claims NOTHING about presence — it says only that it could not look', () => {
+    // The producer's words: "a consumer that renders that as 'not found'
+    // reintroduces the conflation hop 3 and hop 4 spent their whole design
+    // keeping apart". This is the ban, not just a difference check: any copy
+    // edit that reintroduces absence language here REDs.
+    const text = renderWith('could_not_check').toLowerCase()
+    expect(text).toContain("couldn't read your model")
+    for (const banned of ["isn't in", 'not in this model', 'not found', 'does not exist']) {
+      expect(text, `could_not_check must not claim absence (found "${banned}")`).not.toContain(
+        banned,
+      )
+    }
+  })
+
+  it('surfaces the state machine-readably, undegraded, for each member', () => {
+    for (const member of ['none', 'not_in_model', 'could_not_check'] as const) {
+      const { unmount } = render(
+        <MessageBubble
+          message={makeMsg({ groundedSelection: { element_ids: [SALARY_ID], unresolved: member } })}
+          onChipClick={noop}
+        />,
+      )
+      expect(screen.getByTestId('grounded-on-notice').getAttribute('data-unresolved')).toBe(member)
+      unmount()
+    }
+  })
+
+  it('`none` discloses nothing — there is nothing missing to report', () => {
+    render(
+      <MessageBubble
+        message={makeMsg({ groundedSelection: groundedOnSalary })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.queryByTestId('grounded-on-unresolved')).toBeNull()
+  })
+})
+
+describe('GroundedOnNotice — the empty-and-honest producer states', () => {
+  it('empty ids + not_in_model → the disclosure alone, and NO grounding claim', () => {
+    render(
+      <MessageBubble
+        message={makeMsg({ groundedSelection: { element_ids: [], unresolved: 'not_in_model' } })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.getByTestId('grounded-on-unresolved')).toBeTruthy()
+    expect(screen.queryByTestId('grounded-on-elements')).toBeNull()
+  })
+
+  it('empty ids + none → nothing renders at all (silence is the honest output)', () => {
+    render(
+      <MessageBubble
+        message={makeMsg({ groundedSelection: { element_ids: [], unresolved: 'none' } })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.queryByTestId('grounded-on-notice')).toBeNull()
+  })
+
+  it('an id this canvas cannot name is DROPPED, never rendered as a raw id', () => {
+    render(
+      <MessageBubble
+        message={makeMsg({ groundedSelection: { element_ids: [ABSENT_ID], unresolved: 'none' } })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.queryByTestId('grounded-on-notice')).toBeNull()
+    expect(screen.queryByText(ABSENT_ID)).toBeNull()
+  })
+
+  it('a partial join names what it can and states NO count', () => {
+    render(
+      <MessageBubble
+        message={makeMsg({
+          groundedSelection: { element_ids: [SALARY_ID, ABSENT_ID], unresolved: 'none' },
+        })}
+        onChipClick={noop}
+      />,
+    )
+    const named = screen.getAllByTestId('grounded-on-element')
+    expect(named).toHaveLength(1)
+    expect(named[0].getAttribute('data-element-id')).toBe(SALARY_ID)
+    // No quantity claim anywhere in the notice — a count would be false here.
+    expect(screen.getByTestId('grounded-on-notice').textContent).not.toMatch(/\b2\b|\btwo\b/i)
+  })
+})
+
+describe('resolveGroundedLabels — the id-first, fail-closed join', () => {
+  const nodes = [
+    { id: SALARY_ID, data: { label: SALARY_LABEL } },
+    { id: MARGIN_ID, data: { label: MARGIN_LABEL } },
+  ]
+  const edges = [{ id: EDGE_ID, source: SALARY_ID, target: MARGIN_ID }]
+
+  it('joins a node id to its label, keyed on id', () => {
+    expect(resolveGroundedLabels([SALARY_ID], nodes, edges)).toEqual([
+      { id: SALARY_ID, label: SALARY_LABEL },
+    ])
+  })
+
+  it('names an edge as source → target, matching useSelectionContext', () => {
+    expect(resolveGroundedLabels([EDGE_ID], nodes, edges)).toEqual([
+      { id: EDGE_ID, label: `${SALARY_LABEL} → ${MARGIN_LABEL}` },
+    ])
+  })
+
+  it('drops an unknown id rather than fabricating a label', () => {
+    expect(resolveGroundedLabels([ABSENT_ID], nodes, edges)).toEqual([])
+  })
+
+  it('drops a node with no usable label rather than echoing its id at the user', () => {
+    expect(resolveGroundedLabels(['n-blank'], [{ id: 'n-blank', data: { label: '  ' } }], [])).toEqual(
+      [],
+    )
+    expect(resolveGroundedLabels(['n-none'], [{ id: 'n-none' }], [])).toEqual([])
+  })
+
+  it('preserves input order and does not sort', () => {
+    expect(resolveGroundedLabels([MARGIN_ID, SALARY_ID], nodes, edges).map((e) => e.id)).toEqual([
+      MARGIN_ID,
+      SALARY_ID,
+    ])
+  })
+})

--- a/src/canvas/conversation/__tests__/groundedSelection.wire.spec.ts
+++ b/src/canvas/conversation/__tests__/groundedSelection.wire.spec.ts
@@ -1,0 +1,192 @@
+/**
+ * `_grounded_selection` — THE WIRE BINDING (CEE hop 4b, consumer half).
+ *
+ * EVERY EXPECTATION HERE IS DERIVED FROM THE PRODUCER'S BYTES at CEE
+ * `bf4a1d28`, not from this repo's reading of what the field ought to mean
+ * (CLAUDE.md trap 13c — a mutant kit measures whether a test can DETECT a
+ * change, never whether the EXPECTATION is right, so an oracle taken from the
+ * consumer's own head scores perfectly on the wrong exam):
+ *
+ *   · `src/orchestrator-v5/context/grounded-selection.ts`
+ *       :50-81  the shape, and `element_ids` MAY be empty ("EMPTY is meaningful
+ *               and honest")
+ *       :71-79  `not_in_model` / `could_not_check` MUST NOT COLLAPSE
+ *       :86-89  ungrounded ⇒ the KEY IS ABSENT, never `null`
+ *       :104    `if (focus === undefined) return null`
+ *   · `src/orchestrator-v5/context/context-pack-assembler.ts`
+ *       :834    the CLOSED ENUM `'none' | 'not_in_model' | 'could_not_check'`
+ *   · `src/orchestrator/route-v2.ts`
+ *       :1543   `if (egress.ok && ctx.groundedSelection)` — unconditional on
+ *               the success path, no flag
+ *
+ * ⭐ THE CARRIER IS PROVEN BY EXECUTION, NOT BY INSPECTION. The question that
+ * kills a slice like this is *does the non-enumerable `__additive__` sidecar
+ * actually reach the reader?* — a spread anywhere on the way loses it. The first
+ * describe block therefore drives the REAL `parseV5Response` over a REAL
+ * `Response` carrying the sidecar exactly as CEE emits it, and reads it back
+ * through the production accessor. Nothing here hand-builds the sidecar and
+ * then asserts the accessor can read a hand-built sidecar, which would prove
+ * only that the test and the accessor agree.
+ */
+import { describe, it, expect } from 'vitest'
+import { parseV5Response } from '../../../v5/responseParser'
+import {
+  extractGroundedSelectionSidecar,
+  parseGroundedSelection,
+  type GroundedUnresolved,
+} from '../groundedSelection'
+
+/** Canonical canvas ids — distinct, non-guessable tokens so a match is identity. */
+const FACTOR_ID = 'node-engineer-salary-7c1f'
+const OPTION_ID = 'node-hire-contractor-93ab'
+
+/** The required declared surface, minimal valid values (see the parser specs). */
+const BASE_PAYLOAD = {
+  response_version: 2,
+  assistant_text: 'Engineer salary is the biggest cost driver here.',
+  blocks: [],
+  suggested_actions: [],
+  insights: [],
+  stage_indicator: 'frame',
+} as const
+
+function makeResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+describe('_grounded_selection — the carrier actually delivers (real parser, real Response)', () => {
+  it('survives parseV5Response and is readable through the production accessor', async () => {
+    const result = await parseV5Response(
+      makeResponse({
+        ...BASE_PAYLOAD,
+        _grounded_selection: { element_ids: [FACTOR_ID], unresolved: 'none' },
+      }),
+    )
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') return
+
+    // The declared surface is untouched — the sidecar is not smuggled into it.
+    expect((result.response as { assistant_text: string }).assistant_text).toBe(
+      BASE_PAYLOAD.assistant_text,
+    )
+
+    const grounded = extractGroundedSelectionSidecar(result.response)
+    expect(grounded, 'the sidecar did not survive the parse — the carrier is cut').not.toBeNull()
+    // IDENTITY, not a value predicate another element could satisfy (trap 19).
+    expect(grounded!.element_ids).toEqual([FACTOR_ID])
+    expect(grounded!.unresolved).toBe('none')
+  })
+
+  it('an undeclared root key is NOT promoted onto the strict surface', async () => {
+    const result = await parseV5Response(
+      makeResponse({
+        ...BASE_PAYLOAD,
+        _grounded_selection: { element_ids: [FACTOR_ID], unresolved: 'none' },
+      }),
+    )
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') return
+    // Enumerable surface stays clean: the key rides the non-enumerable sidecar.
+    expect(Object.keys(result.response)).not.toContain('_grounded_selection')
+  })
+
+  it('⭐ FABRICATION GUARD — a turn with NO sidecar yields null, so no claim can be made', async () => {
+    const result = await parseV5Response(makeResponse({ ...BASE_PAYLOAD }))
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') return
+    expect(extractGroundedSelectionSidecar(result.response)).toBeNull()
+  })
+
+  it('preserves PERSISTED-GRAPH ORDER as received — never re-sorted', async () => {
+    // Producer contract grounded-selection.ts:54-62. Reverse-alphabetical on
+    // purpose: an accidental sort would be visible.
+    const result = await parseV5Response(
+      makeResponse({
+        ...BASE_PAYLOAD,
+        _grounded_selection: { element_ids: [OPTION_ID, FACTOR_ID], unresolved: 'none' },
+      }),
+    )
+    expect(result.kind).toBe('response')
+    if (result.kind !== 'response') return
+    expect(extractGroundedSelectionSidecar(result.response)!.element_ids).toEqual([
+      OPTION_ID,
+      FACTOR_ID,
+    ])
+  })
+})
+
+describe('_grounded_selection — accessor read paths', () => {
+  it('reads the top-level key as a defensive fallback (un-demoted parser change)', () => {
+    const grounded = extractGroundedSelectionSidecar({
+      _grounded_selection: { element_ids: [OPTION_ID], unresolved: 'none' },
+    })
+    expect(grounded).toEqual({ element_ids: [OPTION_ID], unresolved: 'none' })
+  })
+
+  it('returns null for a non-object response rather than throwing', () => {
+    expect(extractGroundedSelectionSidecar(undefined)).toBeNull()
+    expect(extractGroundedSelectionSidecar(null)).toBeNull()
+    expect(extractGroundedSelectionSidecar('a string')).toBeNull()
+  })
+})
+
+describe('parseGroundedSelection — the CLOSED ENUM, and it stays closed', () => {
+  // Derived from context-pack-assembler.ts:834. Iterated rather than hand-cased
+  // so a member cannot be silently skipped.
+  const MEMBERS: readonly GroundedUnresolved[] = ['none', 'not_in_model', 'could_not_check']
+
+  it.each(MEMBERS)('accepts the producer member %s and preserves it verbatim', (member) => {
+    const parsed = parseGroundedSelection({ element_ids: [FACTOR_ID], unresolved: member })
+    expect(parsed).not.toBeNull()
+    expect(parsed!.unresolved).toBe(member)
+  })
+
+  it('⭐ the three members are DISTINCT values — nothing normalises them together', () => {
+    const parsed = MEMBERS.map((m) =>
+      parseGroundedSelection({ element_ids: [], unresolved: m })!.unresolved,
+    )
+    expect(new Set(parsed).size).toBe(MEMBERS.length)
+  })
+
+  it('fails closed on an unrecognised unresolved value (a 4th member needs an explicit edit)', () => {
+    expect(parseGroundedSelection({ element_ids: [FACTOR_ID], unresolved: 'not_sure' })).toBeNull()
+    expect(parseGroundedSelection({ element_ids: [FACTOR_ID] })).toBeNull()
+    expect(parseGroundedSelection({ element_ids: [FACTOR_ID], unresolved: 7 })).toBeNull()
+  })
+})
+
+describe('parseGroundedSelection — EMPTY element_ids is valid, not malformed', () => {
+  it('⭐ preserves an empty set with a reason — the producer emits exactly this', () => {
+    // Witnessed in the producer's own suite: grounded-selection-route-level.test.ts
+    // :295-296 asserts `element_ids: []` with `unresolved: 'not_in_model'`.
+    // Rejecting this shape would silently drop the producer's honest
+    // "nothing resolved, and here is why" turn.
+    const parsed = parseGroundedSelection({ element_ids: [], unresolved: 'not_in_model' })
+    expect(parsed).not.toBeNull()
+    expect(parsed!.element_ids).toEqual([])
+    expect(parsed!.unresolved).toBe('not_in_model')
+  })
+
+  it('fails closed when element_ids is absent or not an array', () => {
+    expect(parseGroundedSelection({ unresolved: 'none' })).toBeNull()
+    expect(parseGroundedSelection({ element_ids: FACTOR_ID, unresolved: 'none' })).toBeNull()
+    expect(parseGroundedSelection({ element_ids: null, unresolved: 'none' })).toBeNull()
+  })
+
+  it('drops non-string / blank ids without failing the payload, and never invents one', () => {
+    const parsed = parseGroundedSelection({
+      element_ids: [FACTOR_ID, '', '   ', 42, null, OPTION_ID],
+      unresolved: 'none',
+    })
+    expect(parsed!.element_ids).toEqual([FACTOR_ID, OPTION_ID])
+  })
+
+  it('rejects a non-object payload', () => {
+    expect(parseGroundedSelection(null)).toBeNull()
+    expect(parseGroundedSelection('x')).toBeNull()
+    expect(parseGroundedSelection(undefined)).toBeNull()
+  })
+})

--- a/src/canvas/conversation/groundedSelection.ts
+++ b/src/canvas/conversation/groundedSelection.ts
@@ -1,0 +1,168 @@
+/**
+ * Grounded-selection sidecar — WHICH model elements this turn's answer was
+ * grounded on (CEE hop 4b, ROADMAP 2.1250-family).
+ *
+ * This module is the SINGLE typed accessor for that sidecar:
+ *   - parseGroundedSelection():          defensive validation of the wire shape
+ *   - extractGroundedSelectionSidecar(): the wire binding, fail-closed
+ *
+ * ── WIRE CONTRACT (DERIVED AT THE PRODUCER'S BYTES, CEE `bf4a1d28`) ─────────
+ * Read from `src/orchestrator-v5/context/grounded-selection.ts` and
+ * `src/orchestrator/route-v2.ts` — never from this repo's reading of what the
+ * field "ought" to mean (CLAUDE.md trap 13c: a mutant kit validates
+ * sensitivity, never a wrong oracle).
+ *
+ * FIELD: a top-level `_grounded_selection` key on the CEE V5 response BODY
+ *   (leading underscore). NOT declared in `@talchain/schemas` at 0.40.0 —
+ *   `OlumiResponseSchema` is `.strict()`, so CEE strips the key before egress
+ *   validation and re-attaches it after (`route-v2.ts:1543`). Same mechanic and
+ *   the same class as `_reasoning` and `_answer_shape`.
+ *
+ * SHAPE (`GroundedSelection`, grounded-selection.ts:50-81): {
+ *   element_ids: readonly string[]   // canonical canvas ids
+ *   unresolved:  'none' | 'not_in_model' | 'could_not_check'
+ * }
+ *
+ * ⭐ WHAT THE FIELD CLAIMS, AND IT IS NARROWER THAN THE NAME SUGGESTS
+ * (grounded-selection.ts:4-12, quoted): it answers *"Which model elements was
+ * THIS turn's answer grounded on?"* — a producer-side fact about the answer's
+ * CONTEXT (the elements CEE placed in the routing prompt's `focus` section). It
+ * is **deliberately NOT a claim that the answer's TEXT mentions each one**; no
+ * code on either side reads the model's output. Our copy therefore says the
+ * answer was *answered using* these elements, and never that the answer
+ * *discusses*, *names* or *is about* them — that would be an over-claim the
+ * producer explicitly refuses to make.
+ *
+ * ⭐⭐ `not_in_model` AND `could_not_check` MUST NOT COLLAPSE. The producer is
+ * emphatic (grounded-selection.ts:71-79, context-pack-assembler.ts:830-833):
+ * `not_in_model` = the graph WAS read and does not contain it (showing nothing
+ * is honest). `could_not_check` = the graph could NOT be read, so we do not
+ * KNOW whether it is there. *"A consumer that renders that as 'not found'
+ * reintroduces the conflation hop 3 and hop 4 spent their whole design keeping
+ * apart."* This module keeps them as distinct values and
+ * `GroundedOnNotice` renders two different sentences; both are pinned.
+ *
+ * EMPTY `element_ids` IS MEANINGFUL AND HONEST, not a malformed payload
+ * (grounded-selection.ts:64-66): the turn pointed at something and nothing
+ * resolvable came back — `unresolved` says why. Witnessed in the producer's own
+ * suite (`grounded-selection-route-level.test.ts:295-296`: `element_ids: []`
+ * with `unresolved: 'not_in_model'`). So emptiness must NOT fail the parse; it
+ * must render the disclosure alone, with no grounding claim.
+ *
+ * ABSENCE IS THE UNGROUNDED SIGNAL. `projectGroundedSelection` returns `null`
+ * for an ungrounded turn and route-v2 attaches nothing, so the KEY IS ABSENT —
+ * never `_grounded_selection: null` (grounded-selection.ts:86-89). A turn with
+ * no selection is byte-identical to every pre-hop-4b turn. This module returns
+ * `null` for that case and the bubble renders exactly as today. **No grounding
+ * claim may ever be made on a turn that carried no sidecar** — that is the
+ * fabrication this consumer's guards exist to prevent.
+ *
+ * EMITTED UNCONDITIONALLY on the success path — `if (egress.ok &&
+ * ctx.groundedSelection)` (route-v2.ts:1543): no flag, no debug token, and so
+ * no UI flag here either (Paul's standing ruling: ship capabilities ON). The
+ * typed fallback envelope never carries it, because an egress-violation body is
+ * not an answer about the user's selected element.
+ *
+ * ORDER IS PERSISTED-GRAPH ORDER, not request order (grounded-selection.ts:54-62)
+ * — identical to the order the elements appear in the prompt's `focus` section.
+ * We render in the order received and never re-sort, so what the user reads
+ * matches what the model was given.
+ *
+ * WHERE IT SURFACES ON THE UI SIDE: `_grounded_selection` is not a declared
+ * top-level key, so `responseParser`'s `splitAdditiveExtensions` demotes it into
+ * the non-enumerable `__additive__` sidecar — exactly as it does `_reasoning`
+ * and `_answer_shape`. We read it there, and ALSO probe the SAME
+ * `_grounded_selection` key at the top level as a defensive fallback (guards a
+ * future parser change that leaves the underscore key un-demoted). That
+ * fallback does NOT catch a formal schema promotion: a real promotion drops the
+ * underscore (→ `grounded_selection`), which neither probe names.
+ */
+import { ADDITIVE_EXTENSIONS_KEY, type OlumiResponseWithExtensions } from '../../v5/responseParser'
+
+/**
+ * Why anything the turn pointed at is missing — the producer's CLOSED ENUM,
+ * copied verbatim from `ContextPackFocus['unresolved']`
+ * (context-pack-assembler.ts:834). Never widened here, and never collapsed.
+ */
+export type GroundedUnresolved = 'none' | 'not_in_model' | 'could_not_check'
+
+/** The three members, as data, so the parse and its guard cannot drift apart. */
+const UNRESOLVED_VALUES: ReadonlySet<string> = new Set<GroundedUnresolved>([
+  'none',
+  'not_in_model',
+  'could_not_check',
+])
+
+export interface GroundedSelection {
+  /**
+   * Canonical canvas ids of the elements the answer was grounded on, in
+   * persisted-graph order. MAY BE EMPTY — see the file header; emptiness is a
+   * meaningful state, not a malformed one.
+   */
+  element_ids: string[]
+  /** Why anything is missing. Read WITH `element_ids`, never without it. */
+  unresolved: GroundedUnresolved
+}
+
+/**
+ * Defensive validation of the producer's shape.
+ *
+ * FAIL-CLOSED, and the two fields fail closed for DIFFERENT reasons:
+ *
+ *   · `unresolved` must be one of the three known members. An unrecognised
+ *     value means the wire is not what this consumer was written against, and
+ *     the honest response is silence: we cannot interpret it, and rendering the
+ *     grounding half of an uninterpretable payload is precisely how the
+ *     `not_in_model`/`could_not_check` conflation would creep back in. A fourth
+ *     member arriving is a contract change that requires an explicit edit here.
+ *
+ *   · `element_ids` must be an ARRAY (absence or a non-array is malformed), but
+ *     an EMPTY array is valid and preserved. Non-string / blank entries are
+ *     dropped rather than failing the whole payload — safe ONLY because this
+ *     consumer never states a COUNT of grounded elements, so a shortened list
+ *     can never become a false quantity claim. Do not add a count without
+ *     revisiting this.
+ */
+export function parseGroundedSelection(raw: unknown): GroundedSelection | null {
+  if (!raw || typeof raw !== 'object') return null
+  const o = raw as Record<string, unknown>
+
+  const unresolved = o.unresolved
+  if (typeof unresolved !== 'string' || !UNRESOLVED_VALUES.has(unresolved)) return null
+
+  if (!Array.isArray(o.element_ids)) return null
+  const element_ids = o.element_ids
+    .filter((id): id is string => typeof id === 'string' && id.trim().length > 0)
+    .map((id) => id.trim())
+
+  return { element_ids, unresolved: unresolved as GroundedUnresolved }
+}
+
+/**
+ * The producer's field name. A leading underscore because it is a CEE-internal
+ * sidecar rather than a declared contract field.
+ */
+const GROUNDED_SELECTION_FIELD = '_grounded_selection' as const
+
+/**
+ * Wire binding. Reads the grounded-selection sidecar off a live CEE turn
+ * response. Mirrors `extractAnswerShapeSidecar`: the additive-extensions
+ * sidecar the parser demotes unknown keys into, then the same
+ * `_grounded_selection` key at the top level as a defensive fallback.
+ *
+ * Fail-closed through `parseGroundedSelection` — an absent or malformed payload
+ * yields `null`, and the caller then renders the bubble with NO grounding claim
+ * of any kind.
+ */
+export function extractGroundedSelectionSidecar(response: unknown): GroundedSelection | null {
+  if (!response || typeof response !== 'object') return null
+  const r = response as Record<string, unknown>
+  const additive = (response as OlumiResponseWithExtensions)?.[ADDITIVE_EXTENSIONS_KEY] as
+    | Record<string, unknown>
+    | undefined
+
+  return (
+    parseGroundedSelection(additive?.[GROUNDED_SELECTION_FIELD]) ??
+    parseGroundedSelection(r[GROUNDED_SELECTION_FIELD])
+  )
+}

--- a/src/canvas/conversation/types.ts
+++ b/src/canvas/conversation/types.ts
@@ -8,6 +8,7 @@
 import type { StageType } from '@talchain/schemas/boundary'
 import type { CEEAnalysisReady, CEEGoalConstraint, CEEInterventionV3 } from '../../adapters/cee/types'
 import type { AnswerShape } from './answerShape'
+import type { GroundedSelection } from './groundedSelection'
 
 // ---------------------------------------------------------------------------
 // § 1 — Conversation messages
@@ -75,6 +76,24 @@ export interface ConversationMessage {
    * history falls back to the full-text render (same treatment as `reasoning`).
    */
   answerShape?: AnswerShape
+  /**
+   * CEE hop 4b: WHICH model elements this turn's answer was grounded on —
+   * `_grounded_selection` on the V5 body, parsed + fail-closed by
+   * `extractGroundedSelectionSidecar` (groundedSelection.ts, which carries the
+   * full producer contract). When present the bubble renders a
+   * `GroundedOnNotice`; when ABSENT the bubble renders exactly as today and
+   * makes NO grounding claim — absence is the producer's ungrounded signal
+   * (the key is omitted, never sent as null), so a claim here would be a
+   * fabrication. No flag: CEE emits it unconditionally on the success path, so
+   * this auto-lights-up.
+   *
+   * Ephemeral: derived from the live turn and NOT persisted — hydrated history
+   * renders without a grounding notice, the same treatment as `reasoning` and
+   * `answerShape`. That is deliberate rather than a gap: the ids are canonical
+   * canvas ids, and a rehydrated thread can be read against a model those ids
+   * no longer name.
+   */
+  groundedSelection?: GroundedSelection
   /**
    * Transcript honesty (dress-rehearsal trust item #3, 2026-07-20): delivery
    * state of a visible user send on the LIVE V5 path.

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -62,6 +62,7 @@ import { START_NEW_DRAFT_CHIP_ID } from './chipDispatch'
 import { isOrchestratorV2Enabled, isOrchestratorStreamingEnabled, isThreadHydrateEnabled, isThreadPersistEnabled, isPreAnalysisEnrichedEnabled, isReasoningDisclosureEnabled } from '../../flags'
 import { ADDITIVE_EXTENSIONS_KEY, type OlumiResponseWithExtensions } from '../../v5/responseParser'
 import { extractAnswerShapeSidecar } from './answerShape'
+import { extractGroundedSelectionSidecar } from './groundedSelection'
 // Leg 3 blocker fix: the wire->camelCase coaching mapper lives in the CEE
 // client adapter (DraftChat/useRetryDraft path); the V5 inline-draft seam
 // reuses it so one mapper owns the coaching wire shape.
@@ -5109,6 +5110,23 @@ export function useConversation(): UseConversationReturn {
             // merged into `content` (attached as its own field, rendered by
             // AnswerBody). See answerShape.ts for the full contract note.
             const answerShape = extractAnswerShapeSidecar(target.response)
+            // CEE hop 4b — WHICH model elements this answer was grounded on.
+            // `_grounded_selection` rides the SAME `__additive__` demotion as
+            // `_reasoning` and `_answer_shape` (it is undeclared at the pinned
+            // schema, and CEE's egress schema is `.strict()`), so it is read
+            // through the typed accessor rather than off the OlumiResponse
+            // surface. Emitted UNCONDITIONALLY by the producer on the success
+            // path (route-v2.ts:1543 — no flag, no debug token), so there is no
+            // UI flag here either.
+            //
+            // ⚠ FAIL-CLOSED, AND THE ABSENT CASE IS LOAD-BEARING: an ungrounded
+            // turn carries NO key at all (the producer returns null and
+            // attaches nothing), extractGroundedSelectionSidecar returns null,
+            // and the conditional spread below attaches nothing — so the bubble
+            // makes no grounding claim. Attaching a default/empty value here
+            // would fabricate a grounding on every ungrounded turn, which is
+            // the precise defect the wire spec's guards pin.
+            const groundedSelection = extractGroundedSelectionSidecar(target.response)
             addMessage({
               id: crypto.randomUUID(),
               role: 'assistant',
@@ -5117,6 +5135,7 @@ export function useConversation(): UseConversationReturn {
               ...(actionChips.length > 0 ? { actionChips } : {}),
               ...(reasoning ? { reasoning } : {}),
               ...(answerShape ? { answerShape } : {}),
+              ...(groundedSelection ? { groundedSelection } : {}),
               timestamp: new Date(),
             })
 


### PR DESCRIPTION
**SUPERSEDES #705.** That PR's producer half (CEE #965) merged on 15 Aug, so `_grounded_selection` has
been LIVE on staging with **no UI consumer at all** — the estate's dominant defect class, measured:
`groundedSelection`/`GroundedFocusNotice` = **0 production files** at `37f626b6` (contrast control
`__additive__` = 19 files in the same sweep, so that zero is real absence, not a blind instrument).
#705 itself is 2+ days behind and predates #735/#736/#738/#741/#742/#743/#744. **Close #705 when this merges.**

## What a user now SEES

Select a node → ask about it → the reply arrives **and says which elements of the model it was answered
using**, named, directly under the answer it belongs to.

Ask with nothing selected and **nothing is added** — the bubble is byte-identical to today.

## The producer is the oracle, derived at CEE `bf4a1d28` (not from #705's reading of it)

| Fact | Producer bytes |
|---|---|
| Shape `{ element_ids, unresolved }` | `context/grounded-selection.ts:50-81` |
| `unresolved` CLOSED ENUM `none \| not_in_model \| could_not_check` | `context/context-pack-assembler.ts:834` |
| Ungrounded ⇒ **key ABSENT**, never `null` | `grounded-selection.ts:86-89`, `:104` |
| `element_ids` MAY be **empty and that is honest** | `grounded-selection.ts:64-66`; producer suite `grounded-selection-route-level.test.ts:295-296` |
| Emitted **unconditionally** on the success path, no flag | `orchestrator/route-v2.ts:1543` |
| Order = **persisted-graph order** | `grounded-selection.ts:54-62` |
| Rides `__additive__` on the UI side | `grounded-selection.ts:39-41` |

⭐ **The narrowest fact, and it shaped the copy:** the field answers *"which elements was this turn's
answer grounded on?"* — a fact about the answer's **CONTEXT**, and *"deliberately NOT a claim that the
answer's TEXT mentions each one"*. So the copy is **"Answered using X"** — never "this answer is about X",
which would over-claim exactly what the producer refuses to.

⭐⭐ **`not_in_model` and `could_not_check` MUST NOT COLLAPSE** (producer's own emphasis): *"a consumer that
renders that as 'not found' reintroduces the conflation hop 3 and hop 4 spent their whole design keeping
apart."* Two distinct sentences, and a **banned-phrase assertion** on the `could_not_check` copy so a
future copy edit that quietly makes them synonymous REDs.

## Mount decision: the REPLY, not the canvas (this is where I depart from #705)

#705 marked the node on the canvas. I mounted in `MessageBubble` — the post-#736 **one render authority**
for an assistant turn — for three reasons that are structural, not stylistic:

1. **History stays true.** The bubble is per-message; the canvas is one global slot. Under canvas marking,
   the *latest* turn's marks sit beside every older answer in the transcript — a mis-attribution the user
   cannot detect. #705's own design conceded the slice must clear marks on every turn for this reason.
2. **The two unresolved states become renderable at all.** Under node marking both mark *nothing*, so
   #705 had to add a separate notice component anyway. Here all three states live in **one** surface.
3. **No second focus authority** (trap 21). `highlightedNodes`/`highlightedEdges` is already read by
   focus-mode and applied-edit treatments; #705 added a third writer with different semantics. **This PR
   writes NO store state at all** — it is a pure read, so it cannot collide with either.

Trap 3b: the mount is **unflagged**, matching the producer's unconditional emit, and every render
assertion drives the real `MessageBubble` — a spec rendering the notice directly would pass identically
if the mount were deleted.

## The chain

| Hop | Where |
|---|---|
| Demoted to `__additive__` | `src/v5/responseParser.ts` (existing, unchanged) |
| Read + re-validated, fail-closed | `src/canvas/conversation/groundedSelection.ts` |
| ⚠ Consumer call site | `useConversation.ts` — beside `extractAnswerShapeSidecar`, same conditional-spread shape |
| Carried per-message | `types.ts` — `groundedSelection?: GroundedSelection` (ephemeral, like `reasoning`/`answerShape`) |
| Rendered | `GroundedOnNotice.tsx`, mounted in `MessageBubble.tsx` |

**The carrier is proven by EXECUTION, not inspection.** The question that kills a slice like this is *does
the non-enumerable `__additive__` sidecar actually reach the reader?* — a spread anywhere loses it. The
wire spec drives the **real `parseV5Response` over a real `Response`** carrying the sidecar as CEE emits
it, then reads it back through the production accessor. Nothing hand-builds a sidecar and then proves the
accessor can read a hand-built sidecar.

## Verification

**RED-first at pristine**, in a throwaway worktree **outside** the repo root. Two variants, because the
first is weak evidence and I am reporting it as such:
- full pristine → both specs fail at **COLLECT** (modules absent). Proves only that they test new code.
- ⭐ **modules present, WIRING ABSENT** (the actual defect state this lane fixes) → **10 RED / 26 GREEN**,
  named signatures: `Unable to find an element by: [data-testid="grounded-on-element"]` /
  `[data-testid="grounded-on-unresolved"]` / `[data-testid="grounded-on-notice"]`.
  ⚠ **Stated rather than counted:** the 26 that pass include the fabrication negatives, which are
  **vacuous without the wiring** — nothing renders at pristine either. That is precisely why the
  fabrication **mutants** below are the load-bearing evidence, not the pristine pass.

**Isolation proven by WRITING, not by locating** (trap 9g): sentinel written into the worktree left the
source clone's `git status` clean; inodes differ (`646620040` vs `646101188`). Restores are HEAD-relative
(trap 9h). Applied-check scoped to `src/`, **leading and trailing controls both read exactly 0 / 36 GREEN**.
Every case asserts **36 collected** — a shrunk collect is a hard error, never a pass (trap 2b).

**Nine mutants, all biting, DISTINCT red sets** (uniformity would be evidence about the probe, trap 20):

| Mutant | Effect | Result |
|---|---|---|
| m1 mount deleted | drop the `<GroundedOnNotice/>` mount | **10 RED** |
| ⭐ m2 wire fabrication | accessor fails **OPEN** with a default instead of `null` | **1 RED** — the wire fabrication guard |
| ⭐ m3 mount fabrication | ungrounded reply gets a grounding claim | **1 RED** — the render fabrication guard |
| m4 collapse | `could_not_check` speaks `not_in_model`'s sentence | **2 RED** incl. the absence-language ban |
| ⭐ m5a identity: FIXED id | name `nodes[0]` regardless of the payload | **4 RED** |
| m5b identity: name everything | iterate the canvas, not `element_ids` | **12 RED** |
| m6 closed enum fails open | accept an unrecognised `unresolved` | **1 RED** |
| m7 meaningful-empty rejected | fail the parse on `element_ids: []` | **2 RED** |
| m8 label fabrication | echo a raw id for an unnameable element | **4 RED** |

⭐ **m5a is the DISCRIMINATING PAIR, not a single biting mutant** (trap 19): under a fixed-id
implementation *"names the element the answer WAS grounded on"* stays **GREEN** while *"a DIFFERENT
grounded id names the OTHER element"* **REDs**. A single biting mutant proves sensitivity to *something*;
only the pair proves sensitivity to the **named object**.

⚠ **Both fabrication guards are pinned at BOTH layers** — the accessor (m2) and the mount (m3) — because
either alone could fabricate independently.

**Gates at my tip, in the required check's own STEP ORDER** (trap 22e — `Staging Gate`'s `tsc` job runs
**Lint → Type check → guards**, so lint runs first, not last):
- `pnpm run lint` — **PASS**, 0 errors (1189 pre-existing warnings); hooks ratchet 229/13 **exactly at baseline**
- `pnpm run typecheck` — **PASS**, 3445/3485 files loaded; **2307 errors vs baseline 2325, NONE ADDED**
- `pnpm run ci:guard:zustand` — **PASS** (the notice uses single-field selectors; a bare object selector is the React #185 landmine this guard catches)
- `pnpm run ci:guard:duplicates` — **PASS**
- `src/canvas/conversation` full directory — **173 files / 2335 passed / 0 failed**
- My two specs asserted to collect **by name**: 36 tests, non-zero. UI suites run with `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY`.

⚠ **I DECLINED the gate's `--update-baseline` invitation, and measured why rather than assuming.** The
gate reports "drift shrank 2325 → 2307, tighten it in this PR". I ran the same gate on **pristine
`37f626b6`** and it prints the **identical** `2307 / baseline 2325` and the same "18 fixed" notice — so the
shrink is entirely **pre-existing and not mine**, and banking it here would misattribute another lane's
work to this PR.

## Refutations and findings

1. ⚠ **I duplicated an existing authority and caught it, from a test-run listing rather than by
   inspection.** My first implementation hand-rolled the id→label traversal — and
   `conversation/utils/resolveElementLabel.ts` already does exactly that (nodes first, then edges from
   their endpoints, `undefined` when it cannot say). That would have been a **second authority on what an
   element is called** (trap 21). **Refactored to delegate**; only the id-binding and fail-closed dropping
   remain here. The refactor moved two mutant targets, and the harness's applied-check **hard-failed**
   rather than silently scoring unapplied mutations as equivalent — the whole battery was re-derived and
   re-run (results above are post-refactor).
2. ⚠ **Pre-existing divergence, reported not resolved** (scope-expansion rule): `resolveElementLabel`
   composes an edge label with an **ASCII** arrow while `useSelectionContext` — the SelectionPill the user
   actually clicked — uses `→`. So the notice can name an edge slightly differently from the pill that
   asked about it. I did **not** change `resolveElementLabel`: it populates `target_label` on `direct_edit`
   scenario events, and editing it would alter recorded event shapes. The edge test pins *the delegated
   authority's* form rather than a glyph, so it cannot drift silently.
3. **`#705`'s canvas anchors all still exist** at this tip (`store.ts` `highlightedNodes`, `BaseNode.tsx`
   ring treatment, `ReactFlowGraph.tsx`) — its design was not invalidated by the intervening merges. I
   departed from it on the three structural grounds above, not because it had rotted.
4. **Deliberately NOT persisted**, and this is a real limitation, not an oversight: the ids are canonical
   canvas ids, and a rehydrated thread can be read against a model those ids no longer name. Hydrated
   history therefore shows no grounding notice — same treatment as `reasoning`/`answerShape`. A persisted
   version needs a label snapshot, which is a separate decision.
5. **Not journey-witnessed.** This is CODE EXISTS → TESTED, plus a wire-level carrier proof through the
   real parser. It is **not** WIRE-WITNESSED against live CEE and **not** JOURNEY-WITNESSED; those need a
   deploy and a fresh-session run.

## ⚠ Open-PR overlap (checked at my tip, reporting rather than resolving)

`#731` and `#727` both touch **`MessageBubble.tsx` + `types.ts` + `useConversation.ts`** — the same three
files, because they are the same *kind* of change (a new per-message reader). My edits are purely additive
and in distinct regions (a new optional field, a new extraction const + one spread entry, one JSX block),
so conflicts should be adjacent-line rather than semantic. Per trap 24, if two of these collide the
resolution is to **keep both readers**, never to take one side wholesale. `#745` and `#714` do not overlap.

**Fences respected:** no changes to `useResultsSectionData.ts`, `ConditionalWinnerCards.tsx`,
`useAnalysisRunState`/selector files, `src/collab/**`, model-tab-v2, or versions files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
