### PR TITLE
feat(shell): de-tab Compare via the shell contract's presentedAsTab mechanism

### DIFF
--- a/src/canvas/components/__tests__/OutputsDock.assistantOpenedAttribution.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.assistantOpenedAttribution.spec.tsx
@@ -74,6 +74,16 @@ const {
   // compareTab ON, journeyTab OFF. `MOUNT-1` asserts that exact strip, so if
   // a flag moves under this spec the binding fails LOUD instead of quietly
   // testing a component the deployment does not render.
+  //
+  // ⚠⚠ AMENDED 18 Aug 2026, AND THE FLAG DID NOT MOVE — THE CONTRACT DID.
+  // `mockIsCompareTabEnabled` STAYS `true`, because `netlify.toml:157` still
+  // sets `VITE_FEATURE_COMPARE_TAB = "1"` and this block's job is to state the
+  // deployed FLAG posture truthfully. Compare left the strip by CONTRACT
+  // (`workspaceShell/shellContract.ts`, Fable's ruling), which is the stronger
+  // statement and is not a flag. So the expected strip below is now
+  // ["Olumi","Analysis","Model"] with compareTab ON — flipping the mock to
+  // `false` to "make it pass" would have made this comment a lie and hollowed
+  // the trap-3b binding it exists to hold.
   mockIsJourneyTabEnabled: vi.fn(() => false),
   mockIsCompareTabEnabled: vi.fn(() => true),
   mockIsAiPanelV2Enabled: vi.fn(() => true),
@@ -338,7 +348,7 @@ describe('ROADMAP 2.1132 — the assistant attributes the panel gestures it actu
     // before anything below asserts a presence or an absence inside it.
     const strip = screen.getByRole('navigation', { name: 'Outputs sections' })
     expect(strip).toBeInTheDocument()
-    expect(tabLabels(strip)).toEqual(['Olumi', 'Analysis', 'Compare', 'Model'])
+    expect(tabLabels(strip)).toEqual(['Olumi', 'Analysis', 'Model'])
 
     // Absent before any gesture — so the presence below is the gesture's doing.
     expect(notice()).not.toBeInTheDocument()

--- a/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
@@ -5,6 +5,7 @@ import { OutputsDock, OUTPUTS_DOCK_STORAGE_KEY } from '../OutputsDock'
 import { useCanvasStore } from '../../store'
 import { STORAGE_KEY as RUN_HISTORY_STORAGE_KEY } from '../../store/runHistory'
 import { __resetTelemetryCounters, __getTelemetryCounters } from '../../../lib/telemetry'
+import { trackCompareOpened } from '../../utils/sandboxTelemetry'
 import { useGuidanceStore } from '../../stores/guidanceStore'
 // 34edc1fd ("conversation singleton + explicit first-use submit signal",
 // 2026-05-19) made OutputsDockProviderHost consume useConversationContext,
@@ -198,10 +199,15 @@ describe('OutputsDock DOM', () => {
     // The TEMPORARY 'Alt view' tab (id 'altview') that sat directly after
     // Analysis is RETIRED with the V7 fork it hosted. Its ABSENCE from this
     // list is the assertion: one Analysis surface, no A/B twin.
+    //
+    // 'Compare' left the same way on 18 Aug 2026 (Fable's ruling) — hidden BY
+    // CONTRACT in `workspaceShell/shellContract.ts`, with its flag still ON.
+    // The list stays EXACT and ORDERED; nothing is loosened. `compareDeTab
+    // .contract.spec.tsx` is the pin that says why, and REDs if the row is
+    // reverted.
     expect(tabs.map(tab => tab.textContent)).toEqual([
       'Olumi',
       'Analysis',
-      'Compare',
       'Model',
     ])
   })
@@ -239,12 +245,15 @@ describe('OutputsDock DOM', () => {
     expect(screen.queryByTestId('outputs-dock-body')).toBeNull()
 
     const resultsIcon = screen.getByRole('button', { name: 'Analysis' })
-    const compareIcon = screen.getByRole('button', { name: 'Compare' })
     const modelIcon = screen.getByRole('button', { name: 'Model' })
 
     expect(resultsIcon).toBeInTheDocument()
-    expect(compareIcon).toBeInTheDocument()
     expect(modelIcon).toBeInTheDocument()
+    // The collapsed rail maps the SAME `OUTPUT_TABS` the expanded strip does
+    // (`OutputsDock.tsx:2444`), so Compare's contract row closes both. Asserted
+    // as an ABSENCE here, bound by the exact accessible name, so the rail
+    // cannot quietly keep an affordance the strip dropped.
+    expect(screen.queryByRole('button', { name: 'Compare' })).not.toBeInTheDocument()
 
     fireEvent.click(modelIcon)
 
@@ -257,9 +266,12 @@ describe('OutputsDock DOM', () => {
   it('persists active tab and open state via useDockState', () => {
     const { unmount } = renderOutputsDock()
 
-    // Switch to Compare tab and leave dock open
-    const compareTab = screen.getByRole('button', { name: 'Compare' })
-    fireEvent.click(compareTab)
+    // Switch to a NON-DEFAULT tab and leave the dock open. This was Compare
+    // until 18 Aug 2026; Compare is hidden by contract now, and Model is the
+    // remaining non-default surface — the case is about PERSISTENCE, and any
+    // tab that is not the 'results' default exercises it identically.
+    const modelTab = screen.getByRole('button', { name: 'Model' })
+    fireEvent.click(modelTab)
 
     // Unmount and remount to verify persisted state
     unmount()
@@ -273,7 +285,7 @@ describe('OutputsDock DOM', () => {
     expect(aside.style.bottom).toContain('var(--bottombar-h)')
 
     // Header label (aria-live) should reflect active tab
-    const headerLabel = screen.getByText('Compare', {
+    const headerLabel = screen.getByText('Model', {
       selector: 'span[aria-live="polite"]',
     })
     expect(headerLabel).toBeInTheDocument()
@@ -310,7 +322,18 @@ describe('OutputsDock DOM', () => {
     expect(params.get('tab')).toBeNull()
   })
 
-  it('emits sandbox.compare.opened when Compare tab is opened', () => {
+  it('no longer offers a Compare tab to open, so its open-telemetry cannot fire from the strip', () => {
+    // ⭐ RULING (Fable, 18 Aug 2026). This case used to click the Compare tab
+    // and assert `sandbox.compare.opened === 1`. That affordance is gone —
+    // Compare is hidden by contract — so the old assertion would now fail on a
+    // missing element, which says nothing about the ruling.
+    //
+    // It is RETARGETED rather than deleted: same site, same telemetry counter,
+    // bound by identity to the Compare tab's exact accessible name, and it REDs
+    // if the tab returns. `trackCompareOpened()` at `OutputsDock.tsx:2162` is
+    // deliberately LEFT IN PLACE — Compare's code is not being retired, and the
+    // counter still fires on the programmatic activation paths the ruling did
+    // not close (see the compare row's comment in `shellContract.ts`).
     try {
       localStorage.setItem('feature.telemetry', '1')
     } catch {}
@@ -318,11 +341,21 @@ describe('OutputsDock DOM', () => {
 
     renderOutputsDock()
 
-    const compareTab = screen.getByRole('button', { name: 'Compare' })
-    fireEvent.click(compareTab)
+    expect(screen.queryByRole('button', { name: 'Compare' })).not.toBeInTheDocument()
+    // Positive control (trap 13): the harness CAN see tab buttons and CAN read
+    // this counter map — so the two absences below are the ruling's doing and
+    // not a blind query or an uninitialised counter store.
+    expect(screen.getByRole('button', { name: 'Model' })).toBeInTheDocument()
+    expect(__getTelemetryCounters()['sandbox.compare.opened']).toBe(0)
 
-    const counters = __getTelemetryCounters()
-    expect(counters['sandbox.compare.opened']).toBe(1)
+    // POSITIVE CONTROL (trap 13): a counter reading 0 is only evidence of an
+    // ABSENCE if that counter can be shown to MOVE. Firing the tracker directly
+    // proves the key is live and the map is being read — so the 0 above is
+    // "the strip never opened Compare", not "this assertion is pointed at a
+    // dead key". The tracker is deliberately still exported and still callable:
+    // Compare's code is not being retired by this ruling.
+    trackCompareOpened()
+    expect(__getTelemetryCounters()['sandbox.compare.opened']).toBe(1)
   })
 
   it('auto-switches back to Results tab when results become active', () => {
@@ -1089,9 +1122,16 @@ describe('I.2a: Secondary action button interaction', () => {
     expect(tabs.map(tab => tab.textContent)).toEqual([
       'Olumi',
       'Analysis',
-      'Compare',
       'Model',
     ])
+    // ⭐ 18 Aug 2026: 'Compare' left this list the same way Journey did, and
+    // THIS case is where the difference between the two shows. Journey's flag
+    // is absent, so a green "Journey is hidden" can never tell contract from
+    // flag. Compare's flag is forced ON in this very block (see the doMock
+    // above) — so its absence here is proof the CONTRACT is what holds a tab
+    // shut. Bound by identity below, and pinned in full by
+    // `compareDeTab.contract.spec.tsx`.
+    expect(within(tabNav).queryByRole('button', { name: 'Compare' })).not.toBeInTheDocument()
     // Bound by IDENTITY to Journey, so a rename of some other tab cannot
     // satisfy this line (trap 19).
     expect(within(tabNav).queryByRole('button', { name: 'Journey' })).not.toBeInTheDocument()
@@ -1324,13 +1364,16 @@ describe('F9: dock-level run announcer (single voice for start/settle)', () => {
     expect(screen.getAllByTestId('analysis-run-announcer')).toHaveLength(1)
   })
 
-  it('announces rerun start and settle while the Compare tab is fronted, exactly once', () => {
+  it('announces rerun start and settle while a NON-Analysis tab is fronted, exactly once', () => {
     // A RERUN (complete -> streaming) does not trip the I.1 auto-switch, so
-    // Compare stays fronted for the whole run — exactly the F9 scenario
-    // (rerun dispatched with another tab in view was silent and frozen).
+    // the fronted tab stays fronted for the whole run — exactly the F9
+    // scenario (rerun dispatched with another tab in view was silent and
+    // frozen). This drove the Compare tab until 18 Aug 2026, when Compare was
+    // hidden by contract; Model is the remaining non-Analysis surface and the
+    // property under test is "not Analysis", not "Compare".
     seedIdle(true)
     renderOutputsDock()
-    fireEvent.click(screen.getByRole('button', { name: 'Compare' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Model' }))
 
     startRun(true)
     expect(screen.getByTestId('analysis-run-announcer')).toHaveTextContent(
@@ -1364,7 +1407,9 @@ describe('F9: dock-level run announcer (single voice for start/settle)', () => {
   it('stays silent on a FIRST run: the auto-switch fronts the Analysis tab, whose furniture speaks', () => {
     seedIdle(false)
     renderOutputsDock()
-    fireEvent.click(screen.getByRole('button', { name: 'Compare' }))
+    // Was the Compare tab until 18 Aug 2026 (hidden by contract). Any fronted
+    // tab that is NOT Analysis exercises the auto-switch this case is about.
+    fireEvent.click(screen.getByRole('button', { name: 'Model' }))
 
     startRun(false)
     // The I.1 auto-switch yanked the dock to the Analysis tab, where the

--- a/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
@@ -359,6 +359,36 @@ describe('OutputsDock DOM', () => {
   })
 
   it('auto-switches back to Results tab when results become active', () => {
+    // ⚠ PIN THE PRECONDITION IN-TEST (trap 13b). This case was passing on a
+    // NEIGHBOUR'S SIDE EFFECT, and de-tabbing Compare exposed it — measured,
+    // not guessed:
+    //
+    //   `updates ?tab= query parameter when tabs are clicked` ends by clicking
+    //   Analysis, and `handleTabClick` does `setShowResultsPanel(tab ===
+    //   'results')` — so it leaves `showResultsPanel` TRUE in the canvas store,
+    //   which is module state this file never resets. The next case used to
+    //   click the COMPARE tab, which set it back to FALSE purely as a side
+    //   effect. Compare's tab is gone (Fable, 18 Aug 2026), that click went
+    //   with it, and the flag now arrives here TRUE. Probed directly:
+    //   `showResultsPanel = true, results.status = idle` at this line.
+    //
+    // With it TRUE the merged auto-switch effect no longer takes its
+    // `if (!statusTransitioned && !showResultsPanel) return` exit at mount, so
+    // it runs and arms the 50ms React-#185 debounce (`OutputsDock.tsx`,
+    // `lastDockOpenRef`). The status transition below then lands INSIDE that
+    // window and is swallowed, the tab never switches, and the case fails on a
+    // missing 'Analysis' header. It is a pure timing race — locally the gap
+    // exceeds 50ms and it passes; on CI it does not, and shard 1/4 went red
+    // while the same shard was green at the base commit and on eleven other
+    // recent runs.
+    //
+    // So the flag is set explicitly here. The case is about the auto-switch,
+    // not about what the previous test happened to click.
+    act(() => {
+      useCanvasStore.setState({ showResultsPanel: false } as any)
+    })
+    expect(useCanvasStore.getState().showResultsPanel).toBe(false)
+
     renderOutputsDock()
 
     // Move away from Results tab

--- a/src/canvas/components/__tests__/compareDeTab.contract.spec.tsx
+++ b/src/canvas/components/__tests__/compareDeTab.contract.spec.tsx
@@ -97,11 +97,20 @@ describe('Compare is de-tabbed by contract (Fable, 18 Aug 2026)', () => {
     // CONTRAST CONTROL in the same run — absence is only evidence when the
     // things that must be present read present (trap 13e).
     expect(ids).toEqual(['olumi', 'results', 'diagnostics'])
-    // 30s, not the 5s default: importing OutputsDock cold pulls a large module
-    // graph and the default timeout fired BEFORE the assertions ran. A timeout
-    // is not a RED — it proves nothing about the predicate (trap 13) — so the
-    // budget is set where the case fails on its own assertion or not at all.
-  }, 30_000)
+    // ⚠ 120s, and the number is deliberate, not padding. Importing OutputsDock
+    // cold through `resetModules` + `doMock` pulls a very large module graph:
+    // measured 27.1s on this machine, and the 5s default fired BEFORE any
+    // assertion ran. A first 30s budget was WORSE THAN USELESS — it sat just
+    // above the measured cost, so the case passed at 27.1s and then reported
+    // 30001ms / 30009ms / 30004ms under three mutants and the trailing control:
+    // FOUR identical clock-limit readings that look exactly like a biting
+    // mutant and are not (trap 20 — when a per-item probe returns the same
+    // answer for every item, suspect the probe). A timeout is not a RED; it
+    // proves nothing about the predicate. The budget must sit far enough above
+    // the cost that this case can only ever fail on its own assertion.
+    // The same cold-import cost already times out the two OUTPUT_TABS cases in
+    // `aiPanelV2.parity.spec.tsx` at their 5s default on a slow machine.
+  }, 120_000)
 
   it('DT-3: presentedSurfaces() drops compare and keeps the other three, in strip order', () => {
     expect(presentedSurfaces().map(s => s.id)).toEqual(['olumi', 'results', 'diagnostics'])

--- a/src/canvas/components/__tests__/compareDeTab.contract.spec.tsx
+++ b/src/canvas/components/__tests__/compareDeTab.contract.spec.tsx
@@ -1,0 +1,131 @@
+/**
+ * ⭐ RULING (Fable, 18 Aug 2026): COMPARE IS REMOVED FROM THE PRESENTED TAB ROW.
+ *
+ * Compare is structurally empty for every staging guest —
+ * `useCompareHistoryHydration.ts:79` early-returns without a `userId`, so the
+ * surface a guest reaches has nothing in it — and its tab is a competing
+ * hierarchy beside Analysis. It is therefore hidden BY CONTRACT
+ * (`presentedAsTab: false` in `workspaceShell/shellContract.ts`), the same
+ * mechanism Journey was given on 17 Aug.
+ *
+ * ⚠ SCOPE OF THIS RULING, STATED PRECISELY (trap 20 — a row must restate the
+ * scope, never generalise it):
+ *   - Compare's TAB is removed. That is all this spec is about.
+ *   - Compare's CODE IS NOT DELETED. Retirement is a separate decision.
+ *   - The accordion-inside-Analysis half of the original proposal is DEFERRED
+ *     and is NOT built here.
+ *
+ * ── WHY EACH CASE IS SHAPED THE WAY IT IS ─────────────────────────────────
+ * The load-bearing case is DT-2: `presentedAsTab: false` must beat the FLAG.
+ * `compareTab` is ON in the build config (`netlify.toml:157`
+ * `VITE_FEATURE_COMPARE_TAB = "1"`), so unlike Journey — whose flag is absent,
+ * and which therefore cannot distinguish "hidden by contract" from "dark by
+ * flag" — Compare is a genuine test of the contract's strength. If the
+ * contract row were reverted, the flag alone would light the tab again.
+ *
+ * Every assertion binds by IDENTITY to the compare surface id, never to "some
+ * surface is hidden" or to a label predicate (trap 19), and every absence
+ * assertion carries a CONTRAST CONTROL in the same run — the surfaces that
+ * must STILL be present (trap 13e). A blanket mutant that hid every surface
+ * would satisfy a bare `not.toContain('compare')`; it cannot satisfy these.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+// Importing OutputsDock pulls in services/threadService → src/lib/supabase,
+// which throws at import time without SUPABASE_URL/KEY. Same stub, and for the
+// same reason, as `aiPanelV2.parity.spec.tsx`.
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+
+import {
+  WORKSPACE_SURFACES,
+  WORKSPACE_SURFACE_ORDER,
+  MAX_PRESENTED_SURFACES,
+  presentedSurfaces,
+} from '../workspaceShell/shellContract'
+
+describe('Compare is de-tabbed by contract (Fable, 18 Aug 2026)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    try {
+      window.localStorage.removeItem('feature.compareTab')
+    } catch {}
+  })
+
+  it('DT-1: the compare ROW says hidden, and says why', () => {
+    // Bound by identity to the compare row. "Some surface is hidden" — which
+    // journey already satisfies — cannot pass this.
+    expect(WORKSPACE_SURFACES.compare.presentedAsTab).toBe(false)
+    expect(WORKSPACE_SURFACES.compare.hiddenReason.trim().length).toBeGreaterThan(0)
+    // …and journey's row is untouched, so this is not passing because some
+    // sweep flipped every row (the blanket-mutant discriminator).
+    expect(WORKSPACE_SURFACES.journey.presentedAsTab).toBe(false)
+    expect(WORKSPACE_SURFACES.results.presentedAsTab).toBe(true)
+    expect(WORKSPACE_SURFACES.olumi.presentedAsTab).toBe(true)
+    expect(WORKSPACE_SURFACES.diagnostics.presentedAsTab).toBe(true)
+  })
+
+  it('DT-2: the CONTRACT beats the FLAG — compareTab ON does not light the tab', async () => {
+    // ⭐ THE LOAD-BEARING CASE. `getOutputTabsForParity()` is what both the
+    // expanded strip and the collapsed icon rail map over, and it is also what
+    // the `?tab=` deep-link reader validates against
+    // (`OutputsDock.tsx:1651-1662`) — one authority, three consumers. Driving
+    // it with the flag forced ON is the only way to prove the contract row,
+    // not the flag, is holding the tab shut.
+    vi.doMock('../../../flags', async importOriginal => {
+      const actual = await importOriginal<typeof import('../../../flags')>()
+      return { ...actual, isCompareTabEnabled: () => true, isAiPanelV2Enabled: () => true }
+    })
+    const { getOutputTabsForParity } = await import('../OutputsDock')
+    const flags = await import('../../../flags')
+
+    // Pin the precondition IN-TEST (trap 13b): assert the flag really is ON in
+    // the module graph this derivation just read, so a green result is the
+    // contract's doing and not a broken flag accessor.
+    expect(flags.isCompareTabEnabled()).toBe(true)
+
+    const ids = getOutputTabsForParity().map(t => t.id)
+    expect(ids).not.toContain('compare')
+    // CONTRAST CONTROL in the same run — absence is only evidence when the
+    // things that must be present read present (trap 13e).
+    expect(ids).toEqual(['olumi', 'results', 'diagnostics'])
+    // 30s, not the 5s default: importing OutputsDock cold pulls a large module
+    // graph and the default timeout fired BEFORE the assertions ran. A timeout
+    // is not a RED — it proves nothing about the predicate (trap 13) — so the
+    // budget is set where the case fails on its own assertion or not at all.
+  }, 30_000)
+
+  it('DT-3: presentedSurfaces() drops compare and keeps the other three, in strip order', () => {
+    expect(presentedSurfaces().map(s => s.id)).toEqual(['olumi', 'results', 'diagnostics'])
+  })
+
+  it('DT-4: the strip budget moved WITH the Record, not independently of it', () => {
+    // `MAX_PRESENTED_SURFACES` is a recorded literal, NOT a derivation — so it
+    // is a hand-maintained mirror of the Record and this is the assertion that
+    // makes it fail loud (trap 12). Deriving it instead would make
+    // shell-conformance's "the strip never has to lay out more than the
+    // recorded maximum" a tautology that can never RED on a new surface, which
+    // is a guard agreeing with itself (trap 13b) — so the literal stays and
+    // this pins it in both directions: it REDs if a surface is presented AND
+    // if one is hidden without the budget being re-recorded.
+    expect(MAX_PRESENTED_SURFACES).toBe(presentedSurfaces().length)
+    expect(MAX_PRESENTED_SURFACES).toBe(3)
+  })
+
+  it('DT-5: compare keeps its ORDER slot and its Record row — hidden, not retired', () => {
+    // The ruling hides the tab; it does NOT delete Compare. If a later lane
+    // decides to retire the surface, THIS is the case that must be deleted
+    // deliberately rather than a row quietly vanishing.
+    expect(WORKSPACE_SURFACE_ORDER).toContain('compare')
+    expect(WORKSPACE_SURFACES.compare.id).toBe('compare')
+    expect(WORKSPACE_SURFACES.compare.label).toBe('Compare')
+  })
+})

--- a/src/canvas/components/workspaceShell/shellContract.ts
+++ b/src/canvas/components/workspaceShell/shellContract.ts
@@ -327,8 +327,36 @@ export const WORKSPACE_SURFACES: Record<OutputTab, WorkspaceSurfaceDescriptor> =
     footerBar: 'none',
     scroll: 'shell',
     padding: 'shell',
-    presentedAsTab: true,
-    hiddenReason: '',
+    // ⭐ RULING (Fable, 18 Aug 2026): Compare's tab leaves the presented row.
+    // It is STRUCTURALLY EMPTY for every staging guest —
+    // `useCompareHistoryHydration.ts:79` early-returns without a `userId`, so a
+    // guest who opens it reaches nothing — and beside Analysis it is a
+    // competing hierarchy for the same question. Journey's row above is the
+    // precedent and the same mechanism.
+    //
+    // ⚠ SCOPE, STATED NARROWLY (trap 20 — a record must not generalise the
+    // finding it came from): this hides the TAB. Compare's CODE IS NOT DELETED;
+    // retirement is a separate decision. Folding Compare into Analysis as an
+    // accordion was the other half of the proposal and is DEFERRED, not built.
+    //
+    // ⚠⚠ AND THE LIMIT OF THIS FIELD, BECAUSE THE HEADER ABOVE OVERSTATES IT.
+    // `presentedAsTab: false` is a statement about the TAB ROW — the strip, the
+    // collapsed icon rail, and the `?tab=` deep link all derive from
+    // `presentedSurfaces()` and are closed by it. It is NOT a statement about
+    // reachability: the dock's activation guards are keyed on the FLAG, not on
+    // this field (`OutputsDock.tsx:519`, `:580`), and `compareTab` is ON in the
+    // build config (`netlify.toml:157`). So a programmatic `setActiveOutputTab
+    // ('compare')` still fronts the Compare BODY (`OutputsDock.tsx:3155`) with
+    // no tab lit — reachable today from `CompactOptionSpread.tsx:87`,
+    // `OptionPanel.tsx:422`, the `showComparePanel` effect
+    // (`ReactFlowGraph.tsx:819` → `OutputsDock.tsx:1902`) and an `open_panel`
+    // ui_directive. Journey never exposed this because its flag is absent.
+    // Closing it means teaching those guards to read this contract instead of
+    // the flag; that is a SEPARATE, briefed change and is deliberately not
+    // improvised here.
+    presentedAsTab: false,
+    hiddenReason:
+      'Structurally empty for guests (compare history needs a userId); folds into Analysis pending the /v2/run retirement decision (Fable, 18 Aug 2026)',
   },
   diagnostics: {
     id: 'diagnostics',
@@ -386,19 +414,34 @@ export const WORKSPACE_SURFACE_ORDER: readonly OutputTab[] = [
 ]
 
 /**
- * The maximum number of tabs the strip can ever be asked to lay out.
+ * The number of tabs the strip is currently asked to lay out.
  *
- * Recorded and asserted, so a sixth surface REDs rather than silently
- * overflowing the row at the drag floor. This counts surfaces that are
- * PRESENTED — a hidden one costs no strip width.
+ * ⚠ THIS IS A RECORDED LITERAL, NOT A DERIVATION, AND THAT IS DELIBERATE —
+ * the header of this file bans hand-maintained mirrors, so the exception needs
+ * its reason stated. Setting it to `presentedSurfaces().length` would make
+ * shell-conformance's *"the strip never has to lay out more than the recorded
+ * maximum"* a tautology: it could never RED, because the budget would move to
+ * meet whatever the Record said. A guard that agrees with itself is worse than
+ * no guard. So the number stays written down, the conformance case asserts
+ * EQUALITY against the Record, and any change to the presented set — a surface
+ * added OR one hidden — must be re-recorded here deliberately.
+ *
+ * ⚠ The prose here used to say *"a sixth surface REDs"* while the value was 4;
+ * it was written when five surfaces were presented and was never re-read. Do
+ * not restate the count in words. Derive it: `presentedSurfaces().length`.
+ *
+ * Was 4 until 18 Aug 2026; 3 since Compare's row was hidden by contract.
  */
-export const MAX_PRESENTED_SURFACES = 4
+export const MAX_PRESENTED_SURFACES = 3
 
 /**
  * The surfaces offered as tabs, in strip order.
  *
  * Flag state still applies on top of this (Olumi and Compare are flagged);
- * `presentedAsTab: false` is the stronger statement and is not a flag.
+ * `presentedAsTab: false` is the stronger statement and is not a flag — a
+ * surface hidden here stays out of the strip with its flag ON, which is what
+ * the Compare row is a live test of (`journey`'s flag is absent, so it could
+ * never distinguish the two).
  */
 export function presentedSurfaces(): WorkspaceSurfaceDescriptor[] {
   // Iterate the RECORD (membership), then sort by ORDER (presentation). An id


### PR DESCRIPTION
## Ruling implemented

**Fable, 18 Aug 2026.** Compare's tab is removed from the presented tab row **now**. It is structurally empty for every staging guest — `useCompareHistoryHydration.ts:79` early-returns without a `userId` — and beside Analysis it is a competing hierarchy for the same question.

**Scope, stated narrowly (trap 20):**
- Compare's **TAB** is removed. That is all.
- Compare's **CODE IS NOT DELETED**. Retirement is a separate decision.
- The accordion-inside-Analysis half of the proposal is **DEFERRED** and is not built here.

## Mechanism — the existing one, no parallel authority

`presentedAsTab: false` + an honest `hiddenReason` on the `compare` row of `WORKSPACE_SURFACES`. Journey's row (17 Aug) is the precedent.

Verified the tab row has **one authority**: the expanded strip, the collapsed icon rail (`OutputsDock.tsx:2444`) and the `?tab=` deep-link reader (`OutputsDock.tsx:1651-1662`, which validates against `OUTPUT_TABS`) **all** derive from `presentedSurfaces()` via `getOutputTabsForParity()` (`:443`). One row closes all three. No hard-coded tab list exists elsewhere.

## ⚠ Corrected premise (the brief was wrong at the tip)

The brief expected `MAX_PRESENTED_SURFACES` to be **derived** from the Record so the count would move automatically. **It is a recorded literal** (was `4`).

It is left a literal deliberately. Deriving it would make shell-conformance's *"the strip never has to lay out more than the recorded maximum"* (`shell-conformance.spec.ts:747`, an equality) a **tautology that can never RED on a new surface** — a guard agreeing with itself (trap 13b). So it is re-recorded as `3`, and `compareDeTab` **DT-4** pins it to the Record in **both** directions: it REDs if a surface is presented *or* hidden without the budget being re-recorded.

Its docstring also said *"a sixth surface REDs"* while the value was `4` — stale prose from when five surfaces were presented. Removed; the doc now says derive it.

## ⚠ Boundary reported, NOT improvised around

`presentedAsTab: false` is a **TAB-ROW** statement, not a **reachability** statement — and the field's own docstring (`shellContract.ts:264-267`) overstates it as *"the capability is not mounted for users"*.

The dock's activation guards are keyed on the **FLAG**, not on this field:
- `OutputsDock.tsx:519` — `state.activeTab === 'compare' && !isCompareTabEnabled()`
- `OutputsDock.tsx:580` — the same test for the external-tab sync

and `compareTab` is **ON** (`netlify.toml:157` `VITE_FEATURE_COMPARE_TAB = "1"`). So a programmatic `setActiveOutputTab('compare')` still fronts the Compare **body** (`OutputsDock.tsx:3155`) with no tab lit. Live producers:

| Producer | Path |
|---|---|
| `CompactOptionSpread.tsx:87` | "Compare options" button |
| `OptionPanel.tsx:422` | `<ResultsLink label="Compare all options" tab="compare" />` |
| `ReactFlowGraph.tsx:819` → `OutputsDock.tsx:1902` | `showComparePanel` one-shot effect |
| `applyV5State` | AI `open_panel { kind:'tab', id:'compare' }` ui_directive |

Journey never exposed this because **its flag is absent** — so it can never distinguish "hidden by contract" from "dark by flag". Compare can, which is why DT-2 is the load-bearing case.

**Smallest enabling change** (not made here, needs briefing): teach those two guards to read `presentedSurfaces()` instead of / in addition to the flag. Documented at the compare row so the next lane finds it at the site.

## Evidence

**RED-first** at pristine `fd7ef82c`, new spec added and contract untouched — 5 tests collected by name, 4 RED on their own assertions, DT-5 the deliberate green control:

| Case | Pristine |
|---|---|
| DT-1 compare row hidden + reason | RED `expected true to be false` |
| DT-2 contract beats flag (compareTab ON) | RED `expected [olumi,results,compare,…] to not include 'compare'` |
| DT-3 `presentedSurfaces()` order | RED array inequality |
| DT-4 budget tracks the Record | RED `expected 4 to be 3` |
| DT-5 compare row still exists (control) | GREEN |

A first 30s budget on DT-2 sat just above its measured 27.1s cold-import cost and produced **four identical ~30000ms clock limits** under three mutants and the trailing control — indistinguishable from a biting mutant (trap 20). Raised to 120s so it can only fail on its predicate. Fixed in `3c2c6a6`.

**Discriminating mutant pair**, throwaway worktree *outside* the repo root, isolation proven by **sentinel write** (distinct inodes; source SHA unchanged after writing into the worktree — trap 9g), HEAD-relative restores, clean-tree assert before/after each, applied-check scoped to `src/` (control reads exactly 0), **and a trailing control that matches the opening control 5/5**:

- **M1** — restore `presentedAsTab: true` for Compare → **DT-1/2/3/4 RED**, DT-5 green. The spec bites.
- **M2** — hide a **different** surface (`diagnostics`) instead → every **Compare-identity assertion stayed GREEN**; the cases died at lines **73, 99, 116, 128** — all *after* the compare lines, all the other surface's own coverage. Binding is by identity, not by "some surface is hidden" (trap 19).
- **M3** — delete `.filter(s => s.presentedAsTab)`, the mechanism itself → DT-2/3/4 RED, DT-1 green (row unchanged). Proves the spec is bound to the mechanism, not just the data.

**Displaced specs — 8 cases, fixed at source, never by loosening:**
- Both exact ordered tab-list assertions stay **exact** (`OutputsDock.dom.spec.tsx:201`, `:1089`, `assistantOpenedAttribution.spec.tsx:341`), now `['Olumi','Analysis','Model']`.
- `assistantOpenedAttribution`'s `mockIsCompareTabEnabled` **stays `true`** — the deployed flag did not move, the contract did. Flipping it to `false` to make the suite pass would have made the trap-3b posture comment a lie.
- The `sandbox.compare.opened` case is **retargeted, not deleted**: same site, asserts the tab is absent and the counter stays 0, with a **positive control** that fires `trackCompareOpened()` directly to prove the counter is live and the 0 is a real absence (trap 13).
- The Journey-hidden case gains a Compare assertion — it already forces `compareTab` ON, so it is now the DOM-level proof that the contract beats the flag.

**Pre-existing, NOT caused by this change and deliberately not absorbed:** `aiPanelV2.parity.spec.tsx`'s two `OUTPUT_TABS` cases time out at their 5s default on a slow machine — reproduced at **pristine `fd7ef82c`** with the change stashed (2 failed | 5 passed). Same cold-import cost as DT-2.

Not merging — for review.

---

## CI at head `02b97664` — polled to conclusion, `.status=="completed"` filtered before `.conclusion` (trap 24b)

**`Staging Gate` — the one required check on `staging` — SUCCESS.**

| Check | Result |
|---|---|
| Staging Gate | success |
| TypeScript + Lint | success |
| Typecheck Gate Self-Test | success |
| Full Test Suite shards 1-4 / Summary | success |
| Production Build | success |
| Security Audit (pnpm) | success |
| CEE Contract Validation | success |
| **Visual Regression (advisory)** | **failure - see below** |

Local gate proxy, run in the derived step order: `lint` PASS (0 errors; hooks ratchet exactly at baseline) then `typecheck` PASS (3504/3544 files, ratchet **exactly** at baseline 2306, zero new diagnostics) then `ci:guard:zustand`, `ci:guard:starters`, `check:vendor`, `ci:guard:schemas-version`, `ci:guard:ds:enforce` all PASS.

### A real CI failure this PR caused, found and fixed at source (`02b9766`)

The first push went red on `OutputsDock.dom.spec.tsx > auto-switches back to Results tab when results become active` — **a case this PR never edited**. Attributed, not assumed: that shard was **green at the base commit `fd7ef82c` and on eleven other recent runs**, and failed only here.

Measured chain:
1. `updates ?tab= query parameter when tabs are clicked` ends by clicking Analysis; `handleTabClick` does `setShowResultsPanel(tab === 'results')`, leaving `showResultsPanel` **TRUE** in canvas-store module state this file never resets.
2. The next case used to click the **Compare** tab, which set it back to FALSE *purely as a side effect*. De-tabbing Compare removed that click.
3. **Probed directly** at the failing line: `showResultsPanel = true, results.status = idle`.
4. TRUE means the merged auto-switch effect skips its `if (!statusTransitioned && !showResultsPanel) return` exit at mount, runs, and arms the **50 ms React-#185 debounce** (`lastDockOpenRef`). The test's status transition then lands inside that window and is swallowed — the tab never switches and the 'Analysis' header never appears.
5. A pure timing race: locally the gap exceeds 50 ms and it passes; on CI it does not.

Fixed by **pinning the case's own precondition in-test** (trap 13b), not by restoring a hidden coupling to whatever the previous test happened to click. The case is now order-independent — strictly better than before.

### Visual Regression (advisory) — expected, and NOT self-blessed

Green at the base and on eight other recent runs; **red only here**. 13 failed / 15 passed.

**12 of the 13 are the intended change**: every reference containing the dock now differs because the strip has three tabs instead of four — `fresh draft`, `blocked / provisional`, `Model tab`, `Olumi conversation tab`, `graph at default zoom` (each at 1280x800 and 1440x900), and `dock is 416px, tabs do not overflow` (1280x800, 1920x1080).

**The references are deliberately NOT re-blessed in this PR.** Re-blessing accepted visual truth is the owning seam's call under the Regression Shield ruling, not a build lane's, and doing it here would fold a reference change into a contract change.

**The 13th is different and is NOT a tab diff**: the harness self-test reports its own noise floor above its required margin — `noise floor 0.000645 is not comfortably below the tolerance 0.0005`. That is the instrument declaring itself unreliable. Whether the strip relayout raised the noise floor or it is environmental is **not established** — flagged, not diagnosed.

**Not merging — for review.**
