### PR TITLE
feat(graph): one edge-style authority + readable labels

### DIFF
--- a/scripts/conversation-type-census.mjs
+++ b/scripts/conversation-type-census.mjs
@@ -20,7 +20,10 @@
  * FAIL-LOUD RULES (trap-12: a silent gap in a census is worse than no census):
  *   - unknown named text-* size class            → error
  *   - `font:` shorthand in CSS                   → error
- *   - rem/em/calc/clamp font-size                → error (add handling first)
+ *   - rem/em/calc/clamp font-size                → error (add handling first),
+ *     with ONE sanctioned exception: `text-[length:calc(Npx*var(--x,1))]`, the
+ *     canvas counter-scale, which resolves to its declared N (see
+ *     COUNTER_SCALED_PX below — anything wider than that shape still errors)
  *   - template-interpolated `text-${...}`        → error
  *   - typography token name not found            → error
  *   - non-literal inline fontSize/fontWeight     → error
@@ -91,14 +94,33 @@ function parseTypographyTokens() {
   return tokens
 }
 
+/**
+ * The one arbitrary-length shape the census resolves rather than rejects:
+ * `text-[length:calc(13px*var(--canvas-label-scale,1))]`. The custom property's
+ * fallback MUST be exactly 1, so the declared px is the size everywhere the
+ * property is unset. Anything else keeps erroring.
+ */
+const COUNTER_SCALED_PX = /^text-\[length:calc\((\d+(?:\.\d+)?)px\*var\(--[a-z0-9-]+,\s*1\)\)\]$/
+
 function classesToTraits(classString, context) {
   const traits = { size: null, weight: null, lineHeight: null }
   for (const cls of classString.split(/\s+/)) {
     let m
     if ((m = cls.match(/^text-\[(\d+(?:\.\d+)?)px\]$/))) {
       traits.size = Number(m[1])
+    } else if ((m = cls.match(COUNTER_SCALED_PX))) {
+      // ONE sanctioned calc shape: a declared px multiplied by a counter-scale
+      // custom property that DEFAULTS TO 1. The census measures the declared
+      // type scale, and `var(--x, 1)` resolves to the declared px wherever the
+      // property is unset — which is everywhere outside the canvas subtree. So
+      // the size this census cares about is unchanged, and the regex is narrow
+      // enough that any OTHER calc/clamp/rem still falls through to the error
+      // below. See src/canvas/utils/zoomLegibility.ts for why the canvas tokens
+      // carry it. Deliberately NOT a general calc evaluator: a census that
+      // guesses at arithmetic is worse than one that refuses it (trap 12).
+      traits.size = Number(m[1])
     } else if ((m = cls.match(/^text-\[/))) {
-      errors.push(`${context}: unsupported arbitrary text class "${cls}" (only [Npx] handled)`)
+      errors.push(`${context}: unsupported arbitrary text class "${cls}" (only [Npx] and [length:calc(Npx*var(--x,1))] handled)`)
     } else if ((m = cls.match(/^text-(xs|sm|base|lg|xl|\dxl)$/))) {
       if (!(m[1] in TW_SIZE_PX)) errors.push(`${context}: unknown text size "${cls}"`)
       else traits.size = TW_SIZE_PX[m[1]]

--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -15,6 +15,7 @@ import { useInitialLayoutGuard } from './hooks/useInitialLayoutGuard'
 import { usePrefersReducedMotion } from './hooks/usePrefersReducedMotion'
 import { useEditedSinceRun } from './hooks/useEditedSinceRun'
 import { LodSync } from './components/LodSync'
+import { CanvasLabelScaleSync } from './components/CanvasLabelScaleSync'
 import { CanvasLodNotice } from './components/CanvasLodNotice'
 import { cameraDuration } from './utils/cameraMotion'
 import { useFocusCamera } from './hooks/useFocusCamera'
@@ -2204,6 +2205,11 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
             </svg>
             {/* D2: level-of-detail zoom watcher — main canvas only. */}
             <LodSync />
+            {/* Counter-scales canvas label text against the viewport transform
+                so DS v5 §2.3's 13/11/10px are the sizes actually rendered, not
+                the sizes before a 0.50 auto-fit halves them. Main canvas only:
+                the Compare-tab minis are deliberately simplified views. */}
+            <CanvasLabelScaleSync />
             {/* Says so when LodSync has blanked the labels — measured at 0 of 5
                 viewports before this shipped; see the component's header. */}
             <CanvasLodNotice />

--- a/src/canvas/components/CanvasLabelScaleSync.tsx
+++ b/src/canvas/components/CanvasLabelScaleSync.tsx
@@ -1,0 +1,59 @@
+/**
+ * CanvasLabelScaleSync — writes `--canvas-label-scale` onto this React Flow
+ * instance's root element so canvas label text renders at its DECLARED size
+ * regardless of the viewport zoom.
+ *
+ * WHY A CSS VARIABLE ON AN ANCESTOR, and not a prop or a store field.
+ * -------------------------------------------------------------------
+ * The scale changes on every zoom tick. Threading it through props, or through
+ * the canvas store the way `LodSync` threads `lodActive`, would re-render every
+ * node and every edge on every wheel event — the cost the LOD flag was
+ * deliberately designed around ("selecting the derived boolean, not the raw
+ * zoom, means this component re-renders only when the flag flips"). A custom
+ * property set on an ANCESTOR is inherited by the whole subtree and repaints
+ * without React touching a single node component.
+ *
+ * SCOPE IS BY CONSTRUCTION. The property is written to the closest `.react-flow`
+ * root, found from this component's own marker element — never
+ * `document.querySelector`, which would reach the Compare-tab mini-maps and any
+ * other React Flow instance on the page. Anything outside that subtree (panels,
+ * inspector, tooltips portalled to `body`) never sees the property and falls
+ * back to `1` through each token's own `var(…, 1)` default, so the type scale
+ * off-canvas is untouched.
+ *
+ * Mounted as a child of the MAIN <ReactFlow> only, exactly like `LodSync`.
+ */
+import { useEffect, useRef } from 'react'
+import { useStore } from '@xyflow/react'
+import { labelCounterScale, CANVAS_LABEL_SCALE_VAR } from '../utils/zoomLegibility'
+
+/**
+ * Quantisation step for the written value.
+ *
+ * The scale is continuous, but a font-size difference below ~1% is not a
+ * rendering difference — and writing a fresh string to the DOM on every frame of
+ * a pinch gesture is pure churn. Rounding to two decimals means a wheel-zoom
+ * writes a handful of times instead of once per frame. It is NOT a legibility
+ * parameter: at the auto-fit floor the quantised scale is exact.
+ */
+const SCALE_QUANTUM = 100
+
+export function CanvasLabelScaleSync() {
+  // Selecting the QUANTISED SCALE (a number), not the raw transform, so this
+  // component re-renders only when the written value would actually change.
+  const scale = useStore((s) => Math.round(labelCounterScale(s.transform[2]) * SCALE_QUANTUM) / SCALE_QUANTUM)
+  const markerRef = useRef<HTMLSpanElement | null>(null)
+
+  useEffect(() => {
+    const root = markerRef.current?.closest('.react-flow') as HTMLElement | null
+    if (!root) return
+    root.style.setProperty(CANVAS_LABEL_SCALE_VAR, String(scale))
+    return () => {
+      // Leave the instance as we found it. A stale scale outliving this
+      // component would silently mis-size a later mount of the same root.
+      root.style.removeProperty(CANVAS_LABEL_SCALE_VAR)
+    }
+  }, [scale])
+
+  return <span ref={markerRef} data-testid="canvas-label-scale-sync" style={{ display: 'none' }} />
+}

--- a/src/canvas/components/__tests__/CanvasLabelScaleSync.spec.tsx
+++ b/src/canvas/components/__tests__/CanvasLabelScaleSync.spec.tsx
@@ -1,0 +1,90 @@
+/**
+ * CanvasLabelScaleSync — the transport for the label counter-scale.
+ *
+ * The arithmetic is proved in `zoomLegibility.counterScale.spec.ts`. What is
+ * proved HERE is the seam that arithmetic travels through, because a correct
+ * function written onto the wrong element, or onto every element, is the same
+ * defect as no function at all.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, cleanup } from '@testing-library/react'
+import { CanvasLabelScaleSync } from '../CanvasLabelScaleSync'
+import { CANVAS_LABEL_SCALE_VAR, labelCounterScale } from '../../utils/zoomLegibility'
+
+let zoom = 1
+
+vi.mock('@xyflow/react', () => ({
+  useStore: (selector: any) => selector({ transform: [0, 0, zoom] }),
+}))
+
+/** Mount inside a stand-in for React Flow's own root element. */
+function mountAt(z: number) {
+  zoom = z
+  const host = document.createElement('div')
+  host.className = 'react-flow'
+  document.body.appendChild(host)
+  const outside = document.createElement('div')
+  document.body.appendChild(outside)
+  const result = render(<CanvasLabelScaleSync />, { container: host })
+  return { host, outside, ...result }
+}
+
+afterEach(() => {
+  cleanup()
+  document.body.innerHTML = ''
+  zoom = 1
+})
+
+describe('CanvasLabelScaleSync', () => {
+  it('writes the counter-scale for the current zoom onto the React Flow root', () => {
+    const { host } = mountAt(0.5)
+    expect(host.style.getPropertyValue(CANVAS_LABEL_SCALE_VAR)).toBe(String(labelCounterScale(0.5)))
+  })
+
+  it('CONTRAST CONTROL: the value differs by zoom — it is not a constant', () => {
+    // A transport that writes the same string whatever it is given would pass
+    // the test above and deliver nothing. Two zooms, two answers (trap 20: a
+    // probe returning identical results for every input is reporting on itself).
+    const a = mountAt(0.5).host.style.getPropertyValue(CANVAS_LABEL_SCALE_VAR)
+    cleanup(); document.body.innerHTML = ''
+    const b = mountAt(1).host.style.getPropertyValue(CANVAS_LABEL_SCALE_VAR)
+    expect(a).not.toBe(b)
+    expect(b).toBe('1')
+  })
+
+  it('SCOPE: never touches an element outside its own React Flow instance', () => {
+    // The Compare-tab minis are separate instances and panels are outside the
+    // canvas entirely. A `document.querySelector` implementation would pass
+    // every other test in this file and silently rescale the whole app.
+    const { outside } = mountAt(0.5)
+    expect(outside.style.getPropertyValue(CANVAS_LABEL_SCALE_VAR)).toBe('')
+    expect(document.body.style.getPropertyValue(CANVAS_LABEL_SCALE_VAR)).toBe('')
+  })
+
+  it('removes the property on unmount, leaving the root as it was found', () => {
+    // A stale scale outliving the component would mis-size a later mount, and
+    // nothing would report it.
+    const { host, unmount } = mountAt(0.5)
+    expect(host.style.getPropertyValue(CANVAS_LABEL_SCALE_VAR)).not.toBe('')
+    unmount()
+    expect(host.style.getPropertyValue(CANVAS_LABEL_SCALE_VAR)).toBe('')
+  })
+
+  it('does not throw when no React Flow root is present', () => {
+    // Store doubles and isolated harnesses mount components bare. This must
+    // degrade to "no counter-scale", never to a crash that takes the canvas out.
+    zoom = 0.5
+    expect(() => render(<CanvasLabelScaleSync />)).not.toThrow()
+  })
+
+  it('quantises to two decimals so a wheel gesture is not a write per frame', () => {
+    const { host } = mountAt(0.7)
+    const written = Number(host.style.getPropertyValue(CANVAS_LABEL_SCALE_VAR))
+    // 1/0.7 = 1.4285714…  → 1.43
+    expect(written).toBe(1.43)
+    // …and the quantisation is EXACT at the auto-fit settle zoom, where it
+    // matters: 1/0.5 = 2 needs no rounding at all.
+    cleanup(); document.body.innerHTML = ''
+    expect(Number(mountAt(0.5).host.style.getPropertyValue(CANVAS_LABEL_SCALE_VAR))).toBe(2)
+  })
+})

--- a/src/canvas/edges/StyledEdge.tsx
+++ b/src/canvas/edges/StyledEdge.tsx
@@ -24,6 +24,12 @@ import { useShallow } from 'zustand/react/shallow'
 import type { EdgeData, EdgePathType } from '../domain/edges'
 import { shouldShowEdgeLabel } from './edgeLabelVisibility'
 import { computeDirectionStroke } from './directionStroke'
+import {
+  readContestedState,
+  resolveEdgeStroke,
+  resolveEdgeDash,
+  type EdgePresentationState,
+} from './edgePresentation'
 import { resolvePersistentLabelPlacements, type PlacementEdge } from './edgeLabelCollision'
 import { applyEdgeVisualProps } from '../theme/edges'
 import { formatConfidence, shouldShowLabel, getEdgeConfidence } from '../domain/edges'
@@ -58,9 +64,10 @@ import { useAssistantFocusStore } from '../stores/assistantFocusStore'
 
 // Structural edge grey — brief constant, not a theme token. Used for the
 // thin 1px solid stroke on decision→option and option→factor edges so they
-// recede visually next to causal edges. Exported so tests track the colour
-// via the constant rather than a hard-coded literal.
-export const STRUCTURAL_EDGE_COLOUR = '#B8B8B8'
+// recede visually next to causal edges. Re-exported so the many existing tests
+// that import it from here keep working; it now LIVES in `edgePresentation`,
+// beside the rule that applies it.
+export { STRUCTURAL_EDGE_COLOUR } from './edgePresentation'
 
 // Stable empty set for the lens-disabled branch of the store selector —
 // a fresh Set per call would defeat useShallow's reference equality.
@@ -345,27 +352,12 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
     [beliefExists]
   )
 
-  // Contested edge styling — dashed info-colour stroke scaled by max_divergence
-  // Resolved or absent validation: revert to normal rendering.
-  // If max_divergence is absent, treat as non-contested (no inferred divergence).
+  // Contested edge state — reduced to four named facts by the one authority
+  // (`edgePresentation.readContestedState`), which also owns the
+  // divergence-scaled dash. The gate itself is unchanged: status contested AND
+  // user_action pending AND a divergence actually supplied.
   const validation = edgeData?.validation
-  const isContested = validation?.status === 'contested'
-    && validation?.user_action === 'pending'
-    && validation?.max_divergence !== undefined
-    && validation?.max_divergence !== null
-  const needsUserInput = isContested && (validation?.pass2?.needs_user_input === true)
-
-  // Contested dash: gap scales with max_divergence (0→1 maps to 4→8px gap)
-  // needs_user_input gets a tighter dash for stronger visual signal
-  const contestedDashArray = isContested
-    ? (() => {
-        const divergence = validation!.max_divergence
-        const gap = needsUserInput ? 3 : Math.round(4 + divergence * 4)
-        // Dash width scales between 1.5px and 3px: 1.5 + divergence * 1.5
-        const dashWidth = Number((1.5 + divergence * 1.5).toFixed(1))
-        return `${dashWidth} ${gap}`
-      })()
-    : null
+  const contested = useMemo(() => readContestedState(validation), [validation])
 
   // Fix 1: Line style encodes existence certainty ONLY, not direction
   // Direction is already encoded via color (green/red) and sign (+/−)
@@ -373,10 +365,21 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
   // D.1: Unified confidence check via getEdgeConfidence (returns null when missing)
   const edgeConfidenceValue = getEdgeConfidence(edgeData as Record<string, unknown> | undefined)
 
-  // B.I.10: Pre-run overlay — dashed stroke for edges with NO confidence set.
-  // F.2: Controls dash pattern only; colour is derived from direction.
+  // B.I.10 (SUPERSEDED as a STYLE, retained as a MARKER — 17 Aug 2026).
+  //
+  // This used to be `!isResultsMode && edgeConfidenceValue === null` and it
+  // dashed the edge, commented "needs attention". Both halves were defects:
+  //   • On a fresh AI draft NO edge has a confidence, so "needs attention"
+  //     marked the entire graph — Paul's ruling that exception styling must not
+  //     become the default. `edgePresentation.EDGE_DASH_RULES` no longer carries
+  //     a `pre_run_incomplete` rule.
+  //   • `!isResultsMode` is an APP PHASE (`results.status === 'complete'`), so
+  //     completing an analysis restyled edges the user had not touched. That is
+  //     the flip Paul witnessed on the Analysis tab, and it is why the term is
+  //     gone from the predicate rather than merely unused: an edge's resting
+  //     appearance is a function of the edge.
   // A confidence of 0 is a valid user choice (low), not "missing".
-  const isPreRunIncompleteEdge = !isResultsMode && edgeConfidenceValue === null
+  const isMissingConfidenceEdge = edgeConfidenceValue === null
 
   // Determine label visibility and styling
   const labelVisibility = useMemo(
@@ -718,6 +721,29 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
     showEdgeHint: Boolean(showEdgeHint),
   })
 
+  // ── Stroke + dash, from the one authority ────────────────────────────────
+  //
+  // NOTE WHAT IS NOT IN THIS STATE: `isResultsMode`. An edge's resting colour
+  // and dash are a function of the EDGE. Interaction states (hover, selection,
+  // highlight, lens) are transient and user-driven and stay; analysis
+  // completion is neither, and used to restyle a graph nobody had edited.
+  const presentationState: EdgePresentationState = useMemo(() => ({
+    isStructural: isStructuralEdge,
+    lensMode,
+    causalParams: causalEdgeParams,
+    evidenceClass: evidenceEdgeClass,
+    contested,
+    isHighlighted: isHighlightedEdge,
+    polarityStroke: directionStroke,
+    existenceDash: existenceCertaintyDash,
+    visualPropsDash: visualProps.strokeDasharray,
+  }), [
+    isStructuralEdge, lensMode, causalEdgeParams, evidenceEdgeClass, contested,
+    isHighlightedEdge, directionStroke, existenceCertaintyDash, visualProps.strokeDasharray,
+  ])
+  const edgeStroke = useMemo(() => resolveEdgeStroke(presentationState), [presentationState])
+  const edgeDash = useMemo(() => resolveEdgeDash(presentationState), [presentationState])
+
   // Causal lens: hide structural edges entirely
   if (isLensHidden) return null
 
@@ -742,7 +768,7 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
         stroke="transparent"
         strokeWidth={EDGE_HIT_AREA_WIDTH}
         style={{ pointerEvents: 'stroke', cursor: 'pointer' }}
-        {...(isPreRunIncompleteEdge ? { 'data-testid': 'overlay-missing-confidence' } : {})}
+        {...(isMissingConfidenceEdge ? { 'data-testid': 'overlay-missing-confidence' } : {})}
       >
         {isStructuralEdge && structuralTooltip && <title>{structuralTooltip}</title>}
       </path>
@@ -806,42 +832,19 @@ export const StyledEdge = memo(({ id, source, target, sourceX, sourceY, targetX,
             // fragile-badged, so they never bump.
             return isAnalysisFragileEdge && !isStructuralEdge ? Math.max(base, 4) : base
           })(),
-          // Fix 1: Use existence certainty for line style, fallback to visual props
-          // B.I.10: Pre-run incomplete edges get dashed stroke to indicate "needs attention"
-          // Priority: structural (solid) > contested dash > pre-run incomplete dash > existence certainty > visual props
-          strokeDasharray: (() => {
-            if (isStructuralEdge) return undefined
-            if (isContested) return contestedDashArray
-            if (isPreRunIncompleteEdge) return '6 3'
-            return existenceCertaintyDash ?? visualProps.strokeDasharray
-          })(),
-          // Graph Interaction P1: Highlighted edges get brighter color
-          // F.2: Direction colour always applies — yellow only for truly uninitialised edges
-          // Pre-run overlay controls dash pattern only, not colour
-          stroke: (() => {
-            // Structural edges: fixed grey regardless of lens / highlight
-            if (isStructuralEdge) return STRUCTURAL_EDGE_COLOUR
-            // Causal lens: neutral colour; danger ONLY for a STATED negative
-            // (ROADMAP 2.954). Danger-red is a direction claim, so it renders
-            // from the resolved direction — never from the sign of a mean the
-            // UI itself may have fabricated (`effect_direction: 'unknown'`
-            // edges used to draw red here off the fallback sign).
-            if (lensMode === 'causal' && causalEdgeParams) {
-              return causalEdgeParams.direction === 'negative' ? 'var(--semantic-danger, #ef4444)' : 'var(--text-body, #3F3F3E)'
-            }
-            // Evidence lens: colour by provenance classification
-            if (lensMode === 'evidence' && evidenceEdgeClass) {
-              switch (evidenceEdgeClass) {
-                case 'evidence': return 'var(--semantic-success, #22c55e)'
-                case 'assumed': return 'var(--semantic-warning, #eab308)'
-                case 'unknown': return 'var(--semantic-danger, #ef4444)'
-              }
-            }
-            if (isContested) {
-              return needsUserInput ? 'var(--semantic-warning)' : 'color-mix(in srgb, var(--semantic-warning) 70%, transparent)'
-            }
-            return isHighlightedEdge ? 'var(--semantic-info)' : (directionStroke ?? visualProps.stroke)
-          })(),
+          // ⭐ ONE AUTHORITY, ONE STATED PRECEDENCE (17 Aug 2026).
+          //
+          // Both channels used to be ordered early-return chains written inline
+          // here. Nobody had ever chosen that order — it was the sequence the
+          // branches were added in, and it silently made polarity unreachable on
+          // every contested edge. `edgePresentation` owns the decision now:
+          // `EDGE_STROKE_RULES` / `EDGE_DASH_RULES` are ordered arrays, the
+          // resolvers return the NAMED rule that fired, and both orderings are
+          // asserted against those arrays in `edgePresentation.spec.ts`. Adding
+          // a branch here again — rather than a rule there — is the regression
+          // this refactor exists to make impossible to do quietly.
+          strokeDasharray: edgeDash.value,
+          stroke: edgeStroke.value,
           // Opacity is a lens-only channel now. exists_probability is a SINGLE
           // encoding — the dash (existenceCertaintyDash above), which stays
           // legible at every zoom level and doesn't fight the analysis halo.

--- a/src/canvas/edges/__tests__/StyledEdge.contested.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.contested.spec.tsx
@@ -204,18 +204,44 @@ describe('StyledEdge — contested visual styling', () => {
     capturedStyle = undefined
   })
 
-  it('pending contested edge with max_divergence renders dashed warning stroke', () => {
+  // ⭐ UPDATED 17 Aug 2026 — PAUL'S RULING, not a drifting expectation.
+  //
+  // These three cases used to assert that ANY pending contest painted the edge
+  // warning-orange. That was the defect: `isContested` returned before the
+  // polarity stroke was evaluated, so orange was unconditional, and on a fresh
+  // AI draft the exception treatment IS the default. Paul's ruling (17 Aug):
+  // "orange must NOT universally mean 'unvetted'; reserve exception styling for
+  // genuinely exceptional/contested states."
+  //
+  // `makeValidation`'s default reason is `strength_band_change` — the passes
+  // disagree about the STRENGTH BAND and AGREE about the sign — so the edge now
+  // keeps its polarity and the contest rides the dash. The exception hue is
+  // asserted, on its own twins, immediately below. See
+  // `edgePresentation.spec.ts` for the full precedence and
+  // `StyledEdge.presentationStability.spec.tsx` for the founder-witnessed harms.
+  it('pending contest over an AGREED sign keeps its polarity and dashes', () => {
     const style = renderEdge({
       weight: 0.5,
       direction: 'positive',
       validation: makeValidation({ max_divergence: 0.6 }),
     })
 
-    // Stroke should be the 70% mixed warning colour (contested = needs attention)
+    // No alarm hue: the thing in dispute is the strength band, not the sign.
+    expect(style.stroke).not.toContain('--semantic-warning')
+
+    // The contest is still shown — divergence-scaled: width = 1.5 + 0.6*1.5 =
+    // 2.4, gap = 4 + 0.6*4 = 6. Unchanged by the refactor.
+    expect(style.strokeDasharray).toBe('2.4 6')
+  })
+
+  it('OPPOSITE-DIRECTION TWIN: a sign_flip contest DOES take the warning stroke', () => {
+    const style = renderEdge({
+      weight: 0.5,
+      direction: 'positive',
+      validation: makeValidation({ max_divergence: 0.6, contested_reasons: ['sign_flip'] }),
+    })
     expect(style.stroke).toContain('color-mix')
     expect(style.stroke).toContain('--semantic-warning')
-
-    // Dash array should be divergence-scaled: width = 1.5 + 0.6*1.5 = 2.4, gap = 4 + 0.6*4 = 6
     expect(style.strokeDasharray).toBe('2.4 6')
   })
 
@@ -242,17 +268,33 @@ describe('StyledEdge — contested visual styling', () => {
   it('POSITIVE CONTROL: a contested edge does NOT render as if validation were absent', () => {
     // Without this, every negative arm below could pass by comparing two
     // identically-broken renders. This proves the differential helper CAN fail.
-    const data = {
+    //
+    // ⚠ The discriminating channel is now the DASH, not the stroke — the whole
+    // point of the ruling above. Asserted on BOTH contest classes so the control
+    // cannot be satisfied by the exception hue alone.
+    const agreedSign = {
       weight: 0.5,
       direction: 'positive',
       validation: makeValidation({ max_divergence: 0.6 }),
     }
-    const withValidation = contestedStyleSignature(renderEdge(data))
-    const control = contestedStyleSignature(renderEdge(withoutValidation(data)))
+    const withValidation = contestedStyleSignature(renderEdge(agreedSign))
+    const control = contestedStyleSignature(renderEdge(withoutValidation(agreedSign)))
 
     expect(withValidation).not.toEqual(control)
-    expect(withValidation.stroke).toContain('--semantic-warning')
-    expect(control.stroke).not.toContain('--semantic-warning')
+    expect(withValidation.strokeDasharray).toBe('2.4 6')
+    expect(control.strokeDasharray).not.toBe('2.4 6')
+    // …and the agreed-sign contest is specifically NOT alarming.
+    expect(withValidation.stroke).not.toContain('--semantic-warning')
+
+    // TWIN: the sign_flip class still discriminates on the STROKE too.
+    const disputedSign = {
+      ...agreedSign,
+      validation: makeValidation({ max_divergence: 0.6, contested_reasons: ['sign_flip'] }),
+    }
+    const disputed = contestedStyleSignature(renderEdge(disputedSign))
+    expect(disputed.stroke).toContain('--semantic-warning')
+    expect(contestedStyleSignature(renderEdge(withoutValidation(disputedSign))).stroke)
+      .not.toContain('--semantic-warning')
   })
 
   it('resolved contested edge reverts to standard non-contested style', () => {
@@ -311,7 +353,9 @@ describe('StyledEdge — contested visual styling', () => {
     })
 
     expect(style.strokeDasharray).toBe('1.5 4')
-    expect(style.stroke).toContain('color-mix')
+    // Reason is `strength_band_change`, so the sign is not in dispute and the
+    // polarity survives — see the ruling note at the top of this describe.
+    expect(style.stroke).not.toContain('--semantic-warning')
   })
 
   it('max_divergence 1 produces maximum dash width (3.0) and gap (8)', () => {

--- a/src/canvas/edges/__tests__/StyledEdge.presentationStability.spec.tsx
+++ b/src/canvas/edges/__tests__/StyledEdge.presentationStability.spec.tsx
@@ -1,0 +1,287 @@
+/**
+ * StyledEdge — the MOUNTED consumer of `edgePresentation` (P2).
+ *
+ * `edgePresentation.spec.ts` proves the pure rules. This file proves the
+ * component actually feeds them the right state and paints the result — a
+ * producer-side proof says nothing about what a user sees, and this seam has
+ * form: the precedence defect it closes lived entirely in how StyledEdge
+ * ORDERED its branches, not in any function.
+ *
+ * Two founder-witnessed harms are pinned here, each with its opposite-direction
+ * twin (a fix that trades a false alarm for a silent one is not a fix):
+ *
+ *   H1  a contested edge rendered warning-orange unconditionally, so polarity
+ *       was unreachable        ⇄  twin: a sign_flip contest MUST still alarm
+ *   H2  the same edge restyled when an analysis completed, because the
+ *       "needs attention" dash read `results.status`
+ *                              ⇄  twin: a stated existence uncertainty MUST
+ *                                 still dash
+ *
+ * ⚠ jsdom cannot prove visibility and this file does not try. Everything here is
+ * an assertion about the STYLE VALUES StyledEdge hands to BaseEdge.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { Position } from '@xyflow/react'
+import { StyledEdge } from '../StyledEdge'
+
+// ── Mutable app state, so one render can differ from the next ───────────────
+
+let resultsStatus: 'idle' | 'complete' = 'idle'
+let capturedStyle: React.CSSProperties | undefined
+/** Every `results.status` the component's own store selector actually read. */
+const statusesSeenByComponent: string[] = []
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return {
+    ...actual,
+    BaseEdge: (props: any) => {
+      capturedStyle = props.style
+      return <path data-testid="base-edge" />
+    },
+    EdgeLabelRenderer: ({ children }: any) => <div>{children}</div>,
+    getBezierPath: () => ['M0 0 L100 100', 50, 50],
+    getSmoothStepPath: () => ['M0 0 L100 100', 50, 50],
+    getStraightPath: () => ['M0 0 L100 100', 50, 50],
+    useReactFlow: () => ({ getNode: () => null, getEdges: () => [], getNodes: () => [] }),
+    useStore: (selector: any) => selector({ nodes: [] }),
+  }
+})
+
+vi.mock('../../store', () => ({
+  useCanvasStore: vi.fn((selector: any) =>
+    selector({
+      updateEdgeData: vi.fn(),
+      runMeta: { ceeReview: null },
+      results: { status: (statusesSeenByComponent.push(resultsStatus), resultsStatus), report: null },
+      hoveredOptionId: null,
+      highlightedEdges: new Set<string>(),
+      dimmedEdgeIds: new Set<string>(),
+      lens: {
+        active: 'full',
+        _dimmedEdgeIds: new Set<string>(),
+        _sensitivityWeights: new Map<string, number>(),
+        _sensitivityQuartiles: null,
+        _fragileEdgeIds: new Set<string>(),
+        _lensFragileLabels: new Map<string, string>(),
+      },
+    }),
+  ),
+}))
+
+vi.mock('../../store/edgeLabelMode', () => ({
+  useEdgeLabelMode: vi.fn((selector: any) => selector({ mode: 'human' })),
+}))
+vi.mock('../../hooks/useTheme', () => ({ useIsDark: () => false }))
+vi.mock('../../hooks/useFirstTimeHints', () => ({
+  useEdgeEditHint: () => ({ showHint: false, dismissHint: vi.fn() }),
+}))
+vi.mock('../../hooks/usePrefersReducedMotion', () => ({ usePrefersReducedMotion: () => false }))
+vi.mock('../../../flags', () => ({ isGraphLensEnabled: () => false }))
+vi.mock('../../utils/fragileEdgeMatch', () => ({
+  isEdgeFragile: () => false,
+  getFragileEdgeSwitchProbability: () => null,
+}))
+// importOriginal-SPREAD, never a hand-listed replacement (CLAUDE.md trap 12):
+// a `vi.mock` factory REPLACES the module, so a hand-written list silently drops
+// every export added after it was written. Only the two stubs below are
+// overridden, and `existenceCertaintyToLineStyle` keeps its REAL behaviour so
+// the existence-dash twin is a genuine measurement.
+vi.mock('../../utils/graphDisplayCalculations', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../utils/graphDisplayCalculations')>()),
+  calculateEdgeImportance: () => 0.5,
+  weightMagnitudeToStrokeWidth: () => 2,
+}))
+vi.mock('../../theme/edges', () => ({
+  applyEdgeVisualProps: () => ({ strokeWidth: 2, strokeDasharray: undefined, stroke: '#888', curvature: 0.15 }),
+}))
+vi.mock('../../ui/inspector-v2/inspectorStrings', () => ({
+  getStrengthDescription: () => 'moderate',
+  getProvenanceLabel: () => '',
+}))
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+const baseProps = {
+  id: 'e1', source: 'n1', target: 'n2',
+  sourceX: 0, sourceY: 0, targetX: 100, targetY: 100,
+  sourcePosition: Position.Right, targetPosition: Position.Left, selected: false,
+}
+
+/**
+ * A realistic CEE-drafted causal edge: a STATED positive direction over a STATED
+ * strength, carrying the provenance stamps `resolveEdgeDirectionDisplay` and
+ * `resolveEdgeSignedStrengthDisplay` require. Without the stamps both resolvers
+ * refuse and the polarity collapses to neutral grey — which would make every
+ * "polarity survives" assertion below pass on the wrong colour.
+ */
+function draftedEdge(overrides: Record<string, unknown> = {}) {
+  return {
+    weight: 0.5,
+    direction: 'positive',
+    weightSource: 'cee',
+    directionSource: 'cee',
+    ...overrides,
+  }
+}
+
+function contestedValidation(overrides: Record<string, unknown> = {}) {
+  return {
+    status: 'contested',
+    contested_reasons: ['strength_band_change'],
+    pass1: { strength_mean: 0.3, strength_std: 0.1, exists_probability: 0.8 },
+    pass2: {
+      strength_mean: 0.7, strength_std: 0.15, exists_probability: 0.9,
+      reasoning: 'test', basis: 'domain_prior', needs_user_input: false,
+    },
+    max_divergence: 0.6,
+    distance_to_goal: 1,
+    evoi_rank: null, evoi_impact: null,
+    was_shown: true, user_action: 'pending',
+    resolved_value: null, resolved_by: 'default',
+    ...overrides,
+  }
+}
+
+function renderEdge(data: Record<string, unknown>) {
+  capturedStyle = undefined
+  const { unmount } = render(<StyledEdge {...(baseProps as any)} data={data} />)
+  const style = capturedStyle!
+  unmount()
+  return { stroke: style.stroke, strokeDasharray: style.strokeDasharray }
+}
+
+const POSITIVE = 'var(--edge-positive)'
+
+afterEach(() => {
+  resultsStatus = 'idle'
+  capturedStyle = undefined
+  statusesSeenByComponent.length = 0
+})
+
+describe('StyledEdge — the fixture itself is honest (precondition pins)', () => {
+  it('the drafted-edge fixture really does render a POLARITY colour, not neutral grey', () => {
+    // Pins this file's own precondition in-test (trap 13b). Every assertion
+    // below distinguishes "polarity survived" from "orange won"; if the fixture
+    // silently lost its provenance stamps the polarity would be neutral grey and
+    // those assertions would still pass, measuring nothing.
+    expect(renderEdge(draftedEdge()).stroke).toBe(POSITIVE)
+  })
+
+  it('CONTRAST CONTROL: the same edge WITHOUT provenance stamps is neutral, not green', () => {
+    const stroke = renderEdge({ weight: 0.5, direction: 'positive' }).stroke
+    expect(stroke).not.toBe(POSITIVE)
+    expect(stroke).toContain('--edge-neutral')
+  })
+})
+
+describe('H1 — orange stops being the default; polarity survives a contest', () => {
+  it('a contested edge whose contest is NOT about the sign renders its polarity', () => {
+    const s = renderEdge(draftedEdge({ validation: contestedValidation() }))
+    expect(s.stroke).toBe(POSITIVE)
+    expect(s.stroke).not.toContain('--semantic-warning')
+  })
+
+  it('…and the contest is still visible, on the dash', () => {
+    expect(renderEdge(draftedEdge({ validation: contestedValidation() })).strokeDasharray).toBe('2.4 6')
+  })
+
+  it('TWIN: a sign_flip contest DOES render the exception hue', () => {
+    const s = renderEdge(draftedEdge({ validation: contestedValidation({ contested_reasons: ['sign_flip'] }) }))
+    expect(s.stroke).toContain('--semantic-warning')
+    expect(s.stroke).not.toBe(POSITIVE)
+  })
+
+  it('TWIN: needs_user_input DOES render the exception hue at full strength', () => {
+    const s = renderEdge(draftedEdge({
+      validation: contestedValidation({
+        pass2: {
+          strength_mean: 0.7, strength_std: 0.15, exists_probability: 0.9,
+          reasoning: 'test', basis: 'domain_prior', needs_user_input: true,
+        },
+      }),
+    }))
+    expect(s.stroke).toBe('var(--semantic-warning)')
+  })
+})
+
+describe('H2 — an edge\'s resting appearance is a function of the EDGE, not the app phase', () => {
+  /**
+   * ⚠ SCOPE, STATED PRECISELY. The claim is about the two RESTING style channels
+   * Paul watched change — stroke colour and dash. It is NOT a claim that nothing
+   * about an edge may change after analysis: label visibility deliberately does
+   * (`shouldShowEdgeLabel` surfaces top-strength labels once results exist), and
+   * that is a designed behaviour, not this defect.
+   */
+  const cases: ReadonlyArray<readonly [string, Record<string, unknown>]> = [
+    ['a plain drafted edge with no confidence set', draftedEdge()],
+    ['a drafted edge with a stated existence probability', draftedEdge({ beliefExists: 0.8 })],
+    ['a contested edge', draftedEdge({ validation: contestedValidation() })],
+    ['a sign_flip contested edge', draftedEdge({ validation: contestedValidation({ contested_reasons: ['sign_flip'] }) })],
+    ['an edge with a low existence probability', draftedEdge({ beliefExists: 0.3 })],
+  ]
+
+  it.each(cases)('%s renders identically before and after an analysis completes', (_label, data) => {
+    resultsStatus = 'idle'
+    const before = renderEdge(data)
+    resultsStatus = 'complete'
+    const after = renderEdge(data)
+    expect(after).toEqual(before)
+  })
+
+  it('POSITIVE CONTROL: the harness CAN see a difference between two renders', () => {
+    // Without this, every case above could pass by comparing two identically
+    // broken renders — or by a mock that pins the style regardless of input.
+    const a = renderEdge(draftedEdge())
+    const b = renderEdge(draftedEdge({ validation: contestedValidation({ contested_reasons: ['sign_flip'] }) }))
+    expect(a).not.toEqual(b)
+  })
+
+  it('POSITIVE CONTROL: the mutable results status really does reach the component', () => {
+    // Without this the cases above could pass because the lever was never
+    // connected — an "identical" result from a variable nobody read is the
+    // vacuity this estate keeps paying for (trap 13). Asserts the component's
+    // OWN store selector observed both values.
+    resultsStatus = 'idle'
+    renderEdge(draftedEdge())
+    resultsStatus = 'complete'
+    renderEdge(draftedEdge())
+    expect(new Set(statusesSeenByComponent)).toEqual(new Set(['idle', 'complete']))
+  })
+})
+
+describe('H2b — "needs attention" is no longer the default treatment', () => {
+  it('a fresh drafted edge with NO confidence renders SOLID, not dashed', () => {
+    // Was `'6 3'` for every confidence-less edge while results were incomplete —
+    // i.e. every edge of every fresh AI draft.
+    expect(renderEdge(draftedEdge()).strokeDasharray).toBeUndefined()
+  })
+
+  it('TWIN: an edge with a STATED low existence probability still dashes', () => {
+    // Removing the fabricated uncertainty signal must not remove the real one.
+    const dash = renderEdge(draftedEdge({ beliefExists: 0.3 })).strokeDasharray
+    expect(dash).toBeTruthy()
+    expect(dash).not.toBe('6 3')
+  })
+
+  it('the missing-confidence marker survives, and no longer depends on the app phase', () => {
+    // e2e `inspector-phase1.spec.ts` T5 asserts this test id is attached.
+    for (const status of ['idle', 'complete'] as const) {
+      resultsStatus = status
+      const { queryByTestId, unmount } = render(<StyledEdge {...(baseProps as any)} data={draftedEdge()} />)
+      expect(queryByTestId('overlay-missing-confidence')).not.toBeNull()
+      unmount()
+    }
+  })
+
+  it('…and is absent once an existence probability IS set', () => {
+    // `getEdgeConfidence` reads `beliefExists`/`belief` — the SAME field the
+    // existence-certainty dash reads. The two dash branches therefore
+    // partitioned on one field's presence, and the pre-run half was inventing a
+    // dash for a value nobody had stated.
+    const { queryByTestId, unmount } = render(<StyledEdge {...(baseProps as any)} data={draftedEdge({ beliefExists: 0.8 })} />)
+    expect(queryByTestId('overlay-missing-confidence')).toBeNull()
+    unmount()
+  })
+})

--- a/src/canvas/edges/__tests__/edgePresentation.spec.ts
+++ b/src/canvas/edges/__tests__/edgePresentation.spec.ts
@@ -1,0 +1,307 @@
+/**
+ * edgePresentation — the one authority for edge stroke + dash.
+ *
+ * WHAT THIS FILE IS FOR, AND WHAT IT DELIBERATELY DOES NOT DO
+ * -----------------------------------------------------------
+ * Every assertion binds to the NAMED RULE that fired (`decision.rule`), not only
+ * to the colour string it produced. Several rules can emit the same hue — the
+ * evidence lens's `assumed` and the contested branch both reach for
+ * `--semantic-warning` — so a test that asserts only a colour can pass while a
+ * completely different rule is doing the work (CLAUDE.md trap 19: bind by
+ * identity, never by a value predicate another object could satisfy). Asserting
+ * the rule id makes the precedence itself the thing under test.
+ *
+ * The ordering is asserted against `EDGE_STROKE_RULES` / `EDGE_DASH_RULES`
+ * directly, so a future reorder is a RED, not a silent repaint.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  EDGE_STROKE_RULES,
+  EDGE_DASH_RULES,
+  STRUCTURAL_EDGE_COLOUR,
+  NOT_CONTESTED,
+  DIRECTION_DISPUTING_REASON,
+  readContestedState,
+  resolveEdgeStroke,
+  resolveEdgeDash,
+  type EdgePresentationState,
+  type ContestedState,
+} from '../edgePresentation'
+
+const POLARITY_GREEN = 'var(--edge-positive)'
+
+/** A plain, quiet, AI-drafted edge: polarity stated, nothing exceptional. */
+function state(overrides: Partial<EdgePresentationState> = {}): EdgePresentationState {
+  return {
+    isStructural: false,
+    lensMode: 'full',
+    causalParams: null,
+    evidenceClass: null,
+    contested: NOT_CONTESTED,
+    isHighlighted: false,
+    polarityStroke: POLARITY_GREEN,
+    existenceDash: null,
+    visualPropsDash: undefined,
+    ...overrides,
+  }
+}
+
+/** Wire `validation` for a live contest. Defaults to a NON-direction reason. */
+function validation(overrides: Record<string, unknown> = {}) {
+  return {
+    status: 'contested',
+    contested_reasons: ['strength_band_change'],
+    pass1: { strength_mean: 0.3, strength_std: 0.1, exists_probability: 0.8 },
+    pass2: {
+      strength_mean: 0.7, strength_std: 0.15, exists_probability: 0.9,
+      reasoning: 'test', basis: 'domain_prior', needs_user_input: false,
+    },
+    max_divergence: 0.6,
+    distance_to_goal: 1,
+    evoi_rank: null,
+    evoi_impact: null,
+    was_shown: true,
+    user_action: 'pending',
+    resolved_value: null,
+    resolved_by: 'default',
+    ...overrides,
+  }
+}
+
+const contestedNonDirection: ContestedState = readContestedState(validation())
+const contestedSignFlip: ContestedState = readContestedState(
+  validation({ contested_reasons: ['sign_flip'] }),
+)
+const contestedNeedsInput: ContestedState = readContestedState(
+  validation({
+    pass2: {
+      strength_mean: 0.7, strength_std: 0.15, exists_probability: 0.9,
+      reasoning: 'test', basis: 'domain_prior', needs_user_input: true,
+    },
+  }),
+)
+
+describe('edgePresentation — the precedence is data, not paste order', () => {
+  it('states the stroke precedence as an ordered list, highest first', () => {
+    expect([...EDGE_STROKE_RULES]).toEqual([
+      'structural',
+      'lens_causal',
+      'lens_evidence',
+      'contested_needs_user_input',
+      'contested_direction_disputed',
+      'highlighted',
+      'polarity',
+    ])
+  })
+
+  it('states the dash precedence as an ordered list, and carries NO pre-run rule', () => {
+    expect([...EDGE_DASH_RULES]).toEqual([
+      'structural',
+      'contested',
+      'existence_certainty',
+      'visual_props',
+    ])
+    // The defect this module was written to remove: a "needs attention" dash
+    // applied to every confidence-less edge, gated on an app phase.
+    expect(EDGE_DASH_RULES).not.toContain('pre_run_incomplete')
+  })
+
+  it('every rule the stroke resolver can return is declared in the ordered list', () => {
+    // Derived, not mirrored: exercises one state per rule and checks the
+    // returned id is a member. Catches a rule added to the resolver and
+    // forgotten in the list — the hand-maintained-mirror defect (trap 12).
+    const reached = [
+      resolveEdgeStroke(state({ isStructural: true })).rule,
+      resolveEdgeStroke(state({ lensMode: 'causal', causalParams: { direction: 'negative' } })).rule,
+      resolveEdgeStroke(state({ lensMode: 'evidence', evidenceClass: 'assumed' })).rule,
+      resolveEdgeStroke(state({ contested: contestedNeedsInput })).rule,
+      resolveEdgeStroke(state({ contested: contestedSignFlip })).rule,
+      resolveEdgeStroke(state({ isHighlighted: true })).rule,
+      resolveEdgeStroke(state()).rule,
+    ]
+    expect(new Set(reached)).toEqual(new Set(EDGE_STROKE_RULES))
+  })
+})
+
+describe('edgePresentation — colour belongs to polarity', () => {
+  it('a quiet, unconfirmed, AI-drafted edge renders its polarity and nothing else', () => {
+    const d = resolveEdgeStroke(state())
+    expect(d.rule).toBe('polarity')
+    expect(d.value).toBe(POLARITY_GREEN)
+  })
+
+  it("PAUL'S RULING: a contested edge whose contest is NOT about the sign keeps its polarity", () => {
+    const d = resolveEdgeStroke(state({ contested: contestedNonDirection }))
+    expect(d.rule).toBe('polarity')
+    expect(d.value).toBe(POLARITY_GREEN)
+    expect(d.value).not.toContain('--semantic-warning')
+  })
+
+  it('OPPOSITE-DIRECTION TWIN: a sign_flip contest DOES take the exception hue', () => {
+    // Without this, the rule above could be satisfied by deleting the exception
+    // styling altogether — trading a false alarm for a silent one.
+    const d = resolveEdgeStroke(state({ contested: contestedSignFlip }))
+    expect(d.rule).toBe('contested_direction_disputed')
+    expect(d.value).toContain('--semantic-warning')
+  })
+
+  it('OPPOSITE-DIRECTION TWIN: needs_user_input takes the exception hue at full strength', () => {
+    const d = resolveEdgeStroke(state({ contested: contestedNeedsInput }))
+    expect(d.rule).toBe('contested_needs_user_input')
+    expect(d.value).toBe('var(--semantic-warning)')
+  })
+
+  it('needs_user_input outranks a sign_flip contest — one edge, one colour, stated order', () => {
+    const both = readContestedState(validation({
+      contested_reasons: ['sign_flip'],
+      pass2: {
+        strength_mean: 0.7, strength_std: 0.15, exists_probability: 0.9,
+        reasoning: 'test', basis: 'domain_prior', needs_user_input: true,
+      },
+    }))
+    expect(resolveEdgeStroke(state({ contested: both })).rule).toBe('contested_needs_user_input')
+  })
+
+  it('a contested edge still outranks the transient highlight, as it always did', () => {
+    expect(
+      resolveEdgeStroke(state({ contested: contestedSignFlip, isHighlighted: true })).rule,
+    ).toBe('contested_direction_disputed')
+  })
+
+  it('structural grey outranks every other rule, including a sign_flip contest', () => {
+    const d = resolveEdgeStroke(state({
+      isStructural: true,
+      contested: contestedSignFlip,
+      isHighlighted: true,
+      lensMode: 'evidence',
+      evidenceClass: 'unknown',
+    }))
+    expect(d.rule).toBe('structural')
+    expect(d.value).toBe(STRUCTURAL_EDGE_COLOUR)
+  })
+
+  it('the causal lens keeps its own vocabulary, above the contested rules', () => {
+    const d = resolveEdgeStroke(state({
+      lensMode: 'causal',
+      causalParams: { direction: 'negative' },
+      contested: contestedSignFlip,
+    }))
+    expect(d.rule).toBe('lens_causal')
+    expect(d.value).toContain('--semantic-danger')
+  })
+
+  it('the causal lens paints an UNSTATED direction in its neutral body colour, not polarity', () => {
+    // The lens's own refusal to claim a sign. `causalParams` present with a null
+    // direction is a different fact from `causalParams` absent, and collapsing
+    // them would drop the edge out of the lens entirely (trap 21).
+    const d = resolveEdgeStroke(state({ lensMode: 'causal', causalParams: { direction: null } }))
+    expect(d.rule).toBe('lens_causal')
+    expect(d.value).toContain('--text-body')
+  })
+
+  it('an unrecognised evidence class is not a claim we can paint — it falls through', () => {
+    const d = resolveEdgeStroke(state({ lensMode: 'evidence', evidenceClass: 'not_a_class' }))
+    expect(d.rule).toBe('polarity')
+  })
+})
+
+describe('edgePresentation — the contest is ALWAYS visible, on the dash', () => {
+  it('every contested edge dashes, whatever colour won above', () => {
+    for (const c of [contestedNonDirection, contestedSignFlip, contestedNeedsInput]) {
+      const d = resolveEdgeDash(state({ contested: c }))
+      expect(d.rule).toBe('contested')
+      expect(d.value).toBe(c.dash)
+    }
+  })
+
+  it('the divergence-scaled dash is unchanged by this refactor', () => {
+    expect(readContestedState(validation({ max_divergence: 0.6 })).dash).toBe('2.4 6')
+    expect(readContestedState(validation({ max_divergence: 0 })).dash).toBe('1.5 4')
+    expect(readContestedState(validation({ max_divergence: 1 })).dash).toBe('3 8')
+    // needs_user_input pins the GAP at 3 regardless of divergence; the width
+    // still scales (1.5 + 0.6 × 1.5 = 2.4).
+    expect(contestedNeedsInput.dash).toBe('2.4 3')
+    expect(readContestedState(validation({
+      max_divergence: 0.8,
+      pass2: {
+        strength_mean: 0.7, strength_std: 0.15, exists_probability: 0.9,
+        reasoning: 'test', basis: 'domain_prior', needs_user_input: true,
+      },
+    })).dash).toBe('2.7 3')
+  })
+
+  it('OPPOSITE-DIRECTION TWIN: a genuinely uncertain edge still dashes from existence certainty', () => {
+    // Removing the fake "needs attention" dash must not remove the real one.
+    const d = resolveEdgeDash(state({ existenceDash: '6,4' }))
+    expect(d.rule).toBe('existence_certainty')
+    expect(d.value).toBe('6,4')
+  })
+
+  it('a quiet edge with nothing stated is SOLID — no alarm by default', () => {
+    const d = resolveEdgeDash(state())
+    expect(d.rule).toBe('visual_props')
+    expect(d.value).toBeUndefined()
+  })
+
+  it('structural edges are always solid', () => {
+    const d = resolveEdgeDash(state({ isStructural: true, contested: contestedSignFlip, existenceDash: '6,4' }))
+    expect(d.rule).toBe('structural')
+    expect(d.value).toBeUndefined()
+  })
+})
+
+describe('readContestedState — the gate, and what it refuses to infer', () => {
+  it('reads a live contest', () => {
+    expect(contestedNonDirection.isContested).toBe(true)
+  })
+
+  it.each([
+    ['agreed status', validation({ status: 'agreed' })],
+    ['a resolved contest', validation({ user_action: 'accepted_pass2' })],
+    ['a dismissed contest', validation({ user_action: 'dismissed' })],
+    ['absent max_divergence', (() => { const v = validation(); delete (v as any).max_divergence; return v })()],
+    ['null max_divergence', validation({ max_divergence: null })],
+    ['a non-numeric max_divergence', validation({ max_divergence: '0.6' })],
+    ['absent validation', undefined],
+    ['null validation', null],
+    ['a non-object validation', 'contested'],
+  ])('is NOT contested for %s', (_label, v) => {
+    expect(readContestedState(v)).toEqual(NOT_CONTESTED)
+  })
+
+  it('names sign_flip as the one reason that puts the direction in dispute', () => {
+    expect(DIRECTION_DISPUTING_REASON).toBe('sign_flip')
+  })
+
+  it.each([
+    'strength_band_change',
+    'confidence_band_change',
+    'existence_boundary_crossing',
+    'raw_magnitude',
+  ])('%s leaves the direction undisputed — the producer says the passes agree on the sign', (reason) => {
+    // Derived from the PRODUCER's enum (src/types/validation.ts `ContestedReason`),
+    // not from an observed corpus: of the five declared reasons only `sign_flip`
+    // is a disagreement about direction.
+    expect(readContestedState(validation({ contested_reasons: [reason] })).directionDisputed).toBe(false)
+  })
+
+  it('finds sign_flip alongside other reasons', () => {
+    expect(
+      readContestedState(validation({ contested_reasons: ['raw_magnitude', 'sign_flip'] })).directionDisputed,
+    ).toBe(true)
+  })
+
+  it.each([
+    ['absent', (() => { const v = validation(); delete (v as any).contested_reasons; return v })()],
+    ['null', validation({ contested_reasons: null })],
+    ['a bare string rather than an array', validation({ contested_reasons: 'sign_flip' })],
+  ])('FAILS QUIET when contested_reasons is %s — still contested, direction NOT disputed', (_l, v) => {
+    // P5: painting the exception hue here would assert a direction disagreement
+    // on no evidence. The contest is still shown, on the dash.
+    const c = readContestedState(v)
+    expect(c.isContested).toBe(true)
+    expect(c.directionDisputed).toBe(false)
+    expect(c.dash).not.toBeNull()
+    expect(resolveEdgeStroke(state({ contested: c })).rule).toBe('polarity')
+  })
+})

--- a/src/canvas/edges/edgePresentation.ts
+++ b/src/canvas/edges/edgePresentation.ts
@@ -1,0 +1,315 @@
+/**
+ * edgePresentation — THE single authority for a causal edge's stroke colour and
+ * dash pattern.
+ *
+ * WHY THIS MODULE EXISTS (measured defect, deployed staging bundle, 17 Aug 2026)
+ * -----------------------------------------------------------------------------
+ * StyledEdge resolved both channels with two ordered early-return chains written
+ * inline in a `style` prop. The order was never stated anywhere, so it was not a
+ * decision anyone could review — it was the sequence the branches happened to be
+ * added in. Two consequences shipped:
+ *
+ *   1. `isContested` returned BEFORE the polarity stroke was ever evaluated, so
+ *      a contested edge rendered warning-orange UNCONDITIONALLY and its polarity
+ *      was unreachable. Read the producer's own enum (`src/types/validation.ts`):
+ *      `contested` means "two independent AI passes disagree on this edge's
+ *      PARAMETERS", and of the five `ContestedReason` members only `sign_flip`
+ *      is a disagreement about the DIRECTION. For the other four —
+ *      `strength_band_change`, `confidence_band_change`,
+ *      `existence_boundary_crossing`, `raw_magnitude` — both passes AGREE on the
+ *      sign, and the orange deleted a fact nobody was contesting.
+ *   2. The pre-run "needs attention" dash was gated on `!isResultsMode`, an
+ *      APP-GLOBAL (`results.status === 'complete'`). The identical edge, with
+ *      identical data, therefore restyled when an analysis completed. Paul
+ *      witnessed exactly this: edges reading red/green and then flipping to
+ *      orange-dotted after interacting with the Analysis tab.
+ *
+ * PAUL'S RULING (17 Aug 2026), which this module implements:
+ *   "orange must NOT universally mean 'unvetted'; reserve exception styling for
+ *    genuinely exceptional/contested states."
+ * On a fresh AI-drafted model essentially every edge is unconfirmed, so an
+ * exception treatment applied to "unconfirmed" IS the default treatment, and the
+ * graph reads as alarming when nothing is actually wrong.
+ *
+ * THE THREE RULES THIS MODULE ENCODES
+ * -----------------------------------
+ *  A. COLOUR IS POLARITY'S CHANNEL. Nothing overwrites the polarity stroke
+ *     except a state that makes the polarity itself untrustworthy or that
+ *     requires the user to act on this specific edge. This is the same treatment
+ *     R6 already gave the fragility marker in StyledEdge (moved onto a
+ *     drop-shadow so it "composes with the green/red direction stroke instead of
+ *     replacing it").
+ *  B. AN EDGE'S RESTING APPEARANCE IS A FUNCTION OF THE EDGE. No resting channel
+ *     may read an app phase. Interaction states (hover, selection, highlight,
+ *     lens) are transient and explicitly user-driven; analysis COMPLETION is
+ *     not, and may not restyle a graph the user did not change.
+ *  C. THE PRECEDENCE IS DATA. `EDGE_STROKE_RULES` / `EDGE_DASH_RULES` are ordered
+ *     arrays, each resolver returns the NAMED rule that fired, and the ordering
+ *     is asserted in `edgePresentation.spec.ts`. A future reordering is a diff on
+ *     a list, not an invisible consequence of where a branch was pasted.
+ *
+ * Every resolver returns `{ value, rule }`. Tests bind to `rule` — the identity
+ * of the decision — rather than to a colour string another rule could also
+ * produce (CLAUDE.md trap 19: an assertion must bind to its object by identity,
+ * never by a value predicate another object could satisfy).
+ */
+
+import type { ValidationMetadata } from '../../types/validation'
+
+// ── Colour constants ────────────────────────────────────────────────────────
+
+/** Structural (decision→option, option→factor) edges: fixed grey, always. */
+export const STRUCTURAL_EDGE_COLOUR = '#B8B8B8'
+
+/**
+ * The exception hue. Reserved — see `resolveEdgeStroke` — for the two states
+ * that earn it. `needsUserInput` gets it at full strength; a direction actually
+ * in dispute gets the 70% mix, because "we cannot show you a direction" is a
+ * quieter claim than "please resolve this".
+ */
+const WARNING_FULL = 'var(--semantic-warning)'
+const WARNING_MIXED = 'color-mix(in srgb, var(--semantic-warning) 70%, transparent)'
+
+// ── State ───────────────────────────────────────────────────────────────────
+
+/**
+ * The contested facts this module needs, already reduced from
+ * `ValidationMetadata`. Kept as a named type so the reduction
+ * (`readContestedState`) is separately testable from the precedence.
+ */
+export interface ContestedState {
+  /**
+   * A live, unresolved contest. Mirrors StyledEdge's long-standing gate:
+   * status contested AND the user has not acted AND a divergence was actually
+   * supplied (an absent divergence is not silently inferred).
+   */
+  readonly isContested: boolean
+  /**
+   * Pass 2 asked for the user's input on THIS edge. A genuine user-flagged
+   * state, and the strongest claim on the exception hue.
+   */
+  readonly needsUserInput: boolean
+  /**
+   * The passes disagree about the SIGN (`contested_reasons` includes
+   * `sign_flip`). Only then is the polarity itself untrustworthy.
+   *
+   * ⚠ FAILS QUIET, DELIBERATELY. When `contested_reasons` is absent or not an
+   * array we CANNOT establish that the direction is disputed, so this is false
+   * and the polarity stroke survives. Painting orange there would assert "we
+   * disagree about this edge's direction" on no evidence (P5), and would delete
+   * a direction that IS grounded in the edge's own provenance-gated field. The
+   * contest is still shown — the dash below fires for every contested edge.
+   */
+  readonly directionDisputed: boolean
+  /** Divergence-scaled dash, or null when not contested. */
+  readonly dash: string | null
+}
+
+export const NOT_CONTESTED: ContestedState = {
+  isContested: false,
+  needsUserInput: false,
+  directionDisputed: false,
+  dash: null,
+}
+
+/** The `ContestedReason` that puts the SIGN in dispute. */
+export const DIRECTION_DISPUTING_REASON = 'sign_flip'
+
+/**
+ * Reduce a wire `validation` object to the four facts the precedence needs.
+ *
+ * Takes `unknown` on purpose: `validation` crosses the CEE→UI boundary through
+ * `overlayEdge`, which has no `DEFAULT_EDGE_DATA` entry for it and therefore
+ * applies whatever the wire supplied without a runtime validator. Narrow here
+ * rather than trusting the declared type (P1: the defect lives one seam past
+ * the guard).
+ */
+export function readContestedState(validation: unknown): ContestedState {
+  if (validation === null || typeof validation !== 'object') return NOT_CONTESTED
+  const v = validation as Partial<ValidationMetadata>
+
+  const divergence = v.max_divergence
+  const isContested =
+    v.status === 'contested' &&
+    v.user_action === 'pending' &&
+    typeof divergence === 'number' &&
+    Number.isFinite(divergence)
+  if (!isContested) return NOT_CONTESTED
+
+  const needsUserInput = v.pass2?.needs_user_input === true
+  const reasons = v.contested_reasons
+  const directionDisputed =
+    Array.isArray(reasons) && reasons.includes(DIRECTION_DISPUTING_REASON)
+
+  // Dash: gap scales with divergence (0→1 maps to 4→8px); needs_user_input gets
+  // a tighter gap for a stronger signal. Unchanged from the original branch —
+  // this module moves WHERE the decision is made, not what the contested dash
+  // looks like.
+  const d = divergence as number
+  const gap = needsUserInput ? 3 : Math.round(4 + d * 4)
+  const dashWidth = Number((1.5 + d * 1.5).toFixed(1))
+
+  return { isContested, needsUserInput, directionDisputed, dash: `${dashWidth} ${gap}` }
+}
+
+/** Everything the two resolvers may read. Nothing else is in scope. */
+export interface EdgePresentationState {
+  readonly isStructural: boolean
+  /** Active lens, or 'full' for the default (no-lens) view. */
+  readonly lensMode: string
+  /**
+   * Causal-lens parameters, or null when the lens has none for this edge.
+   *
+   * ⚠ THE OBJECT'S PRESENCE AND ITS `direction` ARE TWO DIFFERENT FACTS and must
+   * not be collapsed (CLAUDE.md trap 21). `CausalLensEdgeParams.direction` is
+   * `null` when nobody STATED a direction, and the causal lens still paints
+   * those edges — in its neutral body colour, which is its way of refusing to
+   * claim a sign. Flattening this to a bare direction would silently drop that
+   * edge out of the lens branch entirely and repaint it with default-view
+   * polarity, which is the opposite of what the lens is for.
+   */
+  readonly causalParams: { readonly direction: 'positive' | 'negative' | null } | null
+  /** Evidence-lens classification, when that lens is active. */
+  readonly evidenceClass: string | null
+  readonly contested: ContestedState
+  readonly isHighlighted: boolean
+  /**
+   * The polarity colour from `computeDirectionStroke`. ALWAYS a string — that
+   * function returns its neutral grey rather than null for every no-verdict
+   * case, so there is no "no polarity" hole for another rule to fill.
+   */
+  readonly polarityStroke: string
+  /** Dash from `existenceCertaintyToLineStyle`, or null/undefined when unset. */
+  readonly existenceDash: string | null | undefined
+  /** Dash from the legacy visual-props map. Last resort. */
+  readonly visualPropsDash: string | undefined
+}
+
+// ── Stroke ──────────────────────────────────────────────────────────────────
+
+/**
+ * Stroke precedence, highest first. THE ORDER IS THE CONTRACT — asserted in
+ * `edgePresentation.spec.ts` against this exact array.
+ */
+export const EDGE_STROKE_RULES = [
+  /** Structural scaffolding recedes; never carries a data claim. */
+  'structural',
+  /** Causal lens: an explicit alternative encoding with its own key. */
+  'lens_causal',
+  /** Evidence lens: ditto. */
+  'lens_evidence',
+  /** Pass 2 asked the user to act on THIS edge. Exception hue, full strength. */
+  'contested_needs_user_input',
+  /** The passes disagree about the SIGN — no honest polarity to show. */
+  'contested_direction_disputed',
+  /** Transient interaction highlight. */
+  'highlighted',
+  /**
+   * The default, and the point of the whole module: polarity, including the
+   * neutral grey that `computeDirectionStroke` returns for every unset or
+   * unstated value. A quiet graph is the resting state.
+   */
+  'polarity',
+] as const
+
+export type EdgeStrokeRule = (typeof EDGE_STROKE_RULES)[number]
+
+export interface EdgeStrokeDecision {
+  readonly value: string
+  readonly rule: EdgeStrokeRule
+}
+
+export function resolveEdgeStroke(state: EdgePresentationState): EdgeStrokeDecision {
+  if (state.isStructural) {
+    return { value: STRUCTURAL_EDGE_COLOUR, rule: 'structural' }
+  }
+
+  if (state.lensMode === 'causal' && state.causalParams !== null) {
+    return {
+      value:
+        state.causalParams.direction === 'negative'
+          ? 'var(--semantic-danger, #ef4444)'
+          : 'var(--text-body, #3F3F3E)',
+      rule: 'lens_causal',
+    }
+  }
+
+  if (state.lensMode === 'evidence' && state.evidenceClass !== null) {
+    switch (state.evidenceClass) {
+      case 'evidence':
+        return { value: 'var(--semantic-success, #22c55e)', rule: 'lens_evidence' }
+      case 'assumed':
+        return { value: 'var(--semantic-warning, #eab308)', rule: 'lens_evidence' }
+      case 'unknown':
+        return { value: 'var(--semantic-danger, #ef4444)', rule: 'lens_evidence' }
+    }
+    // An unrecognised class is not a claim we can paint; fall through.
+  }
+
+  // ── The exception hue, and the only two states that earn it ───────────────
+  //
+  // Both are narrower than `status === 'contested'`, which is the whole point:
+  // "contested" is a common outcome of a two-pass review and cannot carry an
+  // alarm colour without becoming the default. Contest is still ALWAYS visible
+  // — `resolveEdgeDash` fires the divergence-scaled dash for every contested
+  // edge, composing with whatever colour wins here.
+  if (state.contested.isContested && state.contested.needsUserInput) {
+    return { value: WARNING_FULL, rule: 'contested_needs_user_input' }
+  }
+  if (state.contested.isContested && state.contested.directionDisputed) {
+    return { value: WARNING_MIXED, rule: 'contested_direction_disputed' }
+  }
+
+  if (state.isHighlighted) {
+    return { value: 'var(--semantic-info)', rule: 'highlighted' }
+  }
+
+  return { value: state.polarityStroke, rule: 'polarity' }
+}
+
+// ── Dash ────────────────────────────────────────────────────────────────────
+
+/**
+ * Dash precedence, highest first.
+ *
+ * ⚠ `pre_run_incomplete` IS DELIBERATELY ABSENT. StyledEdge used to dash every
+ * edge with no confidence value while `results.status !== 'complete'`, with the
+ * comment "needs attention". Two defects in one branch: on a fresh AI draft that
+ * is EVERY edge, so the attention marker marked nothing (Paul's ruling above);
+ * and its `!isResultsMode` term is an app phase, so completing an analysis
+ * restyled edges the user had not touched (rule B in the module header). Missing
+ * confidence is the ordinary state of drafted structure, not an exception, and
+ * genuine uncertainty already has a channel — `existence_certainty` below, which
+ * reads a value the producer actually stated.
+ */
+export const EDGE_DASH_RULES = [
+  /** Structural scaffolding is always solid. */
+  'structural',
+  /**
+   * Every contested edge, whatever colour won above. This is the composing
+   * channel that keeps the contest visible once orange stops being automatic.
+   */
+  'contested',
+  /** exists_probability below the certainty threshold — a stated value. */
+  'existence_certainty',
+  /** Legacy visual-props map. */
+  'visual_props',
+] as const
+
+export type EdgeDashRule = (typeof EDGE_DASH_RULES)[number]
+
+export interface EdgeDashDecision {
+  readonly value: string | undefined
+  readonly rule: EdgeDashRule
+}
+
+export function resolveEdgeDash(state: EdgePresentationState): EdgeDashDecision {
+  if (state.isStructural) return { value: undefined, rule: 'structural' }
+  if (state.contested.isContested && state.contested.dash !== null) {
+    return { value: state.contested.dash, rule: 'contested' }
+  }
+  if (state.existenceDash !== null && state.existenceDash !== undefined) {
+    return { value: state.existenceDash, rule: 'existence_certainty' }
+  }
+  return { value: state.visualPropsDash, rule: 'visual_props' }
+}

--- a/src/canvas/utils/__tests__/zoomLegibility.counterScale.spec.ts
+++ b/src/canvas/utils/__tests__/zoomLegibility.counterScale.spec.ts
@@ -1,0 +1,193 @@
+/**
+ * zoomLegibility — the label counter-scale.
+ *
+ * ⚠ WHAT THIS FILE IS ALLOWED TO CLAIM. jsdom has no layout engine: it cannot
+ * measure a glyph, and a passing DOM assertion about a class name proves the
+ * class is present and NOTHING about how large the text is on screen. So this
+ * file makes no visibility claim. It asserts the ARITHMETIC that decides the
+ * rendered size — `declared × counterScale(zoom) × zoom` — and the px table in
+ * the PR body is generated from these same numbers. A browser is still the only
+ * thing that can witness legibility.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  LABEL_LEGIBLE_ZOOM,
+  labelCounterScale,
+  renderedLabelPx,
+  CANVAS_LABEL_SCALE_VAR,
+} from '../zoomLegibility'
+
+/** DS v5 §2.3, as declared in src/styles/typography.ts. */
+const DECLARED = { nodeTitle: 13, nodeLabel: 11, edgeLabel: 10 } as const
+
+/** DS v5 §2.4: panel and canvas contexts bottom out at 10px. */
+const DS_CANVAS_FLOOR_PX = 10
+
+describe('labelCounterScale — bounded in both directions, by construction', () => {
+  it('is the identity at 1:1 — an unzoomed canvas renders the declared scale', () => {
+    expect(labelCounterScale(1)).toBe(1)
+  })
+
+  it('never counter-scales while the user is zoomed IN', () => {
+    // Past 1:1 magnification is the user's own deliberate gesture and text
+    // should grow with it. Scaling text DOWN to compensate would fight them.
+    for (const z of [1.25, 1.5, 2, 4]) expect(labelCounterScale(z)).toBe(1)
+  })
+
+  it('is exactly 1/zoom across the band the product calls legible', () => {
+    for (const z of [0.5, 0.6, 0.75, 0.9, 0.99]) {
+      expect(labelCounterScale(z)).toBeCloseTo(1 / z, 10)
+    }
+  })
+
+  it('caps at 1 / LABEL_LEGIBLE_ZOOM below the floor — never unbounded', () => {
+    const cap = 1 / LABEL_LEGIBLE_ZOOM
+    for (const z of [0.49, 0.3, 0.1, 0.001]) expect(labelCounterScale(z)).toBe(cap)
+  })
+
+  it('returns the identity for a zoom that cannot produce a meaningful scale', () => {
+    // Infinity or NaN reaching a CSS calc() would blank the label rather than
+    // mis-size it — the worse failure, and silent.
+    for (const z of [0, -1, NaN, Infinity, -Infinity]) expect(labelCounterScale(z)).toBe(1)
+    expect(labelCounterScale(undefined as unknown as number)).toBe(1)
+  })
+
+  it('is monotonic non-increasing in zoom — no discontinuity at the boundaries', () => {
+    let previous = Infinity
+    for (let z = 0.05; z <= 2; z += 0.01) {
+      const s = labelCounterScale(z)
+      expect(s).toBeLessThanOrEqual(previous + 1e-12)
+      previous = s
+    }
+  })
+})
+
+describe('renderedLabelPx — the invariant the DS actually asks for', () => {
+  it('THE POINT: rendered px === declared px everywhere in the legible band', () => {
+    for (const [name, declared] of Object.entries(DECLARED)) {
+      for (const z of [LABEL_LEGIBLE_ZOOM, 0.55, 0.6, 0.72, 0.85, 0.95, 1]) {
+        expect(renderedLabelPx(declared, z), `${name} at zoom ${z}`).toBeCloseTo(declared, 10)
+      }
+    }
+  })
+
+  it('every canvas token clears the DS v5 §2.4 canvas floor at the auto-fit settle zoom', () => {
+    // `useFitViewOnLayoutVersion` passes LABEL_LEGIBLE_ZOOM as fitView's
+    // minZoom, and a post-draft graph clamps there — so this IS the zoom the
+    // product parks a fresh user at.
+    for (const [name, declared] of Object.entries(DECLARED)) {
+      expect(renderedLabelPx(declared, LABEL_LEGIBLE_ZOOM), name)
+        .toBeGreaterThanOrEqual(DS_CANVAS_FLOOR_PX)
+    }
+  })
+
+  it('OPPOSITE-DIRECTION TWIN: WITHOUT the counter-scale the same zoom breaks the floor', () => {
+    // The fix must be shown to be load-bearing. This is the measured "before":
+    // 6.5 / 5.5 / 5.0px at the settle zoom. If this assertion ever fails, the
+    // counter-scale has stopped being the thing doing the work.
+    const before = Object.values(DECLARED).map(px => px * LABEL_LEGIBLE_ZOOM)
+    expect(before).toEqual([6.5, 5.5, 5])
+    for (const px of before) expect(px).toBeLessThan(DS_CANVAS_FLOOR_PX)
+  })
+
+  it('OPPOSITE-DIRECTION TWIN: zoomed OUT, text never renders larger than declared', () => {
+    // The bound in the other direction, and the one that keeps titles inside
+    // their cards: a counter-scale with no ceiling would blow node text out of
+    // the box as the user zoomed away.
+    //
+    // ⚠ NOTE THE DOMAIN — `z ≤ 1`, and it is not a convenience. My first draft
+    // asserted this for ALL zooms and it failed at 1.01, correctly: above 1:1
+    // the scale is the identity and text SHOULD grow with the magnification.
+    // An invariant written against the failure mode I was fixing rather than
+    // against the spec (CLAUDE.md trap 13d) — the twin below is the other half.
+    for (const declared of Object.values(DECLARED)) {
+      for (let z = 0.05; z <= 1; z += 0.01) {
+        expect(renderedLabelPx(declared, z), `declared ${declared} at zoom ${z}`)
+          .toBeLessThanOrEqual(declared + 1e-9)
+      }
+    }
+  })
+
+  it('OPPOSITE-DIRECTION TWIN: zoomed IN, text grows with the magnification', () => {
+    // The counter-scale must not silently cancel a deliberate zoom-in.
+    for (const declared of Object.values(DECLARED)) {
+      expect(renderedLabelPx(declared, 2)).toBeCloseTo(declared * 2, 10)
+      expect(renderedLabelPx(declared, 1.5)).toBeCloseTo(declared * 1.5, 10)
+    }
+  })
+
+  it('degrades gracefully below the floor rather than falling off a cliff', () => {
+    // Below LABEL_LEGIBLE_ZOOM the LOD view has hidden most labels; the few that
+    // are kept (goal / decision / the leading option) shrink linearly from the
+    // capped scale instead of vanishing.
+    expect(renderedLabelPx(DECLARED.nodeTitle, 0.45)).toBeCloseTo(11.7, 6)
+    expect(renderedLabelPx(DECLARED.nodeTitle, 0.4)).toBeCloseTo(10.4, 6)
+  })
+})
+
+describe('the seam between this module and the type tokens', () => {
+  /**
+   * ⛔ A DERIVED GUARD, not a second copy of the answer (CLAUDE.md trap 12).
+   *
+   * `src/styles/typography.ts` spells the custom property LITERALLY, inside
+   * three Tailwind arbitrary values — Tailwind needs the class string whole at
+   * build time, so no import can reach in there. That makes it a hand-maintained
+   * mirror of `CANVAS_LABEL_SCALE_VAR`, and the failure mode is silent in the
+   * worst way: rename the constant and every token quietly resolves to its
+   * `var(…, 1)` fallback, the counter-scale stops applying, and not one test
+   * goes red. So the guard reads the real file and derives.
+   *
+   * ⚠ WHAT THIS CANNOT DO, stated rather than glossed: it proves the two files
+   * AGREE. It cannot prove the declared sizes are RIGHT — that is DS v5 §2.3's
+   * job, and the `DECLARED` table above is the hand-written corpus that notices
+   * if they drift. Derivation and corpus are not redundant; ship both.
+   */
+  const tokenSource = readFileSync(
+    resolve(__dirname, '../../../styles/typography.ts'),
+    'utf8',
+  )
+
+  /**
+   * ⚠ THE EXPECTATION IS BUILT AS AN ESCAPED REGEXP, NOT AN INTERPOLATED
+   * `var(…)` STRING — and that is not style, it is a guard interaction.
+   * `css-var-census` walks the TS AST for `var(--${…})` template literals and
+   * treats each as a DYNAMIC reference site; `css-var-resolution.spec` then pins
+   * the exact SET of files that carry one. Writing the expectation as
+   * `` `…var(${CANVAS_LABEL_SCALE_VAR},1)…` `` made THIS TEST FILE a dynamic site
+   * and turned that product guard red — measured, not hypothesised. The fix
+   * belongs here: a test must not enter a manifest of product var() sites, and
+   * relaxing the guard's pin to accommodate a spec would blunt a guard that
+   * exists to notice exactly this kind of new site.
+   */
+  const expectedFontSize = (declared: number) =>
+    new RegExp(`calc\\(${declared}px\\*var\\(${CANVAS_LABEL_SCALE_VAR},1\\)\\)`)
+
+  it.each(Object.entries(DECLARED))(
+    '%s carries the counter-scale at its declared %ipx, spelling the exact property name',
+    (token, declared) => {
+      const line = tokenSource
+        .split('\n')
+        .find(l => new RegExp(`^\\s{2}${token}:`).test(l))
+      expect(line, `token ${token} not found in typography.ts`).toBeDefined()
+      expect(line).toMatch(expectedFontSize(declared))
+    },
+  )
+
+  it('CONTROL: the derived expectation can FAIL — it is not a regex that matches anything', () => {
+    // A pattern built by interpolation is one typo away from matching everything
+    // it is pointed at. Prove it discriminates before trusting the arms above.
+    expect('nodeTitle: \'text-[13px] font-semibold\'').not.toMatch(expectedFontSize(13))
+    expect(expectedFontSize(13).test('calc(11px*var(--canvas-label-scale,1))')).toBe(false)
+  })
+
+  it('CONTRAST CONTROL: a NON-canvas token is untouched by the counter-scale', () => {
+    // Proves the probe above can distinguish, and pins the blast radius: panel
+    // and conversation copy must not inherit a canvas zoom compensation.
+    const panelMeta = tokenSource.split('\n').find(l => /^\s{2}panelMeta:/.test(l))
+    expect(panelMeta).toBeDefined()
+    expect(panelMeta).not.toContain(CANVAS_LABEL_SCALE_VAR)
+    expect(panelMeta).toContain('text-[11px]')
+  })
+})

--- a/src/canvas/utils/zoomLegibility.ts
+++ b/src/canvas/utils/zoomLegibility.ts
@@ -55,3 +55,89 @@ export const LABEL_LEGIBLE_ZOOM = 0.5
 export function labelsRenderedAtZoom(zoom: number): boolean {
   return zoom >= LABEL_LEGIBLE_ZOOM
 }
+
+/**
+ * ⭐ THE CONSTANT ABOVE NAMED SOMETHING IT DID NOT DELIVER (measured 17 Aug 2026).
+ * ---------------------------------------------------------------------------
+ * `LABEL_LEGIBLE_ZOOM` decides two things: where level-of-detail drops the
+ * labels, and — since this module shipped — the `minZoom` floor the post-layout
+ * auto-fit is allowed to park at (`useFitViewOnLayoutVersion`). It fixed the
+ * blank-first-view defect: labels now RENDER after a draft. It never made them
+ * READABLE, and nothing in the module checked.
+ *
+ * Canvas label text is DOM inside React Flow's viewport transform, and that
+ * transform scales text. `vector-effect="non-scaling-stroke"` exempts strokes,
+ * not glyphs. So the rendered size of a label is `declared × zoom`, and a
+ * post-draft graph clamps at exactly this floor:
+ *
+ *   nodeTitle 13px × 0.50 = 6.5px    nodeLabel 11px × 0.50 = 5.5px
+ *   edgeLabel 10px × 0.50 = 5.0px
+ *
+ * against a Design System v5 §2.4 canvas floor of 10px. Paul: "hard to read even
+ * on a reasonably sized screen."
+ *
+ * WHY COUNTER-SCALING AND NOT A HIGHER FLOOR — the derivation, not a preference.
+ * `rendered = declared × fontScale × zoom`. Three variables, and only one is
+ * free:
+ *   • `zoom` is NOT free. It is whatever fitView needs to show the whole model;
+ *     the floor merely clamps it, and clamping harder crops the model on first
+ *     view. (Measured, and already paid for once: a prior lane bought 136px of
+ *     panel width for the graph and delivered no legibility, because the fit
+ *     clamped at this floor at EVERY width.)
+ *   • `declared` is NOT free. DS v5 §2.3 fixes the canvas scale at 13/11/10 and
+ *     §2.4 forbids inventing another one.
+ *   • `fontScale` IS free, and it is the only channel that is a function of the
+ *     same quantity that destroys legibility. So it is the one to use.
+ *
+ * The rule below therefore holds `rendered === declared` across the whole band
+ * the product calls legible, which is exactly what the constant's name has
+ * always claimed. It is bounded in both directions by construction:
+ * counter-scaling never exceeds `1 / LABEL_LEGIBLE_ZOOM`, and never exceeds 1
+ * once the user zooms in past 1:1 (magnification is then the user's own
+ * deliberate choice, and text should grow with it).
+ */
+
+/**
+ * The font-size multiplier canvas label text must carry at `zoom` for its
+ * rendered size to equal its declared size.
+ *
+ * Derived from `LABEL_LEGIBLE_ZOOM`; introduces no second literal (CLAUDE.md
+ * trap 12 — this module exists because two hand-kept copies of one number
+ * agreed on the day they were written and nothing would have gone red when they
+ * stopped).
+ *
+ *   zoom ≥ 1                       → 1                    (no counter-scale)
+ *   LABEL_LEGIBLE_ZOOM ≤ zoom < 1  → 1 / zoom             (rendered = declared)
+ *   zoom < LABEL_LEGIBLE_ZOOM      → 1 / LABEL_LEGIBLE_ZOOM   (capped; LOD has
+ *                                    hidden most labels below here anyway, and
+ *                                    the few that are kept stay as large as the
+ *                                    cap allows)
+ *
+ * A non-finite or non-positive zoom cannot produce a meaningful scale, so it
+ * returns 1 — the identity — rather than Infinity or NaN reaching a CSS value.
+ */
+export function labelCounterScale(zoom: number): number {
+  if (typeof zoom !== 'number' || !Number.isFinite(zoom) || zoom <= 0) return 1
+  return 1 / Math.min(1, Math.max(zoom, LABEL_LEGIBLE_ZOOM))
+}
+
+/**
+ * The rendered size, in CSS px, of canvas text declared at `declaredPx` when the
+ * viewport sits at `zoom` and the counter-scale above is applied.
+ *
+ * Exported because it is the ONLY honest way to make a legibility claim in a
+ * jsdom test: jsdom has no layout, so a passing DOM assertion proves a class is
+ * present and proves nothing about size on screen. Specs assert this arithmetic
+ * instead, and say so.
+ */
+export function renderedLabelPx(declaredPx: number, zoom: number): number {
+  return declaredPx * labelCounterScale(zoom) * zoom
+}
+
+/**
+ * The CSS custom property that carries `labelCounterScale` into the canvas type
+ * tokens. Set on the React Flow root by `CanvasLabelScaleSync`; unset (and
+ * therefore 1, via each token's `var()` fallback) everywhere else, so panel and
+ * inspector copy is untouched.
+ */
+export const CANVAS_LABEL_SCALE_VAR = '--canvas-label-scale'

--- a/src/styles/brand.css
+++ b/src/styles/brand.css
@@ -220,6 +220,19 @@
   --edge-negative-dark: #F06595;
   --edge-neutral-dark: #A1A1AA;
 
+  /* Canvas label counter-scale. NOT a colour and NOT a size — a unitless
+     multiplier the three canvas type tokens (nodeTitle / nodeLabel / edgeLabel)
+     apply to their DECLARED px, so DS v5 §2.3's 13/11/10 are the sizes actually
+     rendered rather than the sizes before React Flow's viewport transform
+     halves them. 1 is the identity and the correct value everywhere except
+     inside a zoomed-out canvas: `CanvasLabelScaleSync` overrides it on the
+     React Flow root only, from `labelCounterScale(zoom)`. Defined here so the
+     property RESOLVES — `css-var-resolution.spec` requires every var() in
+     TS/TSX to name a real token, and the tokens' inline `var(…, 1)` fallback
+     must agree with this declaration or the census reports fallback drift.
+     Rule and bounds: src/canvas/utils/zoomLegibility.ts */
+  --canvas-label-scale: 1;
+
   --goal-rgb: 245 196 51;
 
   --goal: rgb(var(--goal-rgb));

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -40,9 +40,25 @@ export const typography = {
   tabular: 'text-sm font-sans leading-normal tabular-nums', // 14px
 
   // Canvas/Graph - Inter (smaller for dense UI)
-  nodeTitle: 'text-[13px] font-semibold font-sans leading-tight',
-  nodeLabel: 'text-[11px] font-sans leading-tight',
-  edgeLabel: 'text-[10px] font-sans leading-tight',
+  //
+  // ⭐ THE DECLARED SIZES BELOW ARE DS v5 §2.3 AND HAVE NOT CHANGED: 13 / 11 / 10.
+  // What changed (17 Aug 2026) is that they are now what the user actually SEES.
+  //
+  // Canvas labels are DOM inside React Flow's viewport transform, which scales
+  // glyphs. A post-draft graph clamps at the `LABEL_LEGIBLE_ZOOM` floor of 0.50,
+  // so these three tokens were rendering at 6.5 / 5.5 / 5.0px — against §2.4's
+  // 10px canvas floor, and past the point where the §2.4 small-font guardrail
+  // (10–11px only for non-essential metadata) means anything at all.
+  //
+  // `--canvas-label-scale` is the counter-scale, written onto the React Flow
+  // root by `CanvasLabelScaleSync` as `1 / zoom` across the legible band. The
+  // `var(…, 1)` fallback is load-bearing: OUTSIDE that subtree the property is
+  // unset, so every non-canvas use of these tokens resolves to exactly the same
+  // font-size it had before this change. Derivation and bounds:
+  // `src/canvas/utils/zoomLegibility.ts`.
+  nodeTitle: 'text-[length:calc(13px*var(--canvas-label-scale,1))] font-semibold font-sans leading-tight',
+  nodeLabel: 'text-[length:calc(11px*var(--canvas-label-scale,1))] font-sans leading-tight',
+  edgeLabel: 'text-[length:calc(10px*var(--canvas-label-scale,1))] font-sans leading-tight',
 
   // Results Panel — strict 4-size system (Brief 5.5 §2.1 lock)
   // Only these four tokens should be used inside src/components/results/


### PR DESCRIPTION
Two founder-witnessed defects on the graph canvas, both fixed at their cause rather than at their symptom. This is mounted-product work: Paul will see it.

**P-COMPLIANCE: read `STANDING-BRIEF-PREAMBLE.md` v4, P1–P9.** Block at the end.

---

## Finding 1 — one edge-style authority

`StyledEdge` resolved stroke and dash with two ordered early-return chains written inline in a `style` prop. **Nobody had ever chosen that order** — it was the sequence branches were added in — and it made `isContested` return **before** the polarity stroke was ever evaluated. So a contested edge rendered warning-orange unconditionally and its polarity was **unreachable**.

**Derived from the producer (P7), not from a corpus.** `src/types/validation.ts` is explicit: `contested` means *"two independent AI passes disagree on this edge's PARAMETERS"*, and of the five declared `ContestedReason` members **only `sign_flip` is a disagreement about the direction**. For `strength_band_change`, `confidence_band_change`, `existence_boundary_crossing` and `raw_magnitude` both passes **agree on the sign** — and the orange was deleting a fact nobody was contesting.

Paul's ruling (17 Aug): *orange must NOT universally mean "unvetted"; reserve exception styling for genuinely exceptional/contested states.*

### State → style precedence, now explicit and asserted

`src/canvas/edges/edgePresentation.ts` owns the decision. `EDGE_STROKE_RULES` / `EDGE_DASH_RULES` are **ordered arrays**, each resolver returns the **named rule that fired**, and both orderings are asserted against those arrays. Tests bind to the rule id, not to a colour another rule could also emit.

**STROKE — highest precedence first**

| # | Rule | Fires when | Value | Change |
|---|------|-----------|-------|--------|
| 1 | `structural` | decision→option / option→factor | `#B8B8B8` | — |
| 2 | `lens_causal` | causal lens has params for this edge | danger red (stated negative) else body colour | — |
| 3 | `lens_evidence` | evidence lens class present | success / warning / danger | — |
| 4 | `contested_needs_user_input` | contested **and** `pass2.needs_user_input` | `var(--semantic-warning)` | **narrowed** |
| 5 | `contested_direction_disputed` | contested **and** `contested_reasons` includes `sign_flip` | `color-mix(warning 70%)` | **narrowed** |
| 6 | `highlighted` | transient path highlight | `var(--semantic-info)` | — |
| 7 | `polarity` | **the default** | `computeDirectionStroke` → green / rose / neutral grey | **now reachable** |

Rows 4–5 were previously **one** rule firing on `status === 'contested'` alone, above both 6 and 7.

**DASH — highest precedence first**

| # | Rule | Fires when | Value |
|---|------|-----------|-------|
| 1 | `structural` | structural edge | solid |
| 2 | `contested` | **every** contested edge | divergence-scaled (unchanged formula) |
| 3 | `existence_certainty` | `exists_probability` stated and low | from `existenceCertaintyToLineStyle` |
| 4 | `visual_props` | fallback | legacy map |

**`pre_run_incomplete` is deleted.** It was `!isResultsMode && confidence === null` → `'6 3'`, commented *"needs attention"*. Two defects in one branch:

- On a fresh AI draft **no** edge has a confidence, so the attention marker marked everything — the exception styling *was* the default.
- `!isResultsMode` is an **app phase** (`results.status === 'complete'`), so completing an analysis restyled edges the user had not touched. **This is the flip Paul witnessed on the Analysis tab.** An edge's resting appearance is now a function of the edge.

Also derived while doing this: `getEdgeConfidence` reads `beliefExists`/`belief` — the **same field** the existence-certainty dash reads. The two dash branches partitioned on one field's presence, and the pre-run half was inventing a dash for a value nobody had stated. The `overlay-missing-confidence` marker is kept (e2e `inspector-phase1` T5 asserts it) but no longer depends on the phase.

**Deliberately fails quiet.** When `contested_reasons` is absent, null, or not an array we cannot establish that the direction is disputed, so `directionDisputed` is false: the polarity survives and the contest still shows on the dash. Painting orange there would assert a direction disagreement on no evidence (P5) and delete a direction that *is* grounded in the edge's provenance-gated field.

**Two dead branches found and named, not silently kept:** `computeDirectionStroke` never returns null, so the old `directionStroke ?? visualProps.stroke` fallback was unreachable — `visualProps.stroke` has no live consumer for colour.

---

## Finding 2 — legibility

Canvas labels are DOM inside React Flow's viewport transform, which scales glyphs (`vector-effect="non-scaling-stroke"` exempts strokes, not text). `useFitViewOnLayoutVersion` passes `LABEL_LEGIBLE_ZOOM` as `fitView`'s `minZoom`, and a post-draft graph **clamps there** — so 0.50 is the zoom the product parks a fresh user at.

**Why counter-scaling and not a higher floor — derived, not preferred.** `rendered = declared × fontScale × zoom`; three variables, one free:

- **`zoom` is not free.** It is whatever `fitView` needs to show the whole model. Clamping harder crops the model on first view — and this trade is already proven worthless: a prior lane bought 136px of panel width for the graph and delivered no legibility, because the fit clamped at this floor at **every** width.
- **`declared` is not free.** DS v5 §2.3 fixes the canvas scale at 13/11/10 and §2.4 forbids inventing another.
- **`fontScale` is free**, and it is the only channel that is a function of the same quantity that destroys legibility.

`labelCounterScale(zoom) = 1 / min(1, max(zoom, LABEL_LEGIBLE_ZOOM))` — introducing no second numeric literal (trap 12; `zoomLegibilitySingleSource.spec` stays green). Carried to the three canvas tokens by `--canvas-label-scale`, written onto the React Flow root by `CanvasLabelScaleSync` and **defined as `1` in `brand.css`** so it resolves and so everything outside the canvas subtree is untouched.

### Rendered px — before / after

Settle zoom **0.50** at both viewports: the `minZoom` clamp binds, so the two are identical. *(Scope: derived from the clamp plus the prior lane's measurement that the unclamped fit sits below 0.5 across fit-box widths 760–896px. Not re-measured in a browser at this tip — jsdom cannot prove visibility, so the arithmetic is the claim.)*

| Token | Declared | 1280×800 before | 1280×800 after | 1440×900 before | 1440×900 after |
|-------|---------:|----------------:|---------------:|----------------:|---------------:|
| `nodeTitle` | 13px | **6.5px** | **13.0px** | **6.5px** | **13.0px** |
| `nodeLabel` | 11px | **5.5px** | **11.0px** | **5.5px** | **11.0px** |
| `edgeLabel` | 10px | **5.0px** | **10.0px** | **5.0px** | **10.0px** |

DS v5 §2.4 canvas floor is 10px. Every token was below it; every token now meets or clears it.

For a smaller graph that fits without clamping (worked example, zoom 0.72):

| Token | before | after |
|-------|-------:|------:|
| `nodeTitle` | 9.4px | 13.0px |
| `nodeLabel` | 7.9px | 11.0px |
| `edgeLabel` | 7.2px | 10.0px |

**Bounded in both directions, by construction and by twin:** the scale never exceeds `1 / LABEL_LEGIBLE_ZOOM`, and it is the identity at and above 1:1 so a deliberate zoom-in still magnifies. Below the floor the LOD view already hides most labels; kept titles (goal / decision / leading option) degrade linearly from the cap — 11.7px at 0.45, 10.4px at 0.40 — rather than vanishing.

**One guard patched, narrowly.** `scripts/conversation-type-census.mjs` rejected every non-`text-[Npx]` arbitrary class and would have failed all 5 tests of `conversation-type-census.spec.ts` **at collection**, for a reason unrelated to the conversation panel it is named after. It now resolves exactly one extra shape — `text-[length:calc(Npx*var(--x,1))]`, fallback pinned to `1` — and anything wider still errors. Census output is byte-identical to pristine: `errors [] · files 102 · sizes [11,12,14,24]`.

---

## Evidence

**RED-first at pristine `42f6cb6a`** (isolated worktree, isolation proved by writing a sentinel and asserting the source clone unchanged; distinct inodes):

| RED signature | |
|---|---|
| `H1 › a contested edge whose contest is NOT about the sign renders its polarity` | ✗ |
| `H2 › a plain drafted edge with no confidence set renders identically before and after an analysis completes` | ✗ |
| `H2b › a fresh drafted edge with NO confidence renders SOLID, not dashed` | ✗ |
| `H2b › the missing-confidence marker survives, and no longer depends on the app phase` | ✗ |

Every **opposite-direction twin** already passed at pristine, which is the point — the fix must not trade a false alarm for a silent one: `TWIN: a sign_flip contest DOES render the exception hue`, `TWIN: needs_user_input DOES render the exception hue at full strength`, `TWIN: an edge with a STATED low existence probability still dashes`.

**Mutants — 16/16 bitten.** Throwaway worktree at an absolute path outside the repo root, on committed state; restores from a pristine **archive**, never `git checkout --` (trap 9h); applied-check scoped to changed files **exactly 1** for every mutant, control **exactly 0** before and after; pristine tree typechecks first (1978 diagnostics) as P4's mandatory control.

| Mutant | Result |
|--------|--------|
| M1 contested fires on status alone (**reintroduces the original defect**) | RED 1/17 |
| M2 `directionDisputed` always true | RED 8/37 ⚠ |
| M3 **twin** `directionDisputed` always false (alarm deleted) | RED 4/37 ⚠ |
| M4 `needs_user_input` loses the exception hue | RED 1/17 |
| M5 reinstate the pre-run needs-attention dash | RED 1/17 |
| M6 **twin** drop existence-certainty dash (real uncertainty deleted) | RED 1/37 ⚠ |
| M7 stroke precedence reordered (highlight above contested) | RED 1/37 |
| M8 StyledEdge feeds the dead `visualProps` fallback | RED 3/17 |
| M9 StyledEdge re-couples the marker to the app phase | RED 1/17 |
| M10 counter-scale removed (pre-fix behaviour) | RED 5/17 |
| M11 **twin** cap removed (unbounded below the floor) | RED 2/17 |
| M12 **twin** ceiling removed (counter-scales while zoomed in) | RED 2/17 |
| M13 a canvas token silently loses the counter-scale | RED 1/17 |
| M14 the sync writes to `document.body` | RED 5/6 |
| M15 the sync leaves a stale scale on unmount | RED 1/6 |
| M16 the sync writes a constant | RED 3/6 |

⚠ **Disclosed, not glossed:** M2/M3/M6 each orphan a local and produce exactly **one** extra `noUnusedLocals` diagnostic (1979 vs 1978). Vitest strips types so each mutation executed and bit on assertions, so the RED is a genuine behavioural signal — but those three mutants are not type-clean and their result should be read that way. All 13 others are type-identical to pristine.

**Collected counts asserted BY NAME** (an aggregate cannot see a new spec collecting zero): `edgePresentation` **37** · `StyledEdge.presentationStability` **17** · `StyledEdge.contested` **11** · `zoomLegibility.counterScale` **17** · `CanvasLabelScaleSync` **6**. `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported for every run.

**Gates, in the required check's step order:**
- `pnpm run lint` → **0 errors** (1189 pre-existing warnings); rules-of-hooks ratchet **229 across 13 files, exactly matching baseline** — the new `useMemo`s add no conditional hook.
- `pnpm run typecheck` → **PASSED**; drift **shrank** 2325 → 2306. Baseline deliberately **not** regenerated.
- Regression sweep `src/canvas` + `tests/canvas` + `tests/ci-guards`: **519 files / 7385 tests passed**, 1 skipped file / 28 skipped tests.
- `css-var-resolution.spec` and `conversation-type-census.spec`: green, empty delta vs pristine (`fallbackDrift` 35 both sides, mine not among them).

**Two guard interactions found by running them, and fixed in the right place:**
1. `--canvas-label-scale` was referenced but undefined, which reds `every var(--…) in TS/TSX names a property that is actually defined`. Defined in `brand.css` as the guard's own message instructs.
2. My spec's interpolated `` `…var(${CONST},1)…` `` made **the test file** a dynamic-var site and reddened the product guard's pinned site manifest. Rewritten as an escaped RegExp — a test must not enter a manifest of product `var()` sites, and relaxing the pin to accommodate a spec would blunt the guard that exists to notice new sites. A control proves the pattern still discriminates.

**Corrected two of my own errors mid-flight, rather than tuning around them:** an invariant asserting *"text never renders larger than declared"* for **all** zooms failed at 1.01 — correctly, since above 1:1 text should grow. It was written against the failure mode I was fixing rather than against the spec (trap 13d); its domain is now `z ≤ 1` with an explicit twin for `z > 1`. And the mounted spec's fixtures used a `confidence` key `getEdgeConfidence` never reads.

---

## Not done — named rather than left implied

- **`EvidenceGapBadge` (`:66`) uses a raw inline `fontSize: '7px'`**, not a token, so it does not counter-scale: still ~3.5px rendered at 0.50. It is a decorative `?` inside a 12px dot, `aria-hidden`, with the real label on a hover zone — DS §2.4-compliant on the "reachable at 12–14px" clause. Raising it would overflow the dot; resizing the dot is node-geometry work outside this lane's fence.
- **`lodBoostTitle` (`BaseNode.tsx:454`) keeps its raw `text-lg`**, a §2.4 raw-utility violation, so a kept title below the LOD floor is not counter-scaled. Untouched deliberately: `render-matrix.spec.tsx:1276`'s negative arm is keyed to that literal and would go **vacuous** rather than red if the class changed.
- **Whether CEE writes `validation.status: 'contested'` broadly is NOT derived.** I read the UI-side contract (`src/types/validation.ts`), not CEE's emitter, so I cannot state a rate. The design does not depend on it: both the broad and the narrow case now render quietly, and the exception hue is gated on two independently narrow conditions. **`pass2.needs_user_input`'s rate is likewise unmeasured** — if CEE sets it widely, orange stays wide, and that is the one residual breadth risk in this change.
- **No browser witness.** jsdom cannot prove visibility; the px table is arithmetic. A live witness on staging is still owed.
- **Legend copy untouched.** `CanvasLegendPopover`'s orange dashed swatch remains literally true for the cases that still paint orange. Any further copy stops and asks Paul (R6).

---

## P-COMPLIANCE BLOCK — read v4, P1–P9

- **P7** — producer semantics read from the **producer's own declaration**: `src/types/validation.ts:4-6` (*"two independent AI passes disagree"*) and its `ContestedReason` enum `:17-22`, which is what establishes that only `sign_flip` disputes the sign. No corpus census was used to choose the predicate; the spec asserts the four non-`sign_flip` reasons individually.
- **P2** — behaviour checked through the **mounted consumer**: `StyledEdge.presentationStability.spec.tsx` renders the real `StyledEdge` and asserts the style values handed to `BaseEdge` — `var(--edge-positive)` for a contested-but-agreed-sign edge, `var(--semantic-warning)` for `needs_user_input`, `color-mix(…warning 70%…)` for `sign_flip`, `undefined` dash for a confidence-less draft edge.
- **P1** — one seam **beyond** the guard: the guard is `readContestedState`'s gate; the seam past it is `resolveEdgeStroke`/`resolveEdgeDash` **and** the mounted render. Malformed `validation` driven through the real chain — non-object, `contested_reasons` as a bare string, string `max_divergence` — and asserted that the **surrounding edge still renders** with its polarity and its dash rather than throwing or blanking.
- **P5** — no model/session/history claim is made by this change. The nearest thing to a claim is the polarity colour, and it is grounded in the **provenance-gated** read (`resolveEdgeDirectionDisplay` + `resolveEdgeSignedStrengthDisplay` via `computeDirectionStroke`), pinned by a fixture precondition test plus a contrast control proving an unstamped edge renders neutral, not green.
- **P6** — no system-inferred structure manufactures an obligation; this change **removes** one. The `'6 3'` "needs attention" dash was the product marking its own un-actioned inferences as the user's outstanding work on every edge of every fresh draft.
- **P8** — no new question or affordance is emitted. The two states that keep the exception hue are the ones with an existing acceptance path: `needs_user_input` and `sign_flip` both surface in `EdgeReviewDisagreement` / `EdgePanel`'s contested block, which is where a user resolves them.
- **P4** — the mutated tree **was** typechecked: pristine control 1978 diagnostics asserted first; 13 of 16 mutants type-identical; M2/M3/M6 at 1979 (one `noUnusedLocals` orphan each), disclosed above with what that does and does not license.
- **P9** — n/a for a new rare surface: nothing here fires on a small fraction of sessions. `sign_flip` and `needs_user_input` are rare **by design**, and both are pinned by seeded fixtures rather than by looking and waiting.

---

⛔ **No merge from this lane.** Independent review before merge is mandatory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
