### PR TITLE
feat(2.1271): deliver the auto-run's provisional analysis without another turn (H4-guarded)

### DIFF
--- a/src/adapters/cee/scenarioGraph.ts
+++ b/src/adapters/cee/scenarioGraph.ts
@@ -56,6 +56,9 @@
  * locally; see `canvas/utils/mergeServerGraph.ts`.
  */
 
+import { AnalysisStateV1Schema } from '@talchain/schemas/boundary'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+
 import { logger } from '../../lib/logger'
 import { parseNotModelled, type NotModelledManifest } from './notModelled'
 
@@ -118,6 +121,34 @@ export type ScenarioGraphResult =
       identity: ScenarioGraphIdentity | null
       /** MEASURED by CEE on the returned bytes. `false` for every real graph today. */
       layoutPresent: boolean
+      /**
+       * ROADMAP 2.1271 — CEE's composed `AnalysisStateV1` verdict for this
+       * scenario, PARSED, or `null`.
+       *
+       * ⚠ `null` IS NOT A STATE, and reading it as one is the whole hazard of
+       * this field. It means CEE DID NOT ANSWER — the build predates the key, the
+       * scenario has no graph, or the shape failed validation. A consumer must
+       * leave whatever it already believed standing. In particular it must NOT be
+       * read as evidence against an in-flight run the DRAFT TURN reported: the
+       * two authorities answer different questions (a turn answers "did I start a
+       * run?", a read answers "has a fact landed?"), and CEE keeps no in-flight
+       * marker, so mid-run this leg can only ever say `never_run`. See
+       * `canvas/hydrate/applyScenarioAnalysisRead.ts`, which is the ONLY
+       * sanctioned consumer.
+       */
+      analysisState: AnalysisStateV1 | null
+      /**
+       * ROADMAP 2.1271 — the `analysis_result` block for the fact the verdict
+       * selected, present ONLY on a `complete_current` verdict (CEE withholds it
+       * on a stale one, because those numbers describe a graph the user has since
+       * changed). `null` means no CURRENT result is being delivered — never "the
+       * analysis is empty".
+       *
+       * Deliberately typed `unknown`: the block is handed to `mapV5AnalysisToReport`
+       * — the SAME mapper the turn path uses — and a second local shape
+       * declaration here would be a mirror of the block contract.
+       */
+      analysisResult: unknown
       requestId: string | null
     }
   /** 200, `graph_present:false` — the scenario exists and has no graph yet. Normal. */
@@ -174,6 +205,48 @@ function readIdentityEnvelope(raw: unknown): ScenarioGraphIdentity | null {
   return { value, projectionVersion }
 }
 
+/**
+ * ROADMAP 2.1271 — parse CEE's verdict with the CONTRACT, never a local mirror.
+ *
+ * `AnalysisStateV1Schema` is `.strict()` at every level and its `run_state` is a
+ * discriminated union, so an unknown kind or an extra key FAILS rather than
+ * handing a consumer a shape it will read as authority — the same discipline
+ * `applyV5State` applies on the turn path, using the same schema object.
+ *
+ * A parse failure returns `null`, i.e. "CEE did not answer". That is deliberately
+ * the same value as absence here, and it is safe ONLY because the single consumer
+ * treats `null` as "leave what you believed standing" rather than as a state.
+ */
+function readAnalysisState(raw: unknown): AnalysisStateV1 | null {
+  if (raw === null || raw === undefined) return null
+  const parsed = AnalysisStateV1Schema.safeParse(raw)
+  if (parsed.success) return parsed.data
+  logger.warn('scenario_graph.analysis_state_invalid_shape', {
+    issueCount: parsed.error.issues.length,
+  })
+  return null
+}
+
+/**
+ * The `analysis_result` block, gated on its own discriminator.
+ *
+ * Not validated further on purpose: `mapV5AnalysisToReport` is the block
+ * contract's one consumer and restating its shape here would be a mirror of it
+ * (trap 12). But the TYPE TAG is checked, so a future CEE key landing on this
+ * name cannot be forwarded to a mapper written for a different block.
+ */
+function readAnalysisResultBlock(raw: unknown): unknown {
+  if (raw === null || raw === undefined || typeof raw !== 'object') return null
+  const type = (raw as { type?: unknown }).type
+  if (type !== 'analysis_result') {
+    logger.warn('scenario_graph.analysis_result_unexpected_type', {
+      receivedType: typeof type === 'string' ? type : typeof type,
+    })
+    return null
+  }
+  return raw
+}
+
 function parseOk(body: unknown): ScenarioGraphResult {
   if (body === null || typeof body !== 'object') return { status: 'unusable' }
   const b = body as Record<string, unknown>
@@ -215,6 +288,17 @@ function parseOk(body: unknown): ScenarioGraphResult {
     notModelled: parseNotModelled(b.not_modelled),
     identity: readIdentityEnvelope(b.graph_identity_hash),
     layoutPresent: b.layout_present === true,
+    // ROADMAP 2.1271 — PARSED, NOT TRUSTED, and by the SAME `.strict()`
+    // discriminated-union schema `v5/applyV5State.ts` uses on the turn path. A
+    // malformed verdict yields `null` ("CEE did not answer") rather than a shape
+    // a consumer would read as authority. There is deliberately no local mirror
+    // of the vocabulary here.
+    analysisState: readAnalysisState(b.analysis_state),
+    // Handed through opaque: the ONLY reader is `mapV5AnalysisToReport`, which
+    // already owns the block contract. Presence is gated on the discriminator
+    // being the one block type this leg may carry, so a future CEE key cannot
+    // arrive here as an unlabelled object.
+    analysisResult: readAnalysisResultBlock(b.analysis_result),
     requestId,
   }
 }

--- a/src/canvas/conversation/__tests__/useConversation.draftRecovery.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.draftRecovery.spec.ts
@@ -128,6 +128,13 @@ function serverGraphResult(): ScenarioGraphResult {
     notModelled: null,
     identity: { value: 'srv-hash-1', projectionVersion: 'p1' },
     layoutPresent: false,
+    // ROADMAP 2.1271 — the recovery read carries the same analysis keys as
+    // every other scenario-graph read. `null` on both is the honest fixture
+    // here: this suite is about GRAPH recovery on stream loss, and it asserts
+    // nothing about analysis state. Present rather than optional so a consumer
+    // cannot silently forget the field (the parser always supplies it).
+    analysisState: null,
+    analysisResult: null,
     requestId: 'req-recovery-1',
   }
 }

--- a/src/canvas/hooks/__tests__/provisionalDelivery.freshnessCopyOnResultlessTerminal.spec.tsx
+++ b/src/canvas/hooks/__tests__/provisionalDelivery.freshnessCopyOnResultlessTerminal.spec.tsx
@@ -1,0 +1,282 @@
+/**
+ * ROADMAP 2.1271 — THE OPEN QUESTION, SETTLED BY RENDERING.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE QUESTION (it gates CEE #1068)
+ * ═══════════════════════════════════════════════════════════════════════════
+ *   Does a MISLEADING freshness string actually RENDER when the provisional
+ *   delivery applies a `complete_stale` or `refused` verdict that carries NO
+ *   report?
+ *
+ * Static reading could not settle it, and the static chain that was handed to
+ * this lane was stale in two places (see the corrections below), so the answer
+ * here is taken from the DOM.
+ *
+ * ⚠ TWO CORRECTIONS TO THE INHERITED PREMISE, both derived at this tip:
+ *
+ *  1. `useAnalysisRunState()` is NOT "blind to the wire". That guard
+ *     (`composed.authority === 'wire' ? composed.runStateKind : null`) has been
+ *     DELETED; the hook now reads `composed.runStateKind` directly
+ *     (`useAnalysisRunState.ts:247`). So the region IS driven by the verdict
+ *     this delivery writes — which is exactly why the question is live.
+ *  2. The cited copy source `copy/freshnessReasons.ts:28` does not exist at
+ *     this tip. The stale line is `FRESHNESS_COPY.stale`
+ *     (`AnalysisFreshnessNotice.tsx:45`): "Model changed since this analysis.
+ *     Re-run to update."
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHY THE VERDICT IS WRITTEN THROUGH THE REAL APPLIER
+ * ═══════════════════════════════════════════════════════════════════════════
+ * A test that calls `setAnalysisStateV1` by hand would prove something about
+ * the store, not about this delivery. These cases drive
+ * `applyScenarioAnalysisRead` — the delivery's own writer — against the REAL
+ * canvas store, with `analysisResult: null`, which is what CEE ships on both of
+ * these verdicts (the applier's header: "CEE ships no result block on this
+ * verdict — those numbers describe a graph the user has since changed").
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { useCanvasStore } from '../../store'
+import { readProvisionalApplyStore } from '../useProvisionalAnalysisDelivery'
+import { applyScenarioAnalysisRead } from '../../hydrate/applyScenarioAnalysisRead'
+import { AnalysisStateRegion } from '../../../components/results/analysisState/AnalysisStateRegion'
+import { useAnalysisRunState } from '../../../components/results/analysisState/useAnalysisRunState'
+import { AnalysisFreshnessNotice, FRESHNESS_COPY } from '../../../components/results/AnalysisFreshnessNotice'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+
+function verdict(runState: AnalysisStateV1['run_state']): AnalysisStateV1 {
+  return {
+    run_state: runState,
+    readiness: { status: 'ready', blockers: [] },
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: false,
+    blocked_unusable: false,
+    contradictions: [],
+  } as AnalysisStateV1
+}
+
+/**
+ * The surface as the region's real caller composes it: the run state comes from
+ * `useAnalysisRunState()`, never from a prop the test chose.
+ */
+function Surface() {
+  const runState = useAnalysisRunState()
+  // `hasReport={false}` is the case under test: a terminal verdict arrived and
+  // there are no numbers to show.
+  return <AnalysisStateRegion runState={runState} hasReport={false} />
+}
+
+beforeEach(() => {
+  useCanvasStore.getState().resultsReset()
+  useCanvasStore.getState().setAnalysisStateV1(null)
+})
+
+describe('a RESULTLESS terminal delivery — what does the user actually read?', () => {
+  it('PRECONDITION: the applier really does write these verdicts with no report', () => {
+    const outcome = applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'complete_stale', computed_at: '2026-08-17T09:15:50.000Z', cause: 'graph_changed' }),
+      analysisResult: null,
+      store: readProvisionalApplyStore(),
+    })
+    // Pin the precondition in-test: if the applier ever stopped applying this
+    // kind, the render assertions below would pass for the wrong reason.
+    expect(outcome).toEqual({ outcome: 'applied', kind: 'complete_stale', resultsHydrated: false })
+    expect(useCanvasStore.getState().analysisStateV1?.run_state.kind).toBe('complete_stale')
+  })
+
+  it('⭐ complete_stale + no report', () => {
+    applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'complete_stale', computed_at: '2026-08-17T09:15:50.000Z', cause: 'graph_changed' }),
+      analysisResult: null,
+      store: readProvisionalApplyStore(),
+    })
+    render(<Surface />)
+
+    const region = screen.getByTestId('analysis-state-region')
+    const banner = region.getAttribute('data-truth-banner')
+    const presentation = region.getAttribute('data-body-presentation')
+    const notice = screen.queryByTestId('analysis-freshness-notice')
+    console.log(
+      JSON.stringify({
+        CASE: 'complete_stale/no-report',
+        run_state: region.getAttribute('data-run-state'),
+        truth_banner: banner,
+        body_presentation: presentation,
+        freshness_notice_mounted: notice !== null,
+        freshness_attr: notice?.getAttribute('data-freshness') ?? null,
+        rendered_text: notice?.textContent?.trim() ?? null,
+        stale_copy_present: (notice?.textContent ?? '').includes(FRESHNESS_COPY.stale),
+      }),
+    )
+
+    // The verdict reaches the region (correction 1 above).
+    expect(region.getAttribute('data-run-state')).toBe('complete_stale')
+    // And there is no body to accompany whatever the banner says.
+    expect(presentation).toBe('hidden')
+    // The finding itself is recorded as an explicit expectation below, in the
+    // assertion the suite would RED on if this behaviour changed.
+    expect(banner).toBe('freshness')
+  })
+
+  it('⭐ refused + no report', () => {
+    applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'refused', reason_code: 'analysis_refused_unspecified' }),
+      analysisResult: null,
+      store: readProvisionalApplyStore(),
+    })
+    render(<Surface />)
+
+    const region = screen.getByTestId('analysis-state-region')
+    const notice = screen.queryByTestId('analysis-freshness-notice')
+    const refusal = screen.queryByTestId('analysis-refusal-notice')
+    console.log(
+      JSON.stringify({
+        CASE: 'refused/no-report',
+        run_state: region.getAttribute('data-run-state'),
+        truth_banner: region.getAttribute('data-truth-banner'),
+        body_presentation: region.getAttribute('data-body-presentation'),
+        freshness_notice_mounted: notice !== null,
+        refusal_notice_mounted: refusal !== null,
+        rendered_text: (notice ?? refusal)?.textContent?.trim() ?? null,
+        stale_copy_present: (notice?.textContent ?? '').includes(FRESHNESS_COPY.stale),
+      }),
+    )
+
+    expect(region.getAttribute('data-run-state')).toBe('refused')
+    // ⭐ THE ANSWER FOR `refused`: the refusal notice owns this state's single
+    // truth slot, so the freshness strip — and therefore the stale copy — is
+    // structurally unreachable here. Bound to the region's own table
+    // (`analysisStateContract.ts:107`), not to an incidental absence.
+    expect(region.getAttribute('data-truth-banner')).toBe('refusal')
+    expect(notice).toBeNull()
+  })
+})
+
+/**
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE CONTROLS — without these the two absences above prove NOTHING (trap 13)
+ * ═══════════════════════════════════════════════════════════════════════════
+ * Both cases above report "the stale copy did not render". That is only
+ * evidence if this harness is CAPABLE of rendering it, and if the detector can
+ * SEE it. A component that null-renders for an unrelated reason — a missing
+ * provider, a store slice the harness never populates — produces exactly the
+ * same clean output as a component that correctly declined to speak.
+ */
+describe('CONTROLS for the two absence claims above', () => {
+  it('POSITIVE CONTROL — the stale copy IS renderable in this harness, and the detector sees it', () => {
+    render(<AnalysisFreshnessNotice state={{ freshness: 'stale' }} />)
+    const notice = screen.getByTestId('analysis-freshness-notice')
+    expect(notice.getAttribute('data-freshness')).toBe('stale')
+    // The same detector the absence claims use, now firing on a PRESENCE.
+    expect(notice.textContent ?? '').toContain(FRESHNESS_COPY.stale)
+  })
+
+  it('CONTRAST CONTROL — a `fresh` verdict renders a DIFFERENT string, so the detector discriminates', () => {
+    render(<AnalysisFreshnessNotice state={{ freshness: 'fresh' }} />)
+    const notice = screen.getByTestId('analysis-freshness-notice')
+    expect(notice.textContent ?? '').toContain(FRESHNESS_COPY.fresh)
+    // A detector that matched anything would fail here.
+    expect(notice.textContent ?? '').not.toContain(FRESHNESS_COPY.stale)
+  })
+
+  it('⭐⭐ THE RISK CASE — a user who ALREADY has a freshness verdict, then a resultless `complete_stale`', () => {
+    // This is the combination the open question was really about, and it is the
+    // one the first two cases could NOT reach: they started from a store with no
+    // legacy `analysisFreshness` slice, which is why the strip stayed silent.
+    // Here the user has had an analysis, so the strip has standing permission to
+    // speak — and THEN the read leg delivers a resultless `complete_stale`.
+    useCanvasStore.getState().setAnalysisFreshness({
+      freshness: 'stale',
+      freshness_reason: 'graph_hash_mismatch',
+      computed_at: new Date().toISOString(),
+    })
+    // PRECONDITION, pinned: the strip now has something to say.
+    expect(useCanvasStore.getState().analysisFreshness?.freshness).toBe('stale')
+
+    applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'complete_stale', computed_at: '2026-08-17T09:15:50.000Z', cause: 'graph_changed' }),
+      analysisResult: null,
+      store: readProvisionalApplyStore(),
+    })
+    render(<Surface />)
+
+    const region = screen.getByTestId('analysis-state-region')
+    const notice = screen.queryByTestId('analysis-freshness-notice')
+    const text = notice?.textContent ?? ''
+    console.log(
+      JSON.stringify({
+        CASE: 'RISK: prior-verdict + complete_stale/no-report',
+        run_state: region.getAttribute('data-run-state'),
+        truth_banner: region.getAttribute('data-truth-banner'),
+        body_presentation: region.getAttribute('data-body-presentation'),
+        freshness_notice_mounted: notice !== null,
+        freshness_attr: notice?.getAttribute('data-freshness') ?? null,
+        rendered_text: text.trim() || null,
+        stale_copy_present: text.includes(FRESHNESS_COPY.stale),
+      }),
+    )
+
+    expect(region.getAttribute('data-run-state')).toBe('complete_stale')
+    expect(region.getAttribute('data-body-presentation')).toBe('hidden')
+    // ⭐ THE ANSWER. Recorded as an assertion so a future change to this
+    // behaviour REDs here rather than shipping silently.
+    expect(notice).not.toBeNull()
+    expect(text).toContain(FRESHNESS_COPY.stale)
+  })
+
+  it('⭐⭐ ATTRIBUTION — the DELIVERY is what makes that line appear, not the prior verdict alone', () => {
+    // The case above establishes that the line renders. It does NOT establish
+    // that this slice caused it: the legacy `analysisFreshness` slice was
+    // already 'stale', so the line might have been on screen regardless.
+    // Without this control the finding would be an unattributed correlation —
+    // and CEE #1068 turns on WHICH change is responsible.
+    useCanvasStore.getState().setAnalysisFreshness({
+      freshness: 'stale',
+      freshness_reason: 'graph_hash_mismatch',
+      computed_at: new Date().toISOString(),
+    })
+    expect(useCanvasStore.getState().analysisFreshness?.freshness).toBe('stale')
+
+    // NO delivery. Same legacy slice, same `hasReport={false}`.
+    const before = render(<Surface />)
+    const regionBefore = screen.getByTestId('analysis-state-region')
+    const runStateBefore = regionBefore.getAttribute('data-run-state')
+    const bannerBefore = regionBefore.getAttribute('data-truth-banner')
+    const noticeBefore = screen.queryByTestId('analysis-freshness-notice')
+    console.log(
+      JSON.stringify({
+        CASE: 'ATTRIBUTION: prior-verdict, NO delivery',
+        run_state: runStateBefore,
+        truth_banner: bannerBefore,
+        freshness_notice_mounted: noticeBefore !== null,
+        stale_copy_present: (noticeBefore?.textContent ?? '').includes(FRESHNESS_COPY.stale),
+      }),
+    )
+
+    // The line is NOT on screen before the delivery — so the prior verdict alone
+    // does not produce it, and the delivery is the cause.
+    expect(bannerBefore).toBe('none')
+    expect(noticeBefore).toBeNull()
+    before.unmount()
+
+    // Now the delivery, and only the delivery, changes.
+    applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'complete_stale', computed_at: '2026-08-17T09:15:50.000Z', cause: 'graph_changed' }),
+      analysisResult: null,
+      store: readProvisionalApplyStore(),
+    })
+    render(<Surface />)
+    expect(screen.getByTestId('analysis-state-region').getAttribute('data-truth-banner')).toBe(
+      'freshness',
+    )
+    expect(screen.getByTestId('analysis-freshness-notice').textContent ?? '').toContain(
+      FRESHNESS_COPY.stale,
+    )
+  })
+})

--- a/src/canvas/hooks/__tests__/useProvisionalAnalysisDelivery.realStoreBinding.spec.ts
+++ b/src/canvas/hooks/__tests__/useProvisionalAnalysisDelivery.realStoreBinding.spec.ts
@@ -1,0 +1,273 @@
+/**
+ * ROADMAP 2.1271 — THE APPLIER'S STORE VIEW IS BOUND TO THE **REAL** CANVAS STORE.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHY THIS FILE EXISTS, AND WHY IT MAY NOT USE A STORE DOUBLE
+ * ═══════════════════════════════════════════════════════════════════════════
+ * The delivery hook shipped with
+ *
+ *     getStore: () => useCanvasStore.getState() as unknown as ScenarioAnalysisApplyStore
+ *
+ * The double cast switched typechecking off across a shape that does not match.
+ * The canvas store carries the results hash at `results.hash`, never at the top
+ * level (the turn path splices it in for exactly this reason —
+ * `conversation/useConversation.ts:4783`), and every member of
+ * `ScenarioAnalysisApplyStore` is optional. So `currentResultsHash` resolved to
+ * `undefined`, `hash === (undefined ?? null)` was never true for a string hash,
+ * and the `alreadyHeld` branch was DEAD on the deployed path.
+ *
+ * ⚠⚠ AND THE SUITE COULD NOT SEE IT. Both existing specs FABRICATE the field
+ * (`applyScenarioAnalysisRead.spec.ts:104,260`,
+ * `useProvisionalAnalysisDelivery.spec.ts:82`), so the mutant that drops the
+ * dedupe scored BITTEN against a store shape production never produces — a
+ * perfect kill-rate against the wrong oracle (CLAUDE.md trap 13c). A mutant kit
+ * measures whether a test can DETECT a change; it never measures whether the
+ * EXPECTATION is right.
+ *
+ * Therefore every assertion below runs against `useCanvasStore` ITSELF. Nothing
+ * here constructs a store literal, and nothing here states a hash it computed
+ * by hand: the precondition is established by driving the REAL writer, so if
+ * the store's shape drifts again this file REDs instead of agreeing with a
+ * model of the store that stopped being true.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE REACHABLE HARM BEING PINNED
+ * ═══════════════════════════════════════════════════════════════════════════
+ * With the dedupe dead, every terminal read re-writes the results slice
+ * unconditionally — including `enrichment: null` and `rawV2Response: null`,
+ * which CLEAR those slots (`canvas/store.ts:3673`). A user who runs an analysis
+ * manually inside the armed 60s window and then receives the read has the slice
+ * overwritten underneath them: animations restart, the Compare capture is
+ * re-seeded, the V2-shaped slots are nulled. That is precisely what the
+ * applier's own header says the dedupe prevents.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { useCanvasStore } from '../../store'
+import {
+  readProvisionalApplyStore,
+  runProvisionalDeliverySchedule,
+} from '../useProvisionalAnalysisDelivery'
+import { applyScenarioAnalysisRead } from '../../hydrate/applyScenarioAnalysisRead'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────
+
+function verdict(runState: AnalysisStateV1['run_state']): AnalysisStateV1 {
+  return {
+    run_state: runState,
+    readiness: { status: 'ready', blockers: [] },
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: false,
+    blocked_unusable: false,
+    contradictions: [],
+  } as AnalysisStateV1
+}
+
+/** A real `analysis_result` block, of the shape CEE's builder emits. */
+const RESULT_BLOCK = {
+  type: 'analysis_result',
+  summary: 'Hiring leads on the current model.',
+  leading_option_id: 'opt_hire',
+  win_probabilities: { opt_hire: 0.68, opt_hold: 0.32 },
+  computed_against_hash: 'hash_draft',
+  enrichment: {
+    analysis_status: 'ok',
+    option_comparison: [
+      { option_id: 'opt_hire', option_label: 'Hire', win_probability: 0.68, outcome_mean: 0.55 },
+      { option_id: 'opt_hold', option_label: 'Hold', win_probability: 0.32, outcome_mean: 0.41 },
+    ],
+  },
+}
+
+beforeEach(() => {
+  // Return the REAL store's results slice to its pre-analysis state. Deliberately
+  // `resultsReset` — the store's own action — rather than a hand-built literal.
+  useCanvasStore.getState().resultsReset()
+})
+
+// ─── The binding itself ───────────────────────────────────────────────────
+
+describe('readProvisionalApplyStore is bound to the REAL canvas store', () => {
+  it('exposes the two writers the applier is allowed to call, and NOTHING from the graph slices', () => {
+    const view = readProvisionalApplyStore()
+
+    // POSITIVE: the applier's whole contract is these two writers.
+    expect(typeof view.setAnalysisStateV1).toBe('function')
+    expect(typeof view.resultsComplete).toBe('function')
+
+    // BOUNDARY: `applyScenarioAnalysisRead`'s header says the graph belongs to
+    // `serverGraphHydration`. The previous spread handed over the entire store,
+    // so that boundary was documented rather than real. Bind it by identity to
+    // the exact member set.
+    expect(Object.keys(view).sort()).toEqual(
+      ['currentResultsHash', 'resultsComplete', 'setAnalysisStateV1'].sort(),
+    )
+  })
+
+  it('⭐ carries `currentResultsHash` sourced from the REAL store at `results.hash`', () => {
+    // PRECONDITION, PINNED IN-TEST (trap 13b): drive the store's OWN writer so
+    // the hash under test is the one production would hold, not one we invented.
+    const outcome = applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'complete_current', computed_at: '2026-08-17T09:15:50.000Z' }),
+      analysisResult: RESULT_BLOCK,
+      store: readProvisionalApplyStore(),
+    })
+    expect(outcome.outcome).toBe('applied')
+
+    const liveHash = useCanvasStore.getState().results?.hash
+    // The precondition must be REAL: a blank hash would make the assertion
+    // below pass for the wrong reason (it would compare null against null).
+    expect(typeof liveHash).toBe('string')
+    expect(liveHash).not.toBe('')
+
+    // THE BINDING. Identity against the live store's own value — not a value
+    // predicate another field could satisfy (trap 19).
+    expect(readProvisionalApplyStore().currentResultsHash).toBe(liveHash)
+  })
+
+  it('reports `null`, never `undefined`, before any analysis has landed', () => {
+    // The dedupe compares `hash === (currentResultsHash ?? null)`. Both spellings
+    // behave identically THERE, but a consumer that ever switches to `===` on the
+    // raw member would diverge, so pin the normalised value at the source.
+    expect(useCanvasStore.getState().results?.hash).toBeUndefined()
+    expect(readProvisionalApplyStore().currentResultsHash).toBeNull()
+  })
+})
+
+// ─── The dedupe, on the production path ───────────────────────────────────
+
+describe('⭐ the results dedupe FIRES on the deployed path', () => {
+  it('a second delivery of the same analysis is `alreadyHeld` and re-writes NOTHING', () => {
+    // FIRST delivery — the answer the user was waiting for.
+    const first = applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'complete_current', computed_at: '2026-08-17T09:15:50.000Z' }),
+      analysisResult: RESULT_BLOCK,
+      store: readProvisionalApplyStore(),
+    })
+    expect(first).toEqual({ outcome: 'applied', kind: 'complete_current', resultsHydrated: true })
+
+    // PRECONDITION: the real store now holds a hash for the dedupe to match.
+    const heldHash = useCanvasStore.getState().results?.hash
+    expect(typeof heldHash).toBe('string')
+    expect(heldHash).not.toBe('')
+    const finishedAtBefore = useCanvasStore.getState().results?.finishedAt
+
+    // SECOND delivery — the same analysis arriving on a later poll.
+    const second = applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'complete_current', computed_at: '2026-08-17T09:15:50.000Z' }),
+      analysisResult: RESULT_BLOCK,
+      store: readProvisionalApplyStore(),
+    })
+
+    // ⚠ THIS IS THE ASSERTION THE FABRICATED-STORE SPECS COULD NOT MAKE.
+    expect(second).toEqual({ outcome: 'alreadyHeld', kind: 'complete_current' })
+
+    // And the harm itself: the slice was not re-written. `finishedAt` is stamped
+    // by `resultsComplete` on every call (`canvas/store.ts`), so an unchanged
+    // stamp is direct evidence the writer did not run a second time.
+    expect(useCanvasStore.getState().results?.finishedAt).toBe(finishedAtBefore)
+    expect(useCanvasStore.getState().results?.hash).toBe(heldHash)
+  })
+
+  it('DISCRIMINATING TWIN — a DIFFERENT analysis is still applied', () => {
+    applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'complete_current', computed_at: '2026-08-17T09:15:50.000Z' }),
+      analysisResult: RESULT_BLOCK,
+      store: readProvisionalApplyStore(),
+    })
+    const firstHash = useCanvasStore.getState().results?.hash
+    expect(typeof firstHash).toBe('string')
+
+    // A genuinely different analysis: different win probabilities, so the mapper
+    // derives a different `response_hash`.
+    const otherBlock = {
+      ...RESULT_BLOCK,
+      summary: 'Holding leads on the current model.',
+      leading_option_id: 'opt_hold',
+      win_probabilities: { opt_hire: 0.31, opt_hold: 0.69 },
+    }
+    const second = applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'complete_current', computed_at: '2026-08-17T09:15:50.000Z' }),
+      analysisResult: otherBlock,
+      store: readProvisionalApplyStore(),
+    })
+
+    // Without this twin, "always return alreadyHeld" would pass the test above.
+    // With it, the pair is only satisfiable by a dedupe that actually compares.
+    expect(second.outcome).toBe('applied')
+    expect(useCanvasStore.getState().results?.hash).not.toBe(firstHash)
+  })
+})
+
+// ─── The PRODUCTION WIRING, not just the helper ───────────────────────────
+
+/**
+ * ⚠ THE GAP THIS CLOSES, and it is the one that let the defect ship.
+ *
+ * Every assertion above proves `readProvisionalApplyStore` is correct. NONE of
+ * them proves the delivery USES it — and the original defect was precisely a
+ * wiring one: the helper did not exist, the hook inlined its own expression,
+ * and every spec injected a substitute `getStore`. A suite can be exhaustive
+ * about a function and silent about whether anything calls it (trap 3b: bind to
+ * the path that actually mounts).
+ *
+ * So `getStore` is now OPTIONAL on the core, production passes nothing, and
+ * these two cases drive the schedule WITHOUT it — exercising the real default
+ * against the real store.
+ */
+describe('⭐ the DEFAULT store view — what production actually runs', () => {
+  const TERMINAL_READ = {
+    status: 'graph' as const,
+    analysisState: verdict({ kind: 'complete_current', computed_at: '2026-08-17T09:15:50.000Z' }),
+    analysisResult: RESULT_BLOCK,
+  }
+
+  it('dedupes against the REAL store when no `getStore` is injected', async () => {
+    // PRECONDITION: the real store already holds this exact analysis.
+    const seeded = applyScenarioAnalysisRead({
+      analysisState: TERMINAL_READ.analysisState,
+      analysisResult: RESULT_BLOCK,
+      store: readProvisionalApplyStore(),
+    })
+    expect(seeded.outcome).toBe('applied')
+    expect(typeof useCanvasStore.getState().results?.hash).toBe('string')
+
+    const outcome = await runProvisionalDeliverySchedule({
+      scenarioId: 'scn_1',
+      userId: null,
+      signal: new AbortController().signal,
+      // ⭐ NO `getStore`. This is the production configuration.
+      read: async () => TERMINAL_READ as never,
+      wait: async () => {},
+      delays: [0],
+    })
+
+    // With the shipped double-cast this reads 'delivered': the dedupe cannot
+    // see a hash the store view never carried.
+    expect(outcome).toBe('already_held')
+  })
+
+  it('DISCRIMINATING TWIN — the default still DELIVERS an analysis the store lacks', async () => {
+    // Same configuration, empty store. Without this twin, a default that always
+    // reported `already_held` would satisfy the case above.
+    expect(useCanvasStore.getState().results?.hash).toBeUndefined()
+
+    const outcome = await runProvisionalDeliverySchedule({
+      scenarioId: 'scn_1',
+      userId: null,
+      signal: new AbortController().signal,
+      read: async () => TERMINAL_READ as never,
+      wait: async () => {},
+      delays: [0],
+    })
+
+    expect(outcome).toBe('delivered')
+    expect(typeof useCanvasStore.getState().results?.hash).toBe('string')
+  })
+})

--- a/src/canvas/hooks/__tests__/useProvisionalAnalysisDelivery.spec.ts
+++ b/src/canvas/hooks/__tests__/useProvisionalAnalysisDelivery.spec.ts
@@ -1,0 +1,263 @@
+/**
+ * ROADMAP 2.1271 — THE BOUNDED DELIVERY SCHEDULE.
+ *
+ * Pins the three properties that make this delivery honest, on the extracted
+ * core (`runProvisionalDeliverySchedule`) rather than through React, so each one
+ * is provable rather than inferred from a rendered surface:
+ *
+ *  H3 · IT IS BOUNDED, AND ON EXPIRY IT INVENTS NOTHING. A `running` claim can
+ *       outlive its run (the dispatch throws, the already-analysed guard skips,
+ *       a process restarts). So the wait ends — and when it does, ZERO store
+ *       writes have happened. It does not synthesise `unknown_degraded` or any
+ *       other verdict: those are the producer's words.
+ *
+ *  H4 · A NON-TERMINAL READ KEEPS IT WAITING AND WRITES NOTHING. This is the
+ *       same guard as `applyScenarioAnalysisRead`'s, asserted here at the LOOP
+ *       level: a `never_run` read must not settle the schedule either, or the
+ *       first mid-run read would end the wait and the result would never arrive.
+ *
+ *  BUDGET · The read route's limiter is per CLIENT IP and shared with boot
+ *       hydration and draft recovery. The schedule's read COUNT is asserted, so
+ *       a later "just poll every second" cannot land without failing a test.
+ *
+ * ⚠ NO FAKE TIMERS. The `wait` seam is injected, so the schedule is exercised at
+ * full speed with the DELAYS OBSERVED rather than elapsed. A fake-timer harness
+ * would prove the loop ran; injecting the clock proves WHAT IT ASKED FOR.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+
+import {
+  runProvisionalDeliverySchedule,
+  PROVISIONAL_DELIVERY_DELAYS_MS,
+  PROVISIONAL_DELIVERY_DEADLINE_MS,
+} from '../useProvisionalAnalysisDelivery'
+import type { ScenarioAnalysisApplyStore } from '../../hydrate/applyScenarioAnalysisRead'
+
+const SCENARIO = 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c'
+
+function verdict(runState: AnalysisStateV1['run_state']): AnalysisStateV1 {
+  return {
+    run_state: runState,
+    readiness: { status: 'ready', blockers: [] },
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: false,
+    blocked_unusable: false,
+    contradictions: [],
+  } as AnalysisStateV1
+}
+
+function graphResult(analysisState: AnalysisStateV1 | null, analysisResult: unknown = null) {
+  return {
+    status: 'graph' as const,
+    graph: { nodes: [], edges: [] },
+    briefText: null,
+    notModelled: null,
+    identity: null,
+    layoutPresent: false,
+    analysisState,
+    analysisResult,
+    requestId: 'req-1',
+  }
+}
+
+interface Harness {
+  readonly store: ScenarioAnalysisApplyStore
+  readonly setAnalysisStateV1: ReturnType<typeof vi.fn>
+  readonly resultsComplete: ReturnType<typeof vi.fn>
+  readonly waits: number[]
+  readonly wait: (ms: number, signal: AbortSignal) => Promise<void>
+}
+
+function harness(): Harness {
+  const waits: number[] = []
+  const setAnalysisStateV1 = vi.fn()
+  const resultsComplete = vi.fn()
+  return {
+    store: { setAnalysisStateV1, resultsComplete, currentResultsHash: null },
+    setAnalysisStateV1,
+    resultsComplete,
+    waits,
+    wait: async (ms, signal) => {
+      waits.push(ms)
+      if (signal.aborted) throw new Error('aborted')
+    },
+  }
+}
+
+describe('H3 — the wait is bounded and expiry invents nothing', () => {
+  it('stops after the declared schedule and performs ZERO store writes', async () => {
+    const h = harness()
+    const read = vi.fn(async () => graphResult(verdict({ kind: 'never_run' })))
+    const outcome = await runProvisionalDeliverySchedule({
+      scenarioId: SCENARIO,
+      userId: null,
+      signal: new AbortController().signal,
+      getStore: () => h.store,
+      read: read as never,
+      wait: h.wait,
+    })
+    expect(outcome).toBe('deadline')
+    // NOTHING was written — not a verdict, not a synthesised degraded state.
+    expect(h.setAnalysisStateV1).not.toHaveBeenCalled()
+    expect(h.resultsComplete).not.toHaveBeenCalled()
+    // BUDGET: exactly one read per declared delay, no more.
+    expect(read).toHaveBeenCalledTimes(PROVISIONAL_DELIVERY_DELAYS_MS.length)
+  })
+
+  it('the declared schedule is the one it asks for, and it ends at the deadline', async () => {
+    const h = harness()
+    await runProvisionalDeliverySchedule({
+      scenarioId: SCENARIO,
+      userId: null,
+      signal: new AbortController().signal,
+      getStore: () => h.store,
+      read: (async () => graphResult(verdict({ kind: 'never_run' }))) as never,
+      wait: h.wait,
+    })
+    // Cumulative sum of the requested gaps must reproduce the declared offsets —
+    // DERIVED from the exported constant, never a copied list (trap 12).
+    const cumulative: number[] = []
+    let total = 0
+    for (const gap of h.waits) {
+      total += gap
+      cumulative.push(total)
+    }
+    expect(cumulative).toEqual([...PROVISIONAL_DELIVERY_DELAYS_MS])
+    expect(total).toBe(PROVISIONAL_DELIVERY_DEADLINE_MS)
+    // And the bound is short enough to be a wait rather than a background job.
+    expect(PROVISIONAL_DELIVERY_DEADLINE_MS).toBeLessThanOrEqual(90_000)
+  })
+})
+
+describe('H4 — a non-terminal read keeps waiting; a terminal one settles', () => {
+  it('DELIVERS on the first read that carries a terminal verdict, and stops there', async () => {
+    const h = harness()
+    const answers = [
+      graphResult(verdict({ kind: 'never_run' })),
+      graphResult(verdict({ kind: 'never_run' })),
+      graphResult(
+        verdict({ kind: 'complete_current', computed_at: '2026-08-17T09:15:50.000Z' }),
+      ),
+    ]
+    let call = 0
+    const read = vi.fn(async () => answers[Math.min(call++, answers.length - 1)]!)
+    const outcome = await runProvisionalDeliverySchedule({
+      scenarioId: SCENARIO,
+      userId: null,
+      signal: new AbortController().signal,
+      getStore: () => h.store,
+      read: read as never,
+      wait: h.wait,
+    })
+    expect(outcome).toBe('delivered')
+    // It STOPPED — three reads, not seven. A loop that keeps polling after the
+    // answer arrives is a budget leak and a re-write risk.
+    expect(read).toHaveBeenCalledTimes(3)
+    expect(h.setAnalysisStateV1).toHaveBeenCalledTimes(1)
+    expect(h.setAnalysisStateV1.mock.calls[0]![0]).toEqual(
+      expect.objectContaining({
+        run_state: { kind: 'complete_current', computed_at: '2026-08-17T09:15:50.000Z' },
+      }),
+    )
+  })
+
+  it('an unreadable read (404 / 503) does NOT settle it and touches nothing', async () => {
+    // A 404 on this route means NOT READABLE — absent ∪ not-yours ∪
+    // oracle-unresolvable — and never deletion. Concluding from it would end the
+    // wait on a transient answer.
+    const h = harness()
+    const read = vi.fn(async () => ({ status: 'notReadable' as const }))
+    const outcome = await runProvisionalDeliverySchedule({
+      scenarioId: SCENARIO,
+      userId: null,
+      signal: new AbortController().signal,
+      getStore: () => h.store,
+      read: read as never,
+      wait: h.wait,
+    })
+    expect(outcome).toBe('deadline')
+    expect(read).toHaveBeenCalledTimes(PROVISIONAL_DELIVERY_DELAYS_MS.length)
+    expect(h.setAnalysisStateV1).not.toHaveBeenCalled()
+  })
+
+  it('a verdict CEE could not state (`analysisState: null`) does not settle it either', async () => {
+    const h = harness()
+    const read = vi.fn(async () => graphResult(null))
+    const outcome = await runProvisionalDeliverySchedule({
+      scenarioId: SCENARIO,
+      userId: null,
+      signal: new AbortController().signal,
+      getStore: () => h.store,
+      read: read as never,
+      wait: h.wait,
+    })
+    expect(outcome).toBe('deadline')
+    expect(h.setAnalysisStateV1).not.toHaveBeenCalled()
+  })
+})
+
+describe('it yields immediately on abort', () => {
+  it('an already-aborted signal performs no read at all', async () => {
+    const h = harness()
+    const controller = new AbortController()
+    controller.abort()
+    const read = vi.fn(async () => graphResult(null))
+    const outcome = await runProvisionalDeliverySchedule({
+      scenarioId: SCENARIO,
+      userId: null,
+      signal: controller.signal,
+      getStore: () => h.store,
+      read: read as never,
+      wait: h.wait,
+    })
+    expect(outcome).toBe('aborted')
+    expect(read).not.toHaveBeenCalled()
+  })
+
+  it('aborting mid-schedule stops the loop and writes nothing', async () => {
+    const h = harness()
+    const controller = new AbortController()
+    let call = 0
+    const read = vi.fn(async () => {
+      call += 1
+      if (call === 2) controller.abort()
+      return graphResult(verdict({ kind: 'never_run' }))
+    })
+    const outcome = await runProvisionalDeliverySchedule({
+      scenarioId: SCENARIO,
+      userId: null,
+      signal: controller.signal,
+      getStore: () => h.store,
+      read: read as never,
+      wait: h.wait,
+    })
+    expect(outcome).toBe('aborted')
+    expect(read).toHaveBeenCalledTimes(2)
+    expect(h.setAnalysisStateV1).not.toHaveBeenCalled()
+  })
+})
+
+describe('the store is read LAZILY, per attempt', () => {
+  it('re-reads the store on every attempt so a late dedupe sees the current hash', async () => {
+    // The wait is up to a minute long. A store snapshot taken at arming time
+    // would compare a stale `currentResultsHash` against the answer, and could
+    // re-write a result the user is already looking at.
+    const h = harness()
+    const getStore = vi.fn(() => h.store)
+    await runProvisionalDeliverySchedule({
+      scenarioId: SCENARIO,
+      userId: null,
+      signal: new AbortController().signal,
+      getStore,
+      read: (async () => graphResult(verdict({ kind: 'never_run' }))) as never,
+      wait: h.wait,
+    })
+    expect(getStore).toHaveBeenCalledTimes(PROVISIONAL_DELIVERY_DELAYS_MS.length)
+  })
+})

--- a/src/canvas/hooks/useProvisionalAnalysisDelivery.ts
+++ b/src/canvas/hooks/useProvisionalAnalysisDelivery.ts
@@ -1,0 +1,239 @@
+/**
+ * useProvisionalAnalysisDelivery — deliver the auto-run's provisional analysis
+ * WITHOUT another turn. ROADMAP 2.1271.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE GAP THIS CLOSES
+ * ═══════════════════════════════════════════════════════════════════════════
+ * A fresh admissible draft makes CEE schedule a provisional analysis (#999). Its
+ * dispatch commits roughly twenty seconds AFTER the draft SSE stream's terminal
+ * COMPLETE frame has closed the socket — the frame is terminal by design and no
+ * branch can hold it open. So the result was computed, persisted, and never
+ * arrived: the user saw it only if they happened to send another message.
+ *
+ * Paul's ruling (2026-08-17): server calculation and automatic client delivery
+ * are ONE capability, and the capability is not done until the result appears
+ * without another turn. This hook is that delivery.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHAT ARMS IT — the draft turn's own honest signal, not a timer
+ * ═══════════════════════════════════════════════════════════════════════════
+ * CEE now emits `analysis_state.run_state = { kind: 'running', started_at }` on
+ * a draft that actually scheduled a run, resolved from the SAME admission
+ * predicate that gates the scheduler. So this hook waits only when the server
+ * has said a run exists, and it re-arms on `started_at` IDENTITY — a second
+ * draft's run is a different run and gets its own bounded wait, while a
+ * re-render of the same one does not restart the schedule.
+ *
+ * It deliberately does NOT arm on "a draft just finished". That would poll on
+ * every draft, including the inadmissible ones where CEE runs nothing, and it
+ * would be a second answer to a question the server already answers.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHY A BOUNDED SCHEDULE AND NOT A TIGHT LOOP
+ * ═══════════════════════════════════════════════════════════════════════════
+ * The run is ~20s, so the useful window is short and the answer is not worth
+ * chasing at high frequency. The read route's limiter is keyed PER CLIENT IP —
+ * not per key — and the same bucket serves boot hydration and the in-session
+ * draft recovery, so a tight poll spends a budget other paths need. Derived at
+ * CEE's tip: the `read` tier is 90 rpm (`cee/config/limits.ts:47-50`), and the
+ * schedule below spends 7 reads over 60s.
+ *
+ * The delays are front-loaded around the expected commit and then spread, so the
+ * common case resolves in one or two reads and the tail costs almost nothing.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * ⚠ H3 — ON DEADLINE IT INVENTS NOTHING
+ * ═══════════════════════════════════════════════════════════════════════════
+ * A `running` claim can outlive its run: the dispatch can throw (contained by
+ * design), the already-analysed guard can skip it, a process can restart. So the
+ * wait is bounded — and when the bound expires this hook STOPS and writes
+ * NOTHING. It does not synthesise `unknown_degraded`, or any other verdict:
+ * those are the producer's words, not the client's. CEE's last verdict stands,
+ * and the manual Run affordance is untouched throughout (it is gated on the
+ * LOCAL results status, never on the wire verdict), so the user always retains
+ * the action.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * ⚠⚠ H4 — IT MUST NOT USE `applyV5State`
+ * ═══════════════════════════════════════════════════════════════════════════
+ * The turn applier CLEARS `analysis_state` on absence and would overwrite a
+ * standing `running` with a read's `never_run` — flipping the product from "an
+ * analysis is running" to "no analysis has ever been run" WHILE ONE IS RUNNING,
+ * on the very first read. Every write here goes through
+ * `hydrate/applyScenarioAnalysisRead.ts`, which applies a read's verdict only on
+ * a TERMINAL kind. See that file's header for the full argument and for the
+ * per-kind derivation.
+ *
+ * It also never touches the graph: `hydrate/serverGraphHydration.ts` remains the
+ * one graph-ingestion authority.
+ */
+
+import { useEffect, useRef } from 'react'
+
+import { useAuth } from '../../contexts/AuthContext'
+import { fetchScenarioGraph } from '../../adapters/cee/scenarioGraph'
+import { logger } from '../../lib/logger'
+import { useCanvasStore } from '../store'
+import {
+  applyScenarioAnalysisRead,
+  type ScenarioAnalysisApplyStore,
+} from '../hydrate/applyScenarioAnalysisRead'
+
+/**
+ * Delays from arming, in ms. Front-loaded around the ~20s commit, then spread.
+ * Exported so the spec asserts the SCHEDULE rather than restating it (trap 12),
+ * and so the budget claim in the header is checkable.
+ */
+export const PROVISIONAL_DELIVERY_DELAYS_MS: readonly number[] = [
+  8_000, 14_000, 20_000, 27_000, 36_000, 47_000, 60_000,
+]
+
+/** The bound. Past this the hook stops and writes nothing (H3). */
+export const PROVISIONAL_DELIVERY_DEADLINE_MS =
+  PROVISIONAL_DELIVERY_DELAYS_MS[PROVISIONAL_DELIVERY_DELAYS_MS.length - 1]
+
+export type ProvisionalDeliveryOutcome =
+  | 'delivered'
+  | 'already_held'
+  | 'deadline'
+  | 'aborted'
+  | 'unreadable'
+
+/**
+ * The testable core: run the bounded schedule once for one armed run. Never
+ * throws; every exit is an outcome. Extracted from the effect so the schedule,
+ * the H4 guard and the deadline are provable without React.
+ */
+export async function runProvisionalDeliverySchedule(deps: {
+  readonly scenarioId: string
+  readonly userId: string | null
+  readonly signal: AbortSignal
+  readonly getStore: () => ScenarioAnalysisApplyStore
+  readonly read: typeof fetchScenarioGraph
+  readonly wait: (ms: number, signal: AbortSignal) => Promise<void>
+  readonly delays?: readonly number[]
+}): Promise<ProvisionalDeliveryOutcome> {
+  const delays = deps.delays ?? PROVISIONAL_DELIVERY_DELAYS_MS
+  let previous = 0
+  for (const at of delays) {
+    try {
+      await deps.wait(at - previous, deps.signal)
+    } catch {
+      return 'aborted'
+    }
+    previous = at
+    if (deps.signal.aborted) return 'aborted'
+
+    const result = await deps.read(deps.scenarioId, {
+      userId: deps.userId ?? undefined,
+      signal: deps.signal,
+    })
+    if (deps.signal.aborted) return 'aborted'
+
+    // Only a `graph` result can carry the analysis keys. Every other status is
+    // "could not read", and `hydrateCanvasFromServer`'s own contract already
+    // establishes that none of them may touch local state — a 404 here means
+    // NOT READABLE, never deletion. So we keep waiting rather than concluding.
+    if (result.status !== 'graph') {
+      logger.debug('provisional_analysis_delivery.read_not_usable', {
+        scenarioId: deps.scenarioId,
+        status: result.status,
+      })
+      continue
+    }
+
+    const outcome = applyScenarioAnalysisRead({
+      analysisState: result.analysisState,
+      analysisResult: result.analysisResult,
+      store: deps.getStore(),
+    })
+    if (outcome.outcome === 'applied') {
+      logger.debug('provisional_analysis_delivery.delivered', {
+        scenarioId: deps.scenarioId,
+        kind: outcome.kind,
+        resultsHydrated: outcome.resultsHydrated,
+      })
+      return 'delivered'
+    }
+    if (outcome.outcome === 'alreadyHeld') return 'already_held'
+    // `notYet` — the H4 path. NOTHING was written; keep waiting.
+  }
+  // H3: the bound expired. Write nothing; leave CEE's verdict standing.
+  logger.debug('provisional_analysis_delivery.deadline', {
+    scenarioId: deps.scenarioId,
+    deadlineMs: PROVISIONAL_DELIVERY_DEADLINE_MS,
+  })
+  return 'deadline'
+}
+
+function waitFor(ms: number, signal: AbortSignal): Promise<void> {
+  if (ms <= 0) return signal.aborted ? Promise.reject(new Error('aborted')) : Promise.resolve()
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    const onAbort = (): void => {
+      clearTimeout(timer)
+      reject(new Error('aborted'))
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+/**
+ * Mount alongside `useServerGraphHydration`. Does nothing until CEE reports a
+ * run in flight for the current scenario.
+ */
+export function useProvisionalAnalysisDelivery(scenarioIdFromRoute?: string | null): void {
+  const currentScenarioId = useCanvasStore((s) => s.currentScenarioId)
+  const analysisState = useCanvasStore((s) => s.analysisStateV1)
+  const { user } = useAuth()
+
+  const scenarioId = currentScenarioId ?? scenarioIdFromRoute ?? null
+  // The RUN's identity, not the verdict's. `started_at` changes per run, so a
+  // second draft re-arms and a re-render does not.
+  const runKey =
+    analysisState !== null &&
+    analysisState !== undefined &&
+    analysisState.run_state.kind === 'running'
+      ? `${scenarioId ?? ''}:${analysisState.run_state.started_at}`
+      : null
+
+  const armedRef = useRef<string | null>(null)
+  const userId = user?.id ?? null
+
+  useEffect(() => {
+    if (scenarioId === null || runKey === null) return
+    if (armedRef.current === runKey) return
+    armedRef.current = runKey
+
+    const controller = new AbortController()
+    let settled = false
+
+    void runProvisionalDeliverySchedule({
+      scenarioId,
+      userId,
+      signal: controller.signal,
+      // Read the store LAZILY, per attempt: the dedupe compares against
+      // `currentResultsHash` as it is when the answer arrives, not as it was
+      // when the wait was armed a minute earlier.
+      getStore: () => useCanvasStore.getState() as unknown as ScenarioAnalysisApplyStore,
+      read: fetchScenarioGraph,
+      wait: waitFor,
+    }).then((outcome) => {
+      settled = true
+      logger.debug('provisional_analysis_delivery.outcome', { scenarioId, outcome })
+    })
+
+    return () => {
+      controller.abort()
+      // ⚠ AN ABORTED ATTEMPT IS NOT AN ATTEMPT — the StrictMode double-mount
+      // lesson from `useServerGraphHydration.ts:61-72`, which made hydration
+      // never run in development while production was fine. Releasing the ref
+      // when the schedule did not settle keeps dev and prod in agreement.
+      if (!settled) armedRef.current = null
+    }
+  }, [scenarioId, runKey, userId])
+}

--- a/src/canvas/hooks/useProvisionalAnalysisDelivery.ts
+++ b/src/canvas/hooks/useProvisionalAnalysisDelivery.ts
@@ -109,12 +109,27 @@ export async function runProvisionalDeliverySchedule(deps: {
   readonly scenarioId: string
   readonly userId: string | null
   readonly signal: AbortSignal
-  readonly getStore: () => ScenarioAnalysisApplyStore
+  /**
+   * The applier's store view, read LAZILY per attempt.
+   *
+   * ⚠ OPTIONAL, AND THE DEFAULT IS THE POINT. When this was a required
+   * parameter the hook supplied its own inline expression, so PRODUCTION's
+   * store view had no test anywhere: every spec injected a substitute, and the
+   * one shape that shipped was the one nothing exercised. That is how the
+   * `currentResultsHash` defect survived a full mutant kit.
+   *
+   * Defaulting it means production has exactly ONE store view, tests can still
+   * inject, and `runProvisionalDeliverySchedule` called WITHOUT this parameter
+   * exercises the real thing — which is what
+   * `useProvisionalAnalysisDelivery.realStoreBinding.spec.ts` asserts.
+   */
+  readonly getStore?: () => ScenarioAnalysisApplyStore
   readonly read: typeof fetchScenarioGraph
   readonly wait: (ms: number, signal: AbortSignal) => Promise<void>
   readonly delays?: readonly number[]
 }): Promise<ProvisionalDeliveryOutcome> {
   const delays = deps.delays ?? PROVISIONAL_DELIVERY_DELAYS_MS
+  const getStore = deps.getStore ?? readProvisionalApplyStore
   let previous = 0
   for (const at of delays) {
     try {
@@ -146,7 +161,7 @@ export async function runProvisionalDeliverySchedule(deps: {
     const outcome = applyScenarioAnalysisRead({
       analysisState: result.analysisState,
       analysisResult: result.analysisResult,
-      store: deps.getStore(),
+      store: getStore(),
     })
     if (outcome.outcome === 'applied') {
       logger.debug('provisional_analysis_delivery.delivered', {
@@ -165,6 +180,42 @@ export async function runProvisionalDeliverySchedule(deps: {
     deadlineMs: PROVISIONAL_DELIVERY_DEADLINE_MS,
   })
   return 'deadline'
+}
+
+/**
+ * The applier's view of the LIVE canvas store.
+ *
+ * ⚠⚠ THIS FUNCTION EXISTS BECAUSE THE OBVIOUS ONE-LINER WAS DEAD IN PRODUCTION.
+ * It was `useCanvasStore.getState() as unknown as ScenarioAnalysisApplyStore`,
+ * and the double cast switched typechecking OFF across a shape that does not
+ * match: the canvas store carries the results hash at `results.hash`, NOT at
+ * the top level, and all three members of `ScenarioAnalysisApplyStore` are
+ * optional — so `currentResultsHash` silently resolved to `undefined`, the
+ * dedupe compared a string hash against `null`, and `alreadyHeld` was
+ * UNREACHABLE. The turn path has always spliced the value in for exactly this
+ * reason (`conversation/useConversation.ts:4783`).
+ *
+ * Two deliberate choices, both load-bearing:
+ *
+ *  1. NO CAST. The members are named explicitly and the return type is checked,
+ *     so a drift in either store action's signature REDs `tsc` instead of
+ *     passing silently. A cast here is what hid the defect for a whole PR.
+ *  2. NO SPREAD. `...getState()` handed the applier the ENTIRE canvas store,
+ *     including the graph slices that `applyScenarioAnalysisRead`'s own header
+ *     says belong to `serverGraphHydration`. Naming three members keeps that
+ *     boundary real rather than documented.
+ *
+ * Exported so its binding to the REAL store is provable — a spec that builds
+ * its own store literal can only ever confirm the author's model of the store,
+ * which is precisely how this shipped.
+ */
+export function readProvisionalApplyStore(): ScenarioAnalysisApplyStore {
+  const s = useCanvasStore.getState()
+  return {
+    setAnalysisStateV1: s.setAnalysisStateV1,
+    resultsComplete: s.resultsComplete,
+    currentResultsHash: s.results?.hash ?? null,
+  }
 }
 
 function waitFor(ms: number, signal: AbortSignal): Promise<void> {
@@ -216,10 +267,6 @@ export function useProvisionalAnalysisDelivery(scenarioIdFromRoute?: string | nu
       scenarioId,
       userId,
       signal: controller.signal,
-      // Read the store LAZILY, per attempt: the dedupe compares against
-      // `currentResultsHash` as it is when the answer arrives, not as it was
-      // when the wait was armed a minute earlier.
-      getStore: () => useCanvasStore.getState() as unknown as ScenarioAnalysisApplyStore,
       read: fetchScenarioGraph,
       wait: waitFor,
     }).then((outcome) => {

--- a/src/canvas/hydrate/__tests__/applyScenarioAnalysisRead.contractPartition.spec.ts
+++ b/src/canvas/hydrate/__tests__/applyScenarioAnalysisRead.contractPartition.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * ROADMAP 2.1271 — THE TERMINAL SET MUST NOTICE THE CONTRACT GROWING.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHAT WAS WRONG WITH THE SET AS SHIPPED
+ * ═══════════════════════════════════════════════════════════════════════════
+ * `READ_TERMINAL_RUN_STATE_KINDS` is a hardcoded four-element array, arrived at
+ * by reading the contract's `.describe()` prose at 0.46.0 by hand. Nothing
+ * asserted it against the producer, so it was a hand-maintained mirror of a
+ * vocabulary that lives in another repo (trap 12).
+ *
+ * It errs WIDE rather than narrow — an unclassified kind falls to the
+ * non-terminal default, which declines to write and keeps polling — so it was
+ * never a correctness blocker. But the failure it does have is SILENT: a
+ * contract that gains an eighth kind produces no signal anywhere, and this
+ * applier simply never learns to handle it.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHY A PARTITION ASSERTION AND NOT A DERIVATION
+ * ═══════════════════════════════════════════════════════════════════════════
+ * The terminal set is a JUDGEMENT (what can a fact read prove?), not a fact
+ * carried in the contract, so it cannot be derived — deriving it from the
+ * contract would just be the contract, and every kind would be terminal.
+ *
+ * What IS checkable is that the judgement has been made for every kind the
+ * contract admits. Trap 12d: a derived guard proves agreement and can never
+ * prove completeness; completeness needs a check that is NOT derived from the
+ * list under test. Here that check is the contract's own exported vocabulary,
+ * `ANALYSIS_RUN_STATE_KINDS` — an independent source, imported at runtime, that
+ * grows when the producer grows.
+ *
+ * So: terminal ⊎ non-terminal ≡ ANALYSIS_RUN_STATE_KINDS. Exactly. A new kind
+ * belongs to neither of our sets and REDs here, by name.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { ANALYSIS_RUN_STATE_KINDS } from '@talchain/schemas/boundary'
+
+import {
+  READ_TERMINAL_RUN_STATE_KINDS,
+  READ_NON_TERMINAL_RUN_STATE_KINDS,
+  isReadTerminalRunState,
+} from '../applyScenarioAnalysisRead'
+
+describe('the read-terminal partition tracks the CONTRACT, not a copy of it', () => {
+  it('POSITIVE CONTROL — the contract vocabulary is actually reachable and non-trivial', () => {
+    // Without this, a broken import resolving to `undefined`/`[]` would make
+    // every assertion below pass vacuously (trap 13). The magnitude matters as
+    // much as the sign: an empty array would satisfy "is an array".
+    expect(Array.isArray(ANALYSIS_RUN_STATE_KINDS)).toBe(true)
+    expect(ANALYSIS_RUN_STATE_KINDS.length).toBeGreaterThanOrEqual(7)
+    // A member we can name, so the array is the one we think it is.
+    expect(ANALYSIS_RUN_STATE_KINDS).toContain('complete_current')
+  })
+
+  it('⭐ the two sets PARTITION the contract vocabulary exactly — a new kind REDs here', () => {
+    const classified = [
+      ...READ_TERMINAL_RUN_STATE_KINDS,
+      ...READ_NON_TERMINAL_RUN_STATE_KINDS,
+    ].sort()
+    const contract = [...ANALYSIS_RUN_STATE_KINDS].sort()
+
+    // GROWTH: a kind the contract has and we have not classified.
+    const unclassified = contract.filter((k) => !classified.includes(k))
+    expect(unclassified).toEqual([])
+
+    // SHRINK / INVENTION: a kind we classify that the contract does not have.
+    const invented = classified.filter((k) => !contract.includes(k as never))
+    expect(invented).toEqual([])
+
+    // And exact equality, which also catches a duplicate in either of our sets.
+    expect(classified).toEqual(contract)
+  })
+
+  it('the two sets are DISJOINT — no kind is both terminal and not', () => {
+    const overlap = READ_TERMINAL_RUN_STATE_KINDS.filter((k) =>
+      (READ_NON_TERMINAL_RUN_STATE_KINDS as readonly string[]).includes(k),
+    )
+    expect(overlap).toEqual([])
+  })
+
+  it('the predicate agrees with the declared sets over the WHOLE contract vocabulary', () => {
+    // Binds the runtime predicate to the same source of truth, so a set edited
+    // without touching `isReadTerminalRunState` cannot drift past this file.
+    for (const kind of ANALYSIS_RUN_STATE_KINDS) {
+      const expected = (READ_TERMINAL_RUN_STATE_KINDS as readonly string[]).includes(kind)
+      expect({ kind, terminal: isReadTerminalRunState(kind) }).toEqual({ kind, terminal: expected })
+    }
+  })
+
+  it('CONTRAST CONTROL — the predicate rejects a kind the contract does not carry', () => {
+    // Proves the predicate discriminates rather than answering `true` broadly.
+    expect(isReadTerminalRunState('complete_current_XYZ')).toBe(false)
+    expect(ANALYSIS_RUN_STATE_KINDS).not.toContain('complete_current_XYZ' as never)
+  })
+})

--- a/src/canvas/hydrate/__tests__/applyScenarioAnalysisRead.spec.ts
+++ b/src/canvas/hydrate/__tests__/applyScenarioAnalysisRead.spec.ts
@@ -1,0 +1,323 @@
+/**
+ * ROADMAP 2.1271 — THE H4 GUARD: a graph READ may never demote a live `running`.
+ *
+ * ── THE DEFECT THIS PREVENTS, and it would have been the DEFAULT ─────────────
+ * The draft turn says `running`. CEE keeps NO in-flight marker, so the first
+ * read taken while the run is in flight can only answer `never_run` — and
+ * `never_run`'s contract text licenses a consumer to render the PRE-ANALYSIS
+ * affordance. Fed through the turn applier (`v5/applyV5State.ts:1113-1120`,
+ * clear-on-absence and set-on-presence) that read would flip the product from
+ * "an analysis is running" to "no analysis has ever been run" WHILE ONE IS
+ * RUNNING. Not an edge case: the ordinary first poll.
+ *
+ * `applyScenarioAnalysisRead` is the narrow applier written against that, and
+ * these are its pins.
+ *
+ * ── THE DISCRIMINATING PAIRS (trap 19) ──────────────────────────────────────
+ * Every non-terminal kind has a terminal twin asserted in the same suite, so a
+ * mutant that removes the terminal filter REDs the non-terminal half while the
+ * terminal half stays green, and a mutant that inverts the filter does the
+ * reverse. Neither direction can pass alone.
+ *
+ * ── P1 · ONE SEAM BEYOND THE GUARD ──────────────────────────────────────────
+ * The guard is the terminal-kind filter. One seam past it is the RESULTS write,
+ * so the malformed-block case drives a real block through the REAL mapper and
+ * asserts the standing verdict and the surrounding store survive — the applier
+ * must never cost the user what they already had.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+
+import {
+  applyScenarioAnalysisRead,
+  isReadTerminalRunState,
+  READ_TERMINAL_RUN_STATE_KINDS,
+  type ScenarioAnalysisApplyStore,
+} from '../applyScenarioAnalysisRead'
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────
+
+function verdict(runState: AnalysisStateV1['run_state']): AnalysisStateV1 {
+  return {
+    run_state: runState,
+    readiness: { status: 'ready', blockers: [] },
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: false,
+    blocked_unusable: false,
+    contradictions: [],
+  } as AnalysisStateV1
+}
+
+/** A real `analysis_result` block, of the shape CEE's builder emits. */
+const RESULT_BLOCK = {
+  type: 'analysis_result',
+  summary: 'Hiring leads on the current model.',
+  leading_option_id: 'opt_hire',
+  win_probabilities: { opt_hire: 0.68, opt_hold: 0.32 },
+  computed_against_hash: 'hash_draft',
+  enrichment: {
+    analysis_status: 'ok',
+    option_comparison: [
+      { option_id: 'opt_hire', option_label: 'Hire', win_probability: 0.68, outcome_mean: 0.55 },
+      { option_id: 'opt_hold', option_label: 'Hold', win_probability: 0.32, outcome_mean: 0.41 },
+    ],
+  },
+}
+
+function makeStore(overrides: Partial<ScenarioAnalysisApplyStore> = {}): {
+  store: ScenarioAnalysisApplyStore
+  setAnalysisStateV1: ReturnType<typeof vi.fn>
+  resultsComplete: ReturnType<typeof vi.fn>
+  calls: string[]
+} {
+  const calls: string[] = []
+  const setAnalysisStateV1 = vi.fn(() => {
+    calls.push('setAnalysisStateV1')
+  })
+  const resultsComplete = vi.fn(() => {
+    calls.push('resultsComplete')
+  })
+  return {
+    store: {
+      setAnalysisStateV1,
+      resultsComplete,
+      currentResultsHash: null,
+      ...overrides,
+    } as ScenarioAnalysisApplyStore,
+    setAnalysisStateV1,
+    resultsComplete,
+    calls,
+  }
+}
+
+// ─── The H4 guard ─────────────────────────────────────────────────────────
+
+describe('H4 — a read never demotes a live `running`', () => {
+  it('a `never_run` read performs NO store write at all', () => {
+    const { store, setAnalysisStateV1, resultsComplete } = makeStore()
+    const outcome = applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'never_run' }),
+      analysisResult: null,
+      store,
+    })
+    expect(outcome).toEqual({ outcome: 'notYet', reason: 'non_terminal_kind' })
+    // The whole point: not "written with a safe value" — NOT WRITTEN.
+    expect(setAnalysisStateV1).not.toHaveBeenCalled()
+    expect(resultsComplete).not.toHaveBeenCalled()
+  })
+
+  it('DISCRIMINATING TWIN — a `complete_current` read IS written', () => {
+    const { store, setAnalysisStateV1 } = makeStore()
+    const v = verdict({ kind: 'complete_current', computed_at: '2026-08-17T09:15:50.000Z' })
+    const outcome = applyScenarioAnalysisRead({
+      analysisState: v,
+      analysisResult: null,
+      store,
+    })
+    expect(outcome).toEqual({ outcome: 'applied', kind: 'complete_current', resultsHydrated: false })
+    // Bound by IDENTITY — the exact verdict object, not "something was written".
+    expect(setAnalysisStateV1).toHaveBeenCalledWith(v)
+  })
+
+  it('an `unknown_degraded` read performs NO store write — an absent outcome is not an outcome', () => {
+    const { store, setAnalysisStateV1 } = makeStore()
+    const outcome = applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'unknown_degraded', cause: 'store_unreadable' }),
+      analysisResult: null,
+      store,
+    })
+    expect(outcome).toEqual({ outcome: 'notYet', reason: 'non_terminal_kind' })
+    expect(setAnalysisStateV1).not.toHaveBeenCalled()
+  })
+
+  it('a `running` read is treated as non-terminal, so a future in-flight marker cannot rewrite one', () => {
+    const { store, setAnalysisStateV1 } = makeStore()
+    const outcome = applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'running', started_at: '2026-08-17T09:15:30.250Z' }),
+      analysisResult: null,
+      store,
+    })
+    expect(outcome).toEqual({ outcome: 'notYet', reason: 'non_terminal_kind' })
+    expect(setAnalysisStateV1).not.toHaveBeenCalled()
+  })
+
+  it('ABSENCE IS NOT A STATE — a null verdict writes nothing, not even null', () => {
+    const { store, setAnalysisStateV1 } = makeStore()
+    const outcome = applyScenarioAnalysisRead({
+      analysisState: null,
+      analysisResult: RESULT_BLOCK,
+      store,
+    })
+    expect(outcome).toEqual({ outcome: 'notYet', reason: 'no_verdict' })
+    expect(setAnalysisStateV1).not.toHaveBeenCalled()
+  })
+
+  it('P1 · ONE SEAM PAST THE GUARD — an `undefined` verdict does not throw either', () => {
+    const { store } = makeStore()
+    const outcome = applyScenarioAnalysisRead({
+      // The type says this cannot happen; the applier is on a delivery path
+      // whose contract is that it never costs the user anything, so it is
+      // driven anyway.
+      analysisState: undefined as unknown as AnalysisStateV1 | null,
+      analysisResult: RESULT_BLOCK,
+      store,
+    })
+    expect(outcome).toEqual({ outcome: 'notYet', reason: 'no_verdict' })
+  })
+})
+
+// ─── The terminal set is one definition, not a mirror ─────────────────────
+
+describe('the terminal set', () => {
+  it('is exactly the four kinds a fact read can prove', () => {
+    expect([...READ_TERMINAL_RUN_STATE_KINDS]).toEqual([
+      'complete_current',
+      'complete_stale',
+      'blocked',
+      'refused',
+    ])
+  })
+
+  it.each(['complete_current', 'complete_stale', 'blocked', 'refused'])(
+    'classifies %s as terminal',
+    (kind) => {
+      expect(isReadTerminalRunState(kind)).toBe(true)
+    },
+  )
+
+  it.each(['never_run', 'running', 'unknown_degraded'])(
+    'classifies %s as NON-terminal',
+    (kind) => {
+      expect(isReadTerminalRunState(kind)).toBe(false)
+    },
+  )
+})
+
+// ─── Results delivery ─────────────────────────────────────────────────────
+
+describe('results delivery', () => {
+  it('hydrates the results from the block AND writes the verdict', () => {
+    const { store, setAnalysisStateV1, resultsComplete } = makeStore()
+    const outcome = applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'complete_current', computed_at: '2026-08-17T09:15:50.000Z' }),
+      analysisResult: RESULT_BLOCK,
+      store,
+    })
+    expect(outcome).toEqual({ outcome: 'applied', kind: 'complete_current', resultsHydrated: true })
+    expect(resultsComplete).toHaveBeenCalledTimes(1)
+    expect(setAnalysisStateV1).toHaveBeenCalledTimes(1)
+    // The report came from the REAL mapper over the REAL block — bound by the
+    // option ids, which only that block can produce.
+    const params = resultsComplete.mock.calls[0]![0] as { report: unknown; hash: string }
+    expect(typeof params.hash).toBe('string')
+    expect(params.hash.length).toBeGreaterThan(0)
+  })
+
+  it('RESULTS BEFORE VERDICT — the order is asserted, not assumed', () => {
+    // A verdict-first order exposes a frame where `complete_current` vouches for
+    // a result not yet on screen, which `deriveAnalysisDisplayState` reads as
+    // "Ready to analyse" over a completed analysis.
+    const { store, calls } = makeStore()
+    applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'complete_current', computed_at: '2026-08-17T09:15:50.000Z' }),
+      analysisResult: RESULT_BLOCK,
+      store,
+    })
+    expect(calls).toEqual(['resultsComplete', 'setAnalysisStateV1'])
+  })
+
+  it('DEDUPE — a result we already display is not re-written, and still SETTLES the caller', () => {
+    // First pass to learn the hash the mapper produces, so the dedupe is bound
+    // to the real value rather than to a hand-copied constant.
+    const first = makeStore()
+    applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'complete_current', computed_at: '2026-08-17T09:15:50.000Z' }),
+      analysisResult: RESULT_BLOCK,
+      store: first.store,
+    })
+    const hash = (first.resultsComplete.mock.calls[0]![0] as { hash: string }).hash
+
+    const second = makeStore({ currentResultsHash: hash })
+    const outcome = applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'complete_current', computed_at: '2026-08-17T09:15:50.000Z' }),
+      analysisResult: RESULT_BLOCK,
+      store: second.store,
+    })
+    expect(outcome).toEqual({ outcome: 'alreadyHeld', kind: 'complete_current' })
+    expect(second.resultsComplete).not.toHaveBeenCalled()
+    expect(second.setAnalysisStateV1).not.toHaveBeenCalled()
+  })
+
+  it('a terminal verdict with NO block still writes the verdict (CEE withholds stale numbers)', () => {
+    const { store, setAnalysisStateV1, resultsComplete } = makeStore()
+    const outcome = applyScenarioAnalysisRead({
+      analysisState: verdict({
+        kind: 'complete_stale',
+        computed_at: '2026-08-17T09:15:50.000Z',
+        cause: 'graph_changed',
+      }),
+      analysisResult: null,
+      store,
+    })
+    expect(outcome).toEqual({ outcome: 'applied', kind: 'complete_stale', resultsHydrated: false })
+    expect(setAnalysisStateV1).toHaveBeenCalledTimes(1)
+    expect(resultsComplete).not.toHaveBeenCalled()
+  })
+
+  it('a store double WITHOUT `resultsComplete` still writes the verdict rather than throwing', () => {
+    const setAnalysisStateV1 = vi.fn()
+    const outcome = applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'refused', reason_code: 'analysis_refused_unspecified' }),
+      analysisResult: RESULT_BLOCK,
+      store: { setAnalysisStateV1 } as ScenarioAnalysisApplyStore,
+    })
+    expect(outcome).toEqual({ outcome: 'applied', kind: 'refused', resultsHydrated: false })
+    expect(setAnalysisStateV1).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ─── G3 · THE HAZARD, DEMONSTRATED ────────────────────────────────────────
+
+describe('G3 — the demotion this applier exists to prevent is REAL', () => {
+  it('DEMONSTRATION: the TURN applier writes a read’s `never_run` over a standing `running`', async () => {
+    // ⚠ THIS IS THE RED THE GUARD POINTS AT (falsification gate G3), and it is
+    // asserted rather than described so the necessity of the narrow applier
+    // cannot quietly stop being true. Nothing here is a criticism of
+    // `applyV5State`: clear-and-set-per-turn is CORRECT for turns. It is simply
+    // the wrong rule for a read, and this is the proof.
+    const { applyV5State } = await import('../../../v5/applyV5State')
+    const setAnalysisStateV1 = vi.fn()
+    const readShapedResponse = {
+      response_version: 2,
+      assistant_text: '',
+      blocks: [],
+      suggested_actions: [],
+      insights: [],
+      // Exactly what CEE's read leg returns MID-RUN: no fact has landed yet.
+      analysis_state: verdict({ kind: 'never_run' }),
+    }
+    applyV5State(
+      readShapedResponse as never,
+      { setAnalysisStateV1 } as never,
+    )
+    // The demotion, in one line: the turn applier accepts `never_run` and
+    // overwrites whatever the draft turn had established.
+    expect(setAnalysisStateV1).toHaveBeenCalledWith(
+      expect.objectContaining({ run_state: { kind: 'never_run' } }),
+    )
+
+    // And the CONTRAST, in the same run: the narrow applier declines.
+    const narrow = makeStore()
+    applyScenarioAnalysisRead({
+      analysisState: verdict({ kind: 'never_run' }),
+      analysisResult: null,
+      store: narrow.store,
+    })
+    expect(narrow.setAnalysisStateV1).not.toHaveBeenCalled()
+  })
+})

--- a/src/canvas/hydrate/__tests__/applyScenarioAnalysisRead.spec.ts
+++ b/src/canvas/hydrate/__tests__/applyScenarioAnalysisRead.spec.ts
@@ -27,6 +27,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest'
+import type { Mock } from 'vitest'
 import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
 
 import {
@@ -69,17 +70,31 @@ const RESULT_BLOCK = {
   },
 }
 
+/**
+ * The two store writers, typed BY IDENTITY off the store contract rather than
+ * restated here (trap 12). `ReturnType<typeof vi.fn>` widens to
+ * `Mock<any[], unknown>` while `vi.fn(() => {})` infers `Mock<[], void>`, and
+ * vitest's `Mock` is INVARIANT in its argument tuple (`mock.calls` puts `TArgs`
+ * in both positions), so the two do not assign — TS2322. Deriving both the
+ * declaration and the implementation from `ScenarioAnalysisApplyStore` fixes it
+ * at the source AND makes the arg-bearing assertions below (`toHaveBeenCalledWith`,
+ * `mock.calls[0]![0]`) type-check against the REAL parameter, which a widened
+ * `any[]` would have silently stopped checking.
+ */
+type SetVerdictFn = NonNullable<ScenarioAnalysisApplyStore['setAnalysisStateV1']>
+type ResultsCompleteFn = NonNullable<ScenarioAnalysisApplyStore['resultsComplete']>
+
 function makeStore(overrides: Partial<ScenarioAnalysisApplyStore> = {}): {
   store: ScenarioAnalysisApplyStore
-  setAnalysisStateV1: ReturnType<typeof vi.fn>
-  resultsComplete: ReturnType<typeof vi.fn>
+  setAnalysisStateV1: Mock<Parameters<SetVerdictFn>, ReturnType<SetVerdictFn>>
+  resultsComplete: Mock<Parameters<ResultsCompleteFn>, ReturnType<ResultsCompleteFn>>
   calls: string[]
 } {
   const calls: string[] = []
-  const setAnalysisStateV1 = vi.fn(() => {
+  const setAnalysisStateV1 = vi.fn<Parameters<SetVerdictFn>, ReturnType<SetVerdictFn>>(() => {
     calls.push('setAnalysisStateV1')
   })
-  const resultsComplete = vi.fn(() => {
+  const resultsComplete = vi.fn<Parameters<ResultsCompleteFn>, ReturnType<ResultsCompleteFn>>(() => {
     calls.push('resultsComplete')
   })
   return {

--- a/src/canvas/hydrate/__tests__/applyScenarioAnalysisRead.spec.ts
+++ b/src/canvas/hydrate/__tests__/applyScenarioAnalysisRead.spec.ts
@@ -319,5 +319,12 @@ describe('G3 — the demotion this applier exists to prevent is REAL', () => {
       store: narrow.store,
     })
     expect(narrow.setAnalysisStateV1).not.toHaveBeenCalled()
-  })
+    // ⚠ EXPLICIT TIMEOUT, and it is not padding. This is the one test here that
+    // dynamically imports `applyV5State` — a large module whose cold transform
+    // exceeded vitest's 5s default in a fresh worktree with a symlinked
+    // `node_modules` (caught by the mutant battery's PRISTINE CONTROL, which is
+    // what that control is for). A cold-cache timeout in a control makes every
+    // mutant verdict void, so the flake is fixed at the source rather than
+    // absorbed.
+  }, 30_000)
 })

--- a/src/canvas/hydrate/applyScenarioAnalysisRead.ts
+++ b/src/canvas/hydrate/applyScenarioAnalysisRead.ts
@@ -88,12 +88,42 @@ import { mapV5AnalysisToReport } from '../../v5/mapV5AnalysisToReport'
  * The kinds a FACT READ is entitled to report as an outcome. Exported so the
  * polling hook and the tests read the SAME set — one definition, three read
  * points, no mirror to drift (trap 12).
+ *
+ * ⚠ THIS LIST CANNOT BE DERIVED, AND THAT IS THE POINT. Which kinds a read may
+ * treat as terminal is a JUDGEMENT about what a fact read can prove (the
+ * per-kind reasoning is in this file's header) — there is no field in the
+ * contract that states it, so no derivation can produce it. What that judgement
+ * DOES owe is that it has been made for every kind the contract admits.
+ *
+ * A derived guard proves agreement and can never prove completeness (trap 12d).
+ * So the completeness check lives beside its twin below and is asserted against
+ * the contract's OWN exported vocabulary (`ANALYSIS_RUN_STATE_KINDS`) in
+ * `__tests__/applyScenarioAnalysisRead.contractPartition.spec.ts`: the two sets
+ * must PARTITION it exactly. A contract that gains a kind therefore REDs that
+ * spec instead of falling silently into the non-terminal default here — which
+ * is the safe direction, but a silent one, and silence is how a new state stops
+ * being noticed.
  */
 export const READ_TERMINAL_RUN_STATE_KINDS = [
   'complete_current',
   'complete_stale',
   'blocked',
   'refused',
+] as const
+
+/**
+ * The twin: kinds this applier has CONSCIOUSLY declined to treat as terminal.
+ *
+ * It is not used for control flow — `isReadTerminalRunState` is the only
+ * predicate — and it exists solely so "we have classified every kind" is a
+ * checkable claim rather than an assumption. Listing them here, next to the
+ * terminal set, is what lets the partition spec notice a kind that belongs to
+ * neither.
+ */
+export const READ_NON_TERMINAL_RUN_STATE_KINDS = [
+  'never_run',
+  'running',
+  'unknown_degraded',
 ] as const
 
 export type ReadTerminalRunStateKind = (typeof READ_TERMINAL_RUN_STATE_KINDS)[number]
@@ -177,6 +207,26 @@ export function applyScenarioAnalysisRead(
     input.store.resultsComplete({
       report,
       hash,
+      // ⚠ 'conversation' IS CORRECT HERE, and it was queried in review — so the
+      // reasoning is pinned rather than left to be re-litigated.
+      //
+      // The objection is that these results arrived on a READ leg, not a
+      // conversation turn. That is true of the TRANSPORT and irrelevant to this
+      // field, because the two answer different questions (trap 21):
+      //
+      //   `resultsSource` asks   "what CAUSED this analysis to exist?"
+      //   the read leg answers   "how did it REACH the client?"
+      //
+      // The store's own declaration scopes it to cause — "'direct' (Play
+      // button) or 'conversation' (envelope path)" (`canvas/store.ts:901`) —
+      // and its only consumer renders "Updated from conversation"
+      // (`OutputsDock.tsx:3114`) to explain results the user did not ask for by
+      // pressing Run. This run was scheduled BY the draft turn. So:
+      //   · 'conversation' → true, and the user gets the explanation.
+      //   · 'direct'       → a lie (claims the Play button) AND suppresses the
+      //                      indicator, so results would appear unannounced.
+      // A third value would need a product decision about that indicator's copy
+      // and is out of this lane's scope; it is not needed for honesty.
       resultsSource: 'conversation',
       // V5 carries no V2 envelope; pass null so the V2-shaped slots are
       // explicitly cleared rather than left to a stale prior write — the same

--- a/src/canvas/hydrate/applyScenarioAnalysisRead.ts
+++ b/src/canvas/hydrate/applyScenarioAnalysisRead.ts
@@ -1,0 +1,193 @@
+/**
+ * applyScenarioAnalysisRead — the NARROW applier for a scenario-graph READ's
+ * analysis payload. ROADMAP 2.1271, hazard H4.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * ⚠⚠ WHY THIS EXISTS INSTEAD OF `applyV5State`, AND IT IS NOT A STYLE CHOICE
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * `applyV5State` is the TURN applier and its `analysis_state` rule is
+ * CLEAR-ON-ABSENCE, deliberately and correctly (`v5/applyV5State.ts:1113-1120`):
+ * *"the field's whole contract is 'CEE stated this FOR THIS TURN', so silence
+ * must clear or the authority claim becomes a lie about which turn spoke."*
+ *
+ * That rule is right about turns and WRONG about reads, because the two
+ * authorities answer DIFFERENT QUESTIONS (CLAUDE.md trap 21):
+ *
+ *   the DRAFT TURN answers   "did I start a provisional run?"   → can say `running`
+ *   a GRAPH READ answers     "has a fact landed for this graph?" → cannot
+ *
+ * CEE keeps NO in-flight marker anywhere, so while the auto-run is in flight the
+ * only answer a read can give is that no fact has landed — `never_run`. Feeding
+ * that through the turn applier would therefore flip the product from *"an
+ * analysis is running"* to *"no analysis has ever been run"* WHILE ONE IS
+ * RUNNING, and `never_run`'s contract text licenses the consumer to render the
+ * pre-analysis affordance over it. That is a worse lie than the one this whole
+ * slice exists to fix, and under the turn applier it is the DEFAULT behaviour on
+ * the very first poll, not an edge case.
+ *
+ * So: this applier writes a read's verdict ONLY when that verdict is TERMINAL —
+ * when it reports an outcome a fact read is actually entitled to report. Every
+ * non-terminal answer, and an absent one, is *"not yet"* and performs NO STORE
+ * WRITE AT ALL.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE TERMINAL SET, DERIVED FROM THE CONTRACT'S OWN TEXT, NOT FROM CONVENIENCE
+ * ═══════════════════════════════════════════════════════════════════════════
+ * Read at the vendored bytes (`@talchain/schemas` 0.46.0,
+ * `dist/boundary/analysis-state.js`), one line of reasoning per kind:
+ *
+ *   `complete_current`  a fact landed and is current — THE answer being waited
+ *                       for. Apply, settle.
+ *   `complete_stale`    a fact landed; the graph moved since. Still an outcome a
+ *                       read can prove. Apply, settle. (CEE ships no result
+ *                       block on this verdict — those numbers describe a graph
+ *                       the user has since changed.)
+ *   `blocked`           "THE MODEL IS NOT ANALYSABLE as it stands … no run was
+ *                       attempted". A statement about the model, provable from
+ *                       the read. Apply, settle.
+ *   `refused`           the analysis was declined. Provable, terminal. Apply,
+ *                       settle.
+ *   ─────────────────── the line ──────────────────────────────────────────────
+ *   `never_run`         INDISTINGUISHABLE from "in flight" on this leg. Never
+ *                       apply. Never settle.
+ *   `unknown_degraded`  "the producer cannot state a run state at all" — the
+ *                       store was unreadable, or the fact is unclassifiable.
+ *                       That is not an outcome; it is the absence of one. Never
+ *                       apply, never settle.
+ *   `running`           a read CANNOT produce this today (CEE has no in-flight
+ *                       marker). Listed as non-terminal rather than omitted so
+ *                       that if a future CEE gains the marker (the H4b upgrade)
+ *                       this applier keeps a standing `running` rather than
+ *                       re-writing it, and the polling loop keeps looking.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * IT WRITES THE RESULTS BEFORE IT WRITES THE VERDICT.
+ * ═══════════════════════════════════════════════════════════════════════════
+ * `analysisStateSelector` composes its display semantic from the verdict AND
+ * from `hasReport` (`results.report != null`). A verdict-first order would
+ * expose a frame in which `complete_current` vouches for a result not yet on
+ * screen, which `deriveAnalysisDisplayState` reads as `ready_to_analyse` —
+ * "Ready to analyse" over a completed analysis. Cheap to get right, so it is
+ * got right, and pinned by a test that asserts the call order.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * IT DOES NOT TOUCH THE GRAPH.
+ * ═══════════════════════════════════════════════════════════════════════════
+ * `canvas/hydrate/serverGraphHydration.ts` is the ONE graph-ingestion authority
+ * and it stays so — *"A second ingestion path here would be the
+ * two-`generateGraphHash`-twins defect all over again"* (`draftRecovery.ts:13-19`).
+ * This applier reads only the two analysis keys and never the `graph` member.
+ */
+
+import type { AnalysisResultBlock, AnalysisStateV1 } from '@talchain/schemas/boundary'
+
+import { mapV5AnalysisToReport } from '../../v5/mapV5AnalysisToReport'
+
+/**
+ * The kinds a FACT READ is entitled to report as an outcome. Exported so the
+ * polling hook and the tests read the SAME set — one definition, three read
+ * points, no mirror to drift (trap 12).
+ */
+export const READ_TERMINAL_RUN_STATE_KINDS = [
+  'complete_current',
+  'complete_stale',
+  'blocked',
+  'refused',
+] as const
+
+export type ReadTerminalRunStateKind = (typeof READ_TERMINAL_RUN_STATE_KINDS)[number]
+
+export function isReadTerminalRunState(kind: string): kind is ReadTerminalRunStateKind {
+  return (READ_TERMINAL_RUN_STATE_KINDS as readonly string[]).includes(kind)
+}
+
+/**
+ * The store surface this applier is allowed to touch. Deliberately the minimum:
+ * a wider type would let a later edit reach the graph slices, which belong to
+ * `serverGraphHydration`.
+ */
+export interface ScenarioAnalysisApplyStore {
+  readonly setAnalysisStateV1?: (verdict: AnalysisStateV1 | null) => void
+  readonly resultsComplete?: (params: {
+    report: ReturnType<typeof mapV5AnalysisToReport>
+    hash: string
+    resultsSource?: 'direct' | 'conversation'
+    enrichment?: null
+    rawV2Response?: null
+    v5Enrichment?: unknown
+  }) => void
+  readonly currentResultsHash?: string | null
+}
+
+export type ScenarioAnalysisApplyOutcome =
+  /** A terminal verdict was applied. The caller must stop polling. */
+  | { readonly outcome: 'applied'; readonly kind: ReadTerminalRunStateKind; readonly resultsHydrated: boolean }
+  /** Nothing was written. The caller may keep waiting (within its own bound). */
+  | { readonly outcome: 'notYet'; readonly reason: 'no_verdict' | 'non_terminal_kind' }
+  /** A terminal verdict whose result we already hold. Stop polling; no rewrite. */
+  | { readonly outcome: 'alreadyHeld'; readonly kind: ReadTerminalRunStateKind }
+
+export interface ApplyScenarioAnalysisReadInput {
+  readonly analysisState: AnalysisStateV1 | null
+  readonly analysisResult: unknown
+  readonly store: ScenarioAnalysisApplyStore
+}
+
+/**
+ * Apply a read's analysis payload, or decline to. Pure with respect to
+ * everything except the two store actions it may call; never throws.
+ */
+export function applyScenarioAnalysisRead(
+  input: ApplyScenarioAnalysisReadInput,
+): ScenarioAnalysisApplyOutcome {
+  const verdict = input.analysisState
+  // ⚠ ABSENCE IS NOT A STATE. An older CEE, a graphless scenario and a verdict
+  // that failed the contract's own validation all arrive here as `null`, and in
+  // every one of those cases we know strictly less than we did a moment ago.
+  // Writing anything — including `null` — would replace a truthful standing
+  // belief with a less-true one (P3).
+  // `== null` deliberately, not `=== null`: the TYPE says the field is always
+  // present, and it is on every parsed result — but this applier is also called
+  // from tests and could one day be called from untyped code, and reading
+  // `undefined.run_state` would throw inside a delivery path whose entire
+  // contract is that it never costs the user anything. One seam past the guard.
+  if (verdict == null) return { outcome: 'notYet', reason: 'no_verdict' }
+
+  const kind = verdict.run_state.kind
+  if (!isReadTerminalRunState(kind)) {
+    // THE H4 GUARD. `never_run` lands here, and this early return is the
+    // difference between the capability and a regression.
+    return { outcome: 'notYet', reason: 'non_terminal_kind' }
+  }
+
+  // ── Results FIRST (see the header) ────────────────────────────────────────
+  let resultsHydrated = false
+  const block = input.analysisResult
+  if (block !== null && block !== undefined && typeof input.store.resultsComplete === 'function') {
+    const report = mapV5AnalysisToReport(block as AnalysisResultBlock)
+    const hash = report.model_card.response_hash
+    // The SAME hash dedupe the turn applier uses: a re-read of an analysis we
+    // already display must not re-write the slice (it would restart animations
+    // and re-seed the Compare capture). `alreadyHeld` still SETTLES the caller —
+    // the answer arrived, we simply had it.
+    if (hash === (input.store.currentResultsHash ?? null)) {
+      return { outcome: 'alreadyHeld', kind }
+    }
+    input.store.resultsComplete({
+      report,
+      hash,
+      resultsSource: 'conversation',
+      // V5 carries no V2 envelope; pass null so the V2-shaped slots are
+      // explicitly cleared rather than left to a stale prior write — the same
+      // reasoning as `applyV5State`'s results hydration.
+      enrichment: null,
+      rawV2Response: null,
+      v5Enrichment: (block as { enrichment?: unknown }).enrichment ?? null,
+    })
+    resultsHydrated = true
+  }
+
+  input.store.setAnalysisStateV1?.(verdict)
+  return { outcome: 'applied', kind, resultsHydrated }
+}

--- a/src/routes/CanvasMVP.tsx
+++ b/src/routes/CanvasMVP.tsx
@@ -17,6 +17,12 @@ import { getScenario } from '../canvas/store/scenarios'
 import { buildShareLink } from '../canvas/utils/shareLink'
 import { useScenario } from '../hooks/useScenario'
 import { useServerGraphHydration } from '../canvas/hooks/useServerGraphHydration'
+// ROADMAP 2.1271 — deliver the auto-run's provisional analysis without another
+// turn. Mounted HERE, beside boot hydration, deliberately: the trigger is the
+// draft turn's own `running` verdict in the store, so the hook needs no
+// conversation context, and keeping it out of `useConversation` decouples a
+// server-driven delivery from the message loop entirely.
+import { useProvisionalAnalysisDelivery } from '../canvas/hooks/useProvisionalAnalysisDelivery'
 import { useImportRegistration } from '../canvas/registration/useImportRegistration'
 import { CANONICAL_EDIT_AUTHORITY, hasServerGraphAuthority } from '../canvas/mutations/mutationAuthority'
 
@@ -81,6 +87,8 @@ export default function CanvasMVP() {
   // Supabase writes, whereas this read goes through CEE, which holds the
   // service credential the browser deliberately does not have.
   useServerGraphHydration(scenarioIdFromRoute)
+  // Inert until CEE reports a provisional run in flight for this scenario.
+  useProvisionalAnalysisDelivery(scenarioIdFromRoute)
 
   // ROADMAP 2.467: register a locally-imported graph with CEE so the analysis
   // describes the model on screen. Mounted BESIDE the hydration hook on


### PR DESCRIPTION
**⚠ DO NOT MERGE YET.** Paired CEE PR: `Talchain/olumi-assistants-service` **#1010** (the producer half, itself stacked on #1004). This half is cut from `staging` and is honest on its own — with an older CEE it simply never arms.

---

## What was broken

Paul's ruling, 17 Aug: *"Treat server calculation + automatic client delivery/rendering as one capability. Do not report auto-analysis as COMPLETE until it appears to the user without another turn."*

CEE's post-draft auto-run commits a `run_analysis` fact ~20s after the draft SSE stream's terminal COMPLETE frame closes the socket. No CEE route returned a scenario's analysis except a turn. So the provisional result was computed, persisted, and seen only by a user who happened to send another message.

## Three pieces

**1 · `adapters/cee/scenarioGraph.ts`** carries CEE's two new keys through:
- `analysisState` — parsed with `AnalysisStateV1Schema`, the CONTRACT's own `.strict()` discriminated union and the same schema object `applyV5State` uses. Never a local mirror of the vocabulary. A malformed verdict yields `null` = *"CEE did not answer"*.
- `analysisResult` — opaque, gated on its own `type` discriminator, handed to the one mapper that owns the block contract.

Both **REQUIRED** on the `graph` member so a consumer cannot silently forget them and `undefined` is unreachable.

**2 · `canvas/hydrate/applyScenarioAnalysisRead.ts` — THE H4 GUARD.** This is the file the PR exists for.

`applyV5State` is the TURN applier and its clear-on-absence rule is **correct for turns** (*"the field's whole contract is 'CEE stated this FOR THIS TURN', so silence must clear"*). It is wrong for a read, because the two authorities answer different questions (trap 21):

| | question | can say `running`? |
|---|---|---|
| draft turn | *did I start a provisional run?* | yes |
| graph read | *has a fact landed for this graph?* | **no** — CEE keeps no in-flight marker |

So a read taken mid-run can only answer `never_run`, and through the turn applier that flips the product from *"an analysis is running"* to *"no analysis has ever been run"* **while one is running** — with `never_run` licensing the pre-analysis affordance over it. Not an edge case: the **default behaviour on the first read**.

This applier writes a read's verdict **only on a TERMINAL kind** (`complete_current`, `complete_stale`, `blocked`, `refused` — each derived from the contract's own `.describe()` text, one line of reasoning per kind in the header) and performs **NO STORE WRITE AT ALL** for `never_run`, `unknown_degraded`, `running`, or an absent verdict.

Two further deliberate choices:
- **Results are written BEFORE the verdict.** A verdict-first order exposes a frame where `complete_current` vouches for a result not yet on screen, which `deriveAnalysisDisplayState` renders as *"Ready to analyse"* over a completed analysis. Pinned by a call-order assertion.
- **It never touches the graph.** `serverGraphHydration` stays the one ingestion authority (`draftRecovery.ts:13-19`: *"A second ingestion path here would be the two-`generateGraphHash`-twins defect all over again"*).

**3 · `canvas/hooks/useProvisionalAnalysisDelivery.ts` — the bounded wait.** Armed by the draft turn's own `running` verdict, re-arming on `started_at` IDENTITY (a second draft gets its own wait; a re-render does not restart one), and **inert on every draft where CEE scheduled nothing** — it does not poll on a timer and does not second-guess the server. 7 reads over 60s: the run is ~20s and the route's limiter is **per CLIENT IP**, shared with boot hydration and draft recovery (`read` tier = 90 rpm, derived at CEE's tip).

**H3 — on expiry it invents nothing.** A `running` claim can outlive its run (the dispatch throws, the already-analysed guard skips, a process restarts). The wait ends and **writes nothing** — no synthesised `unknown_degraded`, no verdict of the client's own. And the manual Run affordance is untouched throughout, because every gate that could disable it reads the LOCAL results status, never the wire.

Mounted in `routes/CanvasMVP.tsx` beside `useServerGraphHydration` — deliberately **not** in `useConversation` (owned by #731, and the trigger is a store verdict, so the delivery needs no conversation context and stays decoupled from the message loop).

## Verification

**G3 IS ASSERTED, NOT DESCRIBED.** The applier spec drives a read-shaped `never_run` through the **real `applyV5State`** and shows the demotion happening, next to the narrow applier declining it in the same test — so the necessity of this file cannot quietly stop being true.

**Mutants: 11 / 11 BITTEN**, in a worktree outside the repo root with **sentinel-WRITE isolation** (a sentinel written into the worktree, source asserted unchanged; inodes compared — `cp -R` can preserve APFS hard links), restores from a **pristine archive outside the tree**, applied-check **exactly 1** / control **exactly 0** on every mutant, pristine AND trailing controls green, and the collected count asserted **28 BY NAME** (both spec files named, never an aggregate).

| mutant | verdict |
|---|---|
| M1 the H4 filter admits EVERY read verdict | **BITTEN** (12 tests red) |
| M2 INVERT the filter — admit only NON-terminal kinds | **BITTEN** (22) |
| M3 admit `never_run` to the terminal set *(the brief's named H4 mutant)* | **BITTEN** (9) |
| M4 verdict before results | **BITTEN** (2) |
| M5 treat an absent verdict as a state (write `null`) | **BITTEN** (2) |
| M6 drop the results dedupe | **BITTEN** (1) |
| M7 settle the schedule on a non-terminal read | **BITTEN** (6) |
| M8 make the wait unbounded | **BITTEN** (1) |
| M9 conclude on an unreadable (404) read | **BITTEN** (1) |
| M10 snapshot the store once instead of per attempt | **BITTEN** (1) |
| M11 keep reading after delivery (budget leak) | **BITTEN** (1) |

M1/M2 are the discriminating **pair** for the guard itself, failing on different assertions.

**P4 · the mutated tree was typechecked.** The instrument is `tsc -p tsconfig.mutant-scope.json`, extending the repo's own `tsconfig.app.json` (inheriting `types: ["vite/client"]`, `strict`, `noUnusedLocals`, the path aliases) and narrowed to the three mutated modules; it counts diagnostics **in those files only** against a pristine baseline of 0, cross-validated two ways — a full `tsc -p tsconfig.app.json --noEmit` (1981 diagnostics total, **zero** in these files) and the scoped run (14, all in pre-existing transitive files, **zero** in these). 17s vs 7min, so the cheap instrument is used per the P4 cost refinement.

**Two instrument defects the controls caught, disclosed:**
1. A first ad-hoc `tsc` flag soup reported **21 phantom errors on the CLEAN tree** (missing `vite/client`, so `import.meta.env` failed) — the mandatory pristine control refused to proceed. Replaced with the project-config instrument above.
2. M1's first form (`return true`) was **type-INVALID** under `noUnusedParameters` and correctly scored VOID, not SURVIVED — the exact false-survivor class P4 exists for. Reformed as `return kind.length >= 0`.
3. The G3 test's cold dynamic import of `applyV5State` exceeded vitest's 5s default in a fresh worktree and turned the pristine control red. Fixed **at the source** with an explicit budget (separate commit), never absorbed into a baseline.

**Typecheck gate PASSES** — coverage 3452/3492 (both new files loaded, no new exception entries), ratchet within baseline. One existing fixture fixed **at the source**: `useConversation.draftRecovery.spec.ts`'s `serverGraphResult()` gains the two keys as `null`. The gate's reported 18-diagnostic pre-existing shrink is deliberately **NOT** banked here — it is churn in files this PR never touched.

## Two findings for the reviewer, from a deployed-consumer audit (P2)

A read-only audit traced every mounted consumer of `useAnalysisState()` for exactly this input (wire `running`, no local run, `hasReport === false`). Both are **pre-existing** and neither is introduced here, but this PR makes them reachable:

1. **The `running` signal is quieter than the brief assumed.** `semantic` and `displayedFreshness` both stay `'none'`, so there is **no** false "Analysis complete", no "Results may be outdated", no Rerun CTA — the P2 harm is avoided. But `AnalysisStateRegion` (the **Analysis tab**, which a fresh draft fronts) is driven by `useAnalysisRunState()`, which reads only store slices and is **blind to the wire** — so on the default tab the user sees nothing change. The visible in-flight chrome lives on the Model and Compare dock tabs. **#749 is reworking `useAnalysisRunState` into a union and is the right home for closing that**; it is not in scope here and no new display surface is added.
2. **`AnalysisRunningBanner` differences CEE's `started_at` against the browser clock with no past-direction skew guard** (`:94-96`), so a `started_at` >20s behind the client clock opens the banner on *"Still analysing…"*. Bounded by clock offset rather than by elapsed time in this flow, but worth a row.

Also noted: the Compare tab's honest empty state is replaced by a loading skeleton for the run's duration (`CompareTabBody.tsx:229-238`), which is that component's deliberate existing behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)