### PR TITLE
fix(hero): retire the UI-invented stability cliff from isReadyToBrief (ROADMAP 2.1228)

### DIFF
--- a/src/components/results/analysis-hero/__tests__/hygiene.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/hygiene.spec.ts
@@ -47,7 +47,17 @@ const sources = productionSources(MODULE_DIR)
 
 describe('Analysis hero source hygiene', () => {
   it('scans a non-empty production source set (guard is alive)', () => {
-    expect(sources.map((s) => s.file)).toContain('buildHeroModel.ts')
+    // Names a file at BOTH depths on purpose. Every other `it` in this file
+    // asserts an ABSENCE over `sources`, so all of them go vacuous if the scan
+    // shrinks — and until 2.1228 the subdirectory half of that scan was held
+    // alive only incidentally, by the trust/stability pin happening to contain
+    // two `actOnIt/` entries. Emptying that pin retired the only control on the
+    // recursion: deleting the `isDirectory()` walk left this whole spec GREEN
+    // (measured), silently un-covering `actOnIt/` — the directory holding the
+    // module 2.1228 changed. Assert the depth explicitly instead.
+    expect(sources.map((s) => s.file)).toEqual(
+      expect.arrayContaining(['buildHeroModel.ts', 'rankActOnItRows.ts']),
+    )
   })
 
   it.each([

--- a/src/components/results/analysis-hero/__tests__/hygiene.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/hygiene.spec.ts
@@ -82,26 +82,30 @@ describe('Analysis hero source hygiene', () => {
    * grew, you introduced a fabrication path. Only shrink it alongside the
    * change that genuinely removes a read.
    *
-   * THE TWO ENTRIES ARE NOT THE SAME KIND OF DEBT — the guard's blanket
-   * rationale ("no producer display-safe label exists") is stale for one of
-   * them and exactly right for the other:
+   * THE ENTRIES ARE NOT THE SAME KIND OF DEBT — the guard's blanket rationale
+   * ("no producer display-safe label exists") is stale for one and was exactly
+   * right for the other:
    *
    *   · `robustnessVerdict` — a display-safe label DOES exist. `types.ts`
    *     documents it as sourced only from PLoT's `robustness.display_verdict`,
    *     fail-closed normalised. Reading it is the sanctioned path; the fix is
-   *     to consume the producer's label explicitly.
-   *   · `recommendationStability` — the ban is correct. It is a bare 0-1 float
-   *     with no display-safe label, and the `< 0.85` cliff in `isReadyToBrief`
-   *     is a UI-INVENTED threshold. The fix is producer-side, or a licensed
-   *     constant.
-   *
-   * Both are rowed separately. Neither is fixed in this train.
+   *     to consume the producer's label explicitly. STILL PINNED (ROADMAP
+   *     2.1227).
+   *   · `recommendationStability` — ✅ RESOLVED, ROADMAP 2.1228, and the pin
+   *     SHRANK BY EXACTLY THIS ONE ENTRY alongside the change that removed the
+   *     read. `isReadyToBrief` no longer consults it: the `>= 0.85` cliff was
+   *     UI-INVENTED, and the producer deliberately WITHHOLDS the field it
+   *     gated on (PLoT `src/routes/v2/run.ts:3266-3277` — it is the leader's
+   *     `win_probability` relabelled, so emitting it under a stability name was
+   *     "a fabricated second statistic"). The predicate now relies solely on
+   *     the producer's display-safe verdict. See
+   *     `../actOnIt/__tests__/rankActOnItRows.spec.ts` §6/§7 for the
+   *     bidirectional divergence pin that bounds the behavioural change.
    */
   const TRUST_STABILITY_RE =
     /robustnessLevel|robustnessLabel|robustnessVerdict|recommendationStability/g
 
   const KNOWN_TRUST_STABILITY_READS: readonly string[] = [
-    'rankActOnItRows.ts::recommendationStability',
     'rankActOnItRows.ts::robustnessVerdict',
   ]
 

--- a/src/components/results/analysis-hero/__tests__/hygiene.spec.ts
+++ b/src/components/results/analysis-hero/__tests__/hygiene.spec.ts
@@ -8,8 +8,11 @@
  *   - UI-created banding thresholds (a `>= 0.x ?` style ternary — the
  *     prototype's band()/trustWord() shape);
  *   - reads of the trust/stability fields the hero must not consume
- *     (the robustness trio and recommendationStability — no producer
- *     display-safe label exists, so any read would be a fabrication path);
+ *     (`robustnessLevel`, `robustnessLabel`, `recommendationStability` — no
+ *     producer display-safe label exists for these, so any read is a
+ *     fabrication path. ⚠ `robustnessVerdict` is deliberately NOT in that list
+ *     since ROADMAP 2.1227: it IS the producer's display-safe field and reading
+ *     it is the sanctioned path — see the block comment below);
  *   - imports from the focus-now module (its inertness guard forbids
  *     external importers — patterns were copied, not imported).
  */
@@ -82,32 +85,51 @@ describe('Analysis hero source hygiene', () => {
    * grew, you introduced a fabrication path. Only shrink it alongside the
    * change that genuinely removes a read.
    *
-   * THE ENTRIES ARE NOT THE SAME KIND OF DEBT — the guard's blanket rationale
-   * ("no producer display-safe label exists") is stale for one and was exactly
-   * right for the other:
+   * ⭐ THE SET IS NOW EMPTY, AND THE BAN IS FLAT AGAIN. The two entries were
+   * NOT the same kind of debt — the guard's blanket rationale ("no producer
+   * display-safe label exists") was stale for one and exactly right for the
+   * other. Both are now resolved, in opposite ways, and the difference is the
+   * whole lesson of this block:
    *
-   *   · `robustnessVerdict` — a display-safe label DOES exist. `types.ts`
-   *     documents it as sourced only from PLoT's `robustness.display_verdict`,
-   *     fail-closed normalised. Reading it is the sanctioned path; the fix is
-   *     to consume the producer's label explicitly. STILL PINNED (ROADMAP
-   *     2.1227).
-   *   · `recommendationStability` — ✅ RESOLVED, ROADMAP 2.1228, and the pin
-   *     SHRANK BY EXACTLY THIS ONE ENTRY alongside the change that removed the
-   *     read. `isReadyToBrief` no longer consults it: the `>= 0.85` cliff was
-   *     UI-INVENTED, and the producer deliberately WITHHOLDS the field it
-   *     gated on (PLoT `src/routes/v2/run.ts:3266-3277` — it is the leader's
-   *     `win_probability` relabelled, so emitting it under a stability name was
-   *     "a fabricated second statistic"). The predicate now relies solely on
-   *     the producer's display-safe verdict. See
+   *   · `recommendationStability` — ✅ ROADMAP 2.1228. The ban was CORRECT and
+   *     the CODE was wrong, so the READ was deleted. `isReadyToBrief` no longer
+   *     consults it: the `>= 0.85` cliff was UI-INVENTED, and the producer
+   *     deliberately WITHHOLDS the field it gated on (PLoT
+   *     `src/routes/v2/run.ts:3266-3277` — it is the leader's `win_probability`
+   *     relabelled, so emitting it under a stability name was "a fabricated
+   *     second statistic"). The predicate relies solely on the producer's
+   *     display-safe verdict now. See
    *     `../actOnIt/__tests__/rankActOnItRows.spec.ts` §6/§7 for the
-   *     bidirectional divergence pin that bounds the behavioural change.
+   *     bidirectional divergence pin bounding that behavioural change.
+   *
+   *   · `robustnessVerdict` — ✅ ROADMAP 2.1227. The CODE was correct and the
+   *     BAN was wrong, so the SYMBOL LEFT THE REGEX. A display-safe label does
+   *     exist: `types.ts` documents this field as sourced ONLY from PLoT's
+   *     `robustness.display_verdict`, fail-closed normalised in
+   *     `useResultsSectionData.ts:1974-1986` (only the four producer enum
+   *     tokens populate it; absent field or unrecognised token → undefined →
+   *     the honest "Robustness unknown" state). Reading it IS the sanctioned
+   *     path — it is what `types.ts` instructs surfaces to use for the binary
+   *     glyph — so banning it and then pinning the violation was recording a
+   *     debt that did not exist.
+   *
+   * ⚠ NOTE WHICH SYMBOL DID *NOT* LEAVE. `robustnessLevel` is still banned and
+   * that is deliberate: `types.ts` says it is PLoT-level structured data that
+   * "must NOT drive the binary Robust/Sensitive glyph", and it carries a
+   * UI-SEM-005 stability fallback. The two are differently-named twins and only
+   * one is display-safe — unbanning the wrong one would have been this estate's
+   * chronic defect. So the ban keeps its three genuinely-unlicensed symbols and
+   * an EMPTY known-gap set, which is the healthy end state the flat ban had
+   * before the cockpit consolidation.
+   *
+   * THE PIN STILL BITES IN BOTH DIRECTIONS FROM EMPTY: a new banned read makes
+   * the found set GROW (RED), and padding this list with an entry nothing
+   * matches makes it OVERSTATE (RED). Both are proved by mutants.
    */
   const TRUST_STABILITY_RE =
-    /robustnessLevel|robustnessLabel|robustnessVerdict|recommendationStability/g
+    /robustnessLevel|robustnessLabel|recommendationStability/g
 
-  const KNOWN_TRUST_STABILITY_READS: readonly string[] = [
-    'rankActOnItRows.ts::robustnessVerdict',
-  ]
+  const KNOWN_TRUST_STABILITY_READS: readonly string[] = []
 
   it('trust/stability field reads match the pinned known-gap set EXACTLY', () => {
     const found = new Set<string>()
@@ -124,6 +146,28 @@ describe('Analysis hero source hygiene', () => {
     ).toEqual([...KNOWN_TRUST_STABILITY_READS].sort())
   })
 
+  /**
+   * ROADMAP 2.1227 — THE UN-BAN IS ITSELF PINNED, IN BOTH DIRECTIONS.
+   *
+   * `robustnessVerdict` left the regex deliberately (it is the producer's
+   * display-safe field and reading it is sanctioned). Without this test, the
+   * un-ban is invisible: someone re-adding the symbol would make the pin RED
+   * with a message telling them a fabrication path had appeared, and the
+   * tempting "fix" would be to re-pin the sanctioned read as a debt again.
+   *
+   * The second assertion is the load-bearing half — it stops the un-ban being
+   * over-applied to the NON-display-safe twin.
+   */
+  it('the display-safe verdict is unbanned; its non-display-safe twin is NOT', () => {
+    // Both assertions rebuild the pattern from `.source`: `TRUST_STABILITY_RE`
+    // carries the `g` flag, and `.test()` on a global regex advances `lastIndex`,
+    // so calling it twice on the shared instance would make the second result
+    // depend on the first. A stateful instrument is not an instrument.
+    const banned = () => new RegExp(TRUST_STABILITY_RE.source)
+    expect(banned().test('data.robustnessVerdict')).toBe(false)
+    expect(banned().test('data.robustnessLevel')).toBe(true)
+  })
+
   it('positive controls: each pattern fires on the code it bans', () => {
     const banding = /[><]=?\s*(?:0?\.\d+|\d+(?:\.\d+)?e-\d+)\s*\?/i
     expect(/dangerouslySetInnerHTML|\binnerHTML\b/.test('el.innerHTML = x')).toBe(true)
@@ -131,7 +175,11 @@ describe('Analysis hero source hygiene', () => {
     expect(banding.test("conf >= 0.65 ? 'Firm' : 'Fragile'")).toBe(true)
     expect(banding.test("p > .5 ? 'likely' : 'unlikely'")).toBe(true)
     expect(banding.test("score >= 1e-1 ? 'a' : 'b'")).toBe(true)
-    expect(/robustnessVerdict/.test('data.robustnessVerdict')).toBe(true)
+    // Re-pointed by ROADMAP 2.1227 from `robustnessVerdict` (deliberately
+    // unbanned) to `robustnessLevel` — its NON-display-safe twin, which is
+    // still banned. A positive control aimed at a symbol the regex no longer
+    // contains would assert nothing.
+    expect(/robustnessLevel/.test('data.robustnessLevel')).toBe(true)
     // Assembled from parts rather than written as one source-text literal:
     // the sibling guard (focus-now module's own inertness spec) regex-scans
     // raw file text repo-wide for an import-shaped string ending in the
@@ -145,14 +193,14 @@ describe('Analysis hero source hygiene', () => {
 
   it('comment-strip both directions: comment mentions vanish, code (incl. bracket-key) still trips', () => {
     const fetchRe = /\bfetch\s*\(|\baxios\b|XMLHttpRequest|EventSource|WebSocket/
-    const verdictRe = /robustnessLevel|robustnessLabel|robustnessVerdict|recommendationStability/
+    const verdictRe = /robustnessLevel|robustnessLabel|recommendationStability/
     // Comment-borne mentions are blanked → not scanned (the #386/#403 footgun):
     expect(fetchRe.test(stripComments('// must never introduce a second fetch(', 'x.ts'))).toBe(false)
-    expect(verdictRe.test(stripComments('/* must not read robustnessVerdict */', 'x.ts'))).toBe(false)
+    expect(verdictRe.test(stripComments('/* must not read robustnessLevel */', 'x.ts'))).toBe(false)
     // Real code still trips, INCLUDING a bracket-string read (why we keep
     // strings — blankNonCode would have blanked this and missed it):
     expect(fetchRe.test(stripComments('const r = await fetch(url)', 'x.ts'))).toBe(true)
-    expect(verdictRe.test(stripComments("const v = data['robustnessVerdict']", 'x.ts'))).toBe(true)
+    expect(verdictRe.test(stripComments("const v = data['robustnessLevel']", 'x.ts'))).toBe(true)
     // A live focus-now import string is kept and caught. Assemble the
     // specifier (do NOT spell out an import-shaped focus-now literal in source)
     // — the sibling focus-now inertness guard regex-scans this file; same

--- a/src/components/results/analysis-hero/actOnIt/__tests__/rankActOnItRows.spec.ts
+++ b/src/components/results/analysis-hero/actOnIt/__tests__/rankActOnItRows.spec.ts
@@ -645,10 +645,20 @@ describe('rankActOnItRows — §5 readyToBrief posture', () => {
  * VERBATIM copy of the DELETED `analysisHeroV17/stateSelection.ts`
  * (`git show ae153fa1^:src/components/results/analysisHeroV17/stateSelection.ts`).
  *
- * This is the oracle the module's own header names: it claims `isReadyToBrief`
- * is EXACTLY `selectHeroState(...) === 'strong'`, and that the two weak guards
- * it drops are entailed. The claim is settled here BY EXECUTION rather than by
- * assertion in a comment.
+ * This WAS a pure equivalence oracle: the module's header claimed
+ * `isReadyToBrief` is EXACTLY `selectHeroState(...) === 'strong'`.
+ *
+ * ⚠ ROADMAP 2.1228 — IT IS NOW AN EQUIVALENCE *EXCEPT AN EXACTLY-PINNED
+ * DIVERGENCE SET*, AND THE DIVERGENCE IS THE FIX. The legacy selector required
+ * `stability >= 0.85` — a UI-INVENTED cliff on a bare 0-1 float. That conjunct
+ * is retired; the producer's display-safe `robustnessVerdict` is now the only
+ * trust authority. So the two predicates deliberately disagree on exactly the
+ * rows the cliff used to block, and nowhere else.
+ *
+ * The oracle is KEPT rather than deleted precisely because that is the claim
+ * worth pinning: `LEGACY_DIVERGENCE_ROWS` below REDs if the divergence GROWS
+ * (some other conjunct was relaxed) or SHRINKS (the cliff came back). Deleting
+ * the oracle would have made the blast radius of this change unobservable.
  */
 type LegacyHeroState = 'weak' | 'moderate' | 'reflect' | 'strong'
 
@@ -731,10 +741,11 @@ describe('isReadyToBrief — §6 equivalence with selectHeroState(...) === "stro
    * rows that discriminate the dropped weak guards. Each row is checked BOTH
    * ways: the oracle's verdict, and `isReadyToBrief`'s.
    *
-   * ⚠ Scope: finite stability values and absence only. `selectHeroState`
-   * accepted `Infinity` as "strong"; `isReadyToBrief` requires
-   * `Number.isFinite`, so the two DIVERGE there — in the conservative
-   * direction. That divergence is out of this table's scope by construction.
+   * ⚠ Scope: finite stability values and absence only. The pre-2.1228
+   * `isReadyToBrief` required `Number.isFinite(stability)` where the legacy
+   * selector accepted `Infinity` as "strong"; that divergence is out of this
+   * table's scope by construction and is now moot in any case — the predicate
+   * no longer reads stability at all, so no stability value can move it.
    */
   const table: Array<{ name: string; input: LegacyInputs }> = [
     // WEAK branch
@@ -775,9 +786,90 @@ describe('isReadyToBrief — §6 equivalence with selectHeroState(...) === "stro
     { name: 'weak guard 4 boundary: 2 options + verdict robust', input: legacyBase({ optionCount: 2, stability: 0.9, robustnessVerdict: 'robust' }) },
   ]
 
-  it.each(table)('agrees with the legacy selector: $name', ({ input }) => {
-    const expected = selectHeroState(input) === 'strong'
-    expect(isReadyToBrief(dataFromLegacy(input), input.fragileEdgeCount)).toBe(expected)
+  /**
+   * THE EXACT SET OF ROWS ON WHICH THE RETIRED CLIFF USED TO CHANGE THE ANSWER.
+   *
+   * Both rows satisfy every conjunct that survives 2.1228 — a recommended
+   * option, ≥2 options, producer verdict `robust`, ≤1 evidence gap, zero
+   * fragile edges — and the legacy selector still returned non-strong, for one
+   * reason only: `stability >= 0.85` failed.
+   *
+   *   · `stability 0.849` — the arbitrary cliff, one thousandth below.
+   *   · `absent stability` — ⭐ THE LIVE SHAPE. PLoT DELIBERATELY WITHHOLDS
+   *     `robustness.recommendation_stability` from the /v2/run wire
+   *     (`src/routes/v2/run.ts:3266-3277`, lane PLoT-H item B, 2026-07-07: it
+   *     is the leader's `win_probability` relabelled, "zero independent
+   *     information", and the UI printing it was "a fabricated second
+   *     statistic"). So on every fresh run the field is undefined and the
+   *     legacy cliff could never be met — the ready-to-brief row was DARK.
+   *     This row is the un-darkening.
+   */
+  const LEGACY_DIVERGENCE_ROWS: readonly string[] = [
+    'absent stability + verdict robust + clean signals',
+    'boundary: stability 0.849 + verdict robust',
+  ]
+
+  it.each(table)('agrees with the legacy selector except where pinned: $name', ({ name, input }) => {
+    const legacyStrong = selectHeroState(input) === 'strong'
+    const actual = isReadyToBrief(dataFromLegacy(input), input.fragileEdgeCount)
+    if (LEGACY_DIVERGENCE_ROWS.includes(name)) {
+      // Pinned divergence, and it is PERMISSIVE-ONLY BY ASSERTION: the legacy
+      // cliff blocked, the producer verdict licenses. Asserting both halves
+      // (not just `!==`) is what stops a future regression that diverges in the
+      // other direction — blocking a run the legacy selector allowed — from
+      // passing here as "still diverging".
+      expect(legacyStrong, `${name}: legacy must have BLOCKED this row`).toBe(false)
+      expect(actual, `${name}: the producer verdict must now license it`).toBe(true)
+      return
+    }
+    expect(actual).toBe(legacyStrong)
+  })
+
+  /**
+   * THE BIDIRECTIONAL PIN — the load-bearing guard of ROADMAP 2.1228.
+   *
+   * Same discipline as the hygiene known-gap set: a GROWN divergence means a
+   * conjunct was relaxed that nobody licensed (most dangerously
+   * `robustnessVerdict === 'robust'`, which is LOAD-BEARING per
+   * ROBUSTNESS-VERDICT-CONTRACT); a SHRUNK divergence means the UI-invented
+   * cliff was reintroduced. Either way this REDs, and neither is fixable by
+   * editing the list.
+   */
+  it('the divergence from the legacy selector is EXACTLY the pinned stability-cliff set', () => {
+    const diverged = table
+      .filter(
+        ({ input }) =>
+          (selectHeroState(input) === 'strong') !==
+          isReadyToBrief(dataFromLegacy(input), input.fragileEdgeCount),
+      )
+      .map(({ name }) => name)
+      .sort()
+    expect(
+      diverged,
+      'divergence from the legacy selector drifted: a GROWN set means a conjunct ' +
+        'was relaxed beyond the retired stability cliff, a SHRUNK set means the ' +
+        'cliff is back. Do not edit the pin to match reality.',
+    ).toEqual([...LEGACY_DIVERGENCE_ROWS].sort())
+  })
+
+  /**
+   * PIN THE CAUSE, NOT JUST THE COUNT (trap 13b — a discriminator must pin its
+   * own precondition in-test). Without this, the divergence set could stay the
+   * right SIZE while its members diverged for an unrelated reason.
+   */
+  it.each(LEGACY_DIVERGENCE_ROWS)('%s diverges because of the cliff and nothing else', (name) => {
+    const row = table.find((r) => r.name === name)
+    expect(row, `divergence row "${name}" is not in the table`).toBeDefined()
+    const input = row!.input
+    // The retired conjunct is the ONLY one that fails on this row...
+    expect(input.stability === null || input.stability < 0.85).toBe(true)
+    // ...and every surviving conjunct is satisfied, so the row genuinely
+    // isolates the cliff.
+    expect(input.hasWinner).toBe(true)
+    expect(input.optionCount).toBeGreaterThanOrEqual(2)
+    expect(input.robustnessVerdict).toBe('robust')
+    expect(input.evidenceGapCount).toBeLessThanOrEqual(1)
+    expect(input.fragileEdgeCount).toBe(0)
   })
 
   it('the table discriminates — it contains BOTH strong and non-strong rows', () => {
@@ -792,11 +884,20 @@ describe('isReadyToBrief — §6 equivalence with selectHeroState(...) === "stro
 // ── §7 isReadyToBrief — boundaries derived from the implementation ──────────
 
 describe('isReadyToBrief — §7 conjunct-by-conjunct', () => {
-  /** Every conjunct satisfied — the one TRUE baseline the negatives vary from. */
+  /**
+   * Every conjunct satisfied — the one TRUE baseline the negatives vary from.
+   *
+   * ⭐ ROADMAP 2.1228: `stability` is deliberately ABSENT here, because that is
+   * the shape the producer actually ships. PLoT withholds
+   * `robustness.recommendation_stability` from /v2/run, so a fresh run reaches
+   * this predicate with the field undefined. The baseline is now the live shape
+   * rather than a fixture-only one (trap 16-inverse: a fixture you wrote
+   * yourself is not evidence about the wire — so the baseline is pinned to what
+   * the wire carries).
+   */
   const readyOverrides: DataOverrides = {
     hasWinner: true,
     optionCount: 2,
-    stability: 0.85,
     robustnessVerdict: 'robust',
     gapCount: 1,
   }
@@ -826,18 +927,80 @@ describe('isReadyToBrief — §7 conjunct-by-conjunct', () => {
     ).toBe(false)
   })
 
-  it('requires stability >= 0.85 — 0.85 passes, 0.849 does not', () => {
-    expect(isReadyToBrief(makeData({ ...readyOverrides, stability: 0.85 }), 0)).toBe(true)
-    expect(isReadyToBrief(makeData({ ...readyOverrides, stability: 0.849 }), 0)).toBe(false)
-    expect(isReadyToBrief(makeData({ ...readyOverrides, stability: 1 }), 0)).toBe(true)
+  /**
+   * ROADMAP 2.1228 — REPLACES two retired tests:
+   *   · `requires stability >= 0.85 — 0.85 passes, 0.849 does not`
+   *   · `rejects an absent or non-finite stability rather than treating it as high`
+   *
+   * Both encoded the UI-INVENTED cliff as the specification. They are not
+   * "fixed" by moving the number: the predicate must not consult the field at
+   * all, so the assertion is written against the SPEC (the producer's
+   * display-safe verdict is the single trust authority) rather than against the
+   * failure mode (trap 13d).
+   *
+   * NOTE the value list spans the whole domain the type admits AND the domain it
+   * does not — including the values whose special-casing the old guard existed
+   * for (absent / NaN / ±Infinity). A corpus that omitted them could not certify
+   * that no residual stability branch survives (trap 13d(c): check what the
+   * corpus EXCLUDES).
+   */
+  it('ignores recommendationStability entirely — no value of it can move the verdict', () => {
+    const everyStability = [
+      undefined,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      -1,
+      0,
+      0.1,
+      0.5,
+      0.699,
+      0.7,
+      0.8,
+      0.849,
+      0.85,
+      1,
+      42,
+    ]
+    for (const stability of everyStability) {
+      expect(
+        isReadyToBrief(makeData({ ...readyOverrides, stability }), 0),
+        `stability ${String(stability)} must not change the answer — the producer ` +
+          'verdict is the only trust authority',
+      ).toBe(true)
+    }
   })
 
-  it('rejects an absent or non-finite stability rather than treating it as high', () => {
-    expect(isReadyToBrief(makeData({ ...readyOverrides, stability: undefined }), 0)).toBe(false)
-    expect(isReadyToBrief(makeData({ ...readyOverrides, stability: Number.NaN }), 0)).toBe(false)
-    expect(
-      isReadyToBrief(makeData({ ...readyOverrides, stability: Number.POSITIVE_INFINITY }), 0),
-    ).toBe(false)
+  /**
+   * THE OPPOSITE-DIRECTION TWIN (trap 22b): retiring the cliff must not have
+   * relaxed anything else. Every case here runs at the LIVE shape — stability
+   * absent, exactly as the producer ships it — because that is the shape in
+   * which a residual "no stability means unknown, so allow it" bug would hide.
+   *
+   * Each case CAN fail: at the pinned fix each is a genuine false, and flipping
+   * the corresponding conjunct in the source turns it red (proved by the mutant
+   * kit, not asserted here).
+   */
+  it('retiring the cliff relaxed nothing else — every other guard still bites at the live shape', () => {
+    const live = { ...readyOverrides, stability: undefined }
+    // The producer verdict remains load-bearing (ROBUSTNESS-VERDICT-CONTRACT):
+    for (const verdict of ['moderate', 'fragile', 'not_assessed'] as const) {
+      expect(
+        isReadyToBrief(makeData({ ...live, robustnessVerdict: verdict }), 0),
+        `verdict "${verdict}" must not brief`,
+      ).toBe(false)
+    }
+    expect(isReadyToBrief(makeData({ ...live, robustnessVerdict: undefined }), 0)).toBe(false)
+    // Edge fragility is an INDEPENDENT measurement from recommendation
+    // stability (ISL: "fragile_edges is a separate indicator of edge-level
+    // sensitivity", and is_robust=true can co-occur with fragile edges), so
+    // this guard is doing work the verdict does not do:
+    expect(isReadyToBrief(makeData(live), 1)).toBe(false)
+    expect(isReadyToBrief(makeData(live), Number.NaN)).toBe(false)
+    // Evidence-gap and option-count guards:
+    expect(isReadyToBrief(makeData({ ...live, gapCount: 2 }), 0)).toBe(false)
+    expect(isReadyToBrief(makeData({ ...live, optionCount: 1 }), 0)).toBe(false)
+    expect(isReadyToBrief(makeData({ ...live, hasWinner: false }), 0)).toBe(false)
   })
 
   it('allows at most one evidence gap', () => {
@@ -868,6 +1031,27 @@ describe('isReadyToBrief — §7 conjunct-by-conjunct', () => {
     // AnalysisHeroContainer passes `fragileEdgeCount ?? Number.NaN` precisely
     // so a caller that forgets to thread the count gets the conservative answer.
     expect(isReadyToBrief(makeData(readyOverrides), Number.NaN)).toBe(false)
+  })
+
+  /**
+   * ⭐ THE UN-DARKENING, AT THE ROW RATHER THAN THE PREDICATE.
+   *
+   * A true predicate is not a user-visible row. This walks the same composition
+   * `AnalysisHeroContainer.tsx:102` walks — `rankActOnItRows(data, { readyToBrief:
+   * isReadyToBrief(data, fragile) })` — on the shape the producer actually
+   * emits, and binds to the row BY KEY (identity, never a value predicate
+   * another row could satisfy — trap 19).
+   *
+   * Before 2.1228 this could not have passed on this fixture at any stability
+   * value, because the producer does not send one.
+   */
+  it('the producer-shaped fresh run reaches the ready-to-brief ROW, not just the predicate', () => {
+    const data = makeData({ ...readyOverrides, stability: undefined })
+    const rows = rankActOnItRows(data, { readyToBrief: isReadyToBrief(data, 0) })
+    expect(rows.map((r) => r.key)).toContain('ready-brief')
+    const ready = rows.find((r) => r.key === 'ready-brief')!
+    expect(ready.category).toBe('ready')
+    expect(ready.priority).toBe('Ready')
   })
 })
 

--- a/src/components/results/analysis-hero/actOnIt/rankActOnItRows.ts
+++ b/src/components/results/analysis-hero/actOnIt/rankActOnItRows.ts
@@ -132,14 +132,21 @@ import {
  * divergence REDs if it grows (a conjunct was relaxed) or shrinks (the cliff
  * came back).
  *
- * ⚠ KNOWN GAP, PINNED NOT HIDDEN. The `robustnessVerdict` read below is banned
- * by `../__tests__/hygiene.spec.ts` and recorded there in an EXACTLY-pinned
- * known-gap set that REDs if it grows or shrinks. That ban is STALE — PLoT does
- * publish a display-safe verdict and `types.ts` documents this field as sourced
- * only from it, fail-closed normalised — and clearing the pin entry is ROADMAP
- * 2.1227, not this change. Do not resolve it by editing the pin. The
- * `recommendationStability` entry was removed from that set BY THIS CHANGE,
- * alongside the removal of the read itself.
+ * ── THE KNOWN-GAP SET IN `../__tests__/hygiene.spec.ts` IS NOW EMPTY ────────
+ *
+ * Both entries that named this file are resolved, and in OPPOSITE ways:
+ *  · `recommendationStability` (ROADMAP 2.1228) — the ban was right and the
+ *    code was wrong, so the READ IS GONE, as described above.
+ *  · `robustnessVerdict` (ROADMAP 2.1227) — the code was right and the ban was
+ *    STALE, so THE SYMBOL LEFT THE REGEX. `types.ts` documents this field as
+ *    sourced only from PLoT's `robustness.display_verdict`, fail-closed
+ *    normalised in `useResultsSectionData.ts:1974-1986`, and instructs surfaces
+ *    to use it for the binary glyph. The read below IS the sanctioned path, so
+ *    pinning it was recording a debt that did not exist.
+ *    ⚠ `robustnessLevel` remains banned and that is the point — it is the
+ *    NON-display-safe twin, carrying a UI-SEM-005 stability fallback, and
+ *    `types.ts` says it must not drive the binary verdict. Unbanning the wrong
+ *    twin would have been the differently-named-twins defect.
  *
  * The `robustnessVerdict === 'robust'` conjunct is LOAD-BEARING and must not be
  * relaxed: it is now the ONLY trust authority in this predicate (single-source

--- a/src/components/results/analysis-hero/actOnIt/rankActOnItRows.ts
+++ b/src/components/results/analysis-hero/actOnIt/rankActOnItRows.ts
@@ -46,8 +46,8 @@ import {
  * ⚠ DERIVED, NOT INVENTED. The salvaged `stateSelection.selectHeroState`
  * returned one of `weak | moderate | reflect | strong`, but `rankHeroRows`
  * only ever discriminated `strong` from everything else — `moderate` and
- * `reflect` took the identical branch. So only the `strong` predicate is
- * carried over, and it is carried over EXACTLY:
+ * `reflect` took the identical branch. So only the `strong` predicate was
+ * carried over:
  *
  *   selectHeroState returns 'strong'  ⟺
  *     hasWinner
@@ -57,34 +57,94 @@ import {
  *     ∧ robustnessVerdict === 'robust'
  *     ∧ stability ≥ 0.85 ∧ gaps ≤ 1 ∧ fragileEdgeCount === 0
  *
- * The two bracketed weak guards are entailed by `stability ≥ 0.85 ∧ gaps ≤ 1`
- * (0.85 ≮ 0.5, and 1 < 3 ≤ 4), so dropping them changes nothing. That
- * equivalence is proved by execution — not asserted here — in
- * `./__tests__/rankActOnItRows.spec.ts`, which replays the original selector's
- * own table against this predicate.
+ * ⚠ THE HEADER'S EQUIVALENCE CLAIM WAS FALSE WHEN FIRST WRITTEN, and the
+ * correction is worth keeping. This module landed in the cockpit consolidation
+ * citing a proof spec that DID NOT EXIST: 278 lines of live ranking logic
+ * (reached from `AnalysisHeroContainer`) with zero tests, under a header
+ * claiming execution proof. The spec exists now. A comment asserting a proof is
+ * not evidence of one — check the file before trusting the next such sentence,
+ * including this one. (Its test count is deliberately NOT restated here: the
+ * previous number went stale within weeks. Run the file.)
  *
- * ⚠ THAT SENTENCE WAS FALSE WHEN FIRST WRITTEN, and the correction is worth
- * keeping. This module landed in the cockpit consolidation citing a proof
- * spec that DID NOT EXIST: 278 lines of live ranking logic (reached from
- * `AnalysisHeroContainer`) with zero tests, under a header claiming execution
- * proof. The spec now exists (67 tests, 19 mutants, 0 survivors) and the claim
- * is true. A comment asserting a proof is not evidence of one — check the file
- * before trusting the next such sentence, including this one.
+ * ── ROADMAP 2.1228: THE `stability ≥ 0.85` CONJUNCT IS RETIRED ──────────────
  *
- * ⚠ KNOWN GAP, PINNED NOT HIDDEN. The two reads below —
- * `robustnessVerdict` and `recommendationStability` — are banned by
- * `../__tests__/hygiene.spec.ts` (no producer display-safe label => any read
- * is a fabrication path). They are recorded there in an EXACTLY-pinned
- * known-gap set that REDs if it grows or shrinks, rather than being carved out
- * of the guard. The two are different debts and are rowed separately: the ban
- * is stale for `robustnessVerdict` (PLoT does publish a display-safe verdict),
- * and correct for `recommendationStability` (the `0.85` cliff below is
- * UI-invented). Do not resolve either by editing the pin.
+ * It is gone, and the predicate now DELIBERATELY DIVERGES from the legacy
+ * selector on exactly the rows that cliff used to block. Three findings, each
+ * derived at the producer's bytes rather than reasoned from this repo:
  *
- * The `robustnessVerdict === 'robust'` conjunct is LOAD-BEARING and must not
- * be relaxed: raw stability alone must never unlock a "ready to brief" claim
- * (single-source rule, ROBUSTNESS-VERDICT-CONTRACT). Older producers omit the
- * field, and then this predicate is simply unreachable — the honest direction.
+ * 1. THE CLIFF WAS UI-INVENTED. `0.85` appears in no contract, no schema and no
+ *    producer. It banded a bare 0-1 float with no display-safe label.
+ *
+ * 2. ⭐ THE PRODUCER DELIBERATELY WITHHOLDS THE FIELD IT GATED ON, so the
+ *    conjunct made this predicate UNREACHABLE ON EVERY FRESH RUN. PLoT stopped
+ *    emitting `robustness.recommendation_stability` on /v2/run (lane PLoT-H
+ *    item B, 2026-07-07; `src/routes/v2/run.ts:3266-3277`) because ISL derives
+ *    it as `option_wins[winner]/n_samples` — the leader's `win_probability`
+ *    relabelled, "zero independent information" — and the UI printing it as
+ *    "N% stability" was "a fabricated second statistic". `useResultsSectionData`
+ *    populates the field from that wire slot and nothing else, so it arrives
+ *    undefined and `typeof stability !== 'number'` returned false forever. The
+ *    ready-to-brief row was DARK, and its own spec fixtures were the only place
+ *    the cliff could be satisfied (trap 16-inverse: reachability inside one
+ *    service is not reachability in the system, and a fixture you wrote
+ *    yourself is not evidence about the wire).
+ *
+ * 3. THE CLIFF WAS A MIRROR OF A PRODUCER BAND THAT HAS ALREADY MOVED. What the
+ *    producer's own `robust` verdict entails, traced end to end:
+ *      · PLoT `robustness-display-verdict.ts:182-207` — `display_verdict ===
+ *        'robust'` ⟺ robustness computed ∧ `is_robust === true` ∧
+ *        `level === 'high'` (BOTH facts required; an explicit `is_robust:
+ *        false` always wins → 'fragile').
+ *      · ISL `src/api/robustness.py:1230` — `level === 'high'` ⟺ `is_robust`
+ *        ∧ `confidence > 0.8`.
+ *      · ISL `robustness_analyzer_v2.py:6015` + `:1670` — `is_robust` ⟺
+ *        `recommendation_stability >= ROBUST_THRESHOLD (0.7)`; and since ISL
+ *        #114 the `confidence` slot IS the bare stability fraction
+ *        (`_stability_confidence_figure`, `:3391`).
+ *      ⟹ `robust` entails `recommendation_stability > 0.8`.
+ *    So the UI's 0.85 sat 0.05 above a producer threshold it duplicated — and
+ *    that threshold has already shifted once (pre-#114 the `confidence` slot
+ *    carried `stability × (1 − 1/√n)`, putting the entailed floor near 0.826 at
+ *    n=1000). A UI constant tracking a producer band it cannot see is the
+ *    hand-maintained mirror this estate keeps paying for.
+ *
+ * WHAT THE CHANGE COSTS, STATED HONESTLY: the licensing band widens from
+ * `≥ 0.85` to the producer's `> 0.8`. That is a real relaxation of ~5 points of
+ * stability, and it is the correct direction — inside that band the producer's
+ * own display-safe verdict says `robust`, and meaning is producer-owned. It
+ * cannot let a FRAGILE result brief: `is_robust === false` or a low/very_low
+ * level maps to 'fragile' before any of this is reached.
+ *
+ * THE OTHER CONJUNCTS ARE UNTOUCHED, and two points matter:
+ *  · The bracketed weak guards are entailed by `gaps ≤ 1` ALONE (gaps ≤ 1 ⟹
+ *    ¬(gaps ≥ 3) ∧ ¬(gaps ≥ 4)). The old header credited the entailment to
+ *    `stability ≥ 0.85 ∧ gaps ≤ 1`; the stability half was never doing any of
+ *    that work, which is why retiring it reopens neither guard.
+ *  · `fragileEdgeCount === 0` is an INDEPENDENT measurement, not a proxy for
+ *    stability — ISL's own note at `robustness_analyzer_v2.py:6013-6014` is that
+ *    "fragile_edges is a separate indicator of edge-level sensitivity", and
+ *    `is_robust: true` can co-occur with fragile edges. So edge fragility still
+ *    blocks a brief on its own, and that guard is now carrying the load the
+ *    cliff was imagined to carry.
+ *
+ * Both the divergence set and the "nothing else was relaxed" twin are pinned by
+ * execution in `./__tests__/rankActOnItRows.spec.ts` §6/§7, bidirectionally: the
+ * divergence REDs if it grows (a conjunct was relaxed) or shrinks (the cliff
+ * came back).
+ *
+ * ⚠ KNOWN GAP, PINNED NOT HIDDEN. The `robustnessVerdict` read below is banned
+ * by `../__tests__/hygiene.spec.ts` and recorded there in an EXACTLY-pinned
+ * known-gap set that REDs if it grows or shrinks. That ban is STALE — PLoT does
+ * publish a display-safe verdict and `types.ts` documents this field as sourced
+ * only from it, fail-closed normalised — and clearing the pin entry is ROADMAP
+ * 2.1227, not this change. Do not resolve it by editing the pin. The
+ * `recommendationStability` entry was removed from that set BY THIS CHANGE,
+ * alongside the removal of the read itself.
+ *
+ * The `robustnessVerdict === 'robust'` conjunct is LOAD-BEARING and must not be
+ * relaxed: it is now the ONLY trust authority in this predicate (single-source
+ * rule, ROBUSTNESS-VERDICT-CONTRACT). Older producers omit the field, and then
+ * this predicate is simply unreachable — the honest direction.
  */
 export function isReadyToBrief(
   data: ResultsSectionDataReturn,
@@ -94,8 +154,6 @@ export function isReadyToBrief(
   if (!rec?.recommendedOption) return false
   if ((rec.allOptions?.length ?? 0) < 2) return false
   if (rec.robustnessVerdict !== 'robust') return false
-  const stability = rec.recommendationStability
-  if (typeof stability !== 'number' || !Number.isFinite(stability) || stability < 0.85) return false
   const gaps = (data?.confidence?.topEvidenceGaps ?? data?.confidence?.evidenceGaps ?? []).length
   if (gaps > 1) return false
   return fragileEdgeCount === 0

--- a/src/components/results/analysis-hero/actOnIt/rankActOnItRows.ts
+++ b/src/components/results/analysis-hero/actOnIt/rankActOnItRows.ts
@@ -88,6 +88,22 @@ import {
  *    the cliff could be satisfied (trap 16-inverse: reachability inside one
  *    service is not reachability in the system, and a fixture you wrote
  *    yourself is not evidence about the wire).
+ *    ⚠ AND IT WAS DARK ON PERSISTED RUNS TOO — this was first recorded the
+ *    other way ("satisfiable from a pre-withdrawal snapshot"), inferred from a
+ *    773-run field census. The producer's EMISSION HISTORY settles it and says
+ *    the opposite: PLoT withdrew `recommendation_stability` in #199
+ *    (`1823e07f`, 07 Jul 10:33 +0100) and first emitted `display_verdict` in
+ *    #202 (`38d589cd`, 07 Jul 14:44 +0100) — 4 h 11 min LATER. No PLoT build
+ *    ever co-emitted the two fields this predicate required, so no `robustness`
+ *    object taken from a single /v2/run response, fresh or hydrated, could
+ *    satisfy both conjuncts. The only residual path is a CROSS-SLOT mix: the
+ *    verdict is read from `store.rawV2Response` (`useResultsSectionData:1288`)
+ *    while stability is read from `report?.robustness` (`:1896`), so a hydrated
+ *    legacy `report` beside a fresh response could combine them. Not witnessed.
+ *    Consequence for this change: it is behaviourally INERT on legacy snapshots
+ *    except in the same `(0.8, 0.85]` band it opens for fresh runs.
+ *    (A census tells you what a field happens to contain; only the producer
+ *    tells you what it could ever have contained alongside another field.)
  *
  * 3. THE CLIFF WAS A MIRROR OF A PRODUCER BAND THAT HAS ALREADY MOVED. What the
  *    producer's own `robust` verdict entails, traced end to end:


### PR DESCRIPTION
## What

`isReadyToBrief` required `recommendationStability >= 0.85` — a UI-invented threshold on a bare 0-1 float with no display-safe producer label. **Retired.** The producer's display-safe `robustnessVerdict` is now the predicate's only trust authority.

This is **option (c)** of ROADMAP 2.1228: one authority, no UI-invented number. Options (a) and (b) are refuted below at the producer's bytes.

`robustnessVerdict === 'robust'` is **untouched** and remains load-bearing (ROBUSTNESS-VERDICT-CONTRACT). Its stale pin entry is ROADMAP **2.1227**, a separate row, deliberately left in place.

## Why — derived at the producer, not reasoned from this repo

**1. The producer DELIBERATELY WITHHOLDS the field the cliff gated on**, so the conjunct made this predicate unreachable on every fresh run.

PLoT stopped emitting `robustness.recommendation_stability` on `/v2/run` (lane PLoT-H item B, 2026-07-07 — `plot-lite-service` staging `8bf54150`, `src/routes/v2/run.ts:3266-3277`). In the producer's own words: ISL derives it as `option_wins[winner]/n_samples`, the leader's `win_probability` relabelled, *"zero independent information"*, and the UI printing it as "N% stability" was *"a fabricated second statistic. Omission is honest absence; the UI has an absence path."*

`useResultsSectionData.ts:1896-1900` populates the field from that wire slot **and nothing else**, so it arrives `undefined` and `typeof stability !== 'number'` returned `false` forever. **The ready-to-brief row was dark; the cliff was satisfiable only in its own fixtures.**

Contrast control on PLoT's live-capture golden fixture (`isl-v2-live-20260707`): `recommendation_stability` absent, `ranking_stability` absent, `display_verdict` **present** in the same robustness object — real absence, not probe blindness.

**2. What the producer's `robust` verdict entails**, traced end to end (this is the trap-13c check — is `display_verdict` weaker than the cliff in a way that would let a fragile ranking brief?):

| hop | file:line | rule |
|---|---|---|
| PLoT | `routes/v2/robustness-display-verdict.ts:182-207` | `'robust'` ⟺ robustness computed ∧ `is_robust === true` ∧ `level === 'high'` (both facts required; explicit `is_robust: false` → `'fragile'` first) |
| ISL | `api/robustness.py:1230` | `level === 'high'` ⟺ `is_robust` ∧ `confidence > 0.8` |
| ISL | `robustness_analyzer_v2.py:6015` + `:1670` | `is_robust` ⟺ `recommendation_stability >= ROBUST_THRESHOLD (0.7)` |
| ISL | `robustness_analyzer_v2.py:3391` | since ISL #114 the `confidence` slot **is** the bare stability fraction |

⟹ **`robust` entails `recommendation_stability > 0.8`.**

So the UI's `0.85` duplicated a producer band sitting 0.05 below it — **and that band has already moved once** (pre-#114 the slot carried `stability × (1 − 1/√n)`, putting the entailed floor near 0.826 at n=1000). A UI constant tracking a producer threshold it cannot see is the hand-maintained mirror this estate keeps paying for.

**Honest cost, stated plainly:** the licensing band widens from `>= 0.85` to the producer's `> 0.8`. That is a real ~5-point relaxation, and it is the correct direction — inside that band the producer's own display-safe verdict says `robust`, and meaning is producer-owned. It **cannot** let a fragile result brief: `is_robust === false` or a low/very_low level maps to `'fragile'` before any of this is reached.

**Why not (a) or (b):** (a) a producer-side "stable enough to brief" signal would duplicate `display_verdict`, and PLoT has already ruled this quantity carries zero independent information — it withheld it for that reason. (b) a contract-licensed constant is still a UI-invented number, and it would still gate on a field the producer does not send.

## The other conjuncts are untouched

- The two bracketed weak guards are entailed by **`gaps <= 1` alone** (`gaps <= 1` ⟹ `¬(gaps >= 3) ∧ ¬(gaps >= 4)`). The old header credited the entailment to `stability >= 0.85 ∧ gaps <= 1`; the stability half was never doing any of that work, which is why retiring it reopens neither guard.
- `fragileEdgeCount === 0` is an **independent measurement**, not a stability proxy — ISL's own note at `robustness_analyzer_v2.py:6013-6014` is that *"fragile_edges is a separate indicator of edge-level sensitivity"*, and `is_robust: true` can co-occur with fragile edges. Edge fragility still blocks a brief on its own.

## Tests

The legacy `selectHeroState` oracle is **kept**, and becomes an equivalence-**except-an-exactly-pinned-divergence** check, so the blast radius of this change is observable rather than deleted along with the oracle. The pin is bidirectional: it REDs if the divergence **grows** (a conjunct was relaxed — most dangerously the load-bearing verdict) or **shrinks** (the cliff came back).

Exactly two rows diverge, both **permissive-only by assertion** (legacy blocked / producer licenses, asserted as two separate halves so a divergence in the other direction cannot pass as "still diverging"), and each pins its own cause:
- `boundary: stability 0.849 + verdict robust` — the arbitrary cliff, one thousandth below
- `absent stability + verdict robust + clean signals` — **the live shape**, i.e. the un-darkening

Retired (2), both of which encoded the UI-invented cliff as the specification:
- `requires stability >= 0.85 — 0.85 passes, 0.849 does not`
- `rejects an absent or non-finite stability rather than treating it as high`

Added (6): the bidirectional divergence pin; a per-row cause pin (×2); a whole-domain *"no value of `recommendationStability` moves the verdict"* test spanning `undefined`/`NaN`/`±Infinity`/negatives as well as the ordinary range; an **opposite-direction twin** proving nothing else was relaxed; and a **row-level witness** walking the container's own composition (`AnalysisHeroContainer.tsx:102`) and binding to the row by key.

Re-derived (34): the 29 §6 table rows under the renamed agreement test, plus 5 pre-existing §7 tests whose baseline moved from `stability: 0.85` to **stability absent** — the §7 baseline is now the shape the producer actually ships rather than a fixture-only one.

Spec: **81 → 85 tests**, all green. (The row's "67 tests" figure was stale at this tip.)

## Hygiene pin

Shrinks by **exactly** the resolved entry:

```diff
 const KNOWN_TRUST_STABILITY_READS: readonly string[] = [
-  'rankActOnItRows.ts::recommendationStability',
   'rankActOnItRows.ts::robustnessVerdict',
 ]
```

The pin still bites **both ways** after the shrink, proved by mutants: a GROW mutant (a new banned read added to production source) REDs it, and a SHRINK mutant (the remaining read removed while the pin still lists it) REDs it.

## Verification

Mutation kit in a throwaway worktree **outside** the repo root, isolation proven **by writing a sentinel** and asserting the source tree unchanged (differing inodes checked too — trap 9g), HEAD-relative restores from a pristine archive, clean-tree assertion before and after every mutant, applied-check scoped to `src/`.

| mutant | expected | observed |
|---|---|---|
| M1 restore the 0.85 cliff | RED | RED (11 assertions) |
| M2 verdict conjunct relaxed to `!== 'fragile'` | RED | RED (12) |
| M3 verdict conjunct deleted | RED | RED (14) |
| M4 gaps guard `> 1` → `> 2` | RED | RED (5) |
| M5 fragile guard `=== 0` → `>= 0` | RED | RED (4) |
| M6 option count `< 2` → `< 1` | RED | RED (2) |
| H1 hygiene pin GROW | RED | RED |
| H2 hygiene pin SHRINK | RED | RED |
| **D1 inert edit (discrimination probe)** | **GREEN** | **GREEN** |

Applied-check `1` on every mutant, control `0`, leading and trailing controls green (93/93), tree clean at exit. D1 is there because a harness that REDs on any edit proves nothing about specificity (trap 20's corollary: keep one probe whose expected answer differs).

Gates at tip, running the required check's **full step sequence** in order (`lint` → `typecheck` → the four guards — trap 22e):
- `pnpm run lint` — **0 errors**; hooks ratchet exactly at baseline (229 known violations / 13 files)
- `pnpm run typecheck` — **PASSED**, coverage 3443/3483, ratchet 2307 vs baseline 2325
- `ci:guard:zustand`, `ci:guard:starters`, `check:vendor`, `ci:guard:schemas-version` — all pass

⚠ The typecheck gate invites `--update-baseline` for an 18-diagnostic shrink. **Declined, with a control:** a pristine `origin/staging` worktree at `813ec4b1` reports the **identical** 2307/2325 and the same notice, so the shrink is entirely pre-existing and banking it here would claim a cleanup this PR did not do (trap 2b).

## Out of scope, reported at the boundary

Five surfaces outside the hygiene guard's scanned module still read the withheld field, four rendering the very percentage PLoT withdrew it to stop: `TrustOneLiner.tsx:64-74`, `model-tab/ModelHealthSection.tsx:134-135`, `model-tab/StatusBar.tsx:80-84`, `compare-tab/TrajectorySection.tsx:48-49`, `OutputsDock.tsx:1456`. They should be dead on fresh runs (absence path); the residual risk is hydrated payloads captured before 2026-07-07, when PLoT did emit the field. Not touched here. The hygiene spec scans only `analysis-hero/`, which is why a manual sweep was needed to see them — widening that ban is the durable fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# ⭐ WHAT THIS RESTORES FOR THE USER (recorded at the coordinator's escalation)

**This PR restores a DARK AFFORDANCE.** The "Create decision brief" row could not appear on a fresh run *at any stability value*, because the value the gate required does not arrive. That is the user-visible point of the change, and it was nearly shipped as a tidy-up.

Proven by **executing both predicates** against PLoT's real live-capture bytes (`isl-v2-live-20260707/plot-v2-run.golden.json`), not by reading source — standing brief **P2** (*compare against the mounted consumer, not just producer bytes*):

| check | result |
|---|---|
| producer omits `recommendation_stability` **and** `ranking_stability`, with `display_verdict` **present** in the same object (contrast control) | ✅ |
| consumer normalisation (`useResultsSectionData.ts:1896-1900`) therefore yields `recommendationStability === undefined` | ✅ |
| **A/B on a producer-shaped `robust` run: OLD predicate `false`, NEW predicate `true`** | ✅ |
| the genuinely-`fragile` run the producer actually sent still cannot brief — **either way** | ✅ |

The old gate's first stability check was `typeof stability !== 'number'`, so `undefined` short-circuited to `false` before the `>= 0.85` comparison was ever reached.

**Two independent confirmations of the withdrawal**, one per side of the wire:
- producer: PLoT `src/routes/v2/run.ts:3266-3277`
- consumer: this repo's own `AdvancedSection.tsx:65-70` — *"`recommendation_stability` is DEPRECATED and no longer emitted by the producer (vendored 0.15.0 enrichment.js:250-262 — it was byte-identical to the leader's win_probability)"*

Neither report-builder adapter synthesises the field; both merely copy it through (`adapters/plot/v2/responseMapper.ts:547`, `v5/mapV5AnalysisToReport.ts:1170-1173`), so `undefined` propagates.

## ⚠ Scoping this claim — CORRECTED AFTER REVIEW: the universal version was substantially RIGHT

I was asked to confirm the predicate has been "permanently false since 7 Jul". I first recorded that the evidence *refuted* the universal claim. **Review overturned that**, from the producer's emission history rather than from a field census — so the corrected statement is below and the original is struck through, because a wrong scoping sentence in a merged PR body is what the next session inherits:

- **Established:** for any run whose `report.robustness` comes from the current producer, the pre-2.1228 predicate returned `false` — the row was unreachable.
- ~~**Refutes the universal:** `analysisEnrichmentShape.ts:83` records `recommendation_stability` *"legitimately absent in 426/773 runs"* — i.e. present in 347, so a hydrated pre-7-Jul snapshot could have satisfied the cliff.~~ **WITHDRAWN.** The arithmetic is right (773−426=347) but it grounds only in an **undated, hand-maintained in-source comment**, and it answers the wrong question: the predicate required **both** conjuncts, and the census speaks to only one of them.
- ⭐ **The producer's emission history settles it the other way.** PLoT withdrew `recommendation_stability` in **#199 (`1823e07f`, 07 Jul 10:33:14 +0100)** and first emitted `display_verdict` in **#202 (`38d589cd`, 07 Jul 14:44:17 +0100)** — **4 h 11 min later**. No PLoT build ever co-emitted the two fields, so no `robustness` object taken from a single `/v2/run` response — fresh **or hydrated** — could satisfy `verdict === 'robust'` ∧ `stability >= 0.85`. My scope slipped from one conjunct to the predicate (trap 20), inside the correction written to fix a scope error, and it is a **P7 miss**: I selected the conclusion from the corpus that happened to contain the field instead of from the producer that writes it. Two `git log` calls settle it.
- **The one residual satisfiability path** (recorded so the next lane need not find it): the verdict is read from `store.rawV2Response.robustness.display_verdict` (`useResultsSectionData.ts:1288`) while stability is read from `report?.robustness` (`:1896`) — **two independent store slots**, so a hydrated legacy `report` beside a fresh `rawV2Response` could combine a pre-7-Jul stability with a post-#202 verdict. Not derived to a reachable session state; **not witnessed**.
- **Not established:** no live wire capture was taken in this lane. The claim is *derived*, not journey-witnessed.

So, corrected: **dark on every run whose `robustness` object comes from a single `/v2/run` response — fresh or persisted** — because the withdrawal predates the verdict's first emission by four hours. The practical consequence is reassuring and worth stating plainly: **this change is behaviourally inert on legacy snapshots except in the identical `(0.8, 0.85]` band it opens for fresh runs.** Derived, not journey-witnessed.

| persisted snapshot | old predicate | new predicate | change |
|---|---|---|---|
| stability 0.9, `display_verdict` **absent** (pre-#202) | false | false | none |
| stability 0.9, verdict `fragile`/`moderate`/`not_assessed` | false | false | none |
| stability 0.9 **and** verdict `robust` | true | true | none |
| stability ∈ (0.8, 0.85] and verdict `robust` | false | **true** | same band as fresh runs |

This also makes **option (c) the only coherent choice**: (a) and (b) would both threshold a value that never arrives.

---

# ROADMAP 2.1227 — resolved in the same motion (commit 2)

The two known-gap entries naming this file are resolved **in opposite directions**, and the difference is the whole lesson:

- **`recommendationStability` (2.1228)** — the ban was **correct**, the code was wrong → **the read was deleted**.
- **`robustnessVerdict` (2.1227)** — the code was **correct**, the ban was **stale** → **the symbol left the regex**.

`types.ts:363-370` documents the field as sourced ONLY from PLoT's `robustness.display_verdict`, fail-closed normalised at `useResultsSectionData.ts:1974-1986` (only the four producer enum tokens populate it; absent or unrecognised → `undefined` → the honest "Robustness unknown"). Reading it **is** the sanctioned path, so banning it and pinning the violation recorded a debt that did not exist.

**⚠ `robustnessLevel` remains banned, deliberately** — it is the non-display-safe twin (PLoT-level structured data plus a UI-SEM-005 stability fallback) which `types.ts` says must NOT drive the binary glyph. Unbanning the wrong twin would have been the differently-named-twins defect, so the un-ban is pinned in **both** directions by a new control (verdict unbanned AND level still banned).

The known-gap set is now **EMPTY** and the ban is flat again over its three genuinely-unlicensed symbols. It still bites both ways from empty: a new banned read makes the set **GROW**; padding the list makes it **OVERSTATE**.

**Scope held (not done here):** the fuller "Seam-A mapper lift" (rows 1.6/1.6b — moving the `display_verdict` normalisation out of `useResultsSectionData` into `mapRobustness`, which carries **zero** `display_verdict` today) touches `src/lib/mappers/mapRobustness.ts` and `useResultsSectionData.ts` — shared files adjacent to the fenced selector/union-swap lane. Per the scope-expansion rule this lane stops at the boundary and reports it. Nothing in 2.1227 requires it: the read already consumes the fail-closed producer field.

---

# Harness — standing brief P4 (typecheck the mutated tree)

My first kit satisfied applied-check/control/sentinel/HEAD-relative restores but **did not typecheck the mutated trees**. Vitest strips types, so an invalid-TS mutant runs, passes and reads as **SURVIVED**. Closed:

`tsc -p tsconfig.app.json` never exits 0 here (1979 pre-existing ratchet diagnostics), so the assertion is a **diagnostic-set diff** against an unmutated baseline, not an exit code.

| mutated tree | new diagnostics |
|---|---|
| **D1 — the unbanned-verdict read (the only GREEN survivor, so the only false-survivor risk)** | **0 → type-valid** |
| G1 robustnessLevel read | 0 → type-valid |
| M1 cliff restored | 0 → type-valid |
| M2 verdict conjunct deleted | 0 → type-valid |
| **positive control — deliberately type-invalid mutant** | **caught: `TS2322: Type 'string' is not assignable to type 'number'`** |

The control matters: without it, "0 new diagnostics" everywhere would be indistinguishable from a check that cannot fail.

**Full kit at the final tip** (`fe552d6c`), control 94/94, applied-check exactly 1 per mutant, trailing control green, tree clean at exit:

| mutant | expected | observed |
|---|---|---|
| G1 banned read: `robustnessLevel` (the twin) | RED | RED |
| G2 banned read: `robustnessLabel` | RED | RED |
| G3 banned read: `recommendationStability` | RED | RED |
| O1 pin padded from empty (overstate direction) | RED | RED |
| R1 `robustnessVerdict` re-added to the ban regex | RED | RED |
| M1 the 0.85 cliff restored | RED | RED (11) |
| M2 verdict conjunct deleted | RED | RED (13) |
| **D1 read the UNBANNED `robustnessVerdict`** | **GREEN** | **GREEN** |

## Honest reporting of what did NOT run

The local whole-repo suite was started twice and **killed both times** (session capacity, then CPU starvation against the gates). It **never produced a summary, so it yields nothing and is not counted as evidence**. The authority is CI, which runs the same suite in 4 shards plus a cross-shard under-collection guard — green on commit 1 and re-run on commit 2.

Cites `olumi-docs/feedback-2026-08-16/STANDING-BRIEF-PREAMBLE.md` — **P2** (consumer check) and **P4** (harness).

**Local affected-area slice** (`src/components/results` + `src/lib/mappers` + the postAnalysisFooter robustness consumer), run to completion at `fe552d6c`: **242 files / 4386 tests, all passed.** This is the local run that did conclude, and it covers every consumer of the two fields in question.

**CI on `fe552d6c`: 13/13 green** — all four Full Test Suite shards, Full Test Suite Summary, TypeScript + Lint, Typecheck Gate Self-Test, Production Build, Security Audit, Staging Gate. `mergeable_state=clean`. Not merged, per brief.

