### PR TITLE
fix(analysis): withdraw a fabricated critique sentence; burn results-tree raw typography to zero

### DIFF
--- a/src/components/results/CompactOptionSpread.tsx
+++ b/src/components/results/CompactOptionSpread.tsx
@@ -75,7 +75,7 @@ export function CompactOptionSpread({ options }: Props) {
       data-testid="compact-option-spread"
     >
       <p className={`${typography.panelBody} text-text-body min-w-0 truncate`}>
-        <span className="font-semibold">Option spread:</span> {parts.join(' · ')}
+        <strong>Option spread:</strong> {parts.join(' · ')}
       </p>
       <button
         type="button"

--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -242,10 +242,15 @@ function ContestedDriverQuickSelect({ driver }: { driver: DriverItem }) {
           key={preset.label}
           type="button"
           onClick={() => handlePresetClick(i)}
+          // DS v5 §2.4: size/weight come from `panelMeta`, never from inline
+          // `fontSize`/`fontWeight` — which no class-based guard can see. The
+          // selected state was also carrying a weight bump (600 vs 500); it is
+          // already signalled by the border and background below, so the extra
+          // channel is dropped rather than re-expressed (§1: no channel should
+          // duplicate another).
+          className={typography.panelMeta}
           style={{
             fontFamily: 'inherit',
-            fontSize: '11px',
-            fontWeight: selectedIndex === i ? 600 : 500,
             padding: '4px 10px',
             borderRadius: '999px',
             border: `1px solid ${selectedIndex === i ? 'var(--info)' : 'var(--border-default)'}`,
@@ -261,9 +266,8 @@ function ContestedDriverQuickSelect({ driver }: { driver: DriverItem }) {
         value={customValue}
         onChange={handleInputChange}
         aria-label="Custom confidence value"
+        className={typography.panelMeta}
         style={{
-          fontSize: '11px',
-          fontWeight: 600,
           width: '44px',
           padding: '3px 6px',
           border: '1px solid var(--border-default)',

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -380,7 +380,7 @@ function T1DominantNudge({
       <p className={`${typography.panelMeta} text-text-body min-w-0 flex-1 flex items-baseline gap-1 overflow-hidden`}>
         <span className="whitespace-nowrap"><strong>Dominant factor:</strong></span>
         {/* Visible identity span — always renders the raw user label, even in v17 mode. */}
-        <span className="font-semibold whitespace-nowrap">{dominantLabel}</span>
+        <strong className="whitespace-nowrap">{dominantLabel}</strong>
         <span className={`truncate min-w-0 flex-1 text-text-light`}>{explanation}</span>
       </p>
       {dominantFocusId && onFocusNode && (

--- a/src/components/results/__tests__/humaniseCritique.spec.ts
+++ b/src/components/results/__tests__/humaniseCritique.spec.ts
@@ -52,7 +52,10 @@ describe('humaniseCritique', () => {
       makeItem({ code: 'CONSTRAINT_MISSING_RANGE', affectedNodes: ['fac_timeline'] }),
       nodeLabels,
     )
-    expect(result.title).toBe('Timeline is missing a range for its constraint')
+    // Re-grounded in the producer (N-21 item 4): PLoT emits this as INFO with
+    // "no downstream impact", so the copy no longer implies the target cannot
+    // be evaluated. The label resolution this case exists to pin is unchanged.
+    expect(result.title).toBe('Timeline has no range to check your target against')
     expect(result.suggestion).toBe('Set range')
     expect(result.factorId).toBe('fac_timeline')
   })

--- a/src/components/results/__tests__/v12.2-factor-labels.spec.tsx
+++ b/src/components/results/__tests__/v12.2-factor-labels.spec.tsx
@@ -54,7 +54,9 @@ describe('Fix 5: Constraint investigate items name the factor', () => {
 
     const result = humaniseCritique(item, nodeLabels)
 
-    expect(result.title).toBe('Revenue Target is missing a range for its constraint')
+    // Copy re-grounded in the producer (N-21 item 4). This case pins LABEL
+    // RESOLUTION, not the sentence, and the label is still named.
+    expect(result.title).toBe('Revenue Target has no range to check your target against')
     expect(result.title).not.toContain('This factor')
   })
 

--- a/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
+++ b/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
@@ -153,7 +153,7 @@ function StatusState({ model }: { model: HeroStatusModel }) {
               label: HERO_COPY.paused.askLabel,
             })
           }
-          className={`${typography.panelMeta} inline-flex items-center rounded-full bg-primary px-3 py-1.5 font-semibold text-text-on-color transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+          className={`${typography.panelBody} inline-flex items-center rounded-full bg-primary px-3 py-1.5 text-text-on-color transition-opacity hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
         >
           {HERO_COPY.paused.resolveButton}
         </button>
@@ -721,7 +721,7 @@ export function AnalysisHeroPanel({
             </span>
             <span
               data-testid="hero-next-rec-title"
-              className={`${typography.panelBody} block truncate font-semibold text-text-header`}
+              className={`${typography.panelHeader} block truncate text-text-header`}
             >
               {nextRecommendation}
             </span>

--- a/src/components/results/analysis-hero/HeroEvidenceDisclosure.tsx
+++ b/src/components/results/analysis-hero/HeroEvidenceDisclosure.tsx
@@ -226,13 +226,18 @@ export function HeroEvidenceDisclosure({
           <Crosshair aria-hidden="true" className="h-3 w-3 flex-none text-info" />
         )}
         {d.direction != null && (
-          <span
+          // DS v5 §2.4: `<strong>` carries the emphasis semantically instead of a
+          // raw weight utility, matching the pattern already used for inline
+          // emphasis inside panel text (TriageActionCardsBody). The glyph is
+          // aria-hidden and the direction is also stated in the sr-only span
+          // below, so the weight is a visual cue only.
+          <strong
             data-testid="hero-driver-sign"
             aria-hidden="true"
-            className={`font-semibold ${d.direction === 'positive' ? 'text-success' : 'text-danger'}`}
+            className={d.direction === 'positive' ? 'text-success' : 'text-danger'}
           >
             {d.direction === 'positive' ? '+' : '-'}
-          </span>
+          </strong>
         )}
         <span className="min-w-0 truncate text-left">{d.label}</span>
         {/* Direction perceivable without the sign glyph/colour. */}
@@ -622,7 +627,7 @@ export function HeroEvidenceDisclosure({
             <div className="space-y-2" data-testid="hero-evidence-trade-offs">
               {evidence.tradeOffs.map((t) => (
                 <div key={t.option} className="space-y-1">
-                  <p className={`${typography.panelBody} font-semibold text-text-header`}>
+                  <p className={`${typography.panelHeader} text-text-header`}>
                     {t.option}
                   </p>
                   {/* Prototype .trade-grid: 2×2 bordered cells, de-emphasised

--- a/src/components/results/coaching/AskOlumiDrawer.tsx
+++ b/src/components/results/coaching/AskOlumiDrawer.tsx
@@ -28,6 +28,7 @@ import { X } from 'lucide-react'
 import { useGuidanceStore } from '../../../canvas/stores/guidanceStore'
 import { focusModelTarget } from '../../../canvas/utils/focusHelpers'
 import { MODEL_LIMIT_CAVEAT } from '../utils/modelLimitCaveat'
+import { typography } from '../../../styles/typography'
 import { useAskOlumiStore } from './askOlumiStore'
 
 const TOAST_MS = 1800
@@ -145,7 +146,7 @@ export function AskOlumiDrawer() {
           className="fixed bottom-[18px] right-[18px] z-[25] w-[min(370px,calc(100vw-36px))] rounded-xl border border-panel-border bg-panel shadow-2"
         >
           <div className="flex items-center gap-2 px-[11px] pt-[10px]">
-            <h2 className="flex-1 text-sm font-semibold text-text-header">
+            <h2 className={`${typography.panelHeader} flex-1 text-text-header`}>
               Work through it with Olumi
             </h2>
             <button
@@ -161,7 +162,7 @@ export function AskOlumiDrawer() {
             {showContextLine && (
               <p
                 data-testid="ask-olumi-context"
-                className="mb-2 rounded-[9px] border border-info px-2.5 py-2 text-xs text-text-body"
+                className={`${typography.panelBody} mb-2 rounded-[9px] border border-info px-2.5 py-2 text-text-body`}
               >
                 {context}
               </p>
@@ -170,7 +171,7 @@ export function AskOlumiDrawer() {
                 work-through never reads as a real-world forecast. Copy only. */}
             <p
               data-testid="ask-olumi-model-limit"
-              className="mb-2 text-[11px] leading-snug text-text-light"
+              className={`${typography.panelMeta} mb-2 text-text-light`}
             >
               {MODEL_LIMIT_CAVEAT}
             </p>
@@ -180,10 +181,10 @@ export function AskOlumiDrawer() {
               value={draft}
               onChange={(e) => setDraft(e.target.value)}
               rows={3}
-              className="min-h-[64px] w-full resize-y rounded-[9px] border border-panel-border bg-transparent px-2.5 py-2 text-xs text-text-body focus:border-info focus:outline-none"
+              className={`${typography.panelBody} min-h-[64px] w-full resize-y rounded-[9px] border border-panel-border bg-transparent px-2.5 py-2 text-text-body focus:border-info focus:outline-none`}
             />
             {!canSend && (
-              <p className="mt-1 text-[11px] leading-snug text-text-light">
+              <p className={`${typography.panelMeta} mt-1 text-text-light`}>
                 Open the Olumi chat to send this — the conversation is not
                 available right now.
               </p>
@@ -193,7 +194,7 @@ export function AskOlumiDrawer() {
                 <button
                   type="button"
                   onClick={handleFocusCanvas}
-                  className="rounded-full border border-panel-border bg-transparent px-2.5 py-1.5 text-xs text-text-body hover:bg-panel-hover"
+                  className={`${typography.panelBody} rounded-full border border-panel-border bg-transparent px-2.5 py-1.5 text-text-body hover:bg-panel-hover`}
                 >
                   Focus on canvas
                 </button>
@@ -202,7 +203,7 @@ export function AskOlumiDrawer() {
                 type="button"
                 onClick={handleSend}
                 disabled={!canSend || draft.trim() === ''}
-                className="inline-flex items-center gap-1.5 rounded-full border border-primary bg-primary px-[11px] py-[7px] text-xs font-semibold text-text-on-color hover:border-primary-hover hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-40"
+                className={`${typography.panelBody} inline-flex items-center gap-1.5 rounded-full border border-primary bg-primary px-[11px] py-[7px] text-text-on-color hover:border-primary-hover hover:bg-primary-hover disabled:cursor-not-allowed disabled:opacity-40`}
               >
                 Send
               </button>
@@ -214,7 +215,7 @@ export function AskOlumiDrawer() {
         <div
           role="status"
           data-testid="ask-olumi-toast"
-          className="pointer-events-none fixed bottom-[18px] left-1/2 z-[30] max-w-[min(90vw,430px)] -translate-x-1/2 rounded-full bg-text-header px-[13px] py-2 text-xs text-text-on-color opacity-95"
+          className={`${typography.panelBody} pointer-events-none fixed bottom-[18px] left-1/2 z-[30] max-w-[min(90vw,430px)] -translate-x-1/2 rounded-full bg-text-header px-[13px] py-2 text-text-on-color opacity-95`}
         >
           {toast}
         </div>

--- a/src/components/results/decision-overview/ActionsMenu.tsx
+++ b/src/components/results/decision-overview/ActionsMenu.tsx
@@ -171,7 +171,7 @@ export function ActionsMenu() {
               onClick={() => runMethod(m)}
               className="block w-full rounded-md px-2 py-1.5 text-left hover:bg-panel-hover"
             >
-              <span className={`${typography.panelBody} block font-semibold text-text-header`}>{m.title}</span>
+              <span className={`${typography.panelHeader} block text-text-header`}>{m.title}</span>
               <span className={`${typography.panelMeta} block text-text-light`}>{m.description}</span>
             </button>
           ))}
@@ -185,7 +185,7 @@ export function ActionsMenu() {
               onClick={() => runGlobal(a)}
               className="block w-full rounded-md px-2 py-1.5 text-left hover:bg-panel-hover"
             >
-              <span className={`${typography.panelBody} block font-semibold text-text-header`}>{a.title}</span>
+              <span className={`${typography.panelHeader} block text-text-header`}>{a.title}</span>
               <span className={`${typography.panelMeta} block text-text-light`}>{a.description}</span>
             </button>
           ))}

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -519,7 +519,7 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
           className={`h-2 w-2 flex-none rounded-full ${STATE_DOT_TONE[state]}`}
         />
         <span className="min-w-0 flex-1">
-          <span className={`${typography.panelBody} block font-semibold text-text-header`}>{copy.line}</span>
+          <span className={`${typography.panelHeader} block text-text-header`}>{copy.line}</span>
           <span className={`${typography.panelMeta} block text-text-light`}>{copy.note}</span>
         </span>
         <ChevronDown
@@ -546,7 +546,7 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
                   className={`h-[7px] w-[7px] flex-none rounded-full border bg-transparent ${dotTone}`}
                 />
                 <span className="min-w-0">
-                  <span className={`${typography.panelBody} block font-semibold text-text-header`}>{dim}</span>
+                  <span className={`${typography.panelHeader} block text-text-header`}>{dim}</span>
                   {/* A null note renders NOTHING — not an empty line. Silence is
                       the honest state for a dimension we cannot speak to. */}
                   {note !== null && (

--- a/src/components/results/strengthen/StrengthenPanel.tsx
+++ b/src/components/results/strengthen/StrengthenPanel.tsx
@@ -134,8 +134,21 @@ function RecRow({
       >
         <Icon aria-hidden="true" data-testid="strengthen-rec-icon" className="mt-px h-[17px] w-[17px] text-factor" />
         <span className="min-w-0">
-          <span className={`${typography.panelBody} block font-semibold text-text-header`}>
-            {rec.title}
+          {/* ── DS v5 §2.4: THE BADGES ARE SIBLINGS OF THE TITLE, NOT CHILDREN ──
+              This block used to be one body-token span carrying a raw weight
+              override, with the three badges nested INSIDE it and each carrying
+              a raw weight RESET to climb back out of the inherited bold. That
+              is four raw typography utilities to express one title and three
+              pills, and the resets only existed because of the override above
+              them.
+              Un-nesting removes all four: the title takes `panelHeader` (the
+              sanctioned 14px semibold "section title / key emphasis" step,
+              which is also the correct hierarchy for a recommendation title)
+              and each badge takes `panelMeta` at its own natural weight.
+              `align-middle` + `ml-1.5` keep them on the title's baseline, so
+              the rendered arrangement is unchanged. */}
+          <span className="block">
+            <span className={`${typography.panelHeader} text-text-header`}>{rec.title}</span>
             {/* Stage 2 — honest severity badge: rendered ONLY when the producer
                 categorised this finding (phase-3 recs). Absent category = no
                 badge (the PR-427 honest-absent posture); the UI's own triggers
@@ -144,21 +157,21 @@ function RecRow({
               <span
                 data-testid="strengthen-rec-severity"
                 data-category={rec.category}
-                className={`${typography.panelMeta} ml-1.5 inline-flex items-center rounded-pill border bg-transparent px-1.5 font-normal align-middle ${SEVERITY_BADGE_CLASS[rec.category]}`}
+                className={`${typography.panelMeta} ml-1.5 inline-flex items-center rounded-pill border bg-transparent px-1.5 align-middle ${SEVERITY_BADGE_CLASS[rec.category]}`}
               >
                 {COPY.severityLabel[rec.category]}
               </span>
             )}
             {record.status === 'in_progress' && (
               <span
-                className={`${typography.panelMeta} ml-1.5 inline-flex items-center rounded-pill border border-info/30 bg-transparent px-1.5 font-normal text-text-body align-middle`}
+                className={`${typography.panelMeta} ml-1.5 inline-flex items-center rounded-pill border border-info/30 bg-transparent px-1.5 text-text-body align-middle`}
               >
                 {COPY.inProgressPill}
               </span>
             )}
             {record.status === 'reopened' && (
               <span
-                className={`${typography.panelMeta} ml-1.5 inline-flex items-center rounded-pill border border-warning/30 bg-transparent px-1.5 font-normal text-text-body align-middle`}
+                className={`${typography.panelMeta} ml-1.5 inline-flex items-center rounded-pill border border-warning/30 bg-transparent px-1.5 text-text-body align-middle`}
               >
                 {COPY.reopenedPill}
               </span>
@@ -191,7 +204,7 @@ function RecRow({
         <div className="space-y-1.5 pb-3 pl-[42px] pr-3">
           <p className={`${typography.panelBody} text-text-body`}>{rec.whyNow}</p>
           <p className={`${typography.panelBody} text-text-header`}>
-            <span className="font-semibold text-info">{COPY.tryThisLead}</span> {rec.tryThis}
+            <strong className="text-info">{COPY.tryThisLead}</strong> {rec.tryThis}
           </p>
           <p className={`${typography.panelMeta} text-text-light`}>{rec.sourceLine}</p>
 
@@ -199,7 +212,7 @@ function RecRow({
             <button
               type="button"
               onClick={() => onPrimaryAction(record)}
-              className={`${typography.panelBody} rounded-pill bg-primary px-3 py-1 font-semibold text-text-on-color transition-colors hover:bg-primary-hover active:bg-primary-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+              className={`${typography.panelBody} rounded-pill bg-primary px-3 py-1 text-text-on-color transition-colors hover:bg-primary-hover active:bg-primary-active focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
             >
               {rec.action.label}
             </button>
@@ -331,7 +344,7 @@ export function StrengthenPanel({
             <button
               type="button"
               onClick={handleUndo}
-              className={`${typography.panelBody} font-semibold text-info hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+              className={`${typography.panelBody} text-info hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
             >
               {COPY.undo}
             </button>

--- a/src/components/results/utils/__tests__/humaniseCritique.constraintRangeProvenance.spec.ts
+++ b/src/components/results/utils/__tests__/humaniseCritique.constraintRangeProvenance.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * The constraint-range critique copy must be grounded in the PRODUCER, and the
+ * two constraint rows a bare factor emits must not read as the same finding.
+ *
+ * ── WHAT THE LEDGER SAID, AND WHY IT WAS WRONG (N-21, item 4) ───────────────
+ * N-21 recorded "two producer codes collapsing to one sentence". Derived at the
+ * producer's bytes (PLoT `staging` @ fb63b03d, ISL @ 28fe0c9, schemas @ 8149308,
+ * with contrast controls — `CONSTRAINT_MISSING_RANGE` 13 hits,
+ * `CONSTRAINT_TARGET_NO_OBSERVED_VALUE` 16, `MISSING_OBSERVED_STATE` 8, while
+ * `CONSTRAINT_NO_DERIVABLE_RANGE` reads 0/0/0), that framing is REFUTED twice:
+ *
+ *  1. `CONSTRAINT_NO_DERIVABLE_RANGE` IS NOT A PRODUCER CODE. No emitter in any
+ *     of the three repos produces it. It is a UI-local invention whose template
+ *     duplicated `CONSTRAINT_TARGET_NO_OBSERVED_VALUE`'s title verbatim
+ *     ("{label} has no estimate set" / "Set estimate"). The duplicate sentence
+ *     was ours, not the producer's.
+ *  2. The genuine pair a user sees on one factor is
+ *     `CONSTRAINT_TARGET_NO_OBSERVED_VALUE` (severity `warning`) AND
+ *     `CONSTRAINT_MISSING_RANGE` (severity `info`) — PLoT's
+ *     `preflight-v2.ts:619` has no `continue` after the first push, so a bare
+ *     factor with neither `observed_state.value` nor `state_space.range` trips
+ *     both in one pass. They are TWO REAL FINDINGS and must be NAMED APART, not
+ *     deduplicated. (L-37's lesson: a ledger row is a symptom, not a fix spec.)
+ *
+ * ── THE FABRICATION THAT SHIPPED ────────────────────────────────────────────
+ * PLoT declares the range case "informational only (no downstream impact since
+ * constraint values pass through raw to ISL)" (`preflight-v2.ts:670-671`) and
+ * humanises it as "The constraint on {label} cannot be range-checked. The
+ * constraint value will be used as-is." The UI's invented template asserted the
+ * OPPOSITE — "Constraint results may be less precise. Set a value to sharpen
+ * the analysis." — a consequence the producer explicitly says does not exist,
+ * and the sibling `CONSTRAINT_MISSING_RANGE` template asserted "A range is
+ * needed to assess whether this target can be met", when the producer says the
+ * target IS still assessed and only the sanity-check is skipped. P7: the
+ * producer declares the meaning; where the UI disagreed, the UI was wrong.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { humaniseCritique } from '../humaniseCritique'
+import type { UncertaintyItem } from '../../types'
+
+const SRC = join(__dirname, '..', 'humaniseCritique.ts')
+
+const item = (over: Partial<UncertaintyItem>): UncertaintyItem => ({
+  code: 'GENERAL',
+  message: 'msg',
+  ...over,
+})
+
+const LABELS = new Map([['fac_churn', 'Customer churn']])
+
+describe('constraint-range critique copy is grounded in the producer', () => {
+  // ── CONTROL, per trap 13: the instrument must be able to SEE a template at
+  // all before any of the assertions below mean anything. Bound by identity to
+  // a code whose producer emission was counted in the same sweep (16 hits).
+  it('CONTROL: the humaniser resolves a real producer code to a labelled title', () => {
+    const r = humaniseCritique(
+      item({ code: 'CONSTRAINT_TARGET_NO_OBSERVED_VALUE', affectedNodes: ['fac_churn'] }),
+      LABELS,
+    )
+    expect(r.title).toBe('Customer churn has no estimate set')
+    expect(r.suggestion).toBe('Set estimate')
+  })
+
+  it('the two REAL producer codes a bare factor emits are named apart', () => {
+    const noValue = humaniseCritique(
+      item({ code: 'CONSTRAINT_TARGET_NO_OBSERVED_VALUE', affectedNodes: ['fac_churn'] }),
+      LABELS,
+    )
+    const noRange = humaniseCritique(
+      item({ code: 'CONSTRAINT_MISSING_RANGE', affectedNodes: ['fac_churn'] }),
+      LABELS,
+    )
+    // Both are real findings and both keep rendering — this is NOT a dedup.
+    expect(noValue.title.length).toBeGreaterThan(0)
+    expect(noRange.title.length).toBeGreaterThan(0)
+    // …but a user must be able to tell them apart. Titles AND descriptions.
+    expect(noRange.title).not.toBe(noValue.title)
+    expect(noRange.description).not.toBe(noValue.description)
+  })
+
+  it('the range note does not claim a consequence the producer says it has not', () => {
+    const r = humaniseCritique(
+      item({ code: 'CONSTRAINT_MISSING_RANGE', affectedNodes: ['fac_churn'] }),
+      LABELS,
+    )
+    // PLoT: "no downstream impact since constraint values pass through raw to
+    // ISL". Copy asserting reduced precision or an unevaluable target
+    // contradicts the emitter.
+    expect(r.description).not.toMatch(/less precise|unreliable|can be met|cannot be (met|evaluated)/i)
+    // …and it must say the positive thing the producer declares: the value is
+    // used as set.
+    expect(`${r.title} ${r.description}`).toMatch(/as you set it|used as-is|exactly as/i)
+  })
+
+  it('a GENERAL row carrying PLoT\'s range MESSAGE maps to the range finding, not the value one', () => {
+    // PLoT's message verbatim (preflight-v2.ts:677).
+    const r = humaniseCritique(
+      item({
+        code: 'GENERAL',
+        message:
+          'Constraint "constraint_fac_churn_max" target node "fac_churn" has no derivable range. Constraint value will be compared as-is by ISL.',
+        affectedNodes: ['fac_churn'],
+      }),
+      LABELS,
+    )
+    const range = humaniseCritique(
+      item({ code: 'CONSTRAINT_MISSING_RANGE', affectedNodes: ['fac_churn'] }),
+      LABELS,
+    )
+    expect(r.title).toBe(range.title)
+    // The defect: it used to resolve to the no-estimate sentence.
+    expect(r.title).not.toMatch(/has no estimate set/i)
+    // Never echo the producer's internal identifiers.
+    expect(r.displayText ?? '').not.toMatch(/constraint_|ISL|derivable/i)
+  })
+
+  it('the invented CONSTRAINT_NO_DERIVABLE_RANGE code has no template of its own', () => {
+    // ⚠ BOUND TO BEHAVIOUR, NOT TO A SOURCE GREP. The first version of this
+    // assertion was `expect(src).not.toContain('CONSTRAINT_NO_DERIVABLE_RANGE')`
+    // and it went RED against the fixed tree — because the deletion COMMENT
+    // names the key it deleted. A source-text absence check cannot tell a live
+    // map entry from prose about a dead one, so it was the wrong instrument for
+    // the claim. An unmapped code falls through to the generic fallback, and
+    // THAT is observable.
+    const r = humaniseCritique(
+      item({ code: 'CONSTRAINT_NO_DERIVABLE_RANGE', message: 'msg', affectedNodes: ['fac_churn'] }),
+      LABELS,
+    )
+    expect(r.title).toBe('Review this factor\'s inputs')
+    expect(r.displayText).toBeNull()
+    // …and specifically NOT the sentence it used to fabricate.
+    expect(r.title).not.toMatch(/has no estimate set/i)
+  })
+
+  it('the contamination detector keeps the phrase it needs (structural backstop)', () => {
+    // `INTERNAL_TOKEN_REGEX` also matches "no derivable range", for a DIFFERENT
+    // job: never render a raw producer message as a title. Deleting the
+    // template must not collaterally strip that. Source-read is the right
+    // instrument here because the claim IS about the source.
+    const src = readFileSync(SRC, 'utf8')
+    expect(src).toContain('no derivable range')
+    // CONTRAST CONTROL (trap 13e): the same read sees the codes that must
+    // remain, so a pass cannot come from an empty or failed read.
+    expect(src).toContain('CONSTRAINT_MISSING_RANGE')
+    expect(src).toContain('CONSTRAINT_TARGET_NO_OBSERVED_VALUE')
+  })
+})

--- a/src/components/results/utils/__tests__/humaniseCritique.spec.ts
+++ b/src/components/results/utils/__tests__/humaniseCritique.spec.ts
@@ -266,19 +266,35 @@ describe('humaniseCritique', () => {
     })
   })
 
-  describe('V16.2: CONSTRAINT_NO_DERIVABLE_RANGE', () => {
-    it('maps explicit code to humanised template', () => {
+  /**
+   * ⭐ REWRITTEN (N-21 item 4). This block used to be titled
+   * "V16.2: CONSTRAINT_NO_DERIVABLE_RANGE" and pinned three expectations onto a
+   * code NO PRODUCER EMITS (0 hits across PLoT fb63b03d / ISL 28fe0c9 /
+   * schemas 8149308, against sibling-code contrast controls of 13/16/8). Its
+   * expectations were therefore pinning a UI fabrication in place: the same
+   * "has no estimate set" / "Set estimate" pair that
+   * `CONSTRAINT_TARGET_NO_OBSERVED_VALUE` already owns, plus a "less precise"
+   * consequence PLoT explicitly denies for the range case.
+   *
+   * The BEHAVIOUR under test is kept — a `GENERAL` row carrying PLoT's range
+   * message must still resolve to a specific, labelled sentence rather than the
+   * generic fallback — but it is re-bound to the real producer code. This is a
+   * changed expectation, not a deleted one; the deeper provenance argument and
+   * its controls live in `humaniseCritique.constraintRangeProvenance.spec.ts`.
+   */
+  describe('PLoT range message → CONSTRAINT_MISSING_RANGE', () => {
+    it('maps the real producer code to its own humanised template', () => {
       const result = humaniseCritique(
-        makeItem({ code: 'CONSTRAINT_NO_DERIVABLE_RANGE', affectedNodes: ['fac_risk_churn'] }),
+        makeItem({ code: 'CONSTRAINT_MISSING_RANGE', affectedNodes: ['fac_risk_churn'] }),
         new Map([['fac_risk_churn', 'Risk Churn']]),
       )
-      expect(result.title).toBe('Risk Churn has no estimate set')
-      expect(result.description).toContain('less precise')
-      expect(result.suggestion).toBe('Set estimate')
+      expect(result.title).toBe('Risk Churn has no range to check your target against')
+      expect(result.description).toContain('exactly as you set it')
+      expect(result.suggestion).toBe('Set range')
       expect(result.factorId).toBe('fac_risk_churn')
     })
 
-    it('detects "no derivable range" in GENERAL code message', () => {
+    it('detects "no derivable range" in a GENERAL code message and lands on the RANGE finding', () => {
       const result = humaniseCritique(
         makeItem({
           code: 'GENERAL',
@@ -287,12 +303,15 @@ describe('humaniseCritique', () => {
         }),
         new Map([['risk_churn', 'Risk Churn']]),
       )
-      expect(result.title).toBe('Risk Churn has no estimate set')
-      expect(result.displayText).toBe('Risk Churn has no estimate set')
-      expect(result.suggestion).toBe('Set estimate')
+      expect(result.title).toBe('Risk Churn has no range to check your target against')
+      expect(result.displayText).toBe('Risk Churn has no range to check your target against')
+      expect(result.suggestion).toBe('Set range')
+      // The defect this replaces: it used to answer with the no-estimate copy,
+      // which is a different producer finding entirely.
+      expect(result.title).not.toContain('has no estimate set')
     })
 
-    it('returns null displayText when resolved label contains internal tokens', () => {
+    it('derives a clean label from the node id when no label map is supplied', () => {
       const result = humaniseCritique(
         makeItem({
           code: 'GENERAL',
@@ -301,8 +320,8 @@ describe('humaniseCritique', () => {
         }),
       )
       // factorIdToLabel derives "Churn" which is clean → displayText should be set
-      expect(result.title).toBe('Churn has no estimate set')
-      expect(result.displayText).toBe('Churn has no estimate set')
+      expect(result.title).toBe('Churn has no range to check your target against')
+      expect(result.displayText).toBe('Churn has no range to check your target against')
     })
   })
 })

--- a/src/components/results/utils/humaniseCritique.ts
+++ b/src/components/results/utils/humaniseCritique.ts
@@ -125,9 +125,21 @@ const CODE_TEMPLATES: Record<string, TemplateFactory> = {
     description: 'Results may be unreliable without a current value for this constraint.',
     suggestion: 'Set estimate',
   }),
+  // ⭐ RE-GROUNDED IN THE PRODUCER (N-21 item 4, P7). PLoT emits this as
+  // `createInfo`, and its own branch comment declares the case "informational
+  // only (no downstream impact since constraint values pass through raw to
+  // ISL)" (`preflight-v2.ts:670-671`); its humanised copy reads "The constraint
+  // on {label} cannot be range-checked. The constraint value will be used
+  // as-is." The previous description — "A range is needed to assess whether
+  // this target can be met" — asserted the target could NOT be assessed, which
+  // the emitter contradicts: the target IS assessed, only the sanity-check
+  // against a min/max is skipped. The suggestion stays because setting a range
+  // genuinely clears the note (P8: the ask has an acceptance path); what goes
+  // is the false consequence attached to not doing it.
   CONSTRAINT_MISSING_RANGE: (label) => ({
-    title: `${label} is missing a range for its constraint`,
-    description: 'A range is needed to assess whether this target can be met.',
+    title: `${label} has no range to check your target against`,
+    description:
+      'Your target is used exactly as you set it. Recording a lowest and highest value for this factor lets Olumi sanity-check it.',
     suggestion: 'Set range',
   }),
   CONSTRAINT_FILTERED_TEMPORAL: () => ({
@@ -140,11 +152,17 @@ const CODE_TEMPLATES: Record<string, TemplateFactory> = {
     description: 'The target for this constraint falls outside the range the model can assess.',
     suggestion: 'Review',
   }),
-  CONSTRAINT_NO_DERIVABLE_RANGE: (label) => ({
-    title: `${label} has no estimate set`,
-    description: 'Constraint results may be less precise. Set a value to sharpen the analysis.',
-    suggestion: 'Set estimate',
-  }),
+  // ⛔ `CONSTRAINT_NO_DERIVABLE_RANGE` WAS HERE AND IS DELETED (N-21 item 4).
+  // It was a UI-LOCAL INVENTION: swept at the producers with contrast controls
+  // (PLoT `staging` fb63b03d / ISL 28fe0c9 / schemas 8149308) it reads 0/0/0,
+  // while the sibling codes read 13/16/8 — so the zero is real absence, not a
+  // blind instrument. Its template duplicated
+  // `CONSTRAINT_TARGET_NO_OBSERVED_VALUE`'s title and suggestion VERBATIM
+  // ("{label} has no estimate set" / "Set estimate"), which is the duplicate
+  // sentence N-21 reported; and its description ("results may be less precise")
+  // asserted a consequence PLoT explicitly denies for the range case.
+  // The real producer code for that message is `CONSTRAINT_MISSING_RANGE`,
+  // which already has its own honest template above.
   INBOUND_STRENGTH_SUM_EXCEEDED: (label) => ({
     title: `The factors driving ${label} may be over-weighted`,
     description: 'The combined strength of connections into this node exceeds the expected range. Consider reducing some edge strengths.',
@@ -330,9 +348,22 @@ export function humaniseCritique(
     return { ...result, displayText, factorId }
   }
 
-  // V16.2: Message-based detection for known ISL patterns sent as GENERAL code
+  // Message-based safety net for a row that carries PLoT's range MESSAGE under
+  // a code this map does not hold (historically `GENERAL`).
+  //
+  // ⭐ RE-POINTED (N-21 item 4). It used to resolve to the invented
+  // `CONSTRAINT_NO_DERIVABLE_RANGE` template, i.e. the "has no estimate set"
+  // sentence — a DIFFERENT finding from the one the message describes. The
+  // phrase is PLoT's `CONSTRAINT_MISSING_RANGE` message verbatim
+  // (`preflight-v2.ts:677`), so that is the template it must reach.
+  //
+  // Note this branch sits AFTER the code-keyed lookup, and
+  // `CONSTRAINT_MISSING_RANGE` IS in the map — so for any correctly-coded
+  // producer row it is unreachable by construction. It survives only as the
+  // net for a mis-coded one, and it now lands on the same sentence that row
+  // would have got.
   if (/no derivable range/i.test(item.message)) {
-    const result = CODE_TEMPLATES.CONSTRAINT_NO_DERIVABLE_RANGE(factorLabel)
+    const result = CODE_TEMPLATES.CONSTRAINT_MISSING_RANGE(factorLabel)
     const displayText = INTERNAL_TOKEN_REGEX.test(result.title) ? null : result.title
     return { ...result, displayText, factorId }
   }

--- a/tests/ci-guards/shell-conformance.spec.ts
+++ b/tests/ci-guards/shell-conformance.spec.ts
@@ -465,6 +465,25 @@ describe('workspace shell — child surfaces: raw typography, pinned per file', 
    * rebuilt to avoid. Exact equality in both directions: a lane that burns
    * some down lowers its number here, and the diff is the proof.
    */
+  // ⭐ BURNED DOWN TO ZERO, 18 Aug 2026 (B2 Analysis convergence): all EIGHT
+  // `src/components/results/**` entries are gone from this map because the
+  // measured count for each is now 0 — 30 occurrences retired in one pass
+  // (AskOlumiDrawer 10, StrengthenPanel 7, DriversSection 4, and 2 each in
+  // AnalysisHeroPanel / HeroEvidenceDisclosure / ActionsMenu /
+  // DecisionOverviewCard, 1 in TriageActionCardsBody). The whole results tree
+  // now measures ZERO under this rule AND under the DS ratchet's narrower one.
+  //
+  // How, so the next lane does not re-introduce them: block titles took
+  // `panelHeader` (the sanctioned 14px semibold step) instead of a body token
+  // plus a raw weight; buttons took `panelBody` per the DS's panel-button rule;
+  // inline emphasis inside body/meta text took `<strong>`, the pattern already
+  // in TriageActionCardsBody, which carries the emphasis semantically rather
+  // than through a banned utility; StrengthenPanel's three `font-normal` badge
+  // RESETS disappeared once the badges stopped being nested inside a bolded
+  // title; and DriversSection's inline `fontSize`/`fontWeight` — the class the
+  // header rightly calls invisible to every class-based regex — became
+  // `panelMeta`, dropping a selected-state weight bump that duplicated the
+  // border/background channel.
   const RAW_TYPOGRAPHY_BY_FILE: Record<string, number> = {
     'src/canvas/compare-tab/CompareFooter.tsx': 2,
     'src/canvas/compare-tab/DotProgression.tsx': 2,
@@ -498,14 +517,6 @@ describe('workspace shell — child surfaces: raw typography, pinned per file', 
     'src/canvas/shared/AnalysisFooter.tsx': 2,
     'src/canvas/ui/inspector/StrengthBar.tsx': 1,
     'src/components/Tooltip.tsx': 1,
-    'src/components/results/DriversSection.tsx': 4,
-    'src/components/results/TriageActionCardsBody.tsx': 1,
-    'src/components/results/analysis-hero/AnalysisHeroPanel.tsx': 2,
-    'src/components/results/analysis-hero/HeroEvidenceDisclosure.tsx': 2,
-    'src/components/results/coaching/AskOlumiDrawer.tsx': 10,
-    'src/components/results/decision-overview/ActionsMenu.tsx': 2,
-    'src/components/results/decision-overview/DecisionOverviewCard.tsx': 2,
-    'src/components/results/strengthen/StrengthenPanel.tsx': 7,
     'src/styles/typography.ts': 38,
     'src/v5/blocks/V5AnalysisResultBlock.tsx': 4,
     'src/v5/blocks/V5CoachingBlock.tsx': 2,
@@ -562,8 +573,8 @@ describe('workspace shell — child surfaces: raw typography, pinned per file', 
     // measuring almost nothing, which is how this kind of ratchet dies.
     const files = Object.keys(RAW_TYPOGRAPHY_BY_FILE).length
     const total = Object.values(RAW_TYPOGRAPHY_BY_FILE).reduce((a, b) => a + b, 0)
-    expect(files).toBe(45)
-    expect(total).toBe(164)
+    expect(files).toBe(37)
+    expect(total).toBe(134)
   })
 })
 

--- a/tools/ci-guards/ds-compliance-baseline.json
+++ b/tools/ci-guards/ds-compliance-baseline.json
@@ -6173,22 +6173,13 @@
     "panel-typography-scoped": {
       "mode": "ratchet",
       "description": "Raw text-/font- utilities in panel scope — must use panelHeader/Body/Meta (DS v5 §2.4)",
-      "total": 34,
+      "total": 10,
       "byFile": {
-        "src/components/results/coaching/AskOlumiDrawer.tsx": 8,
-        "src/components/results/strengthen/StrengthenPanel.tsx": 4,
         "src/canvas/panels/TemplatesPanel.tsx": 3,
         "src/canvas/ui/EdgeInspector.tsx": 3,
         "src/canvas/panels/AdapterStatusBanner.tsx": 2,
-        "src/components/results/analysis-hero/AnalysisHeroPanel.tsx": 2,
-        "src/components/results/analysis-hero/HeroEvidenceDisclosure.tsx": 2,
-        "src/components/results/analysisHeroV17/HeroFooter.tsx": 2,
-        "src/components/results/decision-overview/ActionsMenu.tsx": 2,
-        "src/components/results/decision-overview/DecisionOverviewCard.tsx": 2,
         "src/canvas/panels/InspectorPanel.tsx": 1,
-        "src/canvas/panels/IssuesPanel.tsx": 1,
-        "src/components/results/CompactOptionSpread.tsx": 1,
-        "src/components/results/TriageActionCardsBody.tsx": 1
+        "src/canvas/panels/IssuesPanel.tsx": 1
       },
       "signatures": {
         "panel-typography-scoped :: src/canvas/panels/AdapterStatusBanner.tsx :: text-xs": {
@@ -6232,78 +6223,6 @@
           "file": "src/canvas/ui/EdgeInspector.tsx",
           "token": "font-medium",
           "sample": "<span className=\"font-medium\">{sourceLabel}</span>"
-        },
-        "panel-typography-scoped :: src/components/results/CompactOptionSpread.tsx :: font-semibold": {
-          "count": 1,
-          "file": "src/components/results/CompactOptionSpread.tsx",
-          "token": "font-semibold",
-          "sample": "<span className=\"font-semibold\">Option spread:</span> {parts.join(' · ')}"
-        },
-        "panel-typography-scoped :: src/components/results/TriageActionCardsBody.tsx :: font-semibold": {
-          "count": 1,
-          "file": "src/components/results/TriageActionCardsBody.tsx",
-          "token": "font-semibold",
-          "sample": "<span className=\"font-semibold whitespace-nowrap\">{dominantLabel}</span>"
-        },
-        "panel-typography-scoped :: src/components/results/analysis-hero/AnalysisHeroPanel.tsx :: font-semibold": {
-          "count": 2,
-          "file": "src/components/results/analysis-hero/AnalysisHeroPanel.tsx",
-          "token": "font-semibold",
-          "sample": "className={`${typography.panelMeta} inline-flex items-center rounded-full bg-primary px-3 py-1.5 font-semibold text-text"
-        },
-        "panel-typography-scoped :: src/components/results/analysis-hero/HeroEvidenceDisclosure.tsx :: font-semibold": {
-          "count": 2,
-          "file": "src/components/results/analysis-hero/HeroEvidenceDisclosure.tsx",
-          "token": "font-semibold",
-          "sample": "className={`font-semibold ${d.direction === 'positive' ? 'text-success' : 'text-danger'}`}"
-        },
-        "panel-typography-scoped :: src/components/results/analysisHeroV17/HeroFooter.tsx :: font-semibold": {
-          "count": 1,
-          "file": "src/components/results/analysisHeroV17/HeroFooter.tsx",
-          "token": "font-semibold",
-          "sample": "<strong className=\"text-text-header font-semibold\">Also:</strong>"
-        },
-        "panel-typography-scoped :: src/components/results/analysisHeroV17/HeroFooter.tsx :: font-medium": {
-          "count": 1,
-          "file": "src/components/results/analysisHeroV17/HeroFooter.tsx",
-          "token": "font-medium",
-          "sample": "className={`px-3 py-1.5 rounded-full bg-primary text-text-on-color border border-primary hover:bg-primary-hover focus-vi"
-        },
-        "panel-typography-scoped :: src/components/results/coaching/AskOlumiDrawer.tsx :: text-sm": {
-          "count": 1,
-          "file": "src/components/results/coaching/AskOlumiDrawer.tsx",
-          "token": "text-sm",
-          "sample": "<h2 className=\"flex-1 text-sm font-semibold text-text-header\">"
-        },
-        "panel-typography-scoped :: src/components/results/coaching/AskOlumiDrawer.tsx :: font-semibold": {
-          "count": 2,
-          "file": "src/components/results/coaching/AskOlumiDrawer.tsx",
-          "token": "font-semibold",
-          "sample": "<h2 className=\"flex-1 text-sm font-semibold text-text-header\">"
-        },
-        "panel-typography-scoped :: src/components/results/coaching/AskOlumiDrawer.tsx :: text-xs": {
-          "count": 5,
-          "file": "src/components/results/coaching/AskOlumiDrawer.tsx",
-          "token": "text-xs",
-          "sample": "className=\"mb-2 rounded-[9px] border border-info px-2.5 py-2 text-xs text-text-body\""
-        },
-        "panel-typography-scoped :: src/components/results/decision-overview/ActionsMenu.tsx :: font-semibold": {
-          "count": 2,
-          "file": "src/components/results/decision-overview/ActionsMenu.tsx",
-          "token": "font-semibold",
-          "sample": "<span className={`${typography.panelBody} block font-semibold text-text-header`}>{m.title}</span>"
-        },
-        "panel-typography-scoped :: src/components/results/decision-overview/DecisionOverviewCard.tsx :: font-semibold": {
-          "count": 2,
-          "file": "src/components/results/decision-overview/DecisionOverviewCard.tsx",
-          "token": "font-semibold",
-          "sample": "<span className={`${typography.panelBody} block font-semibold text-text-header`}>{copy.line}</span>"
-        },
-        "panel-typography-scoped :: src/components/results/strengthen/StrengthenPanel.tsx :: font-semibold": {
-          "count": 4,
-          "file": "src/components/results/strengthen/StrengthenPanel.tsx",
-          "token": "font-semibold",
-          "sample": "<span className={`${typography.panelBody} block font-semibold text-text-header`}>"
         }
       }
     },


### PR DESCRIPTION
## B2 Analysis convergence — wave 1 (Phase 2, non-removal)

Base `staging` @ `dd089a50`. **No visible content block is removed in this PR.** The
KEEP / CUT / REHOME table for the Analysis surface is reported separately and awaits
Paul's veto before any removal lands.

### 1. A UI-invented critique code that duplicated a real one's sentence — withdrawn

N-21 item 4 recorded *"two producer codes collapsing to one sentence"*. Derived at the
producers with contrast controls (PLoT `staging` `fb63b03d`, ISL `28fe0c9`, schemas
`8149308`), **that framing is refuted twice**:

1. **`CONSTRAINT_NO_DERIVABLE_RANGE` is not a producer code.** It reads **0/0/0** across
   all three repos while its siblings read **13/16/8** in the same sweep, so the zero is
   real absence and not a blind instrument. It was a UI-local invention whose template
   duplicated `CONSTRAINT_TARGET_NO_OBSERVED_VALUE`'s title *and* suggestion verbatim
   (`"{label} has no estimate set"` / `"Set estimate"`). **The duplicate sentence was ours.**
2. **The genuine pair is two real findings and both are kept.**
   `CONSTRAINT_TARGET_NO_OBSERVED_VALUE` (warning) and `CONSTRAINT_MISSING_RANGE` (info)
   both fire on one factor because PLoT's `preflight-v2.ts:619` has no `continue` after
   the first push. They are now *named apart*, not deduplicated — L-37's lesson applied.

Also corrected a **fabricated consequence**: PLoT declares the range case *"informational
only (no downstream impact since constraint values pass through raw to ISL)"*, while the
UI asserted *"results may be less precise"* and *"A range is needed to assess whether this
target can be met"*. The producer says the target **is** assessed and only the sanity-check
is skipped. P7: where the copy and the producer disagreed, the copy was wrong.

The `/no derivable range/i` net is **re-pointed** at `CONSTRAINT_MISSING_RANGE` (the phrase
is that code's message verbatim) rather than deleted, so a mis-coded row keeps a specific
sentence. `"Set range"` stays — setting a range genuinely clears the note, so the ask has
an acceptance path (P8).

### 2. Raw typography in the results tree: 30 → 0 (DS v5 §2.4)

`src/components/results/**` now measures **zero** under both the DS ratchet's rule and the
stricter shell-conformance rule (which also catches `text-[Npx]`, `font-normal` and inline
`fontSize`/`fontWeight`).

This is conformance, and it does real hierarchy work: card and menu titles were rendering at
**body size with a bolt-on weight**, so titles and body text sat on the same step. Titles now
take `panelHeader`, buttons take `panelBody`, and inline emphasis takes `<strong>` — the
pattern already present in `TriageActionCardsBody`, so no new visual language is invented.

`AskOlumiDrawer` was entirely untokenised (10 of the 30) and is now fully tokenised, every
swap at exact parity except the Send button, which drops semibold per the panel-button rule.

**Both ratchets moved down in this PR because both demand it.** `shell-conformance.spec.ts`
is exact-equality in both directions and correctly went RED on the burn-down. The DS baseline
was descended **surgically**: `--update` would also have descended three classes sitting below
baseline from other lanes' work in files this lane does not own, which would red a sibling's
in-flight PR. A stale pin (`analysisHeroV17/HeroFooter.tsx`, a file absent at this HEAD) is
retired with the rest.

### Gates run at this tip
- `scripts/ci/typecheck-gate.sh` — **PASS**, 2306 diagnostics, exactly at baseline. Pristine
  control run first (P4): clean tree passes the same gate.
- `tests/ci-guards/shell-conformance.spec.ts` — 49/49.
- `src/components/results` — **242 files / 4265 tests, all green**, with
  `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported.
- `eslint` on every changed file — 0 errors (1 warning, pre-existing and byte-identical at
  `dd089a50`); rules-of-hooks ratchet exactly at baseline (229/13).
- New spec `humaniseCritique.constraintRangeProvenance.spec.ts` — **RED-first**: 3 of 5
  assertions failed at pristine; 6 collected by name.

### Reviewer note on an instrument defect I hit and fixed
One assertion was first written as a source-grep absence check and went **RED against the
fixed tree**, because the deletion comment names the key it deleted. A text-absence check
cannot tell a live map entry from prose about a dead one. It is re-bound to runtime fallback
behaviour, which prose cannot fool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
