### PR TITLE
fix(ci): the DS guard can finally gate — stripper fixed, then enforced

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -264,13 +264,24 @@ jobs:
       - name: Duplicate-suffix guard
         run: pnpm run ci:guard:duplicates
 
-      # Design System v5 drift ratchet — REPORT-ONLY soak (Stage 2a). Surfaces
-      # net-new legacy tokens / raw hex / all-caps / panel-typography vs the
-      # committed baseline; DS debt does NOT fail CI, but a missing/corrupt baseline
-      # DOES (guard misconfiguration). Promote DS-debt detection to ci:guard:ds:enforce
-      # in a follow-up once the baseline has soaked.
-      - name: Design System v5 drift (report-only soak)
-        run: pnpm run ci:guard:ds
+      # Design System v5 drift ratchet — ENFORCING (Stage 2b). Net-new legacy
+      # tokens / raw hex / all-caps / panel-typography vs the committed baseline
+      # now FAIL, as does a missing/corrupt baseline (guard misconfiguration).
+      #
+      # It was report-only for a month because the July soak's 65 "net-new" hexes
+      # were all false positives (PR refs like #739 read as 3-digit hex) — the
+      # diagnosis was recorded and the stripper was never fixed, so no DS rule
+      # gated anything. The stripper is fixed first, then this is promoted; the
+      # reverse order turns CI red on comments.
+      #
+      # ⚠ THIS STEP ALONE DOES NOT GATE. Nothing in ci.yml is a required check —
+      # `staging` protection requires exactly one, "Staging Gate", in
+      # staging-full-tests.yml. The enforcing copy that actually blocks is in that
+      # workflow's `tsc` job. Derived 2026-08-17:
+      #   gh api repos/Talchain/DecisionGuideAI/branches/staging/protection \
+      #     --jq '.required_status_checks.contexts'   → ["Staging Gate"]
+      - name: Design System v5 drift (enforcing)
+        run: pnpm run ci:guard:ds:enforce
 
   # ── Typecheck gate self-test (positive control) ──────────────────────
   # PARITY WITH staging-full-tests.yml. The `tsc` job above asserts an ABSENCE

--- a/.github/workflows/staging-full-tests.yml
+++ b/.github/workflows/staging-full-tests.yml
@@ -144,6 +144,25 @@ jobs:
       - name: Vendored schemas version constant is derived, not drifted
         run: pnpm run ci:guard:schemas-version
 
+      # ── Design System v5 drift ratchet ──────────────────────────────────
+      # ⚠ WIRED HERE ON PURPOSE, NOT ONLY IN ci.yml — same reasoning as the
+      # bundle-credentials guard in the `build` job below.
+      #
+      # `staging` protection requires exactly ONE check: "Staging Gate", whose
+      # `needs` list is [tsc, typecheck-selftest, vitest, vitest-summary, build].
+      # Nothing in ci.yml is required, so the DS guard living only there would
+      # advise and never block — which is precisely what happened: it shipped
+      # report-only in ci.yml, its false-positive class was diagnosed in the July
+      # soak and left unfixed, and from then on NO Design System rule gated
+      # anything at all.
+      #
+      # Derived 2026-08-17:
+      #   gh api repos/Talchain/DecisionGuideAI/branches/staging/protection \
+      #     --jq '.required_status_checks.contexts'   → ["Staging Gate"]
+      # Re-derive before assuming this is still where the blocking happens.
+      - name: Design System v5 drift (enforcing)
+        run: pnpm run ci:guard:ds:enforce
+
   # ── Typecheck gate self-test (positive control) ──────────────────────
   # The `tsc` job above asserts an ABSENCE ("no new type errors, no invisible
   # files"). That assertion is worth nothing unless the gate can be shown to

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "migrate:tokens": "node scripts/migrate-olumi-tokens.mjs",
     "test:e2e:firefox": "playwright test --project=firefox -c playwright.config.ts",
     "test:e2e:webkit": "playwright test --project=webkit -c playwright.config.ts",
-    "ci:all": "npm run typecheck && npm run lint && npm run test:contracts && npm run test:full && npm run e2e && npm run ci:guard:zustand && npm run ci:guard:duplicates && npm run ci:guard:ds",
+    "ci:all": "npm run typecheck && npm run lint && npm run test:contracts && npm run test:full && npm run e2e && npm run ci:guard:zustand && npm run ci:guard:duplicates && npm run ci:guard:ds:enforce",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "generate:flag-env": "node scripts/generate-flag-env.mjs",

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -972,7 +972,12 @@ function OptionCard({
           {option.downside !== undefined ? (
             <div className="mt-1" data-testid={`option-downside-${option.id}`}>
               <p className={`${typography.panelMeta} text-text-light`}>
-                <span className="font-medium">{DOWNSIDE_HEADING_COPY}</span>{' '}
+                {/* Run-in label. DS v5 §2.4 bans raw font-size AND font-weight
+                    utilities in panel scope, and the sanctioned three-size scale
+                    (panelHeader/Body/Meta) has no 11px emphasis step — so the
+                    label is distinguished by the semantic COLOUR token against
+                    the paragraph's text-text-light, not by a raw weight. */}
+                <span className="text-text-header">{DOWNSIDE_HEADING_COPY}</span>{' '}
                 {/* ROADMAP 2.580 member 4: the magnitudes still go through
                     `formatRangeValue` (unchanged precision); the unit is
                     attached only when the goal stated one AND the values are

--- a/src/components/results/analysis-hero/actOnIt/ActOnItSection.tsx
+++ b/src/components/results/analysis-hero/actOnIt/ActOnItSection.tsx
@@ -195,7 +195,10 @@ function MicroIntervention({
   return (
     <div className="space-y-1" data-testid="hero-act-on-it-row-steps">
       <div className="flex items-center gap-2">
-        <span className={`${typography.panelMeta} font-semibold text-text-header`}>
+        {/* DS v5 §2.4: no raw font-weight in panel scope. panelMeta carries no
+            weight step, so the label reads as a label via text-text-header
+            against the list items' text-text-body below. */}
+        <span className={`${typography.panelMeta} text-text-header`}>
           {HERO_COPY.actOnIt.stepsLabel}
         </span>
         {estimatedMinutes != null && <MinutesBadge minutes={estimatedMinutes} />}

--- a/src/components/results/modals/HowComputedModal.tsx
+++ b/src/components/results/modals/HowComputedModal.tsx
@@ -190,7 +190,12 @@ export function HowComputedCard({ model }: HowComputedCardProps) {
         <div className="mt-1 flex flex-col gap-2">
           {C.whatItDoes.map((item) => (
             <div key={item.heading}>
-              <p className={`${typography.panelBody} font-semibold text-text-header`}>{item.heading}</p>
+              {/* Sub-heading inside a Section whose own <h3> is already
+                  panelHeader (14 semibold) — promoting this to panelHeader would
+                  make the two indistinguishable. DS v5 §2.4 bans the raw weight,
+                  so the sub-heading stays at panelBody and is distinguished from
+                  its body paragraph by text-text-header vs text-text-body. */}
+              <p className={`${typography.panelBody} text-text-header`}>{item.heading}</p>
               <p className={`${typography.panelBody} text-text-body`}>{item.body}</p>
             </div>
           ))}

--- a/src/components/results/strengthElicitation/AssumedStrengthCard.tsx
+++ b/src/components/results/strengthElicitation/AssumedStrengthCard.tsx
@@ -34,6 +34,19 @@
  * It still writes NO graph state. The strength is set in the panel this opens,
  * by `useEdgeMutations.setStrength`, which remains the single writer of
  * `weight`/`weightSource`. A write here would be a second writer of that field.
+ *
+ * ── TYPOGRAPHY: THE SANCTIONED SCALE, NOT RAW UTILITIES ─────────────────────
+ * This card first shipped with raw Tailwind size and weight utilities, which
+ * DS v5 §2.4 bans in panel scope (`src/styles/typography.ts:47-54` declares the
+ * strict set for src/components/results/: heroDisplay / panelHeader / panelBody /
+ * panelMeta). It now uses panelHeader for the title, panelBody for prose and the
+ * action, and panelMeta for the tertiary "others" line — so the card sits on the
+ * same three-size scale as every sibling. Do not reintroduce a raw size or weight
+ * utility here: the DS guard now ENFORCES this class and will red the gate.
+ *
+ * Note the guard scans COMMENTS for this class on purpose — spelling a banned
+ * utility in prose here would itself red the gate, because a utility named in a
+ * comment is an instruction that gets copied into code.
  */
 
 import { memo } from 'react'
@@ -47,6 +60,7 @@ import {
   assumedStrengthWhy,
 } from './assumedStrengthCopy'
 import type { AssumedStrengthDecision } from './selectAssumedStrengthToResolve'
+import { typography } from '../../../styles/typography'
 
 export interface AssumedStrengthCardProps {
   decision: AssumedStrengthDecision
@@ -70,7 +84,7 @@ function AssumedStrengthCardImpl({ decision, onResolve }: AssumedStrengthCardPro
     if (copy === null) return null
     return (
       <div className="border-t border-panel-border pt-2" data-testid="assumed-strength-refusal">
-        <p className="text-sm text-text-body">{copy}</p>
+        <p className={`${typography.panelBody} text-text-body`}>{copy}</p>
       </div>
     )
   }
@@ -86,27 +100,27 @@ function AssumedStrengthCardImpl({ decision, onResolve }: AssumedStrengthCardPro
       data-edge-id={selected.edgeId}
       aria-label={ASSUMED_STRENGTH_TITLE}
     >
-      <h4 className="text-sm font-medium text-text-heading" data-testid="assumed-strength-title">
+      <h4 className={`${typography.panelHeader} text-text-heading`} data-testid="assumed-strength-title">
         {ASSUMED_STRENGTH_TITLE}
       </h4>
-      <p className="text-sm text-text-body" data-testid="assumed-strength-lead">
+      <p className={`${typography.panelBody} text-text-body`} data-testid="assumed-strength-lead">
         {assumedStrengthLead(selected)}
       </p>
-      <p className="text-sm text-text-body" data-testid="assumed-strength-why">
+      <p className={`${typography.panelBody} text-text-body`} data-testid="assumed-strength-why">
         {assumedStrengthWhy(selected)}
       </p>
-      <p className="text-sm text-text-body" data-testid="assumed-strength-ask">
+      <p className={`${typography.panelBody} text-text-body`} data-testid="assumed-strength-ask">
         {ASSUMED_STRENGTH_ASK}
       </p>
       {others !== null && (
-        <p className="text-xs text-text-muted" data-testid="assumed-strength-others">
+        <p className={`${typography.panelMeta} text-text-muted`} data-testid="assumed-strength-others">
           {others}
         </p>
       )}
       {onResolve !== undefined && (
         <button
           type="button"
-          className="text-sm font-medium text-accent underline underline-offset-2"
+          className={`${typography.panelBody} text-accent underline underline-offset-2`}
           data-testid="assumed-strength-action"
           onClick={() => onResolve(selected.edgeId)}
         >

--- a/tests/ci-guards/check-ds-compliance.spec.ts
+++ b/tests/ci-guards/check-ds-compliance.spec.ts
@@ -3,26 +3,34 @@
  * (tools/ci-guards/check-ds-compliance.mjs).
  *
  * Proves, against ISOLATED fixtures (tools/ci-guards/__fixtures__/ds-compliance),
- * that the ratchet/hard-fail LOGIC works — even though the production gate ships
- * report-only/soak. The production gate scans `src/` only and never these fixtures.
+ * that the ratchet/hard-fail LOGIC works, and that `--update` cannot wind the
+ * ratchet backwards silently. The production gate scans `src/` only and never
+ * these fixtures; it is now ENFORCING, in ci.yml and — because only that one is a
+ * required check — in staging-full-tests.yml's `tsc` job.
+ *
+ * The token-level false-positive classes that kept this guard advisory for a month
+ * (PR refs in comment prose and in string literals) are pinned separately, in
+ * tests/ci-guards/ds-token-context.spec.ts.
  */
 import { describe, it, expect, afterAll } from 'vitest'
-import { execFileSync } from 'node:child_process'
-import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import path from 'node:path'
 
 const GUARD = 'tools/ci-guards/check-ds-compliance.mjs'
 const FX = 'tools/ci-guards/__fixtures__/ds-compliance'
 
+/**
+ * BOTH streams, on BOTH outcomes. The previous helper used execFileSync, whose
+ * return value is stdout only, so anything the guard warned on stderr while still
+ * exiting 0 was invisible to a test — which is exactly the shape of a guard that
+ * "prints loudly" and is never observed doing it.
+ */
 function run(args: string[]): { status: number; out: string } {
-  try {
-    const out = execFileSync('node', [GUARD, ...args], { encoding: 'utf8' })
-    return { status: 0, out }
-  } catch (e: unknown) {
-    const err = e as { status?: number; stdout?: string; stderr?: string }
-    return { status: err.status ?? 1, out: (err.stdout ?? '') + (err.stderr ?? '') }
-  }
+  const r = spawnSync('node', [GUARD, ...args], { encoding: 'utf8' })
+  if (r.error) throw r.error
+  return { status: r.status ?? 1, out: (r.stdout ?? '') + (r.stderr ?? '') }
 }
 
 describe('DS v5 compliance ratchet guard', () => {
@@ -68,6 +76,45 @@ describe('DS v5 compliance ratchet guard', () => {
     const { status, out } = run(['--root', `${FX}/excluded`, '--baseline', empty])
     expect(status).toBe(0)
     expect(out).toMatch(/production-hex \[ratchet\]: 1\b/)
+  })
+
+  it('BASELINE HONESTY: --update REFUSES to raise a gating signature count, and names what it refused', () => {
+    // A baseline you can wind backwards without saying so is not a ratchet.
+    // Bootstrap a CLEAN baseline, then point the same baseline at the DIRTY tree:
+    // regenerating would raise gating counts, so the update must refuse.
+    const bl = path.join(tmp, 'ratchet-clean.json')
+    const boot = run(['--root', `${FX}/clean`, '--baseline', bl, '--update'])
+    expect(boot.status).toBe(0)
+    const before = readFileSync(bl, 'utf8')
+
+    const { status, out } = run(['--root', `${FX}/dirty`, '--baseline', bl, '--update'])
+    expect(status).toBe(1)
+    expect(out).toMatch(/REFUSED/)
+    expect(out).toMatch(/may only move DOWNWARD/)
+    // It must name the class it refused, not just fail.
+    expect(out).toMatch(/production-hex/)
+    // And the refusal must not have written the file.
+    expect(readFileSync(bl, 'utf8')).toBe(before)
+  })
+
+  it('BASELINE HONESTY: --update --force blesses an increase but PRINTS every signature raised', () => {
+    const bl = path.join(tmp, 'ratchet-forced.json')
+    run(['--root', `${FX}/clean`, '--baseline', bl, '--update'])
+    const { status, out } = run(['--root', `${FX}/dirty`, '--baseline', bl, '--update', '--force'])
+    expect(status).toBe(0)
+    expect(out).toMatch(/FORCED past the ratchet assertion/)
+    expect(out).toMatch(/production-hex/)
+    expect(out).toMatch(/baseline written/)
+    // Blessed, therefore now the ratchet floor — and green from here.
+    expect(run(['--root', `${FX}/dirty`, '--baseline', bl, '--enforce']).status).toBe(0)
+  })
+
+  it('BASELINE HONESTY: a DOWNWARD move is allowed without --force', () => {
+    const bl = path.join(tmp, 'ratchet-down.json')
+    run(['--root', `${FX}/dirty`, '--baseline', bl, '--update', '--force'])
+    const { status, out } = run(['--root', `${FX}/clean`, '--baseline', bl, '--update'])
+    expect(status).toBe(0)
+    expect(out).toMatch(/ratchet assertion PASSED/)
   })
 
   it('MISCONFIG: a missing/unreadable baseline FAILS even in report-only (default) mode', () => {

--- a/tests/ci-guards/ds-token-context.spec.ts
+++ b/tests/ci-guards/ds-token-context.spec.ts
@@ -1,0 +1,171 @@
+// tests/ci-guards/ds-token-context.spec.ts
+//
+// Unit spec for tools/ci-guards/lib/ds-token-context.mjs — the two pure functions
+// that decide WHERE a `#hex` token sits and WHAT it is.
+//
+// WHY THIS SPEC EXISTS AT ALL. The DS guard's `production-hex` class was left
+// REPORT-ONLY for a month because its comment stripper was a per-line prefix test
+// and produced 65 false positives (PR references such as `#739` in comment prose)
+// in the July soak. While it was advisory, NO Design System rule gated anything.
+// The prefix test is now a state machine and the ambiguous `#NNN` shape is settled
+// by position — and both halves are pinned here so the next reader cannot
+// "simplify" the state machine back into a prefix test without a red.
+//
+// The corpus below is drawn from REAL staging source at 289b730d, file:line named
+// per case, not from the author's imagination — the two false-positive classes and
+// the five live colour literals are all quoted verbatim.
+import { describe, it, expect } from 'vitest'
+import {
+  stripComments,
+  isColourValuePosition,
+  isAmbiguousNumericHex,
+} from '../../tools/ci-guards/lib/ds-token-context.mjs'
+
+const HEX = /#[0-9a-fA-F]{6}\b|#[0-9a-fA-F]{3}\b/g
+
+/**
+ * The guard's `production-hex` detector, reduced to the two functions under test.
+ * Kept here rather than imported so this spec pins the CONTRACT the guard relies
+ * on; the guard-level behaviour is covered by check-ds-compliance.spec.ts.
+ */
+function detect(source: string): string[] {
+  const out: string[] = []
+  for (const code of stripComments(source)) {
+    let m: RegExpExecArray | null
+    HEX.lastIndex = 0
+    while ((m = HEX.exec(code)) !== null) {
+      if (/var\(--[\w-]+,\s*$/.test(code.slice(0, m.index))) continue
+      if (isAmbiguousNumericHex(m[0]) && !isColourValuePosition(code, m.index)) continue
+      out.push(m[0])
+    }
+  }
+  return out
+}
+
+describe('stripComments — block-comment state, not a line prefix', () => {
+  it('preserves the line count exactly, so line indices stay shared with the raw source', () => {
+    for (const src of ['a', 'a\n', 'a\nb', 'a\nb\n', '', '\n', '/* x\ny */\nz']) {
+      expect(stripComments(src).length).toBe(src.split('\n').length)
+    }
+  })
+
+  it('preserves column offsets (blanks, never deletes) so var(--t, #hex) slices still align', () => {
+    const src = 'const a = 1 /* note */ + 2'
+    const [line] = stripComments(src)
+    expect(line.length).toBe(src.length)
+    expect(line.startsWith('const a = 1 ')).toBe(true)
+    expect(line).not.toMatch(/note/)
+  })
+
+  it('blanks a CONTINUATION line of a block comment — the 13-of-16 false-positive class', () => {
+    // src/v5/blocks/V5EvidenceBlock.tsx:60 — the continuation line starts with
+    // PROSE, so `line.trimStart().startsWith('*')` never fired on it.
+    const src = [
+      '/**',
+      ' * Header line.',
+      'THE UNCERTAINTY CHANNEL — #670 mechanism, consumed through the shared',
+      ' */',
+      "const c = '#abcdef'",
+    ].join('\n')
+    expect(detect(src)).toEqual(['#abcdef'])
+  })
+
+  it('blanks a JSX {/* … */} block across lines', () => {
+    // src/canvas/components/OutputsDock.tsx:2377 shape.
+    const src = ['{/* Analysis freshness is owned by the', 'versions lane, #739). The trigger carries NO', '*/}'].join('\n')
+    expect(detect(src)).toEqual([])
+  })
+
+  it('does NOT treat // inside a string literal as a comment', () => {
+    const src = "const u = 'https://example.com/x'\nconst c = '#123456'"
+    expect(detect(src)).toEqual(['#123456'])
+  })
+
+  it('does NOT treat /* inside a string literal as opening a comment', () => {
+    const src = ["const g = 'a/*b'", "const c = '#abcdef'"].join('\n')
+    expect(detect(src)).toEqual(['#abcdef'])
+  })
+
+  it('keeps a template literal open across lines, and closes ordinary strings at the newline', () => {
+    const src = ['const t = `line one', 'line two`', "const c = '#654321'"].join('\n')
+    expect(detect(src)).toEqual(['#654321'])
+  })
+
+  it('still strips a TRAILING line comment on a line of live code', () => {
+    expect(detect("const c = '#abcdef' // was #fedcba")).toEqual(['#abcdef'])
+  })
+
+  it('handles an escaped quote without falling out of the string', () => {
+    const src = ["const s = 'it\\'s fine' // #333", "const c = '#000'"].join('\n')
+    expect(detect(src)).toEqual(['#000'])
+  })
+})
+
+describe('isAmbiguousNumericHex — only the shape that collides with issue refs', () => {
+  it('is true for the 3-char all-digit shape', () => {
+    for (const t of ['#000', '#900', '#457', '#739']) expect(isAmbiguousNumericHex(t)).toBe(true)
+  })
+
+  it('is false when a hex LETTER is present, or when the token is 6 chars', () => {
+    for (const t of ['#fee', '#abc', '#0a0', '#abcdef', '#123456']) {
+      expect(isAmbiguousNumericHex(t)).toBe(false)
+    }
+  })
+})
+
+describe('isColourValuePosition — value slot vs mid-prose', () => {
+  it('accepts the start of a value slot', () => {
+    for (const line of ["x: '#000'", 'x:#000', 'a(#000', 'a=#000', 'a,#000', '[#000', '{#000', '#000']) {
+      expect(isColourValuePosition(line, line.indexOf('#'))).toBe(true)
+    }
+  })
+
+  it('rejects mid-prose, including after a full stop and after a word', () => {
+    for (const line of ['see #457 root cause', 'the hole #506 measured', 'threshold. #457 root cause']) {
+      expect(isColourValuePosition(line, line.indexOf('#'))).toBe(false)
+    }
+  })
+})
+
+describe('the discriminating pair, on real staging source at 289b730d', () => {
+  // POSITIVE CONTROL. These five are LIVE colour literals in shipped product
+  // code and are exactly why "reject digit-only hex tokens" is the wrong fix:
+  // that rule would make the guard blind to all five.
+  const LIVE_COLOUR_LITERALS: ReadonlyArray<readonly [string, string, string]> = [
+    ['src/components/GraphCanvas.tsx:353', "            color: mode === 'connect' ? '#fff' : '#000',", '#000'],
+    ['src/components/GraphCanvas.tsx:529', "                  fill={connectFrom === node.id ? '#fff' : '#000'}", '#000'],
+    ['src/lib/ErrorBoundary.tsx:42', "            color: '#900',", '#900'],
+    ['src/main.tsx:124', "        <div style={{ padding: 12, background: '#fee', color: '#900',", '#900'],
+    [
+      'src/main.tsx:227',
+      "      container.style.cssText = 'padding:12px;background:#fee;color:#900;font:13px ui-monospace,monospace';",
+      '#900',
+    ],
+  ]
+
+  it.each(LIVE_COLOUR_LITERALS)('KEEPS the live colour literal at %s', (_site, line, token) => {
+    expect(detect(line)).toContain(token)
+  })
+
+  // CONTRAST CONTROL. Same `#NNN` shape, in prose. An absence claim needs both:
+  // the positive control proves the detector still sees colours, the contrast
+  // proves the drop is discrimination and not blindness.
+  const PR_REFERENCES: ReadonlyArray<readonly [string, string]> = [
+    ['src/canvas/domain/analyticalNodeFields.ts:121', '    note: "Written with threshold_source=\'user\'. #457 root cause when the allowlist omitted it.",'],
+    ['src/canvas/domain/analyticalNodeFields.ts:156', '    note: "Live since #453 and analysis-affecting.",'],
+    ['src/lib/scientificValidation/confidenceValidation.ts:131', "      ? ['No factor carries confidence_provenance — PR #170 work has not propagated yet.']"],
+    ['src/lib/scientificValidation/flipThresholdValidation.ts:85', "      'flip_thresholds_status is not yet emitted by PLoT (PR #167 work in flight). ' +"],
+    ['src/test/claimDrift/claimDriftWalker.ts:989', "      '# That is the hole #506 measured in the typecheck gate (37 diagnostics landed',"],
+  ]
+
+  it.each(PR_REFERENCES)('DROPS the PR reference in string prose at %s', (_site, line) => {
+    expect(detect(line)).toEqual([])
+  })
+
+  it('discriminates the two on ONE line: a colour is kept where a reference is dropped', () => {
+    // The single strongest case: same shape, same line, opposite verdicts. A
+    // blind detector cannot produce a discrimination it is not making.
+    const line = "  const bg = '#900' // see #457"
+    expect(detect(line)).toEqual(['#900'])
+  })
+})

--- a/tests/ci-guards/ds-token-context.spec.ts
+++ b/tests/ci-guards/ds-token-context.spec.ts
@@ -58,12 +58,19 @@ describe('stripComments — block-comment state, not a line prefix', () => {
   })
 
   it('blanks a CONTINUATION line of a block comment — the 13-of-16 false-positive class', () => {
-    // src/v5/blocks/V5EvidenceBlock.tsx:60 — the continuation line starts with
-    // PROSE, so `line.trimStart().startsWith('*')` never fired on it.
+    // src/canvas/components/OutputsDock.tsx:2377. The continuation line starts
+    // with PROSE, so `line.trimStart().startsWith('*')` never fired on it.
+    //
+    // ⚠ THE REFERENCE HERE IS DELIBERATELY PRECEDED BY `, ` — a value-slot
+    // character. That makes this case reachable ONLY by the state machine: the
+    // position rule would KEEP `, #739`, so if someone replaces stripComments
+    // with a prefix test this test reds. Measured: it does (mutant M4). A
+    // mid-prose reference would have passed under the prefix test too, via the
+    // other rule, and would have proved nothing about this one.
     const src = [
       '/**',
-      ' * Header line.',
-      'THE UNCERTAINTY CHANNEL — #670 mechanism, consumed through the shared',
+      ' * Analysis freshness is owned by the',
+      'versions lane, #739). The trigger deliberately carries NO',
       ' */',
       "const c = '#abcdef'",
     ].join('\n')

--- a/tools/ci-guards/check-ds-compliance.mjs
+++ b/tools/ci-guards/check-ds-compliance.mjs
@@ -11,19 +11,33 @@
  * file A — the brief's core requirement. Deliberate tradeoff: a within-file,
  * same-token add+remove is net-zero and is not flagged (it is not an "elsewhere" hide).
  *
- * ── Modes (Stage 2a ships REPORT-ONLY / soak) ──────────────────────────────
+ * ── Modes (Stage 2b: ENFORCING — the soak is over) ─────────────────────────
  *   (default)    Scan `src`, compare to baseline, PRINT net-new + summary, exit 0
- *                for detected violations. This is the soak rollout: it surfaces drift
- *                without blocking pushes. A follow-up flips the default to --enforce
- *                once the baseline has soaked. (A missing/corrupt baseline is a
- *                misconfiguration and ALWAYS exits 1 — even here.)
- *   --enforce    exit 1 if any net-new violation exists. Used by the guard's
- *                own fixture self-test to PROVE the ratchet/hard-fail logic,
- *                and by the future promotion to a blocking gate.
- *   --update     Regenerate the baseline JSON from the current scan root.
+ *                for detected violations. Retained for local inspection only.
+ *                (A missing/corrupt baseline is a misconfiguration and ALWAYS
+ *                exits 1 — even here.)
+ *   --enforce    exit 1 if any net-new violation exists. THIS is what CI runs, in
+ *                both ci.yml and — because only that one is required — the
+ *                `tsc` job of staging-full-tests.yml, which the "Staging Gate"
+ *                aggregator depends on.
+ *   --update     Regenerate the baseline JSON from the current scan root. REFUSES
+ *                to run if that would raise any gating signature's count: the
+ *                ratchet may only move downward (see assertRatchetOnlyDescends).
+ *   --force      With --update only: bless an increase anyway, printing every
+ *                signature blessed. Never silent.
  *   --root <dir> Scan a different root (default `src`). Used by the self-test
  *                to point at the isolated fixtures; production always scans src.
  *   --json       Emit machine-readable summary.
+ *
+ * ── WHY THIS IS NOW ENFORCING (and was not for a month) ────────────────────
+ * Stage 2a shipped report-only because the July soak surfaced 65 "net-new" hexes
+ * that were ALL false positives — PR references such as `#739` in comment prose,
+ * matched as 3-digit hex. The diagnosis was recorded and the guard was left
+ * advisory rather than fixed, so from then on NO Design System rule gated
+ * anything. The stripper is fixed (tools/ci-guards/lib/ds-token-context.mjs, with
+ * the measurement and the false-negative controls in its header) and the guard is
+ * promoted in the same change, in that order — promoting first would have turned
+ * CI red on comments.
  *
  * The production gate scans `src/` ONLY. Deliberately-bad fixtures live under
  * tools/ci-guards/__fixtures__/ (outside src/) and are scanned only by the
@@ -37,6 +51,7 @@
  */
 import { promises as fs } from 'fs'
 import path from 'path'
+import { stripComments, isColourValuePosition, isAmbiguousNumericHex } from './lib/ds-token-context.mjs'
 
 const ROOT = process.cwd()
 
@@ -67,6 +82,11 @@ const under = (p, dir) => p === dir || p.startsWith(dir + '/')
  *    types must not be (re)introduced anywhere, including dev tooling.
  *  - .css / .module.css: only `legacy-tailwind-token` scans .css at all; the other
  *    classes scan .ts/.tsx only, so CSS modules are excluded by extension.
+ *  - Comments (line, block and JSX `{/* … *\/}`): excluded ONLY from `production-hex`,
+ *    via `stripComments: true`. A hex in a comment is documentation, not usage. The
+ *    other classes deliberately still scan comments: a `bg-sand` or `text-xs` written
+ *    into a comment is a migration instruction that WILL be copied into code.
+ *    Changing that would silently lower three baselines — do not "unify" it.
  */
 const CLASSES = [
   {
@@ -83,21 +103,23 @@ const CLASSES = [
     inScope: (p) =>
       /\.(ts|tsx)$/.test(p) && !isTest(p) &&
       !under(p, 'components/debug') && !under(p, 'poc') && !under(p, 'canvas/theme'),
-    lineTokens: (line) => {
-      // Comments are NOT colour usage: the unstripped detector counted issue
-      // refs (#343, #202 — valid 3-digit "hex") and documented-rationale hues
-      // in comments as production drift; all 65 "net-new" hexes in the July
-      // soak were this false positive. Skip block-comment lines and strip
-      // trailing line comments — a hex that survives is in live code.
-      const t = line.trimStart()
-      if (t.startsWith('//') || t.startsWith('*') || t.startsWith('/*') || t.startsWith('{/*')) return []
-      const code = line.replace(/(^|[\s{(,;])\/\/.*$/, '$1')
+    // Comments are NOT colour usage, and comment membership is multi-line STATE,
+    // so this class is fed comment-blanked lines by stripComments() rather than
+    // testing each line's prefix. See lib/ds-token-context.mjs for why a prefix
+    // test cannot work and why "reject digit-only tokens" is measurably wrong.
+    stripComments: true,
+    lineTokens: (code) => {
       const out = []
       let m
       HEX.lastIndex = 0
       while ((m = HEX.exec(code)) !== null) {
         // Scoping decision #1: var(--token, #hex) fallbacks are excluded.
+        // (stripComments preserves column offsets so this slice still aligns.)
         if (/var\(--[\w-]+,\s*$/.test(code.slice(0, m.index))) continue
+        // A bare `#NNN` is either a colour or a PR/issue reference in a STRING
+        // literal, which no comment stripper can reach. Settle it by POSITION:
+        // a colour sits at the start of a value slot, a reference sits mid-prose.
+        if (isAmbiguousNumericHex(m[0]) && !isColourValuePosition(code, m.index)) continue
         out.push(m[0].toUpperCase())
       }
       return out
@@ -161,19 +183,35 @@ async function scan(rootDir) {
     let text
     try { text = await fs.readFile(abs, 'utf8') } catch { continue }
     const lines = text.split('\n')
+    // Computed lazily and at most once per file; stripComments() returns exactly
+    // one entry per source line (asserted below) so line indices stay shared
+    // between the raw and stripped views — the raw line is what gets sampled.
+    let stripped = null
     for (const c of CLASSES) {
       // Scope is decided on the path RELATIVE TO THE SCAN ROOT (scopeRel), so the
       // same class scopes work for production (root=src) and fixtures (root=fixture
       // dir mirroring the src layout). `rel` (repo-relative) is used only for the
       // human-readable file path and the occurrence signature.
       if (!c.inScope(scopeRel)) continue
-      for (const line of lines) {
-        for (const token of c.lineTokens(line)) {
-          const sig = sigKey(c.id, rel, token, line)
+      let scanLines = lines
+      if (c.stripComments) {
+        if (stripped === null) {
+          stripped = stripComments(text)
+          if (stripped.length !== lines.length) {
+            throw new Error(`stripComments changed the line count for ${rel} (${stripped.length} vs ${lines.length}) — offsets would be wrong`)
+          }
+        }
+        scanLines = stripped
+      }
+      for (let i = 0; i < scanLines.length; i++) {
+        for (const token of c.lineTokens(scanLines[i])) {
+          const sig = sigKey(c.id, rel, token)
           const bucket = result[c.id]
           bucket.total++
           bucket.byFile[rel] = (bucket.byFile[rel] || 0) + 1
-          if (!bucket.signatures[sig]) bucket.signatures[sig] = { count: 0, file: rel, token, sample: line.trim().slice(0, 120) }
+          // Sample the RAW line, always: a blanked comment is unreadable, and the
+          // sample is the only thing a human reviewing the baseline diff can see.
+          if (!bucket.signatures[sig]) bucket.signatures[sig] = { count: 0, file: rel, token, sample: lines[i].trim().slice(0, 120) }
           bucket.signatures[sig].count++
         }
       }
@@ -212,17 +250,67 @@ function fmtBaseline(current) {
     _meta: {
       purpose: 'DS v5 drift ratchet baseline (Stage 2a). Net-new occurrence-signatures above these counts are flagged.',
       scanRoot: 'src',
-      rollout: 'report-only / soak — production gate prints but does not block; promote to --enforce in a follow-up.',
-      regenerate: 'node tools/ci-guards/check-ds-compliance.mjs --update',
+      rollout: 'ENFORCING — CI runs --enforce in ci.yml and in staging-full-tests.yml`s `tsc` job, which the required "Staging Gate" check depends on.',
+      regenerate: 'node tools/ci-guards/check-ds-compliance.mjs --update  (refuses to raise any gating signature count; --force blesses loudly)',
     },
     classes,
   }
+}
+
+/**
+ * THE RATCHET MUST ONLY MOVE DOWNWARD.
+ *
+ * `--update` used to write the baseline unconditionally, with no assertion of any
+ * kind — so real drift could be blessed by whoever ran it next, silently, and the
+ * gate would then be green about the very violation it had just been taught to
+ * accept. A ratchet you can wind backwards without saying so is not a ratchet.
+ *
+ * Mechanically: the new baseline IS the current scan, so "no gating signature's
+ * count rises" is exactly "the current scan has no net-new in a gating class".
+ * One check therefore covers both statements of the rule.
+ *
+ * SCOPE, stated honestly. This is UNCONDITIONAL whenever a baseline already
+ * exists, and it is inherently like-for-like: it compares the current scan against
+ * the very file it is about to overwrite. Two consequences worth knowing:
+ *  - Bootstrapping (no readable baseline yet) has nothing to compare and is allowed,
+ *    with a printed line saying so.
+ *  - Re-pointing an existing baseline at a DIFFERENT --root is not like-for-like, so
+ *    the assertion refuses. That is the intended answer, not a limitation: use
+ *    --force, or a fresh baseline path.
+ * What it does NOT cover: a change to a detector that makes it see LESS. That
+ * lowers the baseline legitimately and is indistinguishable, mechanically, from
+ * genuine debt repair — it stays a REVIEW obligation on the guard's own diff.
+ */
+function assertRatchetOnlyDescends(current, baseline, { force }) {
+  const netNew = diff(current, baseline)
+  const gaining = Object.entries(netNew).filter(([, v]) => v.mode === 'ratchet')
+  if (!gaining.length) {
+    console.log('DS-compliance --update: ratchet assertion PASSED — no gating signature count rises.')
+    return
+  }
+  const total = gaining.reduce((s, [, v]) => s + v.items.reduce((n, i) => n + i.delta, 0), 0)
+  const header = force ? 'DS-compliance --update: FORCED past the ratchet assertion' : 'DS-compliance --update: REFUSED'
+  const log = force ? console.warn : console.error
+  log(`\n${header} — ${total} occurrence(s) across ${gaining.length} gating class(es) would be RAISED:`)
+  for (const [id, v] of gaining) {
+    log(`  ${id}:`)
+    for (const it of v.items) log(`    +${it.delta}  ${it.file}  ${it.token}  ${it.sample}`)
+  }
+  if (force) {
+    console.warn('\nBlessed deliberately via --force. Every signature raised is listed above; put the justification in the commit message.')
+    return
+  }
+  console.error('\nThe DS ratchet may only move DOWNWARD. Fix the violations above, or — if this')
+  console.error('is a deliberate widening of a detector — re-run with `--update --force`, which')
+  console.error('prints every signature it blesses so the change is reviewable in the diff.')
+  process.exit(1)
 }
 
 async function main() {
   const args = process.argv.slice(2)
   const enforce = args.includes('--enforce')
   const update = args.includes('--update')
+  const force = args.includes('--force')
   const asJson = args.includes('--json')
   const rootIdx = args.indexOf('--root')
   const scanRoot = rootIdx >= 0 ? args[rootIdx + 1] : 'src'
@@ -237,6 +325,15 @@ async function main() {
   const current = await scan(path.resolve(ROOT, scanRoot))
 
   if (update) {
+    // Read the OUTGOING baseline first: the assertion is a comparison, so an
+    // update that cannot see what it is replacing cannot be checked.
+    let prev = null
+    try { prev = JSON.parse(await fs.readFile(baselinePath, 'utf8')) } catch { /* bootstrap */ }
+    if (prev === null) {
+      console.log('DS-compliance --update: no readable existing baseline — bootstrapping, nothing to ratchet against.')
+    } else {
+      assertRatchetOnlyDescends(current, prev, { force })
+    }
     await fs.writeFile(baselinePath, JSON.stringify(fmtBaseline(current), null, 2) + '\n')
     console.log('DS-compliance baseline written:', path.relative(ROOT, baselinePath))
     for (const c of CLASSES) console.log(`  ${c.id} (${c.mode}): ${current[c.id].total}`)

--- a/tools/ci-guards/ds-compliance-baseline.json
+++ b/tools/ci-guards/ds-compliance-baseline.json
@@ -4561,7 +4561,7 @@
     "production-hex": {
       "mode": "ratchet",
       "description": "Raw hex colour literals in production .ts/.tsx (excl. debug/poc/theme/tests + var() fallbacks)",
-      "total": 311,
+      "total": 312,
       "byFile": {
         "src/components/ContractInspector.tsx": 67,
         "src/canvas/export/decisionBrief.ts": 33,
@@ -4604,7 +4604,8 @@
         "src/lib/scientificValidation/confidenceValidation.ts": 1,
         "src/lib/scientificValidation/flipThresholdValidation.ts": 1,
         "src/pages/sandbox-guide/components/canvas/GhostEdge.tsx": 1,
-        "src/plotLite/GhostPanel.tsx": 1
+        "src/plotLite/GhostPanel.tsx": 1,
+        "src/canvas/edges/edgePresentation.ts": 1
       },
       "signatures": {
         "production-hex :: src/canvas/ReactFlowGraph.tsx :: #F87171": {
@@ -5836,6 +5837,12 @@
           "file": "src/routes/PlotWorkspace.tsx",
           "token": "#DDD6FE",
           "sample": "const noteColors = ['#fef3c7', '#fde68a', '#fed7aa', '#fecaca', '#ddd6fe']"
+        },
+        "production-hex :: src/canvas/edges/edgePresentation.ts :: #B8B8B8": {
+          "count": 1,
+          "file": "src/canvas/edges/edgePresentation.ts",
+          "token": "#B8B8B8",
+          "sample": "export const STRUCTURAL_EDGE_COLOUR = '#B8B8B8'"
         }
       }
     },

--- a/tools/ci-guards/lib/ds-token-context.d.mts
+++ b/tools/ci-guards/lib/ds-token-context.d.mts
@@ -1,0 +1,33 @@
+// tools/ci-guards/lib/ds-token-context.d.mts
+// Types for the DS-guard token-context helpers, so TypeScript consumers (their
+// spec, and the guard itself if it is ever ported) are checked rather than
+// silently `any`. Same convention as flag-deployment-drift.d.mts.
+//
+// The implementation is plain .mjs deliberately: `node
+// tools/ci-guards/check-ds-compliance.mjs` must run with no build step and no
+// loader. This file gives it types without that cost.
+
+/**
+ * True for a `#hex` token whose own characters cannot settle colour-vs-reference:
+ * the 3-character all-digit shape (`#000`–`#999`), which collides with PR/issue
+ * references. `#fee` (has a hex letter) and any 6-digit token are unambiguous.
+ */
+export declare function isAmbiguousNumericHex(token: string): boolean
+
+/**
+ * True when the `#` at `index` in `codeLine` sits where a VALUE belongs (start of
+ * line, or immediately after `:` `;` `,` `(` `=` `[` `{` or an opening quote)
+ * rather than mid-prose. Used only for the ambiguous shape above.
+ */
+export declare function isColourValuePosition(codeLine: string, index: number): boolean
+
+/**
+ * Blank every comment in `text`, returning EXACTLY ONE ENTRY PER SOURCE LINE with
+ * comment characters replaced by spaces (never removed), so column offsets still
+ * align with the original source.
+ *
+ * Carries block-comment and string/template state ACROSS lines — that is the whole
+ * point: block-comment continuation lines start with prose, so a per-line prefix
+ * test cannot see them.
+ */
+export declare function stripComments(text: string): string[]

--- a/tools/ci-guards/lib/ds-token-context.mjs
+++ b/tools/ci-guards/lib/ds-token-context.mjs
@@ -1,0 +1,128 @@
+/**
+ * ds-token-context.mjs — WHERE a token sits, and WHAT it is.
+ *
+ * Two small pure functions used by check-ds-compliance.mjs's `production-hex` class.
+ * They live here, separately unit-tested, because the July soak's 65 "net-new"
+ * hexes were ALL false positives produced by a per-line prefix test standing in for
+ * these two questions — and the guard was left report-only rather than fixed, which
+ * is how the whole Design System became unenforced. See ds-token-context.spec.ts.
+ *
+ * ── WHY A STATE MACHINE AND NOT A PREFIX TEST ───────────────────────────────
+ * The previous stripper asked "does this LINE start with //, *, /* or {/*?".
+ * That is a per-line question about a MULTI-LINE construct, so it is blind to the
+ * continuation lines of a block comment, which start with prose:
+ *
+ *     {\/* Analysis freshness is owned by the
+ *         versions lane, #739). The trigger carries NO   <-- prose start: SCANNED
+ *      *\/}
+ *
+ * 13 of the 16 net-new hexes measured on staging 289b730d were exactly this line
+ * class. A prefix test cannot be extended to cover it: block-comment membership is
+ * STATE, carried across lines. Do not "simplify" stripComments() back into a test
+ * on line.trimStart() — that is the defect it exists to remove.
+ *
+ * ── WHY A CONTEXT RULE AND NOT "REJECT DIGIT-ONLY TOKENS" ───────────────────
+ * The remaining false positives are `#NNN` PR references inside STRING literals,
+ * which no comment stripper can reach:
+ *
+ *     note: "The user's success target ... #457 root cause when the old persist ..."
+ *
+ * The tempting fix — "a hex made only of digits is a PR number, not a colour" — is
+ * measurably WRONG. These are live colour literals in shipped product code:
+ *
+ *     src/components/GraphCanvas.tsx:353  color: mode === 'connect' ? '#fff' : '#000'
+ *     src/components/GraphCanvas.tsx:529  fill={connectFrom === node.id ? '#fff' : '#000'}
+ *     src/lib/ErrorBoundary.tsx:42        color: '#900'
+ *     src/main.tsx:124                    background: '#fee', color: '#900'
+ *     src/main.tsx:227                    'padding:12px;background:#fee;color:#900;...'
+ *
+ * Rejecting digit-only tokens would make the guard blind to all five. So the
+ * ambiguity is resolved by POSITION, not by the token's own characters: a colour
+ * value sits at the start of a value slot (after `:` `;` `,` `(` `=` `[` `{` or an
+ * opening quote); a PR reference sits mid-sentence, after prose.
+ */
+
+/** A `#hex` token whose characters cannot themselves settle colour-vs-reference. */
+export function isAmbiguousNumericHex(token) {
+  // Only the 3-character shape collides with issue references, and only when it
+  // carries no hex LETTER: `#fee`/`#eee` are unambiguously colours, and a 4-digit
+  // reference such as `#1004` never matches the detector's `\b` at all. A 6-digit
+  // token is likewise never an issue reference in this estate.
+  return /^#[0-9]{3}$/.test(token)
+}
+
+/** Characters that open a value slot; a colour may legitimately follow any of them. */
+const VALUE_SLOT_LEFT = /[:;,(=[{'"`]\s*$/
+
+/**
+ * True when `index` (the offset of `#` in `codeLine`) sits where a VALUE belongs,
+ * rather than mid-prose. Deliberately permissive on `(` and `,` so a future
+ * `linear-gradient(#000, #fff)` is still caught; the block-comment machine, not
+ * this rule, is what removes `(#629)`-style references in comment prose.
+ */
+export function isColourValuePosition(codeLine, index) {
+  const left = codeLine.slice(0, index)
+  return left.trim() === '' || VALUE_SLOT_LEFT.test(left)
+}
+
+/**
+ * Blank every comment in `text`, returning ONE ENTRY PER SOURCE LINE with comment
+ * characters replaced by spaces (never removed) so that column offsets — which
+ * isColourValuePosition() and the guard's `var(--token, #hex)` exclusion both read —
+ * still line up with the original source.
+ *
+ * Tracks, across lines: block-comment depth (`/* … *\/`, which is also how JSX
+ * `{\/* … *\/}` is handled) and string/template-literal state, so that `//` inside
+ * `'https://example.com'` is not mistaken for a comment and a template literal may
+ * legitimately span lines.
+ *
+ * KNOWN LIMITATION, deliberate and measured: regex literals are not parsed, so a
+ * regex containing `//` or `/*` would be read as opening a comment. That can only
+ * ever DROP detections, never invent them; the promotion PR enumerated every token
+ * the change drops across `src/` and confirmed each is a PR reference in prose.
+ * Interpolations inside template literals keep their text (over-keeping, which is
+ * the safe direction for a guard).
+ */
+export function stripComments(text) {
+  const src = String(text)
+  const n = src.length
+  const lines = []
+  let line = ''
+  let inBlock = false
+  let quote = null // "'" | '"' | '`'
+  let i = 0
+
+  while (i <= n) {
+    const ch = i < n ? src[i] : '\n' // sentinel closes the final line
+    if (ch === '\n') {
+      lines.push(line)
+      line = ''
+      // A line comment ends at the newline. Only template literals survive one.
+      if (quote !== '`') quote = null
+      i++
+      if (i > n) break
+      continue
+    }
+    if (inBlock) {
+      if (ch === '*' && src[i + 1] === '/') { inBlock = false; line += '  '; i += 2 }
+      else { line += ' '; i += 1 }
+      continue
+    }
+    if (quote) {
+      line += ch
+      if (ch === '\\' && i + 1 < n && src[i + 1] !== '\n') { line += src[i + 1]; i += 2; continue }
+      if (ch === quote) quote = null
+      i += 1
+      continue
+    }
+    if (ch === '/' && src[i + 1] === '/') {
+      while (i < n && src[i] !== '\n') { line += ' '; i += 1 }
+      continue
+    }
+    if (ch === '/' && src[i + 1] === '*') { inBlock = true; line += '  '; i += 2; continue }
+    if (ch === "'" || ch === '"' || ch === '`') { quote = ch; line += ch; i += 1; continue }
+    line += ch
+    i += 1
+  }
+  return lines
+}


### PR DESCRIPTION
## Why this is not a small change

**Until this PR, no Design System class gated anything.** `ci.yml` ran the guard in
report-only soak, so every visual rule in DS v5 was unenforced — and the reason it was
left that way is recorded in the guard's own header: the July soak surfaced 65 "net-new"
raw hexes that were **all false positives** (PR references such as `#739` read as 3-digit
hex). The diagnosis was written down and the stripper was never fixed. This PR fixes the
stripper, *then* enforces — that order matters, because promoting first turns CI red on
comments.

### ⚠ Premise correction: promoting `ci.yml` alone would still have gated nothing

`ci.yml` is **not a required check**. Branch protection requires exactly one:

```
gh api repos/Talchain/DecisionGuideAI/branches/staging/protection \
  --jq '.required_status_checks.contexts'    → ["Staging Gate"]
```

`Staging Gate` lives in `staging-full-tests.yml` with
`needs: [tsc, typecheck-selftest, vitest, vitest-summary, build]`, and `ci:guard:ds`
appeared **nowhere** in that workflow. So the enforcing guard is wired into that
workflow's `tsc` job as well — the same precedent, and for the same reason, as the
`ci:guard:bundle-credentials` step already in its `build` job ("a guard living only there
would advise and never block"). Without this half the PR would have been theatre.

## Net-new per class, before → after

Measured at pristine `289b730d`, then at this branch:

| gating class | pristine net-new | after | how |
|---|---|---|---|
| `production-hex` | **16** (every one a false positive) | **0** | detector fixed; no source edit needed |
| `panel-typography-scoped` | **6** (all genuine) | **0** | 6 source fixes |
| `legacy-tailwind-token` | 0 | 0 | — |
| `uppercase-text` | 0 | 0 | — |
| **`--enforce` exit code** | **1** | **0** | |

The 16 hex false positives were two measured classes: **13** block-comment
*continuation* lines (they start with prose, so a `line.trimStart()` prefix test never
saw them) and **3** `#NNN` PR references inside **string literals**, which no comment
stripper can reach.

Tree-wide detector effect: **299 → 286** (comment state machine) **→ 279** (colour-position
rule). **20 occurrences dropped, every one the ambiguous `#NNN` shape.**

## The refuted shortcut, and the five literals that refute it

"Reject digit-only hex tokens" was proposed and is **measurably wrong** — these are live
colour literals in shipped product code, and that rule would make the guard blind to all
five:

| site | code |
|---|---|
| `src/components/GraphCanvas.tsx:353` | `color: mode === 'connect' ? '#fff' : '#000'` |
| `src/components/GraphCanvas.tsx:529` | `fill={connectFrom === node.id ? '#fff' : '#000'}` |
| `src/lib/ErrorBoundary.tsx:42` | `color: '#900'` |
| `src/main.tsx:124` | `background: '#fee', color: '#900'` |
| `src/main.tsx:227` | `'padding:12px;background:#fee;color:#900;…'` |

(The brief named this last one as `ErrorBoundary.tsx:42`; the repo has **six** files with
that basename and the live literal is in `src/lib/`, not `src/canvas/`.)

So the ambiguity is settled by **position**, not by the token's own characters: a colour
sits at the start of a value slot, a PR reference sits mid-prose.

**Controls, both in the same run** — positive: all five literals still detected;
contrast: the PR references no longer are. Zero non-`#NNN` tokens were dropped anywhere in
`src/`, which also rules out over-stripping by the state machine.

## The discriminating mutant set

Isolated worktree at an absolute path outside the repo root; isolation proved by **writing**
a sentinel and asserting the source did not change (inodes differ); restores from a pristine
`git archive`, never from the other copy; tree asserted clean before and after each mutant;
applied-check exactly 1 with the control reading exactly 0.

| mutant | expected | result |
|---|---|---|
| M1 reintroduce a real 6-digit hex colour in product code | RED | **RED** — flags `#AB12CD` |
| M1b reintroduce a real **all-digit** hex colour | RED | **RED** — flags `#010` |
| M2 add PR references in a **block comment** | GREEN | **GREEN** |
| M2b add PR references in a **string literal** | GREEN | **GREEN** |
| M3 add a raw `text-xs` in a panel file | RED | **RED** — flags `text-xs` |
| M4 revert `stripComments` to the old prefix test | spec RED | **RED** — 3 named tests, incl. the continuation case |
| M5 remove the colour-position rule | guard RED | **RED** — `#457`/`#453`/`#506` return |
| M6 **the refuted shortcut** | spec RED | **RED** — *all five* live-colour tests fail |
| M7 remove the `--update` ratchet assertion | spec RED | **RED** — all three baseline-honesty tests fail |

M1–M3 is the trio that proves the guard *discriminates the classes* rather than merely
passing. M4 and M6 form the load-bearing pair: M4 reds only what the **state machine** can
satisfy, M6 reds only what the **position rule** can — so neither fix can be removed
silently. M4 initially passed the continuation test *for the wrong reason* (the position
rule also covered that line); the fixture was changed to the real `OutputsDock.tsx:2377`
line, whose reference follows `, ` — a value-slot character the position rule keeps — so
only the state machine can satisfy it. Second commit, and measured.

**P4:** pristine tree typechecks first (`EXIT=0`, 0 diagnostics); batched mutated-tree
typecheck also `EXIT=0`, 0 diagnostics, so a type-invalid mutant would have been visible
rather than a false survivor. The batch deliberately includes the `noUnusedLocals` orphan
case (M2b declares a const).

## The 6 typography fixes

Derived from the **producer** — `src/styles/typography.ts:47-54` declares the strict
results-panel set (`heroDisplay` / `panelHeader` / `panelBody` / `panelMeta`) — not from
what the files happened to contain. DS v5 §2.4 bans raw **weight** as explicitly as raw
size, and the sanctioned scale has no 11px or 12px emphasis step, so **emphasis is carried
by the semantic colour token, not by a raw weight utility**:

- `OptionCards.tsx:975` — run-in label `font-medium` → `text-text-header` inside the
  `panelMeta` paragraph's `text-text-light`.
- `ActOnItSection.tsx:198` — dropped `font-semibold`; `text-text-header` already
  distinguishes the label from the list items' `text-text-body`.
- `HowComputedModal.tsx:193` — dropped `font-semibold`. Note the enclosing `Section`'s own
  `<h3>` is *already* `panelHeader`, so promoting this sub-heading would have made the two
  indistinguishable.
- `AssumedStrengthCard.tsx` — the whole card was raw utilities (6× `text-sm`, 2×
  `font-medium`, 1× `text-xs`); now `panelHeader` for the title, `panelBody` for prose and
  the action, `panelMeta` for the tertiary line.

Baseline held **zero** for all four files, so every occurrence had to go, not just one.

**Worth knowing:** `panel-typography-scoped` scans **comments** by design (a banned utility
named in a comment is an instruction that gets copied into code). A header comment
documenting this fix tripped the guard until it was reworded — that is the class working
correctly, and it is now noted in the file.

## Baseline honesty: mechanical, with one stated gap

`--update` previously wrote the baseline **with no assertion of any kind**, so any drift
could be blessed silently. It now refuses to raise any gating signature's count, naming
every signature it refused; `--force` blesses but prints them all. Three tests pin it
(refuse / force-prints / downward-allowed), and M7 proves they bite.

**Mechanical**, and unconditional whenever a baseline exists. Stated plainly, what it does
**not** cover: a change to a *detector* that makes it see **less** lowers the baseline
legitimately and is mechanically indistinguishable from genuine debt repair. That remains a
**review** obligation on the guard's own diff — this PR is itself an instance of it, which
is why the dropped-token enumeration is above rather than asserted.

**Not done here, deliberately:** the baseline is **not** regenerated, so its pre-existing
downward slack stays (`legacy-tailwind-token` Δ−515, `production-hex` Δ−32, `uppercase-text`
Δ−19). Tightening it from this base would red staging the moment a concurrently-merging
lane's already-landed token fell outside my snapshot. Slack is per-signature, so it cannot
hide a *new* violation — which is what the gate is for. Tightening is a separate,
rebase-at-merge-time follow-up.

## Verification

- Required `tsc` job, all 7 steps in CI order, locally: `lint` → `typecheck` →
  `ci:guard:zustand` → `ci:guard:starters` → `check:vendor` → `ci:guard:schemas-version` →
  `ci:guard:ds:enforce` — **all EXIT=0**.
- `tests/ci-guards/ds-token-context.spec.ts` **24/24**,
  `tests/ci-guards/check-ds-compliance.spec.ts` **11/11**, counts asserted **by name**
  rather than inferred from a suite total.
- `ci:all` also promoted to `ci:guard:ds:enforce` so the local aggregate stops disagreeing
  with CI.

## Files

Guard seam only: `tools/ci-guards/check-ds-compliance.mjs`, new
`tools/ci-guards/lib/ds-token-context.{mjs,d.mts}` (typed per the existing
`flag-deployment-drift.d.mts` convention), the two specs, both workflows, `package.json`,
and the 4 source files carrying the 6 typography violations. **No baseline change.**
`StyledEdge.tsx` appears in the pristine false-positive list but is **not touched** — the
stripper fix removes it, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Side effect worth naming: this closes the standing pre-push red

`scripts/validate-prepush.sh:337` — **Check 8, "Design System v5 drift (enforced — net-new
blocks)"** — has been calling `--enforce` since 16 Jul. So the *pre-push* gate was already
enforcing while CI was not, and `staging` therefore **could not pass its own pre-push gate**:
`CLAUDE.md` records exactly this ("check 8 (DS v5 drift) fails on pristine `03707a72` with
identical counts, proven with a control worktree") and warns against "fixing" it by accepting
a `--update-baseline` prompt.

This PR closes it **the right way** — by fixing the detector's false positives and the six
genuine violations — and **without touching the baseline**. Reproduced here: `--enforce` was
`EXIT=1` on pristine `289b730d` and is `EXIT=0` on this branch.

**Reported, not edited** (outside this lane's seam): the comment at
`scripts/validate-prepush.sh:334-335` claims "the hex detector is comment-aware as of the same
change — issue refs like `#343` in comments are not colours". That was only ever true of
comment lines a *prefix test* could recognise, and it is the overclaim that let this sit
report-only for a month. It wants a one-line correction by whoever owns that file.

## Cross-class no-op check

Only the two intended classes moved. `legacy-tailwind-token` **1650 → 1650**,
`uppercase-text` **60 → 60**, `emoji-icon` **28 → 28** — byte-identical, confirming the
stripper is scoped to `production-hex` alone and did not silently lower three other
baselines. `production-hex` 299 → 279 (detector) and `panel-typography-scoped` 44 → 32
(exactly the 12 occurrences removed by the 6 fixes).

---

## Rebase onto the staging tip — and the first thing the gate caught was not mine

Rebased from `289b730d` onto `0f22854b` (four PRs landed while this was in flight:
#756–#759). CI runs `pull_request` against the **merge ref**, so the first push failed the
new step — correctly. `--enforce` on the rebase surfaced **exactly one** net-new gating
violation, and it belongs to #758:

```
src/canvas/edges/edgePresentation.ts:62
export const STRUCTURAL_EDGE_COLOUR = '#B8B8B8'      # b3a2b4bf, "one edge-style authority (#758)"
```

A genuine raw hex colour — not a false positive — merged **while the guard was still
report-only**, which is the exact hole this PR closes. **The gate's first act was to catch
real drift that the report-only posture had waved through.**

**Baselined, not fixed**, for two reasons: it is pre-existing debt *relative to
enforcement* (existing debt does not block; only additions to it do — that is what the
baseline is for), and `edgePresentation.ts`/`StyledEdge.tsx` belong to that lane, so
tokenising a just-merged edge-style authority is its owner's call, not this lane's.

Added **surgically — one signature entry plus count bookkeeping, 9 insertions**.
`--update --force` was the alternative but rewrites the whole file (~500 lines of unrelated
slack), burying the one deliberate blessing in noise. A one-entry diff is reviewable; a
regeneration is not.

**Proven it grants no immunity** (worktree re-derived at the post-baseline head, pristine
green, control 0):

| mutant | expected | result |
|---|---|---|
| M8 a **different** hex added to `edgePresentation.ts` | RED | **RED** — flags `#C9C9C9` |
| M9 a **second** occurrence of `#B8B8B8` in it | RED | **RED** — count 2 > baseline 1 |

An earlier run of these two was **voided and redone**: the commit had not actually taken
(the baseline edit was unstaged), so they executed against a tree without the baseline entry
— which makes M9 vacuous, since `#B8B8B8` reds trivially against a baseline of 0.

**→ Action for the #758 owner:** replace `'#B8B8B8'` with a semantic token and remove the
baseline entry. Filed here rather than done here, per lane ownership.

### Also worth flagging for anyone rebasing onto this tip

`e2e/visual/harness.ts` and `e2e/visual/selftest.visual.spec.ts` (from #757) import `pngjs`
and `pixelmatch`, newly added to `package.json`/the lockfile. A lane holding a
pre-rebase `node_modules` gets three `TS2307` typecheck-ratchet failures that look like new
drift and are purely a stale install — `pnpm install --frozen-lockfile` after rebasing.

---

## Disclosure: my local full-suite run had 1 failure, and it is pre-existing

Reporting this rather than leaving it in a log. The local full run at the pre-rebase head
finished **1 failed / 24,387 passed / 52 skipped (24,440)**. The failure:

```
src/canvas/components/__tests__/aiPanelV2.parity.spec.tsx
  > OUTPUT_TABS list does NOT include "olumi" when flag is explicitly disabled (rollback)
  Error: Test timed out in 5000ms
```

**Measured, not assumed, to be pre-existing.** A control worktree at pristine
`origin/staging` (`0f22854b`), same environment and same `node_modules`, with none of this
PR's changes present, **reproduces the failure**. The spec also references **zero** of this
PR's changed files. And it is **flaky**: 1 failure in the full run, 2 in isolation, 1 at
pristine — a timeout-shaped flake, and my run took 62 minutes because a mutant battery and a
typecheck were contending on the same machine.

CI is the authority here and it is green: **all 4 `Full Test Suite` shards plus
`Full Test Suite Summary` passed** at `559aaf20`.

**Flagging for whoever owns AI Panel V2:** that assertion is timing-dependent enough to fail
locally on pristine `staging`. Not touched from here — out of seam.

### One instrument note worth carrying

The background-task notification for that run reported **"exit code 0"** — that was the
*wrapper script's* exit, not vitest's. The log's own line read `EXIT=1`. A harness that
reports the exit code of the last command in a pipeline will call a failing suite green;
read the suite's own summary, never the wrapper's status.
