### PR TITLE
fix(canvas): canvas label legibility at the auto-fit zoom + one Baseline vocabulary

### DIFF
--- a/e2e/visual/nodeTextLegibility.visual.spec.ts
+++ b/e2e/visual/nodeTextLegibility.visual.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * Canvas node text must be READABLE at the zoom the product picks for the user.
+ *
+ * WHY THIS IS A BROWSER TEST. jsdom has no layout and no viewport transform, so
+ * a passing DOM assertion proves a class is present and proves nothing about
+ * the size of a glyph on screen (CLAUDE.md trap 3). The sibling census
+ * (`src/canvas/nodes/__tests__/nodeTextCounterScale.census.spec.ts`) proves
+ * every declared size is routed through a counter-scaled token; only this spec
+ * can prove what that renders to. Neither replaces the other.
+ *
+ * WHAT IT MEASURES. Canvas label text is DOM inside React Flow's viewport
+ * transform, which scales glyphs, so `rendered = computed x zoom`. The
+ * counter-scale (`--canvas-label-scale`, see `src/canvas/utils/zoomLegibility.ts`)
+ * inflates `computed` by `1/zoom` across the legible band so that `rendered`
+ * equals the DECLARED size. A raw `text-[10px]` or an inline `fontSize` cannot
+ * see that variable and therefore renders at `declared x zoom`.
+ *
+ * MEASURED AT THE TIP THIS SPEC LANDED ON (Chromium, 3 starters x 2 laptop
+ * viewports, hermetic harness, at the POST-LAYOUT AUTO-FIT zoom of 0.5000):
+ *   node title  declared 13px -> 13.00px rendered  (was already correct)
+ *   edge pill   declared 10px ->  5.00px rendered  BEFORE this lane
+ *   edge pill   declared 10px -> 10.00px rendered  AFTER
+ * 17-21 such pills were on screen per starter.
+ *
+ * STATE-CLASS: fresh. Each starter is seeded into a fresh page and left at the
+ * zoom the AUTO-FIT chooses — the only zoom the product picks FOR the user, and
+ * therefore the only one it owes legibility at. The toolbar's "fit to view" is
+ * an explicit user gesture and is unfloored by design.
+ */
+import { test, expect } from '@playwright/test'
+import { VIEWPORTS, clearNotifications, openCanvas, preparePage, seedStarterDraft } from './harness'
+
+/** Every starter the product ships — the corpus, from outside this file. */
+const STARTERS = ['build-vs-buy', 'market-entry', 'vendor-selection'] as const
+
+/**
+ * Design System v5 §2.4: "Panel and canvas contexts use 10-12px for information
+ * density, always via tokens, never raw classes." 10px is the floor, and §2.3
+ * fixes the canvas scale at 13/11/10.
+ */
+const MIN_CANVAS_PX = 10
+
+/**
+ * `CanvasLabelScaleSync` quantises the counter-scale to two decimals
+ * (`SCALE_QUANTUM = 100`) so a pinch gesture does not rewrite the DOM every
+ * frame. That quantisation is deliberate and documented as "NOT a legibility
+ * parameter", but it does mean a counter-scaled 10px label can land a hair
+ * under 10px at a zoom whose reciprocal is not exact: measured 9.99px at zoom
+ * 0.5776 (scale 1/0.5776 = 1.7313, written as 1.73).
+ *
+ * The bound is `declared x halfQuantum x zoom` = `13 x 0.005 x 1` < 0.07px, so
+ * 0.1px is a derived allowance rather than a number chosen to make a red go
+ * away. It is far below the ~1px at which a rendering difference is visible,
+ * and it is NOT wide enough to hide the defect this spec exists for — that one
+ * was a factor of TWO (5.0px against a declared 10px), not a hundredth.
+ */
+const QUANTISATION_TOLERANCE_PX = 0.1
+
+/**
+ * Text inside the node card that is knowingly NOT counter-scaled, pinned EXACTLY
+ * — the same set as `KNOWN_FIXED` in the census, and pinned here too because a
+ * gap recorded in the suite is honest while a gap invisible to it is how this
+ * defect shipped in the first place. Each declares a size outside the DS v5
+ * §2.3 canvas scale, so fixing it is a visual-design ruling, not a mechanical
+ * substitution.
+ *
+ * ⚠ KEYED ON THE **DECLARED** SIZE, NOT THE RENDERED ONE. The first version of
+ * this pin listed rendered sizes ('7px', '12px'), which are only those values at
+ * a zoom of exactly 0.50 — it passed at 1280x800 and failed the moment a starter
+ * settled at 0.5776. A control pinned to a quantity that moves is a control with
+ * an expiry date nobody wrote down (CLAUDE.md trap 12b). Declared size is
+ * zoom-invariant: a FIXED element's computed size IS its declared size, because
+ * it never sees `--canvas-label-scale`.
+ */
+const KNOWN_FIXED_DECLARED_PX = [7, 12, 18] as const
+
+/** Runs in the page; `page.evaluate` gets no closure, so this is self-contained. */
+const readNodeText = () => {
+  const flow = document.querySelector('.react-flow') as HTMLElement
+  const vp = document.querySelector('.react-flow__viewport') as HTMLElement
+  const zoom = new DOMMatrixReadOnly(getComputedStyle(vp).transform).a
+  const labelScale = getComputedStyle(flow).getPropertyValue('--canvas-label-scale').trim()
+
+  const readings: Array<{ computedPx: number; renderedPx: number; text: string }> = []
+  for (const node of Array.from(document.querySelectorAll('.react-flow__node'))) {
+    for (const el of Array.from(node.querySelectorAll('*'))) {
+      // Only elements that own visible text of their own.
+      const own = Array.from(el.childNodes)
+        .filter((n) => n.nodeType === Node.TEXT_NODE)
+        .map((n) => n.textContent ?? '')
+        .join('')
+        .trim()
+      if (!own) continue
+      const cs = getComputedStyle(el)
+      if (cs.visibility === 'hidden' || cs.display === 'none') continue
+      if ((el as HTMLElement).closest('.sr-only')) continue
+      const computed = parseFloat(cs.fontSize)
+      // `computed` already carries the counter-scale (the tokens are
+      // `calc(Npx * var(--canvas-label-scale))`), so this is what the user sees.
+      // A counter-scaled element has `computed = declared x labelScale`; a fixed
+      // one has `computed = declared`. So the computed size IS the declared size
+      // for exactly the elements this pin is about.
+      readings.push({ computedPx: +computed.toFixed(2),
+                      renderedPx: +(computed * zoom).toFixed(2), text: own.slice(0, 40) })
+    }
+  }
+  return { zoom: +zoom.toFixed(4), labelScale, nodeCount: document.querySelectorAll('.react-flow__node').length, readings }
+}
+
+for (const viewport of VIEWPORTS) {
+  for (const starter of STARTERS) {
+    test(`node text is legible at the auto-fit zoom — ${starter} @ ${viewport.name}`, async ({ page }) => {
+      await preparePage(page, viewport)
+      await openCanvas(page)
+      const seeded = await seedStarterDraft(page, starter)
+      await clearNotifications(page)
+      // Let the post-layout auto-fit's camera animation finish.
+      await page.waitForTimeout(2000)
+
+      const { zoom, labelScale, nodeCount, readings } = await page.evaluate(readNodeText)
+
+      // ── Preconditions, pinned in-test (trap 13b: a guard must pin its own
+      // precondition, or a silent seeding failure passes every assertion).
+      expect(seeded.nodeCount, 'starter seeded no nodes').toBeGreaterThan(10)
+      expect(nodeCount, 'no nodes rendered').toBeGreaterThan(10)
+      expect(readings.length, 'no node text measured — the sweep is blind').toBeGreaterThan(20)
+      expect(zoom, 'auto-fit parked below the legibility floor').toBeGreaterThanOrEqual(0.5)
+      expect(Number(labelScale), 'the counter-scale variable is not on the React Flow root')
+        .toBeGreaterThan(0)
+
+      // ── CONTRAST CONTROL. The sweep must be shown to DISCRIMINATE: at a zoom
+      // below 1 a counter-scaled element and a fixed one differ, and if every
+      // reading came back identical the assertion below would pass for the
+      // wrong reason (trap 20 — uniformity is evidence about the instrument).
+      if (zoom < 1) {
+        const rendered = new Set(readings.map((r) => r.renderedPx))
+        expect(rendered.size, 'every reading identical — the sweep is not discriminating')
+          .toBeGreaterThan(1)
+      }
+
+      // ── THE CLAIM. Every glyph the user sees inside a node card is at or above
+      // the DS v5 §2.4 canvas floor, except the pinned set.
+      const below = readings.filter((r) => r.renderedPx < MIN_CANVAS_PX - QUANTISATION_TOLERANCE_PX)
+      const unexplained = below.filter(
+        (r) => !(KNOWN_FIXED_DECLARED_PX as readonly number[]).includes(r.computedPx),
+      )
+      expect(
+        unexplained.map((r) => `${r.computedPx}px declared -> ${r.renderedPx}px rendered  "${r.text}"`),
+        `text rendering under ${MIN_CANVAS_PX}px at zoom ${zoom} that is NOT in the pinned set`,
+      ).toEqual([])
+
+      // ── The node title is the headline claim: it renders at its DECLARED size.
+      const titles = await page.evaluate(() => {
+        const vp = document.querySelector('.react-flow__viewport') as HTMLElement
+        const z = new DOMMatrixReadOnly(getComputedStyle(vp).transform).a
+        return Array.from(document.querySelectorAll('[data-testid="node-title"]'))
+          .map((t) => +(parseFloat(getComputedStyle(t).fontSize) * z).toFixed(2))
+      })
+      expect(titles.length).toBeGreaterThan(10)
+      for (const t of titles) expect(t, 'node title not rendering at its declared 13px').toBeCloseTo(13, 0)
+
+      // ⭐ THE REGRESSION THIS LANE CLOSED, bound BY IDENTITY rather than by a
+      // value predicate another element could satisfy (CLAUDE.md trap 19): the
+      // strength pills EdgePills renders on each node card. They declared 10px
+      // as a raw `text-[10px]` and therefore rendered at `10 x zoom`.
+      const strengthPills = await page.evaluate(() => {
+        const vp = document.querySelector('.react-flow__viewport') as HTMLElement
+        const z = new DOMMatrixReadOnly(getComputedStyle(vp).transform).a
+        return Array.from(document.querySelectorAll('.react-flow__node span'))
+          .filter((el) => /^[\u2191\u2193]?\s*\d+%$/.test((el.textContent ?? '').trim()))
+          .map((el) => +(parseFloat(getComputedStyle(el).fontSize) * z).toFixed(2))
+      })
+      expect(strengthPills.length, 'no strength pills on screen — this claim is untested here')
+        .toBeGreaterThan(5)
+      for (const p of strengthPills) {
+        expect(p, 'strength pill is not rendering at its declared 10px — the counter-scale is not reaching it')
+          .toBeGreaterThanOrEqual(MIN_CANVAS_PX - QUANTISATION_TOLERANCE_PX)
+      }
+    })
+  }
+}

--- a/src/canvas/__tests__/baselineVocabulary.canvas.spec.ts
+++ b/src/canvas/__tests__/baselineVocabulary.canvas.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * ONE WORD FOR THE STATUS-QUO OPTION ON THE CANVAS, AND IT IS "BASELINE".
+ *
+ * Paul's ruling: the do-nothing option is presented consistently as "Baseline".
+ * The canvas was saying three different things at once — the panels badged the
+ * option "Baseline" / "Baseline option" while the product's own "add a
+ * baseline" affordance minted a node whose visible TITLE was literally
+ * "Status Quo", and the node's own chips asked the user about "the status quo"
+ * and "doing nothing". Three vocabularies for one object, and the node title is
+ * the one the user reads first.
+ *
+ * WHY A GUARD AND NOT JUST A RENAME. There was no label authority to rename —
+ * `baselineDetection.ts` owned DETECTION (14 call sites, all reading
+ * `.isBaseline`) while every visible string was hand-written at its render
+ * site, and three would-be authorities (`displayLabel`, `getBaselineBadgeProps`,
+ * `BASELINE_BADGE_LABEL`) had ZERO non-test consumers. A hand-written string in
+ * N places is the drift mechanism, so the fix is a single exported constant and
+ * this guard over the canvas render surface.
+ *
+ * ⚠ TWO DELIBERATE CARVE-OUTS, both derived rather than assumed:
+ *
+ * 1. "STATUS QUO BIAS" IS A DIFFERENT CONCEPT AND MUST NOT BE RENAMED. It is a
+ *    named cognitive bias carried on the wire as `status_quo_bias` and rendered
+ *    from `shared/biasSignalTitles.ts`. "Baseline bias" is not a thing, and a
+ *    blanket rename would corrupt the CEE bias vocabulary. The sweep below
+ *    excludes the bias phrase BY NAME and proves the exclusion is earned.
+ *
+ * 2. INTERNAL DISCRIMINANTS ARE NOT COPY. `is_baseline`, `status_quo_bias`,
+ *    `STATUS_QUO_UNREACHABLE`, `opt_status_quo` and `STATUS_QUO_PATTERNS` are
+ *    identifiers, not sentences; renaming them would break the wire. Only
+ *    prose is swept.
+ *
+ * SCOPE, stated so an absence claim means something: `src/canvas/nodes` and
+ * `src/canvas/hooks` — the surfaces that mint and render the node itself.
+ * Panels and starter fixtures are deliberately NOT in scope here; the shipped
+ * starters carry "(Status Quo)" inside captured CEE drafts, and those are
+ * recorded evidence rather than fixtures to keep current.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { BASELINE_OPTION_LABEL, detectBaseline } from '../utils/baselineDetection'
+
+const ROOT = path.resolve(__dirname, '../../..')
+const SCOPE = ['src/canvas/nodes', 'src/canvas/hooks']
+
+/** The bias name, which is a different concept and stays. */
+const BIAS_PHRASE = /status[- ]quo bias/i
+/** Prose forms of the option's name that the ruling replaces. */
+const BANNED = [/\bstatus quo\b/i, /\bdo nothing\b/i, /\bdoing nothing\b/i]
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const e of readdirSync(dir)) {
+    const p = path.join(dir, e)
+    if (statSync(p).isDirectory()) {
+      if (e === '__tests__' || e === '__fixtures__') continue
+      walk(p, out)
+    } else if (/\.tsx?$/.test(e) && !/\.spec\.|\.stories\./.test(e)) out.push(p)
+  }
+  return out
+}
+
+/**
+ * Every quoted string literal, with its line — COMMENTS STRIPPED FIRST.
+ *
+ * The first version of this swept comments too and flagged eleven sites, of
+ * which seven were prose ABOUT the code rather than prose shown to a user. A
+ * guard that reds on an explanatory comment is a guard people learn to work
+ * around, and the ruling is about what the product SAYS, not about how the
+ * source describes itself. (The comments were updated anyway; they are simply
+ * not what this pin defends.)
+ */
+function stringLiterals(src: string): Array<{ line: number; text: string }> {
+  const out: Array<{ line: number; text: string }> = []
+  let inBlock = false
+  src.split('\n').forEach((raw, i) => {
+    let l = raw
+    if (inBlock) {
+      const end = l.indexOf('*/')
+      if (end === -1) return
+      l = l.slice(end + 2)
+      inBlock = false
+    }
+    const open = l.indexOf('/*')
+    if (open !== -1) { inBlock = l.indexOf('*/', open) === -1; l = l.slice(0, open) + (inBlock ? '' : l.slice(l.indexOf('*/', open) + 2)) }
+    const line = l.replace(/\/\/.*$/, '')
+    for (const m of line.matchAll(/'([^'\\]{4,})'|"([^"\\]{4,})"|`([^`\\]{4,})`/g)) {
+      out.push({ line: i + 1, text: m[1] ?? m[2] ?? m[3] })
+    }
+  })
+  return out
+}
+
+describe('canvas baseline vocabulary (Paul, 18 Aug 2026)', () => {
+  const files = SCOPE.flatMap((d) => walk(path.join(ROOT, d)))
+  const hits = files.flatMap((f) =>
+    stringLiterals(readFileSync(f, 'utf8')).map((h) => ({ ...h, file: path.relative(ROOT, f) })),
+  )
+
+  it('the sweep actually reads prose (positive control)', () => {
+    // An empty sweep satisfies every absence assertion below (trap 13).
+    expect(files.length).toBeGreaterThan(20)
+    expect(hits.length).toBeGreaterThan(200)
+  })
+
+  it('CONTRAST CONTROL: the predicate FIRES, and the bias carve-out is earned', () => {
+    // (a) The banned predicate must be shown to fire at all, or the absence
+    //     assertion below passes for the wrong reason (trap 13).
+    const sample = 'Why does the status quo do better than the other options?'
+    expect(BANNED.some((re) => re.test(sample)), 'banned predicate never fires — sweep is blind').toBe(true)
+
+    // (b) The carve-out must be doing real work: the bias phrase is a string the
+    //     banned predicate WOULD flag, and the carve-out is what spares it.
+    const biasTitle = 'Status quo bias: inaction risks often underestimated.'
+    expect(BANNED.some((re) => re.test(biasTitle)), 'carve-out guards nothing').toBe(true)
+    expect(BIAS_PHRASE.test(biasTitle), 'carve-out does not match the bias phrase').toBe(true)
+
+    // (c) …and the concept it spares must still EXIST, or the carve-out is a
+    //     licence for a phrase nothing uses. Derived from the bias registry,
+    //     which is the producer of that title (it is composed into the tooltip
+    //     at useScienceIcons.ts, so it is never a literal in this scope).
+    const registry = readFileSync(path.join(ROOT, 'src/canvas/shared/biasSignalTitles.ts'), 'utf8')
+    expect(registry, 'the status-quo-bias concept has gone — re-derive this carve-out')
+      .toMatch(/status_quo_bias:\s*\{\s*title:\s*'Status quo bias'/)
+  })
+
+  it('no canvas node copy names the option anything but "Baseline"', () => {
+    const offenders = hits
+      .filter((h) => !BIAS_PHRASE.test(h.text))
+      .filter((h) => BANNED.some((re) => re.test(h.text)))
+      .map((h) => `${h.file}:${h.line}  "${h.text.slice(0, 80)}"`)
+    expect(offenders, `canvas copy still uses a non-"Baseline" name:\n${offenders.join('\n')}`).toEqual([])
+  })
+
+  it('the minted baseline node takes its title from the ONE authority', () => {
+    const src = readFileSync(path.join(ROOT, 'src/canvas/hooks/useAddBaseline.ts'), 'utf8')
+    expect(src, 'useAddBaseline hardcodes a title instead of importing the constant')
+      .toMatch(/label:\s*BASELINE_OPTION_LABEL/)
+    expect(src).toMatch(/BASELINE_OPTION_LABEL.*from ['"]\.\.\/utils\/baselineDetection['"]/)
+    expect(BASELINE_OPTION_LABEL).toBe('Baseline')
+  })
+
+  it('the authority\'s own label is detected as a baseline by the detector', () => {
+    // Binds the two halves together: if someone changes the constant to a word
+    // `detectBaseline` does not recognise, the product would mint a node its
+    // own detector calls a normal option. Pins its own precondition in-test.
+    expect(detectBaseline(BASELINE_OPTION_LABEL).isBaseline).toBe(true)
+    // Discrimination: the detector is not simply saying yes to everything.
+    expect(detectBaseline('Adopt Segment').isBaseline).toBe(false)
+  })
+})

--- a/src/canvas/hooks/useAddBaseline.ts
+++ b/src/canvas/hooks/useAddBaseline.ts
@@ -1,7 +1,7 @@
 /**
  * useAddBaseline Hook (P2 Task 2)
  *
- * Shared hook for creating a "Status Quo" baseline option.
+ * Shared hook for creating the "Baseline" option.
  * Extracted from PreAnalysisPanel.handleAddBaseline for reuse in Results panel.
  *
  * Features:
@@ -12,6 +12,7 @@
  */
 
 import { useCallback } from 'react'
+import { BASELINE_OPTION_LABEL } from '../utils/baselineDetection'
 import { useCanvasStore } from '../store'
 import { focusNodeById } from '../utils/focusHelpers'
 
@@ -23,14 +24,14 @@ interface UseAddBaselineOptions {
 }
 
 interface UseAddBaselineReturn {
-  /** Add a "Status Quo" baseline option to the graph */
+  /** Add the "Baseline" option to the graph */
   addBaseline: () => boolean
   /** Check if a baseline already exists */
   hasBaseline: boolean
 }
 
 /**
- * Hook for creating a "Status Quo" baseline option.
+ * Hook for creating the "Baseline" option.
  * Returns a function that creates the baseline and a flag indicating if one exists.
  */
 export function useAddBaseline(options: UseAddBaselineOptions = {}): UseAddBaselineReturn {
@@ -100,7 +101,7 @@ export function useAddBaseline(options: UseAddBaselineOptions = {}): UseAddBasel
     updateNode(newNode.id, {
       data: {
         ...newNode.data,
-        label: 'Status Quo',
+        label: BASELINE_OPTION_LABEL,
         kind: 'option',
         is_baseline: true,
         interventions,

--- a/src/canvas/hooks/usePreAnalysisData.ts
+++ b/src/canvas/hooks/usePreAnalysisData.ts
@@ -373,7 +373,7 @@ function getMissingBaselineIssue(
     severity: 'low',
     category: 'framing',
     title: 'No baseline option identified',
-    why: 'Consider marking one option as your "do nothing" or "status quo" baseline for comparison.',
+    why: 'Consider marking one option as your baseline — the option where nothing changes — for comparison.',
     focus: undefined,
     actions: [
       { key: 'mark_baseline', label: CTA_LABELS.markBaseline, kind: 'navigate' },

--- a/src/canvas/hooks/usePreRunValidation.ts
+++ b/src/canvas/hooks/usePreRunValidation.ts
@@ -202,7 +202,7 @@ function validateGoalNode(
 /**
  * Whether a CEE option is resolved for run purposes.
  *
- * Baseline options ("do nothing") correctly carry empty interventions, so they
+ * Baseline options (the option where nothing changes) correctly carry empty interventions, so they
  * are exempt from the intervention requirement.
  *
  * ROADMAP 2.924 — this is the SINGLE predicate behind both the soft-bypass gate
@@ -347,7 +347,7 @@ function validateOverallStatus(
     // not a genuine structural problem.
     const isSoftStatus = disposition === 'soft_bypassable'
 
-    // Baseline options correctly have empty interventions ("do nothing").
+    // Baseline options correctly have empty interventions (nothing changes).
     // Exclude them from the intervention requirement in the soft bypass check.
     const allOptionsResolved = isSoftStatus && (ceeAnalysisReady.options?.every(
       isCeeOptionResolved

--- a/src/canvas/hooks/useScienceIcons.ts
+++ b/src/canvas/hooks/useScienceIcons.ts
@@ -193,7 +193,7 @@ export function useScienceIcons(nodeId: string, nodeType: NodeType): ScienceIcon
           id: 'status-quo-bias',
           icon: statusQuo.icon,
           tooltip: `${statusQuo.title}: inaction risks often underestimated.`,
-          action: 'What could go wrong with doing nothing?',
+          action: 'What could go wrong with staying on the baseline?',
           colour: 'text-warning',
           priority: 6,
         })

--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -1207,7 +1207,7 @@ export const OptionNode = memo((props: NodeProps) => {
               <span
                 data-testid={`option-stable-number-${props.id}`}
                 aria-label={`Option ${stableOptionNumber}`}
-                className={`${typography.panelMeta} inline-flex h-4 min-w-[16px] items-center justify-center rounded border border-panel-border px-1 text-text-light`}
+                className={`${typography.nodeLabel} inline-flex h-4 min-w-[16px] items-center justify-center rounded border border-panel-border px-1 text-text-light`}
               >
                 {stableOptionNumber}
               </span>
@@ -1294,8 +1294,8 @@ export const OptionNode = memo((props: NodeProps) => {
             {structuredDeltas.map(d => (
               <span
                 key={d.factorId}
-                className="inline-flex items-center gap-0.5 font-sans leading-tight px-[5px] py-[1px] rounded-full border border-panel-border bg-transparent text-text-body"
-                style={{ fontSize: 11, borderWidth: '0.5px' }}
+                className={`${typography.nodeLabel} inline-flex items-center gap-0.5 px-[5px] py-[1px] rounded-full border border-panel-border bg-transparent text-text-body`}
+                style={{ borderWidth: '0.5px' }}
               >
                 {d.direction === 'up' ? (
                   <ArrowUp size={10} className="text-success flex-shrink-0" />

--- a/src/canvas/nodes/OptionNode.tsx
+++ b/src/canvas/nodes/OptionNode.tsx
@@ -195,7 +195,7 @@ function computeAllDifferentiators(
   const optionInterventions = new Map<string, Map<string, InterventionEntry>>()
   for (const optNode of optionNodes) {
     // Explicit flag wins; regex fallback only fires when flag is null/undefined.
-    // Explicit `false` must suppress the regex (prevents "Status Quo" labels on
+    // Explicit `false` must suppress the regex (prevents "Baseline" labels on
     // non-baseline options from being treated as baseline).
     const explicit = (optNode.data as any)?.is_baseline as boolean | null | undefined
     const isBaseline = explicit ?? detectBaseline((optNode.data?.label as string) ?? '').isBaseline
@@ -914,8 +914,8 @@ export const OptionNode = memo((props: NodeProps) => {
         // Baseline chips already pre-existed inside layer2Content; keep them.
         return (
           <div className="flex gap-1 flex-wrap mt-1.5">
-            <NodeChip chipId="option_why_win_lose" actionType="explain_results" label="Why is this ahead or behind on your goal?" message={`Why does the status quo (${optionLabel}) do better or worse against my goal than the other options?`} />
-            <NodeChip chipId="option_risks_of_inaction" actionType={null} label="Risks of inaction" message="What are the risks of choosing to do nothing?" />
+            <NodeChip chipId="option_why_win_lose" actionType="explain_results" label="Why is this ahead or behind on your goal?" message={`Why does the baseline (${optionLabel}) do better or worse against my goal than the other options?`} />
+            <NodeChip chipId="option_risks_of_inaction" actionType={null} label="Risks of inaction" message="What are the risks of staying with the baseline?" />
           </div>
         )
       }

--- a/src/canvas/nodes/__tests__/nodeTextCounterScale.census.spec.ts
+++ b/src/canvas/nodes/__tests__/nodeTextCounterScale.census.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * DERIVED CENSUS — every font size rendered INSIDE the React Flow viewport
+ * transform must carry the canvas label counter-scale.
+ *
+ * WHY THIS EXISTS (browser-measured, Chromium, tip `dd089a50`, 3 shipped
+ * starters x 2 laptop viewports, hermetic visual harness).
+ * ---------------------------------------------------------------------------
+ * `#758` and its geometry follow-up gave canvas label text a counter-scale
+ * (`--canvas-label-scale`, see `utils/zoomLegibility.ts`) so a label renders at
+ * its DECLARED size instead of `declared x zoom`. Measured at the zoom a
+ * post-draft auto-fit actually parks at (0.5000, scale 2.00):
+ *
+ *   node title   declared 26px -> RENDERED 13.00px   (the counter-scale works)
+ *   edge pill    declared 10px -> RENDERED  5.00px   (it does not)
+ *
+ * The counter-scale reaches text through the three canvas tokens in
+ * `typography.ts` and ONLY through them. Five sites inside the node card had
+ * been written as raw utilities or inline styles instead — `text-[10px]`,
+ * `style={{ fontSize: 11 }}` — so they never saw it, and rendered at HALF
+ * their declared size on the first view of every model. 17-21 such pills were
+ * on screen per starter.
+ *
+ * That is the same defect Design System v5 Sec 2.4 already forbids in prose:
+ * "No raw typography utilities... Always use semantic tokens from
+ * typography.ts", and "Panel and canvas contexts use 10-12px for information
+ * density, always via tokens, never raw classes." The DS rule and the
+ * legibility rule are the same rule — a raw utility is precisely the thing the
+ * counter-scale cannot reach. This census is that prose, executable.
+ *
+ * WHY A CENSUS AND NOT A LIST OF THE FIVE SITES. A hand-kept list of offenders
+ * is the dominant defect class in this codebase (CLAUDE.md trap 12): it is
+ * correct the day it is written and silently wrong afterwards. So the scope is
+ * walked from disk, every font-size mechanism is RESOLVED (Tailwind utilities,
+ * `typography.X` token references parsed out of `typography.ts` at run time,
+ * inline `fontSize`), and anything the resolver does not understand is a hard
+ * ERROR rather than a silent pass.
+ *
+ * ⚠ WHAT THIS CENSUS IS AND IS NOT. It proves that every declared size in
+ * scope is routed through a counter-scaled token. It CANNOT prove a rendered
+ * size — jsdom has no layout and this spec never renders anything (CLAUDE.md
+ * trap 3). The rendered-pixel claim is browser-only and lives in
+ * `e2e/visual/nodeTextLegibility.visual.spec.ts`. Neither supersedes the
+ * other: this one stops a new raw utility being added, that one proves the
+ * pixels. Ship both.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+
+const ROOT = path.resolve(__dirname, '../../../..')
+const SCOPE = path.join(ROOT, 'src/canvas/nodes')
+const TYPOGRAPHY = path.join(ROOT, 'src/styles/typography.ts')
+
+/**
+ * Rendered OUTSIDE the viewport transform, so the counter-scale must NOT apply
+ * — `createPortal` to `document.body` escapes the transformed subtree, and a
+ * counter-scaled token there would render at 2x. Excluded BY MECHANISM (the
+ * file portals), not by preference; the assertion below re-derives that the
+ * exclusion is still earned.
+ */
+const PORTALLED = ['NodePopover.tsx']
+
+/**
+ * Sizes inside the node card that are NOT yet counter-scaled, pinned EXACTLY.
+ *
+ * These are an honest, visible gap rather than an invisible one: each declares
+ * a size that is not in the DS v5 Sec 2.3 canvas scale (13/11/10), so routing it
+ * through a canvas token would silently RESIZE the element rather than merely
+ * counter-scale it — a visual-design decision this lane is not entitled to
+ * take on its own. They are recorded here so the suite is green for the right
+ * reason, and REDs if the set GROWS (a new raw size arrived) or SHRINKS (one
+ * was fixed and this pin went stale).
+ *
+ * Rendered size at the 0.50 auto-fit floor, for whoever picks these up:
+ *   EvidenceGapBadge 7px  -> 3.5px  (also below the DS v5 Sec 2.4 10px floor at
+ *                                    zoom 1, so it needs a size ruling, not a
+ *                                    counter-scale)
+ *   NodeCoachingMarker 12px (typography.caption) -> 6.0px
+ *   BaseNode 18px (text-lg, the low-zoom LOD title boost) -> varies with zoom
+ */
+const KNOWN_FIXED = [
+  'BaseNode.tsx:text-lg',
+  'EvidenceGapBadge.tsx:inline-7',
+  'shared/NodeCoachingMarker.tsx:typography.caption',
+] as const
+
+const TW_NAMED = new Set(['xs', 'sm', 'base', 'lg', 'xl', '2xl', '3xl', '4xl', '5xl', '6xl'])
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const p = path.join(dir, entry)
+    if (statSync(p).isDirectory()) {
+      if (entry === '__tests__' || entry === '__fixtures__') continue
+      walk(p, out)
+    } else if (/\.tsx?$/.test(entry) && !/\.spec\.|\.stories\./.test(entry)) {
+      out.push(p)
+    }
+  }
+  return out
+}
+
+/** Parse `typography.ts` for every token → its class string. Derived, never mirrored. */
+function readTypographyTokens(): Map<string, string> {
+  const src = readFileSync(TYPOGRAPHY, 'utf8')
+  const body = src.slice(src.indexOf('export const typography'))
+  const tokens = new Map<string, string>()
+  for (const m of body.matchAll(/^\s{2}([a-zA-Z][a-zA-Z0-9]*):\s*'([^']*)'/gm)) tokens.set(m[1], m[2])
+  return tokens
+}
+
+/** A token carries the counter-scale iff its class string reads the CSS variable. */
+function isCounterScaled(classString: string): boolean {
+  return classString.includes('var(--canvas-label-scale')
+}
+
+interface Hit { file: string; line: number; key: string; mechanism: string; counterScaled: boolean }
+
+function census(): { hits: Hit[]; errors: string[]; files: number; tokens: number } {
+  const tokens = readTypographyTokens()
+  const errors: string[] = []
+  const hits: Hit[] = []
+  const files = walk(SCOPE)
+
+  for (const file of files) {
+    const rel = path.relative(SCOPE, file)
+    if (PORTALLED.includes(path.basename(file))) continue
+    const lines = readFileSync(file, 'utf8').split('\n')
+
+    lines.forEach((text, i) => {
+      const line = i + 1
+      const push = (key: string, mechanism: string, counterScaled: boolean) =>
+        hits.push({ file: rel, line, key: `${rel}:${key}`, mechanism, counterScaled })
+
+      // 1. Arbitrary-value size: text-[10px] or text-[length:calc(...)]
+      for (const m of text.matchAll(/text-\[(?:length:)?([^\]]+)\]/g)) {
+        const value = m[1]
+        if (/^calc\(\s*\d+(?:\.\d+)?px\s*\*\s*var\(--canvas-label-scale/.test(value)) {
+          push(`counterscaled-${value.match(/(\d+)px/)?.[1]}`, 'arbitrary', true)
+        } else if (/^\d+(?:\.\d+)?px$/.test(value)) {
+          push(`text-[${value}]`, 'arbitrary', false)
+        } else {
+          errors.push(`${rel}:${line} unresolvable arbitrary text size: text-[${value}]`)
+        }
+      }
+
+      // 2. Named Tailwind size utility
+      for (const m of text.matchAll(/\btext-([a-z0-9]+)\b(?!-)/g)) {
+        if (TW_NAMED.has(m[1])) push(`text-${m[1]}`, 'tailwind-named', false)
+      }
+
+      // 3. typography.X / typo('X') token reference
+      for (const m of text.matchAll(/typography\.([a-zA-Z][a-zA-Z0-9]*)|typo\('([a-zA-Z][a-zA-Z0-9]*)'/g)) {
+        const name = m[1] ?? m[2]
+        const cls = tokens.get(name)
+        if (cls === undefined) { errors.push(`${rel}:${line} unknown typography token: ${name}`); continue }
+        if (!/text-/.test(cls)) continue // token declares no size
+        push(`typography.${name}`, 'token', isCounterScaled(cls))
+      }
+
+      // 4. Inline style fontSize. The VALUE is captured first and classified
+      // second — a negative lookahead here backtracks over `\s*` and reports a
+      // literal as non-literal (caught while writing this census).
+      for (const m of text.matchAll(/fontSize:\s*([^,}\n]+)/g)) {
+        const raw = m[1].trim().replace(/['"]/g, '')
+        const px = /^(\d+(?:\.\d+)?)(?:px)?$/.exec(raw)
+        if (px) push(`inline-${px[1]}`, 'inline', false)
+        else errors.push(`${rel}:${line} non-literal inline fontSize: ${raw}`)
+      }
+    })
+  }
+  return { hits, errors, files: files.length, tokens: tokens.size }
+}
+
+describe('canvas node text — counter-scale census (DS v5 §2.3/§2.4)', () => {
+  const { hits, errors, files, tokens } = census()
+
+  it('resolves every font-size mechanism in scope, and SEES type at all', () => {
+    expect(errors, errors.join('\n')).toEqual([])
+    // Positive control (trap 13): an empty scan satisfies every absence
+    // assertion below while measuring nothing.
+    expect(files, 'census walked no files').toBeGreaterThan(10)
+    expect(tokens, 'typography.ts parsed no tokens').toBeGreaterThan(20)
+    expect(hits.length, 'census found no font sizes at all').toBeGreaterThan(10)
+  })
+
+  it('CONTRAST CONTROL: the census can tell counter-scaled from fixed', () => {
+    // Absence claims need a positive AND a contrast control. If the resolver
+    // silently classified everything one way, the pin below would pass for the
+    // wrong reason.
+    expect(hits.some(h => h.counterScaled), 'no counter-scaled hit seen — resolver blind').toBe(true)
+    expect(hits.some(h => !h.counterScaled), 'no fixed hit seen — resolver blind').toBe(true)
+  })
+
+  it('the counter-scale reaches text ONLY through the three canvas tokens', () => {
+    const scaled = new Set(hits.filter(h => h.counterScaled && h.mechanism === 'token')
+      .map(h => h.key.split(':').pop()))
+    expect([...scaled].sort()).toEqual(['typography.edgeLabel', 'typography.nodeLabel', 'typography.nodeTitle'])
+  })
+
+  it('every font size inside the node card is counter-scaled, except the pinned set', () => {
+    const fixed = [...new Set(hits.filter(h => !h.counterScaled).map(h => h.key))].sort()
+    // EXACT, both directions: RED if a raw size is added, RED if one of these
+    // is fixed and this pin is not updated with it.
+    expect(fixed).toEqual([...KNOWN_FIXED].sort())
+  })
+
+  it('the portal exclusion is still EARNED, not assumed', () => {
+    for (const f of PORTALLED) {
+      const src = readFileSync(path.join(SCOPE, 'shared', f), 'utf8')
+      expect(src, `${f} no longer portals — it is inside the transform and must be censused`)
+        .toMatch(/createPortal\(/)
+    }
+  })
+})

--- a/src/canvas/nodes/shared/EdgePills.tsx
+++ b/src/canvas/nodes/shared/EdgePills.tsx
@@ -18,6 +18,7 @@
  * Per spec Section 14: 0.5px border, default colour, 10px font, border-radius 10px.
  */
 import { useMemo } from 'react'
+import { typography } from '../../../styles/typography'
 import { ArrowUp, ArrowDown } from 'lucide-react'
 import { useCanvasStore } from '../../store'
 import { NodeShapeIndicator } from '../NodeShapeIndicator'
@@ -86,7 +87,7 @@ export function EdgePills({ nodeId }: EdgePillsProps) {
       {pills.map(p => (
         <span
           key={p.id}
-          className="inline-flex items-center gap-0.5 text-[10px] font-sans leading-tight px-[5px] py-[1px] rounded-[10px] border-[0.5px] border-panel-border text-text-light"
+          className={`${typography.edgeLabel} inline-flex items-center gap-0.5 px-[5px] py-[1px] rounded-[10px] border-[0.5px] border-panel-border text-text-light`}
         >
           {/* Direction for screen readers — the arrow glyph below is aria-hidden,
               so without this the pill would announce only the % and label.

--- a/src/canvas/nodes/shared/MetricPills.tsx
+++ b/src/canvas/nodes/shared/MetricPills.tsx
@@ -5,7 +5,11 @@
  * contact; the tooltip/aria still carry the full provenance). Bias coaching is
  * NOT a pill here: it lives on the header ScienceIcon (one bias-coaching
  * surface per node — bias-coaching slice, proposal 2026-07-16 §1.5(2)).
- * Font 10px (edgeLabel). Pill padding 1px 5px. Border-radius 10px. Gap 3px.
+ * Font 10px via the `edgeLabel` TOKEN. It was a raw utility until 18 Aug 2026,
+ * and a raw utility cannot see `--canvas-label-scale`: measured in Chromium,
+ * these pills rendered at 5.0px at the 0.50 auto-fit floor while their sibling
+ * node title rendered at its declared 13px. DS v5 §2.4 forbids the raw form for
+ * exactly this reason. Pill padding 1px 5px. Border-radius 10px. Gap 3px.
  *
  * Lane C4 (influence-scale disclosure): the influence number comes from the
  * shared display model (useNodeDisplayMetadata → driverDisplayModel), which on
@@ -19,6 +23,7 @@
  * (influenceScaleCopy) DriversSection consumes too, so the surfaces cannot
  * drift (review fix 3).
  */
+import { typography } from '../../../styles/typography'
 import type { DriverDisplayProvenance } from '../../../components/results/driverDisplayModel'
 import { influenceExplanation, influencePillAriaLabel } from '../../../components/results/influenceScaleCopy'
 
@@ -69,7 +74,7 @@ export function MetricPills({
     <div className="flex gap-[3px] mt-1.5 items-center flex-wrap">
       {hasInfluence && (
         <span
-          className="text-[10px] font-sans leading-tight px-[5px] py-[1px] rounded-[10px] border border-info/40 text-text-body"
+          className={`${typography.edgeLabel} px-[5px] py-[1px] rounded-[10px] border border-info/40 text-text-body`}
           title={influenceTitle}
           // Review fix 5: aria-label on a role-less <span> is unreliably
           // announced (generic role), and `title` alone is keyboard/touch
@@ -85,7 +90,7 @@ export function MetricPills({
       )}
       {hasConfidence && (
         <span
-          className="text-[10px] font-sans leading-tight px-[5px] py-[1px] rounded-[10px] border border-factor/60 text-text-body inline-flex items-center gap-0.5"
+          className={`${typography.edgeLabel} px-[5px] py-[1px] rounded-[10px] border border-factor/60 text-text-body inline-flex items-center gap-0.5`}
           // Disclosure travels WITH the number, in the same element, so the
           // figure cannot be rendered bare. Same vocabulary the Drivers panel
           // ships ("Default estimate — not yet validated with evidence" /

--- a/src/canvas/nodes/shared/StatusPill.tsx
+++ b/src/canvas/nodes/shared/StatusPill.tsx
@@ -8,8 +8,14 @@
  * Spec (Polish 4 Task 6): 10px text, 500 weight, 2px×8px padding, 10px radius,
  * warning at 15% bg / 40% border, warning text colour. The original 9px/1px
  * spec was unreadable at typical canvas zoom (80–100%). British English: colour.
+ *
+ * ⭐ 18 Aug 2026: that 11px was an INLINE `fontSize`, so it never saw the canvas
+ * counter-scale and rendered at 5.5px at the 0.50 auto-fit floor — smaller than
+ * the 9px this note records as already rejected at 80–100%. Same declared size,
+ * now via the `nodeLabel` token (DS v5 §2.3), which carries the counter-scale.
  */
 import { memo } from 'react'
+import { typography } from '../../../styles/typography'
 
 interface StatusPillProps {
   label: string
@@ -21,8 +27,8 @@ export const StatusPill = memo(({ label, title }: StatusPillProps) => (
   <span
     role="status"
     aria-label={title ?? label}
-    className="absolute -top-2 -right-1 z-10 inline-flex items-center font-sans font-medium text-warning bg-warning/15 border border-warning/40 rounded-[10px]"
-    style={{ fontSize: 11, padding: '2px 8px', lineHeight: 1.2, borderWidth: '0.5px' }}
+    className={`${typography.nodeLabel} absolute -top-2 -right-1 z-10 inline-flex items-center font-medium text-warning bg-warning/15 border border-warning/40 rounded-[10px]`}
+    style={{ padding: '2px 8px', lineHeight: 1.2, borderWidth: '0.5px' }}
     title={title ?? label}
     data-testid="needs-input-pill"
   >

--- a/src/canvas/utils/baselineDetection.ts
+++ b/src/canvas/utils/baselineDetection.ts
@@ -23,6 +23,29 @@
  * proper labeling and comparison handling.
  */
 
+/**
+ * ⭐ THE ONE USER-FACING NAME FOR THE DO-NOTHING OPTION (Paul, 18 Aug 2026).
+ *
+ * This module already owned DETECTION — 14 call sites, every one of them
+ * reading `.isBaseline`. It did not own the NAME, and nothing did: three
+ * would-be authorities in this file and in `inspectorStrings.ts` had zero
+ * non-test consumers, so every visible string was hand-written at its render
+ * site. The canvas then said three things about one object — the panels badged
+ * it "Baseline" while `useAddBaseline` minted a node whose visible TITLE was
+ * "Status Quo" and its own chips asked about "the status quo" and "doing
+ * nothing". A hand-written string in N places is the drift mechanism
+ * (CLAUDE.md trap 12), so the name lives here exactly once.
+ *
+ * ⚠ NOT to be confused with `status_quo_bias`, a named cognitive bias carried
+ * on the wire and rendered from `shared/biasSignalTitles.ts`. That is a
+ * different concept and keeps its name — "Baseline bias" is not a thing.
+ *
+ * ⚠ The value must remain something `detectBaseline` itself recognises, or the
+ * product would mint a node its own detector reads as an ordinary option.
+ * `baselineVocabulary.canvas.spec.ts` pins exactly that.
+ */
+export const BASELINE_OPTION_LABEL = 'Baseline'
+
 // Keywords that indicate a baseline/status quo option
 const BASELINE_KEYWORDS = [
   'keep',


### PR DESCRIPTION
## B5 — graph/workspace convergence: canvas label legibility + baseline vocabulary

**Base `staging` @ `dd089a50`. Deployed staging is at that exact SHA (`/version.json`), so every browser measurement below is directly comparable to the product a user loads.**

---

### ⚠ The brief's headline premise was STALE at this tip — corrected, with evidence

The brief stated labels are *"DOM inside the viewport transform with NO counter-scaling"*, so a 13px title renders at ~6.5px. **That is no longer true.** The counter-scale landed before this lane: `labelCounterScale` / `MAX_LABEL_COUNTER_SCALE` / `CANVAS_LABEL_SCALE_VAR` in `zoomLegibility.ts`, transported by `CanvasLabelScaleSync` (mounted at `ReactFlowGraph.tsx:2213`), consumed by the three canvas tokens.

Measured in Chromium (hermetic visual harness, 3 shipped starters × 2 laptop viewports, at the **post-layout auto-fit** zoom — the only zoom the product picks *for* the user):

| | declared | rendered @ zoom 0.5000 |
|---|---|---|
| node title | 13px | **13.00px** ✅ already correct |
| strength / influence / confidence / status pills | 10–11px | **5.0–5.5px** ❌ |

### What was actually broken, and why

Five sites inside the node card declared their size as a **raw `text-[10px]` or an inline `fontSize: 11`**. A raw utility cannot see `--canvas-label-scale`, so those rendered at `declared × zoom` — half size — while the title beside them was correct. **17–21 such pills on screen per starter.**

Design System v5 §2.4 already forbids the raw form ("Always use semantic tokens from `typography.ts` … never raw classes"). **The DS rule and the legibility rule are the same rule**, which makes this a conformance change rather than a new visual language: every declared size is preserved exactly (10 → `edgeLabel`, 11 → `nodeLabel`), so nothing moves at zoom 1 and the pills double at the settle zoom.

`OptionNode`'s stable-number badge also used the **panel** token `panelMeta` on a canvas node — same 11px, now the canvas token.

### Guarded two ways, because neither instrument can do the other's job

- **`src/canvas/nodes/__tests__/nodeTextCounterScale.census.spec.ts`** — derives every font-size mechanism in `src/canvas/nodes` (Tailwind utilities, `typography.X` refs **parsed out of `typography.ts` at run time**, inline `fontSize`) and REDs on any size not counter-scaled. Unresolvable mechanisms are a hard error, not a silent pass. Three knowingly-fixed sizes are pinned **exactly**, so the set cannot grow *or* shrink silently. jsdom-level: proves **routing**.
- **`e2e/visual/nodeTextLegibility.visual.spec.ts`** — measures **rendered pixels in Chromium** at the auto-fit zoom. Browser-level: proves the **pixels**. jsdom cannot support this claim (trap 3).

### Second change — one name for the do-nothing option, and it is "Baseline"

The canvas said three things about one object: panels badged it "Baseline" while the add-a-baseline affordance minted a node whose visible **title** was `'Status Quo'`, and that node's chips asked about "the status quo" and "doing nothing".

There was **no label authority to rename**: `baselineDetection.ts` owned *detection* (14 call sites, all reading `.isBaseline`) and nothing owned the *name* — `displayLabel`, `getBaselineBadgeProps` and `BASELINE_BADGE_LABEL` each had **zero** non-test consumers. Added `BASELINE_OPTION_LABEL` and routed the minting site through it; fixed four user-visible strings.

- ⚠ **`status_quo_bias` is a different concept** — a named cognitive bias on the wire, rendered from `shared/biasSignalTitles.ts` — and keeps its name. The guard carves it out explicitly **and proves the carve-out is earned**.
- ⚠ **Starters deliberately untouched:** the five shipped starters carry `(Status Quo)` inside **captured CEE drafts**. Those are recorded evidence, not fixtures to keep current — rewriting them would falsify a capture.

---

### Evidence

**Mutation-checked, both instruments:**
- **M1** revert `EdgePills` to the raw utility → census RED naming the file; **browser spec RED on all 6**, reporting `10px declared -> 5px rendered`; typecheck ratchet also caught the orphaned import (`+1` vs baseline).
- **M2** revert `StatusPill` only → census REDs naming **StatusPill and not EdgePills** — discrimination, not mere sensitivity.
- **M3** revert the baseline label → guard REDs on two assertions.
- Isolation proven **by writing a sentinel**, not by locating: separate inodes, source hash unchanged. Applied-check scoped to `src/` = 1 per mutant; control and trailing control = **0**. Restores HEAD-relative. Pristine tree passes the same typecheck gate (the mandatory P4 control).

**Gates** (required-check step order, derived from `.github/workflows/ci.yml`): lint **0 errors** · `pnpm run typecheck` **PASSED, within baseline (2306)** · `vitest run src/canvas/{nodes,hooks,utils}` **167 files / 2689 tests passed** · new specs asserted collecting **5 and 5 BY NAME**.

**Two instrument defects I hit and fixed in my own tools**, disclosed because they are the interesting part: a negative-lookahead in the census backtracked over `\s*` and reported a literal as non-literal; and the browser pin was first written in **rendered** px, which passed at 1280×800 and failed the moment a starter settled at zoom 0.5776 — a control pinned to a quantity that moves (trap 12b). It is now keyed on the **declared** size, which is zoom-invariant. An earlier worktree-isolation check also passed **vacuously on a directory that did not exist**; re-run with existence and HEAD asserted first.

### Not done here — reported, not built

1. **The fit box is 368×742 of a 1280×800 pane.** `computeFitPadding` reserves 468px left (floating Olumi panel) + 444px right (dock) = **71% of the width**. Required fit zoom is then **0.42–0.45**, i.e. *below* the 0.50 legibility floor, so the auto-fit clamps and the model is **cropped by construction** on 4 of 6 starter×viewport combinations. This is the largest remaining first-view problem, it is a deliberate documented trade, and changing it collides with sibling-owned surfaces — re-brief before expanding.
2. **Acceptance #4 (one edge-style authority) is REFUTED**, with a contrast control. Narrowly true only for `stroke` + `strokeDasharray` written inline by `StyledEdge`. Stroke **width**, opacity, filter and animation are still inline early-return chains (`StyledEdge.tsx:793–899`); arrowheads have **no owner and no renderer** (two dead `<marker>` defs); and two live paths restyle main-canvas edges via `className`/`animated`/CSS keyframes, which the cascade lets **beat** the authority's inline values. No test, lint rule or census would notice.
3. **Acceptance #8 (Decision node):** removal is **NOT safe** today. It is mounted for every starter user (node zero of all five). Five hard dependencies: the `Run analysis` CTA lives only there; add-option **dead-ends** without it (`parent_decision_id` is required on the wire); option auto-connect, baseline anchoring and structural-edge classification all key off it. What *is* safe is narrowing its presentation — the triage line, leader headline, stability line and readiness/bias popover are each duplicated elsewhere with no external consumers. **No "Monolith vs Platform" framing exists anywhere** (contrast control: `platform` 154 hits, `monolith` 1, in a test fixture).

### P-COMPLIANCE (read v4, P1–P9)
- **P7** — semantics taken from the **producers**: DS v5 §2.3/§2.4 for the type scale; `zoomLegibility.ts` for the counter-scale contract; `MetricPills`' own header, which already named `edgeLabel` as the intended token while hardcoding the literal. Not inferred from a corpus.
- **P2** — checked at the **mounted consumer**: rendered pixels read off real DOM in Chromium at the deployed flag posture, not producer bytes.
- **P1** — tested one seam **beyond** the token: not "is the class present" (jsdom would pass) but "what does the glyph measure after the viewport transform".
- **P5** — n/a: no claim about the user's model, session or history.
- **P6** — n/a: no inferred structure; no new user obligation.
- **P8** — n/a: no new question or affordance. Existing chip copy was reworded, and its acceptance path is unchanged.
- **P4** — mutated trees typechecked with the repo's **named** gate: M1 caught by the ratchet (`2307` vs baseline `2306`); pristine control passes the same gate.
