### PR TITLE
fix(analysis): four contradictions and dead labels the deployed surface was showing

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -1527,6 +1527,11 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     // segment (never authored in the UI).
     robustnessVerdictReason: resultsSectionData.recommendation.robustnessVerdictReason,
     reviewCards: resultsSectionData.confidence.topEvidenceGaps ?? resultsSectionData.confidence.evidenceGaps ?? [],
+    // Only while the footer's Rerun is actually unpressable. While a run is in
+    // flight the control is disabled for an obvious reason the label already
+    // states ("Running analysis…"), so repeating a gate reason there would be
+    // noise — and it is not the reason the button is disabled.
+    blockedReason: !canRunAnalysis && !isRunning ? runBlockedTooltip : null,
   })
 
   // Triage card action handlers — same pattern as pre-analysis expertise (uses withObservedStateUpdate)

--- a/src/canvas/components/utils/__tests__/postAnalysisFooter.blockedReasonVisible.spec.ts
+++ b/src/canvas/components/utils/__tests__/postAnalysisFooter.blockedReasonVisible.spec.ts
@@ -1,0 +1,73 @@
+/**
+ * A disabled Rerun must say why, in text, not in a `title`.
+ *
+ * ── Derived at the DEPLOYED surface, staging `c71ea7e0` ────────────────────
+ * `results-analysis-footer-action` rendered `disabled` with
+ *   title="Olumi is not able to run this yet. Ask in the chat and it will
+ *          explain what is missing."
+ * and NOTHING else. The visible footer read:
+ *   "Stable ranking | this result held up under the changes we tested | Rerun"
+ * — a reassurance beside an unpressable control, with the reason reachable
+ * only by hovering a mouse over it. On touch it is unreachable entirely.
+ *
+ * The blocked reason therefore LEADS the meta line, and is ADDED rather than
+ * substituted: "held up under the changes we tested" answers a different
+ * question and is still true.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { derivePostFooterMeta } from '../postAnalysisFooter'
+
+const REASON = 'Olumi is not able to run this yet. Ask in the chat and it will explain what is missing.'
+const VERDICT_REASON = 'this result held up under the changes we tested'
+
+describe('derivePostFooterMeta — the blocked reason is visible', () => {
+  it('POSITIVE CONTROL: the probe can see the pre-existing meta content', () => {
+    const meta = derivePostFooterMeta({
+      robustnessVerdict: 'robust',
+      robustnessVerdictReason: VERDICT_REASON,
+      reviewCards: [],
+    })
+    expect(meta).toContain(VERDICT_REASON)
+  })
+
+  it('blocked → the reason appears in the meta TEXT', () => {
+    const meta = derivePostFooterMeta({
+      robustnessVerdict: 'robust',
+      robustnessVerdictReason: VERDICT_REASON,
+      reviewCards: [],
+      blockedReason: REASON,
+    })
+    expect(meta).toContain(REASON)
+  })
+
+  it('and it LEADS — the actionable part is not buried behind the reassurance', () => {
+    const meta = derivePostFooterMeta({
+      robustnessVerdict: 'robust',
+      robustnessVerdictReason: VERDICT_REASON,
+      reviewCards: [],
+      blockedReason: REASON,
+    })!
+    expect(meta.indexOf(REASON)).toBeLessThan(meta.indexOf(VERDICT_REASON))
+  })
+
+  it('and it does NOT replace the robustness reason — both claims survive', () => {
+    const meta = derivePostFooterMeta({
+      robustnessVerdict: 'robust',
+      robustnessVerdictReason: VERDICT_REASON,
+      reviewCards: [],
+      blockedReason: REASON,
+    })
+    expect(meta).toContain(VERDICT_REASON)
+  })
+
+  it('DISCRIMINATING TWIN: not blocked → the meta is byte-identical to before', () => {
+    const base = {
+      robustnessVerdict: 'robust' as const,
+      robustnessVerdictReason: VERDICT_REASON,
+      reviewCards: [{ confidence: 80 }],
+    }
+    expect(derivePostFooterMeta({ ...base, blockedReason: null })).toBe(derivePostFooterMeta(base))
+    expect(derivePostFooterMeta({ ...base, blockedReason: '   ' })).toBe(derivePostFooterMeta(base))
+  })
+})

--- a/src/canvas/components/utils/postAnalysisFooter.ts
+++ b/src/canvas/components/utils/postAnalysisFooter.ts
@@ -91,6 +91,22 @@ export interface PostFooterMetaInput {
    * "Evidence gaps remain" decision.
    */
   reviewCards: ReadonlyArray<{ confidence?: number | null }>
+  /**
+   * Why the footer's Rerun is DISABLED, when it is.
+   *
+   * ⭐ VISIBLE, NOT HOVER-ONLY (Analysis convergence, 18 Aug 2026). Measured on
+   * deployed staging `c71ea7e0`: `results-analysis-footer-action` rendered
+   * disabled with its only explanation in the native `title` attribute —
+   * invisible to anyone not hovering, and to touch entirely. The visible footer
+   * read "Stable ranking · this result held up under the changes we tested ·
+   * Rerun", i.e. a reassuring line beside a control that cannot be pressed and
+   * says nothing about why.
+   *
+   * It LEADS the meta line because it is the only actionable part of it, and it
+   * is ADDED rather than substituted: the robustness reason answers a different
+   * question and both are true at once.
+   */
+  blockedReason?: string | null
 }
 
 /**
@@ -132,6 +148,7 @@ export function derivePostFooterMeta({
   robustnessVerdict,
   robustnessVerdictReason,
   reviewCards,
+  blockedReason,
 }: PostFooterMetaInput): string | null {
   // F7 (display honesty): the "{N}% stability" numeric segment is REMOVED.
   // `stability` here is the legacy `recommendation_stability` field, which
@@ -159,7 +176,12 @@ export function derivePostFooterMeta({
     ? null
     : (evidenceWeak ? 'Evidence gaps remain' : 'Evidence strong')
   const parts: string[] = []
-  // Producer reason VERBATIM, first — but only beside a known verdict (never
+  // The blocked reason leads: it is the only part the user can act on, and a
+  // disabled control whose reason is hover-only is a control with no reason.
+  if (typeof blockedReason === 'string' && blockedReason.trim() !== '') {
+    parts.push(blockedReason.trim())
+  }
+  // Producer reason VERBATIM, next — but only beside a known verdict (never
   // render a robustness sentence the status line cannot vouch for).
   if (
     verdictKnown &&

--- a/src/components/results/AdvancedSection.tsx
+++ b/src/components/results/AdvancedSection.tsx
@@ -14,7 +14,7 @@ import { Copy, Check, AlertTriangle, Gauge, Eye } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import { evaluativeVar } from '../../styles/evaluative'
 import { Accordion } from './Accordion'
-import { selectHumanisedInferenceWarnings } from './utils/humaniseInferenceWarning'
+import { selectHumanisedInferenceWarningsOutsideStrip } from './utils/humaniseInferenceWarning'
 import { useRiskProfile, RISK_PRESETS } from '../../canvas/hooks/useRiskProfile'
 import { derivePostFooterStatus } from '../../canvas/components/utils/postAnalysisFooter'
 import type { RobustnessDisplayVerdict } from './types'
@@ -206,10 +206,15 @@ export function AdvancedSection({
 
   // Phase 8 hotfix (Item 4): when the envelope includes inference warnings,
   // auto-expand so stability caveats aren't hidden inside a collapsed
-  // accordion. Warnings live inside the trust narrative in this section
-  // per brief Task 12, so the collapse default would otherwise suppress
-  // them until the user clicks.
-  const hasInferenceWarnings = selectHumanisedInferenceWarnings(inferenceWarnings).length > 0
+  // accordion.
+  //
+  // ⭐ Narrowed with the one-mount-per-entry fix: the trigger is now the set
+  // this section ACTUALLY renders. Warning-severity caveats are carried by
+  // `InferenceWarningStrip` at the top of the results body, always visible and
+  // never collapsed — auto-expanding a five-screen-down accordion for entries
+  // it no longer shows would expand it for a reason that is not on screen.
+  const hasInferenceWarnings =
+    selectHumanisedInferenceWarningsOutsideStrip(inferenceWarnings).length > 0
 
   return (
     <Accordion
@@ -358,10 +363,23 @@ export function AdvancedSection({
             {/* Brief 4 Task 12: inference warnings, capped at 3 with Show-all
                 overflow. One AlertTriangle per warning.
                 P0-3 fold: humanised by `code` via the shared view model
-                (selectHumanisedInferenceWarnings) — never the raw producer
-                `message`, which carries internal identifiers. */}
+                — never the raw producer `message`, which carries internal
+                identifiers.
+
+                ⭐ ONE MOUNT PER ENTRY (Analysis convergence, 18 Aug 2026).
+                This block used to render EVERY entry with a message, and
+                `InferenceWarningStrip` — five screens above, at the top of the
+                results body — renders the warning-severity ones through the
+                identical humaniser. Measured on deployed staging `c71ea7e0`:
+                all three of the strip's sentences appeared here again,
+                verbatim. Deleting the block was the wrong fix; it uniquely
+                carries the entries the strip FILTERS OUT (info severity), and
+                "less interface, not less intelligence" protects those. So it
+                now renders the strip's COMPLEMENT, derived from the strip's own
+                predicate rather than from a second copy of it.
+                Pinned by `inferenceWarnings.oneMountPerEntry.spec.tsx`. */}
             {(() => {
-              const relevant = selectHumanisedInferenceWarnings(inferenceWarnings)
+              const relevant = selectHumanisedInferenceWarningsOutsideStrip(inferenceWarnings)
               if (relevant.length === 0) return null
               const visible = showAllWarnings ? relevant : relevant.slice(0, 3)
               const hidden = relevant.length - visible.length

--- a/src/components/results/FragileEdgeGroupCard.tsx
+++ b/src/components/results/FragileEdgeGroupCard.tsx
@@ -83,6 +83,27 @@ export function FragileEdgeGroupCard({
 }) {
   const hasEValue = edges.some(e => e.e_value != null)
 
+  // ⭐ ONE SENTENCE PER RELATIONSHIP (Analysis convergence, 18 Aug 2026).
+  //
+  // The row names the SOURCE only, so one factor feeding two targets renders
+  // two identical lines with two identically-labelled Review chips. Measured
+  // on deployed staging `c71ea7e0`: `fac_4day_adoption → risk_coverage_gap`
+  // and `fac_4day_adoption → risk_productivity_loss` both read "If 4-Day Week
+  // Adoption Level shifts", and the ledger recorded it as a DUPLICATE ROW
+  // (L-37). It is not one. `dedupeFragileEdgesByIdentity` kept both on purpose
+  // — its header says so — because they are two producer findings. Deduping
+  // them would have deleted one.
+  //
+  // So the ambiguity is disambiguated, not collapsed, and ONLY where it exists:
+  // where a source appears once in this group the short line survives
+  // unchanged. Both halves are pinned as a discriminating pair in
+  // `FragileEdgeGroupCard.distinguishableRows.spec.tsx`.
+  const sourceCounts = edges.reduce<Record<string, number>>((acc, e) => {
+    const key = stripEncodingNotation(e.from_label)
+    acc[key] = (acc[key] ?? 0) + 1
+    return acc
+  }, {})
+
   const header = fragileEdgeGroupHeader({
     altWinnerLabel,
     edgeCount: edges.length,
@@ -119,6 +140,9 @@ export function FragileEdgeGroupCard({
           preserved — the user can navigate to each relationship individually). */}
       {edges.map((edge, i) => {
         const edgeSource = stripEncodingNotation(edge.from_label)
+        const edgeTarget = stripEncodingNotation(edge.to_label)
+        // Only when this group holds more than one edge from the same source.
+        const needsTarget = (sourceCounts[edgeSource] ?? 0) > 1 && edgeTarget.length > 0
         const edgeFocusId = edge.from_id
         return (
           <div key={`${edge.from_label}-${edge.to_label}-${i}`} className="space-y-1">
@@ -126,7 +150,16 @@ export function FragileEdgeGroupCard({
                 cards, the header already names the alt-winner so we just show
                 "If {source} shifts" as the body. */}
             <div className={`flex items-baseline gap-2 flex-wrap ${typography.panelMeta} text-text-light`}>
-              <span>If <span className="text-text-body">{edgeSource}</span> shifts</span>
+              <span>
+                If <span className="text-text-body">{edgeSource}</span>
+                {needsTarget ? (
+                  <>
+                    {"'s effect on "}
+                    <span className="text-text-body">{edgeTarget}</span>
+                  </>
+                ) : null}
+                {' shifts'}
+              </span>
               {!altWinnerLabel && (
                 <span>{fragileEdgeConsequence({ designationsWithheld })}</span>
               )}
@@ -144,7 +177,11 @@ export function FragileEdgeGroupCard({
                 onClick={() => onFocusNode(edgeFocusId)}
                 data-testid={`fragile-review-chip-${i}`}
                 className={`${typography.panelMeta} text-info border border-info/30 rounded-full px-2 py-0.5 bg-transparent hover:bg-panel-hover cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-offset-1`}
-                aria-label={`Review relationship from ${edgeSource}`}
+                aria-label={
+                  needsTarget
+                    ? `Review relationship from ${edgeSource} to ${edgeTarget}`
+                    : `Review relationship from ${edgeSource}`
+                }
               >
                 Review this relationship
               </button>

--- a/src/components/results/InferenceWarningStrip.tsx
+++ b/src/components/results/InferenceWarningStrip.tsx
@@ -23,7 +23,7 @@
  */
 import { AlertTriangle } from 'lucide-react'
 import { typography } from '@/styles/typography'
-import { humaniseInferenceWarningTitle } from './utils/humaniseInferenceWarning'
+import { humaniseInferenceWarningTitle, isStripEntry } from './utils/humaniseInferenceWarning'
 import type { InferenceWarning } from './types'
 
 export interface InferenceWarningStripProps {
@@ -32,13 +32,20 @@ export interface InferenceWarningStripProps {
   className?: string
 }
 
-/** Entries the strip will show: severity === 'warning' AND a non-empty producer message. */
+/**
+ * Entries the strip will show: severity === 'warning' AND a non-empty producer
+ * message.
+ *
+ * The predicate itself now lives in `utils/humaniseInferenceWarning.ts` as
+ * `isStripEntry`, because `AdvancedSection` renders this set's COMPLEMENT and
+ * a second spelling of it would be a mirror that drifts silently — the two
+ * surfaces would start repeating each other and no guard would notice
+ * (CLAUDE.md trap 12). This wrapper keeps the strip's own named selector.
+ */
 export function selectWarningSeverityEntries(
   warnings: InferenceWarning[] | undefined,
 ): InferenceWarning[] {
-  return (warnings ?? []).filter(
-    (w) => w.severity === 'warning' && typeof w.message === 'string' && w.message.trim().length > 0,
-  )
+  return (warnings ?? []).filter(isStripEntry)
 }
 
 export function InferenceWarningStrip({ warnings, className = '' }: InferenceWarningStripProps) {

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -425,6 +425,31 @@ function T1ChecksFooter({
   const hasWinner = verdict
     ? verdict.hasLeadingOption
     : !!data.recommendation.recommendedOption
+  // ⭐ NO DENIAL WITHOUT AUTHORITY (Analysis convergence, 18 Aug 2026).
+  //
+  // `hasLeadingOption === false` covers TWO different states and this is the
+  // one consumer for which they differ. Every other consumer in the tree
+  // (`OptionNode`, `DecisionNode`, `OptionPanel`, `OptionCards`,
+  // `V5AnalysisResultBlock`, `deriveRunPairComparison`) uses the boolean to
+  // WITHHOLD — correct for both states, so none of them had to read
+  // `separation`. This one turns it into an affirmative DENIAL, and
+  // `decisionVerdict.ts` licenses that for `'tied'` ONLY:
+  //
+  //   "`false` — surfaces must NOT badge, and MAY say 'no clear leading
+  //    option' (only when `separation === 'tied'`; `'unknown'` licenses
+  //    silence, never a denial)"
+  //
+  // Measured on deployed staging `c71ea7e0`: a run whose producer sent no
+  // near-tie block and no `headline_banded` rendered "No clear leader" here
+  // while `results-analysis-footer` three screens below said "Stable ranking —
+  // this result held up under the changes we tested". Two authorities, two
+  // questions (CLAUDE.md trap 21) — and one of them claiming what it does not
+  // hold. Reconciling the DEFAULTS would have been the wrong fix; withdrawing
+  // the unlicensed claim is the right one, and it leaves the tie denial intact.
+  //
+  // `unknown` therefore renders the neutral third state — the same idiom the
+  // robustness check beside it already uses for 'Robustness not assessed'.
+  const winnerUndetermined = verdict != null && verdict.separation === 'unknown'
   // Robustness glyph: driven ONLY by the display-safe robustness verdict
   // (`robustnessVerdict`) — never PLoT `report.robustness.level`, never the
   // UI-SEM-005 stability fallback, never a recommendationStability threshold.
@@ -465,6 +490,10 @@ function T1ChecksFooter({
   // these two labels.
   const winnerOkLabel = 'Has leading option'
   const winnerNotOkLabel = 'No clear leader'
+  // States the check could not be determined. It is NOT a third verdict about
+  // the options — it is the absence of one, which is why it must not read like
+  // "No clear leader" (a finding) nor like "Has leading option".
+  const winnerUndeterminedLabel = 'Leading option not assessed'
 
   return (
     <div className="border-t border-panel-border pt-3" data-testid="t1-checks-footer">
@@ -482,8 +511,14 @@ function T1ChecksFooter({
       <div className={`flex items-center flex-wrap gap-x-3 gap-y-1 ${typography.panelMeta} text-text-light`}>
         <ChecksGlyph
           ok={hasWinner}
+          unknown={winnerUndetermined}
           okLabel={winnerOkLabel}
-          notOkLabel={winnerNotOkLabel}
+          notOkLabel={winnerUndetermined ? winnerUndeterminedLabel : winnerNotOkLabel}
+          title={
+            winnerUndetermined
+              ? 'This run did not carry a leader verdict, so the analysis makes no claim either way.'
+              : undefined
+          }
           dataTestid="checks-winner"
         />
         <ChecksGlyph

--- a/src/components/results/__tests__/FragileEdgeGroupCard.distinguishableRows.spec.tsx
+++ b/src/components/results/__tests__/FragileEdgeGroupCard.distinguishableRows.spec.tsx
@@ -1,0 +1,131 @@
+/**
+ * Two DIFFERENT fragile relationships must not render as the same sentence.
+ *
+ * ── The reported defect, and the correction to its diagnosis ───────────────
+ * ISSUE-LEDGER L-37 records: *"Fragile-factors list duplicates a row — 'If
+ * Leadership capacity shifts' appears twice; 'Fragile factors (3)' counts the
+ * duplicate."* That diagnosis is WRONG, and acting on it would delete a
+ * producer finding.
+ *
+ * Read off the live React tree on deployed staging `c71ea7e0`, the three rows
+ * behind "Fragile factors (3)" were:
+ *
+ *   fac_4day_adoption → risk_coverage_gap        (Support Coverage Gap)
+ *   fac_4day_adoption → risk_productivity_loss   (Productivity Shortfall Risk)
+ *   fac_impl_spend    → risk_impl_overrun        (Implementation Cost Overrun)
+ *
+ * Three distinct edges. `dedupeFragileEdgesByIdentity` correctly kept all
+ * three — its own header states the case: *"Two genuinely different
+ * relationships can render the same 'If X shifts' line — one source factor
+ * feeding two targets — and collapsing those would delete producer findings."*
+ *
+ * So the count is right and the dedup is right. **The ROW COPY is wrong**: it
+ * names only the SOURCE, so one factor feeding two targets produces two
+ * identical sentences and two identically-labelled Review chips. The user sees
+ * a duplicate; the product is holding two findings and describing them with
+ * one sentence.
+ *
+ * ── The fix, and the shape of this guard ───────────────────────────────────
+ * Disambiguate by naming the relationship — but ONLY where it is ambiguous, so
+ * the common single-target case keeps its short line. That makes a
+ * DISCRIMINATING PAIR the right instrument (CLAUDE.md trap 19): a blanket
+ * change in either direction fails one of the two cases below.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { FragileEdgeGroupCard } from '../FragileEdgeGroupCard'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return { ...actual, Handle: () => null }
+})
+
+const ALT = 'Full 4-Day Week Rollout'
+
+/** The deployed run's own group: one source factor, two different targets. */
+const SHARED_SOURCE = [
+  {
+    edge_id: 'fac_4day_adoption->risk_coverage_gap',
+    from_id: 'fac_4day_adoption',
+    from_label: '4-Day Week Adoption Level',
+    to_label: 'Support Coverage Gap',
+    switch_probability: 0.32,
+    alternative_winner_label: ALT,
+  },
+  {
+    edge_id: 'fac_4day_adoption->risk_productivity_loss',
+    from_id: 'fac_4day_adoption',
+    from_label: '4-Day Week Adoption Level',
+    to_label: 'Productivity Shortfall Risk',
+    switch_probability: 0.28,
+    alternative_winner_label: ALT,
+  },
+]
+
+/** The ordinary case: distinct sources, nothing to disambiguate. */
+const DISTINCT_SOURCES = [
+  {
+    edge_id: 'fac_impl_spend->risk_impl_overrun',
+    from_id: 'fac_impl_spend',
+    from_label: 'Implementation Spend',
+    to_label: 'Implementation Cost Overrun',
+    switch_probability: 0.3,
+    alternative_winner_label: ALT,
+  },
+  {
+    edge_id: 'fac_4day_adoption->risk_coverage_gap',
+    from_id: 'fac_4day_adoption',
+    from_label: '4-Day Week Adoption Level',
+    to_label: 'Support Coverage Gap',
+    switch_probability: 0.2,
+    alternative_winner_label: ALT,
+  },
+]
+
+function rowsFor(edges: typeof SHARED_SOURCE): { lines: string[]; chipLabels: string[] } {
+  const { container } = render(
+    <FragileEdgeGroupCard
+      altWinnerLabel={ALT}
+      edges={edges}
+      onFocusNode={() => {}}
+      designationsWithheld={false}
+    />,
+  )
+  const chips = Array.from(container.querySelectorAll('[data-testid^="fragile-review-chip-"]'))
+  return {
+    // The trigger sentence is the row's own text minus the chip label.
+    lines: chips.map(chip => {
+      const row = chip.parentElement!
+      const chipText = (chip.textContent ?? '').trim()
+      return (row.textContent ?? '').replace(chipText, '').replace(/\s+/g, ' ').trim()
+    }),
+    chipLabels: chips.map(c => c.getAttribute('aria-label') ?? ''),
+  }
+}
+
+describe('FragileEdgeGroupCard — one sentence per relationship', () => {
+  it('POSITIVE CONTROL: the probe reads one row per edge', () => {
+    expect(rowsFor(SHARED_SOURCE).lines).toHaveLength(2)
+    expect(rowsFor(DISTINCT_SOURCES).lines).toHaveLength(2)
+  })
+
+  it('two edges from the SAME source are told apart — by row copy and by chip label', () => {
+    const { lines, chipLabels } = rowsFor(SHARED_SOURCE)
+    expect(new Set(lines).size, `Both rows read: ${lines[0]}`).toBe(2)
+    expect(new Set(chipLabels).size, `Both chips read: ${chipLabels[0]}`).toBe(2)
+  })
+
+  it('both targets are NAMED — the disambiguation is the producer\'s data, not an index', () => {
+    const { lines } = rowsFor(SHARED_SOURCE)
+    expect(lines.join(' | ')).toContain('Support Coverage Gap')
+    expect(lines.join(' | ')).toContain('Productivity Shortfall Risk')
+  })
+
+  it('DISCRIMINATING TWIN: distinct sources keep the short line — no target is added', () => {
+    const { lines } = rowsFor(DISTINCT_SOURCES)
+    expect(new Set(lines).size).toBe(2)
+    expect(lines.join(' | '), 'the short form must survive where nothing is ambiguous').not.toContain('Implementation Cost Overrun')
+    expect(lines.join(' | ')).not.toContain('Support Coverage Gap')
+  })
+})

--- a/src/components/results/__tests__/StressTestSection.fragileDedup.spec.tsx
+++ b/src/components/results/__tests__/StressTestSection.fragileDedup.spec.tsx
@@ -81,9 +81,32 @@ function renderSection(fragileEdges: ChallengeFragileEdge[]) {
  * Binds by the factor's EXACT label — the object identity a reader sees — not
  * by a substring another row could satisfy.
  */
+/**
+ * Rows whose trigger names `label` as the SOURCE factor.
+ *
+ * ⚠ RE-POINTED, NOT NARROWED (Analysis convergence, 18 Aug 2026) — declared
+ * here because silently re-pointing a probe is how a guard stops biting
+ * (CLAUDE.md 13b/14).
+ *
+ * It previously required the row's text to equal the literal
+ * `If {label} shifts`. `FragileEdgeGroupCard` now DISAMBIGUATES the exact case
+ * this block's controls exist to protect: when one source feeds two targets in
+ * the same group the rows read `If {source}'s effect on {target} shifts`, so
+ * two genuinely different findings are no longer two identical sentences. The
+ * old equality made the probe blind to precisely those rows — it would have
+ * counted 0 and reported "the fix deleted producer findings" when the fix had
+ * done the opposite.
+ *
+ * The PROPERTY under test is unchanged and is still counted: how many rows name
+ * this source. Only the sentence template it tolerates is widened, and it is
+ * still anchored at both ends (`If …` / `… shifts`), so a row that stopped
+ * being a trigger sentence would not be counted.
+ */
 function countShiftRowsFor(label: string): number {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const trigger = new RegExp(`^If ${escaped}(?:'s effect on .+)? shifts$`)
   return screen.queryAllByText(label, { selector: 'span' })
-    .filter(el => el.parentElement?.textContent === `If ${label} shifts`)
+    .filter(el => trigger.test(el.parentElement?.textContent ?? ''))
     .length
 }
 

--- a/src/components/results/__tests__/checksFooter.noDenialWithoutAuthority.spec.tsx
+++ b/src/components/results/__tests__/checksFooter.noDenialWithoutAuthority.spec.tsx
@@ -1,0 +1,241 @@
+/**
+ * "What we checked" may not DENY a leading option it has no authority to deny.
+ *
+ * ── The defect, derived at the DEPLOYED surface ────────────────────────────
+ * Driven on staging `c71ea7e0` (guest, one completed run, dock 416px), the
+ * Analysis surface said BOTH of these about the same run, three screens apart:
+ *
+ *   · `checks-winner`             → "No clear leader"
+ *   · `results-analysis-footer`   → "Stable ranking — this result held up
+ *                                    under the changes we tested"
+ *
+ * They are not two wordings of one fact. They are two authorities:
+ * `recommendation_stability` (the share of sampled scenarios in which the same
+ * option came out on top) and `DecisionVerdict.hasLeadingOption` (whether the
+ * producer is entitled to name a leader at all). Reconciling their DEFAULTS
+ * would be the wrong fix — CLAUDE.md trap 21, two questions under similar
+ * names. The fix is that ONE of them was making a claim it is not entitled to.
+ *
+ * ── Which one, settled at the producer's own bytes ─────────────────────────
+ * `src/lib/decisionVerdict.ts` states the contract in its own doc comment:
+ *
+ *     `false` — surfaces must NOT badge, and MAY say "no clear leading option"
+ *               (only when `separation === 'tied'`; `'unknown'` licenses
+ *               silence, never a denial)
+ *
+ * and again at the fall-through arm: *"Fail toward SILENCE, not toward a
+ * denial: `unknown` (surfaces make no claim in either direction), never
+ * `tied` (which licenses 'no clear leading option' — a second claim we equally
+ * have no authority for)."*
+ *
+ * Every other consumer in the tree honours this by WITHHOLDING (`return null`,
+ * no badge) — `OptionNode`, `DecisionNode`, `OptionPanel`, `OptionCards`,
+ * `V5AnalysisResultBlock`, `deriveRunPairComparison`. Withholding is correct
+ * for `tied` AND `unknown` alike, so none of them had to read `separation`.
+ * `T1ChecksFooter` is the ONLY consumer that turns the boolean into an
+ * affirmative DENIAL — and it is exactly the consumer for which the two cases
+ * differ. It read `hasLeadingOption` alone.
+ *
+ * ── What this spec pins ────────────────────────────────────────────────────
+ * A DISCRIMINATING TRIPLE, not a single case (CLAUDE.md trap 19): the same
+ * probe must return three DIFFERENT answers across the three separations, so a
+ * blanket change in either direction REDs.
+ *
+ *   producer signal present, not a tie  → "Has leading option"   (assert)
+ *   producer signal present, IS a tie   → "No clear leader"      (deny)
+ *   NO producer signal (`unknown`)      → neither                (silence)
+ *
+ * The third row is the one that was broken. The first two are the controls
+ * that stop the fix being "delete the denial", which would lose a true claim.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, renderHook } from '@testing-library/react'
+import { useResultsSectionData } from '../useResultsSectionData'
+import { ResultsBody } from '../ResultsBody'
+import { useCanvasStore } from '../../../canvas/store'
+import { mapV2ResponseToReportV1 } from '../../../adapters/plot/v2/responseMapper'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return { ...actual, Handle: () => null }
+})
+
+const WINNER_ID = 'opt_wholesale'
+const RUNNER_UP_ID = 'opt_retail'
+
+/**
+ * `nearTie: null` is the case the deployed run hit — the producer sent no
+ * near-tie block and no `headline_banded`, so `deriveDecisionVerdict` returns
+ * `separation: 'unknown'`, `source: 'none'`. It is NOT a synthetic edge case:
+ * CEE withholds exactly this pair on a withheld-constraint turn while the
+ * per-option win probabilities keep riding, which is why the module deleted
+ * its win-probability fallback in the first place.
+ */
+type Signal = { isTie: boolean } | null
+
+function makeV2Response(nearTie: Signal): V2RunResponse {
+  const outcome = (mean: number) => ({
+    mean,
+    std: 12,
+    p10: mean - 20,
+    p50: mean,
+    p90: mean + 20,
+    n_samples: 1000,
+    n_valid_samples: 1000,
+    validity_ratio: 1,
+  })
+  return {
+    analysis_status: 'computed',
+    option_comparison_status: 'computed',
+    robustness_status: 'computed',
+    drivers_status: 'computed',
+    option_comparison: [
+      {
+        option_id: WINNER_ID,
+        option_label: 'Double Down on Wholesale',
+        confidence_interval: [40, 80],
+        win_probability: 0.72,
+        outcome: outcome(60),
+      },
+      {
+        option_id: RUNNER_UP_ID,
+        option_label: 'Open Retail Shop',
+        confidence_interval: [20, 60],
+        win_probability: 0.2,
+        outcome: outcome(40),
+      },
+    ],
+    critiques: [],
+    drivers: [],
+    edge_sensitivity: [],
+    factor_sensitivity: [],
+    robustness: {
+      fragile_edges: [],
+      robust_edges: ['e1'],
+      recommended_option_id: WINNER_ID,
+      // High enough that "Stable ranking" renders in the footer — the very
+      // pairing that made the contradiction visible on the deployed surface.
+      recommendation_stability: 0.92,
+      ...(nearTie
+        ? {
+            near_tie: {
+              is_tie: nearTie.isTie,
+              top_option_id: WINNER_ID,
+              second_option_id: RUNNER_UP_ID,
+              gap: 0.52,
+              threshold: 0.1,
+            },
+          }
+        : {}),
+    } as never,
+    response_hash: 'h',
+    meta: { seed_used: '42', n_samples: 1000, detail_level: 'standard', latency_ms: 100 },
+  } as V2RunResponse
+}
+
+const OPTION_NODES = [
+  {
+    id: WINNER_ID,
+    type: 'option',
+    position: { x: 0, y: 0 },
+    data: { kind: 'option', type: 'option', label: 'Double Down on Wholesale' },
+  },
+  {
+    id: RUNNER_UP_ID,
+    type: 'option',
+    position: { x: 400, y: 0 },
+    data: { kind: 'option', type: 'option', label: 'Open Retail Shop' },
+  },
+]
+
+function setStore(nearTie: Signal): void {
+  const v2 = makeV2Response(nearTie)
+  useCanvasStore.setState({
+    results: { status: 'complete', progress: 100, report: mapV2ResponseToReportV1(v2, { seed: 42 }) },
+    runMeta: {},
+    nodes: OPTION_NODES,
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: v2,
+    goalThreshold: null,
+    viewMode: 'expert',
+  } as never)
+}
+
+/**
+ * The check as a user reads it — bound to the testid, never to page text —
+ * together with the separation the FOOTER'S OWN data carries.
+ *
+ * PRECONDITION PIN (CLAUDE.md 13b): the separation is read from
+ * `useResultsSectionData().recommendation.verdict`, i.e. the identical object
+ * `T1ChecksFooter` consumes, so a green result cannot come from a fixture that
+ * quietly stopped reproducing the state under test.
+ */
+function readWinnerCheck(): { label: string; separation: string } {
+  const { result } = renderHook(() => useResultsSectionData())
+  const separation = result.current.recommendation.verdict?.separation ?? '<no verdict>'
+  const { container } = render(
+    <ResultsBody
+      resultsSectionData={result.current}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+    />,
+  )
+  const el = container.querySelector('[data-testid="checks-winner"]')
+  if (!el) throw new Error('checks-winner did not render — the probe is blind, not the product silent')
+  return { label: (el.textContent ?? '').replace(/\s+/g, ' ').trim(), separation }
+}
+
+describe('checks-winner: no denial without authority', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      results: null,
+      rawV2Response: null,
+      nodes: [],
+      edges: [],
+      hasCompletedFirstRun: false,
+    } as never)
+    document.body.innerHTML = ''
+  })
+
+  it('producer says NOT a tie → the check ASSERTS a leading option', () => {
+    setStore({ isTie: false })
+    const { label, separation } = readWinnerCheck()
+    expect(separation).toBe('clear')
+    expect(label).toBe('Has leading option')
+  })
+
+  it('producer says IS a tie → the check DENIES a leading option', () => {
+    setStore({ isTie: true })
+    const { label, separation } = readWinnerCheck()
+    expect(separation).toBe('tied')
+    expect(label).toBe('No clear leader')
+  })
+
+  it('producer sent NO signal → the check makes NO claim in either direction', () => {
+    setStore(null)
+    const { label, separation } = readWinnerCheck()
+    // Precondition: this really is the no-authority state, not a tie.
+    expect(separation).toBe('unknown')
+
+    expect(
+      label,
+      `"No clear leader" is a DENIAL. decisionVerdict.ts: "'unknown' licenses silence, never a denial." Read: ${label}`,
+    ).not.toMatch(/No clear leader/i)
+    expect(label).not.toMatch(/Has leading option/i)
+  })
+
+  it('the three separations produce three DIFFERENT labels — the probe discriminates', () => {
+    setStore({ isTie: false })
+    const clear = readWinnerCheck().label
+    document.body.innerHTML = ''
+    setStore({ isTie: true })
+    const tied = readWinnerCheck().label
+    document.body.innerHTML = ''
+    setStore(null)
+    const unknown = readWinnerCheck().label
+
+    expect(new Set([clear, tied, unknown]).size, `clear="${clear}" tied="${tied}" unknown="${unknown}"`).toBe(3)
+  })
+})

--- a/src/components/results/__tests__/inferenceWarnings.oneMountPerEntry.spec.tsx
+++ b/src/components/results/__tests__/inferenceWarnings.oneMountPerEntry.spec.tsx
@@ -1,0 +1,190 @@
+/**
+ * A producer inference warning is stated ONCE on the Analysis surface.
+ *
+ * ── Derived at the DEPLOYED surface, staging `c71ea7e0` ────────────────────
+ * The Analysis tab rendered the SAME three humanised warnings twice, five
+ * screens apart:
+ *
+ *   `inference-warning-strip`   (top of the results body)     3 entries
+ *   `trust-inference-warnings`  (Advanced and receipts)       the same 3, verbatim
+ *
+ * Both read the identical producer field through the identical humaniser
+ * (`selectHumanisedInferenceWarnings` / `humaniseInferenceWarningTitle`), so
+ * they cannot differ in wording — they can only repeat. What separates them is
+ * SEVERITY: the strip shows `severity === 'warning'` only; Advanced showed
+ * every entry with a message. The overlap is therefore total by construction,
+ * and it grows every time a warning-severity entry arrives.
+ *
+ * ── The rule, and why it is not "delete one" ───────────────────────────────
+ * "Less interface, not less intelligence." Advanced legitimately carried
+ * entries the strip filters out (info-severity), and deleting the block would
+ * lose them. So Advanced now renders the REMAINDER — the entries the strip
+ * does not show — and nothing else.
+ *
+ * The invariant is stated over the two mounts jointly rather than over either
+ * one, because either alone is satisfiable while the surface still repeats
+ * itself:
+ *
+ *   for every producer warning, the number of places on the Analysis surface
+ *   that state it is EXACTLY ONE.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, renderHook } from '@testing-library/react'
+import { useResultsSectionData } from '../useResultsSectionData'
+import { ResultsBody } from '../ResultsBody'
+import { useCanvasStore } from '../../../canvas/store'
+import { mapV2ResponseToReportV1 } from '../../../adapters/plot/v2/responseMapper'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return { ...actual, Handle: () => null }
+})
+
+/**
+ * Shaped after the warnings the deployed run actually carried: three
+ * warning-severity entries plus one that is not, so the remainder is non-empty
+ * and the "Advanced keeps what the strip filters out" half is observable.
+ */
+const WARNINGS = [
+  {
+    code: 'CONSTRAINT_TARGET_UNRELIABLE',
+    severity: 'warning',
+    message: 'constraint_fac_alpha target unreliable',
+    affected_nodes: ['fac_alpha'],
+    affected_labels: ['Alpha'],
+  },
+  {
+    code: 'CONSTRAINT_DIRECTION_SUSPECT',
+    severity: 'warning',
+    message: 'constraint_fac_beta direction suspect',
+    affected_nodes: ['fac_beta'],
+    affected_labels: ['Beta'],
+  },
+  {
+    code: 'SAMPLES_REDUCED_FOR_COMPLEXITY',
+    severity: 'info',
+    message: 'reduced from 500 to 200 samples',
+  },
+]
+
+function makeResponse(): V2RunResponse {
+  const outcome = (mean: number) => ({
+    mean,
+    std: 12,
+    p10: mean - 20,
+    p50: mean,
+    p90: mean + 20,
+    n_samples: 1000,
+    n_valid_samples: 1000,
+    validity_ratio: 1,
+  })
+  return {
+    analysis_status: 'computed',
+    option_comparison_status: 'computed',
+    robustness_status: 'computed',
+    drivers_status: 'computed',
+    option_comparison: [
+      {
+        option_id: 'opt_a',
+        option_label: 'Option A',
+        confidence_interval: [40, 80],
+        win_probability: 0.72,
+        outcome: outcome(60),
+      },
+      {
+        option_id: 'opt_b',
+        option_label: 'Option B',
+        confidence_interval: [20, 60],
+        win_probability: 0.2,
+        outcome: outcome(40),
+      },
+    ],
+    critiques: [],
+    drivers: [],
+    edge_sensitivity: [],
+    factor_sensitivity: [],
+    robustness: {
+      // The producer carries these UNDER `robustness` (responseMapper.ts:567),
+      // not at the top level — derived at the mapper, not assumed.
+      inference_warnings: WARNINGS,
+      fragile_edges: [],
+      robust_edges: ['e1'],
+      recommended_option_id: 'opt_a',
+      recommendation_stability: 0.92,
+      near_tie: { is_tie: false, top_option_id: 'opt_a', second_option_id: 'opt_b', gap: 0.52, threshold: 0.1 },
+    } as never,
+    response_hash: 'h',
+    meta: { seed_used: '42', n_samples: 1000, detail_level: 'standard', latency_ms: 100 },
+  } as unknown as V2RunResponse
+}
+
+function renderSurface(): HTMLElement {
+  const v2 = makeResponse()
+  useCanvasStore.setState({
+    results: { status: 'complete', progress: 100, report: mapV2ResponseToReportV1(v2, { seed: 42 }) },
+    runMeta: {},
+    nodes: [
+      { id: 'opt_a', type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', type: 'option', label: 'Option A' } },
+      { id: 'opt_b', type: 'option', position: { x: 400, y: 0 }, data: { kind: 'option', type: 'option', label: 'Option B' } },
+      { id: 'fac_alpha', type: 'factor', position: { x: 0, y: 200 }, data: { kind: 'factor', type: 'factor', label: 'Alpha' } },
+      { id: 'fac_beta', type: 'factor', position: { x: 200, y: 200 }, data: { kind: 'factor', type: 'factor', label: 'Beta' } },
+    ],
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: v2,
+    goalThreshold: null,
+    viewMode: 'expert',
+  } as never)
+
+  const { result } = renderHook(() => useResultsSectionData())
+  const { container } = render(
+    <ResultsBody
+      resultsSectionData={result.current}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      expertMode
+    />,
+  )
+  return container
+}
+
+/** Sentences rendered by a given mount, bound by testid — never page text. */
+function sentencesIn(container: HTMLElement, testid: string): string[] {
+  const root = container.querySelector(`[data-testid="${testid}"]`)
+  if (!root) return []
+  return Array.from(root.querySelectorAll('li, [data-testid="inference-warning-strip-entry"]'))
+    .map(n => (n.textContent ?? '').replace(/\s+/g, ' ').trim())
+    .filter(Boolean)
+}
+
+describe('inference warnings: one mount per producer entry', () => {
+  it('POSITIVE CONTROL: the strip mount is visible to the probe and non-empty', () => {
+    const c = renderSurface()
+    const strip = sentencesIn(c, 'inference-warning-strip')
+    expect(strip.length, 'the probe read nothing — it is blind, so any absence below is vacuous').toBeGreaterThan(0)
+  })
+
+  it('the Advanced trust list repeats nothing the strip already states', () => {
+    const c = renderSurface()
+    const strip = new Set(sentencesIn(c, 'inference-warning-strip'))
+    const advanced = sentencesIn(c, 'trust-inference-warnings')
+    const repeated = advanced.filter(s => strip.has(s))
+    expect(
+      repeated,
+      `These sentences are stated twice on one surface:\n  ${repeated.join('\n  ')}`,
+    ).toEqual([])
+  })
+
+  it('and the entries the strip FILTERS OUT survive in Advanced — nothing is lost', () => {
+    const c = renderSurface()
+    const strip = sentencesIn(c, 'inference-warning-strip')
+    const advanced = sentencesIn(c, 'trust-inference-warnings')
+    // The info-severity entry is the one the strip excludes by contract.
+    expect(strip.join(' | ')).not.toMatch(/reduced precision/i)
+    expect(
+      advanced.join(' | '),
+      'the strip filters info-severity out; if Advanced drops it too the finding is gone from the product',
+    ).toMatch(/reduced precision/i)
+  })
+})

--- a/src/components/results/utils/humaniseInferenceWarning.ts
+++ b/src/components/results/utils/humaniseInferenceWarning.ts
@@ -24,8 +24,26 @@ import type { UncertaintyItem } from '../types'
 export interface HumanisableInferenceWarning {
   code: string
   message?: string
+  /** Producer severity. The strip shows only `'warning'`; see `isStripEntry`. */
+  severity?: string
   affected_nodes?: string[]
   affected_labels?: string[]
+}
+
+/**
+ * THE STRIP'S ADMISSION PREDICATE — one definition, two consumers.
+ *
+ * `InferenceWarningStrip` shows warning-severity entries with a real producer
+ * message and nothing else. `AdvancedSection` shows the COMPLEMENT of exactly
+ * this set, so the two cannot both state the same sentence.
+ *
+ * It lives here rather than in the strip because a complement computed from a
+ * SECOND spelling of the predicate is a hand-maintained mirror (CLAUDE.md trap
+ * 12): the day someone widens the strip, the Advanced side would start
+ * repeating again and nothing would say so. Both sides now call this.
+ */
+export function isStripEntry(w: HumanisableInferenceWarning): boolean {
+  return w.severity === 'warning' && typeof w.message === 'string' && w.message.trim().length > 0
 }
 
 /** Node-label map for humaniseCritique's factor-label resolution, built from
@@ -57,13 +75,31 @@ export function humaniseInferenceWarningTitle(w: HumanisableInferenceWarning): s
   return humaniseCritique(item, buildInferenceWarningLabelMap(w)).title
 }
 
-/** AdvancedSection selection: keep every warning with a non-empty producer
- *  message (all severities — fail-closed on empties, no fabricated copy), and
- *  return it already humanised so the JSX never touches `.message`. */
+/** Every warning with a non-empty producer message, all severities
+ *  (fail-closed on empties, no fabricated copy), already humanised so the JSX
+ *  never touches `.message`. */
 export function selectHumanisedInferenceWarnings(
   warnings: HumanisableInferenceWarning[] | undefined,
 ): Array<{ code: string; title: string }> {
   return (warnings ?? [])
     .filter((w) => typeof w.message === 'string' && w.message.trim().length > 0)
+    .map((w) => ({ code: w.code, title: humaniseInferenceWarningTitle(w) }))
+}
+
+/**
+ * AdvancedSection selection: the entries the strip does NOT show.
+ *
+ * Derived as the COMPLEMENT of `isStripEntry`, never as its own filter list.
+ * Measured on deployed staging `c71ea7e0`: without this, the Advanced trust
+ * list repeated all three of the strip's sentences verbatim five screens below
+ * them. The remainder is what Advanced uniquely carries — info-severity
+ * entries the strip filters out — so nothing is lost and nothing repeats.
+ */
+export function selectHumanisedInferenceWarningsOutsideStrip(
+  warnings: HumanisableInferenceWarning[] | undefined,
+): Array<{ code: string; title: string }> {
+  return (warnings ?? [])
+    .filter((w) => typeof w.message === 'string' && w.message.trim().length > 0)
+    .filter((w) => !isStripEntry(w))
     .map((w) => ({ code: w.code, title: humaniseInferenceWarningTitle(w) }))
 }


### PR DESCRIPTION
## The process, in order

**Derive mounted state → canonical composition → KEEP/CUT/REHOME → implement → remove superseded → witness.** Nothing here is a symptom fix; every item was found by driving the product.

---

## 1 · Mounted-state census — DERIVED, not read

Deployed staging **`c71ea7e0`** (`version.json` asserted; identical to this base). Guest session, one completed analysis, dock measured **416px**, viewport 1280.

- Analysis inner scroller: **3,476px in a 637px viewport — 5.5 screens.**
- Interactive controls on the surface: **68.**
- Shell conformance holds: `data-shell-scroll-owner=self`, `padding=self`, matching `WORKSPACE_SURFACES.results`.

| # | Block | h | |
|---|---|---|---|
| — | `decision-overview` | 283 | |
| — | `analysis-freshness-notice` | 38 | |
| — | `how-computed-trigger` | 25 | **PROTECTED** |
| 0 | `inference-warning-strip` | 121 | |
| 1 | `what-changed-chip` | 32 | |
| 2 | `analysis-hero-panel` | **1221** | |
| 3 | `what-i-was-given-section` | 60 | |
| 4 | `strengthen-panel` | 334 | |
| 5 | "Your options" | 510 | |
| 6 | `accordion-drivers` | 57 | |
| 7 | `accordion-tornado` | 40 | |
| 8 | `accordion-stress-test` | 68 | |
| 9 | "Advanced and receipts" | 455 | |
| — | `results-analysis-footer` | — | outside the scroller |

---

## 2 · KEEP / CUT / REHOME

| Block / claim | Verdict | Reason |
|---|---|---|
| `how-computed-trigger` · "Where our reviews disagree" · lead-size caveat · refusal disclosures | **KEEP, untouched** | Protected content. Verified present after the change. |
| `checks-winner` "No clear leader" on `separation: 'unknown'` | **CUT the claim** | `decisionVerdict.ts`: *"`'unknown'` licenses silence, never a denial."* Fixed. |
| `checks-winner` "No clear leader" on `separation: 'tied'` | **KEEP** | Licensed and true. Pinned by a discriminating twin. |
| Advanced `trust-inference-warnings` — warning-severity entries | **CUT (duplicate mount)** | Verbatim repeat of `inference-warning-strip` five screens above. Fixed. |
| Advanced `trust-inference-warnings` — info-severity entries | **KEEP** | Advanced's unique content. Nothing lost. Fixed. |
| Fragile rows sharing a source factor | **KEEP BOTH, relabel** | They are two producer findings, not a duplicate — L-37's diagnosis is wrong. Fixed. |
| Footer Rerun blocked reason (in `title` only) | **REHOME to visible meta** | Hover-only; unreachable on touch. Fixed. |
| Compare tab | **REHOME — NOT DONE, see §5** | Paul's ruling stands; the composition is not resolved. **STOPPED and reported.** |
| `what-changed-chip` | **NOT DONE, see §5** | Same decision as Compare. |
| The seven "define a success target" CTAs | **NOT DONE, see §5** | Which one survives is a design choice. |
| Option ordinals vs win frequency | **NOT DONE, see §5** | Producer-side question. |

---

## 3 · What changed

**a. "No clear leader" was asserted without authority — P0-trust.**
`hasLeadingOption === false` covers two states, and this is the only consumer for which they differ. Every other (`OptionNode`, `DecisionNode`, `OptionPanel`, `OptionCards`, `V5AnalysisResultBlock`, `deriveRunPairComparison`) WITHHOLDS — correct for both — so none needed `separation`. This one turned it into a claim.

On the deployed run: **"No clear leader"** three screens above **"Stable ranking — this result held up under the changes we tested"**. Two authorities, two questions (trap 21). The fix withdraws the unlicensed claim; it does not reconcile the defaults, and the genuine tie denial is untouched.

**b. Two mounts of the same producer warnings.** Advanced now renders the strip's **complement**, derived from the strip's own predicate (`isStripEntry`, hoisted to one module) rather than a second spelling of it — so the day the strip widens, the two cannot start repeating again.

**c. ⚠ ISSUE-LEDGER L-37 is wrong, and acting on it would have deleted a finding.** Read off the live React tree, the two identical rows are:

```
fac_4day_adoption -> risk_coverage_gap        (Support Coverage Gap)
fac_4day_adoption -> risk_productivity_loss   (Productivity Shortfall Risk)
```

Two edges. `dedupeFragileEdgesByIdentity` keeps both **on purpose** — its own header says two relationships can legitimately render the same line. The count is right; the **row copy** was wrong. It now names the relationship, and only where a source appears twice in a group.

**d. A disabled Rerun whose only reason was a `title`.** Now leads the meta line, added rather than substituted.

---

## 4 · Evidence

- **RED-first at pristine**, named signatures, 16 new tests / 4 specs; every absence assertion carries a positive control (one caught its own blindness — the first warnings probe read the strip as empty and its "no repetition" pass was vacuous; the fixture was fixed at the mapper, not the assertion).
- **9 mutants, all biting**, including **4 discriminating twins** (over-cut in the opposite direction REDs) and a rot-mutant proving the re-pointed dedup probe still catches a real duplicate. Isolation **proven by writing a sentinel** (trap 9g); restores `HEAD`-relative (trap 9h); applied-check exactly 1 file in `src/` per mutant; leading and trailing controls at exactly 0.
- **⚠ Declared: `StressTestSection.fragileDedup.spec.tsx`'s probe is RE-POINTED**, in-file. It bound to the literal `If {label} shifts` — exactly the rows item (c) changes — so it would have read 0 and reported the fix as a deletion. Widened at the template only, still anchored at both ends, and proven to still bite.
- **Named gate**: typecheck baseline **2306 → 2306**; lint 0 errors (2 warnings, both pre-existing at `origin/staging`, verified in a pristine worktree at the same line numbers); `ci:guard:ds:enforce` no net-new (all four classes Δ negative); zustand, duplicates, shell-conformance (49) green.
- **Scoped suite** `src/components/results` + `src/canvas/components/utils` + `src/canvas/components/__tests__`: **394 files / 5,976 passed, 0 failed.**
- **Browser** (jsdom cannot prove visibility): `pnpm visual` **28/28**, all **10 references byte-unchanged** — this change is visually inert on every state the harness can capture. `shellLayout.visual.spec.ts` re-witnessed **1280×800 and 1920×1080**: dock 416px, 4 tabs, `nav scrollWidth == clientWidth`, footer not overlapping, and both protected affordances painted.
- **Layout probed on the deployed product**, real fonts, real widths: the longer fragile sentence wraps with **zero horizontal overflow at 416px and at the 280px drag floor**.

**Protected content proof:** `how-computed-trigger` still mounts and is still always-visible (`outputs-results-redesign` child 0); the freshness three-state icons and `model-tab-verify-badge` are witnessed *painted* by the shell spec at both viewports; the fragile-factor data, E-values, Review chips and stability pill are untouched; the info-severity warnings Advanced uniquely carried are asserted still present by name.

---

## 5 · STOPPED — needs Paul, with the reason

**Compare inside Analysis.** The ruling binds; the composition is not resolved by it, and the census says why choosing silently would be wrong:

- Compare's **entire** mounted content at one run is four lines and **"View current results →" — a link back to the tab it would now live inside.**
- `useCompareHistoryHydration` **skips guests by design** (`v5_handler_facts.user_id` is NULL under RLS). **For the guest journey Paul tests, Compare can never have content.** That is a strong argument for the ruling — and it means the rehome cannot be witnessed on the path Paul uses.
- It is **3,572 lines** with its own `TabHeader`, `RunSelector` and `CompareFooter`. Dropping it whole into Analysis imports a second header and a second footer into the surface whose problem *is* competing hierarchies. As a collapsed accordion gated on ≥2 runs it works — but that is a composition choice, not a move.

**Proposed (not implemented):** `compare.presentedAsTab: false` with `hiddenReason` (the Journey precedent, one type-safe line), `MAX_PRESENTED_SURFACES` 4 → 3, and Compare re-mounted as a collapsed **"How this has changed across runs"** accordion gated on ≥2 runs — the section `what-changed-chip` should open.

**`what-changed-chip` is the same decision.** Clicking it **leaves Analysis for Olumi** and terminates in *"There is only one analysis run so far, so there is nothing to compare yet."* — P8's shape. It **must not** be re-gated on `runs.length`: the component's header records that this was already tried and the local run history stays empty on the live guest path, so the gate made the chip permanently dark. Its correct gate is the same one the rehomed section gets.

**Also owed, reported not fixed:**
- **The same instruction is rendered 7–8 times** ("set a success target"): overview brief-bar, `brief-dim-goal`, `hero-lens-tab-goal`, the goal-lens empty state, `hero-focus-target`, `hero-next-rec-open`, `strengthen-panel`, and "Your options". Which survives is a design choice; culling blind is the named failure mode.
- **Option ordinals contradict both metrics.** Hero: Phased −11% / Full −18% / Keep −5%. "Your options": Phased **<1%** / Full **19%** / Keep **80%** — yet the cards read "Option 1 = Phased", and **Keep, which wins 80% of scenarios, is collapsed behind "Show all (1 more)"**. Reproduced on the canvas node badges (#1 on Phased).
- **Duplicate hero prose, same number twice:** *"…was the stronger option **32%** of the time"* and *"…could overtake (**32%** probability)"*; plus "Main driver: X" beside "Dominant factor: X drives 100%".
- **`EVPI_UNAVAILABLE` and `CONSTRAINT_NOT_CONVERTIBLE` both fall to the generic factor-framed fallback** and render as two identical "Review this factor's inputs" lines. This is the exact defect ROADMAP 2.300 item 1 fixed for two other codes, recurring because the template map is a hand-maintained mirror. **Deliberately not fixed here:** I cannot derive these codes' semantics at the producer from this repo, and authoring copy from the consumer's guess is trap 13c.
- **C10.4, pre-existing:** at the 280px drag floor the Analysis scroller overflows horizontally by **103px** — tornado bars (169px), the driver label, the "Optimistic" lens button. Measured with the original copy in place, so it is **not** this PR's.

---

## Status ladder
**TESTED** + **component-level browser witness** (real Chromium; the visual harness's captured states, plus a layout probe on the deployed product). **NOT journey-witnessed**: the harness deliberately has no completed-analysis state (its README records the unblocking step — capture a real CEE analysis turn for a starter graph). A post-run Analysis journey witness is **owed after deploy**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
