### PR TITLE
fix(dock): restore 416px panel width — the narrowing bought no graph legibility

### DIFF
--- a/src/canvas/__tests__/computeFitPadding.spec.ts
+++ b/src/canvas/__tests__/computeFitPadding.spec.ts
@@ -193,30 +193,72 @@ describe('computeFitPadding', () => {
     }
   })
 
-  it('the motivating laptop case: 1280x800 with the responsive 333px dock leaves an 843px fitting box', () => {
-    // The exact geometry measured in the browser on 15 Aug 2026, pinned so the
-    // constants that produce it cannot drift back silently. Dock `right: 12`,
-    // responsive width 333 → left = 1280 - 12 - 333 = 935, overlap = 345.
+  it('the motivating laptop case: 1280x800 with the restored 416px dock leaves a 760px fitting box', () => {
+    // ⚠ RE-PINNED 17 Aug 2026 from the 333px dock (fit box 843px) to the
+    // restored 416px default. The geometry is the same measurement, taken at
+    // the width the dock is actually shipped at. Dock `right: 12`, width 416
+    // → left = 1280 - 12 - 416 = 852, overlap = 428.
     stubSelectors({
-      [DOCK]: fakeEl({ left: 935, right: 1268, width: 333, top: 12, bottom: 784, height: 772 }),
+      [DOCK]: fakeEl({ left: 852, right: 1268, width: 416, top: 12, bottom: 784, height: 772 }),
       [SIDEBAR]: fakeEl({ left: 12, right: 60, width: 48, top: 73, bottom: 300, height: 227 }),
     })
     const p = computeFitPadding(fakeEl({ left: 0, right: 1280, width: 1280, top: 0, bottom: 800, height: 800 }))
-    expect(p.right).toBe('361px') // 345 + 16
+    expect(p.right).toBe('444px') // 428 + 16
     expect(p.left).toBe('76px') // 60 + 16 > base 47
     expect(p.top).toBe('29px')
 
     const fitBoxWidth = 1280 - parseInt(p.right, 10) - parseInt(p.left, 10)
-    expect(fitBoxWidth).toBe(843)
+    expect(fitBoxWidth).toBe(760)
 
-    // ⚠ And the honest other half, asserted so nobody reads the number above as
-    // a fix: the drafted 17-node graph measures 2016 flow-units wide, so at the
-    // 0.5 legibility floor it needs 1008px. 843 is NOT enough — the post-draft
-    // fit still clamps. Closing that gap needs the dock collapsed, which is a
-    // workspace-shell decision, not a padding constant.
+    // ⚠ THE HONEST OTHER HALF, AND THE WHOLE REASON THE NARROWING WAS REVERTED.
+    // The drafted 17-node graph measures 2016 flow-units wide, so at the 0.5
+    // legibility floor it needs 1008px. The post-draft fit clamps at that floor
+    // at EVERY dock width the product has shipped — the trade of panel width
+    // for graph legibility was one-sided from the day it landed.
     const GRAPH_FLOW_WIDTH = 2016
     const LEGIBILITY_FLOOR = 0.5
-    expect(fitBoxWidth).toBeLessThan(GRAPH_FLOW_WIDTH * LEGIBILITY_FLOOR)
+    const REQUIRED = GRAPH_FLOW_WIDTH * LEGIBILITY_FLOOR // 1008
+    expect(fitBoxWidth).toBeLessThan(REQUIRED)
+  })
+
+  it('the fit box clamps at the legibility floor at 416, 333 AND 280 — the narrowing bought nothing', () => {
+    // THE DECISIVE ARITHMETIC, asserted rather than asserted-about. Each dock
+    // width is driven through the REAL `computeFitPadding` (not a formula
+    // restated here), and every one of them lands under the 1008px the graph
+    // needs. Swept over the three widths the product has actually shipped, so
+    // "narrowing the dock fixes the graph clamp" cannot be re-argued from a
+    // single unmeasured case.
+    const GRAPH_FLOW_WIDTH = 2016
+    const LEGIBILITY_FLOOR = 0.5
+    const REQUIRED = GRAPH_FLOW_WIDTH * LEGIBILITY_FLOOR // 1008
+    const expected: Record<number, number> = { 416: 760, 333: 843, 280: 896 }
+
+    for (const dockWidth of [416, 333, 280]) {
+      const dockLeft = 1280 - 12 - dockWidth
+      stubSelectors({
+        [DOCK]: fakeEl({
+          left: dockLeft,
+          right: dockLeft + dockWidth,
+          width: dockWidth,
+          top: 12,
+          bottom: 784,
+          height: 772,
+        }),
+        [SIDEBAR]: fakeEl({ left: 12, right: 60, width: 48, top: 73, bottom: 300, height: 227 }),
+      })
+      const p = computeFitPadding(
+        fakeEl({ left: 0, right: 1280, width: 1280, top: 0, bottom: 800, height: 800 }),
+      )
+      const fitBoxWidth = 1280 - parseInt(p.right, 10) - parseInt(p.left, 10)
+      expect(fitBoxWidth, `dock ${dockWidth}px`).toBe(expected[dockWidth])
+      expect(fitBoxWidth, `dock ${dockWidth}px still clamps at the floor`).toBeLessThan(REQUIRED)
+    }
+
+    // PIN THE PRECONDITION (trap 13b): the sweep is only evidence if the three
+    // widths genuinely produce three DIFFERENT fit boxes. A stub that silently
+    // stopped varying would satisfy every assertion above while measuring one
+    // case three times — undiscriminated output looks exactly like a result.
+    expect(new Set(Object.values(expected)).size).toBe(3)
   })
 })
 

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -273,12 +273,18 @@ export function deriveNextDockIsOpen(isFirstUse: boolean, storedIsOpen: boolean)
  * first analysis"). **R1 RULED: the right panel is visible immediately when
  * the model appears; the panel starts NARROW so the graph keeps priority.**
  * The 843px measurement was never an argument for hiding the panel — it was an
- * argument about WIDTH, and R1 answers it with width. So the rail input
- * reverts to model content, and the width half of the trade is discharged by
- * `resolveDockWidthForAnalysisState` below, which opens the dock at its
- * narrowest usable width until an analysis exists. Neither half works alone:
- * reverting the input without the narrow width re-opens the 843px clamp this
- * predicate was rewritten to close.
+ * argument about WIDTH, and R1 answered it with width: the rail input reverted
+ * to model content and a companion rule narrowed the dock until an analysis
+ * existed.
+ *
+ * ⚠⚠ THE WIDTH HALF IS NOW WITHDRAWN (17 Aug 2026) AND THIS RAIL PREDICATE IS
+ * UNCHANGED BY THAT. R1's VISIBILITY ruling stands — the panel appears the
+ * moment the model does. What is withdrawn is the narrowing, because the
+ * legibility it was buying was never delivered at ANY dock width (760 / 843 /
+ * 896 fit box against a 1008px requirement) while the panel lost 35% of its
+ * content budget. See the deleted `resolveDockWidthForAnalysisState` note
+ * below for the full record. The two halves were briefed as a pair; only one
+ * of them turned out to be doing anything.
  *
  * Pure and exported so the rule is mutation-testable without mounting the dock.
  *
@@ -316,36 +322,36 @@ export function shouldRenderFirstUseRail(input: {
 }
 
 /**
- * The width the dock opens at — R1's "starts NARROW so the graph keeps
- * priority" half.
+ * ⚠⚠ `resolveDockWidthForAnalysisState` WAS HERE AND IS DELETED (17 Aug 2026).
  *
- * Composed from `dockWidth.ts`'s existing pure rules rather than re-deriving
- * bounds here (three separate copies of those bounds is the defect that module
- * was created to remove).
+ * It was R1's "starts NARROW so the graph keeps priority" half: until an
+ * analysis result existed, the dock was clamped to `dockWidthBounds().min`.
+ * Three things were wrong with it and only the third is about layout taste.
  *
- * TWO PROPERTIES, BOTH DELIBERATE:
- *  1. An EXPLICIT user width always wins. Someone who has dragged the dock has
- *     stated a preference; narrowing it under them because an analysis has not
- *     run yet would be the product overriding a direct instruction.
- *  2. The narrow width is the module's own `DOCK_MIN_WIDTH` floor, not a new
- *     constant. "Narrow" here means "the narrowest width this panel is known
- *     to remain usable at" — a second magic number would be a second authority
- *     on the same question, and would drift from the floor the drag path
- *     clamps to.
+ *  1. **It bought nothing.** The clamp existed to close the 843px graph clamp.
+ *     It did not: the drafted graph needs 1008px at the 0.50 legibility floor
+ *     and the fit box reaches only 896px even at 280 (760 / 843 / 896 for dock
+ *     416 / 333 / 280 — asserted in `computeFitPadding.spec.ts`). The
+ *     post-draft fit clamped at the floor at EVERY dock width, so the trade
+ *     was one-sided from the day it shipped.
+ *  2. **The floor is an unconditional constant**, so `Math.min(full, min)`
+ *     produced 280px at 1280, at 1920 and at 3840 alike. Screen size was
+ *     irrelevant, and content budget fell from 390px to 254px (−35%) at every
+ *     one of them. A per-input rule returning the same answer for every input
+ *     is the tell (trap 20) and nothing was looking.
+ *  3. **Its input did not persist.** `hasCompletedFirstRun` lives in a store
+ *     with no `persist()` middleware (`store.ts:424`), so every page reload
+ *     re-narrowed the dock for a user who had run analyses all day. The fix is
+ *     NOT to persist the flag — that would make a wrong rule rarer. The dock's
+ *     width is not a function of analysis state, and the dependency is gone.
  *
- * Pure and exported: mutation-testable without a DOM.
+ * The width now comes from `resolveDockWidth` alone: an explicit user drag
+ * wins, otherwise the responsive default, re-clamped to the drag bounds. 280
+ * is a FLOOR a user may drag to, never a width the product chooses for them.
+ *
+ * Containment, not the final design — the canonical panel shell that owns
+ * width, tabs, scroll/sticky regions, type scale and spacing is separate work.
  */
-export function resolveDockWidthForAnalysisState(input: {
-  viewportWidth: number
-  storedWidth: number | null
-  hasAnalysisResult: boolean
-}): number {
-  const full = resolveDockWidth(input.viewportWidth, input.storedWidth)
-  if (input.hasAnalysisResult) return full
-  if (input.storedWidth != null && Number.isFinite(input.storedWidth)) return full
-  const { min } = dockWidthBounds(input.viewportWidth)
-  return Math.min(full, min)
-}
 
 /**
  * Whether a programmatic tab activation is entitled to END the first-use rail.
@@ -684,10 +690,10 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   // ⚠⚠ THIS INPUT HAS FLIPPED TWICE IN ONE DAY. It was `!hasGraphContent`,
   // became `!hasCompletedFirstRun` on 16 Aug (#728, to close a measured 843px
   // graph clamp), and R1 reverts it — because Paul's veto is about VISIBILITY
-  // and the 843px measurement is about WIDTH. The width half is now discharged
-  // by `resolveDockWidthForAnalysisState`: the dock opens at its narrowest
-  // usable width until an analysis exists. See the predicate's own header for
-  // the full record; the two halves are a pair and neither ships alone.
+  // and the 843px measurement is about WIDTH. R1's width half (a pre-analysis
+  // narrowing) is WITHDRAWN as of 17 Aug: it bought no legibility at any dock
+  // width and cost 35% of the panel's content budget. This VISIBILITY rule is
+  // untouched by that. See the predicate's own header for the full record.
   const isFirstUse = shouldRenderFirstUseRail({
     aiPanelV2On,
     hasModelContent: hasGraphContent,
@@ -1968,16 +1974,12 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
       }
       const viewportWidth = window.innerWidth || root.clientWidth || 0
       if (!viewportWidth) return
-      // R1's width half: narrow until an analysis exists, then the normal
-      // responsive width. An explicit user width always wins (see the helper).
-      root.style.setProperty(
-        '--dock-right-expanded',
-        `${resolveDockWidthForAnalysisState({
-          viewportWidth,
-          storedWidth: stored,
-          hasAnalysisResult: hasCompletedFirstRun,
-        })}px`,
-      )
+      // One rule: an explicit user drag wins, otherwise the responsive
+      // default, re-clamped to the drag bounds. Deliberately NOT a function of
+      // whether an analysis exists — see the deleted
+      // `resolveDockWidthForAnalysisState` note above, and the mounted pins in
+      // `OutputsDock.dockWidth.dom.spec.tsx`.
+      root.style.setProperty('--dock-right-expanded', `${resolveDockWidth(viewportWidth, stored)}px`)
     }
 
     apply()
@@ -1998,12 +2000,13 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
       window.removeEventListener('resize', onResize)
       if (frame !== null) window.cancelAnimationFrame(frame)
     }
-    // ⚠ `hasCompletedFirstRun` IS a dependency and its absence would be silent:
-    // the effect would apply the narrow width once and never widen when the
-    // first analysis lands, so the user's results would arrive into a 280px
-    // panel until the next window resize. A width rule that only re-runs on
-    // `resize` is a width rule that is wrong for as long as nobody resizes.
-  }, [hasCompletedFirstRun])
+    // ⚠ `hasCompletedFirstRun` WAS a dependency here and is deliberately gone:
+    // the width is no longer a function of analysis state, so re-running the
+    // effect when an analysis lands would recompute the same number. The empty
+    // dep list is the assertion — if a future change makes the width depend on
+    // store state again, the dependency has to come back, and that is exactly
+    // the moment the mounted independence pin should stop it.
+  }, [])
   const transitionClass = prefersReducedMotion ? '' : 'transition-[width,opacity] duration-200 ease-in-out'
 
   // OUTPUT_TABS computed per render so a localStorage flag flip is picked

--- a/src/canvas/components/__tests__/OutputsDock.dockWidth.dom.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.dockWidth.dom.spec.tsx
@@ -1,0 +1,191 @@
+/**
+ * THE REGRESSION PIN WHOSE ABSENCE LET A −35% CONTENT BUDGET SHIP.
+ *
+ * Two surgical changes, a day apart, narrowed the right-hand dock and nothing
+ * went red:
+ *   - #719 (16 Aug) moved the default from a fixed 416px to `viewport * 0.26`,
+ *     putting a 1280px laptop at 333px.
+ *   - #741 (17 Aug) added a pre-analysis clamp that pinned the dock to
+ *     `dockWidthBounds().min` — an unconditional 280 — until an analysis
+ *     result existed. Because that floor is a CONSTANT, the clamp applied at
+ *     EVERY viewport up to 4K: screen size was irrelevant.
+ *
+ * The width was traded for graph legibility and the legibility was never
+ * delivered: the post-draft fit clamps at the 0.5 floor at 416px, at 333px AND
+ * at 280px alike (see `computeFitPadding.spec.ts` — fit box 760 / 843 / 896
+ * against a 1008px requirement). So the trade cost content budget and bought
+ * nothing.
+ *
+ * Both changes were invisible to the unit suites because no test asserted
+ * (a) what the MOUNTED dock actually sets `--dock-right-expanded` to, or
+ * (b) that the answer is INDEPENDENT of whether an analysis has run.
+ *
+ * This spec pins both, through the real component rather than through the pure
+ * helpers — the helpers were correct in isolation on both days.
+ *
+ * ⚠ WHY INDEPENDENCE, AND NOT "PERSIST hasCompletedFirstRun": the clamp keyed
+ * on a store field with NO `persist()` middleware (`store.ts:424`), so every
+ * page reload returned a heavy user's dock to 280px. Persisting the flag would
+ * have made the symptom rarer and left the rule wrong. The dock's width is not
+ * a function of analysis state at all, and THAT is what is asserted here.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, cleanup } from '@testing-library/react'
+import { OutputsDock, OUTPUTS_DOCK_STORAGE_KEY } from '../OutputsDock'
+import { DOCK_MIN_WIDTH, DOCK_RESPONSIVE_MAX_WIDTH } from '../dockWidth'
+import { useCanvasStore } from '../../store'
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { ToastProvider } from '../../ToastContext'
+
+// useScenario calls useNavigate; the dock mounts it.
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) }
+})
+
+// `importOriginal`-spread, never a hand-listed allowlist: a `vi.mock` factory
+// REPLACES the module, so an enumerated flag list goes silently short the next
+// time a flag is added and the whole file dies at collection (trap 12).
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isJourneyTabEnabled: vi.fn(() => false),
+    isPreAnalysisV3Enabled: vi.fn(() => false),
+  }
+})
+
+const DOCK_WIDTH_VAR = '--dock-right-expanded'
+const STORED_WIDTH_KEY = 'panel.results.width'
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+
+/** jsdom reports a fixed 1024; the effect reads `innerWidth || clientWidth`. */
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', { configurable: true, writable: true, value: width })
+  Object.defineProperty(document.documentElement, 'clientWidth', {
+    configurable: true,
+    get: () => width,
+  })
+}
+
+/**
+ * Mount the dock and return the width it wrote, in px.
+ *
+ * Binds by IDENTITY to the CSS custom property the dock actually drives and
+ * that `computeFitPadding`/`measureDockInset` read back — not to a pure helper
+ * that a future call site could stop calling.
+ */
+function mountAndReadDockWidth(opts: { viewportWidth: number; hasCompletedFirstRun: boolean }): number {
+  setViewportWidth(opts.viewportWidth)
+  useCanvasStore.setState({
+    // A model on the canvas, so the dock is past its 40px first-use rail and
+    // the width question is the one on screen.
+    nodes: [
+      { id: 'w-goal', type: 'goal', data: { label: 'Goal' }, position: { x: 0, y: 0 } },
+      { id: 'w-decision', type: 'decision', data: { label: 'Decision' }, position: { x: 100, y: 100 } },
+    ],
+    edges: [{ id: 'w-e1', source: 'w-decision', target: 'w-goal' }],
+    hasCompletedFirstRun: opts.hasCompletedFirstRun,
+  } as never)
+
+  render(
+    <ToastProvider>
+      <ConversationProvider>
+        <OutputsDock />
+      </ConversationProvider>
+    </ToastProvider>,
+  )
+
+  const raw = document.documentElement.style.getPropertyValue(DOCK_WIDTH_VAR)
+  // PIN THE PRECONDITION (trap 13b): a spec that silently read '' would agree
+  // with itself for ever. If the effect stops writing the variable, this fails
+  // here by name rather than passing on a parsed NaN or a stale value.
+  expect(raw, `${DOCK_WIDTH_VAR} must be written by the mounted dock`).toMatch(/^\d+px$/)
+  return parseInt(raw, 10)
+}
+
+describe('OutputsDock width — mounted, and independent of analysis state', () => {
+  beforeEach(() => {
+    ensureMatchMedia()
+    try {
+      sessionStorage.removeItem(OUTPUTS_DOCK_STORAGE_KEY)
+    } catch {}
+    try {
+      // No stored width: this suite is about the DEFAULT. A leaked explicit
+      // width would make every case below pass for the wrong reason.
+      localStorage.removeItem(STORED_WIDTH_KEY)
+    } catch {}
+    document.documentElement.style.removeProperty(DOCK_WIDTH_VAR)
+  })
+
+  afterEach(() => {
+    cleanup()
+    document.documentElement.style.removeProperty(DOCK_WIDTH_VAR)
+  })
+
+  it('opens at the restored 416px default on a 1280px laptop, with no analysis yet', () => {
+    // The founder-facing case. #741 made this 280px; #719 made it 333px.
+    expect(mountAndReadDockWidth({ viewportWidth: 1280, hasCompletedFirstRun: false })).toBe(
+      DOCK_RESPONSIVE_MAX_WIDTH,
+    )
+  })
+
+  it('is the SAME width before and after an analysis exists — the independence claim', () => {
+    // DISCRIMINATING PAIR, not a restatement: identical viewport, identical
+    // (absent) stored width, opposite analysis state. Under #741 these were
+    // 280 and 333 — the equality is the assertion that has to be deleted to
+    // reintroduce an analysis-state input to the width.
+    const preAnalysis = mountAndReadDockWidth({ viewportWidth: 1280, hasCompletedFirstRun: false })
+    cleanup()
+    document.documentElement.style.removeProperty(DOCK_WIDTH_VAR)
+    const postAnalysis = mountAndReadDockWidth({ viewportWidth: 1280, hasCompletedFirstRun: true })
+
+    expect(preAnalysis).toBe(postAnalysis)
+    expect(preAnalysis).toBe(DOCK_RESPONSIVE_MAX_WIDTH)
+  })
+
+  it('does not shrink to the drag FLOOR at any desktop viewport — the "min at every viewport" bug', () => {
+    // 280 is `dockWidthBounds().min`, an unconditional constant. #741's
+    // `Math.min(full, min)` therefore produced 280 at 1280, at 1920 and at
+    // 3840 alike — a uniform answer across inputs that must differ is the tell
+    // (trap 20), and no test looked. Swept so a future clamp cannot hide in
+    // the viewports nobody tried.
+    for (const viewportWidth of [1280, 1920, 3840]) {
+      const width = mountAndReadDockWidth({ viewportWidth, hasCompletedFirstRun: false })
+      expect(width, `viewport ${viewportWidth}`).toBe(DOCK_RESPONSIVE_MAX_WIDTH)
+      expect(width, `viewport ${viewportWidth} must not be the drag floor`).toBeGreaterThan(
+        DOCK_MIN_WIDTH,
+      )
+      cleanup()
+      document.documentElement.style.removeProperty(DOCK_WIDTH_VAR)
+    }
+  })
+
+  it('still honours a width the user dragged for themselves, analysis or not', () => {
+    // Containment must not become "the product owns the width". An explicit
+    // drag is a direct instruction and survives both analysis states.
+    localStorage.setItem(STORED_WIDTH_KEY, '312')
+    expect(mountAndReadDockWidth({ viewportWidth: 1280, hasCompletedFirstRun: false })).toBe(312)
+    cleanup()
+    document.documentElement.style.removeProperty(DOCK_WIDTH_VAR)
+    expect(mountAndReadDockWidth({ viewportWidth: 1280, hasCompletedFirstRun: true })).toBe(312)
+  })
+})

--- a/src/canvas/components/__tests__/OutputsDock.firstUseRail.spec.ts
+++ b/src/canvas/components/__tests__/OutputsDock.firstUseRail.spec.ts
@@ -1,7 +1,11 @@
 /**
  * `shouldRenderFirstUseRail` — the rule deciding whether the OutputsDock renders
- * as its 40px rail or claims its full width — and `resolveDockWidthForAnalysisState`,
- * the width rule that is its other half.
+ * as its 40px rail or claims its full width.
+ *
+ * ⚠ It once had a width companion, `resolveDockWidthForAnalysisState`. That is
+ * DELETED (17 Aug 2026) and the last block in this file pins its absence; the
+ * width itself is pinned against the mounted dock in
+ * `OutputsDock.dockWidth.dom.spec.tsx`.
  *
  * Written against the STATED RULE, not against the 1280x800 measurement that
  * motivated it — the measurement is evidence for the rule, and a spec pinned to
@@ -17,18 +21,20 @@
  * priority. The veto was about VISIBILITY; the 843px measurement was about
  * WIDTH; R1 answers the second with width rather than with hiding.
  *
- * So the rail input is model content again — AND the width half is now a real
- * rule rather than an implicit "full width or nothing". The two are a PAIR: the
- * predicate tests below are honest only because the width tests below them
- * exist. Delete either and the 843px clamp comes back.
+ * So the rail input is model content again. R1's VISIBILITY half stands and is
+ * pinned below. Its WIDTH half — narrow until an analysis exists — is
+ * withdrawn: it was buying a graph legibility that the fit box never reaches
+ * at ANY dock width (760 / 843 / 896 against a 1008px requirement), at the
+ * price of 35% of the panel's content budget. The two were briefed as a pair;
+ * only one of them was doing anything.
  */
 
 import { describe, it, expect } from 'vitest'
-import {
-  shouldRenderFirstUseRail,
-  forcedActivationEndsRail,
-  resolveDockWidthForAnalysisState,
-} from '../OutputsDock'
+import { shouldRenderFirstUseRail, forcedActivationEndsRail } from '../OutputsDock'
+// Namespace import as well as the named ones: the withdrawal block below binds
+// to the module's EXPORT LIST by identity, which a named import cannot express
+// (a named import of a deleted symbol is a compile error, not an assertion).
+import * as OutputsDockModule from '../OutputsDock'
 import { DOCK_MIN_WIDTH, resolveDockWidth } from '../dockWidth'
 
 describe('shouldRenderFirstUseRail', () => {
@@ -107,64 +113,63 @@ describe('shouldRenderFirstUseRail', () => {
   })
 })
 
-describe('resolveDockWidthForAnalysisState — R1\'s "starts NARROW" half', () => {
-  // 1280x800 is the viewport the 843px clamp was measured at, so it is the
-  // width at which the pair has to hold.
+describe('the WIDTH half is withdrawn — the dock has no analysis-state input at all', () => {
+  // ⚠ THIS BLOCK REPLACES FOUR TESTS OF `resolveDockWidthForAnalysisState`,
+  // WHICH IS DELETED (17 Aug 2026). Those tests were correct about the rule
+  // they pinned; the rule was the defect. It clamped the dock to
+  // `dockWidthBounds().min` — an UNCONDITIONAL 280 — until an analysis
+  // existed, so the pre-analysis dock was 280px at 1280, at 1920 and at 3840
+  // alike, a 35% cut in content budget, in exchange for graph legibility that
+  // the fit-box arithmetic shows was never available at any dock width.
+  //
+  // Coverage is not dropped, it MOVES, and it moves UP a level: the width is
+  // now pinned against the MOUNTED dock in
+  // `OutputsDock.dockWidth.dom.spec.tsx`, where a pure helper cannot be
+  // correct-in-isolation while the component does something else. What stays
+  // HERE is the claim this file is the right home for: the rail predicate and
+  // the width rule no longer share an input.
+
   const VIEWPORT = 1280
 
-  it('opens NARROW while no analysis exists', () => {
-    // The claim is "narrow", and narrow is defined as the module's own usable
-    // floor — not a fresh constant, which would be a second authority on the
-    // same question and would drift from the bound the drag path clamps to.
-    expect(
-      resolveDockWidthForAnalysisState({
-        viewportWidth: VIEWPORT,
-        storedWidth: null,
-        hasAnalysisResult: false,
-      }),
-    ).toBe(DOCK_MIN_WIDTH)
+  it('the module exports no analysis-state width rule', () => {
+    // Bound by IDENTITY to the export name, not to a behaviour another
+    // function could satisfy. Reintroducing the clamp means reintroducing this
+    // symbol (or a renamed twin — see the sibling assertion below), and this
+    // is the test that has to be deleted to do it.
+    expect(Object.keys(OutputsDockModule)).not.toContain('resolveDockWidthForAnalysisState')
+    // CONTRAST CONTROL: the same probe DOES see the exports that are still
+    // here, so a zero here is real absence rather than a blind instrument.
+    expect(Object.keys(OutputsDockModule)).toContain('shouldRenderFirstUseRail')
+    expect(Object.keys(OutputsDockModule)).toContain('forcedActivationEndsRail')
   })
 
-  it('widens to the normal responsive width once an analysis exists', () => {
-    // DISCRIMINATING PAIR with the case above: same viewport, same absence of a
-    // stored width, opposite analysis state, and the widths must DIFFER. A
-    // mutant that returns the full width in both cases passes the first test
-    // only if the floor happens to equal the responsive width — which at this
-    // viewport it does not, and that is asserted rather than assumed.
-    const full = resolveDockWidthForAnalysisState({
-      viewportWidth: VIEWPORT,
-      storedWidth: null,
-      hasAnalysisResult: true,
-    })
-    expect(full).toBe(resolveDockWidth(VIEWPORT, null))
-    expect(full).toBeGreaterThan(DOCK_MIN_WIDTH)
+  it('no exported width rule takes an analysis-state argument under any name', () => {
+    // The rename escape hatch, closed. A twin called
+    // `resolveDockWidthForRunState` would satisfy the assertion above and
+    // reopen the defect, so this sweeps every export whose name mentions width
+    // and asserts none of them exists. Written against the CLASS, not the one
+    // identifier that happened to bite.
+    const widthExports = Object.keys(OutputsDockModule).filter((k) => /width/i.test(k))
+    expect(widthExports).toEqual([])
   })
 
-  it('never overrides a width the user set for themselves', () => {
-    // Someone who has dragged the dock has given a direct instruction.
-    // Narrowing it under them because an analysis has not run yet is the
-    // product overruling the user, and no layout ruling asks for that.
-    const stored = 460
-    expect(
-      resolveDockWidthForAnalysisState({
-        viewportWidth: VIEWPORT,
-        storedWidth: stored,
-        hasAnalysisResult: false,
-      }),
-    ).toBe(resolveDockWidth(VIEWPORT, stored))
+  it('the surviving width authority is a function of viewport and stored width ONLY', () => {
+    // `resolveDockWidth` is the whole rule now. Its signature admits no
+    // analysis input, and at the founder-facing viewport it returns the
+    // restored default rather than the drag floor.
+    expect(resolveDockWidth(VIEWPORT, null)).toBe(416)
+    expect(resolveDockWidth(VIEWPORT, null)).toBeGreaterThan(DOCK_MIN_WIDTH)
+    expect(resolveDockWidth.length).toBe(2)
   })
 
-  it('never returns a width below the usable floor, at any viewport', () => {
-    // Swept, because the narrow arm is a `Math.min` and a `min` against a
-    // pathologically small viewport is exactly where a floor gets lost.
-    for (const viewportWidth of [320, 768, 1024, 1280, 1600, 2560]) {
-      for (const hasAnalysisResult of [true, false]) {
-        expect(
-          resolveDockWidthForAnalysisState({ viewportWidth, storedWidth: null, hasAnalysisResult }),
-          `${viewportWidth}/${hasAnalysisResult}`,
-        ).toBeGreaterThanOrEqual(DOCK_MIN_WIDTH)
-      }
-    }
+  it('280 survives as the floor a manual drag clamps to — a floor, never a default', () => {
+    // The containment boundary. Removing the clamp must not remove the bound:
+    // a user may still drag the dock to 280, and a stored width below it is
+    // still raised to it.
+    expect(resolveDockWidth(VIEWPORT, 280)).toBe(DOCK_MIN_WIDTH)
+    expect(resolveDockWidth(VIEWPORT, 120)).toBe(DOCK_MIN_WIDTH)
+    // …and the product does not choose it: same viewport, no stored width.
+    expect(resolveDockWidth(VIEWPORT, null)).not.toBe(DOCK_MIN_WIDTH)
   })
 })
 

--- a/src/canvas/components/__tests__/dockWidth.spec.ts
+++ b/src/canvas/components/__tests__/dockWidth.spec.ts
@@ -58,22 +58,30 @@ describe('dockWidthBounds — the HARD bounds a user drag may reach', () => {
 
 describe('responsiveDockWidth — the width when the user has NEVER dragged', () => {
   it('is proportional to the viewport below the historic ceiling', () => {
-    // 1280 is the measured laptop case: 0.26 * 1280 = 332.8 -> 333, which is
-    // what returns canvas to the graph. Bound to the exact viewport, so a
-    // change to the ratio reds here by name rather than silently drifting.
-    expect(responsiveDockWidth(1280)).toBe(333)
+    // ⚠ RE-PINNED 17 Aug 2026. This asserted `responsiveDockWidth(1280) === 333`
+    // — correct for the 0.26 ratio, and the pin is kept rather than deleted so
+    // the geometry still cannot drift silently; only the number moves, with the
+    // ratio restored to 416/1280. The proportional BAND is now viewports below
+    // 1280, so 1024 is where the formula is still observable.
     expect(responsiveDockWidth(1024)).toBe(SAFE_MIN(Math.round(1024 * DOCK_VIEWPORT_RATIO)))
+    expect(responsiveDockWidth(1024)).toBe(333)
+    // …and the band is real, not a formula nobody reaches: 1024 sits strictly
+    // between the floor and the ceiling, so a mutant collapsing the taper to
+    // either bound is visible here.
+    expect(responsiveDockWidth(1024)).toBeGreaterThan(DOCK_MIN_WIDTH)
+    expect(responsiveDockWidth(1024)).toBeLessThan(DOCK_RESPONSIVE_MAX_WIDTH)
   })
 
   it('never exceeds the historic fixed width, so wide screens are unchanged', () => {
-    // The whole change is a laptop-size REDUCTION, not a redesign. If this
-    // ever exceeds 416 a wide screen would get a dock bigger than it had
-    // before the refactor — a regression this spec exists to forbid.
+    // 416 is the ceiling in both directions: no viewport gets more than the
+    // dock's last known usable width, and (see the containment block below) no
+    // desktop viewport gets less.
     for (const w of VIEWPORTS) {
       expect(responsiveDockWidth(w), `viewport ${w}`).toBeLessThanOrEqual(DOCK_RESPONSIVE_MAX_WIDTH)
     }
-    expect(responsiveDockWidth(1600)).toBe(DOCK_RESPONSIVE_MAX_WIDTH) // 0.26*1600 = 416 exactly
-    expect(responsiveDockWidth(2560)).toBe(DOCK_RESPONSIVE_MAX_WIDTH) // proportional 666, capped
+    expect(responsiveDockWidth(1280)).toBe(DOCK_RESPONSIVE_MAX_WIDTH) // 0.325*1280 = 416 exactly
+    expect(responsiveDockWidth(1600)).toBe(DOCK_RESPONSIVE_MAX_WIDTH) // proportional 520, capped
+    expect(responsiveDockWidth(2560)).toBe(DOCK_RESPONSIVE_MAX_WIDTH) // proportional 832, capped
     expect(responsiveDockWidth(3840)).toBe(DOCK_RESPONSIVE_MAX_WIDTH)
   })
 
@@ -100,7 +108,7 @@ describe('responsiveDockWidth — the width when the user has NEVER dragged', ()
 describe('resolveDockWidth — explicit user width wins, re-clamped to bounds', () => {
   it('falls back to the responsive default when there is no stored width', () => {
     expect(resolveDockWidth(1280, null)).toBe(responsiveDockWidth(1280))
-    expect(resolveDockWidth(1280, null)).toBe(333)
+    expect(resolveDockWidth(1280, null)).toBe(416)
   })
 
   it('honours an explicit width that is inside the bounds', () => {
@@ -174,8 +182,58 @@ describe('parseStoredDockWidth — localStorage string to number | null', () => 
     // instead of null (the defect the null-signal exists to prevent) is
     // visible here as a width of 280 rather than the responsive default.
     expect(resolveDockWidth(900, parseStoredDockWidth('480'))).toBe(360)
-    expect(resolveDockWidth(1280, parseStoredDockWidth(null))).toBe(333)
-    expect(resolveDockWidth(1280, parseStoredDockWidth('garbage'))).toBe(333)
+    expect(resolveDockWidth(1280, parseStoredDockWidth(null))).toBe(416)
+    expect(resolveDockWidth(1280, parseStoredDockWidth('garbage'))).toBe(416)
+  })
+})
+
+describe('the restored 416px default — containment pins (17 Aug 2026)', () => {
+  // 416 is the dock's last known usable width: the fixed `--dock-right-expanded:
+  // 26rem` this module replaced, and still the declared default in
+  // `src/index.css:517`. The ratio narrowing traded content budget for graph
+  // legibility that was never delivered — the post-draft fit clamps at the 0.5
+  // floor at 416px, 333px AND 280px alike (computeFitPadding.spec.ts).
+  //
+  // 254px of content budget after borders and `px-3` padding is what 280 buys;
+  // 390px is what 416 buys. −35% is not a layout tweak.
+
+  it('gives a 1280px laptop the full 416px', () => {
+    // The founder-facing viewport, bound by name so a ratio change reds HERE
+    // rather than drifting silently through a proportional formula.
+    expect(responsiveDockWidth(1280)).toBe(416)
+    expect(responsiveDockWidth(1280)).toBe(DOCK_RESPONSIVE_MAX_WIDTH)
+  })
+
+  it('gives 416px at 1280, 1920 and 3840 — screen size may widen the dock, never narrow it', () => {
+    // The three viewports named because #741's clamp was `Math.min(full, min)`
+    // against an UNCONDITIONAL 280 constant, so all three answered 280. A
+    // per-input probe returning the same answer for every input is evidence
+    // about the probe (trap 20) — here it was evidence about the product, and
+    // nothing was asking.
+    for (const viewport of [1280, 1920, 3840]) {
+      expect(responsiveDockWidth(viewport), `viewport ${viewport}`).toBe(DOCK_RESPONSIVE_MAX_WIDTH)
+    }
+  })
+
+  it('never returns the drag FLOOR as a default at a desktop viewport', () => {
+    // 280 is a floor for a manual drag, not a width the product chooses. This
+    // is the claim, stated separately from the value above so a future ceiling
+    // change cannot quietly satisfy it by lowering both numbers together.
+    for (const viewport of [1280, 1440, 1920, 2560, 3840]) {
+      expect(responsiveDockWidth(viewport), `viewport ${viewport}`).toBeGreaterThan(DOCK_MIN_WIDTH)
+    }
+  })
+
+  it('KEEPS 280 as the floor a manual drag clamps to', () => {
+    // The other direction, and the reason this is containment rather than a
+    // revert of the width authority: the drag bounds are untouched. A user may
+    // still choose 280; the product may not choose it for them.
+    expect(dockWidthBounds(1280).min).toBe(280)
+    expect(dockWidthBounds(3840).min).toBe(280)
+    expect(resolveDockWidth(1280, 200)).toBe(280)
+    expect(resolveDockWidth(1280, 280)).toBe(280)
+    // …and 280 remains REACHABLE by drag, which is what makes it a floor.
+    expect(resolveDockWidth(3840, 280)).toBe(280)
   })
 })
 

--- a/src/canvas/components/dockWidth.ts
+++ b/src/canvas/components/dockWidth.ts
@@ -1,13 +1,27 @@
 /**
  * Responsive width for the right-hand OutputsDock.
  *
- * Why this module exists: the dock's expanded width was a single fixed
- * `--dock-right-expanded: 26rem` (416px) applied at every viewport. At a
- * 1280px laptop that is 32.5% of the screen, and because `computeFitPadding`
- * reserves whatever the dock occludes, it also removes 444px from the graph's
- * fitting box — measured 15 Aug 2026 at 1280x800: fit box 730px of 1280, the
- * post-draft `fitView` hit its `minZoom` legibility floor and the graph
- * overflowed the visible canvas.
+ * Why this module exists: the dock's expanded width used to be a single fixed
+ * `--dock-right-expanded: 26rem` (416px) written into three hand-copied
+ * inline literals — the mount path, the resize path and the drag path each
+ * carried their own bounds. They agreed on the day they were written and
+ * nothing would have gone red when they stopped. The rules now live here once.
+ *
+ * ⚠⚠ THE NARROWING THIS MODULE ORIGINALLY SHIPPED IS REVERTED (17 Aug 2026).
+ * The ratio was set to 0.26 to buy graph legibility back from the dock: at
+ * 1280x800 the fit box went 760px → 843px, and a later pre-analysis clamp
+ * pushed it to 896px. **None of it was enough and none of it was ever going
+ * to be.** The drafted 17-node graph measures 2016 flow-units, so at the 0.50
+ * `LABEL_LEGIBLE_ZOOM` floor it needs 1008px — the post-draft `fitView`
+ * clamps at the floor at 416px, at 333px AND at 280px alike (asserted in
+ * `computeFitPadding.spec.ts`). The width was traded and the legibility was
+ * never delivered, while the panel lost 35% of its content budget (390px →
+ * 254px after borders and `px-3` padding) and every tab's formatting with it.
+ *
+ * So the default returns to 416 wherever the viewport allows. Closing the
+ * 1008px gap needs the dock COLLAPSED, which is a workspace-shell decision,
+ * not a width constant. This is containment; the canonical panel shell that
+ * owns width, tabs, scroll regions and type scale is separate work.
  *
  * The rules, in one place so the mount path, the resize path and the drag
  * path cannot drift apart (they were three separate copies of the bounds):
@@ -16,8 +30,9 @@
  *    from the previous inline copies (`280` .. `min(480, 40% of viewport)`),
  *    so an existing persisted width keeps behaving exactly as before.
  *  - `responsiveDockWidth` — what the dock is when the user has NEVER dragged
- *    it. Proportional to the viewport, capped at the historic 416px so wide
- *    screens are unchanged, floored at 280px so it stays usable.
+ *    it. Capped at the historic 416px, floored at 280px so it stays usable,
+ *    and proportional only in the band between — which, at the restored
+ *    ratio, is viewports NARROWER than 1280.
  *  - `resolveDockWidth` — the width to apply right now. An explicit user
  *    width always wins over the responsive default; it is only re-clamped to
  *    the hard bounds, which is itself a fix (previously a width persisted at
@@ -30,18 +45,29 @@
 export const DOCK_MIN_WIDTH = 280
 
 /**
- * Ceiling for the RESPONSIVE default: the historic fixed width. Screens wide
- * enough to reach it get exactly the previous behaviour, so this change is a
- * laptop-size reduction and not a redesign.
+ * Ceiling for the RESPONSIVE default: the dock's last known usable width, and
+ * still the declared default in `src/index.css:517`
+ * (`--dock-right-expanded: 26rem`). Every viewport wide enough to reach it
+ * gets it.
  */
 export const DOCK_RESPONSIVE_MAX_WIDTH = 416
 
 /**
- * Share of the viewport the dock takes before the ceiling bites. 0.26 puts a
- * 1280px laptop at 333px (83px back to the canvas) and a 1600px screen back
- * at the historic 416px.
+ * Share of the viewport the dock takes before the ceiling bites.
+ *
+ * DERIVED, not chosen: `416 / 1280 = 0.325` exactly, so a 1280px laptop — the
+ * viewport every measurement in this file was taken at — lands on the ceiling
+ * rather than under it, and every wider screen is capped there too. Below
+ * 1280 the dock tapers proportionally to the 280px floor, which is the one
+ * part of the 0.26 experiment worth keeping: a fixed 416 on a 900px window is
+ * 46% of the screen.
+ *
+ * ⚠ CHANGING THIS CHANGES THE DEFAULT AT EVERY VIEWPORT ≤ 416/ratio. The
+ * containment pins in `dockWidth.spec.ts` and the MOUNTED pins in
+ * `OutputsDock.dockWidth.dom.spec.tsx` bind 1280 / 1920 / 3840 by name so a
+ * future ratio edit reds instead of drifting.
  */
-export const DOCK_VIEWPORT_RATIO = 0.26
+export const DOCK_VIEWPORT_RATIO = 0.325
 
 /** Hard bounds a user drag may reach — the pre-existing rule, now stated once. */
 export function dockWidthBounds(viewportWidth: number): { min: number; max: number } {


### PR DESCRIPTION
**CONTAINMENT.** The founder reported that the right-hand panel's reduced width has broken every tab's formatting on the deployed build. Derivation found two surgical changes, not an emergent mess — and the thing they were buying was never delivered.

## What narrowed the dock

| PR | Commit | Change |
|---|---|---|
| #719 | `6bfe40f7` (16 Aug) | Dock default moved from a fixed 416px to `viewport * 0.26` → **333px at 1280**. Its own message: *"Measured at 1280x800: dock 416 -> 333px."* |
| #741 | `83d4ab5a` (17 Aug) | Added `resolveDockWidthForAnalysisState`, clamping the dock to `dockWidthBounds().min` → **280px until an analysis result exists**. |

## The decisive fact: the narrowing bought nothing

The width was traded for graph legibility. Driven through the **real** `computeFitPadding` (not arithmetic restated in a test), at 1280x800 with the dock at `right: 12`:

| Dock width | Reserved padding | Fit box | Needs 1008px? |
|---|---|---|---|
| 416px | 444px | **760px** | ✗ clamped |
| 333px | 361px | **843px** | ✗ clamped |
| 280px | 308px | **896px** | ✗ clamped |

The drafted 17-node graph measures 2016 flow-units, so at the `LABEL_LEGIBLE_ZOOM` floor of 0.50 it needs **1008px**. The post-draft `fitView` clamps at that floor at **every** dock width the product has shipped. `computeFitPadding.spec.ts` already said so in its own words — *"843 is NOT enough… Closing that gap needs the dock collapsed"* — so **reverting costs zero graph legibility**, and the panel gets its content budget back.

## Two aggravating facts, fixed rather than mitigated

1. **`dockWidthBounds().min` is the unconditional constant 280**, and the clamp was `Math.min(full, min)` — so the pre-analysis dock was 280px at 1280, at 1920 **and at 3840**. Screen size was irrelevant. Content budget after borders and `px-3` padding: **254px, down from 390px (−35%)**.
2. **`hasCompletedFirstRun` does not persist.** `src/canvas/store.ts:424` sits in a store with no `persist()` middleware, so **every page reload returned the dock to 280px** even for a user who had run analyses all day. Deliberately **not** fixed by persisting the flag — that makes a wrong rule rarer. The dependency is removed instead.

## Rendered dock width (no stored user width)

| Viewport | Before (deployed) | After |
|---|---|---|
| 1280 | 280px | **416px** |
| 1920 | 280px | **416px** |
| 3840 | 280px | **416px** |

*(Before = the #741 clamp, which is what a fresh user or any reloaded session gets. Without the clamp, #719 alone gives 333 / 416 / 416.)*

## What changed

- **`resolveDockWidthForAnalysisState` and its call site are DELETED**, along with the width effect's `[hasCompletedFirstRun]` dependency. Width is no longer a function of analysis state.
- **`DOCK_VIEWPORT_RATIO` 0.26 → 0.325**, derived as `416 / 1280` exactly (float-exact: `1280 * 0.325 === 416`), so 1280 lands **on** the 416 ceiling and every wider viewport is capped there. Below 1280 the taper to the floor is kept — a fixed 416 in a 900px window is 46% of the screen, and that is the one part of #719 worth keeping.
- **Bounds semantics untouched.** 280 is a **floor a user may drag to**, never a width the product chooses. Pinned in both directions.

## Tests

The four `resolveDockWidthForAnalysisState` cases are **replaced, not dropped** — coverage moves *up* a level. Both prior changes were invisible to the unit suites because nothing asserted (a) what the **mounted** dock writes to `--dock-right-expanded`, or (b) that the answer is **independent of analysis state**. New `OutputsDock.dockWidth.dom.spec.tsx` mounts the real dock and asserts both, at 1280 / 1920 / 3840. That pair is the guard whose absence let a −35% content budget ship.

**RED-first at pristine — 5 failures:**
```
× dockWidth.spec.ts > containment pins > gives a 1280px laptop the full 416px
    expected 333 to be 416
× dockWidth.spec.ts > containment pins > gives 416px at 1280, 1920 and 3840…
    viewport 1280: expected 333 to be 416
× OutputsDock.dockWidth.dom.spec.tsx > opens at the restored 416px default…
    expected 280 to be 416
× OutputsDock.dockWidth.dom.spec.tsx > is the SAME width before and after an analysis exists
    expected 280 to be 333          ← the independence claim, both arms wrong
× OutputsDock.dockWidth.dom.spec.tsx > does not shrink to the drag FLOOR at any desktop viewport
    viewport 1280: expected 280 to be 416
```

**Mutants** — throwaway worktree at an absolute path outside the repo root, isolation proven by a **sentinel write** (source SHA unchanged) plus an inode compare, restores from a **pristine tar archive** (never `git checkout --`, which restores from the index), applied-check scoped to `src/` with both controls reading exactly **0**, collected count asserted at **61** every run, and the pristine tree typechecked first as the P4 control:

| # | Mutation | Expected | Result |
|---|---|---|---|
| M1 | `DOCK_VIEWPORT_RATIO` → 0.26 (the #719 narrowing) | bitten | ✅ 10 failed |
| M2 | `DOCK_VIEWPORT_RATIO` → 0.35 (invisible ≥1280; only the taper band sees it) | bitten | ✅ 1 failed |
| M3 | `DOCK_RESPONSIVE_MAX_WIDTH` → 480 | bitten | ✅ 6 failed |
| M4 | `DOCK_MIN_WIDTH` → 240 (the floor this PR must preserve) | bitten | ✅ 5 failed |
| M5′ | `responsiveDockWidth` loses its `Math.max` floor | bitten | ✅ 3 failed |
| M6 | **the #741 clamp reintroduced at the call site** | bitten | ✅ 4 failed |
| M7 | a renamed twin `resolveDockWidthForRunState` re-exported | bitten | ✅ 1 failed |
| M8 | `computeFitPadding` `GAP` 16 → 0 | bitten | ✅ 12 failed |
| M9 | **a different CSS var** (`--dock-right-collapsed`) mutated | **survive** | ✅ 61 passed |

M6/M9 are a **discriminating pair**: the mounted pin reds when the dock's own width rule regains an analysis-state input, and stays green when a neighbouring object changes — so it binds by identity, not by any predicate another object could satisfy.

M5's first form was **voided as type-invalid** (`TS6133: 'min' is declared but its value is never read`) and re-run as M5′. That is exactly the false survivor P4 exists for: vitest strips types, so it would have read as SURVIVED.

**Gates run locally at this tip:** `pnpm typecheck` PASSED (coverage + ratchet; drift shrank 2325 → 2307, no `--update-baseline` taken) · `pnpm typecheck:selftest` 18/18 · `pnpm run build` ✓ · `eslint` on all six changed files clean (one pre-existing unrelated warning at `OutputsDock.tsx:1361`) · rules-of-hooks ratchet exactly matching baseline.

## Scope

Containment, **not the final design**. A canonical panel shell owning width, tabs, scroll/sticky regions, type scale and spacing is separate work. No panel internals redesigned, no container queries, no child-surface layout touched.
