### PR TITLE
fix(pre-run): recognise analysis_ready.status 'blocked' — and kill the status mirror that lost it

### DIFF
--- a/scripts/ci/typecheck-baseline-identities.txt
+++ b/scripts/ci/typecheck-baseline-identities.txt
@@ -768,7 +768,7 @@
 1	src/canvas/ui/inspector/SignedStrengthSlider.tsx	TS6133	'effectCoaching' is declared but its value is never read.
 1	src/canvas/ui/inspector/StrengthBar.stories.tsx	TS2307	Cannot find module '@storybook/react' or its corresponding type declarations.
 4	src/canvas/ui/inspector/StrengthBar.stories.tsx	TS7006	Parameter 'Story' implicitly has an 'any' type.
-1	src/canvas/utils/__tests__/ceeAnalysisReadyValidation.spec.ts	TS2322	Type '"analysis_ready"' is not assignable to type '"needs_encoding" | "needs_user_input" | "needs_user_mapping" | "ready" | undefined'.
+1	src/canvas/utils/__tests__/ceeAnalysisReadyValidation.spec.ts	TS2322	Type '"analysis_ready"' is not assignable to type '"blocked" | "needs_encoding" | "needs_user_input" | "needs_user_mapping" | "ready" | undefined'.
 2	src/canvas/utils/__tests__/ceeAnalysisReadyValidation.spec.ts	TS2322	Type 'number' is not assignable to type 'CEEInterventionV3'.
 9	src/canvas/utils/__tests__/computeOptionPaths.spec.ts	TS2345	Argument of type '({ id: string; interventions: { factorX: number; factorY?: undefined; }; } | { id: string; interventions: { factorY: number; factorX?: undefined; }; })[]' is not assignable to parameter of type 'CeeOption[]'.
 30	src/canvas/utils/__tests__/graphDisplayCalculations.spec.ts	TS2345	Argument of type '({ id: string; interventions: { 'factor-1': number; 'factor-2': number; }; } | { id: string; interventions: { 'factor-1': number; 'factor-2'?: undefined; }; })[]' is not assignable to parameter of type 'OptionWithInterventions[]'.

--- a/src/adapters/cee/types.ts
+++ b/src/adapters/cee/types.ts
@@ -351,6 +351,64 @@ export interface CEEOptionV3 {
   is_baseline?: boolean | null
 }
 
+// ── analysis_ready.status — the ONE recorded producer vocabulary ───────────
+
+/**
+ * CEE's `AnalysisReadyStatus`, recorded here ONCE so the UI has a single place
+ * that answers "what can `analysis_ready.status` be".
+ *
+ * ⚠ WHY THIS IS A RECORDED MIRROR AND NOT A DERIVATION — measured, not assumed.
+ * The enum is NOT exported by the shared contract: `AnalysisReadyStatus` has
+ * ZERO occurrences in the vendored `@talchain/schemas` 0.48.0 tarball AND in
+ * `olumi-schemas` main (`81493081`). Positive/contrast controls in the same
+ * sweep: `ProductReadiness` (6 hits) and `ValidationBlocker` (4 files) are both
+ * present, so the zero is real absence rather than a blind probe.
+ * `ProductReadiness` is a DIFFERENT, three-member enum
+ * (`ready | needs_encoding | needs_user_mapping`) — importing it here would be
+ * worse than this list, not better: it is short by two members.
+ *
+ * So it cannot be derived, and per CLAUDE.md trap 12 the mirror must instead
+ * FAIL LOUD on drift rather than assume-good. Two mechanisms do that:
+ *   1. `STATUS_DISPOSITION` in `usePreRunValidation.ts` is typed
+ *      `Record<RecognisedAnalysisReadyStatus, …>`, so adding a member here
+ *      without deciding what the product DOES about it is a TYPECHECK FAILURE,
+ *      and removing one orphans a key — also a typecheck failure. The build
+ *      breaks; a user never meets an unhandled status as jargon.
+ *   2. `crossSurfaceCoherence.realCaptures.spec.ts` REDs when a status present
+ *      in the real capture corpus is not a member here.
+ *
+ * SOURCE OF TRUTH: cee `src/schemas/analysis-ready.ts:220-227` (read at CEE
+ * staging `83a11574`). Keep the order identical to the producer's enum so a
+ * diff between the two is a straight read.
+ */
+export const ANALYSIS_READY_STATUSES = [
+  'ready',
+  'needs_user_mapping',
+  'needs_encoding',
+  'needs_user_input',
+  'blocked',
+] as const
+
+/** A value CEE's `AnalysisReadyStatus` can hold. */
+export type AnalysisReadyStatus = (typeof ANALYSIS_READY_STATUSES)[number]
+
+/**
+ * NOT a producer value — a sentinel the UI mints itself. `applyV5State.ts:262`
+ * coerces a missing/non-string `analysis_ready.status` to `'unknown'` so the
+ * lenient V5 normaliser never drops the payload. It means "CEE said nothing
+ * about readiness on this turn", which is not a verdict of any kind.
+ */
+export const ANALYSIS_READY_STATUS_UNSUPPLIED = 'unknown'
+
+/** Producer vocabulary ∪ the UI's own unsupplied sentinel. */
+export const RECOGNISED_ANALYSIS_READY_STATUSES = [
+  ...ANALYSIS_READY_STATUSES,
+  ANALYSIS_READY_STATUS_UNSUPPLIED,
+] as const
+
+export type RecognisedAnalysisReadyStatus =
+  (typeof RECOGNISED_ANALYSIS_READY_STATUSES)[number]
+
 /**
  * CEE V3 analysis_ready payload.
  *
@@ -365,13 +423,25 @@ export interface CEEAnalysisReady {
   /** Suggested seed for reproducibility (string, defaults to "42") */
   suggested_seed?: string
   /**
-   * Overall readiness status.
+   * Overall readiness status. Derived from `ANALYSIS_READY_STATUSES` above —
+   * do NOT re-spell the union here; that copy is exactly what drifted.
    * - 'ready': All options resolved, graph is valid, can run analysis
    * - 'needs_encoding': Options have categorical values needing encoding
    * - 'needs_user_mapping': Structural issues (e.g., no causal path to goal)
    * - 'needs_user_input': Deterministic user action required (hard block, no bypass)
+   * - 'blocked': CEE refused — a validation failure prevents analysis. Carries
+   *   `blocked_reason`. Reachable HERE with populated options via the
+   *   `semantic` + `hardBlocked` branch (cee `analysis-ready-helper.ts:1113-1119`).
    */
-  status?: 'ready' | 'needs_encoding' | 'needs_user_mapping' | 'needs_user_input'
+  status?: AnalysisReadyStatus
+  /**
+   * Machine-readable code for WHY CEE refused. Present iff `status === 'blocked'`
+   * (cee `src/schemas/analysis-ready.ts`, `AnalysisReadyPayload.blocked_reason`,
+   * `z.string().min(1).optional()`). Its vocabulary is `ReadinessReasonCode` /
+   * `StructuralViolationCode` / `cause_kind` — the same keys
+   * `ANALYSIS_REFUSAL_REASON_COPY` maps to sentences. NEVER user copy on its own.
+   */
+  blocked_reason?: string
   /**
    * User-facing questions explaining issues when status is not 'ready'.
    * E.g., "The factor 'Price' doesn't have a path to the goal. Is this correct?"

--- a/src/canvas/components/pre-analysis/blockerEnrichment.ts
+++ b/src/canvas/components/pre-analysis/blockerEnrichment.ts
@@ -108,6 +108,32 @@ const BLOCKER_DISPLAY: Record<string, BlockerDisplayMeta> = {
     supportsRetry: true,
     suggestedActions: ['Retry draft', 'Edit brief'],
   },
+  /**
+   * CEE refused the analysis (`analysis_ready.status: 'blocked'`).
+   *
+   * `supportsRetry: false` is the load-bearing field, not the blocker's action:
+   * BlockersSection gates the destructive "Retry Draft" button on THIS flag,
+   * keyed by code. Re-drafting discards options the user added in chat and
+   * would not touch the structural fault CEE objected to, so the button must
+   * not render (P8 — never offer what cannot be honoured).
+   *
+   * `suggestedActions: []` for the same reason: this panel has no affordance
+   * that recovers a refused graph, and listing one we cannot bind would be the
+   * same defect in bullet form. The description carries the producer's own
+   * reason sentence instead — see the pass-through in `enrichBlocker`.
+   *
+   * Severity is 'warning', not 'critical': the reachable reason set includes
+   * `INTERNAL_ERROR` ("This is on our side, not your model"), and an alarm-red
+   * treatment would contradict its own sentence. Same reasoning the reviewed
+   * `AnalysisRefusalNotice` tone note records.
+   */
+  ANALYSIS_BLOCKED: {
+    title: "This model can't be analysed yet",
+    description: 'The analysis was stopped before it ran.',
+    severity: 'warning',
+    supportsRetry: false,
+    suggestedActions: [],
+  },
   ANALYSIS_READY_INVALID: {
     title: 'Invalid analysis response',
     description: 'Analysis response is missing option data. Please re-draft.',
@@ -181,6 +207,8 @@ const BLOCKER_SORT_ORDER: Record<string, number> = {
   GOAL_NODE_KIND_MISMATCH: 12,
   NO_OPTIONS: 13,
   INTERVENTION_TARGETS_OPTION: 14,
+  // Producer refusal — CEE's own hard verdict, above the draft-failure family
+  ANALYSIS_BLOCKED: 19,
   // Draft failure (show second)
   ANALYSIS_NOT_READY: 20,
   ANALYSIS_READY_INVALID: 21,
@@ -238,6 +266,18 @@ export function enrichBlocker(blocker: ValidationBlocker): EnrichedBlocker {
     display = {
       ...display,
       title: `Options need configuration: ${optionNames.join(', ')}${suffix}`,
+    }
+  }
+
+  // ANALYSIS_BLOCKED: the description IS the producer's reason sentence, mapped
+  // from `blocked_reason` by the same table AnalysisRefusalNotice uses. The
+  // static description above is only the fallback for a blocker that somehow
+  // carries no message; deriving both surfaces from one map is what keeps them
+  // from contradicting each other on a single payload.
+  if (blocker.code === 'ANALYSIS_BLOCKED' && blocker.message) {
+    display = {
+      ...display,
+      description: blocker.message,
     }
   }
 

--- a/src/canvas/hooks/__tests__/usePreRunValidation.blockedStatus.spec.ts
+++ b/src/canvas/hooks/__tests__/usePreRunValidation.blockedStatus.spec.ts
@@ -1,0 +1,320 @@
+/**
+ * `analysis_ready.status: 'blocked'` — the pre-run gate must not answer a
+ * producer refusal with engine jargon and a destructive remedy.
+ *
+ * THE DEFECT, AND WHY IT REACHES A USER
+ * -------------------------------------
+ * `usePreRunValidation`'s `RECOGNISED_STATUSES` was a hand-maintained copy of
+ * CEE's `AnalysisReadyStatus` (cee `src/schemas/analysis-ready.ts:220-227`) and
+ * was one member short: it had no `'blocked'`. A blocked payload therefore took
+ * the defensive unrecognised-status branch and produced
+ *   `Unrecognised analysis status "blocked". Please re-draft.`
+ * with `action: { type: 'retry_draft' }` — engine jargon quoting an internal
+ * status name, offering a remedy that DISCARDS options the user added in chat
+ * (the same destruction ROADMAP 2.924 removed from the sibling branch).
+ *
+ * REACHABILITY — derived at the producer, not assumed (trap 16-inverse: a path
+ * being executable says nothing about the producer being able to feed it):
+ *   cee `src/orchestrator/tools/analysis-ready-helper.ts:1113-1119` — the
+ *   `semantic` + `hardBlocked` branch spreads the FULL readiness payload (real
+ *   `goal_node_id`, NON-EMPTY `options`) and overwrites `status: 'blocked'` with
+ *   a `blocked_reason`. That carrier survives the UI's lenient V5 normaliser
+ *   (`src/v5/applyV5State.ts:228-296`, which only requires >=1 normalisable
+ *   option) and is written to the store by `setCeeAnalysisReady`
+ *   (`applyV5State.ts:1191`) — so it arrives here with options populated.
+ *   The OTHER two blocked carriers (`analysis-ready-helper.ts:1123` and
+ *   `orchestrator-v5/compose/analysis-ready-emit.ts:60`) carry `options: []`
+ *   and are rejected upstream; they are not the case under test.
+ *
+ * The fixtures below are that carrier's shape. Assertions bind to the blocker by
+ * CODE and to the message by the EXACT producer-derived sentence — never by a
+ * predicate another blocker could satisfy (trap 19).
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { Node } from '@xyflow/react'
+import {
+  ANALYSIS_READY_STATUSES,
+  ANALYSIS_READY_STATUS_UNSUPPLIED,
+  RECOGNISED_ANALYSIS_READY_STATUSES,
+  type CEEAnalysisReady,
+} from '../../../adapters/cee/types'
+import { SOFT_BYPASS_STATUSES, validateBeforeRun } from '../usePreRunValidation'
+import { KNOWN_READINESS_STATUSES } from '../../../lib/coherence/crossSurfaceCoherence'
+import { enrichBlocker } from '../../components/pre-analysis/blockerEnrichment'
+import {
+  ANALYSIS_REFUSAL_GENERIC_REASON,
+  describeAnalysisRefusalReason,
+} from '../../store/analysisRefusalNotice'
+
+// ---------------------------------------------------------------------------
+// Fixtures — the reachable `blocked` carrier
+// ---------------------------------------------------------------------------
+
+const GOAL_ID = 'goal_revenue'
+const OPTION_A_ID = 'opt_partnerships'
+const OPTION_A_LABEL = 'Grow via partnerships'
+const OPTION_B_ID = 'opt_direct_sales'
+const OPTION_B_LABEL = 'Hire direct sales'
+
+/** A structural code CEE really emits (StructuralViolationCode, graph-structure-validator.ts:22-32). */
+const MAPPED_REASON_CODE = 'NO_PATH_TO_GOAL'
+
+function nodes(): Node[] {
+  return [
+    { id: GOAL_ID, type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Revenue', kind: 'goal' } },
+    { id: OPTION_A_ID, type: 'option', position: { x: 0, y: 0 }, data: { label: OPTION_A_LABEL, kind: 'option' } },
+    { id: OPTION_B_ID, type: 'option', position: { x: 0, y: 0 }, data: { label: OPTION_B_LABEL, kind: 'option' } },
+  ]
+}
+
+/**
+ * The `semantic` + `hardBlocked` carrier: every option fully RESOLVED
+ * (`status: 'ready'`, non-empty interventions) while the overall status is
+ * `blocked`. Options being resolved is the point — it is what makes the
+ * soft-bypass path look tempting, and CEE's hard block must still win.
+ */
+function blockedCarrier(overrides: Partial<CEEAnalysisReady> = {}): CEEAnalysisReady {
+  return {
+    goal_node_id: GOAL_ID,
+    status: 'blocked' as CEEAnalysisReady['status'],
+    blocked_reason: MAPPED_REASON_CODE,
+    options: [
+      { id: OPTION_A_ID, label: OPTION_A_LABEL, status: 'ready', interventions: { fac_reach: 0.4 } },
+      { id: OPTION_B_ID, label: OPTION_B_LABEL, status: 'ready', interventions: { fac_reach: 0.2 } },
+    ],
+    ...overrides,
+  } as CEEAnalysisReady
+}
+
+function blockerCodes(result: ReturnType<typeof validateBeforeRun>): string[] {
+  return result.blockers.map(b => b.code)
+}
+
+// ---------------------------------------------------------------------------
+
+describe('analysis_ready.status "blocked" is recognised and answered honestly', () => {
+  it('does not emit the unrecognised-status jargon message', () => {
+    const result = validateBeforeRun(GOAL_ID, nodes(), [], blockedCarrier())
+    const messages = result.blockers.map(b => b.message)
+    expect(messages).not.toContain('Unrecognised analysis status "blocked". Please re-draft.')
+    for (const message of messages) {
+      expect(message).not.toContain('blocked')
+      expect(message).not.toContain('Unrecognised analysis status')
+    }
+  })
+
+  it('emits ANALYSIS_BLOCKED carrying the producer-derived sentence for its blocked_reason', () => {
+    const result = validateBeforeRun(GOAL_ID, nodes(), [], blockedCarrier())
+    expect(blockerCodes(result)).toContain('ANALYSIS_BLOCKED')
+
+    const blocked = result.blockers.find(b => b.code === 'ANALYSIS_BLOCKED')
+    // Identity-bound: the exact sentence the producer-derived map holds for
+    // THIS code, not "some sentence mentioning the goal".
+    const expected = describeAnalysisRefusalReason(MAPPED_REASON_CODE)
+    expect(expected).toBe(
+      'No option connects to the goal through the model, so there was nothing to compute.',
+    )
+    expect(blocked?.message).toBe(expected)
+  })
+
+  it('offers NO destructive re-draft — and no action at all, because none recovers this state', () => {
+    const result = validateBeforeRun(GOAL_ID, nodes(), [], blockedCarrier())
+    const blocked = result.blockers.find(b => b.code === 'ANALYSIS_BLOCKED')
+    expect(blocked?.action).toBeUndefined()
+    // No OTHER blocker on this payload may smuggle the destructive remedy back.
+    expect(result.blockers.some(b => b.action?.type === 'retry_draft')).toBe(false)
+  })
+
+  it('still blocks the run — recognising the status must not make it runnable', () => {
+    const result = validateBeforeRun(GOAL_ID, nodes(), [], blockedCarrier())
+    expect(result.canRun).toBe(false)
+  })
+
+  it('is NOT soft-bypassed when every option is resolved (CEE hard block wins)', () => {
+    // Same carrier, all options ready with interventions — the exact input that
+    // makes the needs_encoding/needs_user_mapping bypass fire. It must not fire here.
+    const result = validateBeforeRun(GOAL_ID, nodes(), [], blockedCarrier())
+    expect(blockerCodes(result)).toContain('ANALYSIS_BLOCKED')
+    expect(result.warnings.some(w => w.code === 'ANALYSIS_NOT_READY')).toBe(false)
+  })
+
+  it('falls back to the honest generic — never a guessed specific — for an unmapped blocked_reason', () => {
+    const result = validateBeforeRun(
+      GOAL_ID,
+      nodes(),
+      [],
+      blockedCarrier({ blocked_reason: 'A_BRAND_NEW_CEE_CODE' } as Partial<CEEAnalysisReady>),
+    )
+    const blocked = result.blockers.find(b => b.code === 'ANALYSIS_BLOCKED')
+    expect(describeAnalysisRefusalReason('A_BRAND_NEW_CEE_CODE')).toBeNull()
+    expect(blocked?.message).toBe(ANALYSIS_REFUSAL_GENERIC_REASON)
+    expect(blocked?.action).toBeUndefined()
+  })
+
+  it('says only what it can when blocked_reason is absent, and still blocks', () => {
+    const result = validateBeforeRun(
+      GOAL_ID,
+      nodes(),
+      [],
+      blockedCarrier({ blocked_reason: undefined } as Partial<CEEAnalysisReady>),
+    )
+    const blocked = result.blockers.find(b => b.code === 'ANALYSIS_BLOCKED')
+    expect(blocked?.message).toBe(ANALYSIS_REFUSAL_GENERIC_REASON)
+    expect(result.canRun).toBe(false)
+  })
+})
+
+describe('the MOUNTED consumer renders no destructive affordance for it (P2)', () => {
+  // BlockersSection.tsx:199 gates the "Retry Draft" button on
+  // `display.supportsRetry`, keyed by blocker CODE — never on `blocker.action`.
+  // So the code's display metadata, not the action, is what removes the button.
+  it('enrichBlocker gives ANALYSIS_BLOCKED supportsRetry=false and no suggested actions', () => {
+    const result = validateBeforeRun(GOAL_ID, nodes(), [], blockedCarrier())
+    const blocked = result.blockers.find(b => b.code === 'ANALYSIS_BLOCKED')!
+    const enriched = enrichBlocker(blocked)
+    expect(enriched.display.supportsRetry).toBe(false)
+    expect(enriched.display.suggestedActions).toEqual([])
+  })
+
+  it('the rendered description IS the producer-derived sentence, not the generic fallback title text', () => {
+    const result = validateBeforeRun(GOAL_ID, nodes(), [], blockedCarrier())
+    const blocked = result.blockers.find(b => b.code === 'ANALYSIS_BLOCKED')!
+    const enriched = enrichBlocker(blocked)
+    expect(enriched.display.description).toBe(describeAnalysisRefusalReason(MAPPED_REASON_CODE))
+    // Not the UNKNOWN_BLOCKER fallback — that would mean the code has no entry.
+    expect(enriched.display.title).not.toBe('Validation issue')
+  })
+})
+
+describe('THE DRIFT GUARD — one recorded vocabulary, and drift breaks the build', () => {
+  /**
+   * The producer half cannot be DERIVED: CEE's `AnalysisReadyStatus` is not
+   * exported by `@talchain/schemas` at the 0.48.0 pin, nor by olumi-schemas
+   * main — measured with contrast controls (`ProductReadiness`,
+   * `ValidationBlocker` both present in the same sweep). So it is a RECORDED
+   * mirror, and per trap 12 it must fail LOUD instead of assuming good.
+   *
+   * The loud mechanism is TYPE-LEVEL and lives in `usePreRunValidation.ts`:
+   * `STATUS_DISPOSITION` is `Record<RecognisedAnalysisReadyStatus, …>`, so a
+   * member added here without a decision about what the product does is a
+   * missing-property error, and a member removed leaves an excess key. Those
+   * are compile failures, which no test can express — the mutation battery in
+   * the PR record proves both directions.
+   *
+   * What THIS block adds is the runtime half: the recorded list is pinned to
+   * the producer's exact five, and every consumer of the vocabulary is total
+   * over it, so a silent widening cannot pass unnoticed either.
+   */
+  it('pins the recorded vocabulary to CEE AnalysisReadyStatus — exactly five, in producer order', () => {
+    // cee src/schemas/analysis-ready.ts:220-227, read at CEE staging 83a11574.
+    expect([...ANALYSIS_READY_STATUSES]).toEqual([
+      'ready',
+      'needs_user_mapping',
+      'needs_encoding',
+      'needs_user_input',
+      'blocked',
+    ])
+  })
+
+  it("'unknown' is the UI's own sentinel and is NOT part of the producer vocabulary", () => {
+    // applyV5State.ts:262 mints it when CEE sends no usable status. Recording
+    // it as a producer value would assert CEE emits a verdict it never emits.
+    expect(ANALYSIS_READY_STATUSES as readonly string[]).not.toContain(
+      ANALYSIS_READY_STATUS_UNSUPPLIED,
+    )
+    expect(RECOGNISED_ANALYSIS_READY_STATUSES).toContain(ANALYSIS_READY_STATUS_UNSUPPLIED)
+    expect(RECOGNISED_ANALYSIS_READY_STATUSES).toHaveLength(
+      ANALYSIS_READY_STATUSES.length + 1,
+    )
+  })
+
+  it('every recognised status resolves to a branch — none silently falls through', () => {
+    // Totality in the direction a test CAN see: drive each member through the
+    // real validator and require a decision (runnable, or a blocker).
+    for (const status of RECOGNISED_ANALYSIS_READY_STATUSES) {
+      const carrier = blockedCarrier({
+        status: status as CEEAnalysisReady['status'],
+        blocked_reason: status === 'blocked' ? MAPPED_REASON_CODE : undefined,
+      } as Partial<CEEAnalysisReady>)
+      const result = validateBeforeRun(GOAL_ID, nodes(), [], carrier)
+      if (status === 'ready') {
+        expect(result.canRun, `status "${status}" should be runnable`).toBe(true)
+      } else {
+        expect(
+          result.blockers.length + result.warnings.length,
+          `status "${status}" produced neither a blocker nor a warning`,
+        ).toBeGreaterThan(0)
+      }
+      // No recognised status may reach the unrecognised-jargon sentence.
+      for (const b of result.blockers) {
+        expect(b.message).not.toContain('Unrecognised analysis status')
+      }
+    }
+  })
+
+  it('SOFT_BYPASS_STATUSES is derived from the disposition map, not hand-listed', () => {
+    expect([...SOFT_BYPASS_STATUSES].sort()).toEqual(['needs_encoding', 'needs_user_mapping'])
+    // The two members that must never be bypassable.
+    expect(SOFT_BYPASS_STATUSES.has('blocked')).toBe(false)
+    expect(SOFT_BYPASS_STATUSES.has('needs_user_input')).toBe(false)
+    // Every member is a real producer status — a typo could not survive this.
+    for (const status of SOFT_BYPASS_STATUSES) {
+      expect(ANALYSIS_READY_STATUSES as readonly string[]).toContain(status)
+    }
+  })
+
+  it('the coherence module reads the SAME vocabulary — the two lists cannot disagree', () => {
+    // crossSurfaceCoherence kept a second copy of the producer enum. It now
+    // spreads this one, so a change here reaches both surfaces at once.
+    for (const status of ANALYSIS_READY_STATUSES) {
+      expect(KNOWN_READINESS_STATUSES).toContain(status)
+    }
+    expect(KNOWN_READINESS_STATUSES).toHaveLength(ANALYSIS_READY_STATUSES.length + 1)
+  })
+})
+
+describe('OPPOSITE-DIRECTION TWIN — a genuinely unrecognised status keeps the unrecognised path', () => {
+  // Recognising `blocked` must not degrade into recognising everything. A status
+  // outside the producer's vocabulary is still a defensive hard block, because
+  // silently accepting it would trade a jargon message for a silent wrong answer.
+  it('keeps ANALYSIS_NOT_READY + the unrecognised message + retry_draft for an unknown status', () => {
+    const carrier = blockedCarrier({
+      status: 'totally_invented_status' as CEEAnalysisReady['status'],
+      blocked_reason: undefined,
+    } as Partial<CEEAnalysisReady>)
+    const result = validateBeforeRun(GOAL_ID, nodes(), [], carrier)
+
+    expect(blockerCodes(result)).toContain('ANALYSIS_NOT_READY')
+    expect(blockerCodes(result)).not.toContain('ANALYSIS_BLOCKED')
+    const blocker = result.blockers.find(b => b.code === 'ANALYSIS_NOT_READY')
+    expect(blocker?.message).toBe(
+      'Unrecognised analysis status "totally_invented_status". Please re-draft.',
+    )
+    expect(blocker?.action).toEqual({ type: 'retry_draft', label: 'Retry Draft' })
+    expect(result.canRun).toBe(false)
+  })
+
+  it('leaves the four already-recognised statuses on their existing branches', () => {
+    // needs_user_input keeps its own hard block and its own copy.
+    const needsInput = validateBeforeRun(
+      GOAL_ID,
+      nodes(),
+      [],
+      blockedCarrier({ status: 'needs_user_input', blocked_reason: undefined } as Partial<CEEAnalysisReady>),
+    )
+    const inputBlocker = needsInput.blockers.find(b => b.code === 'ANALYSIS_NOT_READY')
+    expect(inputBlocker?.message).toBe('Your decision brief needs changes before analysis can run.')
+    expect(blockerCodes(needsInput)).not.toContain('ANALYSIS_BLOCKED')
+
+    // ready stays runnable.
+    const ready = validateBeforeRun(
+      GOAL_ID,
+      nodes(),
+      [],
+      blockedCarrier({ status: 'ready', blocked_reason: undefined } as Partial<CEEAnalysisReady>),
+    )
+    expect(blockerCodes(ready)).not.toContain('ANALYSIS_BLOCKED')
+    expect(ready.canRun).toBe(true)
+  })
+})

--- a/src/canvas/hooks/__tests__/usePreRunValidation.blockedStatus.spec.ts
+++ b/src/canvas/hooks/__tests__/usePreRunValidation.blockedStatus.spec.ts
@@ -41,6 +41,7 @@ import {
 } from '../../../adapters/cee/types'
 import { SOFT_BYPASS_STATUSES, validateBeforeRun } from '../usePreRunValidation'
 import { KNOWN_READINESS_STATUSES } from '../../../lib/coherence/crossSurfaceCoherence'
+import { deriveAnalysisDisplayState } from '../../utils/deriveAnalysisDisplayState'
 import { enrichBlocker } from '../../components/pre-analysis/blockerEnrichment'
 import {
   ANALYSIS_REFUSAL_GENERIC_REASON,
@@ -261,6 +262,24 @@ describe('THE DRIFT GUARD — one recorded vocabulary, and drift breaks the buil
     // Every member is a real producer status — a typo could not survive this.
     for (const status of SOFT_BYPASS_STATUSES) {
       expect(ANALYSIS_READY_STATUSES as readonly string[]).toContain(status)
+    }
+  })
+
+  it('the display-state helper derives its not-ready set from the SAME vocabulary', () => {
+    // `deriveAnalysisDisplayState` kept a fifth copy of the producer enum (its
+    // negative half). Deriving the complement means a status CEE adds later
+    // renders not-ready rather than a green "Analysis complete".
+    for (const status of ANALYSIS_READY_STATUSES) {
+      const { state } = deriveAnalysisDisplayState({
+        ceeAnalysisReadyStatus: status,
+        hasReport: true,
+        analysisChanged: false,
+      })
+      if (status === 'ready') {
+        expect(state, `"${status}" must not be forced not_ready`).not.toBe('not_ready')
+      } else {
+        expect(state, `"${status}" must render not_ready even with a prior report`).toBe('not_ready')
+      }
     }
   })
 

--- a/src/canvas/hooks/usePreRunValidation.ts
+++ b/src/canvas/hooks/usePreRunValidation.ts
@@ -18,7 +18,15 @@ import type { Node, Edge } from '@xyflow/react'
 import type { UIOption } from '../../types/options'
 import { normaliseOptionFromLegacyNode, type LegacyOptionNode } from '../../types/options'
 import { validateAllEdges, ceeOptionToUIOption } from '../../adapters/plot/v2'
-import type { CEEAnalysisReady } from '../../adapters/cee/types'
+import {
+  RECOGNISED_ANALYSIS_READY_STATUSES,
+  type CEEAnalysisReady,
+  type RecognisedAnalysisReadyStatus,
+} from '../../adapters/cee/types'
+import {
+  ANALYSIS_REFUSAL_GENERIC_REASON,
+  describeAnalysisRefusalReason,
+} from '../store/analysisRefusalNotice'
 import { detectBaseline } from '../utils/baselineDetection'
 import { DEFAULT_EDGE_DATA } from '../domain/edges'
 import { verboseWarn } from '../../utils/verboseLog'
@@ -26,26 +34,75 @@ import { getEdgeKey } from '../domain/edgeUtils'
 import type { ValidationWarning, ValidationBlocker } from '@talchain/schemas'
 
 /**
+ * What this gate DOES about each status it recognises.
+ *
+ * ⭐ THIS MAP IS THE DRIFT GUARD, and it is load-bearing rather than
+ * decorative — every branch below is selected from it, so it cannot agree with
+ * itself while the validator does something else (trap 13b).
+ *
+ * `Record<RecognisedAnalysisReadyStatus, …>` is total by construction:
+ *   • a member ADDED to `RECOGNISED_ANALYSIS_READY_STATUSES` and not given a
+ *     disposition here is a TS2741 missing-property error;
+ *   • a member REMOVED there leaves an excess key here — a TS2353 error.
+ * Either way the BUILD breaks. That is the fail-loud CLAUDE.md trap 12 asks for
+ * where derivation is impossible, and derivation IS impossible here: CEE's
+ * `AnalysisReadyStatus` is not exported by `@talchain/schemas` at the 0.48.0 pin
+ * (measured with contrast controls — see the note on the vocabulary itself).
+ *
+ * Before this map, the recognised set was a hand-typed copy of the producer's
+ * enum that was one member short. `blocked` fell through to the defensive
+ * unrecognised branch, so a refused analysis told the user
+ * `Unrecognised analysis status "blocked". Please re-draft.` and offered a
+ * re-draft that discards options added in chat.
+ */
+type StatusDisposition =
+  /** CEE says this model can be analysed. */
+  | 'runnable'
+  /** CEE REFUSED: a validation failure prevents analysis. `blocked_reason` says why. */
+  | 'producer_blocked'
+  /** Deterministic user action required — hard block, never bypassed. */
+  | 'hard_block_brief'
+  /** LLM metadata omission; bypassable when the option data is actually resolved. */
+  | 'soft_bypassable'
+  /** No readiness verdict on this turn. Not a verdict — but not a licence to run. */
+  | 'generic_not_ready'
+
+const STATUS_DISPOSITION: Record<RecognisedAnalysisReadyStatus, StatusDisposition> = {
+  ready: 'runnable',
+  needs_user_mapping: 'soft_bypassable',
+  needs_encoding: 'soft_bypassable',
+  needs_user_input: 'hard_block_brief',
+  blocked: 'producer_blocked',
+  unknown: 'generic_not_ready',
+}
+
+/**
  * CEE statuses that the LLM produces when it drops metadata (e.g. `category`).
  * These can be soft-bypassed when the actual option data is resolved.
  * Also used by PreAnalysisPanel to determine retry eligibility.
+ *
+ * DERIVED from the disposition map — never hand-listed again.
  */
-export const SOFT_BYPASS_STATUSES: ReadonlySet<string> = new Set([
-  'needs_user_mapping',
-  'needs_encoding',
-])
+export const SOFT_BYPASS_STATUSES: ReadonlySet<string> = new Set(
+  Object.entries(STATUS_DISPOSITION)
+    .filter(([, disposition]) => disposition === 'soft_bypassable')
+    .map(([status]) => status),
+)
 
 /**
- * All recognised analysis_ready.status values.
- * Unrecognised values trigger a defensive hard block.
+ * All recognised analysis_ready.status values. Unrecognised values still trigger
+ * the defensive hard block — recognising `blocked` must not become recognising
+ * everything, or a jargon message is merely traded for a silent wrong answer.
  */
-const RECOGNISED_STATUSES: ReadonlySet<string> = new Set([
-  'ready',
-  'needs_user_mapping',
-  'needs_encoding',
-  'needs_user_input',
-  'unknown',
-])
+const RECOGNISED_STATUSES: ReadonlySet<string> = new Set(
+  RECOGNISED_ANALYSIS_READY_STATUSES,
+)
+
+function dispositionOf(status: string): StatusDisposition | undefined {
+  return RECOGNISED_STATUSES.has(status)
+    ? STATUS_DISPOSITION[status as RecognisedAnalysisReadyStatus]
+    : undefined
+}
 
 // ============================================================================
 // Types
@@ -197,10 +254,14 @@ function describeUnresolvedOptions(
  * analysis_ready is the SINGLE SOURCE OF TRUTH for run gating.
  * Top-level cee_response.options[] is for display only — never used for gating.
  *
- * Status handling:
- * - 'ready': proceed
- * - 'needs_user_input': hard block (deterministic, no bypass)
- * - 'needs_user_mapping' / 'needs_encoding': soft-bypassable when options are resolved
+ * Status handling is selected from STATUS_DISPOSITION, never from a string
+ * comparison, so the set of statuses this function knows how to answer and the
+ * set it recognises cannot drift apart:
+ * - 'runnable'          ('ready'): proceed
+ * - 'producer_blocked'  ('blocked'): CEE refused — explain, offer nothing destructive
+ * - 'hard_block_brief'  ('needs_user_input'): hard block (deterministic, no bypass)
+ * - 'soft_bypassable'   ('needs_user_mapping' / 'needs_encoding'): bypass when options resolve
+ * - 'generic_not_ready' ('unknown'): no verdict; generic block + re-draft
  * - unrecognised: defensive hard block
  */
 function validateOverallStatus(
@@ -216,7 +277,8 @@ function validateOverallStatus(
   }
 
   // Defensive: reject unrecognised status values
-  if (!RECOGNISED_STATUSES.has(ceeAnalysisReady.status)) {
+  const disposition = dispositionOf(ceeAnalysisReady.status)
+  if (!disposition) {
     blockers.push({
       code: 'ANALYSIS_NOT_READY',
       message: `Unrecognised analysis status "${ceeAnalysisReady.status}". Please re-draft.`,
@@ -226,9 +288,48 @@ function validateOverallStatus(
   }
 
   // Check overall status
-  if (ceeAnalysisReady.status !== 'ready') {
+  if (disposition !== 'runnable') {
+    // CEE REFUSED this model. The status is a verdict about the GRAPH
+    // (graph_structure / numeric_integrity / internal — cee
+    // analysis-ready-helper.ts:1109-1113), not about an option the user can
+    // open and fill in, so none of this panel's affordances recovers it.
+    //
+    // P8 — never ask what you cannot accept: we therefore offer NO action
+    // rather than a button whose direct answer we cannot honour. `retry_draft`
+    // would be worse than useless — it discards options the user added in chat
+    // (the destruction ROADMAP 2.924 removed from the sibling branch) while
+    // leaving a structural fault untouched.
+    //
+    // The sentence is DERIVED from the producer's own vocabulary via
+    // `describeAnalysisRefusalReason`, the map `AnalysisRefusalNotice` already
+    // uses for the same `blocked_reason` codes. Sharing one map is what stops
+    // the two surfaces contradicting each other on a single payload — both
+    // render on this turn. An unmapped or absent code gets the honest generic,
+    // never a guessed specific.
+    //
+    // ⚠ NOT INHERITED: `ANALYSIS_REFUSAL_POINTER` ("The assistant's reply
+    // explains the next step"). That guarantee was derived for the
+    // handler-failure carrier (`composeHandlerFailureBody` sets `assistant_text`
+    // on every recoverable branch). THIS carrier is the readiness one, and no
+    // equivalent guarantee has been established for it — so asserting the
+    // pointer here would be a promise about a different producer's behaviour.
+    if (disposition === 'producer_blocked') {
+      const reason = ceeAnalysisReady.blocked_reason
+      const mapped = typeof reason === 'string' && reason.trim().length > 0
+        ? describeAnalysisRefusalReason(reason)
+        : null
+      blockers.push({
+        code: 'ANALYSIS_BLOCKED',
+        message: mapped ?? ANALYSIS_REFUSAL_GENERIC_REASON,
+      })
+      if (ceeAnalysisReady.user_questions?.length) {
+        userQuestions.push(...ceeAnalysisReady.user_questions)
+      }
+      return { blockers, warnings, userQuestions }
+    }
+
     // needs_user_input: deterministic user action required — always hard block
-    if (ceeAnalysisReady.status === 'needs_user_input') {
+    if (disposition === 'hard_block_brief') {
       blockers.push({
         code: 'ANALYSIS_NOT_READY',
         message: 'Your decision brief needs changes before analysis can run.',
@@ -244,7 +345,7 @@ function validateOverallStatus(
     // it drops `category` on factor nodes, check if options are actually
     // resolved. If so, the status was downgraded due to missing metadata —
     // not a genuine structural problem.
-    const isSoftStatus = SOFT_BYPASS_STATUSES.has(ceeAnalysisReady.status)
+    const isSoftStatus = disposition === 'soft_bypassable'
 
     // Baseline options correctly have empty interventions ("do nothing").
     // Exclude them from the intervention requirement in the soft bypass check.

--- a/src/canvas/utils/deriveAnalysisDisplayState.ts
+++ b/src/canvas/utils/deriveAnalysisDisplayState.ts
@@ -34,6 +34,8 @@
  * `useAnalysisDisplayState` hook to consume from a component.
  */
 
+import { ANALYSIS_READY_STATUSES } from '../../adapters/cee/types'
+
 export type AnalysisDisplayState =
   | 'not_ready'
   | 'ready_to_analyse'
@@ -93,12 +95,17 @@ export interface AnalysisDisplayStateView {
  * through — without this entry that state would render green "Analysis
  * complete" whenever a prior report is held. Rendering-level mapping only.
  */
-const EXPLICIT_NOT_READY_STATUSES: ReadonlySet<string> = new Set([
-  'needs_encoding',
-  'needs_user_mapping',
-  'needs_user_input',
-  'blocked',
-])
+/**
+ * DERIVED, not hand-listed: every producer status except the one that means
+ * "analysable". Spelling the negatives out was a fifth copy of CEE's
+ * `AnalysisReadyStatus` — the copy family that shipped the `blocked` defect in
+ * `usePreRunValidation`. Deriving the complement also fails toward DETECTION:
+ * a member CEE adds later is not-ready here by default, rather than silently
+ * rendering a green "Analysis complete".
+ */
+const EXPLICIT_NOT_READY_STATUSES: ReadonlySet<string> = new Set(
+  ANALYSIS_READY_STATUSES.filter(status => status !== 'ready'),
+)
 
 function isExplicitNotReady(status: string | undefined): boolean {
   return status !== undefined && EXPLICIT_NOT_READY_STATUSES.has(status)

--- a/src/lib/coherence/crossSurfaceCoherence.ts
+++ b/src/lib/coherence/crossSurfaceCoherence.ts
@@ -126,6 +126,8 @@ import {
   type AnalysisBlocker,
 } from '@talchain/schemas/boundary'
 
+import { ANALYSIS_READY_STATUSES } from '../../adapters/cee/types'
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Producer vocabularies
 // ─────────────────────────────────────────────────────────────────────────────
@@ -155,22 +157,21 @@ export const READINESS_STATUS_UNSUPPLIED = 'unknown'
 
 /**
  * The full `readiness.status` vocabulary CEE can emit, recorded so drift is
- * VISIBLE rather than silent. Derived from `AnalysisReadyStatus`
- * (CEE `src/schemas/analysis-ready.ts:222-228`) plus the unsupplied sentinel.
+ * VISIBLE rather than silent. `AnalysisReadyStatus`
+ * (CEE `src/schemas/analysis-ready.ts:220-227`) plus the unsupplied sentinel.
  *
- * ⚠ This is a MIRROR of a producer registry, and this estate's dominant defect
- * is exactly that. It is therefore NOT load-bearing for any detector — no pair
- * consults it. It exists solely so
- * `crossSurfaceCoherence.contractDerivation.spec.ts` can assert that every
- * status appearing in the real captures is a member, and RED when one is not.
- * A drift makes the suite fail loud; it never silently changes a verdict.
+ * ⚠ Still a MIRROR of a producer registry — the shared contract does not export
+ * that enum at the 0.48.0 pin, so it cannot be derived from `@talchain/schemas`
+ * (measured, with contrast controls; see `ANALYSIS_READY_STATUSES`). What HAS
+ * changed is that this module no longer keeps its own second copy: the producer
+ * half now comes from the single recorded vocabulary in `adapters/cee/types.ts`,
+ * so this list and `usePreRunValidation`'s gate cannot disagree about what CEE
+ * can say. It remains NOT load-bearing for any detector — no pair consults it —
+ * and exists so `crossSurfaceCoherence.contractDerivation.spec.ts` and the real
+ * captures spec RED when a status turns up that is not a member.
  */
 export const KNOWN_READINESS_STATUSES: readonly string[] = [
-  'ready',
-  'needs_user_mapping',
-  'needs_encoding',
-  'needs_user_input',
-  'blocked',
+  ...ANALYSIS_READY_STATUSES,
   READINESS_STATUS_UNSUPPLIED,
 ]
 

--- a/src/lib/contract-validators.ts
+++ b/src/lib/contract-validators.ts
@@ -7,6 +7,8 @@
  * Validators are defensive and never throw - they return validation results.
  */
 
+import { ANALYSIS_READY_STATUSES } from '../adapters/cee/types'
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -66,7 +68,14 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 // CEE Response Validators
 // ============================================================================
 
-const VALID_CEE_STATUSES = ['ready', 'needs_encoding', 'needs_user_mapping', 'needs_user_input'] as const
+/**
+ * Derived from the ONE recorded producer vocabulary rather than re-spelled.
+ * This list was a third hand-maintained copy of CEE's `AnalysisReadyStatus` and
+ * had the same missing member (`blocked`), so this diagnostic reported a valid
+ * refusal payload as `invalid status "blocked"` — a false contract failure in
+ * the tool people reach for when they suspect a contract failure.
+ */
+const VALID_CEE_STATUSES = ANALYSIS_READY_STATUSES
 const VALID_NODE_KINDS = ['goal', 'factor', 'outcome', 'decision', 'risk', 'action', 'option'] as const
 
 /**


### PR DESCRIPTION
## The defect

`usePreRunValidation.ts:42` held a hand-maintained copy of CEE's `AnalysisReadyStatus` and was **one member short** — it had no `'blocked'`. CEE's enum is closed and five-membered (`cee src/schemas/analysis-ready.ts:220-227`).

A blocked payload therefore took the *defensive unrecognised-status* branch and produced:

```json
{ "code": "ANALYSIS_NOT_READY",
  "message": "Unrecognised analysis status \"blocked\". Please re-draft.",
  "action": { "type": "retry_draft", "label": "Retry Draft" } }
```

Engine jargon quoting an internal status name, offering a remedy that **discards options the user added in chat** — the destruction ROADMAP 2.924 removed from the sibling branch. **P8 violation:** the direct answer to the affordance is destructive and would not touch the structural fault CEE objected to.

## Reachability — derived at the producer, not assumed

`cee analysis-ready-helper.ts:1113-1119`, the `semantic` + `hardBlocked` branch, spreads the **full** readiness payload (real `goal_node_id`, **non-empty** `options`) and overwrites `status: 'blocked'` with a `blocked_reason`. That carrier survives the UI's lenient V5 normaliser (`applyV5State.ts:228-296`, which only requires ≥1 normalisable option) and is written to the store at `applyV5State.ts:1191`.

The other two blocked carriers (`analysis-ready-helper.ts:1123`, `analysis-ready-emit.ts:60`) carry `options: []` and are rejected upstream. The graph_patch path is not affected either — `validateAnalysisReadyContract:40` requires `status === 'ready'`.

Independent corroboration found during the sweep: `deriveAnalysisDisplayState.ts:88-93` records the same finding from a prior lane — *"the Ep2 readiness path can emit 'blocked' WITH populated options, which the lenient normaliser passes through"*.

The **same payload** also sets `AnalysisRefusalNotice` (mounted at `AnalysisStateRegion.tsx:80`), so today the user gets an honest refusal notice and a contradictory jargon blocker side by side.

## Derive, or fail loud — which I did, and why

**FAIL LOUD.** Derivation from the shared contract is impossible at this pin, measured rather than assumed:

| probe | result |
|---|---|
| `AnalysisReadyStatus` in vendored `@talchain/schemas` 0.48.0 | **0** |
| `AnalysisReadyStatus` in `olumi-schemas` main (`81493081`) | **0** |
| contrast control `ProductReadiness` | 6 hits — a *different* 3-member enum, short by two |
| contrast control `ValidationBlocker` | 4 files |

So the zero is real absence, not a blind probe. Importing `ProductReadiness` would be **worse** than the mirror, not better.

The mirror is therefore recorded **once** (`ANALYSIS_READY_STATUSES`, `adapters/cee/types.ts`) and made to fail loud two ways:

1. **Type-level, load-bearing.** `STATUS_DISPOSITION` is `Record<RecognisedAnalysisReadyStatus, StatusDisposition>` and every branch in `validateOverallStatus` is selected from it. A member **added** without deciding what the product does is a missing-property error; a member **removed** leaves an excess key. **The build breaks** — a user never meets an unhandled status as jargon.
2. **Runtime.** The spec pins the vocabulary to the producer's exact five, and `crossSurfaceCoherence`'s real-captures spec REDs on an unseen status.

## The copy, and why it is truthful

The sentence is **not new**. It is derived from `describeAnalysisRefusalReason` — the producer-derived `blocked_reason` → sentence map that `AnalysisRefusalNotice` already uses for the same codes. Sharing one map is what stops the two surfaces contradicting each other on a single payload.

- mapped code → its one precise sentence (`NO_PATH_TO_GOAL` → *"No option connects to the goal through the model, so there was nothing to compute."*)
- unmapped or absent code → the honest generic, **never** a guessed specific.

**Affordance: none.** The status is a verdict about the *graph* (`graph_structure` / `numeric_integrity` / `internal`), not about an option the user can open and fill in — no affordance in this panel recovers it. Per P8 the product says what is wrong rather than offering a button it cannot honour. `supportsRetry: false` is the load-bearing field, because `BlockersSection.tsx:199` gates the destructive button on that flag keyed by CODE, not on the blocker's action.

**Deliberately NOT inherited:** `ANALYSIS_REFUSAL_POINTER` ("The assistant's reply explains the next step"). That guarantee was derived for the *handler-failure* carrier; this is the *readiness* carrier and no equivalent guarantee exists for it.

## Sibling-mirror sweep

Scope: fresh clone, all 4,362 tracked files, `rg -a` (binary-safe), case-insensitive. Contrast control `needs_user_mapping` → 42 files (probe can see); fabricated `needs_user_telepathy` → 0 (probe discriminates).

**Same enum — five copies, all now derived from one:**

| location | was |
|---|---|
| `usePreRunValidation.ts:42` | the defect — missing `blocked` |
| `adapters/cee/types.ts` `CEEAnalysisReady.status` | union missing `blocked` |
| `lib/contract-validators.ts:69` `VALID_CEE_STATUSES` | missing `blocked` — reported a valid refusal as `invalid status "blocked"` |
| `lib/coherence/crossSurfaceCoherence.ts` `KNOWN_READINESS_STATUSES` | complete, but a second copy |
| `canvas/utils/deriveAnalysisDisplayState.ts` `EXPLICIT_NOT_READY_STATUSES` | complete, but a fifth copy (now the derived complement of `ready`) |

**Different concept — deliberately untouched (trap 21).** The per-option enum is a genuinely different, three-member producer enum (`OptionForAnalysisStatus = ready | needs_user_mapping | needs_encoding`), and CEE carries a compile-time guard that `needs_user_input` is payload-level only. These must **not** gain `blocked`: `types/options.ts:116`, `adapters/cee/types.ts:344` (`CEEOptionV3`), `adapters/plot/v2/adapter.ts:764`. Also untouched: `pass2.needs_user_input`, an unrelated edge-contestedness boolean that merely shares the name — a blanket regex would have corrupted it.

Untouched by design: `filterRedundantBlockers` has no `ANALYSIS_BLOCKED` entry, so the blocker is never hidden — the safe default.

## Evidence

- **RED-first at pristine:** 11 collected, **8 failed / 3 passed** (the 3 passers are the opposite-direction twins, which must hold before the fix).
- **Green:** `usePreRunValidation.blockedStatus.spec.ts` — **17 collected, 17 passed, asserted by name**.
- Affected suites: 489 files / 7,882 passed, 0 failures; plus 166 files / 3,009 passed after the fifth-mirror change.
- Gate in the required check's step order (`staging-full-tests.yml`: Lint → Type check): lint 0 errors, hooks ratchet exact; typecheck gate **PASSED**, 2306/2306, no added or disappeared diagnostics.
- One baseline identity line updated — the *same* pre-existing error in the *same* file, re-rendered because the union widened. Surgical, not a regenerate.

### Mutation battery

Throwaway worktree at an absolute path outside the repo root; **isolation proven by WRITING a sentinel** (source SHA unchanged, inodes differ); restores from a pristine **archive**; applied-check scoped to `src/` (exactly 1 per mutant, control exactly 0); per-mutant diagnostic count vs the clean tree (P4); leading **and** trailing controls both exit 0 at 1978 diagnostics / 90 collected.

| mutant | verdict |
|---|---|
| M1 drop `blocked` from the vocabulary | **BITTEN** (tests + typecheck) |
| M2 add a sixth CEE member | **BITTEN** (tests + typecheck) — the drift guard's own proof |
| M3 drop a member from the coherence list | BITTEN |
| M4 route `blocked` to the generic branch | BITTEN |
| M5 restore the destructive `retry_draft` action | BITTEN |
| M6 always generic, never the producer sentence | BITTEN |
| M7 `dispositionOf` returns `true` | **demonstrated equivalent** — see below |
| M8 make `blocked` soft-bypassable | BITTEN |
| M9 consumer re-enables the retry button | BITTEN |
| M10 consumer drops the producer sentence | BITTEN |

**M7 equivalence is demonstrated, not asserted.** `STATUS_DISPOSITION[nonMember]` is already `undefined`, so the `RECOGNISED_STATUSES.has()` guard is not the discriminator and replacing it changes no behaviour (it was still caught at typecheck, 1979 vs 1978). The discriminating variant **M7b** — making an unrecognised status resolve to a real disposition — **REDs the opposite-direction twin** on the exact assertion, proving the twin binds to real behaviour.

## Not verified — stated as UNKNOWN

- **No live/deployed witness.** Every claim here is repo- and producer-bytes level. The rung is CODE EXISTS → TESTED; not DEPLOYED, not WIRE-WITNESSED.
- **Rate of the blocked carrier on real journeys is UNKNOWN** to this lane. The brief's "about a third of core journeys" comes from the incoming CEE P0 and was not re-derived here.
- **`blocked_reason` coverage is UNKNOWN.** `blockingIssues[0].code` may emit codes outside `ANALYSIS_REFUSAL_REASON_COPY`; those fall to the honest generic by design, but which codes actually occur has not been measured.
- **Whether `BlockersSection` is mounted under the deployed flag posture is UNKNOWN** (trap 3b). The sibling 2.924 spec records that under `VITE_FEATURE_PRE_ANALYSIS_V3=1` these surfaces may not mount. The P2 evidence here is the real consumer's pure function executed, not a browser.
