### PR TITLE
fix(trust): absence of a withheld field is not maximum confidence

### DIFF
--- a/src/components/results/ConfidenceSection.tsx
+++ b/src/components/results/ConfidenceSection.tsx
@@ -30,7 +30,8 @@ import { highlightNode, clearHighlight } from '../../canvas/utils/highlightHelpe
 import { EMPTY_STATES } from './emptyStates'
 import { typography } from '../../styles/typography'
 import { classifyUnit } from '../../canvas/utils/labelUtils'
-import { MIN_STABLE_RECOMMENDATION_STABILITY, isStableRobustnessLevel } from './constants'
+import { isStableRobustnessLevel } from './constants'
+import { assessStabilityReadiness } from './utils/stabilityReadiness'
 import { stripEncodingNotation } from './utils/cleanFactorLabel'
 import { groupActionItems, type ActionGroup, type ActionItem } from './utils/groupActionItems'
 import { AlertTriangle, Check, X as XIcon, Info, Lightbulb, Search, ArrowLeftRight, GitBranch, ShieldAlert } from 'lucide-react'
@@ -499,7 +500,12 @@ export function ConfidenceSection({
   const hasNoFragileEdges = uncertainties.length === 0
   const hasStableRobustness = robustnessLevel === undefined || isStableRobustnessLevel(robustnessLevel)
   const hasLowRobustness = robustnessLevel !== undefined && !isStableRobustnessLevel(robustnessLevel)
-  const hasHighStability = (rankingStability ?? 1) >= MIN_STABLE_RECOMMENDATION_STABILITY
+  // ⚠ ABSENCE IS NOT CONFIDENCE. This used to read `(rankingStability ?? 1) >= MIN`,
+  // which coerced a WITHHELD measurement to the MAXIMUM and made the conjunct
+  // below unconditionally true for every user. `assessStabilityReadiness` keeps
+  // "unmeasured" distinct from both "high" and "low" — see that module's header
+  // for why this must not be collapsed back into a single boolean.
+  const stability = assessStabilityReadiness(rankingStability)
 
   // V14.1: Readiness gate — "Good foundation" hidden when coaching says model needs work
   const readinessBlocks = coachingReadiness === 'needs_framing' || coachingReadiness === 'needs_evidence'
@@ -509,14 +515,24 @@ export function ConfidenceSection({
   // - AND (robustness undefined OR high/moderate) AND stability >= 0.6
   // - V14.1: AND readiness is not needs_framing/needs_evidence
   // - V14.1: AND at least one option has winProbability > 0.5
+  // An UNMEASURED conjunct is skipped, exactly as `hasStableRobustness` skips an
+  // absent `robustnessLevel` — it is not treated as satisfied. `blocksReadiness`
+  // is true only when a measurement actually arrived and fell short, so absence
+  // neither blocks readiness nor vouches for it.
   const isFullyReady = tier.tier === 'strong' && improvements.length === 0 && uncertainties.length === 0
-    && hasStableRobustness && hasHighStability
+    && hasStableRobustness && !stability.blocksReadiness
     && !readinessBlocks && (hasWinnerAbove50 !== false)
 
   // Bug 2 fix: Low robustness warning only when robustnessLevel is explicitly low/very_low
-  // OR when stability is below threshold with explicit robustness data
+  // OR when a stability measurement arrived and fell below threshold.
+  // ⚠ The stability arm is gated on the STABILITY measurement's own presence, not
+  // on `robustnessLevel !== undefined`. Those are different fields answering
+  // different questions: the old guard let the presence of `level` license a
+  // claim about `stability`, so a genuinely low measured stability produced no
+  // warning whenever the producer omitted `level` (which it does), while a
+  // non-finite value produced a fabricated one.
   const showLowRobustnessWarning = hasNoFragileEdges
-    && (hasLowRobustness || (robustnessLevel !== undefined && !hasHighStability))
+    && (hasLowRobustness || stability.blocksReadiness)
 
   // v7.10 T6: showTierWarning + tierDescription removed — tier badge now in Accordion header
 

--- a/src/components/results/__tests__/ConfidenceSection.stabilityFailOpen.spec.tsx
+++ b/src/components/results/__tests__/ConfidenceSection.stabilityFailOpen.spec.tsx
@@ -1,0 +1,200 @@
+/**
+ * ABSENCE OF A WITHHELD FIELD IS NOT MAXIMUM CONFIDENCE.
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * `ConfidenceSection` used to gate its readiness verdict on
+ *
+ *     const hasHighStability = (rankingStability ?? 1) >= MIN_STABLE_RECOMMENDATION_STABILITY
+ *
+ * PLoT never emits the field that feeds `rankingStability`. Derived at the
+ * PRODUCER, not from an observed corpus (PLoT `staging` e4f6ef52,
+ * `src/routes/v2/run.ts:3403-3459`): the `robustness` payload is built as an
+ * ALLOW-LIST OBJECT LITERAL — the key is never copied in, there is no
+ * `...islResult.robustness` spread on either response path, and the omission is
+ * pinned route-level by `tests/isl-v2-liveness.fixture.test.ts:202`
+ * (`expect(body.robustness).not.toHaveProperty('recommendation_stability')`).
+ * The older spelling `ranking_stability` is emitted NOWHERE — zero occurrences
+ * in PLoT `src/`, in any schema, type or fixture. The producer's stated reason:
+ * ISL derives the quantity as `option_wins[winner] / n_samples`, i.e. the
+ * leader's `win_probability` relabelled, carrying "zero independent
+ * information", and the UI had been printing it as "N% stability" — a
+ * fabricated second statistic.
+ *
+ * So `rankingStability` is `undefined` on every fresh run, `?? 1` coerced that
+ * absence to the MAXIMUM, and the conjunct was unconditionally true.
+ *
+ * ⚠ WHAT THIS SUITE DOES AND DOES NOT CLAIM — read before adding a case.
+ *
+ * The readiness verdict for the ABSENT case is DELIBERATELY UNCHANGED by this
+ * fix. `(undefined ?? 1) >= 0.6` and "skip an unmeasurable conjunct" are
+ * extensionally EQUAL, so no DOM assertion can separate them, and the
+ * `absence does not change the verdict` case below records that honestly rather
+ * than implying a user-visible win. What the fix changes is that absence is no
+ * longer *represented* as a maximal measurement, plus the two genuine truth
+ * corrections pinned as RED-A and RED-B.
+ *
+ * `ConfidenceSection` itself is ARCHIVED — zero production JSX call sites, and
+ * the results barrel that re-exports it has zero production importers. These
+ * tests therefore pin a LEGACY FIXTURE's logic, not a live user surface. That is
+ * stated here so no later reader mistakes a green run for a live-surface
+ * witness (CLAUDE.md trap 3b).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ConfidenceSection } from '../ConfidenceSection'
+import { assessStabilityReadiness } from '../utils/stabilityReadiness'
+import { MIN_STABLE_RECOMMENDATION_STABILITY } from '../constants'
+import type { ConfidenceSectionData } from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+}))
+
+/**
+ * A payload that satisfies EVERY readiness conjunct except stability, so the
+ * stability arm is the only free variable. Built per-case (not shared+mutated)
+ * so one case cannot leak state into another.
+ */
+function readyExceptStability(
+  overrides: Partial<ConfidenceSectionData> = {},
+): ConfidenceSectionData {
+  return {
+    tier: {
+      tier: 'strong',
+      icon: '✓',
+      label: 'Good foundation',
+      description: 'Your model captures this decision well.',
+    },
+    qualityScore: 90,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    robustnessStatus: 'computed',
+    ...overrides,
+  }
+}
+
+const LOW_CONFIDENCE_COPY = /No fragile edges, but overall confidence is low/
+const READY_COPY = /Your model looks good\. You're ready to decide\./
+
+describe('stability fail-open: absence is not maximum confidence', () => {
+  // ── the predicate, pinned by identity in all three directions ────────────
+  describe('assessStabilityReadiness', () => {
+    it('treats an ABSENT measurement as NOT ASSESSABLE — neither high nor blocking', () => {
+      // The load-bearing assertion of the whole row: `isHigh` must be FALSE.
+      // Under the old `?? 1` coercion the equivalent quantity was TRUE.
+      expect(assessStabilityReadiness(undefined)).toEqual({
+        assessable: false,
+        isHigh: false,
+        blocksReadiness: false,
+      })
+    })
+
+    it('treats null and non-finite values as absent, not as numbers', () => {
+      // `??` does not catch NaN, so the old expression evaluated `NaN >= 0.6`
+      // and a garbage value silently read as "not stable".
+      for (const value of [null, Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+        expect(assessStabilityReadiness(value as number | null), String(value)).toEqual({
+          assessable: false,
+          isHigh: false,
+          blocksReadiness: false,
+        })
+      }
+    })
+
+    it('OPPOSITE-DIRECTION TWIN: a genuinely HIGH measurement still reads high', () => {
+      expect(assessStabilityReadiness(0.85)).toEqual({
+        assessable: true,
+        isHigh: true,
+        blocksReadiness: false,
+      })
+      // Boundary bound to the constant, not to a copied literal — a threshold
+      // move must not silently reclassify the boundary.
+      expect(assessStabilityReadiness(MIN_STABLE_RECOMMENDATION_STABILITY)).toEqual({
+        assessable: true,
+        isHigh: true,
+        blocksReadiness: false,
+      })
+    })
+
+    it('OPPOSITE-DIRECTION TWIN: a genuinely LOW measurement still reads low and blocks', () => {
+      expect(assessStabilityReadiness(0.45)).toEqual({
+        assessable: true,
+        isHigh: false,
+        blocksReadiness: true,
+      })
+      const justBelow = MIN_STABLE_RECOMMENDATION_STABILITY - 0.0001
+      expect(assessStabilityReadiness(justBelow).blocksReadiness).toBe(true)
+    })
+  })
+
+  // ── through the MOUNTED consumer (P2): what the section renders ──────────
+  describe('rendered verdict', () => {
+    it('RED-A: a LOW measured stability warns even when the producer omitted `level`', () => {
+      // PLoT does not emit `robustness.level` either, so `robustnessLevel` is
+      // routinely undefined. The old guard read
+      // `robustnessLevel !== undefined && !hasHighStability`, letting the
+      // presence of `level` license a claim about `stability` — two different
+      // fields answering two different questions (CLAUDE.md trap 21). With
+      // `level` absent, a genuinely low measured stability produced NO warning.
+      render(
+        <ConfidenceSection
+          data={readyExceptStability({ rankingStability: 0.3, robustnessLevel: undefined })}
+        />,
+      )
+      expect(screen.getByText(LOW_CONFIDENCE_COPY)).toBeInTheDocument()
+      expect(screen.queryByText(READY_COPY)).not.toBeInTheDocument()
+    })
+
+    it('RED-B: a NON-FINITE stability must not manufacture a low-confidence claim', () => {
+      // Mirror direction (P3): clearing a fail-open must not install a
+      // fabricated demotion. `NaN >= 0.6` is false, so the old code showed
+      // "Low confidence" on a garbage value it had never measured.
+      render(
+        <ConfidenceSection
+          data={readyExceptStability({ rankingStability: Number.NaN, robustnessLevel: 'high' })}
+        />,
+      )
+      expect(screen.queryByText(LOW_CONFIDENCE_COPY)).not.toBeInTheDocument()
+    })
+
+    it('TWIN: a HIGH measured stability still renders the ready verdict', () => {
+      render(
+        <ConfidenceSection
+          data={readyExceptStability({ rankingStability: 0.85, robustnessLevel: 'high' })}
+        />,
+      )
+      expect(screen.getByText(READY_COPY)).toBeInTheDocument()
+      expect(screen.queryByText(LOW_CONFIDENCE_COPY)).not.toBeInTheDocument()
+    })
+
+    it('TWIN: a LOW measured stability still suppresses the ready verdict', () => {
+      render(
+        <ConfidenceSection
+          data={readyExceptStability({ rankingStability: 0.45, robustnessLevel: 'low' })}
+        />,
+      )
+      expect(screen.getByText(LOW_CONFIDENCE_COPY)).toBeInTheDocument()
+      expect(screen.queryByText(READY_COPY)).not.toBeInTheDocument()
+    })
+
+    it('absence does not change the verdict — a DELIBERATE, RECORDED skip, not a win', () => {
+      // ⚠ THIS PIN RECORDS AN UNRESOLVED PRODUCT QUESTION, NOT AN ACHIEVEMENT.
+      // On a fresh run BOTH robustness signals are absent, and both conjuncts
+      // are skipped — so the section still says "You're ready to decide" with no
+      // stability evidence behind it. That is unchanged by this fix and matches
+      // the deliberate skip `hasStableRobustness` applies to an absent
+      // `robustnessLevel`.
+      //
+      // If the product decides an unmeasurable conjunct must SUPPRESS the
+      // readiness claim, or surface "stability not available", this expectation
+      // must flip — as a reviewed copy decision, never as a silent side effect
+      // of touching the predicate.
+      render(<ConfidenceSection data={readyExceptStability({ rankingStability: undefined })} />)
+      expect(screen.getByText(READY_COPY)).toBeInTheDocument()
+      expect(screen.queryByText(LOW_CONFIDENCE_COPY)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/components/results/utils/stabilityReadiness.ts
+++ b/src/components/results/utils/stabilityReadiness.ts
@@ -1,0 +1,80 @@
+/**
+ * STABILITY READINESS — ABSENCE IS NOT CONFIDENCE.
+ * ═══════════════════════════════════════════════════════════════════════════
+ *
+ * One question, asked once, with absence as a FIRST-CLASS answer rather than a
+ * default: **may a readiness verdict consult the ranking-stability measurement,
+ * and what does that measurement say?**
+ *
+ * ⚠ WHY THIS EXISTS AS A NAMED PREDICATE, AND WHY THE NEXT PERSON MUST NOT
+ * "SIMPLIFY" IT BACK TO A COALESCE.
+ *
+ * The call site used to read:
+ *
+ *     const hasHighStability = (rankingStability ?? 1) >= MIN_STABLE_RECOMMENDATION_STABILITY
+ *
+ * PLoT DELIBERATELY WITHHOLDS `robustness.recommendation_stability`, and the
+ * older spelling was never emitted at all — see the standing ban and its
+ * rationale in `__tests__/withheldFieldReadBan.spec.ts`. So on a fresh run the
+ * value arrives ABSENT, and `?? 1` coerced that absence to the **maximum**
+ * (`1 >= 0.6`). The conjunct was therefore unconditionally TRUE for every user:
+ * a readiness condition that could never fail, still worded as though a
+ * stability measurement had been taken and passed.
+ *
+ * A missing measurement is not a passing measurement. It is also **not a
+ * failing one** — coercing absence to zero would trade a fail-open for a
+ * fabricated "low confidence", which is the same defect pointing the other way.
+ * The only honest reading of absence is NOT ASSESSABLE, so this predicate
+ * reports three states through two deliberately-independent booleans:
+ *
+ *   | measurement        | assessable | isHigh | blocksReadiness |
+ *   |--------------------|------------|--------|-----------------|
+ *   | >= threshold       | true       | true   | false           |
+ *   | <  threshold       | true       | false  | true            |
+ *   | absent/non-finite  | false      | false  | false           |
+ *
+ * `isHigh` and `blocksReadiness` are BOTH false when the value is unavailable.
+ * That is the point, not an oversight: absence may neither satisfy a readiness
+ * conjunct nor manufacture a warning. A caller that wants "does stability stop
+ * us calling this ready?" asks `blocksReadiness`; a caller that wants "did we
+ * measure stability and find it high?" asks `isHigh`. Collapsing the two back
+ * into one boolean is what produced the fail-open, because a single name has to
+ * pick a side for the unmeasured case and either side is a claim.
+ *
+ * Non-finite input (`NaN`, `Infinity`, `null`) is treated as absent, not as a
+ * number. `??` does not catch `NaN`, so the old expression let `NaN` through to
+ * `NaN >= 0.6` — false — and a garbage value silently read as "not stable".
+ */
+import { MIN_STABLE_RECOMMENDATION_STABILITY } from '../constants'
+
+export interface StabilityReadiness {
+  /** A finite numeric measurement arrived. False for absent/null/NaN/Infinity. */
+  assessable: boolean
+  /** Measured AND at or above the threshold. Never true for an absent value. */
+  isHigh: boolean
+  /** Measured AND below the threshold. Never true for an absent value. */
+  blocksReadiness: boolean
+}
+
+/** The unmeasured verdict: neither a pass nor a failure. */
+const NOT_ASSESSABLE: StabilityReadiness = {
+  assessable: false,
+  isHigh: false,
+  blocksReadiness: false,
+}
+
+/**
+ * Classify a ranking-stability measurement for readiness purposes.
+ *
+ * @param stability Raw measurement as it arrives from the wire — routinely
+ *   `undefined`, because the producer withholds it (see the block comment).
+ */
+export function assessStabilityReadiness(
+  stability: number | null | undefined,
+): StabilityReadiness {
+  if (typeof stability !== 'number' || !Number.isFinite(stability)) {
+    return NOT_ASSESSABLE
+  }
+  const isHigh = stability >= MIN_STABLE_RECOMMENDATION_STABILITY
+  return { assessable: true, isHigh, blocksReadiness: !isHigh }
+}


### PR DESCRIPTION
## ⚠ READ FIRST — THE DISPATCH PREMISE IS REFUTED, AND THAT IS THE MAIN FINDING

This lane was dispatched to kill **"a LIVE fabrication firing for every user on every fresh run"**.
The coercion is real and is fixed here. **It was never live.**

`ConfidenceSection.tsx` is **archived and unreachable from the production entry graph**:

| probe | target | contrast control (same run) |
|---|---|---|
| production JSX call sites (`<ConfidenceSection`) | **0** | `ResultsBody` imported by `OutputsDock.tsx:115` — **non-zero** |
| production importers of the results barrel that re-exports it | **0** | same probe finds live sibling imports |
| **deployed staging bundle**, 82/82 chunks, 5,913,346 bytes, zero fetch failures | **0** hits for `You're ready to decide` (both apostrophes), `No fragile edges, but overall confidence is low`, `Good foundation, a few items to consider below`, `Your model looks good`, `ConfidenceSection` | **6 of 7** positive controls hit: bare `Good foundation`, `Chance of hitting your goal` (3), `Strengthen your model` (5), `Partial picture`, `Your model captures this decision well`, `Most worth resolving next` |

The string still exists in source at the deployed SHA, so the module is **dropped at build time** — it
cannot execute in a browser under any flag posture. Absence from the chunk graph is the strong
direction of that claim; presence would have proven nothing.

Its own header (line 2) says so, and its named replacement `DecisionConfidencePanel` **has also been
deleted** (`index.ts:10`); the live headline surface is the analysis cockpit (`analysis-hero/`), which
I checked read-only: **no fail-open coercion on any trust quantity, and no readiness claim at all**
(no "ready to decide", no "Good foundation", no `isFullyReady`). So the harm has no live carrier
anywhere in the UI.

**This fix therefore hardens a legacy spec fixture. It is not a user-facing trust win, and the report
should not be read as one.** It is landed because it is three lines, it removes a fail-open pattern
and a field conflation from the estate, and it leaves the file unable to reintroduce either if anyone
revives it.

---

## What a user sees on a fresh run — before and after

**Identical. "Good foundation / Your model looks good. You're ready to decide." still appears.**

Two independent reasons, and the second is the one that matters:

1. The component is not rendered at all (above).
2. **Even if it were, the fix is provably behaviour-preserving for the absent case.**
   `(undefined ?? 1) >= 0.6` and "skip an unmeasurable conjunct" are **extensionally equal** — both
   yield `true`. The neighbour on the line above (`hasStableRobustness`) already skips an absent
   `robustnessLevel` in exactly the same way, deliberately and with a comment saying so.

⭐ **The consequence, stated plainly because it is the founder's call, not mine:** on a fresh run
**both** robustness conjuncts are vacuous — PLoT emits neither `recommendation_stability` nor
`robustness.level` — so this section is structurally capable of saying *"You're ready to decide"* with
**zero stability evidence behind it**. Option A (below) does not change that, and no purely local fix
can: it is a copy/product decision about what a readiness verdict may claim when a conjunct is
unmeasurable. I have pinned the current behaviour in a test that **names the question and will go RED
if anyone flips it silently**, rather than flipping it unilaterally. Currently moot (dead surface).

## Option chosen: (A) treat absence as *not assessable*, and why

The brief offered (A) exclude the unmeasurable conjunct, or (B) surface a "stability not available"
state. **(A)**, because the surrounding verdict semantics already resolve it: `hasStableRobustness`
on the immediately preceding line skips an absent `robustnessLevel` as a documented deliberate
choice. Conforming to the neighbour was the brief's own instruction absent contrary evidence, and
there is none. (B) would change user-facing copy on every fresh run — Paul's call, and worth nothing
today on a surface that does not render.

What (A) buys, given it is extensionally equal: absence is no longer **represented** as a maximal
measurement. `assessStabilityReadiness` returns three states through two independent booleans —
`isHigh` and `blocksReadiness` are **both false** when nothing was measured, so absence can neither
satisfy a readiness conjunct nor manufacture a warning. Collapsing them back into one boolean is what
produced the fail-open, because a single name must pick a side for the unmeasured case and **either
side is a claim**.

Two genuine truth corrections came out of it, and these *do* change behaviour:

- **`?? ` does not catch `NaN`.** The old expression let `NaN` through to `NaN >= 0.6` → false → a
  garbage value silently read as *"not stable"* and could render "Low confidence". Non-finite input is
  now absent, not a number. (This is the P3 mirror: clearing a fail-open must not install a fabricated
  demotion.)
- **A field conflation (CLAUDE.md trap 21).** The low-stability warning was gated on
  `robustnessLevel !== undefined` — letting the presence of *one* field license a claim about
  *another*. PLoT omits `level`, so a genuinely **low measured** stability produced **no warning at
  all**. It is now gated on the stability measurement's own presence.

## P7 — producer semantics, derived from the producer

PLoT `staging` **e4f6ef52**, `src/routes/v2/run.ts:3403-3459`: the `robustness` payload is an
**allow-list object literal** — no strip, the key is simply never copied in, and there is no
`...islResult.robustness` spread on either response path. Unconditional, pinned route-level by
`tests/isl-v2-liveness.fixture.test.ts:202`
(`expect(body.robustness).not.toHaveProperty('recommendation_stability')`).
`ranking_stability` is emitted **nowhere** — zero occurrences in PLoT `src/`, any schema, type or
fixture. Producer's stated reason: ISL derives it as `option_wins[winner] / n_samples`, i.e. the
leader's `win_probability` relabelled, *"zero independent information"*; the UI had printed it as
"N% stability", a fabricated second statistic. Contrast controls in the same sweep read non-zero for
genuinely emitted siblings (`win_probability` 46 refs in the route, `is_robust` 8, `fragile_edges` 14,
`confidence_basis` emitted at `:3456`).

## RED signature (at pristine `b836d610`, DOM-only variant, no import of the new module)

```
× RED-A: a LOW measured stability warns even when the producer omitted `level`
  → Unable to find an element with the text: /No fragile edges, but overall confidence is low/
× RED-B: a NON-FINITE stability must not manufacture a low-confidence claim
✓ TWIN: a HIGH measured stability still renders the ready verdict
✓ TWIN: a LOW measured stability still suppresses the ready verdict
✓ absence does not change the verdict — a DELIBERATE, RECORDED skip, not a win
Tests  2 failed | 3 passed (5)
```

**2 failed / 3 passed is the point** — a uniform failure would have meant a broken import rather than
a bound test. Isolation proven by **sentinel write** (wrote into the throwaway worktree, asserted the
source clone unchanged; inodes differ, so no APFS hard link), restored from **HEAD / a pristine
archive**, never `git checkout -- `.

## Twin table

| measurement | `assessable` | `isHigh` | `blocksReadiness` | rendered verdict | vs. before |
|---|---|---|---|---|---|
| absent (`undefined`) — **every fresh run** | false | **false** | false | ready verdict shows | **unchanged** |
| `null` / `NaN` / `±Infinity` | false | false | false | no low-confidence claim | **fixed** (was a fabricated "Low confidence") |
| `0.85` (high) | true | true | false | ready verdict shows | unchanged |
| `0.6` (exactly threshold) | true | true | false | ready verdict shows | unchanged |
| `0.45` (low) | true | false | true | "Low confidence" | unchanged |
| `0.3` + `level` **absent** | true | false | true | "Low confidence" | **fixed** (was silent) |

## Mutants — 6/6 bitten

Throwaway worktree at an absolute path **outside** the repo root, mutating only committed state,
applied-check scoped to the two changed files, anchor asserted **unique** before mutating (an
unapplied mutation is indistinguishable from an equivalent one).

| # | mutation | applied | result |
|---|---|---|---|
| M1 | absence coerced back to high (the original fail-open) | 1 | **2 failed** / 7 |
| M2 | drop the non-finite guard | 1 | **2 failed** / 7 |
| M3 | low measurement stops blocking | 1 | **2 failed** / 7 |
| M4 | threshold boundary `>=` → `>` | 1 | **1 failed** / 8 |
| M5 | restore the `level`/`stability` conflation | 1 | **1 failed** / 8 |
| M6 | readiness stops consulting stability | 1 | **1 failed** / 8 |

Control **0** applied before, **0** after, trailing spec **9/9 green**. Bite counts **differ across
mutants** — a constant would have been evidence about the harness (trap 20).

**P4 typecheck of the mutated tree:** pristine tree typechecks first (mandatory control) — baseline
**15** pre-existing diagnostics in the two files; M2 and M6 (the only mutants with orphan risk)
re-measured at **15**, i.e. neither mutation was type-invalid. Per P4's cost refinement the other four
are value swaps that cannot orphan a binding, and with **zero survivors** the false-survivor hazard
P4 guards against cannot arise — it only misreads a *surviving* mutant.

## Fail-open sweep (with controls)

Scope: `src/components/results/` + `src/canvas/`, production files only, forms `?? 1`, `?? true`,
`|| 1`, `?? 1.0`, `?? 100` (unfiltered totals 19 / 10 / 7 / 10 / 0).

**Genuine fail-open on a withheld trust quantity: exactly one — the one fixed here.**

| site | verdict |
|---|---|
| `ConfidenceSection.tsx:502` | **the defect** — absence → maximum. Fixed. |
| `PreAnalysisHealth.tsx:145`, `usePreAnalysisData.ts:620` — `readiness?.can_run_analysis ?? true` | **report, not fix** (not my seam). Permissive default on a *gate*, not an assertion to the user: it enables an affordance rather than claiming a fact. Worth a P8 look (an affordance that cannot be honoured), not a fabrication. |
| `thresholdIdentification.ts:138-139` — `(ci?.upper ?? 1) - (ci?.lower ?? 0)` | benign: coerces a missing CI to *maximum width*, i.e. the conservative direction; used for sort order. |
| `goalConflictDetection.ts:159` — `reduce(...) || 1` | benign: divide-by-zero denominator guard. |
| `RiskProfileSelector.tsx:181` — `range?.step || 1` | benign: slider step, not a trust quantity. |
| `analysis-hero/buildHeroModel.ts:911` — `Math.abs(min) * 0.05 || 1` | benign: chart axis padding. Read-only; that subtree has its own owner. |

**Contrast control (same run):** 6 sites use `recommendation_stability ?? <other spelling>` to resolve
*between the two withheld spellings* while **preserving absence** — `assembleAnalysisInputsSummary.ts:190`,
`useResultsSectionData.ts:3126`, `GoalNode.tsx:72-73` (guards `typeof === 'number'`),
`modelCardAdapter.ts:189`. These are legitimate and deliberately **not** touched; they are the reason a
bare `??` count is not a defect count.

## `useNodeDisplayMetadata` — CONFIRMED, reported not fixed (graph lane owns the file)

Still present at **`src/canvas/hooks/useNodeDisplayMetadata.ts:394-400`**:

```ts
// Task B: Fallback for Goal nodes - use recommendation_stability if probability unavailable
if (nodeType === 'goal' && achievementProbability === null && report.robustness) {
  const stability = report.robustness.recommendation_stability ??
                   report.robustness.recommendationStability
  if (typeof stability === 'number') { stabilityPercentage = stability }
}
```

It substitutes *share of scenarios in which the same option won* into a **goal-achievement** slot — a
different quantity in another's name. It **does** guard on `typeof === 'number'`, so it is dormant on
fresh runs and live only on hydrated legacy payloads (signed-in only). Note the irony: the comment
fourteen lines above it names *"the fabrication this estate forbids"*.

## Also surfaced by the producer sweep — not this repo, worth a row

The withheld number **still reaches the v2 wire as prose**, so suppressing the numeric field did not
remove it: `m1_coaching` carries `"…(N% recommendation stability)"` via
`coaching/executive-summary.ts:122,133`, `coaching/next-actions.ts:137,148-149` and
`coaching/readiness-signals.ts:177,184`, published at `run.ts:3799`. This contradicts PLoT's own lane
doc (`LANE6-producer-honesty-2026-07-07.md:132-134`, *"they do not emit the number"*).

## Guard integrity

`withheldFieldReadBan.spec.ts` passes **unchanged**. Its pinned set is bidirectional — a shrink is a
RED — and this fix deliberately keeps `rankingStability` read in `ConfidenceSection.tsx`, so
`…ConfidenceSection.tsx::rankingStability` still matches and the pin stays exact. The new util
mentions withheld field names **only in comments** (the scanner strips comments but keeps string
literals) and `MIN_STABLE_RECOMMENDATION_STABILITY` is uppercase, which its case-sensitive regex does
not match.

## Verification

- Base moved during the lane: `b836d610` → **`289b730d`**. Rebased; `289b730d` is also the deployed SHA.
- **`Staging Gate` / `tsc` job, all six steps in the required order** — `lint` (0 errors; hooks ratchet
  exactly at baseline) → `typecheck` (**PASSED**, 2307 errors / 563 files, **identical to the clean
  tree — zero new diagnostics**; I did *not* accept the `--update-baseline` prompt, the shrink is
  pre-existing churn) → `ci:guard:zustand` → `ci:guard:starters` → `check:vendor` →
  `ci:guard:schemas-version`. All pass.
- New spec collects **9 tests asserted by name**, not inferred from a total.
- All 7 specs that import `ConfidenceSection` + the read-ban guard: **97 passed**.
- Whole `src/components/results` suite: **238 files / 4240 tests passed**.

## P-COMPLIANCE — read `STANDING-BRIEF-PREAMBLE.md` **v4 · 9 rules (P1–P9)**

- **P7** — derived from the producer, not a corpus: PLoT `src/routes/v2/run.ts:3403-3459` allow-list
  literal + its verbatim rationale + the route-level absence test. Named above.
- **P2** — mounted consumer: assertions execute the real component and read rendered DOM copy
  (`/Your model looks good\. You're ready to decide\./`, `/No fragile edges…/`), not the boolean.
  Extended to the **deployed bundle**, which is how the premise was refuted.
- **P1** — one seam beyond the guard: past the predicate into **render**. Non-finite and absent values
  are driven through `assessStabilityReadiness` → `ConfidenceSection` → DOM, asserting the
  *surrounding* verdict copy survives and is correct, not merely that the guard returned.
- **P5** — no claim about the user's model/session/history is added; the fix **removes** a readiness
  claim's unearned conjunct. The one claim I do make about the live product (that this surface is
  dead) is grounded in the deployed artefact, not in the file's own comment.
- **P6** — no system-inferred structure creates a user obligation; nothing new is asked of the user.
- **P8** — no question or affordance is emitted by this change. The nearest affordance risk found
  (`can_run_analysis ?? true`) is reported for its owner, not silently altered.
- **P4** — mutation harness typechecked the mutated tree: pristine control **passes** at 15 baseline
  diagnostics; M2/M6 mutated trees also **15**. Stated above with the cost-refinement reasoning.
- **P3** — both directions held: the fix does not let a more complete payload displace a truthful
  fallback, and clear-on-absence does **not** demote an in-flight run (in flight ⇒ no report ⇒ not
  assessable ⇒ no warning, pinned by RED-B and the absence case).
- **P9** — n/a: no rare capability is introduced, and the surface is dead, so a seeded witness would
  witness nothing. The state-class of every assertion here is **synthetic fixture**, not fresh-session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
