### PR TITLE
fix(ui): four adjudicated review findings, plus a derived drain-reachability guard that found a third dark drain

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -429,10 +429,20 @@ export function getOutputTabsForParity(): WorkspaceSurfaceDescriptor[] {
   //
   // Journey is absent by CONTRACT, not by flag — `presentedAsTab: false`. See
   // its row in `shellContract.ts` for the ruling and the evidence.
+  //
+  // ⚠ AND THEREFORE THERE IS NO `journey` BRANCH HERE. One used to sit below
+  // the `compare` line (`if (surface.id === 'journey') return
+  // isJourneyTabEnabled()`), and it could never execute: `presentedSurfaces()`
+  // filters on `presentedAsTab` (`shellContract.ts:412`) BEFORE this callback
+  // ever sees a surface, so no journey descriptor reaches it whatever the flag
+  // says. A dead flag check next to two live ones is worse than none — it reads
+  // as "the flag decides", which is exactly the belief the contract row exists
+  // to correct. `presentedSurfaces().map(s => s.id)` is asserted not to contain
+  // 'journey' in `tests/ci-guards/shell-conformance.spec.ts`, and
+  // `OutputsDock.dom.spec.tsx` drives the whole dock with the flag forced ON.
   return presentedSurfaces().filter(surface => {
     if (surface.id === 'olumi') return isAiPanelV2Enabled()
     if (surface.id === 'compare') return isCompareTabEnabled()
-    if (surface.id === 'journey') return isJourneyTabEnabled()
     return true
   })
 }
@@ -2052,7 +2062,10 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   const OUTPUT_TABS = useMemo<WorkspaceSurfaceDescriptor[]>(
     () => getOutputTabsForParity(),
     // eslint-disable-next-line react-hooks/exhaustive-deps -- flag accessors are stable; we re-run by value
-    [aiPanelV2On, isJourneyTabEnabled(), isCompareTabEnabled()],
+    // No `isJourneyTabEnabled()` here: `getOutputTabsForParity` no longer reads
+    // it (journey is hidden by contract), so listing it would re-run this memo
+    // on a value the computation cannot consume.
+    [aiPanelV2On, isCompareTabEnabled()],
   )
 
   // ── Shell width, published once, derived from the live element ────────────

--- a/src/canvas/conversation/__tests__/drainHostReachability.derived.spec.ts
+++ b/src/canvas/conversation/__tests__/drainHostReachability.derived.spec.ts
@@ -1,0 +1,241 @@
+/**
+ * DRAIN-HOST REACHABILITY — DERIVED, not hand-listed.
+ *
+ * ⚠ WHY THIS FILE EXISTS ALONGSIDE `panelApplyReachability.production.spec.tsx`.
+ * That spec pins two drains' mounts by hand-written `expect(source).toContain(…)`
+ * greps — one `it` per drain, added the day each defect was found. It is exactly
+ * the hand-maintained mirror CLAUDE.md trap 12 is about: it can only ever prove
+ * that the drains SOMEONE REMEMBERED TO LIST are hosted, and it reads green for
+ * a drain nobody thought to add. DraftChat hosts FOUR conversation drains; that
+ * spec covers TWO, and the two it does not cover are both DARK on the deployed
+ * flag posture.
+ *
+ * So this file derives the list instead:
+ *
+ *   1. THE DRAIN SET comes from `DraftChat.tsx`'s own imports — every
+ *      `use*Events` / `use*Drain` it pulls from `../conversation/`. Add a fifth
+ *      drain to DraftChat and it appears here on the next run, with no edit.
+ *   2. THE FLAG-ON HOST SET is walked, not asserted: the `aiPanelV2` branch of
+ *      `MaybeConversationProvider` in `ReactFlowGraph.tsx` is sliced out, every
+ *      component it mounts is resolved to its file through ReactFlowGraph's own
+ *      imports, and each of those files is read for drain CALLS.
+ *   3. DARK = (1) minus (2), and it must equal `KNOWN_DARK_DRAINS` EXACTLY.
+ *
+ * ⚠ EXACTLY, IN BOTH DIRECTIONS, AND THE SHRINK MATTERS AS MUCH AS THE GROWTH.
+ * A GROWN set means a drain has gone dark — the defect
+ * `StructuralDeleteDrainHost` was written to close, recurring. A SHRUNK set
+ * means someone has re-hosted a known-dark drain, which is a BEHAVIOUR CHANGE
+ * (see the two assessments recorded beneath `KNOWN_DARK_DRAINS`), not a tidy-up
+ * — it must be a conscious edit to this set, with those costs re-read, rather
+ * than something that lands silently under a green suite.
+ *
+ * ⚠ THIS FILE MAKES NO CLAIM THAT A DARK DRAIN SHOULD BE RE-HOSTED. It records
+ * which are dark and what that costs. Re-hosting is its own decision.
+ *
+ * The flag posture that makes "flag-ON" the real one: `aiPanelV2`
+ * `defaultValue: true` (`flags.ts`), and `ReactFlowGraph.tsx` renders DraftChat
+ * only under `{!isAiPanelV2Enabled() && <DraftChat />}` — so for every fresh
+ * user DraftChat is not mounted and its drains run only in the rollback posture.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+
+const DRAFT_CHAT = 'src/canvas/components/DraftChat.tsx'
+const CANVAS_ROOT = 'src/canvas/ReactFlowGraph.tsx'
+
+/**
+ * A conversation drain: a hook whose job is to put queued canvas state on the
+ * wire.
+ *
+ * ⚠ `Events?`, NOT `Events`. The brief that commissioned this spec described the
+ * family as `use*Events` / `use*Drain` and put the count at four. Both halves of
+ * the plural matter: `useAnalysisCompleteEvent` and `useSessionResumeEvent` are
+ * SINGULAR, so a `Events`-only pattern silently enumerates three of five —
+ * including one it was written to pin. The count is five, and it is derived
+ * here rather than stated, which is the entire point of the file.
+ */
+const DRAIN_NAME = /^use[A-Z][A-Za-z0-9]*(?:Events?|Drain)$/
+
+function read(repoRelative: string): string {
+  return readFileSync(resolve(process.cwd(), repoRelative), 'utf8')
+}
+
+/** Every `import { … } from '…'` in a source file, as (specifiers, module). */
+function imports(source: string): Array<{ names: string[]; module: string }> {
+  const out: Array<{ names: string[]; module: string }> = []
+  const re = /import\s*\{([^}]*)\}\s*from\s*'([^']+)'/g
+  for (const m of source.matchAll(re)) {
+    const names = m[1]
+      .split(',')
+      .map((n) => n.trim().split(/\s+as\s+/).pop()!.trim())
+      .filter((n) => n.length > 0)
+    out.push({ names, module: m[2] })
+  }
+  return out
+}
+
+/** Resolve a relative import to a repo-relative `.tsx`/`.ts` path, or null. */
+function resolveLocal(fromRepoRelative: string, module: string): string | null {
+  if (!module.startsWith('.')) return null
+  const base = resolve(process.cwd(), dirname(fromRepoRelative), module)
+  for (const ext of ['.tsx', '.ts']) {
+    try {
+      readFileSync(base + ext, 'utf8')
+      return base + ext
+    } catch {
+      /* try the next extension */
+    }
+  }
+  return null
+}
+
+function callsHook(source: string, hookName: string): boolean {
+  return new RegExp(`\\b${hookName}\\s*\\(`).test(source)
+}
+
+// ── 1. THE DRAIN SET, from DraftChat's own imports ─────────────────────────
+function enumerateDrains(): string[] {
+  const source = read(DRAFT_CHAT)
+  const names = new Set<string>()
+  for (const { names: specifiers, module } of imports(source)) {
+    if (!module.startsWith('../conversation/')) continue
+    for (const n of specifiers) if (DRAIN_NAME.test(n)) names.add(n)
+  }
+  return [...names].sort()
+}
+
+// ── 2. THE FLAG-ON HOST SET, walked from the canvas root ───────────────────
+function flagOnProviderBlock(): string {
+  const source = read(CANVAS_ROOT)
+  const open = source.indexOf('<ConversationProvider>')
+  const close = source.indexOf('</ConversationProvider>')
+  // A structural precondition, asserted rather than assumed: if the provider is
+  // renamed or restructured, this returns an empty string and EVERY drain reads
+  // dark — an instrument failure that would otherwise look like a finding
+  // (trap 20: uniformity is evidence about the probe).
+  if (open === -1 || close === -1 || close <= open) return ''
+  return source.slice(open, close)
+}
+
+/** Repo-relative paths of the components mounted inside the flag-ON provider. */
+function flagOnHostFiles(): string[] {
+  const block = flagOnProviderBlock()
+  const rootSource = read(CANVAS_ROOT)
+  const mounted = new Set<string>()
+  for (const m of block.matchAll(/<([A-Z][A-Za-z0-9]*)\s*\/>/g)) mounted.add(m[1])
+
+  const files = new Set<string>()
+  for (const { names, module } of imports(rootSource)) {
+    if (!names.some((n) => mounted.has(n))) continue
+    const path = resolveLocal(CANVAS_ROOT, module)
+    if (path !== null) files.add(path)
+  }
+  return [...files].sort()
+}
+
+function flagOnHostedDrains(drains: string[]): string[] {
+  const sources = flagOnHostFiles().map((f) => readFileSync(f, 'utf8'))
+  return drains.filter((d) => sources.some((s) => callsHook(s, d))).sort()
+}
+
+/**
+ * ⭐ THE DRAINS WITH NO FLAG-ON HOST, AND WHAT EACH ONE COSTS.
+ *
+ * Both run ONLY inside DraftChat, which the deployed posture does not mount.
+ * Both are recorded here rather than fixed: re-hosting either changes product
+ * behaviour and is its own decision.
+ *
+ * `useGraphEditEvents` — the sole emitter of `direct_graph_edit`, and the sole
+ *   production caller of `clearGuidanceItems()` (complete manifest:
+ *   `useGraphEditEvents.ts:293`; nothing else in `src/` calls it outside tests).
+ *   Dark, a flag-ON user loses:
+ *     (a) CEE never hears about a local canvas edit between turns. The turn
+ *         itself writes no graph server-side by design, so no persisted state is
+ *         lost — what is lost is CEE's awareness that the model moved.
+ *     (b) STALE COACHING SURVIVES A LOCAL STRUCTURAL EDIT. `clearGuidanceItems()`
+ *         is what drops every guidance item the moment the user changes the
+ *         model; with no host it never runs, so guidance minted against the old
+ *         model stands until the next assistant turn replaces the whole list
+ *         (`useConversation.ts:3911` / `:5078`). This is the user-visible half.
+ *     (c) Journey `direct_edit` scenario events — no loss: that limb is gated on
+ *         `isJourneyTabEnabled()` and Journey is retired by contract
+ *         (`shellContract.ts`, `presentedAsTab: false`).
+ *
+ * `useAnalysisCompleteEvent` — the only post-run guidance evictor
+ *   (`evictStaleItems` on results `preparing|connecting|streaming` → `complete`).
+ *   Dark, a flag-ON user loses NOTHING MEASURABLE TODAY, and that is a corpus
+ *   fact rather than a structural one:
+ *     · its `graph_hash` limb needs `graphChanged: true`, which this call site
+ *       never passes (`guidanceStore.ts:666-687`), so that limb cannot fire even
+ *       when hosted;
+ *     · its `analysis_hash` limb WOULD fire, but CEE emits no `analysis_hash` on
+ *       a coaching block — zero occurrences in the wire corpus against 37 for
+ *       `graph_hash_at_generation` (`v5/blocks/coachingCurrency.ts:109-114`).
+ *   ⚠ SO IT IS A TRIPWIRE, NOT A DEAD LOSS: the day CEE starts emitting
+ *   `analysis_hash`, this hook becomes load-bearing and its absence becomes a
+ *   real defect — silently. That is the reason it is recorded here rather than
+ *   dismissed.
+ *
+ * `useSessionResumeEvent` — sends `session_resume` when the user returns to a
+ *   scenario that already has a graph. Dark, a flag-ON user loses NOTHING, and
+ *   this one is structural rather than corpus-dependent: `session_resume` is not
+ *   in `WIRE_SYSTEM_EVENT_TYPES` (`conversation/types.ts:926`), so
+ *   `serializeSystemEvent` returns `null` for it and `sendSystemEvent`
+ *   short-circuits to `SEND_BLOCKED` before any network call
+ *   (`systemEvents.ts:34` states the intent outright — *"session_resume and
+ *   undo_draft are internal UI events only"*). Hosting it flag-ON would emit
+ *   nothing. ⚠ Same tripwire shape as above: adding `session_resume` to the wire
+ *   vocabulary would make this hook load-bearing, and its absence a real defect,
+ *   with nothing else to notice.
+ */
+const KNOWN_DARK_DRAINS = [
+  'useAnalysisCompleteEvent',
+  'useGraphEditEvents',
+  'useSessionResumeEvent',
+] as const
+
+describe('conversation drains — every DraftChat drain needs a flag-ON host', () => {
+  it('CONTROL: the derivation sees a plausible number of drains, and each is actually called', () => {
+    const drains = enumerateDrains()
+    const draftChat = read(DRAFT_CHAT)
+
+    // Positive control (trap 13/13e): a probe that enumerated nothing would make
+    // every downstream assertion vacuously true.
+    expect(drains.length).toBeGreaterThanOrEqual(5)
+    // A stale import is a false drain. Fail loudly rather than counting it.
+    for (const d of drains) {
+      expect(callsHook(draftChat, d), `${d} is imported by DraftChat but never called`).toBe(true)
+    }
+  })
+
+  it('CONTROL: the flag-ON provider block is found and hosts at least one drain', () => {
+    // CONTRAST CONTROL (trap 13e): absence is only evidence when the same probe
+    // can see a presence. If this reads zero, "two drains are dark" is a
+    // statement about the instrument, not about the product.
+    expect(flagOnProviderBlock().length).toBeGreaterThan(0)
+    expect(flagOnHostFiles().length).toBeGreaterThan(0)
+    expect(flagOnHostedDrains(enumerateDrains()).length).toBeGreaterThan(0)
+  })
+
+  it('the set of drains with NO flag-ON host is EXACTLY the known-dark set', () => {
+    const drains = enumerateDrains()
+    const hosted = new Set(flagOnHostedDrains(drains))
+    const dark = drains.filter((d) => !hosted.has(d)).sort()
+
+    // GROWS  → a drain went dark: the StructuralDeleteDrainHost defect recurring.
+    // SHRINKS → a known-dark drain was re-hosted: a behaviour change that must be
+    //           a conscious edit here, with the costs above re-read.
+    expect(dark).toEqual([...KNOWN_DARK_DRAINS].sort())
+  })
+
+  it('the known-dark set names only real drains (no entry outlives its hook)', () => {
+    const drains = new Set(enumerateDrains())
+    for (const d of KNOWN_DARK_DRAINS) {
+      expect(drains.has(d), `${d} is in KNOWN_DARK_DRAINS but DraftChat no longer imports it`).toBe(
+        true,
+      )
+    }
+  })
+})

--- a/src/canvas/conversation/__tests__/drainHostReachability.derived.spec.ts
+++ b/src/canvas/conversation/__tests__/drainHostReachability.derived.spec.ts
@@ -107,16 +107,32 @@ function enumerateDrains(): string[] {
 }
 
 // ── 2. THE FLAG-ON HOST SET, walked from the canvas root ───────────────────
+/**
+ * ⚠ SCOPED TO THE FUNCTION BODY FIRST, AND THAT IS NOT A TIDY-UP. The first
+ * version of this sliced the whole file between `<ConversationProvider>` and
+ * `</ConversationProvider>`, and `indexOf` matched a DOC-COMMENT mention of the
+ * tag (`ReactFlowGraph.tsx:2512`) rather than the JSX 11 lines below it. The
+ * derivation still returned the right answer — the comment sits just above the
+ * block, so the slice happened to contain it — which is precisely why it was
+ * dangerous: a probe reading the wrong bytes and agreeing anyway (trap 16). It
+ * was caught by a mutant that SURVIVED when it should have bitten.
+ *
+ * Anchoring on the function declaration first puts the comment out of range.
+ */
 function flagOnProviderBlock(): string {
   const source = read(CANVAS_ROOT)
-  const open = source.indexOf('<ConversationProvider>')
-  const close = source.indexOf('</ConversationProvider>')
+  const fnStart = source.indexOf('export function MaybeConversationProvider')
+  if (fnStart === -1) return ''
+  const body = source.slice(fnStart)
+  const open = body.indexOf('<ConversationProvider>')
+  const close = body.indexOf('</ConversationProvider>')
   // A structural precondition, asserted rather than assumed: if the provider is
   // renamed or restructured, this returns an empty string and EVERY drain reads
   // dark — an instrument failure that would otherwise look like a finding
-  // (trap 20: uniformity is evidence about the probe).
+  // (trap 20: uniformity is evidence about the probe). The CONTRAST CONTROL test
+  // below is what turns that into a RED instead of a false discovery.
   if (open === -1 || close === -1 || close <= open) return ''
-  return source.slice(open, close)
+  return body.slice(open, close)
 }
 
 /** Repo-relative paths of the components mounted inside the flag-ON provider. */

--- a/src/canvas/conversation/__tests__/useConversation.structuralDeleteConflictCategory.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.structuralDeleteConflictCategory.spec.ts
@@ -1,0 +1,279 @@
+/**
+ * Structural-delete 409 resolution — the SECOND guaranteed-no-write category.
+ *
+ * THE DEFECT, DERIVED AT THE CEE BYTES (olumi-assistants-service `293da078`,
+ * not inferred from the name):
+ *
+ * CEE has TWO 409 sources on the `structural_delete` path, and BOTH guarantee
+ * the write did not land:
+ *
+ *   1. `system-events/structural-delete.ts:475-484` — the stale gate refuses
+ *      before anything is resolved and returns `conflict_category:
+ *      BASE_HASH_DIVERGED`.
+ *   2. `session/supabase-store.ts:309-318` and `:1070-1079` — the ATOMIC CAS
+ *      (`append_turn_atomic_v3` / `v4`, SQLSTATE OLGC1) throws
+ *      `GraphStaleWriteError` with `conflict_category: 'rpc_cas_conflict'` and
+ *      the message *"Atomic in-transaction CAS: the whole turn rolled back,
+ *      nothing clobbered."* — the guarantee stated by the producer itself.
+ *
+ * Both ride the same envelope: `system-events/dispatch.ts:1176-1197` (the
+ * `structural_delete` arm) copies `err.conflict_category` onto `graphConflict`,
+ * and `orchestrator/route-v2.ts:2476-2504` sends it as a 409 `GRAPH_DIVERGED`
+ * with the category in `details.conflict_category`. The UI reads exactly that
+ * field (`extractConflictCategory`, `v5/failureTypeRetryability.ts:146`).
+ *
+ * At pristine, `useConversation.ts:3012` compared for `BASE_HASH_DIVERGED`
+ * ALONE, so an `rpc_cas_conflict` fell to `unconfirmed_server`: the canvas kept
+ * asserting a deletion the server had declined, under copy that says *"It's
+ * still gone from the canvas"*. A guaranteed no-write rendered as an unknown.
+ *
+ * ⚠ THE FIX IS SET-MEMBERSHIP, NOT A SECOND EQUALITY. The two categories are
+ * one CLASS — "the server proved it wrote nothing" — and the class is what the
+ * revert and the `base_hash_diverged` remedy are entitled to. The remedy copy
+ * ("ask me anything and I'll re-sync with the saved model") holds for both,
+ * because `applyV5State` captures the top-level `graph_hash` off EVERY response
+ * — so any turn refreshes the base hash, whichever gate refused.
+ *
+ * OPPOSITE-DIRECTION TWINS BELOW, and they are the point: a fence category and
+ * an unknown future category must STILL take the honest cannot-confirm line
+ * with NO revert. Widening a set is only safe if the outside of the set is
+ * pinned.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { Node, Edge } from '@xyflow/react'
+
+import { useConversation } from '../useConversation'
+import { useCanvasStore } from '../../store'
+import {
+  STRUCTURAL_DELETE_NOTICE,
+  type StructuralDeleteIntent,
+} from '../../mutations/structuralDelete'
+
+// ---------------------------------------------------------------------------
+// Mocks — seams only; the V5 adapter/parser/router chain stays REAL.
+// (Same harness discipline as useConversation.fence409Honesty.spec.ts.)
+// ---------------------------------------------------------------------------
+
+const mockCallTurn = vi.fn()
+vi.mock('../turnService', () => ({
+  callOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  streamOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  OrchestratorError: class OrchestratorError extends Error {
+    status: number
+    body: unknown
+    constructor(msg: string, status: number, body: unknown) {
+      super(msg)
+      this.name = 'OrchestratorError'
+      this.status = status
+      this.body = body
+    }
+  },
+}))
+
+vi.mock('../../../lib/supabase', () => ({
+  getUserId: async () => null,
+  getSessionIdentity: async () => ({ userId: null, accessToken: null }),
+}))
+
+// `sendSystemEvent` short-circuits to SEND_BLOCKED unless orchestrator V2 is on
+// (`useConversation.ts:6403`), and the flag has no default in `flags.ts`.
+// `importOriginal`-spread rather than a hand-listed factory: a `vi.mock` factory
+// REPLACES the module, so every flag not listed would silently vanish (trap 12).
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return { ...actual, isOrchestratorV2Enabled: () => true }
+})
+
+vi.mock('../../../services/scenarioService', () => ({
+  loadScenario: async () => null,
+  storeAnalysis: async () => undefined,
+}))
+
+vi.mock('../../../lib/posthog', () => ({
+  trackEvent: () => undefined,
+}))
+
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  return {
+    ...actual,
+    isV5Eligible: () => ({ eligible: true }),
+    isV5CanonicalRunPath: () => false,
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SCENARIO_ID = 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4'
+const DELETED_NODE_ID = 'option-expand-eu'
+const BASE_GRAPH_HASH = 'cfded3af0aa14ebd'
+
+/** The element the user deleted, verbatim, as the intent's revert evidence. */
+const DELETED_NODE = {
+  id: DELETED_NODE_ID,
+  type: 'option',
+  position: { x: 120, y: 240 },
+  data: { label: 'Expand into the EU' },
+} as unknown as Node
+
+const SURVIVING_NODE = {
+  id: 'goal-revenue',
+  type: 'goal',
+  position: { x: 0, y: 0 },
+  data: { label: 'Grow revenue' },
+} as unknown as Node
+
+function deleteIntent(): StructuralDeleteIntent {
+  return {
+    id: 'sd-1',
+    removedNodeIds: [DELETED_NODE_ID],
+    removedEdges: [],
+    baseGraphHash: BASE_GRAPH_HASH,
+    claimedNodeIds: [DELETED_NODE_ID],
+    claimedEdgeIds: [],
+    restore: { nodes: [DELETED_NODE], edges: [] as readonly Edge[] },
+  } as StructuralDeleteIntent
+}
+
+/**
+ * The 409 envelope both categories ride, byte-shaped from CEE
+ * `route-v2.ts:2476-2504` (`buildCommitFailureBoundaryError` +
+ * `preStageExtras`). Only `conflict_category` varies between the cases below —
+ * which is exactly the discrimination under test.
+ */
+function conflict409(category: string) {
+  return {
+    error: 'GRAPH_DIVERGED',
+    boundary: 'B1',
+    direction: 'egress',
+    validator: 'turn_commit',
+    details: {
+      phase: 'commit',
+      failure_type: 'GRAPH_DIVERGED',
+      event_kind: 'structural_delete',
+      recovery_action: 'refresh_and_reconfirm',
+      conflict_category: category,
+      expected_base_graph_hash: BASE_GRAPH_HASH,
+    },
+    request_id: `req_${category}`,
+    retryable: false,
+  }
+}
+
+function stub409(category: string) {
+  const body = conflict409(category)
+  const fetchStub = vi.fn(async () => ({
+    ok: false,
+    status: 409,
+    headers: new Headers({ 'content-type': 'application/json' }),
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response))
+  vi.stubGlobal('fetch', fetchStub)
+  return fetchStub
+}
+
+/**
+ * Drive one `structural_delete` turn whose commit 409s with `category`, from a
+ * canvas that has ALREADY had the element optimistically removed (which is the
+ * real pre-state: the store deletes synchronously and the drain sends after).
+ */
+async function driveDelete(category: string) {
+  stub409(category)
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_ID,
+    // Post-optimistic-delete state: the option is gone, the goal remains.
+    nodes: [SURVIVING_NODE],
+    edges: [],
+    results: { status: 'idle' } as never,
+    currentScenarioLastResultHash: null,
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+  } as never)
+
+  const intent = deleteIntent()
+  const { result } = renderHook(() => useConversation())
+  await act(async () => {
+    await result.current
+      .sendSystemEvent(
+        {
+          type: 'structural_delete',
+          payload: {
+            summary: 'Deleted 1 element',
+            base_graph_hash: BASE_GRAPH_HASH,
+            removed_node_ids: [DELETED_NODE_ID],
+            removed_edges: [],
+          },
+        } as never,
+        { structuralDelete: intent, debugSource: 'canvas_delete' },
+      )
+      .catch(() => undefined)
+  })
+
+  const nodeIds = useCanvasStore.getState().nodes.map((n) => n.id)
+  const notices = result.current.messages
+    .filter((m) => m.role === 'assistant' && m.synthetic === true)
+    .map((m) => m.content)
+
+  return { nodeIds, notices }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// The class that is entitled to a revert
+// ---------------------------------------------------------------------------
+
+describe('structural_delete 409 — a guaranteed no-write reverts and says so', () => {
+  it("'rpc_cas_conflict' (the atomic-CAS refusal) puts the element BACK and renders the diverged notice", async () => {
+    const { nodeIds, notices } = await driveDelete('rpc_cas_conflict')
+
+    // Bound by IDENTITY — the exact node the intent named, not a count.
+    expect(nodeIds).toContain(DELETED_NODE_ID)
+    // Bound to the exported constant, not to a prose fragment another string
+    // could satisfy.
+    expect(notices).toContain(STRUCTURAL_DELETE_NOTICE.base_hash_diverged)
+    // The lie this fixes: never claim it is still gone when the server declined.
+    expect(notices).not.toContain(STRUCTURAL_DELETE_NOTICE.unconfirmed_server)
+  })
+
+  it("POSITIVE CONTROL: 'BASE_HASH_DIVERGED' behaves identically (the pre-existing arm is untouched)", async () => {
+    const { nodeIds, notices } = await driveDelete('BASE_HASH_DIVERGED')
+
+    expect(nodeIds).toContain(DELETED_NODE_ID)
+    expect(notices).toContain(STRUCTURAL_DELETE_NOTICE.base_hash_diverged)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The outside of the set — pinned, because widening a set is only safe if its
+// complement is pinned too.
+// ---------------------------------------------------------------------------
+
+describe('structural_delete 409 — everything else is still an honest unknown', () => {
+  it('OPPOSITE TWIN: an unknown future category does NOT revert and takes the cannot-confirm line', async () => {
+    const { nodeIds, notices } = await driveDelete('some_future_conflict_category')
+
+    expect(nodeIds).not.toContain(DELETED_NODE_ID)
+    expect(notices).toContain(STRUCTURAL_DELETE_NOTICE.unconfirmed_server)
+    expect(notices).not.toContain(STRUCTURAL_DELETE_NOTICE.base_hash_diverged)
+  })
+
+  it('OPPOSITE TWIN: a turn-fence category does NOT revert either (no no-write guarantee for that class here)', async () => {
+    const { nodeIds, notices } = await driveDelete('turn_fence_superseded')
+
+    expect(nodeIds).not.toContain(DELETED_NODE_ID)
+    expect(notices).toContain(STRUCTURAL_DELETE_NOTICE.unconfirmed_server)
+    expect(notices).not.toContain(STRUCTURAL_DELETE_NOTICE.base_hash_diverged)
+  })
+})

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -41,6 +41,7 @@ import {
   readStructuralDeleteReceipt,
   revertStructuralDelete,
   STRUCTURAL_DELETE_NOTICE,
+  STRUCTURAL_DELETE_NO_WRITE_CONFLICT_CATEGORIES,
   type StructuralDeleteIntent,
   type StructuralDeleteNoticeKey,
 } from '../mutations/structuralDelete'
@@ -3005,13 +3006,38 @@ export function useConversation(): UseConversationReturn {
           outcome.response.assistant_text.trim().length > 0
         notice = spoke ? null : 'unconfirmed_server'
       } else if (outcome.kind === 'typed_error') {
-        // BASE_HASH_DIVERGED is the ONLY category with a guaranteed no-write and
-        // a remedy that actually works. A fence category or an unknown one gets
-        // the honest cannot-confirm line rather than a reload instruction we
-        // cannot promise resolves anything (P8).
-        const diverged = outcome.conflictCategory === 'BASE_HASH_DIVERGED'
-        shouldRevert = diverged
-        notice = diverged ? 'base_hash_diverged' : 'unconfirmed_server'
+        // SET-MEMBERSHIP, NOT ONE EQUALITY — CEE has TWO 409 sources on this
+        // path and BOTH state a no-write guarantee in their own words. An
+        // equality against the first alone sent the second down the
+        // cannot-confirm line, so the canvas kept asserting a deletion the
+        // server had declined, under copy reading "It's still gone from the
+        // canvas". Derived at the CEE bytes (293da078), not from the names:
+        //
+        //   · BASE_HASH_DIVERGED  — system-events/structural-delete.ts:475-484,
+        //     the stale gate, refused before anything is resolved.
+        //   · rpc_cas_conflict    — session/supabase-store.ts:309-318 (v3) and
+        //     :1070-1079 (v4), the atomic CAS on SQLSTATE OLGC1, whose own
+        //     message is "Atomic in-transaction CAS: the whole turn rolled
+        //     back, nothing clobbered."
+        //
+        // Both arrive identically: dispatch.ts:1176-1197 copies
+        // `err.conflict_category` onto `graphConflict`, and route-v2.ts:2476-2504
+        // sends it as a 409 GRAPH_DIVERGED with the category in
+        // `details.conflict_category`.
+        //
+        // ONE NOTICE FOR BOTH, and the remedy holds for both: `applyV5State`
+        // captures the top-level `graph_hash` off EVERY response, so any turn
+        // re-syncs the base hash whichever gate refused. See
+        // STRUCTURAL_DELETE_NOTICE.base_hash_diverged for why the two more
+        // obvious instructions are affordances terminating in refusal (P8).
+        //
+        // A fence category or an unknown one is still NOT in the set: it gets
+        // the honest cannot-confirm line rather than a promise we cannot keep.
+        const provenNoWrite = STRUCTURAL_DELETE_NO_WRITE_CONFLICT_CATEGORIES.has(
+          outcome.conflictCategory ?? '',
+        )
+        shouldRevert = provenNoWrite
+        notice = provenNoWrite ? 'base_hash_diverged' : 'unconfirmed_server'
       } else {
         notice = 'unconfirmed_transport'
       }

--- a/src/canvas/mutations/structuralDelete.ts
+++ b/src/canvas/mutations/structuralDelete.ts
@@ -470,6 +470,34 @@ export function revertStructuralDelete(
 }
 
 /**
+ * The `details.conflict_category` values on a 409 `GRAPH_DIVERGED` for which
+ * CEE ITSELF STATES the write did not land. Membership here is what entitles
+ * the resolver to revert the canvas and to promise, in
+ * `STRUCTURAL_DELETE_NOTICE.base_hash_diverged`, that nothing was removed.
+ *
+ * ⚠ DERIVED FROM THE PRODUCER, ONE ENTRY PER STATED GUARANTEE (CEE
+ * `293da078`) — never from what a category NAME suggests:
+ *
+ *   · `BASE_HASH_DIVERGED` — `system-events/structural-delete.ts:475-484`.
+ *     The stale gate refuses before any target is resolved; the refusal path
+ *     writes no graph and no turn row.
+ *   · `rpc_cas_conflict`   — `session/supabase-store.ts:309-318` (v3) and
+ *     `:1070-1079` (v4). The atomic in-transaction CAS raises SQLSTATE OLGC1
+ *     and the store throws `GraphStaleWriteError`, whose message is the
+ *     guarantee: *"Atomic in-transaction CAS: the whole turn rolled back,
+ *     nothing clobbered."*
+ *
+ * ⚠ THIS IS A CLOSED SET AND MUST STAY ONE. A category absent from it — a
+ * turn-fence verdict, or any future category — is an UNKNOWN, and an unknown
+ * takes `unconfirmed_server`. Reverting on an unknown would assert "these are
+ * still in your model" with no evidence, which is exactly as unfounded as
+ * leaving them deleted. Add a member only with the producer line that states
+ * the guarantee, and pin its opposite-direction twin.
+ */
+export const STRUCTURAL_DELETE_NO_WRITE_CONFLICT_CATEGORIES: ReadonlySet<string> =
+  new Set(['BASE_HASH_DIVERGED', 'rpc_cas_conflict'])
+
+/**
  * The one honest sentence for a delete whose fate we could not confirm, keyed by
  * OUTCOME rather than composed at each site.
  *

--- a/src/canvas/store/__tests__/analysisRefusalNotice.spec.ts
+++ b/src/canvas/store/__tests__/analysisRefusalNotice.spec.ts
@@ -37,6 +37,7 @@ import {
   deriveAnalysisRefusalNoticeUpdate,
   describeAnalysisRefusalReason,
   ANALYSIS_REFUSAL_REASON_COPY,
+  ANALYSIS_REFUSAL_GENERIC_REASON,
   type AnalysisRefusalNoticeUpdate,
 } from '../analysisRefusalNotice'
 
@@ -190,6 +191,61 @@ describe('describeAnalysisRefusalReason — mapped vocabulary derived from the C
     'OPTION_NO_FACTOR_EDGES',
     'OPTION_NOT_LINKED_TO_DECISION',
   ] as const
+
+  /**
+   * ⚠ THE LIST ABOVE WAS SHORT, AND THE OMISSION WAS THE MOST COMMON CODE ON
+   * THE DEPLOYED WIRE. `ReadinessReasonCode` (analysis-ready-core.ts:56-70 at
+   * CEE `293da078`) is a UNION, and one of its members is
+   * `CanonicalReadinessIssueCode` — a whole second family the list above never
+   * enumerated. The reachability chain, derived rather than assumed:
+   *
+   *   `assessCanonicalAnalysisReadiness` builds `blockingIssues`
+   *     (analysis-ready-helper.ts:1057-1063 — structural violations, then
+   *      `appendSemanticIssues` which pushes the semantic codes into the SAME
+   *      array)
+   *   -> `reasonCodes = [...new Set(blockingIssues.map(i => i.code))]`
+   *      (analysis-ready-core.ts:163-165)
+   *   -> `details.reason_code = verdict.reasonCodes[0]`
+   *      (run-analysis.ts:324, on the `AnalysisNotReadyError` branch)
+   *   -> `blockedReasonForHandlerFailure` returns `details.reason_code`
+   *      (handler-errors.ts:196-202)
+   *   -> `analysis_ready.blocked_reason`.
+   *
+   * WITNESSED, not only derived: CEE PR #1023 measured
+   * `blocked_reason="MISSING_OPTION_VALUE"` against deployed staging on 18 Aug
+   * 2026 — the code the map had no entry for was the one the P0 arrived on.
+   *
+   * `insufficient_analysable_options` is a lower_snake `reason_code` from a
+   * different producer entirely (run-analysis.ts:434-459), reachable only when
+   * excluding unanalysable options leaves fewer than PLoT's two-option minimum.
+   */
+  const CANONICAL_ISSUE_CODES_REACHABLE_FROM_RUN_ANALYSIS = [
+    // CanonicalReadinessIssueCode members NOT already covered above
+    // (analysis-ready-helper.ts:52-66), each with its blocking producer:
+    'MISSING_OPTION_VALUE',            // blockerIssue 'missing_value'      :681-687
+    'AMBIGUOUS_OPTION_VALUE',          // blockerIssue 'ambiguous_value'    :688-694
+    'MISSING_OPTION_CONNECTION',       // blockerIssue 'missing_connection' :695-701
+    'CONSTRAINT_REVIEW_REQUIRED',      // blockerIssue 'constraint_dropped' :702-708
+    'UNREACHABLE_CONTROLLABLE_FACTOR', // blockerIssue mapping-no-option    :672-679
+    'OPTION_NEEDS_MAPPING',            // per-option sweep                  :923-937
+    'OPTION_NEEDS_ENCODING',           // per-option sweep                  :923-937
+    // A distinct producer, not a canonical issue code.
+    'insufficient_analysable_options', // run-analysis.ts                   :434-459
+  ] as const
+
+  it.each(CANONICAL_ISSUE_CODES_REACHABLE_FROM_RUN_ANALYSIS)(
+    'maps the reachable canonical code %s to specific copy',
+    (code) => {
+      const copy = describeAnalysisRefusalReason(code)
+      expect(copy).toBeTypeOf('string')
+      expect((copy as string).length).toBeGreaterThan(0)
+      // OPPOSITE DIRECTION: specific means SPECIFIC — a mapped code must not
+      // silently resolve to the honest generic, which would pass the length
+      // assertion above while telling the user nothing (trap 13b: a guard that
+      // agrees with itself).
+      expect(copy).not.toBe(ANALYSIS_REFUSAL_GENERIC_REASON)
+    },
+  )
 
   it.each(CAUSE_KINDS_REACHABLE_FROM_RUN_ANALYSIS)(
     'maps the reachable cause_kind %s to specific copy',

--- a/src/canvas/store/analysisRefusalNotice.ts
+++ b/src/canvas/store/analysisRefusalNotice.ts
@@ -9,13 +9,32 @@
  *   analysis_ready: { status: 'blocked', blocked_reason: <specific code>,
  *                     options: [], goal_node_id: '', freshness, computed_at }
  *
- * `applyV5State`'s readiness normaliser REJECTS that carrier (empty
- * `goal_node_id` / empty `options`) and clears `ceeAnalysisReady`. That
- * rejection is CORRECT and deliberate — a deployed-UI trace (2026-08-14)
- * established the clearing kills two harms, and the R1-R3 dynamics are
- * premised on it. So the refusal is NOT routed back into readiness. It gets
- * this separate, lightweight, SESSION-LOCAL field instead, extracted from the
- * raw payload before validation.
+ * ⚠ THE SENTENCE THAT USED TO SIT HERE WAS TRUE OF ONE ARM AND WRITTEN AS IF
+ * IT WERE TRUE OF THE CARRIER. It read: *"`applyV5State`'s readiness
+ * normaliser REJECTS that carrier (empty `goal_node_id` / empty `options`) and
+ * clears `ceeAnalysisReady`."* CEE #1023 (merged 2026-08-18) made a second
+ * refusal arm ACCEPTED, so the true statement is:
+ *
+ *   ARM A — EMPTY carrier (`options: []`, `goal_node_id: ''`). Still emitted
+ *     when the turn's structural projection is `ready`, absent or degenerate,
+ *     and on the chip-click arm. The readiness normaliser REJECTS it and clears
+ *     `ceeAnalysisReady`. That rejection is CORRECT and deliberate — a
+ *     deployed-UI trace (2026-08-14) established the clearing kills two harms,
+ *     and the R1-R3 dynamics are premised on it.
+ *   ARM B — IDENTITY-PRESERVING carrier (non-empty `goal_node_id` and
+ *     `options`). `buildAnalysisRefusalReadiness`
+ *     (`analysis-ready-helper.ts:1427-1472` at CEE `293da078`) preserves the
+ *     model's identity when the structural projection is not `ready`, using the
+ *     UI's own accept predicate as its degeneracy guard — so the normaliser
+ *     ACCEPTS it and writes `ceeAnalysisReady` with `status: 'blocked'`.
+ *     `deriveAnalysisDisplayState` maps that to `not_ready`, so an accepted
+ *     refusal still cannot render a green completion.
+ *
+ * NEITHER ARM ROUTES THE REFUSAL BACK INTO READINESS. It gets this separate,
+ * lightweight, SESSION-LOCAL field instead, extracted from the raw payload
+ * before validation — and because the derivation below keys on `status` plus a
+ * non-empty `blocked_reason` and never on the identity fields, both arms set
+ * it identically.
  *
  * ⚠ TWO DISTINCT `status: 'blocked'` CARRIERS EXIST — derived at the CEE bytes
  * (PR #942 head 2ca6c079), not inferred. Only one is a refusal:
@@ -140,6 +159,67 @@ export const ANALYSIS_REFUSAL_REASON_COPY: Readonly<Record<string, string>> = {
     "An option's effect could not be resolved to a value.",
   INTERNAL_ERROR:
     'The analysis stopped on an internal error. This is on our side, not your model.',
+
+  // ── reason_code, CanonicalReadinessIssueCode ──────────────────────────
+  // (analysis-ready-helper.ts:52-66). ⚠ THIS FAMILY WAS MISSING ENTIRELY, and
+  // the omission included `MISSING_OPTION_VALUE`, the code CEE PR #1023
+  // measured on the deployed wire. `ReadinessReasonCode` is a UNION whose
+  // members include `CanonicalReadinessIssueCode`, so covering
+  // `StructuralViolationCode` 10/10 was covering one arm of a union and
+  // reading as complete.
+  //
+  // EVERY SENTENCE BELOW IS DERIVED FROM THE ISSUE BUILDER THAT EMITS THE CODE
+  // (trap 13c / P7 — the producer's semantics, never our reading of the name),
+  // and each is written to be compatible with the message CEE puts in the chat
+  // for the same issue, so the two surfaces cannot contradict each other.
+  //
+  // ⚠ THEY STATE A CLASS, NEVER AN INSTANCE. `blocked_reason` is a bare code:
+  // the option and factor labels live on `readiness_issues[]`, which this
+  // notice does not read. Naming "your Expand-into-the-EU option" here would be
+  // a claim about the user's model that this surface cannot ground (P5). The
+  // pointer line above carries the action; these carry the fact.
+  MISSING_OPTION_VALUE:
+    // blockerIssue 'missing_value' (:681-687): `Choose the missing effect
+    // value for "<option>" on "<factor>".`
+    'An option has no effect value set on one of your factors, so there was nothing to compare.',
+  AMBIGUOUS_OPTION_VALUE:
+    // blockerIssue 'ambiguous_value' (:688-694): `Confirm the effect value…`
+    "An option's effect value could be read in more than one way, so it was not safe to use.",
+  MISSING_OPTION_CONNECTION:
+    // blockerIssue 'missing_connection' (:695-701): `Choose the missing
+    // connection…` — category `option_mapping`.
+    'An option is not connected to the factor it affects, so its effect could not be traced.',
+  CONSTRAINT_REVIEW_REQUIRED:
+    // blockerIssue 'constraint_dropped' (:702-708): `Review the unresolved
+    // constraint…`; `requiredInputForIssue` gives it its own
+    // `constraint_review` kind (:743).
+    'A constraint on this decision was left unresolved, so the analysis stopped rather than ignore it.',
+  UNREACHABLE_CONTROLLABLE_FACTOR:
+    // blockerIssue mapping-with-no-option (:672-679): fires when the payload is
+    // `needs_user_mapping` and the blocker names a FACTOR but no option —
+    // `Choose which option changes "<factor>" and by how much.`
+    'A factor you can control is not changed by any of your options, so nothing connects it to the decision.',
+  OPTION_NEEDS_MAPPING:
+    // per-option sweep (:923-937), `option.status === 'needs_user_mapping'`:
+    // `Choose which factor "<option>" changes and by how much.`
+    'It is not yet recorded which factor one of your options changes, or by how much.',
+  OPTION_NEEDS_ENCODING:
+    // per-option sweep (:923-937), the non-mapping arm: `Choose how "<option>"
+    // should be represented on the effect scale.` The status itself is defined
+    // as "has raw values (categorical/boolean) awaiting numeric encoding"
+    // (schemas/analysis-ready.ts:62). ⚠ A SECOND, NON-BLOCKING producer emits
+    // this code as a `safe_canonicalisation` carrier issue (:1009-1017); that
+    // one never becomes a `blocked_reason`, so this sentence describes the
+    // blocking sense only.
+    "An option's value is not a number yet, so it could not be placed on the effect scale.",
+
+  // ── reason_code, the analysable-option gate (run-analysis.ts:434-459) ──
+  // Not a canonical issue code: a distinct refusal raised BEFORE PLoT, because
+  // `/v2/run` declares `options` with `minItems: 2` and a one-option
+  // "comparison" has a win probability of 1.0 by construction. Aligned with the
+  // `next_step` CEE puts in the chat for the same code.
+  insufficient_analysable_options:
+    'Leaving out the options with no values set left only one to compare, and one option is not a comparison.',
 
   // ── reason_code, StructuralViolationCode (graph-structure-validator.ts:22-32)
   NO_GOAL: 'The model has no goal, so there was nothing to analyse towards.',

--- a/src/v5/__tests__/applyV5State.analysisRefusalNotice.spec.tsx
+++ b/src/v5/__tests__/applyV5State.analysisRefusalNotice.spec.tsx
@@ -7,15 +7,37 @@
  *                     goal_node_id: '', freshness, freshness_reason, computed_at }
  *   stage_indicator: 'analyse'
  *
- * ⚠⚠ THE CONSTRAINT THIS SPEC EXISTS TO PROTECT, AS MUCH AS THE FEATURE.
- * The readiness normaliser REJECTS this carrier (empty goal_node_id / empty
- * options) → `setCeeAnalysisReady(null)` + a deferred
- * `analysis_ready_invalid_shape`. That is CORRECT and must NOT change: a
- * deployed-UI trace (2026-08-14) established the clearing kills two harms and
- * the R1–R3 dynamics are premised on it, and
- * `applyV5State.blockedAnalysisReady.spec.tsx` pins it independently. So the
- * refusal is routed into its OWN slice, and the tests below assert the
- * readiness and freshness behaviour is BYTE-FOR-BYTE what it was.
+ * ⚠⚠ THERE ARE NOW TWO REFUSAL CARRIERS, AND THIS COMMENT USED TO DESCRIBE
+ * ONLY ONE. It read: *"The readiness normaliser REJECTS this carrier (empty
+ * goal_node_id / empty options) ... That is CORRECT and must NOT change."*
+ * That is TRUE OF THE EMPTY CARRIER AND FALSE AS A GENERAL STATEMENT, because
+ * CEE #1023 (merged 2026-08-18) deliberately made the OTHER arm ACCEPTED.
+ * `buildAnalysisRefusalReadiness` (`analysis-ready-helper.ts:1427-1472` at CEE
+ * `293da078`) now takes the turn's structural projection and PRESERVES the
+ * model's identity when that projection is not `ready`:
+ *
+ *   ARM A — EMPTY   `{ status:'blocked', blocked_reason, options:[],
+ *                       goal_node_id:'' }`. Returned byte-identically to before
+ *                       when the structural projection is `ready`, absent, or
+ *                       degenerate, and on the chip-click arm which passes
+ *                       nothing. The normaliser REJECTS it →
+ *                       `setCeeAnalysisReady(null)` + a deferred
+ *                       `analysis_ready_invalid_shape`. That rejection is
+ *                       correct and must not change: a deployed-UI trace
+ *                       (2026-08-14) established the clearing kills two harms,
+ *                       the R1–R3 dynamics are premised on it, and
+ *                       `applyV5State.blockedAnalysisReady.spec.tsx` pins it.
+ *
+ *   ARM B — IDENTITY-PRESERVING `{ status:'blocked', blocked_reason,
+ *                       options:[…non-empty], goal_node_id:'…' }`. The
+ *                       normaliser ACCEPTS it — CEE copied the UI's own accept
+ *                       predicate verbatim as its degeneracy guard — so this
+ *                       arm produces `analysis_ready:set`, NOT a clear.
+ *
+ * Both arms set the refusal notice, because `deriveAnalysisRefusalNoticeUpdate`
+ * keys on `status` + a non-empty `blocked_reason` and nothing else. Arm B is
+ * pinned end to end in its own describe below; the arm-A tests keep asserting
+ * the readiness and freshness behaviour is BYTE-FOR-BYTE what it was.
  *
  * The three-valued update is the point of the seam:
  *   set    — blocked + non-empty blocked_reason
@@ -30,13 +52,19 @@ import { render, screen } from '@testing-library/react'
 import type { OlumiResponse } from '@talchain/schemas/boundary'
 
 import { applyV5State, type V5ApplicatorStore } from '../applyV5State'
+import { deriveAnalysisDisplayState } from '../../canvas/utils/deriveAnalysisDisplayState'
 import { AnalysisRefusalNotice } from '../../components/results/AnalysisRefusalNotice'
 import {
   ANALYSIS_REFUSAL_HEADLINE,
   ANALYSIS_REFUSAL_REASON_COPY,
 } from '../../canvas/store/analysisRefusalNotice'
 
-/** Exact CEE refusal wire shape (buildAnalysisRefusalReadiness + attachComputedAt). */
+/**
+ * ARM A — the EMPTY refusal carrier, exact CEE wire shape
+ * (`buildAnalysisRefusalReadiness` with no/ready/degenerate structural
+ * projection, + attachComputedAt). Still emitted; still rejected by the
+ * readiness normaliser.
+ */
 const REFUSAL_ANALYSIS_READY = {
   status: 'blocked',
   blocked_reason: 'options_not_configured',
@@ -60,6 +88,31 @@ const LEGACY_FRESHNESS_ONLY_ANALYSIS_READY = {
   computed_at: '2026-07-07T10:00:00.000Z',
   freshness: 'unknown',
   freshness_reason: 'legacy_fact_missing_hash',
+}
+
+/**
+ * ARM B — the IDENTITY-PRESERVING refusal carrier (CEE #1023, merged
+ * 2026-08-18). Shape derived from the PRODUCER, not from the name:
+ * `buildAnalysisRefusalReadiness` returns `{ ...refusal, goal_node_id, options }`
+ * where both come straight off the turn's structural projection
+ * (`analysis-ready-helper.ts:1471` at CEE `293da078`), and the option entries
+ * are `OptionForAnalysis` (`src/schemas/analysis-ready.ts:83-101`: id, label,
+ * status, interventions). The function writes NO per-option status of its own.
+ *
+ * `MISSING_OPTION_VALUE` is the code the P0 that motivated #1023 was measured
+ * on, against deployed staging.
+ */
+const IDENTITY_PRESERVING_REFUSAL_ANALYSIS_READY = {
+  status: 'blocked',
+  blocked_reason: 'MISSING_OPTION_VALUE',
+  goal_node_id: '378f195a',
+  options: [
+    { id: 'opt_expand_eu', label: 'Expand into the EU', status: 'needs_encoding', interventions: {} },
+    { id: 'opt_hold', label: 'Hold position', status: 'needs_encoding', interventions: {} },
+  ] as unknown[],
+  freshness: 'unknown',
+  freshness_reason: 'no_successful_run_analysis_fact',
+  computed_at: '2026-08-18T05:00:00.000Z',
 }
 
 const ACCEPTED_ANALYSIS_READY = {
@@ -236,5 +289,141 @@ describe('applyV5State — CEE typed analysis refusal (EXT-2)', () => {
       ANALYSIS_REFUSAL_REASON_COPY.options_not_configured,
     )
     expect(el).toHaveAttribute('data-blocked-reason', 'options_not_configured')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ARM B — the newly reachable accepted carrier, end to end.
+//
+// ⚠ THIS ARM HAD ZERO COVERAGE. Every test above and in
+// `applyV5State.blockedAnalysisReady.spec.tsx` drives the EMPTY carrier, so the
+// suite was fully green about a wire shape the deployed producer now emits and
+// the normaliser now ACCEPTS. A green suite is not evidence about a branch no
+// test reaches.
+//
+// The end-to-end claim is the point (P2 — check the MOUNTED consumer, not the
+// producer bytes): a refusal that is ACCEPTED into the readiness slice must
+// still reach the user as "not ready", never as a green completion. The chain
+// pinned here is `applyV5State` → the readiness status it wrote →
+// `deriveAnalysisDisplayState`, which is the canonical mapper the analysis
+// surfaces consume through `useAnalysisState().displayState`.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('applyV5State — ARM B: the IDENTITY-PRESERVING refusal carrier (CEE #1023)', () => {
+  it('is ACCEPTED into the readiness slice — analysis_ready:set, not cleared', () => {
+    const { store, setCeeAnalysisReady } = makeStore()
+
+    const result = applyV5State(
+      baseResponse({
+        stage_indicator: 'analyse',
+        analysis_ready: IDENTITY_PRESERVING_REFUSAL_ANALYSIS_READY,
+      } as unknown as Partial<OlumiResponse>),
+      store,
+    )
+
+    expect(result.applied).toContain('analysis_ready:set')
+    expect(setCeeAnalysisReady).not.toHaveBeenCalledWith(null)
+    expect(
+      result.deferred.some((d) => d.reason === 'analysis_ready_invalid_shape'),
+    ).toBe(false)
+  })
+
+  it("preserves the model's IDENTITY into the slice — the goal and both option ids, by identity", () => {
+    const { store, setCeeAnalysisReady } = makeStore()
+
+    applyV5State(
+      baseResponse({
+        stage_indicator: 'analyse',
+        analysis_ready: IDENTITY_PRESERVING_REFUSAL_ANALYSIS_READY,
+      } as unknown as Partial<OlumiResponse>),
+      store,
+    )
+
+    const written = setCeeAnalysisReady.mock.calls.at(-1)?.[0] as
+      | { status?: string; goal_node_id?: string; options?: { id: string }[] }
+      | null
+    // Bound by IDENTITY (the exact ids CEE preserved), never by a count — a
+    // count is satisfied by any two options.
+    expect(written?.goal_node_id).toBe('378f195a')
+    expect(written?.options?.map((o) => o.id)).toEqual([
+      'opt_expand_eu',
+      'opt_hold',
+    ])
+    expect(written?.status).toBe('blocked')
+  })
+
+  it('STILL sets the refusal notice — acceptance into readiness does not consume the refusal', () => {
+    const { store, setAnalysisRefusalNotice } = makeStore()
+
+    const result = applyV5State(
+      baseResponse({
+        stage_indicator: 'analyse',
+        analysis_ready: IDENTITY_PRESERVING_REFUSAL_ANALYSIS_READY,
+      } as unknown as Partial<OlumiResponse>),
+      store,
+    )
+
+    expect(setAnalysisRefusalNotice).toHaveBeenCalledTimes(1)
+    expect(setAnalysisRefusalNotice).toHaveBeenCalledWith({
+      blockedReason: 'MISSING_OPTION_VALUE',
+      computedAt: '2026-08-18T05:00:00.000Z',
+    })
+    expect(result.applied).toContain('analysis_refusal_notice:set')
+  })
+
+  it('END TO END: the accepted refusal renders as NOT READY, even with a prior report in hand', () => {
+    const { store, setCeeAnalysisReady } = makeStore()
+
+    applyV5State(
+      baseResponse({
+        stage_indicator: 'analyse',
+        analysis_ready: IDENTITY_PRESERVING_REFUSAL_ANALYSIS_READY,
+      } as unknown as Partial<OlumiResponse>),
+      store,
+    )
+
+    const written = setCeeAnalysisReady.mock.calls.at(-1)?.[0] as
+      | { status?: string }
+      | null
+    // The status the applicator actually wrote is what the mapper receives —
+    // not a status this test chose, which is the difference between pinning the
+    // chain and pinning a fixture (trap 16: a fixture you wrote yourself is not
+    // evidence about the wire).
+    const view = deriveAnalysisDisplayState({
+      ceeAnalysisReadyStatus: written?.status,
+      // The hostile case: a populated prior report would render a green
+      // "Analysis complete" if the refusal status did not override it.
+      hasReport: true,
+      analysisChanged: false,
+    })
+
+    expect(view.state).toBe('not_ready')
+  })
+
+  it("OPPOSITE-DIRECTION TWIN: an ACCEPTED 'ready' carrier is not_ready's opposite — it clears the notice and renders complete", () => {
+    const { store, setAnalysisRefusalNotice, setCeeAnalysisReady } = makeStore()
+
+    const result = applyV5State(
+      baseResponse({
+        stage_indicator: 'analyse',
+        analysis_ready: ACCEPTED_ANALYSIS_READY,
+      } as unknown as Partial<OlumiResponse>),
+      store,
+    )
+
+    expect(setAnalysisRefusalNotice).toHaveBeenCalledWith(null)
+    expect(result.applied).toContain('analysis_refusal_notice:cleared')
+
+    const written = setCeeAnalysisReady.mock.calls.at(-1)?.[0] as
+      | { status?: string }
+      | null
+    const view = deriveAnalysisDisplayState({
+      ceeAnalysisReadyStatus: written?.status,
+      hasReport: true,
+      analysisChanged: false,
+    })
+    // Proves the previous test's `not_ready` is the refusal's doing and not a
+    // constant this harness always produces.
+    expect(view.state).toBe('complete')
   })
 })

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -1100,14 +1100,31 @@ export function applyV5State(
   // `blocked_reason` had ZERO readers repo-wide, and an honest refusal nobody
   // renders is indistinguishable from a silent failure.
   //
-  // ⚠ IT IS DELIBERATELY NOT ROUTED INTO THE READINESS SLICE. The normaliser
-  // below REJECTS this carrier (empty goal_node_id / empty options) and clears
-  // `ceeAnalysisReady`; a deployed-UI trace (2026-08-14) established that
-  // clearing is correct and load-bearing, and
-  // `applyV5State.blockedAnalysisReady.spec.tsx` pins it. So the refusal is
-  // extracted HERE, from the raw payload while it is still in hand and BEFORE
-  // validation, into its own session-local slice. Nothing about the readiness
-  // slice's behaviour changes.
+  // ⚠ IT IS DELIBERATELY NOT ROUTED INTO THE READINESS SLICE — and there are
+  // now TWO refusal carriers, which this comment used to deny. It said the
+  // normaliser "REJECTS this carrier", full stop. That is true of ONE arm only:
+  //
+  //   ARM A — EMPTY (`options: []`, `goal_node_id: ''`). The normaliser below
+  //     REJECTS it and clears `ceeAnalysisReady`; a deployed-UI trace
+  //     (2026-08-14) established that clearing is correct and load-bearing, and
+  //     `applyV5State.blockedAnalysisReady.spec.tsx` pins it. Still emitted for
+  //     a `ready`/absent/degenerate structural projection and on the chip-click
+  //     arm.
+  //   ARM B — IDENTITY-PRESERVING (non-empty `goal_node_id` and `options`).
+  //     CEE #1023 (merged 2026-08-18, `analysis-ready-helper.ts:1427-1472` at
+  //     `293da078`) preserves the model's identity when the turn's structural
+  //     projection is not `ready`, and its degeneracy guard is a VERBATIM copy
+  //     of the accept predicate at :232-234 below. So the normaliser ACCEPTS
+  //     this one: `analysis_ready:set`, no clear, no deferred invalid-shape.
+  //
+  // EITHER WAY THE REFUSAL IS EXTRACTED HERE, from the raw payload while it is
+  // still in hand and BEFORE validation, into its own session-local slice —
+  // `deriveAnalysisRefusalNoticeUpdate` keys on `status` plus a non-empty
+  // `blocked_reason` and never on the identity fields, so both arms set it.
+  // What the normaliser does with the carrier afterwards is unchanged by this
+  // block, on either arm. Arm B is pinned end to end (through to
+  // `deriveAnalysisDisplayState` = `not_ready`) in
+  // `applyV5State.analysisRefusalNotice.spec.tsx`.
   //
   // Three-valued on purpose: a conversational turn RETAINS the notice (silence
   // is not evidence the refusal is over), an accepted analysis_ready or a


### PR DESCRIPTION
Applies the Fable-adjudicated findings from the 17/18 Aug review wave, UI half. Five items, one PR. Base `staging` `c71ea7e0`.

**Two premises in the brief were wrong at my tip, and both corrections are below.**

---

## 1 — `rpc_cas_conflict` is a guaranteed no-write, and the canvas now says so

`useConversation.ts:3012` compared `conflictCategory === 'BASE_HASH_DIVERGED'` alone. CEE has **two** 409 sources on the `structural_delete` path and **both** state a no-write guarantee in their own words — derived at CEE `293da078`, not from the names:

| category | producer | the guarantee, verbatim |
|---|---|---|
| `BASE_HASH_DIVERGED` | `system-events/structural-delete.ts:475-484` | the stale gate refuses before any target is resolved |
| `rpc_cas_conflict` | `session/supabase-store.ts:309-318` (v3), `:1070-1079` (v4) | *"Atomic in-transaction CAS: the whole turn rolled back, nothing clobbered."* |

Both arrive identically — `dispatch.ts:1176-1197` copies `err.conflict_category` onto `graphConflict`, `route-v2.ts:2476-2504` sends it as a 409 `GRAPH_DIVERGED` with the category in `details.conflict_category`, and the UI reads exactly that field (`extractConflictCategory`).

So the second one fell to `unconfirmed_server`: **the canvas kept asserting a deletion the server had declined, under copy reading *"It's still gone from the canvas"***.

Fixed as **set membership**, not a second equality — `STRUCTURAL_DELETE_NO_WRITE_CONFLICT_CATEGORIES` in `structuralDelete.ts`, one entry per stated guarantee with the producer line beside it. The `base_hash_diverged` remedy holds for both: `applyV5State` captures the top-level `graph_hash` off every response, so any turn re-syncs the base hash whichever gate refused.

**RED-first**, named signature `expected [ 'goal-revenue' ] to include 'option-expand-eu'`, with the `BASE_HASH_DIVERGED` positive control and both opposite twins (an unknown future category, a turn-fence category) **green at pristine** — so the widening is bounded on the outside as well as the inside.

## 2 — three comments claimed a rejection that CEE deliberately ended

`applyV5State.ts`, `canvas/store/analysisRefusalNotice.ts` and `applyV5State.analysisRefusalNotice.spec.tsx` all said the readiness normaliser **REJECTS** the refusal carrier and that this "must NOT change". True of one arm; false as a statement about the carrier, since **CEE #1023** (merged 18 Aug 05:42Z) made the other arm accepted — `buildAnalysisRefusalReadiness` (`analysis-ready-helper.ts:1427-1472`) preserves `goal_node_id` and `options` when the structural projection is not `ready`, using **a verbatim copy of the UI's own accept predicate** as its degeneracy guard.

All three now state both arms. Measured, not assumed: ARM B produces `analysis_ready:set`, no clear, no deferred invalid-shape — and the refusal notice is still set.

The arm had **zero coverage**, so five tests were added, ending at the mounted consumer (P2): `applyV5State` → the status it actually wrote → `deriveAnalysisDisplayState` = **`not_ready`**, driven with `hasReport: true` so a green "Analysis complete" would show up. Its opposite twin (an accepted `ready` carrier → `complete`, notice cleared) proves the `not_ready` is the refusal's doing and not a constant.

## 3 — the `blocked_reason` copy map covered one arm of a union

`ANALYSIS_REFUSAL_REASON_COPY` had 10/10 `StructuralViolationCode` and **0/8** of `CanonicalReadinessIssueCode` — the other member of the `ReadinessReasonCode` union. The gap included **`MISSING_OPTION_VALUE`, the code CEE #1023 measured on the deployed wire.**

Reachability derived rather than assumed: `assessCanonicalAnalysisReadiness` → `blockingIssues` (`appendSemanticIssues` pushes the semantic codes into the same array) → `reasonCodes[0]` → `details.reason_code` → `blockedReasonForHandlerFailure` → `blocked_reason`.

Eight entries added — the seven canonical codes plus `insufficient_analysable_options` (a different producer, `run-analysis.ts:434-459`). **Every sentence is derived from the issue builder that emits the code**, with the producer line in a comment beside it (P7 / trap 13c), and each states a **class, never an instance**: `blocked_reason` is a bare code, so naming an option here would be a claim the surface cannot ground (P5). Generic fallback unchanged for genuinely unknown codes, and the new `it.each` asserts a mapped code does **not** resolve to the generic — otherwise the length assertion would pass on a sentence that says nothing.

## 4 — the dead Journey branch is gone

`OutputsDock.tsx:435` (`if (surface.id === 'journey') return isJourneyTabEnabled()`) could never execute: `presentedSurfaces()` filters on `presentedAsTab` (`shellContract.ts:412`) before the callback sees a surface, and journey is `presentedAsTab: false`. A dead flag check beside two live ones reads as *"the flag decides"* — the exact belief the contract row exists to correct. Deleted, with the `isJourneyTabEnabled()` dep dropped from the memo. The two reachable persisted-tab guards (`:516`, `:581`) are untouched, and both pinning specs stay green (86/86).

## 5 — drain-host reachability is now DERIVED, and it found a third dark drain

`panelApplyReachability.production.spec.tsx` pins drain mounts with hand-written `expect(source).toContain(…)`, one `it` per drain, added the day each defect was found — trap 12 exactly. It covers two of five.

The new spec derives all three sides: the drain set from **DraftChat's own imports**, the flag-ON host set by **slicing the `aiPanelV2` branch of `MaybeConversationProvider`, resolving each mounted component to its file through ReactFlowGraph's imports, and reading those files for drain calls**, and DARK as the difference — which must equal `KNOWN_DARK_DRAINS` **exactly**. A grown set means a drain went dark; a **shrunk** set means someone re-hosted one, which is a behaviour change and must be a conscious edit here rather than something that lands silently.

### ⚠ CORRECTED PREMISE: five drains, not four — and three are dark

The brief said four drains, two dark, and described the family as `use*Events`/`use*Drain`. **Both halves of the plural matter**: `useAnalysisCompleteEvent` and `useSessionResumeEvent` are singular, so an `Events`-only pattern enumerates three of five — including one the spec was written to pin. `useSessionResumeEvent` is a **third** drain with no flag-ON host.

### The assessments (recorded, not fixed — re-hosting is its own decision)

**`useGraphEditEvents`** — sole `direct_graph_edit` emitter **and sole production caller of `clearGuidanceItems()`** (complete manifest: `useGraphEditEvents.ts:293`; nothing else in `src/` outside tests). A flag-ON user loses:
- CEE never hears about a local canvas edit between turns. The turn writes no graph server-side by design, so no persisted state is lost — what is lost is CEE's awareness that the model moved.
- **Stale coaching survives a local structural edit.** This is the user-visible half: guidance minted against the old model stands until the next assistant turn replaces the whole list (`useConversation.ts:3911`/`:5078`).
- Journey `direct_edit` events — **no loss**; that limb is gated on `isJourneyTabEnabled()` and Journey is retired by contract.

**`useAnalysisCompleteEvent`** — the only post-run guidance evictor. Costs **nothing measurable today**, and that is a *corpus* fact, not a structural one: its `graph_hash` limb needs `graphChanged: true`, which this call site never passes (`guidanceStore.ts:666-687`), and its `analysis_hash` limb is inert only because CEE emits no `analysis_hash` on a coaching block — zero occurrences against 37 for `graph_hash_at_generation` (`coachingCurrency.ts:109-114`). **It is a tripwire**: the day CEE emits `analysis_hash`, its absence becomes a real defect, silently.

**`useSessionResumeEvent`** — costs **nothing**, and this one *is* structural: `session_resume` is not in `WIRE_SYSTEM_EVENT_TYPES`, so `serializeSystemEvent` returns `null` and the send short-circuits to `SEND_BLOCKED` before any network call. `systemEvents.ts:34` states the intent outright. Hosting it flag-ON would emit nothing. Same tripwire shape.

---

## Evidence

**Mutants: 11 applied, 11 BITTEN, zero survivors** — after a survivor was found and closed. Each reddens exactly one spec; no cross-talk.

⭐ **The survivor is the finding.** `M4` (break the provider tag) SURVIVED, and exposed that `flagOnProviderBlock()` was slicing the file from a **doc-comment mention** of `<ConversationProvider>` (`ReactFlowGraph.tsx:2512`) rather than the JSX 11 lines below. The derivation still returned the right answer, because the comment sits just above the block — **a probe reading the wrong bytes and agreeing anyway** (trap 16). Fixed by anchoring on the function declaration first; M4 now bites on two assertions.

**Isolation proven by WRITING, not by locating** (trap 9g): sentinel appended to the worktree copy, source SHA-256 unchanged, inodes differ. Restores from a **pristine archive outside both trees** (trap 9h), applied-check exactly 1 per mutant, leading and trailing controls exactly 0.

**P4** — the pristine tree typechecks under the repo's own gate **first** (563 files / 2306 errors == baseline 2306, zero new), so no mutant verdict rests on a broken `tsc`. And no mutant survived, so none can be a type-invalid false survivor.

⚠ **Zero collected tests treated as a hard error, and it fired.** Passing all five specs to one `vitest run` printed `No test files found, exiting with code 0` — the exact silent-pass this discipline exists to catch. The harness runs each spec separately and **asserts its expected collected count by name**; a drift voids the run rather than passing it.

**Gate in the required check's step order at this tip:** `check:vendor` → `ci:guard:schemas-version` → `lint` → `typecheck` → `ci:guard:zustand` / `duplicates` / `ds:enforce` / `flags` / `flag-env` — all PASS.

## Collisions

- **PR #714** (the Analysis child surface lane, `components/results/`) — **zero overlap**. No file under `components/results/` is modified here.
- **PR #727** (open, `agent/ui-canonical-receipt-consumer-043`) touches `OutputsDock.tsx`, `DraftChat.tsx`, `useConversation.ts` and `applyV5State.ts` — a textual merge risk on items 1, 2, 4 and 5, flagged rather than worked around.
- **PR #731** (draft) touches `useConversation.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
