### PR TITLE
fix(collab): the front door must not assert a session that never existed (P1 first-session honesty)

### DIFF
--- a/src/collab/__tests__/collabFirstRunFriction.spec.tsx
+++ b/src/collab/__tests__/collabFirstRunFriction.spec.tsx
@@ -74,11 +74,18 @@ const GOOD_CODE = 'CODE-THAT-WORKS-a1b2c3'
 const BAD_CODE = 'CODE-THAT-DOES-NOT-WORK-zzzz'
 const OWNER_TOKEN = 'owner-access-token-friction-IDENTITY'
 
-/** The exact sentence the collab seam mints for a credential refusal. Written
- *  here from the user's side, deliberately NOT imported from the product — a
- *  guard that imports its own expectation only proves the code agrees with
- *  itself. */
-const SIGN_IN_COPY = 'Sign in again to open or close a round.'
+/** The two credential sentences, written here from the user's side and
+ *  deliberately NOT imported from the product — a guard that imports its own
+ *  expectation only proves the code agrees with itself.
+ *
+ *  ⚠ SPLIT 17 Aug 2026, AND THIS FILE IS WHY THE DEFECT SURVIVED. There used to
+ *  be ONE constant, `'Sign in again to open or close a round.'`, asserted on
+ *  BOTH the never-signed-in path and the wire-401 path — the same "two
+ *  questions under one name" collapse as the product code, reproduced in the
+ *  expectations. A suite that gives two different states one expected sentence
+ *  cannot notice that one of them is being lied to. */
+const NOT_SIGNED_IN_COPY = 'Sign in to open or close a round.'
+const SESSION_ENDED_COPY = 'Sign in again to open or close a round.'
 
 type StubResponse = Pick<Response, 'ok' | 'status' | 'json'>
 
@@ -314,7 +321,10 @@ describe('F4/F5: a failure is translated into human copy with a next step', () =
     fireEvent.click(screen.getByTestId('panel-mint'))
 
     await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
-    expect(screen.getByTestId('panel-error')).toHaveTextContent(SIGN_IN_COPY)
+    // NEVER SIGNED IN: no request left the browser, so the copy may not say a
+    // session ended. Pinned in full by panelSetupFirstSessionHonesty.spec.tsx.
+    expect(screen.getByTestId('panel-error')).toHaveTextContent(NOT_SIGNED_IN_COPY)
+    expect(screen.getByTestId('panel-error')).not.toHaveTextContent(SESSION_ENDED_COPY)
     expect(screen.getByTestId('panel-error-guidance')).toBeInTheDocument()
 
     // F5: the affordance the message presupposed but never provided.
@@ -339,7 +349,9 @@ describe('F4/F5: a failure is translated into human copy with a next step', () =
     fireEvent.click(screen.getByTestId('panel-mint'))
 
     await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
-    expect(screen.getByTestId('panel-error')).toHaveTextContent(SIGN_IN_COPY)
+    // THE WIRE SPOKE: a real bearer was sent (the beforeEach signs this owner
+    // in) and refused, so "again" is an observation here.
+    expect(screen.getByTestId('panel-error')).toHaveTextContent(SESSION_ENDED_COPY)
     expect(screen.getByTestId('panel-sign-in')).toBeInTheDocument()
   })
 

--- a/src/collab/__tests__/panelSetupFirstSessionHonesty.spec.tsx
+++ b/src/collab/__tests__/panelSetupFirstSessionHonesty.spec.tsx
@@ -1,0 +1,469 @@
+/**
+ * COLLAB — THE FRONT DOOR MUST NOT ASSERT A SESSION THAT NEVER EXISTED.
+ *
+ * ── THE LIE THIS PINS, WIRE- AND BROWSER-WITNESSED ────────────────────────
+ * Deployed staging `81b5c966`, 17 Aug 2026, fresh context / no storage / no
+ * session (`olumi-docs/witness-collab-2026-08-17/dom/S4-owner-mint-refusal.txt`):
+ * a visitor with NO ACCOUNT filled the whole owner panel form, clicked "Open
+ * the round", and read
+ *
+ *     "Sign in again to open or close a round."
+ *     "Your session has ended. Sign in again in the new tab, then come back
+ *      here and try again — what you have typed on this page is kept."
+ *
+ * They had no session. Nothing ended. And this was NOT a 401 being described:
+ * the capture's `S4.network.json` is `[]` — **ZERO `/bff/collab` requests** —
+ * so no server ever spoke about any session. The client asserted a state it
+ * had not observed.
+ *
+ * ── WHY IT SHIPPED: TWO QUESTIONS UNDER ONE NAME (trap 21) ────────────────
+ * `describeOwnerFailure`'s own header named the two producers apart —
+ * "`sign_in_required` (minted locally, before any request leaves) OR an HTTP
+ * 401 (the server declining the bearer)" — and then answered them in ONE
+ * branch, with copy true only of the second. Both arrived carrying the same
+ * code and the same status, so nothing downstream could tell them apart.
+ *
+ * The two questions:
+ *   • "does this browser hold a credential to send?"  — answered locally, by
+ *     `requireOwnerAccessToken` / `ownerAuthorization`. No request is made, and
+ *     the client learns NOTHING about whether a session ever existed.
+ *   • "did the server accept the credential we sent?"  — answered by the wire.
+ *     A 401 here means a non-empty bearer WAS sent and refused, so "your
+ *     session has ended" is a statement the client observed.
+ *
+ * ── WHAT EACH TEST BINDS, AND WHY IT CANNOT PASS VACUOUSLY ────────────────
+ * Every test PINS ITS OWN PRECONDITION (trap 13b): the never-signed-in tests
+ * assert `/bff/collab` request count === 0 (the witnessed fact that makes the
+ * claim about an unobserved session provable), and the wire twin asserts the
+ * request count === 1 (the server DID speak). A guard that merely read copy
+ * would pass on either branch once the strings happened to line up.
+ *
+ * Assertions bind to the rendered surface by identity — `panel-error`,
+ * `panel-error-guidance`, `panel-sign-in` — never by "some text somewhere".
+ * Expected copy is written here FROM THE USER'S SIDE, deliberately not
+ * imported from the product: a guard that imports its own expectation only
+ * proves the code agrees with itself.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+
+vi.mock('../../lib/supabase', async (importOriginal) => {
+  // Spread the real module rather than hand-list its exports (trap 12). It also
+  // means this spec collects ONLY when the Supabase env vars are set — the
+  // deliberate tripwire, since without them 24 spec files vanish from the run
+  // while the total still prints green.
+  const actual = await importOriginal<typeof import('../../lib/supabase')>()
+  return { ...actual, getSessionIdentity: vi.fn() }
+})
+
+import { getSessionIdentity } from '../../lib/supabase'
+import PanelSetupPage, { describeOwnerFailure } from '../../pages/PanelSetupPage'
+import { CollabRequestError, ownerNotSignedIn, ownerSignInRequired } from '../collabService'
+
+const SCENARIO_ID = 'scn-firstsession-9f2a'
+const OWNER_TOKEN = 'owner-access-token-firstsession-IDENTITY'
+const TYPED_FACTOR = 'factor-witness-probe-17aug'
+
+/** The sentence a NEVER-SIGNED-IN visitor must NOT be told, in any form. */
+const ENDED_CLAIMS = [/session has ended/i, /session has expired/i, /sign in again/i]
+
+type StubResponse = Pick<Response, 'ok' | 'status' | 'json'>
+
+let fetchMock: Mock<[input: RequestInfo | URL, init?: RequestInit], Promise<StubResponse>>
+
+function jsonResponse(body: unknown, status = 200): StubResponse {
+  return { ok: status >= 200 && status < 300, status, json: async () => body }
+}
+
+function renderOwnerPanel(): void {
+  render(
+    <MemoryRouter initialEntries={[`/scenario/${SCENARIO_ID}/panel`]}>
+      <Routes>
+        <Route path="/scenario/:id/panel" element={<PanelSetupPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+/** Exactly the witnessed interaction: fill the form, click "Open the round". */
+function fillFormAndOpen(): void {
+  fireEvent.change(screen.getByTestId('panel-target-id'), { target: { value: TYPED_FACTOR } })
+  fireEvent.change(screen.getByTestId('panel-name-a'), { target: { value: 'Ada' } })
+  fireEvent.change(screen.getByTestId('panel-name-b'), { target: { value: 'Grace' } })
+  fireEvent.click(screen.getByTestId('panel-mint'))
+}
+
+function collabRequests(): Array<[RequestInfo | URL, RequestInit | undefined]> {
+  return fetchMock.mock.calls.filter((c) => String(c[0]).startsWith('/bff/collab')) as Array<
+    [RequestInfo | URL, RequestInit | undefined]
+  >
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  fetchMock = vi.fn(async (input: RequestInfo | URL) =>
+    jsonResponse({ code: 'not_stubbed', message: String(input) }, 404),
+  )
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  localStorage.clear()
+})
+
+describe('a visitor who never signed in is not told their session ended', () => {
+  it('WITNESSED STATE: no session, form submitted → no request leaves, and the copy claims no session ever existed', async () => {
+    // The witnessed state-class: fresh, never signed in. `getSessionIdentity`
+    // returns nulls for "never signed in", for "the session is gone", and for
+    // "getSession itself errored" alike — so the honest copy must be true of
+    // all three, and may assert only what THIS CLIENT observed.
+    vi.mocked(getSessionIdentity).mockResolvedValue({ userId: null, accessToken: null })
+
+    renderOwnerPanel()
+    fillFormAndOpen()
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+
+    // ⭐ THE PRECONDITION, PINNED IN-TEST. This is the witness's own decisive
+    // measurement (`S4.network.json === []`). Without it the copy assertions
+    // below would be a claim about strings; with it they are a claim about a
+    // state the client provably never observed.
+    expect(collabRequests()).toHaveLength(0)
+
+    const guidance = screen.getByTestId('panel-error-guidance')
+    for (const claim of ENDED_CLAIMS) {
+      expect(guidance).not.toHaveTextContent(claim)
+      // The headline carried the falsehood too — "Sign in AGAIN" asserts a
+      // prior session just as much as the guidance does.
+      expect(screen.getByTestId('panel-error')).not.toHaveTextContent(claim)
+    }
+
+    // POSITIVE HALF: an empty or vanished guidance would satisfy every
+    // negative above. The copy must actually say the honest thing.
+    expect(guidance).toHaveTextContent(/no signed-in session in this browser/i)
+    expect(guidance).toHaveTextContent(/nothing was sent/i)
+    expect(screen.getByTestId('panel-error')).toHaveTextContent(
+      /sign in to open or close a round/i,
+    )
+  })
+
+  it('the sign-in affordance is still rendered — this is an invitation, not a dead end', async () => {
+    vi.mocked(getSessionIdentity).mockResolvedValue({ userId: null, accessToken: null })
+
+    renderOwnerPanel()
+    fillFormAndOpen()
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    expect(screen.getByTestId('panel-sign-in')).toBeInTheDocument()
+    // A credential refusal shows no server detail: there is no server sentence.
+    expect(screen.queryByTestId('panel-error-detail')).toBeNull()
+  })
+
+  it('the promise the copy makes is kept: what was typed survives the refusal', async () => {
+    vi.mocked(getSessionIdentity).mockResolvedValue({ userId: null, accessToken: null })
+
+    renderOwnerPanel()
+    fillFormAndOpen()
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    // The guidance tells the visitor to come back and try again because their
+    // typing is kept. A page that cleared the form would make it a second lie.
+    expect(screen.getByTestId('panel-target-id')).toHaveValue(TYPED_FACTOR)
+    expect(screen.getByTestId('panel-name-a')).toHaveValue('Ada')
+  })
+})
+
+describe('DIFFERENT OBJECT: a wire 401 keeps the session-expired copy', () => {
+  it('a bearer WAS sent and refused → "your session has ended" is a state the client observed', async () => {
+    vi.mocked(getSessionIdentity).mockResolvedValue({
+      userId: 'user-abc',
+      accessToken: OWNER_TOKEN,
+    })
+    // CEE's own code for a refused owner bearer, measured on the deployed wire
+    // (witness `probes/gate-probe.txt`, request A): 401 `sign_in_required`.
+    fetchMock.mockImplementation(async (input) =>
+      String(input) === '/bff/collab/rounds'
+        ? jsonResponse(
+            { code: 'sign_in_required', message: 'That token could not be verified.' },
+            401,
+          )
+        : jsonResponse({ code: 'not_stubbed', message: String(input) }, 404),
+    )
+
+    renderOwnerPanel()
+    fillFormAndOpen()
+
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+
+    // ⭐ THE MIRROR PRECONDITION: the request WAS issued with a real bearer, so
+    // the server's refusal is an observation, not an inference. Bound to the
+    // mint URL by identity, and to the exact token — "some call happened"
+    // would be satisfied by the branch under test in the other describe.
+    const sent = collabRequests()
+    expect(sent).toHaveLength(1)
+    expect(String(sent[0][0])).toBe('/bff/collab/rounds')
+    expect(
+      (sent[0][1]?.headers as Record<string, string> | undefined)?.Authorization,
+    ).toBe(`Bearer ${OWNER_TOKEN}`)
+
+    expect(screen.getByTestId('panel-error-guidance')).toHaveTextContent(
+      /your session has ended\. sign in again/i,
+    )
+    expect(screen.getByTestId('panel-sign-in')).toBeInTheDocument()
+  })
+})
+
+describe('THE PAIR: the two answers are not the same answer', () => {
+  it('the never-signed-in copy and the wire-401 copy differ, in headline and in guidance', async () => {
+    vi.mocked(getSessionIdentity).mockResolvedValue({ userId: null, accessToken: null })
+    renderOwnerPanel()
+    fillFormAndOpen()
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    const localTitle = screen.getByTestId('panel-error').textContent ?? ''
+    const localGuidance = screen.getByTestId('panel-error-guidance').textContent ?? ''
+
+    // A second, independent mount for the wire branch: re-collapsing the two
+    // branches makes these four strings equal, and THAT is what this asserts —
+    // directly, rather than through either branch's own copy. `cleanup()`
+    // unmounts the first tree properly; detaching the node by hand left React
+    // committing into an orphan and threw inside the router.
+    cleanup()
+    vi.mocked(getSessionIdentity).mockResolvedValue({
+      userId: 'user-abc',
+      accessToken: OWNER_TOKEN,
+    })
+    fetchMock.mockImplementation(async (input) =>
+      String(input) === '/bff/collab/rounds'
+        ? jsonResponse(
+            { code: 'sign_in_required', message: 'That token could not be verified.' },
+            401,
+          )
+        : jsonResponse({ code: 'not_stubbed', message: String(input) }, 404),
+    )
+    renderOwnerPanel()
+    fillFormAndOpen()
+    await waitFor(() => expect(screen.getByTestId('panel-error')).toBeInTheDocument())
+    const wireTitle = screen.getByTestId('panel-error').textContent ?? ''
+    const wireGuidance = screen.getByTestId('panel-error-guidance').textContent ?? ''
+
+    expect(localGuidance).not.toBe('')
+    expect(wireGuidance).not.toBe('')
+    expect(localGuidance).not.toBe(wireGuidance)
+    expect(localTitle).not.toBe(wireTitle)
+  })
+})
+
+/* ══ THE STRUCTURAL HALF ═══════════════════════════════════════════════════
+ * P5 is structural, not advisory: the product may not assert a state it did not
+ * observe, and a contradicting signal in the same payload must make the claim
+ * IMPOSSIBLE. The three tests above bind the two branches a user reaches today.
+ * They cannot stop a THIRD branch, added next month, retyping the sentence.
+ *
+ * This block can. It walks the predicate's WHOLE DOMAIN and asserts the rule as
+ * a property: no failure that lacks a server answer may carry session-history
+ * language. Because `observation` is a REQUIRED field, a new branch cannot dodge
+ * it — declaring `nothing-was-sent` or `unknown` enrols it in this invariant
+ * automatically, and declaring `server-answered` falsely is itself caught below
+ * by comparing the declaration against the error's own provenance.
+ *
+ * ⚠ THE PREDICATE OVER LANGUAGE IS THE RISK HERE (trap 22), so it is bounded
+ * three ways: the patterns match session-HISTORY PHRASES, never bare words
+ * ("try again" is honest and appears in copy that must pass); the corpus comes
+ * from outside this author — the two sentences the DEPLOYED build emitted, plus
+ * the wire codes the estate's other specs and the live gate probe have actually
+ * produced; and every case has its opposite-direction twin, since the detector
+ * must both find the claim where it belongs and miss it where it does not.
+ */
+
+/** Phrases that CLAIM a session existed and has now ended. */
+const SESSION_HISTORY_CLAIMS: ReadonlyArray<RegExp> = [
+  /sign(?:ed|ing)?[- ]in again/i,
+  /sign in again/i,
+  /session (?:has |had |is )?(?:ended|expired|timed out|over|no longer valid)/i,
+  /(?:signed|logged) out/i,
+  /your session/i,
+]
+
+function claimsSessionHistory(text: string): boolean {
+  return SESSION_HISTORY_CLAIMS.some((p) => p.test(text))
+}
+
+/** A wire failure exactly as `parseError` builds one from a real response. */
+function wireError(code: string, status: number, message: string): CollabRequestError {
+  return new CollabRequestError({ code, message, status })
+}
+
+/**
+ * The domain, with each member's TRUE provenance stated independently of what
+ * the product declares — that independence is what lets the declaration be
+ * checked rather than trusted.
+ *
+ * The wire members are the codes this estate has actually observed: CEE's live
+ * `sign_in_required` / `collab_token_invalid` (17 Aug gate probe, requests A and
+ * C), `collab_owner_only` and the caller-key `FORBIDDEN` (403 spec),
+ * `collab_round_open` / `collab_round_closed` (close-copy spec),
+ * `collab_round_invalid` (friction spec), `expired_token`, `parseError`'s own
+ * `collab_request_failed` default for a non-JSON body, and a code-less 502 from
+ * the edge.
+ */
+const DOMAIN: ReadonlyArray<{
+  name: string
+  err: unknown
+  /** What actually happened, derived from the producer — not read off the result. */
+  truth: 'server-answered' | 'nothing-was-sent' | 'unknown'
+}> = [
+  // Minted by the seam itself, so this member cannot drift from the product.
+  { name: 'local mint: ownerNotSignedIn()', err: ownerNotSignedIn(), truth: 'nothing-was-sent' },
+  { name: 'wire 401 sign_in_required', err: ownerSignInRequired(), truth: 'server-answered' },
+  {
+    name: 'wire 401 collab_token_invalid',
+    err: wireError('collab_token_invalid', 401, 'That token could not be verified.'),
+    truth: 'server-answered',
+  },
+  {
+    name: 'wire 401 expired_token',
+    err: wireError('expired_token', 401, 'Your session has expired. Sign in again and retry.'),
+    truth: 'server-answered',
+  },
+  {
+    name: 'wire 403 collab_owner_only',
+    err: wireError('collab_owner_only', 403, 'No round you own with that id.'),
+    truth: 'server-answered',
+  },
+  {
+    name: 'wire 403 FORBIDDEN (caller-key plugin)',
+    err: wireError('FORBIDDEN', 403, 'Forbidden'),
+    truth: 'server-answered',
+  },
+  {
+    name: 'wire 409 collab_round_open',
+    err: wireError('collab_round_open', 409, 'The round is still open.'),
+    truth: 'server-answered',
+  },
+  {
+    name: 'wire 409 collab_round_closed',
+    err: wireError('collab_round_closed', 409, 'That round is closed.'),
+    truth: 'server-answered',
+  },
+  {
+    name: 'wire 422 collab_round_invalid',
+    err: wireError('collab_round_invalid', 422, 'targets[0].id is not a known factor'),
+    truth: 'server-answered',
+  },
+  {
+    name: 'wire 500 collab_request_failed (parseError default, non-JSON body)',
+    err: wireError('collab_request_failed', 500, 'Something went wrong. Please try again.'),
+    truth: 'server-answered',
+  },
+  {
+    name: 'wire 429 with an unknown code',
+    err: wireError('rate_limited', 429, 'Too many requests.'),
+    truth: 'server-answered',
+  },
+  {
+    name: 'wire 502 code-less origin refusal',
+    err: wireError('collab_request_failed', 502, 'Bad gateway'),
+    truth: 'server-answered',
+  },
+  // Not a CollabRequestError at all: a rejected fetch (offline / CORS), and a
+  // JSON parse failure. Neither tells the client whether anything was answered.
+  { name: 'rejected fetch (TypeError)', err: new TypeError('Failed to fetch'), truth: 'unknown' },
+  { name: 'JSON parse failure', err: new SyntaxError('Unexpected end of JSON input'), truth: 'unknown' },
+  { name: 'a thrown non-Error', err: 'something odd', truth: 'unknown' },
+]
+
+describe('STRUCTURAL: no failure without a server answer may claim a session ended', () => {
+  it('POSITIVE CONTROL: the detector finds the claim in the exact sentences the deployed build emitted', () => {
+    // Without this, every negative assertion below could be passing because the
+    // patterns match nothing at all. These two strings are the witness's own
+    // capture from deployed `81b5c966`.
+    expect(claimsSessionHistory('Sign in again to open or close a round.')).toBe(true)
+    expect(
+      claimsSessionHistory(
+        'Your session has ended. Sign in again in the new tab, then come back here and try again — what you have typed on this page is kept.',
+      ),
+    ).toBe(true)
+  })
+
+  it('CONTRAST CONTROL: the detector does NOT fire on honest copy that merely says "try again"', () => {
+    // The opposite direction, and the reason the patterns are phrases: a
+    // detector that matched the bare word "again" would condemn every honest
+    // retry sentence in this file, and a lane would then loosen it to nothing.
+    expect(
+      claimsSessionHistory(
+        'We found no signed-in session in this browser, so nothing was sent. Sign in in the new tab, then come back here and try again — what you have typed on this page is kept.',
+      ),
+    ).toBe(false)
+    expect(
+      claimsSessionHistory(
+        'Something went wrong before we heard back. Check your connection and try again — nothing has been sent to anyone.',
+      ),
+    ).toBe(false)
+    expect(
+      claimsSessionHistory(
+        'The round is still open. Try again in a moment — nobody has seen anything they should not.',
+      ),
+    ).toBe(false)
+  })
+
+  it('the domain corpus is non-empty and covers both non-answered provenances', () => {
+    // An empty or single-provenance corpus would make the property vacuous.
+    expect(DOMAIN.length).toBeGreaterThanOrEqual(15)
+    expect(DOMAIN.filter((d) => d.truth === 'nothing-was-sent').length).toBeGreaterThanOrEqual(1)
+    expect(DOMAIN.filter((d) => d.truth === 'unknown').length).toBeGreaterThanOrEqual(3)
+    expect(DOMAIN.filter((d) => d.truth === 'server-answered').length).toBeGreaterThanOrEqual(10)
+  })
+
+  it.each(['open', 'close'] as const)(
+    'action=%s — every branch declares its provenance TRUTHFULLY, and only an answered one may name a session',
+    (action) => {
+      for (const member of DOMAIN) {
+        const failure = describeOwnerFailure(member.err, action)
+
+        // 1. THE DECLARATION IS CHECKED, NOT TRUSTED. Re-collapsing the two
+        //    credential branches routes the local mint into the wire branch,
+        //    which declares `server-answered` — and this comparison REDs on it
+        //    even before any copy is read.
+        expect(failure.observation, `${member.name} declared the wrong provenance`).toBe(
+          member.truth,
+        )
+
+        // 2. Nothing may be empty: a blank title or guidance would satisfy
+        //    every negative below by saying nothing at all.
+        expect(failure.title.trim(), `${member.name} title`).not.toBe('')
+        expect(failure.guidance.trim(), `${member.name} guidance`).not.toBe('')
+
+        if (member.truth === 'server-answered') continue
+
+        // 3. THE PROPERTY. No session-history claim anywhere a user can read it.
+        expect(
+          claimsSessionHistory(failure.title),
+          `${member.name}: title claims a session ended without one being observed`,
+        ).toBe(false)
+        expect(
+          claimsSessionHistory(failure.guidance),
+          `${member.name}: guidance claims a session ended without one being observed`,
+        ).toBe(false)
+        expect(
+          claimsSessionHistory(failure.detail ?? ''),
+          `${member.name}: detail claims a session ended without one being observed`,
+        ).toBe(false)
+
+        // 4. A SERVER'S WORDS CANNOT BE QUOTED IF NO SERVER SPOKE.
+        expect(failure.detail, `${member.name} must carry no server detail`).toBeNull()
+      }
+    },
+  )
+
+  it('DISCRIMINATION: the invariant is not vacuous — the answered branches DO name a session', () => {
+    // If the property above held for every member, it would prove nothing about
+    // the discrimination. The wire-401 branch must still say "again": that is
+    // where the sentence is TRUE, and a fix that scrubbed it everywhere would
+    // have traded a lie for a different lie.
+    const wire = describeOwnerFailure(ownerSignInRequired(), 'open')
+    expect(wire.observation).toBe('server-answered')
+    expect(claimsSessionHistory(wire.title) || claimsSessionHistory(wire.guidance)).toBe(true)
+  })
+})

--- a/src/collab/__tests__/panelSetupFirstSessionHonesty.spec.tsx
+++ b/src/collab/__tests__/panelSetupFirstSessionHonesty.spec.tsx
@@ -47,6 +47,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from 'vitest'
 import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { stripComments } from '../../../tests/helpers/stripSourceComments'
 
 vi.mock('../../lib/supabase', async (importOriginal) => {
   // Spread the real module rather than hand-list its exports (trap 12). It also
@@ -261,12 +264,32 @@ describe('THE PAIR: the two answers are not the same answer', () => {
  * IMPOSSIBLE. The three tests above bind the two branches a user reaches today.
  * They cannot stop a THIRD branch, added next month, retyping the sentence.
  *
- * This block can. It walks the predicate's WHOLE DOMAIN and asserts the rule as
- * a property: no failure that lacks a server answer may carry session-history
- * language. Because `observation` is a REQUIRED field, a new branch cannot dodge
+ * This block can. It walks the predicate's DOMAIN AS PINNED BELOW and asserts
+ * the rule as a property: no failure that lacks a server answer may carry
+ * session-history language, and a `server-answered` declaration is checked
+ * against the error's own provenance rather than trusted.
+ *
+ * ⚠ AN EARLIER VERSION OF THIS PARAGRAPH CLAIMED A GUARANTEE NOBODY ENFORCED,
+ * and it is worth saying exactly what was wrong because the shape recurs. It
+ * read: "Because `observation` is a REQUIRED field, a new branch cannot dodge
  * it — declaring `nothing-was-sent` or `unknown` enrols it in this invariant
- * automatically, and declaring `server-answered` falsely is itself caught below
- * by comparing the declaration against the error's own provenance.
+ * automatically." The first half is true and the second does not follow. The
+ * REQUIRED field forces a new branch to DECLARE an observation; it does nothing
+ * to make that branch REACHED. `DOMAIN` is a hand-written corpus, so a branch
+ * keyed on a code no member carries is simply never executed — declared,
+ * unenrolled, and invisible to every assertion here. A comment describing a
+ * guarantee nothing implements is this estate's hand-maintained mirror (trap
+ * 12), and it is at its most expensive in a spec header, where the next reader
+ * takes it as the reason not to look.
+ *
+ * SO THE CLAIM IS NOW IMPLEMENTED RATHER THAN ASSERTED. `COMPLETENESS` below
+ * harvests every `err.code === '<literal>'` branch from `describeOwnerFailure`'s
+ * own SOURCE and requires `DOMAIN` to carry an error for each one — so adding a
+ * branch without adding its corpus member REDs here. Its scope, stated
+ * precisely (trap 20): it harvests CODE-KEYED branches from that one function.
+ * It does not see the `err.status === 401` arm, the `action === 'close'`
+ * conjunct, or any branch reached some other way; those remain covered only by
+ * the corpus members that exercise them.
  *
  * ⚠ THE PREDICATE OVER LANGUAGE IS THE RISK HERE (trap 22), so it is bounded
  * three ways: the patterns match session-HISTORY PHRASES, never bare words
@@ -374,7 +397,99 @@ const DOMAIN: ReadonlyArray<{
   { name: 'a thrown non-Error', err: 'something odd', truth: 'unknown' },
 ]
 
+/* ── THE DERIVED HALF: make the completeness claim TRUE, not merely accurate ──
+ *
+ * `DOMAIN` above is hand-written, which is what lets it state each member's
+ * provenance independently of the product — the property that makes the
+ * declaration checkable rather than trusted. That strength is also its hole: a
+ * hand-written corpus goes silently short the day someone adds a branch.
+ *
+ * So the corpus is checked against a FRESH DERIVATION of the branches it is
+ * supposed to cover, harvested from `describeOwnerFailure`'s source text. The
+ * harvest is deliberately NOT derived from `DOMAIN`, and `DOMAIN` is
+ * deliberately not generated from the harvest: a pin computed from the thing it
+ * validates can only ever agree with itself (trap 13b).
+ */
+const PANEL_SETUP_SOURCE = resolve(process.cwd(), 'src', 'pages', 'PanelSetupPage.tsx')
+
+/**
+ * The source text of `describeOwnerFailure` alone, comments stripped.
+ *
+ * Sliced to the one function rather than scanning the file: `PanelSetupPage`
+ * has other error handling, and a whole-file harvest would demand corpus
+ * members for branches this invariant does not govern. Comments are stripped so
+ * a code named in PROSE — several are, in the branch commentary — cannot be
+ * harvested as a branch that does not exist.
+ *
+ * Both failure modes throw rather than returning empty: an extractor that
+ * silently produces nothing agrees with every assertion made about it, which is
+ * the absence-probe-with-no-positive-control defect (trap 13).
+ */
+function describeOwnerFailureSource(): string {
+  const full = readFileSync(PANEL_SETUP_SOURCE, 'utf8')
+  const start = full.indexOf('export function describeOwnerFailure')
+  if (start === -1) {
+    throw new Error(
+      `describeOwnerFailure not found in ${PANEL_SETUP_SOURCE} — it was renamed, moved, or ` +
+        'stopped being exported. This harvest is pointed at the wrong bytes; fix the pointer, ' +
+        'do not delete the guard.',
+    )
+  }
+  // The closing brace of a top-level function declaration is the first `}` at
+  // column 0 after its start; every nested brace in this function is indented.
+  const end = full.indexOf('\n}\n', start)
+  if (end === -1) {
+    throw new Error('could not find the end of describeOwnerFailure — the slice would be wrong')
+  }
+  const body = full.slice(start, end)
+  if (body.trim() === '') throw new Error('describeOwnerFailure sliced to an empty string')
+  return stripComments(body, 'PanelSetupPage.tsx')
+}
+
+/** Every `err.code === '<literal>'` branch in that function, deduped and sorted. */
+const HARVESTED_CODE_BRANCHES: readonly string[] = [
+  ...new Set(
+    [...describeOwnerFailureSource().matchAll(/err\.code === '([A-Za-z0-9_]+)'/g)].map(
+      (m) => m[1],
+    ),
+  ),
+].sort()
+
 describe('STRUCTURAL: no failure without a server answer may claim a session ended', () => {
+  it('COMPLETENESS: every err.code branch in describeOwnerFailure has a corpus member (harvested from source)', () => {
+    // ── POSITIVE CONTROL: the harvest can see SOMETHING, at a plausible
+    // magnitude. A count alone is not enough (trap 13e) — an extractor reading
+    // the wrong bytes returns a clean, confident zero, and zero uncovered
+    // branches out of zero harvested branches passes every assertion below.
+    expect(
+      HARVESTED_CODE_BRANCHES.length,
+      'the harvest found no code-keyed branches at all — it is reading the wrong bytes',
+    ).toBeGreaterThanOrEqual(4)
+    expect(HARVESTED_CODE_BRANCHES).toContain('not_signed_in')
+    expect(HARVESTED_CODE_BRANCHES).toContain('sign_in_required')
+
+    const corpusCodes = new Set(
+      DOMAIN.map((d) => d.err)
+        .filter((e): e is CollabRequestError => e instanceof CollabRequestError)
+        .map((e) => e.code),
+    )
+
+    // ── CONTRAST CONTROL: the harvest DISCRIMINATES, it does not just echo the
+    // corpus. `collab_round_closed` is in DOMAIN and is deliberately NOT a
+    // branch here (the close call site falls through to the reveal), so a
+    // harvest that had degenerated into "return the corpus" fails this line.
+    expect(corpusCodes.has('collab_round_closed')).toBe(true)
+    expect(HARVESTED_CODE_BRANCHES).not.toContain('collab_round_closed')
+
+    const uncovered = HARVESTED_CODE_BRANCHES.filter((code) => !corpusCodes.has(code))
+    expect(
+      uncovered,
+      'describeOwnerFailure branches on these codes and DOMAIN carries no error for them, so ' +
+        'the honesty invariant never executes those branches. Add a member to DOMAIN stating ' +
+        "the branch's TRUE provenance — do not delete the branch or loosen this guard.",
+    ).toEqual([])
+  })
+
   it('POSITIVE CONTROL: the detector finds the claim in the exact sentences the deployed build emitted', () => {
     // Without this, every negative assertion below could be passing because the
     // patterns match nothing at all. These two strings are the witness's own

--- a/src/collab/__tests__/panelSetupOwnerAuth.spec.tsx
+++ b/src/collab/__tests__/panelSetupOwnerAuth.spec.tsx
@@ -62,8 +62,17 @@ const ROUND_ID = 'rnd-66666666-7777-8888-9999-aaaaaaaaaaaa'
 
 /** The exact sentence a signed-out owner must see. Written here from the
  *  user's side, deliberately NOT imported from the product — a guard that
- *  imports its own expectation only proves the code agrees with itself. */
-const SIGN_IN_COPY = 'Sign in again to open or close a round.'
+ *  imports its own expectation only proves the code agrees with itself.
+ *
+ *  ⚠ CORRECTED 17 Aug 2026. This constant used to read "Sign in AGAIN to open
+ *  or close a round." — and so this file was PINNING A FALSEHOOD: the path it
+ *  drives is a visitor with NO SESSION, and "again" asserts a prior one. The
+ *  local mint and the wire's 401 shared one code, so nothing could tell them
+ *  apart; they are now `not_signed_in` and `sign_in_required` respectively
+ *  (`panelSetupFirstSessionHonesty.spec.tsx` pins the pair). The "again"
+ *  sentence still exists and is still asserted — on the wire branch, where it
+ *  is true. */
+const SIGN_IN_COPY = 'Sign in to open or close a round.'
 
 const MINT_URL = '/bff/collab/rounds'
 const CLOSE_URL = `/bff/collab/rounds/${ROUND_ID}/close`
@@ -257,22 +266,27 @@ describe('a signed-out owner is told so, and NO request is issued', () => {
 })
 
 describe('the collab seam refuses to build an empty bearer — the choke point', () => {
-  it('mintRound throws sign_in_required and issues no request', async () => {
+  // ⚠ THE CODE HERE IS `not_signed_in`, NOT `sign_in_required` (17 Aug 2026).
+  // These three assert the LOCAL mint — nothing has been sent, so nothing has
+  // been declined, and the code must not be the one the WIRE uses to say it
+  // declined a bearer. Sharing one code is how the page came to tell a visitor
+  // with no account that their session had ended.
+  it('mintRound throws not_signed_in and issues no request', async () => {
     await expect(
       mintRound('', { scenarioId: SCENARIO_ID, contextNote: null, targets: [], participants: [] }),
-    ).rejects.toMatchObject({ name: 'CollabRequestError', code: 'sign_in_required', status: 401 })
+    ).rejects.toMatchObject({ name: 'CollabRequestError', code: 'not_signed_in', status: 401 })
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('closeRound throws sign_in_required and issues no request', async () => {
+  it('closeRound throws not_signed_in and issues no request', async () => {
     await expect(closeRound('', ROUND_ID)).rejects.toBeInstanceOf(CollabRequestError)
-    await expect(closeRound('', ROUND_ID)).rejects.toMatchObject({ code: 'sign_in_required' })
+    await expect(closeRound('', ROUND_ID)).rejects.toMatchObject({ code: 'not_signed_in' })
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
-  it('fetchOwnerReveal throws sign_in_required and issues no request', async () => {
+  it('fetchOwnerReveal throws not_signed_in and issues no request', async () => {
     await expect(fetchOwnerReveal('', ROUND_ID)).rejects.toMatchObject({
-      code: 'sign_in_required',
+      code: 'not_signed_in',
       status: 401,
     })
     expect(fetchMock).not.toHaveBeenCalled()

--- a/src/collab/collabService.ts
+++ b/src/collab/collabService.ts
@@ -341,8 +341,42 @@ export async function fetchParticipantDisagreement(roundId: string): Promise<Dis
 /* ── owner ───────────────────────────────────────────────────────────────── */
 
 /**
- * The one place an owner-credential refusal is minted, so every path a user can
+ * ⭐⭐ TWO QUESTIONS, TWO NAMES — and they were ONE name until 17 Aug 2026.
+ *
+ * A credential refusal on the owner path has two producers, answering different
+ * questions, and for a while both minted `sign_in_required` at status 401:
+ *
+ *   • `ownerNotSignedIn()` — "does this browser hold a credential to send?"
+ *     Answered HERE, locally, before any request leaves. When the answer is no,
+ *     the client has observed NOTHING about whether a session ever existed.
+ *   • `ownerSignInRequired()` — "did the server accept the credential we sent?"
+ *     Answered by the WIRE (401 from CEE's `requireOwnerUser`). Reaching it
+ *     proves a non-empty bearer WAS sent and refused.
+ *
+ * Because both carried one code, `PanelSetupPage` could not tell them apart and
+ * told a visitor with NO ACCOUNT "Your session has ended" — browser-witnessed
+ * on deployed `81b5c966` with `S4.network.json === []`, i.e. zero requests, so
+ * no server had said anything about any session. Naming the concepts apart is
+ * the fix; aligning the copy would only have picked which half to lie to.
+ *
+ * ⚠ `status: 401` on the local mint is the status this refusal CORRESPONDS to,
+ * never an observation — no response was received. Discriminate on the CODE.
+ */
+export function ownerNotSignedIn(): CollabRequestError {
+  return new CollabRequestError({
+    code: 'not_signed_in',
+    message: 'Sign in to open or close a round.',
+    status: 401,
+  })
+}
+
+/**
+ * The WIRE's credential refusal, described in one place so every path a user can
  * hit says the same sentence. `PanelSetupPage` renders `.message` verbatim.
+ *
+ * ⚠ NOT the local mint — see `ownerNotSignedIn()` above. "Sign in AGAIN" is a
+ * claim about a session that existed, and it is true only once the server has
+ * declined a bearer this browser actually sent.
  */
 export function ownerSignInRequired(): CollabRequestError {
   return new CollabRequestError({
@@ -376,7 +410,10 @@ export function ownerSignInRequired(): CollabRequestError {
  * it at all until those ratchets existed.
  */
 function ownerAuthorization(accessToken: string): string {
-  if (accessToken.trim() === '') throw ownerSignInRequired()
+  // ⚠ `ownerNotSignedIn`, NOT `ownerSignInRequired`: nothing has been sent, so
+  // nothing has been declined. This throw is the client refusing to send an
+  // empty bearer — it is not a report of anything the server said.
+  if (accessToken.trim() === '') throw ownerNotSignedIn()
   return `Bearer ${accessToken}`
 }
 

--- a/src/collab/ownerAccessToken.ts
+++ b/src/collab/ownerAccessToken.ts
@@ -44,10 +44,19 @@
  */
 
 import { getSessionIdentity } from '../lib/supabase'
-import { ownerSignInRequired } from './collabService'
+import { ownerNotSignedIn } from './collabService'
 
+/**
+ * ⚠ WHAT THE THROW MAY AND MAY NOT CLAIM. `getSessionIdentity()` returns a null
+ * token for THREE different worlds — never signed in, a session that has gone,
+ * and `getSession()` itself erroring — and this function cannot tell them
+ * apart. So it throws `ownerNotSignedIn()`, whose copy is true of all three and
+ * asserts only what was observed here: no credential was available to send.
+ * `ownerSignInRequired()` ("sign in AGAIN") would assert a prior session, which
+ * is exactly the falsehood a visitor with no account was shown on `81b5c966`.
+ */
 export async function requireOwnerAccessToken(): Promise<string> {
   const { accessToken } = await getSessionIdentity()
-  if (accessToken === null || accessToken.trim() === '') throw ownerSignInRequired()
+  if (accessToken === null || accessToken.trim() === '') throw ownerNotSignedIn()
   return accessToken
 }

--- a/src/pages/PanelSetupPage.tsx
+++ b/src/pages/PanelSetupPage.tsx
@@ -48,6 +48,7 @@ import {
   fetchOwnerDisagreement,
   fetchOwnerReveal,
   mintRound,
+  ownerNotSignedIn,
   ownerSignInRequired,
   participantLink,
   type MintedRound,
@@ -80,9 +81,57 @@ const FIELD =
  */
 const SIGN_IN_SENTENCE = ownerSignInRequired().message
 
+/**
+ * ⚠ THE OTHER credential sentence, and it is a DIFFERENT ONE — see the seam's
+ * header. `ownerNotSignedIn()` is minted when this browser holds no credential
+ * to send; `ownerSignInRequired()` describes the wire declining one it sent.
+ * Both are derived here rather than retyped, for the same reason as above.
+ */
+const NOT_SIGNED_IN_SENTENCE = ownerNotSignedIn().message
+
 type OwnerAction = 'open' | 'close'
 
-interface OwnerFailure {
+/**
+ * ⭐⭐ DID A SERVER SAY ANYTHING? — the field that makes the 17 Aug lie
+ * UNREPRESENTABLE rather than merely discouraged (P5, structural).
+ *
+ * The defect was not bad copy. It was copy asserting a state THE CLIENT HAD NOT
+ * OBSERVED — "your session has ended" on a click that sent zero requests. Copy
+ * alone cannot be defended by review: any future branch can retype the sentence.
+ * So every branch must now DECLARE its provenance, and two mechanisms bind that
+ * declaration to what the user is allowed to be told:
+ *
+ *   • THE TYPE. `observation` is required, so a new branch cannot be added
+ *     without answering the question. There is no default to fall into.
+ *   • A DERIVED INVARIANT over the WHOLE domain
+ *     (`panelSetupFirstSessionHonesty.spec.tsx`): any failure that did not come
+ *     from a server answer must carry NO session-history claim, checked by
+ *     iterating the seam's producers rather than a hand-listed pair of cases —
+ *     so a branch added later is covered the moment it declares.
+ *
+ * And the renderer is bound to it too: a server's own words may only be shown
+ * when a server actually spoke.
+ */
+type ServerObservation =
+  /** A response was received and parsed (`parseError`) — the server spoke. */
+  | 'server-answered'
+  /** Refused locally, before any request left the browser. Nothing was heard. */
+  | 'nothing-was-sent'
+  /** A throw that is not a `CollabRequestError`: a rejected fetch, or a parse
+   *  failure AFTER an earlier request in the same action had succeeded. Whether
+   *  anything was answered is genuinely unknown, and unknown may not be
+   *  narrated as if it were observed. */
+  | 'unknown'
+
+/**
+ * ⚠ EXPORTED FOR THE INVARIANT, AND ONLY FOR IT. The rendered-surface tests
+ * still drive the real page through a real click — they are what prove the user
+ * sees this. But an invariant has to cover the predicate's WHOLE DOMAIN, and a
+ * dozen wire codes through a dozen renders would neither be affordable nor
+ * complete. The honesty rule is a property of this pure function, so it is
+ * asserted on this pure function.
+ */
+export interface OwnerFailure {
   /** The headline. Human, and for a credential refusal the seam's own sentence. */
   title: string
   /** What to do next — the part the witness found missing entirely. */
@@ -91,14 +140,18 @@ interface OwnerFailure {
   credential: boolean
   /** The server's own words, shown as secondary detail — never as the message. */
   detail: string | null
+  /** ⚠ NOT decoration and NOT dead: read by the renderer below and by the
+   *  derived honesty invariant. See `ServerObservation`. */
+  observation: ServerObservation
 }
 
 /**
  * Translate a failure into something an owner can act on.
  *
- * ⚠ THE PREDICATE'S DOMAIN, NOT JUST THE CASE IN HAND. A credential refusal is
- * `sign_in_required` (minted locally, before any request leaves) OR an HTTP
- * 401 (the server declining the bearer). 403 IS NOT ONE OF THEM: at CEE's
+ * ⚠ THE PREDICATE'S DOMAIN, NOT JUST THE CASE IN HAND. A credential refusal has
+ * TWO producers answering DIFFERENT QUESTIONS, and this function collapsed them
+ * into one branch until 17 Aug 2026 — see the `not_signed_in` branch below and
+ * `ownerNotSignedIn()`'s header at the seam. 403 IS NOT ONE OF THEM: at CEE's
  * bytes (`route-support.ts` `replyForRefusal`) the only refusal code that
  * answers 403 is `collab_owner_only`, and the service mints it AFTER the
  * bearer has been accepted — a bad bearer 401s in `requireOwnerUser` before
@@ -114,7 +167,7 @@ interface OwnerFailure {
  * edge proxy answers a code-less origin refusal), and for those the honest
  * answer is the unknown-state fallback carrying the server's own words.
  */
-function describeOwnerFailure(err: unknown, action: OwnerAction): OwnerFailure {
+export function describeOwnerFailure(err: unknown, action: OwnerAction): OwnerFailure {
   const fallbackTitle =
     action === 'open' ? 'We could not open the round.' : 'We could not close the round.'
 
@@ -125,9 +178,44 @@ function describeOwnerFailure(err: unknown, action: OwnerAction): OwnerFailure {
         'Something went wrong before we heard back. Check your connection and try again — nothing has been sent to anyone.',
       credential: false,
       detail: null,
+      observation: 'unknown',
     }
   }
 
+  // ⭐ NEVER SIGNED IN — checked FIRST, because this error also carries 401 and
+  // the wire branch below would otherwise swallow it (that swallow WAS the
+  // defect). `not_signed_in` is minted only locally, by `ownerNotSignedIn()`,
+  // and reaching it proves NO REQUEST WAS SENT: the client has heard nothing
+  // from any server about any session, so it may not say one has ended.
+  //
+  // Browser-witnessed on deployed `81b5c966`, 17 Aug 2026: a visitor with no
+  // account filled this form, clicked "Open the round", and was told "Your
+  // session has ended" / "Sign in again" while the capture's request log for
+  // the collab seam was EMPTY (`S4.network.json === []`) — the server had said
+  // nothing at all. The honest copy states what the client observed — that it found
+  // no signed-in session in this browser — which is also true of the two other
+  // worlds behind the same null token (a session that has gone, and a
+  // `getSession()` that errored). It does not claim which of the three it is.
+  if (err.code === 'not_signed_in') {
+    return {
+      title: NOT_SIGNED_IN_SENTENCE,
+      // The action is named in the TITLE ("open or close a round"), so the
+      // guidance does not repeat it — a second copy of the action would be one
+      // more thing to get wrong on the close path.
+      guidance:
+        'We found no signed-in session in this browser, so nothing was sent. Sign in in the new tab, then come back here and try again — what you have typed on this page is kept.',
+      credential: true,
+      // No server sentence exists to show: nothing was asked of one.
+      detail: null,
+      observation: 'nothing-was-sent',
+    }
+  }
+
+  // THE WIRE DECLINED A BEARER WE SENT. Reaching here means the request left
+  // the browser carrying a non-empty token (`ownerAuthorization` throws
+  // `not_signed_in` above rather than sending `Bearer `), so the server DID
+  // speak about this session — which is what makes "has ended" an observation
+  // rather than the guess it was for a visitor who never had one.
   if (err.code === 'sign_in_required' || err.status === 401) {
     return {
       title: SIGN_IN_SENTENCE,
@@ -138,6 +226,7 @@ function describeOwnerFailure(err: unknown, action: OwnerAction): OwnerFailure {
       // verified.") tells the owner nothing they can act on, and repeating it
       // beside the guidance would only muddy it.
       detail: null,
+      observation: 'server-answered',
     }
   }
 
@@ -158,6 +247,7 @@ function describeOwnerFailure(err: unknown, action: OwnerAction): OwnerFailure {
           : 'There is no round you own with that id — it may have been removed, or it was opened under a different account. Signing in again as this account will not change that; if that other account is yours, sign in with it instead. If the round is gone for good, forget the reminder and open a fresh round.',
       credential: false,
       detail: `${err.code} — ${err.message}`,
+      observation: 'server-answered',
     }
   }
 
@@ -177,6 +267,7 @@ function describeOwnerFailure(err: unknown, action: OwnerAction): OwnerFailure {
         'The round is still open. Try again in a moment — nobody has seen anything they should not.',
       credential: false,
       detail: `${err.code} — ${err.message}`,
+      observation: 'server-answered',
     }
   }
 
@@ -190,6 +281,12 @@ function describeOwnerFailure(err: unknown, action: OwnerAction): OwnerFailure {
     // The server's own code is part of the detail: "Internal server error"
     // alone is undiagnosable, and the code is what the wire witness greps for.
     detail: `${err.code} — ${err.message}`,
+    // Every `CollabRequestError` reaching here came from `parseError`, i.e. from
+    // a response: the ONLY locally-minted owner error is `not_signed_in`, caught
+    // above. Scope of that claim: this page's two call sites, `handleMint` and
+    // `handleClose` (`participantHeaders`' local mint is on the participant
+    // path and cannot arrive here).
+    observation: 'server-answered',
   }
 }
 
@@ -826,7 +923,12 @@ export default function PanelSetupPage(): JSX.Element {
               >
                 {failure.guidance}
               </p>
-              {failure.detail !== null && (
+              {/* ⭐ A SERVER'S OWN WORDS MAY ONLY APPEAR IF A SERVER SPOKE.
+                  `detail` is always null on the two non-answered branches
+                  today, so this conjunct changes nothing NOW — it is what makes
+                  the property hold for a future branch that sets a detail it did
+                  not receive, and it is why `observation` is not a dead field. */}
+              {failure.detail !== null && failure.observation === 'server-answered' && (
                 <p
                   data-testid="panel-error-detail"
                   className={`${typography.bodySmall} mt-2 text-text-light`}


### PR DESCRIPTION
## The lie, witnessed on the deployed product

Browser- and wire-witnessed on deployed staging **`81b5c966`**, 17 Aug 2026
(`olumi-docs/witness-collab-2026-08-17/dom/S4-owner-mint-refusal.txt`, `S4b-after-click.png`).

A visitor with **no account** filled the whole owner panel form, clicked **"Open the round"**, and read:

> Sign in again to open or close a round.
> **Your session has ended.** Sign in again in the new tab, then come back here and try again — what you have typed on this page is kept.

They had no session. Nothing ended. And no server had said otherwise: the capture's request log for
the collab seam is **`[]` — zero requests** (`S4.network.json`), so this was the never-signed-in
branch, not a 401 being described. **The client asserted a state it had never observed.**

## Root cause — two questions under one name (trap 21)

`describeOwnerFailure`'s own header named the two producers apart — *"`sign_in_required` (minted
locally, before any request leaves) OR an HTTP 401 (the server declining the bearer)"* — and then
answered them in **one branch**, with copy true only of the second. Both arrived carrying code
`sign_in_required` at status 401, so **nothing downstream could tell them apart**. Aligning the copy
would only have chosen which half to lie to; the fix is to name the concepts apart.

## The split, at the seam

| producer | question it answers | code | may say "your session has ended"? |
|---|---|---|---|
| `ownerNotSignedIn()` — `requireOwnerAccessToken` / `ownerAuthorization` | does this browser hold a credential to **send**? | `not_signed_in` | **no** — nothing was sent, so nothing was declined |
| `ownerSignInRequired()` — `parseError` on a wire 401 | did the server **accept** the credential we sent? | `sign_in_required` | **yes** — a non-empty bearer was sent and refused |

New copy for the never-signed-in visitor, asserting only what the client observed:

> Sign in to open or close a round.
> We found no signed-in session in this browser, so nothing was sent. Sign in in the new tab, then come back here and try again — what you have typed on this page is kept.

It is deliberately true of all three worlds behind a null token — never signed in, a session that has
gone, and a `getSession()` that errored — because `getSessionIdentity()` cannot tell them apart and
so the copy must not claim which it is. The sign-in affordance and the typing-is-kept promise are
unchanged (and the promise is now pinned).

## Structural, not advisory — P5

Copy alone cannot be defended by review: any future branch can retype the sentence. So:

1. **The type.** `OwnerFailure.observation: ServerObservation` (`server-answered` | `nothing-was-sent`
   | `unknown`) is **required** — a new branch cannot be added without declaring whether a server
   spoke. There is no default to fall into.
2. **A derived invariant** over the predicate's **whole domain** (16 members: the seam's own local
   mint, 11 wire codes this estate has actually observed, and three non-`CollabRequestError` throws).
   For every member it checks the declaration **against the error's true provenance**, then asserts
   that nothing without a server answer carries session-history language, and that no server's words
   are quoted when no server spoke. A branch added later is enrolled the moment it declares.
3. **The renderer is bound to it too**: `detail` renders only when `observation === 'server-answered'`
   — a server's own words may not appear if no server spoke.

The language predicate is bounded three ways (trap 22): it matches session-**history phrases**, never
bare words (`"try again"` is honest and must pass); its corpus comes from outside the author — the two
sentences the deployed build actually emitted, plus the wire codes the estate's other specs and the
17 Aug live gate probe produced; and every case has its opposite-direction twin.

## Also found: the suite was pinning the falsehood

Two existing specs asserted the constant `'Sign in again to open or close a round.'` on the
**never-signed-in** path:

- `panelSetupOwnerAuth.spec.tsx` — "a signed-out owner is told so"
- `collabFirstRunFriction.spec.tsx` — **one** `SIGN_IN_COPY` constant asserted on **both** the
  never-signed-in path and the wire-401 path: the same "two questions under one name" collapse,
  reproduced in the expectations. **A suite that gives two different states one expected sentence
  cannot notice that one of them is being lied to** — which is why 27k green tests never saw this.

Both are split; the "again" sentence is still asserted, on the branch where it is true.

## Evidence

- **RED-first at pristine** (`81b5c966`), 5 collected by name, 2 RED on the defect:
  `expect(element).not.toHaveTextContent(/session has ended/i)` receiving *"Your session has ended…"*,
  and `expected 'Your session has ended. Sign in again…' not to be 'Your session has ended. Sign in again…'`.
  The other 3 pass before and after by design — the non-swallow / different-object halves.
- **9 mutants**, throwaway worktree outside the repo root, sentinel-WRITE isolation proven in both
  directions with distinct inodes, HEAD-relative restores, applied-check exactly 1 / control exactly 0,
  clean tree asserted before and after each, collected count 48 asserted by name, **and typecheck on
  every mutated tree** (P4):

| mutant | specs | typecheck | what it proves |
|---|---|---|---|
| re-collapse at the seam (local mint carries `sign_in_required` again) | **RED** (9) | green | the split cannot be undone at the producer |
| re-collapse at the page (delete the `not_signed_in` branch) | **RED** (6) | green | the split cannot be undone at the consumer |
| invert the two branches' copy | **RED** (5) | green | the discrimination is directional |
| false declaration (`nothing-was-sent` → `server-answered`) | **RED** (2) | green | the declaration is checked, not trusted |
| **different object** (mutate the ownership branch instead) | RED **only in the 403 spec** — this spec **11/11 green** | green | binding is to the named branches, not to any error copy |
| **type-only** (retype the field; runtime unchanged) | **GREEN 48/48, 0 failures** | **RED** (5 × TS2322) | P4's hole, and that this harness closes it |
| detector rot (empty the claim patterns) | **RED** (2) | green | the invariant's discrimination is pinned at rest |
| fabricate a server sentence on the local branch | **RED** (2) | green | no server's words without a server |
| remove the renderer's provenance conjunct | GREEN (survivor) | green | **demonstrated equivalent today** — `detail` is already null on both non-answered branches, so the conjunct is defence in depth for a future branch, not a live guard |

- **Gates, in the required check's step order** (`lint` → `typecheck` → guards, derived at this tip):
  lint ✅ · typecheck gate ✅ (coverage 3452/3492, **zero diagnostics added**) · full suite ✅ in CI's
  own 4 shards with `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported.
- The typecheck gate reports drift shrinking 2325 → 2307 and invites `--update-baseline`. **Declined:
  measured byte-identical (563 files / 2307 errors) at pristine `81b5c966` in a separate worktree — the
  shrink is not this PR's and banking it here would be a false claim** (trap 2b).

## Scope

No widening into the mint flow, auth, or account provisioning. `src/collab/**` touched only where the
copy fix required it: the two local throw sites and the new factory beside the existing one.
