### PR TITLE
feat(inspector,model): B4 convergence — no raw ids, the Not-set wall, DS v5 conformance + the gate that missed it, N-20 provenance

### DIFF
--- a/src/canvas/components/model-tab/ContestedEdgeCard.tsx
+++ b/src/canvas/components/model-tab/ContestedEdgeCard.tsx
@@ -297,7 +297,7 @@ export function ContestedEdgeCard({
             useCanvasStore.getState().selectEdgeWithoutHistory(edgeId)
             focusEdgeById(edgeId)
           }}
-          className={`${typography.panelBody} font-medium text-info hover:underline cursor-pointer flex-1 min-w-0 leading-snug text-left`}
+          className={`${typography.panelBody} text-info hover:underline cursor-pointer flex-1 min-w-0 leading-snug text-left`}
         >
           {edgeLabel ?? (
             <>
@@ -327,7 +327,7 @@ export function ContestedEdgeCard({
       {primaryReason && !isResolved && (
         <p className={`${typography.panelMeta} text-text-light mb-1`}>
           {primaryReason}
-          <span className={`${typography.panelMeta} font-semibold text-warning ml-1`}>
+          <span className={`${typography.panelMeta} text-warning ml-1`}>
             Δ {deltaMagnitude.toFixed(2)}
           </span>
         </p>
@@ -351,7 +351,7 @@ export function ContestedEdgeCard({
           <div className="flex items-center gap-1.5 mb-1" data-testid={`contested-pass1-${edgeId}`}>
             <span className="w-1.5 h-1.5 rounded-full bg-info shrink-0" aria-hidden="true" />
             <span className={`${typography.panelMeta} text-text-light`}>Current model:</span>
-            <span className={`${typography.panelMeta} font-medium text-text-header`}>
+            <span className={`${typography.panelMeta} text-text-header`}>
               {pass1Label} ({pass1Mean >= 0 ? '+' : ''}{pass1Mean.toFixed(2)})
             </span>
           </div>
@@ -360,7 +360,7 @@ export function ContestedEdgeCard({
           <div className="flex items-center gap-1.5 mb-2" data-testid={`contested-pass2-${edgeId}`}>
             <span className="w-1.5 h-1.5 rounded-full bg-option shrink-0" aria-hidden="true" />
             <span className={`${typography.panelMeta} text-text-light`}>Independent review:</span>
-            <span className={`${typography.panelMeta} font-medium text-text-header`}>
+            <span className={`${typography.panelMeta} text-text-header`}>
               {pass2Label} ({pass2Mean >= 0 ? '+' : ''}{pass2Mean.toFixed(2)})
             </span>
           </div>
@@ -370,7 +370,7 @@ export function ContestedEdgeCard({
             className={`${typography.panelMeta} text-text-body leading-relaxed`}
             data-testid={`contested-basis-reasoning-${edgeId}`}
           >
-            <span className="font-medium text-info" data-testid={`contested-basis-label-${edgeId}`}>
+            <span className="text-info" data-testid={`contested-basis-label-${edgeId}`}>
               {basisLabel}:
             </span>{' '}
             <span data-testid={`contested-reasoning-${edgeId}`}>{reasoning}</span>

--- a/src/canvas/components/model-tab/FactorsSection.tsx
+++ b/src/canvas/components/model-tab/FactorsSection.tsx
@@ -50,7 +50,7 @@ function CategoryBadge({ category }: { category?: string }) {
   if (!style) return null
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded-full ${typography.panelMeta} font-medium bg-transparent border ${style.border} text-text-body`}
+      className={`inline-flex items-center px-2 py-0.5 rounded-full ${typography.panelMeta} bg-transparent border ${style.border} text-text-body`}
     >
       {style.label}
     </span>
@@ -72,7 +72,7 @@ function AttributionStabilityPill({ level }: { level: string | undefined }) {
   if (!style) return null
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded-full ${typography.panelMeta} font-medium bg-transparent border ${style.border} text-text-body`}
+      className={`inline-flex items-center px-2 py-0.5 rounded-full ${typography.panelMeta} bg-transparent border ${style.border} text-text-body`}
       data-testid="attribution-stability-pill"
     >
       {style.label}
@@ -92,7 +92,7 @@ function RangeDerivationBadge({ source }: { source: string | undefined }) {
   const tooltip = `Range estimated from ${source.replace(/_/g, ' ')}. Consider confirming the plausible range.`
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded-full ${typography.panelMeta} font-medium bg-transparent border border-danger/30 text-text-body`}
+      className={`inline-flex items-center px-2 py-0.5 rounded-full ${typography.panelMeta} bg-transparent border border-danger/30 text-text-body`}
       title={tooltip}
       data-testid="range-derivation-badge"
     >
@@ -409,7 +409,7 @@ function FactorCard({
                 <button
                   type="button"
                   onClick={(e) => { e.stopPropagation(); focusNodeById(node.id) }}
-                  className={`inline-flex items-center px-2 py-0.5 rounded-full border border-info/30 text-text-body hover:bg-panel-hover transition-colors ${typography.panelMeta} font-medium`}
+                  className={`inline-flex items-center px-2 py-0.5 rounded-full border border-info/30 text-text-body hover:bg-panel-hover transition-colors ${typography.panelMeta}`}
                   data-testid={`factor-${node.id}-refine-range`}
                 >
                   Refine range
@@ -537,7 +537,7 @@ function FactorCard({
           {/* Group 1: Current state — only shown when there is something to display */}
           {(isExternal ? (priorRangeMin !== undefined && priorRangeMax !== undefined) : obs.value !== undefined || obs.cap !== undefined) && (
             <>
-              <div className={`${typography.panelMeta} text-text-light font-medium mb-1`}>Current state</div>
+              <div className={`${typography.panelMeta} text-text-light mb-1`}>Current state</div>
               <div className="grid grid-cols-2 gap-x-3 gap-y-0.5">
                 {isExternal && priorRangeMin !== undefined && priorRangeMax !== undefined && (
                   <>
@@ -570,7 +570,7 @@ function FactorCard({
           {/* Group 2: Sensitivity — only shown when at least one sensitivity metric exists */}
           {((uncertaintyDrivers && uncertaintyDrivers.length > 0) || elasticity != null || rankFlipRate != null || factorConfidence?.show === true) && (
             <div className="border-t border-panel-border mt-2 pt-2">
-              <div className={`${typography.panelMeta} text-text-light font-medium mb-1`}>Sensitivity</div>
+              <div className={`${typography.panelMeta} text-text-light mb-1`}>Sensitivity</div>
               {uncertaintyDrivers && uncertaintyDrivers.length > 0 && (
                 <div className="mb-1">
                   <span className={`${typography.panelMeta} text-text-light`}>Uncertainty drivers</span>
@@ -615,7 +615,7 @@ function FactorCard({
 
           {/* Group 3: Metadata */}
           <div className="border-t border-panel-border mt-2 pt-2">
-            <div className={`${typography.panelMeta} text-text-light font-medium mb-1`}>Metadata</div>
+            <div className={`${typography.panelMeta} text-text-light mb-1`}>Metadata</div>
             <div className="grid grid-cols-2 gap-x-3 gap-y-0.5">
               <span className={`${typography.panelMeta} text-text-light`}>Node ID</span>
               <span className={`${typography.panelBody} text-text-body font-mono text-right`} style={{ overflowWrap: 'anywhere', wordBreak: 'break-all' }}>

--- a/src/canvas/components/model-tab/GoalSection.tsx
+++ b/src/canvas/components/model-tab/GoalSection.tsx
@@ -253,7 +253,7 @@ function GoalSectionInner({ goalNode, onSendMessage, goalFitRows }: GoalSectionP
       {/* Full detail expansion */}
       {showDetail && (
         <div className="mt-2.5 pt-2.5 border-t border-panel-border space-y-0.5">
-          <div className={`${typography.panelMeta} text-text-light font-medium`}>Goal threshold</div>
+          <div className={`${typography.panelMeta} text-text-light`}>Goal threshold</div>
           <div className={`${typography.panelBody} text-text-body`}>
             The probability you need to hit for this to count as success
           </div>

--- a/src/canvas/components/model-tab/OptionsSection.tsx
+++ b/src/canvas/components/model-tab/OptionsSection.tsx
@@ -156,7 +156,7 @@ function DeltaChip({ baseline, current, unit, crossUnitSpace }: {
   const positive = delta > 0
   const label = unit ? formatValueWithUnit(Math.abs(delta), unit) : formatSmartNumber(Math.abs(delta))
   return (
-    <span className={`${typography.panelMeta} font-medium ${positive ? 'text-success' : 'text-danger'}`}>
+    <span className={`${typography.panelMeta} ${positive ? 'text-success' : 'text-danger'}`}>
       {positive ? '+' : '-'}{label}
     </span>
   )
@@ -362,7 +362,7 @@ function OptionCard({ option, allNodes, conditionalWinners, hasAnalysisData }: {
         <div className="mt-2 pt-2 border-t border-panel-border">
           {interventions.length > 0 && (
             <>
-              <div className={`${typography.panelMeta} text-text-light font-medium mb-1`}>Normalised targets (model space)</div>
+              <div className={`${typography.panelMeta} text-text-light mb-1`}>Normalised targets (model space)</div>
               <div className={`${typography.panelBody} text-text-body mb-1.5`}>
                 Internal simulation values, overriding each factor's baseline
               </div>

--- a/src/canvas/components/model-tab/ReanalyseBar.tsx
+++ b/src/canvas/components/model-tab/ReanalyseBar.tsx
@@ -70,7 +70,7 @@ export function ReanalyseBar({ onReanalyse }: ReanalyseBarProps) {
         type="button"
         onClick={onReanalyse}
         disabled={!onReanalyse}
-        className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-text-on-color ${typography.panelMeta} font-medium hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed shrink-0`}
+        className={`inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-text-on-color ${typography.panelMeta} hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed shrink-0`}
         data-testid="reanalyse-button"
       >
         <RefreshCw className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />

--- a/src/canvas/components/model-tab/RelationshipsSection.tsx
+++ b/src/canvas/components/model-tab/RelationshipsSection.tsx
@@ -287,7 +287,7 @@ function EdgeCard({
         )}
         {isFragile && (
           <span
-            className={`inline-flex items-center gap-0.5 px-2 py-0.5 rounded-full ${typography.panelMeta} font-medium bg-transparent border border-warning/30 text-text-body shrink-0`}
+            className={`inline-flex items-center gap-0.5 px-2 py-0.5 rounded-full ${typography.panelMeta} bg-transparent border border-warning/30 text-text-body shrink-0`}
             title={fragileTooltip}
           >
             <AlertTriangle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
@@ -455,7 +455,7 @@ function EdgeCard({
           {/* Group 1: Effect — only shown when at least one effect metric is available */}
           {(signedMean !== undefined || strengthStd !== undefined || beliefExists !== undefined) && (
             <>
-              <div className={`${typography.panelMeta} text-text-light font-medium mb-1`}>Effect</div>
+              <div className={`${typography.panelMeta} text-text-light mb-1`}>Effect</div>
               <div className="grid grid-cols-2 gap-x-3 gap-y-0.5">
                 {signedMean !== undefined && (
                   <>
@@ -487,7 +487,7 @@ function EdgeCard({
 
           {/* Group 2: Provenance */}
           <div className="border-t border-panel-border mt-2 pt-2">
-            <div className={`${typography.panelMeta} text-text-light font-medium mb-1`}>Provenance</div>
+            <div className={`${typography.panelMeta} text-text-light mb-1`}>Provenance</div>
             <div className="grid grid-cols-2 gap-x-3 gap-y-0.5">
               <span className={`${typography.panelMeta} text-text-light`}>Provenance</span>
               <span className={`${typography.panelBody} text-text-body text-right`}>
@@ -526,7 +526,7 @@ function EdgeCard({
 
           {/* Group 3: Metadata */}
           <div className="border-t border-panel-border mt-2 pt-2">
-            <div className={`${typography.panelMeta} text-text-light font-medium mb-1`}>Metadata</div>
+            <div className={`${typography.panelMeta} text-text-light mb-1`}>Metadata</div>
             <div className="grid grid-cols-2 gap-x-3 gap-y-0.5">
               <span className={`${typography.panelMeta} text-text-light`}>Edge ID</span>
               <span className={`${typography.panelBody} text-text-body font-mono text-right`} style={{ overflowWrap: 'anywhere', wordBreak: 'break-all' }}>

--- a/src/canvas/components/model-tab/SourceProvenancePill.tsx
+++ b/src/canvas/components/model-tab/SourceProvenancePill.tsx
@@ -59,7 +59,7 @@ export function SourceProvenancePill({ source, showWhenAbsent = true }: SourcePr
 
   return (
     <span
-      className={`inline-flex items-center px-2 py-0.5 rounded-full bg-transparent border ${config.border} text-text-body ${typography.panelMeta} font-medium`}
+      className={`inline-flex items-center px-2 py-0.5 rounded-full bg-transparent border ${config.border} text-text-body ${typography.panelMeta}`}
       title={source ? `Source: ${source}` : 'No source set'}
     >
       {config.label}

--- a/src/canvas/domain/elementLabel.ts
+++ b/src/canvas/domain/elementLabel.ts
@@ -1,0 +1,73 @@
+/**
+ * elementLabel — THE ONE resolver for "what do we call this element on screen".
+ *
+ * ⚠ THE DEFECT THIS CLOSES. The inspector's own header already resolved an
+ * absent label to `'Untitled'` (`InspectorRouter.tsx`), and so do
+ * `useNodeConnections`, `usePreAnalysisInbound`, `BaseNode` and `persist`. The
+ * inspector PANELS did not: fourteen call sites resolved an absent label to the
+ * element's **id** (`String(n.data?.label ?? n.id)`), unconditionally and
+ * outside technical mode. So one and the same unlabelled node read `'Untitled'`
+ * in the panel header and `fac_7c21_budget_growth` three lines below it, in a
+ * connection row. An internal identifier is not a name, and the user has no way
+ * to act on one.
+ *
+ * ⚠ WHY A FUNCTION RATHER THAN SIX MORE INLINE `?? 'Untitled'`. The estate
+ * already carries eight hand-copied `'Untitled'` literals and fourteen
+ * hand-copied id fallbacks; that spread is exactly how the two halves drifted
+ * apart in the first place (trap 12 — derive, do not mirror). One resolver
+ * means the fallback cannot disagree with itself across surfaces, and a
+ * source-scan guard can pin the absence of the id form.
+ *
+ * ⚠ WHAT THIS IS NOT. It does not invent a name. `'Untitled'` is a statement
+ * that the element has no name yet — the same honest-absence rule the model
+ * outline's provenance pill follows when it renders nothing rather than
+ * asserting a value. The id remains available to anyone who needs it: every
+ * panel's technical disclosure prints it under `Node ID` / `Edge key`, and the
+ * model outline prints it in the Advanced tier. Suppressing an identifier from
+ * the plain surface is not hiding information; it is putting it where it means
+ * something.
+ */
+
+/**
+ * The single fallback string. Exported so a guard can pin it and so no caller
+ * has to retype it — a retyped literal is a mirror waiting to drift.
+ */
+export const UNNAMED_ELEMENT_LABEL = 'Untitled'
+
+/**
+ * Resolve an element's display name from its `data` bag.
+ *
+ * Returns the trimmed `label` when the bag carries a non-empty string one, and
+ * `UNNAMED_ELEMENT_LABEL` otherwise. A whitespace-only label is treated as
+ * absent: it is indistinguishable from no label on screen, and rendering it
+ * produces a nameless row with no fallback at all.
+ *
+ * Deliberately takes the DATA BAG, not the node: edges and nodes both reach
+ * this with a `data` object, and a node-shaped parameter would have forced
+ * edge callers to build a fake node.
+ */
+export function resolveElementLabel(data: unknown): string {
+  if (data !== null && typeof data === 'object') {
+    const label = (data as { label?: unknown }).label
+    if (typeof label === 'string' && label.trim() !== '') return label
+  }
+  return UNNAMED_ELEMENT_LABEL
+}
+
+/**
+ * The first STATED name among several candidate data bags, else the honest
+ * no-name fallback.
+ *
+ * Exists for the one real case with two legitimate name sources: an option's
+ * comparison row, where the graph node's own label wins and the analysis
+ * payload's `label` covers an option the graph no longer holds. The id that
+ * used to sit at the end of that chain is not a third source — it is a database
+ * key, and it has been removed rather than demoted.
+ */
+export function resolveFirstStatedLabel(...bags: readonly unknown[]): string {
+  for (const bag of bags) {
+    const resolved = resolveElementLabel(bag)
+    if (resolved !== UNNAMED_ELEMENT_LABEL) return resolved
+  }
+  return UNNAMED_ELEMENT_LABEL
+}

--- a/src/canvas/model-tab-v2/ModelOutline.tsx
+++ b/src/canvas/model-tab-v2/ModelOutline.tsx
@@ -106,6 +106,18 @@ export function outlineLayout(
   }
 }
 
+/**
+ * How many of these rows state no value.
+ *
+ * `primaryValue === null` is the projection's OWN definition of "nothing is
+ * stated" (`types.ts`: *"`null` means nothing is stated — which is a fact to
+ * render, never a zero to invent"*). Reading that same field is what keeps the
+ * group heading and the value cells from drifting apart.
+ */
+function unknownCount(rows: readonly ModelRow[]): number {
+  return rows.reduce((n, r) => (r.primaryValue === null ? n + 1 : n), 0)
+}
+
 export function ModelOutline({
   rows,
   tier,
@@ -156,12 +168,32 @@ export function ModelOutline({
             data-testid={`model-group-v2-${group.id}-toggle`}
             aria-expanded={group.open}
             onClick={() => toggle(group.id)}
-            className={`${typography.label} text-text-header w-full text-left px-2 py-1.5`}
+            className={`${typography.panelHeader} text-text-header w-full text-left px-2 py-1.5`}
           >
             {group.open ? '▾' : '▸'} {GROUP_TITLE[group.id]}
-            <span className={`${typography.caption} text-text-light ml-2`}>
+            <span className={`${typography.panelMeta} text-text-light ml-2`}>
               {group.rows.length}
             </span>
+            {/*
+              The unknown summary — ONE sentence in place of N identical "Not
+              set" strings down the rows (see `ModelRowView`'s value cell).
+
+              ⚠ DERIVED FROM THE SAME FIELD THE CELL READS (`primaryValue ===
+              null`), not from a separately maintained count, so the heading and
+              the rows cannot disagree about what is unstated (trap 12).
+
+              ⚠ RENDERED ONLY WHEN THERE ARE UNKNOWNS. A permanent "0 of 4"
+              would be its own wall — chrome that always renders states nothing
+              about the data.
+            */}
+            {unknownCount(group.rows) > 0 && (
+              <span
+                data-testid={`model-group-v2-${group.id}-unknown-summary`}
+                className={`${typography.panelMeta} text-text-light ml-2`}
+              >
+                {unknownCount(group.rows)} of {group.rows.length} have no value yet
+              </span>
+            )}
           </button>
 
           {group.open &&

--- a/src/canvas/model-tab-v2/ModelRowView.tsx
+++ b/src/canvas/model-tab-v2/ModelRowView.tsx
@@ -368,11 +368,22 @@ function ValueCell({
     )
   }
 
-  // Editable but the canonical transaction is not connected: the control is
-  // dead, so an unknown here is inert text, not an affordance.
-  if (display === null && !editorAvailable) {
-    return <span data-testid={testid} className={typography.tabular} />
-  }
+  /*
+   * ⚠ THE EDITABLE-BUT-UNCONNECTED ROW DELIBERATELY STILL SAYS "Not set", AND
+   * THIS COMMENT EXISTS SO NOBODY "FINISHES THE JOB" BY SILENCING IT.
+   *
+   * A first cut of the wall fix silenced it too, and broke
+   * `ModelTabV2Panel.spec.tsx`'s pinned invariant that the relationship, option
+   * and goal rows render a DISABLED control carrying `NO_AUTHORITY_REASON`. That
+   * invariant is right: a control that says "editing is not connected yet" is
+   * strictly more truthful than an empty cell, and silence here would replace a
+   * truthful fallback with nothing (P3).
+   *
+   * Which means the remaining "Not set" repetition on this surface is NOT a
+   * display defect — it is the visible shape of the edit paths that have no
+   * canonical carrier yet (design §2 F6/F9). Suppressing it would have killed
+   * the symptom and left the defect (trap 23). It is reported, not hidden.
+   */
 
   return (
     <button

--- a/src/canvas/model-tab-v2/ModelRowView.tsx
+++ b/src/canvas/model-tab-v2/ModelRowView.tsx
@@ -338,12 +338,40 @@ function ValueCell({
    */
   const display = row.primaryValue
 
+  /*
+   * ⚠ THE "NOT SET" WALL, AND WHY SILENCE HERE IS NOT A HIDDEN UNKNOWN.
+   *
+   * Every row used to render `display ?? 'Not set'`, so a nine-factor model
+   * stacked twenty-odd identical inert strings down the outline — individually
+   * honest, collectively meaningless, and loud enough to drown the rows that
+   * had something to say.
+   *
+   * The rule now: "Not set" is printed only where it is ACTIONABLE, i.e. where
+   * pressing it opens the editor that fixes it (the arm below). Where nothing
+   * can be done from this cell, the cell is SILENT — and the fact is carried,
+   * once, by the group heading's unknown summary in `ModelOutline`, by this
+   * row's `attention` marker, and by the detail region, which still renders
+   * "Not set" for the selected row.
+   *
+   * This is the rule the provenance pill three elements up already follows
+   * (`showWhenAbsent={false}` — "absence is rendered as absence"); the value
+   * cell simply did not follow its own neighbour. Nothing is invented and
+   * nothing is concealed: the unknown moved from N repetitions to one sentence
+   * plus one marker, which is the difference between stating a fact and
+   * shouting it.
+   */
   if (!row.editable) {
     return (
       <span data-testid={testid} className={typography.tabular}>
-        {display ?? 'Not set'}
+        {display ?? ''}
       </span>
     )
+  }
+
+  // Editable but the canonical transaction is not connected: the control is
+  // dead, so an unknown here is inert text, not an affordance.
+  if (display === null && !editorAvailable) {
+    return <span data-testid={testid} className={typography.tabular} />
   }
 
   return (

--- a/src/canvas/model-tab-v2/__tests__/ModelOutline.unknownsAreSummarised.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/ModelOutline.unknownsAreSummarised.spec.tsx
@@ -49,11 +49,19 @@ function row(over: Partial<ModelRow> & Pick<ModelRow, 'id'>): ModelRow {
   } as ModelRow
 }
 
-/** Three unknown factors, one known — a group that is 3-of-4 unstated. */
+/**
+ * Three unknown factors, one known — a group that is 3-of-4 unstated.
+ *
+ * ⚠ `fac_c` IS NOT EDITABLE, AND THAT IS LOAD-BEARING. The first version of
+ * this fixture made every row `editable: true`, so the value cell's
+ * `!row.editable` arm was never rendered and a mutant restoring the wall on
+ * that arm SURVIVED the whole suite. A fixture that omits a branch certifies
+ * nothing about it (trap 22: check what your corpus EXCLUDES).
+ */
 const FACTORS: readonly ModelRow[] = [
   row({ id: 'fac_a' }),
   row({ id: 'fac_b' }),
-  row({ id: 'fac_c' }),
+  row({ id: 'fac_c', editable: false }),
   row({ id: 'fac_known', primaryValue: '45 days' }),
 ]
 
@@ -85,6 +93,15 @@ describe('B4 · unknown values are summarised at the group, not repeated down th
     expect(cell.textContent).toBe('')
   })
 
+  it('a row that is NOT EDITABLE AT ALL prints nothing either', () => {
+    // The second silent arm. `fac_c` is `editable: false`, which is a different
+    // branch of the value cell from "editable but no live authority" above —
+    // and it was the branch a restore-the-wall mutant slipped through.
+    renderOutline(FACTORS, new Set(['fac_a', 'fac_b', 'fac_c']))
+    const cell = screen.getByTestId('model-row-v2-fac_c-value')
+    expect(cell.textContent).toBe('')
+  })
+
   it('ACTIONABLE unknowns keep saying "Not set" — there it is the control, not a label', () => {
     // The opposite-direction twin of the assertion above. Without it, a change
     // that silenced EVERY unknown would pass the previous test while removing
@@ -109,8 +126,10 @@ describe('B4 · unknown values are summarised at the group, not repeated down th
 
   it('the wall is gone: the outline prints "Not set" at most once per ACTIONABLE row', () => {
     // The headline claim, stated as a count over the whole rendered outline.
-    // Four unknown-bearing rows, one of them actionable => exactly one "Not set".
-    renderOutline(FACTORS, new Set(['fac_a']))
+    // Three unknown-bearing rows, one of them actionable => exactly one "Not set".
+    // Note `fac_c` is in `editConnectedIds` and STILL silent, because it is not
+    // editable — connectivity alone does not make a row an affordance.
+    renderOutline(FACTORS, new Set(['fac_a', 'fac_c']))
     const outline = screen.getByTestId('model-outline-v2')
     const occurrences = (outline.textContent ?? '').split('Not set').length - 1
     expect(occurrences).toBe(1)

--- a/src/canvas/model-tab-v2/__tests__/ModelOutline.unknownsAreSummarised.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/ModelOutline.unknownsAreSummarised.spec.tsx
@@ -85,14 +85,6 @@ describe('B4 · unknown values are summarised at the group, not repeated down th
     expect(summary).toHaveTextContent('3 of 4 have no value yet')
   })
 
-  it('a row with no value and NO live editor prints nothing in its value cell', () => {
-    // `editConnectedIds` empty = no canonical transaction for these rows, so the
-    // editor is not live and a "Not set" here would be inert text.
-    renderOutline(FACTORS, new Set<string>())
-    const cell = screen.getByTestId('model-row-v2-fac_a-value')
-    expect(cell.textContent).toBe('')
-  })
-
   it('a row that is NOT EDITABLE AT ALL prints nothing either', () => {
     // The second silent arm. `fac_c` is `editable: false`, which is a different
     // branch of the value cell from "editable but no live authority" above —
@@ -124,22 +116,26 @@ describe('B4 · unknown values are summarised at the group, not repeated down th
     expect(screen.queryByTestId('model-group-v2-factors-unknown-summary')).toBeNull()
   })
 
-  it('the wall is gone: the outline prints "Not set" at most once per ACTIONABLE row', () => {
-    // The headline claim, stated as a count over the whole rendered outline.
-    // Three unknown-bearing rows, one of them actionable => exactly one "Not set".
-    // Note `fac_c` is in `editConnectedIds` and STILL silent, because it is not
-    // editable — connectivity alone does not make a row an affordance.
-    renderOutline(FACTORS, new Set(['fac_a', 'fac_c']))
+  it('the non-editable row contributes NOTHING to the "Not set" count', () => {
+    /*
+     * The scope of this change, stated exactly. Four rows, three of them with no
+     * value: `fac_a` and `fac_b` are editable (so they keep "Not set" — live for
+     * `fac_a`, honestly disabled for `fac_b`, both of which are affordances or
+     * explanations), and `fac_c` is not editable at all, so it is silent.
+     * => exactly two "Not set", not three.
+     */
+    renderOutline(FACTORS, new Set(['fac_a']))
     const outline = screen.getByTestId('model-outline-v2')
     const occurrences = (outline.textContent ?? '').split('Not set').length - 1
-    expect(occurrences).toBe(1)
+    expect(occurrences).toBe(2)
   })
 
-  it('CONTRAST: with no editors connected at all, the outline prints "Not set" zero times', () => {
-    renderOutline(FACTORS, new Set<string>())
+  it('the group summary carries the FULL unknown count, including the silent row', () => {
+    // The information the silent cell no longer prints is still on screen — and
+    // the summary counts `fac_c` even though its cell says nothing, which is the
+    // whole point of moving it there.
+    renderOutline(FACTORS, new Set(['fac_a']))
     const outline = screen.getByTestId('model-outline-v2')
-    expect(outline.textContent).not.toContain('Not set')
-    // ...and the information is still on screen, in one place instead of three.
     expect(
       within(outline).getByTestId('model-group-v2-factors-unknown-summary'),
     ).toHaveTextContent('3 of 4 have no value yet')

--- a/src/canvas/model-tab-v2/__tests__/ModelOutline.unknownsAreSummarised.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/ModelOutline.unknownsAreSummarised.spec.tsx
@@ -1,0 +1,128 @@
+/**
+ * B4 — THE "NOT SET" WALL.
+ *
+ * The defect: `ModelRowView` rendered `primaryValue ?? 'Not set'` in EVERY row,
+ * so a model with nine factors and a dozen relationships showed twenty-odd
+ * identical inert "Not set" strings stacked down the outline. Each one is
+ * individually honest and collectively meaningless — they carry no information
+ * that distinguishes one row from another, and they drown the rows that DO have
+ * something to say.
+ *
+ * ⚠ THE FIX IS NOT TO HIDE UNKNOWNS, AND THIS SPEC PINS THAT IN BOTH
+ * DIRECTIONS. Never inventing a value is this product's whole differentiator;
+ * suppressing the fact that a value is missing would be the same lie told by
+ * omission. So the information is MOVED, not removed, and three assertions hold
+ * it in place:
+ *
+ *   1. Where the unknown is ACTIONABLE — the row has a live editor — "Not set"
+ *      stays, because there it is not inert text, it is the control you press
+ *      to fix it.
+ *   2. Where it is NOT actionable, the cell is silent and the GROUP HEADING
+ *      states the count. One sentence replaces N identical strings, and the
+ *      count is DERIVED from the same `primaryValue === null` the cell reads,
+ *      so the two cannot disagree (trap 12).
+ *   3. The per-row detail is still available on demand — asserted in
+ *      `ModelDetailRegion`, which continues to render "Not set" for the
+ *      selected row.
+ *
+ * This follows a precedent already in `ModelRowView`: the provenance pill is
+ * rendered with `showWhenAbsent={false}` because "absence is rendered as
+ * absence". The value cell simply did not follow the rule its own neighbour
+ * already followed.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+
+import { ModelOutline } from '../ModelOutline'
+import type { ModelRow } from '../types'
+
+function row(over: Partial<ModelRow> & Pick<ModelRow, 'id'>): ModelRow {
+  return {
+    kind: 'factor',
+    group: 'factors',
+    label: `Label ${over.id}`,
+    primaryValue: null,
+    attention: [],
+    editable: true,
+    ...over,
+  } as ModelRow
+}
+
+/** Three unknown factors, one known — a group that is 3-of-4 unstated. */
+const FACTORS: readonly ModelRow[] = [
+  row({ id: 'fac_a' }),
+  row({ id: 'fac_b' }),
+  row({ id: 'fac_c' }),
+  row({ id: 'fac_known', primaryValue: '45 days' }),
+]
+
+function renderOutline(rows: readonly ModelRow[], editConnectedIds?: ReadonlySet<string>) {
+  return render(
+    <ModelOutline
+      rows={rows}
+      tier="plain"
+      editConnectedIds={editConnectedIds}
+      onBeginEdit={() => {}}
+    />,
+  )
+}
+
+describe('B4 · unknown values are summarised at the group, not repeated down the list', () => {
+  it('the group heading states how many rows have no value yet', () => {
+    renderOutline(FACTORS, new Set<string>())
+    // Bound by identity to the FACTORS group's own summary node, not by
+    // searching the document for a number another group could also render.
+    const summary = screen.getByTestId('model-group-v2-factors-unknown-summary')
+    expect(summary).toHaveTextContent('3 of 4 have no value yet')
+  })
+
+  it('a row with no value and NO live editor prints nothing in its value cell', () => {
+    // `editConnectedIds` empty = no canonical transaction for these rows, so the
+    // editor is not live and a "Not set" here would be inert text.
+    renderOutline(FACTORS, new Set<string>())
+    const cell = screen.getByTestId('model-row-v2-fac_a-value')
+    expect(cell.textContent).toBe('')
+  })
+
+  it('ACTIONABLE unknowns keep saying "Not set" — there it is the control, not a label', () => {
+    // The opposite-direction twin of the assertion above. Without it, a change
+    // that silenced EVERY unknown would pass the previous test while removing
+    // the only way to give a factor its first value (design §2 F9).
+    renderOutline(FACTORS, new Set(['fac_a']))
+    const cell = screen.getByTestId('model-row-v2-fac_a-value')
+    expect(cell).toHaveTextContent('Not set')
+    expect(cell).toBeEnabled()
+  })
+
+  it('a row that HAS a value still shows it, editor or no editor', () => {
+    renderOutline(FACTORS, new Set<string>())
+    expect(screen.getByTestId('model-row-v2-fac_known-value')).toHaveTextContent('45 days')
+  })
+
+  it('no summary is shown when every row in the group has a value', () => {
+    // Discriminating: the summary must be a fact about the data, not chrome
+    // that always renders. A summary reading "0 of 4" would be its own wall.
+    renderOutline([row({ id: 'fac_known', primaryValue: '45 days' })], new Set<string>())
+    expect(screen.queryByTestId('model-group-v2-factors-unknown-summary')).toBeNull()
+  })
+
+  it('the wall is gone: the outline prints "Not set" at most once per ACTIONABLE row', () => {
+    // The headline claim, stated as a count over the whole rendered outline.
+    // Four unknown-bearing rows, one of them actionable => exactly one "Not set".
+    renderOutline(FACTORS, new Set(['fac_a']))
+    const outline = screen.getByTestId('model-outline-v2')
+    const occurrences = (outline.textContent ?? '').split('Not set').length - 1
+    expect(occurrences).toBe(1)
+  })
+
+  it('CONTRAST: with no editors connected at all, the outline prints "Not set" zero times', () => {
+    renderOutline(FACTORS, new Set<string>())
+    const outline = screen.getByTestId('model-outline-v2')
+    expect(outline.textContent).not.toContain('Not set')
+    // ...and the information is still on screen, in one place instead of three.
+    expect(
+      within(outline).getByTestId('model-group-v2-factors-unknown-summary'),
+    ).toHaveTextContent('3 of 4 have no value yet')
+  })
+})

--- a/src/canvas/ui/inspector-v2/InspectorRouter.tsx
+++ b/src/canvas/ui/inspector-v2/InspectorRouter.tsx
@@ -27,6 +27,7 @@ import { OutcomePanel } from './panels/OutcomePanel'
 import { RiskPanel } from './panels/RiskPanel'
 import { GenericNodePanel } from './panels/GenericNodePanel'
 import { InspectorQuickActions } from './shared/InspectorQuickActions'
+import { resolveElementLabel } from '../../domain/elementLabel'
 
 // Entity colour map — used as fallback for inspector header entity colour
 const TOP_BAR_COLORS: Record<string, string> = {
@@ -168,8 +169,8 @@ export const InspectorRouter = memo(function InspectorRouter({
 
     const sourceNode = nodes.find(n => n.id === edge.source)
     const targetNode = nodes.find(n => n.id === edge.target)
-    const sourceLabel = String(sourceNode?.data?.label ?? edge.source)
-    const targetLabel = String(targetNode?.data?.label ?? edge.target)
+    const sourceLabel = resolveElementLabel(sourceNode?.data)
+    const targetLabel = resolveElementLabel(targetNode?.data)
     const edgeLabel = `${sourceLabel} \u2192 ${targetLabel}`
 
     // Edge confidence from beliefExists — PROVENANCE-GATED.

--- a/src/canvas/ui/inspector-v2/InspectorShell.tsx
+++ b/src/canvas/ui/inspector-v2/InspectorShell.tsx
@@ -113,7 +113,7 @@ export const InspectorShell = memo(function InspectorShell({
             <Spline size={22} style={{ color: entityColor }} aria-hidden="true" />
           )}
           <span
-            className={`${typography.panelMeta} font-semibold`}
+            className={`${typography.panelMeta}`}
             style={{ color: entityColor }}
           >
             {typePill}

--- a/src/canvas/ui/inspector-v2/__tests__/GoalPanel.sourceQuoteProvenance.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/GoalPanel.sourceQuoteProvenance.spec.tsx
@@ -1,0 +1,148 @@
+/**
+ * B4 / ledger N-20 — "you said: …" provenance reaches a screen.
+ *
+ * THE FINDING, re-derived at this tip before building on it (a ledger row is a
+ * claim, not evidence):
+ *
+ *   · `source_quote` IS carried end to end. `applyV5State.ts:421` copies it onto
+ *     the persisted `CEEGoalConstraint`, and `constraintsDeepEqual` includes it,
+ *     so a change to the quote alone forces a write. It is authoritative
+ *     persisted state, which is what lets a "you said" claim satisfy P5.
+ *   · It is typed at `adapters/cee/types.ts:314`.
+ *   · It had ZERO render consumers. Contrast control run in the same sweep:
+ *     `goalThreshold` resolves in 82 files. So this was real absence, not a
+ *     blind grep.
+ *   · The row's other half, `label_authored`, returns ZERO hits anywhere in
+ *     `src/` at this tip — it is not a UI field here at all. The ledger row
+ *     names two fields; only one of them exists. Reported, not silently fixed.
+ *
+ * WHAT THIS SURFACE MAY AND MAY NOT CLAIM. It renders the stored quote VERBATIM
+ * and attributes it as the user's own words, because that is exactly what the
+ * producer stored it as. It does not paraphrase, does not summarise, and — the
+ * load-bearing one — does not render at all when no quote is stored. A "you
+ * said" line over an inferred constraint would be the fabrication class this
+ * estate treats as its most serious defect, so the absent case is pinned as
+ * hard as the present one.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+const QUOTE = 'we cannot let gross margin fall below 78%'
+const CONSTRAINT_ID = 'c_margin_floor'
+const OTHER_CONSTRAINT_ID = 'c_headcount_cap'
+
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { stripComments } from '../../../../../tests/helpers/stripSourceComments'
+import {
+  GoalConstraintProvenance,
+  GOAL_CONSTRAINT_PROVENANCE_TESTID,
+} from '../shared/GoalConstraintProvenance'
+
+describe('B4 / N-20 · a constraint the user stated shows the user’s own words', () => {
+  it('renders the stored quote VERBATIM, attributed to the user', () => {
+    render(<GoalConstraintProvenance constraintId={CONSTRAINT_ID} sourceQuote={QUOTE} />)
+
+    // Bound BY IDENTITY to this constraint's own provenance node — not by
+    // searching the document for the quote text, which a second constraint
+    // could also carry (trap 19).
+    const node = screen.getByTestId(`goal-constraint-${CONSTRAINT_ID}-source-quote`)
+    expect(node).toHaveTextContent('You said')
+    // Verbatim: the exact stored string, not a paraphrase and not truncated.
+    expect(node).toHaveTextContent(QUOTE)
+  })
+
+  it('renders NOTHING when no quote is stored — it never attributes words the user did not say', () => {
+    // The opposite-direction twin, and the more important of the two. A
+    // component that always rendered would put "You said …" over an
+    // Olumi-inferred constraint, which is a fabrication of provenance.
+    const { container } = render(
+      <GoalConstraintProvenance constraintId={CONSTRAINT_ID} sourceQuote={undefined} />,
+    )
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.queryByTestId(`goal-constraint-${CONSTRAINT_ID}-source-quote`)).toBeNull()
+  })
+
+  it('renders nothing for a blank or whitespace-only quote', () => {
+    // An empty string is not a statement. Rendering `You said: ""` asserts the
+    // user said something while showing that they said nothing.
+    for (const empty of ['', '   ', '\n']) {
+      const { container, unmount } = render(
+        <GoalConstraintProvenance constraintId={CONSTRAINT_ID} sourceQuote={empty} />,
+      )
+      expect(container).toBeEmptyDOMElement()
+      unmount()
+    }
+  })
+
+  it('two constraints carry their OWN quotes, each addressed by its own id', () => {
+    render(
+      <div>
+        <GoalConstraintProvenance constraintId={CONSTRAINT_ID} sourceQuote={QUOTE} />
+        <GoalConstraintProvenance constraintId={OTHER_CONSTRAINT_ID} sourceQuote="keep the team under 40 people" />
+      </div>,
+    )
+    expect(
+      screen.getByTestId(`goal-constraint-${CONSTRAINT_ID}-source-quote`),
+    ).toHaveTextContent(QUOTE)
+    expect(
+      screen.getByTestId(`goal-constraint-${OTHER_CONSTRAINT_ID}-source-quote`),
+    ).toHaveTextContent('keep the team under 40 people')
+    // Discriminating: each node holds its own quote and not the other's.
+    expect(
+      screen.getByTestId(`goal-constraint-${CONSTRAINT_ID}-source-quote`),
+    ).not.toHaveTextContent('keep the team under 40 people')
+  })
+})
+
+// ── The mount: the panel actually renders it ─────────────────────────────────
+
+/**
+ * ⚠ BOUND TO THE MOUNT PATH (trap 3b). A green component spec says nothing
+ * about a component the panel does not render — this estate has shipped that
+ * exact defect twice in one feature, both times with every component-level
+ * assertion green.
+ *
+ * STATED PRECISELY, because this is a source scan and not a render: it proves
+ * `GoalPanel` RENDERS the component in JSX (not merely imports it) and feeds it
+ * the PERSISTED field. It does not prove the surrounding branch is reachable
+ * for a given user — that is what the goal-constraint journey witness covers.
+ * Deleting the call site, or rewiring it to a different field, goes RED here
+ * while every assertion above stays green.
+ */
+describe('B4 / N-20 · the Goal panel MOUNTS the provenance line', () => {
+  const panelSource = stripComments(
+    readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'panels', 'GoalPanel.tsx'), 'utf8'),
+    'GoalPanel.tsx',
+  )
+
+  it('POSITIVE CONTROL: the scan is reading the real panel', () => {
+    // A read that silently returned '' would satisfy no assertion below by
+    // testing nothing. Anchor on something the panel indisputably contains.
+    expect(panelSource.length).toBeGreaterThan(10_000)
+    expect(panelSource).toContain('GoalPanel')
+    expect(panelSource).toContain('add-constraint-button')
+  })
+
+  it('CONTRAST CONTROL: the scan discriminates — it does not report a symbol the panel lacks', () => {
+    expect(panelSource).not.toContain('GoalConstraintProvenanceThatDoesNotExist')
+  })
+
+  it('the panel RENDERS the provenance component, fed from the persisted field', () => {
+    // `<GoalConstraintProvenance` — the JSX form. A bare import would not match,
+    // so an unmounted-but-imported component still reds this.
+    expect(panelSource).toContain('<GoalConstraintProvenance')
+    expect(panelSource).toContain('sourceQuote={c.source_quote}')
+  })
+
+  it('the testid the panel will emit is the one this spec asserts on', () => {
+    // Derived from the component's own exported builder, so the spec cannot
+    // drift from the surface about what it is looking for (trap 12).
+    expect(GOAL_CONSTRAINT_PROVENANCE_TESTID(CONSTRAINT_ID)).toBe(
+      `goal-constraint-${CONSTRAINT_ID}-source-quote`,
+    )
+  })
+})

--- a/src/canvas/ui/inspector-v2/__tests__/GoalPanel.sourceQuoteProvenance.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/GoalPanel.sourceQuoteProvenance.spec.tsx
@@ -132,10 +132,21 @@ describe('B4 / N-20 · the Goal panel MOUNTS the provenance line', () => {
   })
 
   it('the panel RENDERS the provenance component, fed from the persisted field', () => {
-    // `<GoalConstraintProvenance` — the JSX form. A bare import would not match,
-    // so an unmounted-but-imported component still reds this.
-    expect(panelSource).toContain('<GoalConstraintProvenance')
+    /*
+     * ⚠ A WORD BOUNDARY, NOT A SUBSTRING — this assertion was
+     * `toContain('<GoalConstraintProvenance')` and a mutant that renamed the
+     * element to `<GoalConstraintProvenanceUNMOUNTED` SURVIVED it, because the
+     * original name is still a substring of the renamed one. A `toContain` on a
+     * component name cannot tell a mount from a lookalike that renders nothing.
+     */
+    expect(panelSource).toMatch(/<GoalConstraintProvenance[\s/>]/)
     expect(panelSource).toContain('sourceQuote={c.source_quote}')
+  })
+
+  it('CONTRAST CONTROL: the boundary matcher REJECTS a renamed lookalike', () => {
+    // Proves the fix above is discriminating rather than merely different.
+    expect('<GoalConstraintProvenanceUNMOUNTED\n').not.toMatch(/<GoalConstraintProvenance[\s/>]/)
+    expect('<GoalConstraintProvenance\n').toMatch(/<GoalConstraintProvenance[\s/>]/)
   })
 
   it('the testid the panel will emit is the one this spec asserts on', () => {

--- a/src/canvas/ui/inspector-v2/__tests__/inspectorNoRawIds.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/inspectorNoRawIds.spec.tsx
@@ -1,0 +1,229 @@
+/**
+ * B4 — NO RAW IDENTIFIER REACHES THE USER FROM AN INSPECTOR PANEL.
+ *
+ * The defect, measured at `dd089a50`: fourteen call sites across nine panels
+ * resolved a missing element name to the element's **id**
+ * (`String(n.data?.label ?? n.id)`), unconditionally — not behind technical
+ * mode. The panel HEADER, three lines above, already resolved the same absent
+ * label to `'Untitled'` (`InspectorRouter.tsx:229`). So one unlabelled node was
+ * shown under two different names on one screen, and one of them was a database
+ * key the user cannot act on.
+ *
+ * TWO ASSERTIONS, DELIBERATELY OF DIFFERENT KINDS, because neither alone is
+ * enough:
+ *
+ *   1. A RENDER assertion through the MOUNTED consumer (P2). It proves the
+ *      user-visible outcome on a real panel, and it is bound BY IDENTITY: the
+ *      unlabelled node's id is a unique string that appears nowhere else in the
+ *      fixture, so `queryByText(THAT id)` cannot be satisfied by another
+ *      element (trap 19). It covers exactly one panel.
+ *
+ *   2. A SOURCE SCAN, derived by walking the panel directory, which covers all
+ *      of them and keeps covering a panel added tomorrow. A render test per
+ *      panel would be a hand-maintained mirror of the panel list (trap 12) and
+ *      would go quietly short the moment someone adds the tenth panel.
+ *
+ * The scan carries a POSITIVE control (it detects the real defect form) and a
+ * CONTRAST control (it does NOT flag the sanctioned quoted fallback) — an
+ * absence assertion whose matcher is broken reports a clean sweep by testing
+ * nothing (trap 13).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, dirname, basename } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { stripComments } from '../../../../../tests/helpers/stripSourceComments'
+import { resolveElementLabel, UNNAMED_ELEMENT_LABEL } from '../../../domain/elementLabel'
+
+// ── The mounted-consumer assertion ───────────────────────────────────────────
+
+/**
+ * A string that could only ever be an id. It is deliberately unlike any label
+ * in the fixture, so an assertion naming it is bound to THIS element and cannot
+ * pass because some other node happens to share a value (trap 19).
+ */
+const UNLABELLED_NODE_ID = 'fac_7c21e0_unlabelled_probe'
+const SUBJECT_ID = 'node_subject'
+
+const graph: { nodes: unknown[]; edges: unknown[] } = { nodes: [], edges: [] }
+
+function state() {
+  return {
+    nodes: graph.nodes,
+    edges: graph.edges,
+    updateNode: vi.fn(),
+    updateEdge: vi.fn(),
+    nodeRationales: {},
+  }
+}
+
+vi.mock('../../../store', () => ({
+  useCanvasStore: Object.assign(
+    vi.fn((selector: (s: unknown) => unknown) => selector(state())),
+    { getState: state },
+  ),
+}))
+
+import { GenericNodePanel } from '../panels/GenericNodePanel'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  graph.nodes = [
+    { id: SUBJECT_ID, type: 'action', position: { x: 0, y: 0 }, data: { label: 'Run the pilot' } },
+    // The element under test: present in the graph, connected, and NAMELESS.
+    { id: UNLABELLED_NODE_ID, type: 'factor', position: { x: 0, y: 0 }, data: {} },
+  ]
+  graph.edges = [{ id: 'e1', source: UNLABELLED_NODE_ID, target: SUBJECT_ID, data: {} }]
+})
+
+describe('B4 · an inspector panel never shows the user a raw element id', () => {
+  it('renders the honest no-name fallback for a connected element that has no label', () => {
+    render(<GenericNodePanel nodeId={SUBJECT_ID} techMode={false} onClose={vi.fn()} onNavigate={vi.fn()} />)
+
+    const panel = screen.getByTestId('inspector-generic-panel')
+    expect(within(panel).getByText(UNNAMED_ELEMENT_LABEL)).toBeInTheDocument()
+  })
+
+  it('does NOT print that element’s id anywhere in the panel', () => {
+    render(<GenericNodePanel nodeId={SUBJECT_ID} techMode={false} onClose={vi.fn()} onNavigate={vi.fn()} />)
+
+    const panel = screen.getByTestId('inspector-generic-panel')
+    // Bound by identity: this exact id, which belongs to exactly one element.
+    expect(within(panel).queryByText(UNLABELLED_NODE_ID)).toBeNull()
+    expect(panel.textContent).not.toContain(UNLABELLED_NODE_ID)
+  })
+
+  it('CONTRAST: a named element still shows its own name, not the fallback', () => {
+    graph.nodes = [
+      { id: SUBJECT_ID, type: 'action', position: { x: 0, y: 0 }, data: { label: 'Run the pilot' } },
+      { id: UNLABELLED_NODE_ID, type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Budget headroom' } },
+    ]
+    render(<GenericNodePanel nodeId={SUBJECT_ID} techMode={false} onClose={vi.fn()} onNavigate={vi.fn()} />)
+
+    const panel = screen.getByTestId('inspector-generic-panel')
+    expect(within(panel).getByText('Budget headroom')).toBeInTheDocument()
+    // Proves the first two assertions are discriminating rather than always-true:
+    // the fallback must be ABSENT when a real name exists.
+    expect(within(panel).queryByText(UNNAMED_ELEMENT_LABEL)).toBeNull()
+  })
+})
+
+// ── The resolver itself ──────────────────────────────────────────────────────
+
+describe('B4 · resolveElementLabel states absence, it never invents a name', () => {
+  it('returns the label when one is stated', () => {
+    expect(resolveElementLabel({ label: 'Budget headroom' })).toBe('Budget headroom')
+  })
+
+  it('returns the no-name fallback when the label is absent, empty or blank', () => {
+    expect(resolveElementLabel({})).toBe(UNNAMED_ELEMENT_LABEL)
+    expect(resolveElementLabel({ label: '' })).toBe(UNNAMED_ELEMENT_LABEL)
+    // Whitespace-only is indistinguishable from no label ON SCREEN; treating it
+    // as present renders a nameless row with no fallback at all.
+    expect(resolveElementLabel({ label: '   ' })).toBe(UNNAMED_ELEMENT_LABEL)
+    expect(resolveElementLabel(undefined)).toBe(UNNAMED_ELEMENT_LABEL)
+    expect(resolveElementLabel(null)).toBe(UNNAMED_ELEMENT_LABEL)
+  })
+
+  it('never returns an id: it is not given one', () => {
+    // The signature takes the DATA BAG, so there is no id in scope to leak.
+    // This is the structural half of the guarantee — the scan below is the
+    // behavioural half.
+    expect(resolveElementLabel({ id: UNLABELLED_NODE_ID })).toBe(UNNAMED_ELEMENT_LABEL)
+  })
+})
+
+// ── The source scan, derived by walking the directory ────────────────────────
+
+/**
+ * The defect form: a label read whose fallback is an EXPRESSION rather than a
+ * quoted string. `?? n.id`, `?? e.source`, `?? otherId` all match; the
+ * sanctioned `?? 'Untitled'` and `?? ''` do not.
+ *
+ * Matching the FALLBACK SHAPE rather than a list of id variable names is
+ * deliberate: a scan keyed on `\.id\b` would miss `?? otherId` and `?? e.source`,
+ * which are two of the real call sites.
+ *
+ * ⚠ THIS MATCHER WAS WRONG ON ITS FIRST WRITING AND THE CONTRAST CONTROL BELOW
+ * IS THE ONLY REASON IT DID NOT SHIP. It was `\?\?\s*(?!['"`])` — a negative
+ * lookahead after a greedy-but-optional `\s*`. The regex simply backtracks
+ * `\s*` to zero width and evaluates the lookahead against the SPACE, which is
+ * not a quote, so the sanctioned `?? 'Untitled'` matched too: the guard flagged
+ * all 36 sites including the five already correct. Consuming a CONCRETE
+ * non-quote, non-space character cannot backtrack into that. The general
+ * lesson: `\s*` followed by a negative lookahead asserts nothing, because the
+ * quantifier can always yield the position the lookahead wants.
+ */
+const ID_FALLBACK_LABEL = /\.data\?\.label\s*\?\?\s*[^\s'"`]/g
+
+function idFallbacksIn(src: string, file: string): number {
+  return [...stripComments(src, file).matchAll(ID_FALLBACK_LABEL)].length
+}
+
+const INSPECTOR_DIR = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+function sourceFilesIn(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      if (entry.name !== '__tests__') out.push(...sourceFilesIn(full))
+      continue
+    }
+    if (!/\.tsx?$/.test(entry.name)) continue
+    if (/\.(spec|test|stories)\.tsx?$/.test(entry.name)) continue
+    out.push(full)
+  }
+  return out
+}
+
+describe('B4 · no inspector-v2 source falls back to an id for a display label', () => {
+  const files = sourceFilesIn(INSPECTOR_DIR)
+
+  it('POSITIVE CONTROL: the sweep reaches the panels it claims to cover', () => {
+    // A magnitude check, not a bare non-zero: a walker returning three files
+    // would also "find nothing" below, and that clean result would be an
+    // instrument failure rather than a fact.
+    const names = files.map(f => basename(f))
+    expect(files.length).toBeGreaterThan(40)
+    for (const required of [
+      'GoalPanel.tsx', 'OptionPanel.tsx', 'DecisionPanel.tsx', 'EdgePanel.tsx',
+      'OutcomePanel.tsx', 'RiskPanel.tsx', 'GenericNodePanel.tsx',
+      'FactorControllablePanel.tsx', 'FactorObservablePanel.tsx', 'FactorExternalPanel.tsx',
+      'InspectorRouter.tsx',
+    ]) {
+      expect(names).toContain(required)
+    }
+  })
+
+  it('POSITIVE CONTROL: the matcher detects the real defect form, through the same pipeline', () => {
+    expect(idFallbacksIn('const l = String(n.data?.label ?? n.id)', 'x.tsx')).toBe(1)
+    expect(idFallbacksIn('label: String(other.data?.label ?? otherId),', 'x.tsx')).toBe(1)
+    expect(idFallbacksIn('label: String(src?.data?.label ?? e.source),', 'x.tsx')).toBe(1)
+  })
+
+  it('CONTRAST CONTROL: the matcher does NOT flag a sanctioned quoted fallback', () => {
+    // Without this, a matcher that flagged everything would pass the claim
+    // below by making it unsatisfiable, and a matcher that flagged nothing
+    // would pass it by testing nothing. Both are excluded only by having the
+    // two controls point in opposite directions.
+    expect(idFallbacksIn("const l = String(n.data?.label ?? 'Untitled')", 'x.tsx')).toBe(0)
+    expect(idFallbacksIn("labelContext={{ label: String(node.data?.label ?? '') }}", 'x.tsx')).toBe(0)
+  })
+
+  it('CONTRAST CONTROL: the defect form inside a COMMENT is not counted', () => {
+    expect(idFallbacksIn('// String(n.data?.label ?? n.id)\nconst x = 1', 'x.tsx')).toBe(0)
+  })
+
+  it('no panel, editor or shared component resolves a label to an id', () => {
+    const offenders: string[] = []
+    for (const file of files) {
+      const n = idFallbacksIn(readFileSync(file, 'utf8'), file)
+      if (n > 0) offenders.push(`${basename(file)}: ${n}`)
+    }
+    expect(offenders).toEqual([])
+  })
+})

--- a/src/canvas/ui/inspector-v2/editors/OptionAdvancedEditor.tsx
+++ b/src/canvas/ui/inspector-v2/editors/OptionAdvancedEditor.tsx
@@ -57,7 +57,7 @@ export function OptionAdvancedEditor({ nodeId }: OptionAdvancedEditorProps) {
           <div className="space-y-2">
             {rows.map(row => (
               <div key={row.factorId} className="space-y-0.5">
-                <div className={`${typography.panelMeta} text-text-body font-medium truncate`}>
+                <div className={`${typography.panelMeta} text-text-body truncate`}>
                   {row.label}
                 </div>
                 <AdvancedField

--- a/src/canvas/ui/inspector-v2/panels/DecisionPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/DecisionPanel.tsx
@@ -29,6 +29,7 @@ import { COACHING } from '../coachingConfig'
 import { DecisionAdvancedEditor } from '../editors/DecisionAdvancedEditor'
 import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 import type { EdgeValueDisplay } from '../../../domain/edgeValueProvenance'
+import { resolveElementLabel } from '../../../domain/elementLabel'
 
 export const DecisionPanel = memo(function DecisionPanel({
   nodeId,
@@ -90,7 +91,7 @@ export const DecisionPanel = memo(function DecisionPanel({
         // here, but the type should not lie about the value shape.
         const ivs = (optNode.data as Record<string, unknown>)?.interventions as Record<string, unknown> | undefined
         const ivCount = ivs ? Object.keys(ivs).length : 0
-        const label = String(optNode.data?.label ?? otherId)
+        const label = resolveElementLabel(optNode.data)
         // Explicit `is_baseline` wins; regex fallback only fires when the flag is
         // absent — mirrors OptionNode.tsx / OptionPanel.tsx.
         const explicitIsBaseline = (optNode.data as { is_baseline?: boolean | null })?.is_baseline
@@ -125,7 +126,7 @@ export const DecisionPanel = memo(function DecisionPanel({
           edgeId: e.id,
           nodeId: otherId,
           nodeKind: kind,
-          label: String(otherNode.data?.label ?? otherId),
+          label: resolveElementLabel(otherNode.data),
           strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
@@ -193,15 +194,15 @@ export const DecisionPanel = memo(function DecisionPanel({
               <div className="flex justify-between items-center">
                 <div className="flex items-center gap-1.5">
                   <NodeShapeIndicator nodeKind="option" size={14} />
-                  <span className={`${typography.panelBody} font-medium`}>{opt.label}</span>
+                  <span className={`${typography.panelBody}`}>{opt.label}</span>
                   {opt.isBaseline && (
-                    <span className={`${typography.panelMeta} font-medium px-2 py-0.5 rounded-full bg-transparent text-text-body border border-factor/30`}>
+                    <span className={`${typography.panelMeta} px-2 py-0.5 rounded-full bg-transparent text-text-body border border-factor/30`}>
                       Baseline
                     </span>
                   )}
                 </div>
                 {isResultsMode && opt.winProb != null && (
-                  <span className={`${typography.panelMeta} font-medium text-text-body tabular-nums`}>
+                  <span className={`${typography.panelMeta} text-text-body tabular-nums`}>
                     {formatWinProbability(opt.winProb)}
                   </span>
                 )}

--- a/src/canvas/ui/inspector-v2/panels/EdgePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/EdgePanel.tsx
@@ -46,6 +46,7 @@ import { useEditImpactPreview } from '../../../hooks/useEditImpactPreview'
 import { StrengthBandButtons } from '../shared/StrengthBandButtons'
 import { EdgeAdvancedEditor } from '../editors/EdgeAdvancedEditor'
 import { EdgeReviewDisagreement } from '../shared/EdgeReviewDisagreement'
+import { resolveElementLabel } from '../../../domain/elementLabel'
 
 // ─── Slider component for confidence and uncertainty ───────────────
 function InspectorSlider({
@@ -165,8 +166,12 @@ export const EdgePanel = memo(function EdgePanel({
   // Source/target nodes
   const sourceNode = useMemo(() => nodes.find(n => n.id === edge?.source), [nodes, edge?.source])
   const targetNode = useMemo(() => nodes.find(n => n.id === edge?.target), [nodes, edge?.target])
-  const sourceLabel = String(sourceNode?.data?.label ?? edge?.source ?? '')
-  const targetLabel = String(targetNode?.data?.label ?? edge?.target ?? '')
+  // The id tail (`?? edge?.source`) is gone: an endpoint with no name now reads
+  // as the honest no-name fallback rather than as a graph key. These two feed
+  // the shell title, the intervention notice sentence and the coaching label
+  // context, so the id was reaching the user in three places at once.
+  const sourceLabel = resolveElementLabel(sourceNode?.data)
+  const targetLabel = resolveElementLabel(targetNode?.data)
   const sourceKind = (sourceNode?.type || sourceNode?.data?.kind || 'factor') as NodeType
   const targetKind = (targetNode?.type || targetNode?.data?.kind || 'factor') as NodeType
 
@@ -311,7 +316,7 @@ export const EdgePanel = memo(function EdgePanel({
             <PanelGroup kind="context" label={GROUP_LABELS.context}>
               <StaleGuardBanner hasResults={isResultsMode}>
                 <div className="bg-panel border border-danger/30 p-2.5 rounded-lg">
-                  <div className={`${typography.panelBody} font-medium text-danger flex items-center gap-1`}>
+                  <div className={`${typography.panelBody} text-danger flex items-center gap-1`}>
                     <AlertTriangle size={13} className="text-danger" />
                     {INLINE_LABELS.sensitiveAssumption}
                   </div>

--- a/src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx
@@ -55,6 +55,7 @@ import {
 import { useParticipantName } from '../../../../collab/useParticipantName'
 import { useCitedEvidence } from '../../../../collab/citedEvidenceCache'
 import { CitedEvidenceNote } from '../../../../collab/CitedEvidenceNote'
+import { resolveElementLabel } from '../../../domain/elementLabel'
 
 /**
  * Extract a non-empty string intervention value, accepting either a bare
@@ -348,7 +349,7 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
           interventionValue == null ? extractStringIntervention(raw) : null
         return {
           nodeId: e.source,
-          label: String(src?.data?.label ?? e.source),
+          label: resolveElementLabel(src?.data),
           interventionValue,
           interventionDisplayValue,
           interventionStringValue,
@@ -375,7 +376,7 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
           edgeId: e.id,
           nodeId: e.target,
           nodeKind: kind,
-          label: String(tgt?.data?.label ?? e.target),
+          label: resolveElementLabel(tgt?.data),
           strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
@@ -421,11 +422,11 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
         {/* Provenance pills: factor type identity + extraction source */}
         <div className="mt-2 flex gap-1.5 flex-wrap">
           {node.data?.factorType && (
-            <span className={`${typography.panelMeta} font-medium inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-factor/30`}>
+            <span className={`${typography.panelMeta} inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-factor/30`}>
               {String(node.data.factorType)}
             </span>
           )}
-          <span className={`${typography.panelMeta} font-medium inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-success/30`}>
+          <span className={`${typography.panelMeta} inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-success/30`}>
             {getExtractionLabel(source, attributedTo)}
           </span>
         </div>
@@ -560,7 +561,7 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
               {uncertaintyDrivers.map((d, i) => (
                 <span
                   key={i}
-                  className={`${typography.panelMeta} font-medium inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body`}
+                  className={`${typography.panelMeta} inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body`}
                   style={{ border: '1px solid var(--warning)4D' }}
                 >
                   {d}
@@ -609,7 +610,7 @@ export const FactorControllablePanel = memo(function FactorControllablePanel({
                   nodeKind="option"
                   label={o.label}
                   badge={badgeContent != null ? (
-                    <span className={`${typography.panelMeta} font-medium inline-flex items-center px-2 py-0.5 rounded-full bg-transparent text-text-body border border-option/30`}>
+                    <span className={`${typography.panelMeta} inline-flex items-center px-2 py-0.5 rounded-full bg-transparent text-text-body border border-option/30`}>
                       {badgeContent}
                     </span>
                   ) : undefined}

--- a/src/canvas/ui/inspector-v2/panels/FactorExternalPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorExternalPanel.tsx
@@ -35,6 +35,7 @@ import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProve
 import { useParticipantName } from '../../../../collab/useParticipantName'
 import { useCitedEvidence } from '../../../../collab/citedEvidenceCache'
 import { CitedEvidenceNote } from '../../../../collab/CitedEvidenceNote'
+import { resolveElementLabel } from '../../../domain/elementLabel'
 
 // Quick-set presets
 const QUICK_SET = {
@@ -143,7 +144,7 @@ export const FactorExternalPanel = memo(function FactorExternalPanel({
           edgeId: e.id,
           nodeId: e.target,
           nodeKind: kind,
-          label: String(tgt?.data?.label ?? e.target),
+          label: resolveElementLabel(tgt?.data),
           strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
@@ -189,10 +190,10 @@ export const FactorExternalPanel = memo(function FactorExternalPanel({
 
         {/* Provenance pills: category identity + data source */}
         <div className="mt-2 flex gap-1.5 flex-wrap">
-          <span className={`${typography.panelMeta} font-medium inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-factor/30`}>
+          <span className={`${typography.panelMeta} inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-factor/30`}>
             Outside your control
           </span>
-          <span className={`${typography.panelMeta} font-medium inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-success/30`}>
+          <span className={`${typography.panelMeta} inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-success/30`}>
             {getExtractionLabel(source, attributedTo)}
           </span>
         </div>
@@ -255,7 +256,7 @@ export const FactorExternalPanel = memo(function FactorExternalPanel({
                 onClick={() => handleQuickSet(key)}
                 className={`${typography.panelMeta} px-2.5 py-1 rounded-full cursor-pointer capitalize transition-colors ${
                   selected === key
-                    ? 'border border-primary text-primary font-semibold bg-panel'
+                    ? 'border border-primary text-primary bg-panel'
                     : 'border border-panel-border text-text-light bg-panel hover:bg-panel-hover'
                 }`}
               >

--- a/src/canvas/ui/inspector-v2/panels/FactorObservablePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorObservablePanel.tsx
@@ -41,6 +41,7 @@ import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProve
 import { useParticipantName } from '../../../../collab/useParticipantName'
 import { useCitedEvidence } from '../../../../collab/citedEvidenceCache'
 import { CitedEvidenceNote } from '../../../../collab/CitedEvidenceNote'
+import { resolveElementLabel } from '../../../domain/elementLabel'
 
 export const FactorObservablePanel = memo(function FactorObservablePanel({
   nodeId,
@@ -118,7 +119,7 @@ export const FactorObservablePanel = memo(function FactorObservablePanel({
           edgeId: e.id,
           nodeId: e.target,
           nodeKind: kind,
-          label: String(tgt?.data?.label ?? e.target),
+          label: resolveElementLabel(tgt?.data),
           strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
@@ -163,11 +164,11 @@ export const FactorObservablePanel = memo(function FactorObservablePanel({
 
         {/* Provenance pills: category identity + data source */}
         <div className="mt-2 flex gap-1.5 flex-wrap">
-          <span className={`${typography.panelMeta} font-medium inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-factor/30`}>
+          <span className={`${typography.panelMeta} inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-factor/30`}>
             You measure this
           </span>
           {source && (
-            <span className={`${typography.panelMeta} font-medium inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-success/30`}>
+            <span className={`${typography.panelMeta} inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-success/30`}>
               {getExtractionLabel(source, attributedTo)}
             </span>
           )}

--- a/src/canvas/ui/inspector-v2/panels/GenericNodePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/GenericNodePanel.tsx
@@ -27,6 +27,7 @@ import { TechnicalDisclosure } from '../shared/TechnicalDisclosure'
 import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 import type { EdgeValueDisplay } from '../../../domain/edgeValueProvenance'
 import type { InspectorPanelProps } from '../types'
+import { resolveElementLabel } from '../../../domain/elementLabel'
 
 export const GenericNodePanel = memo(function GenericNodePanel({
   nodeId,
@@ -52,7 +53,7 @@ export const GenericNodePanel = memo(function GenericNodePanel({
           edgeId: e.id,
           nodeId: otherId,
           nodeKind: (other.type || other.data?.kind || 'factor') as NodeType,
-          label: String(other.data?.label ?? otherId),
+          label: resolveElementLabel(other.data),
           strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })

--- a/src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/GoalPanel.tsx
@@ -44,6 +44,8 @@ import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProve
 import { GOAL_ANCHOR_COPY } from '../../../../components/results/utils/goalAnchorCopy'
 import { basisWithholdsPossessive } from '../../../../components/results/utils/selectGoalProbability'
 import { formatGoalTarget } from '../../../../components/results/utils/formatGoalTarget'
+import { resolveElementLabel } from '../../../domain/elementLabel'
+import { GoalConstraintProvenance } from '../shared/GoalConstraintProvenance'
 
 export const GoalPanel = memo(function GoalPanel({
   nodeId,
@@ -211,7 +213,7 @@ export const GoalPanel = memo(function GoalPanel({
   const factorNodes = useMemo(() =>
     nodes.filter(n => n.type === 'factor').map(n => ({
       id: n.id,
-      label: String(n.data?.label ?? n.id),
+      label: resolveElementLabel(n.data),
     })),
   [nodes])
 
@@ -291,7 +293,7 @@ export const GoalPanel = memo(function GoalPanel({
           edgeId: e.id,
           nodeId: e.source,
           nodeKind: kind,
-          label: String(sourceNode?.data?.label ?? e.source),
+          label: resolveElementLabel(sourceNode?.data),
           strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
@@ -404,6 +406,13 @@ export const GoalPanel = memo(function GoalPanel({
                           }`}>{Math.round(prob * 100)}%</span>
                         )}
                       </div>
+                      {/* N-20 — the user's own words, under the constraint they
+                          produced. Renders nothing for an Olumi-inferred
+                          constraint, which carries no `source_quote`. */}
+                      <GoalConstraintProvenance
+                        constraintId={String(c.constraint_id ?? c.id ?? i)}
+                        sourceQuote={c.source_quote}
+                      />
                       {prob !== null && (
                         <div className="mt-1">
                           <DataBar
@@ -568,7 +577,7 @@ export const GoalPanel = memo(function GoalPanel({
                 <button
                   type="button"
                   onClick={handleAddConstraint}
-                  className={`${typography.panelMeta} bg-primary text-text-on-color rounded-lg px-3 py-1 font-medium`}
+                  className={`${typography.panelMeta} bg-primary text-text-on-color rounded-lg px-3 py-1`}
                   data-testid="confirm-add-constraint"
                 >
                   {GOAL_CONSTRAINT_COPY.addButton}

--- a/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
@@ -36,6 +36,7 @@ import { ResultsLink } from '../shared/ResultsLink'
 import { deriveDecisionVerdict, type DecisionVerdictReportLike } from '../../../../lib/decisionVerdict'
 import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
 import type { EdgeValueDisplay } from '../../../domain/edgeValueProvenance'
+import { resolveElementLabel, resolveFirstStatedLabel } from '../../../domain/elementLabel'
 
 export const OptionPanel = memo(function OptionPanel({
   nodeId,
@@ -125,7 +126,7 @@ export const OptionPanel = memo(function OptionPanel({
       // the intervention value above — generic numeric defense.
       return [{
         factorId,
-        factorLabel: String(factorNode?.data?.label ?? factorId),
+        factorLabel: resolveElementLabel(factorNode?.data),
         baseline: unwrapInterventionValue(obs?.value).value ?? undefined,
         rawBaseline: unwrapInterventionValue(obs?.raw_value).value ?? undefined,
         unit: obs?.unit as string | undefined,
@@ -157,7 +158,7 @@ export const OptionPanel = memo(function OptionPanel({
           edgeId: e.id,
           nodeId: e.target,
           nodeKind: kind,
-          label: String(tgt.data?.label ?? e.target),
+          label: resolveElementLabel(tgt.data),
           strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
@@ -179,7 +180,7 @@ export const OptionPanel = memo(function OptionPanel({
         const valueDisplay = formatFactorValue(obs as Parameters<typeof formatFactorValue>[0])
         return {
           id: n.id,
-          label: String(n.data?.label ?? n.id),
+          label: resolveElementLabel(n.data),
           valueDisplay,
           // Defensive unwrap: see the interventions memo above. baseline flows
           // into mutations.setIntervention as the initial intervention value
@@ -200,7 +201,11 @@ export const OptionPanel = memo(function OptionPanel({
     if (!optionComparison || !Array.isArray(optionComparison)) return []
     return (optionComparison as Array<{ option_id: string; win_probability?: number; label?: string }>).map(o => ({
       id: o.option_id,
-      label: String(nodes.find(n => n.id === o.option_id)?.data?.label ?? o.label ?? o.option_id),
+      // Two legitimate name sources, then honest absence — never the id. The
+      // graph node's own label wins; the analysis payload's `label` is the
+      // fallback for an option the graph no longer holds; `o.option_id` is NOT
+      // a third source, it is a database key and has been dropped.
+      label: resolveFirstStatedLabel(nodes.find(n => n.id === o.option_id)?.data, { label: o.label }),
       // winPct: integer percent used for bar width + close-call gap arithmetic.
       // winLabel: user-facing string; routes through formatWinProbability so a
       // non-zero probability that rounds to 0 renders as "< 1%" rather than "0%".
@@ -229,7 +234,7 @@ export const OptionPanel = memo(function OptionPanel({
       <PanelGroup kind="context" label={GROUP_LABELS.context}>
         {isBaselineOption && (
           <div className="mb-2" data-testid="option-baseline-badge">
-            <span className={`${typography.panelMeta} font-medium inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-panel-border`}>
+            <span className={`${typography.panelMeta} inline-flex items-center px-2.5 py-0.5 rounded-full bg-transparent text-text-body border border-panel-border`}>
               Baseline option
             </span>
           </div>
@@ -246,7 +251,7 @@ export const OptionPanel = memo(function OptionPanel({
           >
             <Sparkles size={12} className="text-info mt-0.5 shrink-0" aria-hidden="true" />
             <p className={`${typography.panelMeta} text-text-light`}>
-              <span className="font-medium text-text-body">
+              <span className="text-text-body">
                 {OPTION_STRINGS.draftingNoteAttribution}
               </span>
               {' — '}
@@ -480,7 +485,7 @@ export const OptionPanel = memo(function OptionPanel({
                   {allOptions.map(o => (
                     <div key={o.id} className="flex items-center gap-2 py-0.5">
                       <span
-                        className={`${typography.panelMeta} w-[110px] truncate ${o.isCurrent ? 'font-semibold' : ''} text-text-light`}
+                        className={`${typography.panelMeta} w-[110px] truncate text-text-light`}
                       >
                         {o.label}
                       </span>
@@ -493,7 +498,7 @@ export const OptionPanel = memo(function OptionPanel({
                           }}
                         />
                       </div>
-                      <span className={`${typography.panelMeta} w-7 text-right ${o.isCurrent ? 'font-semibold' : ''} text-text-light`}>
+                      <span className={`${typography.panelMeta} w-7 text-right text-text-light`}>
                         {o.winLabel ?? '—'}
                       </span>
                     </div>

--- a/src/canvas/ui/inspector-v2/panels/OutcomePanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/OutcomePanel.tsx
@@ -29,6 +29,7 @@ import type { InspectorPanelProps } from '../types'
 import { COACHING } from '../coachingConfig'
 import { OutcomeAdvancedEditor } from '../editors/OutcomeAdvancedEditor'
 import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
+import { resolveElementLabel } from '../../../domain/elementLabel'
 
 // ─── Option comparison helpers ─────────────────────────────────────
 
@@ -102,7 +103,7 @@ function OptionComparisonSection({
                 {opt.option_label ?? opt.option_id}
               </span>
               {opt.win_probability != null && (
-                <span className={`${typography.panelMeta} shrink-0 text-option font-medium`}>
+                <span className={`${typography.panelMeta} shrink-0 text-option`}>
                   {Math.round(opt.win_probability * 100)}% win
                 </span>
               )}
@@ -182,7 +183,7 @@ export const OutcomePanel = memo(function OutcomePanel({
           edgeId: e.id,
           nodeId: e.source,
           nodeKind: kind,
-          label: String(src?.data?.label ?? e.source),
+          label: resolveElementLabel(src?.data),
           strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
@@ -205,13 +206,13 @@ export const OutcomePanel = memo(function OutcomePanel({
         {goalContribution != null && (
           <div className="mt-2 px-3 py-2 bg-panel border border-success/30 rounded-lg">
             <div className="flex items-center gap-2">
-              <span className={`${typography.panelMeta} font-medium text-text-body`}>
+              <span className={`${typography.panelMeta} text-text-body`}>
                 {INLINE_LABELS.contributesToGoal}
               </span>
               <div className="flex-1 h-1.5 bg-panel-border rounded-full overflow-hidden">
                 <div className="h-full bg-success rounded-full" style={{ width: `${Math.min(goalContribution, 100)}%` }} />
               </div>
-              <span className={`${typography.panelMeta} font-medium text-text-body`}>{goalContribution}%</span>
+              <span className={`${typography.panelMeta} text-text-body`}>{goalContribution}%</span>
             </div>
             {!isResultsMode && (
               <p className={`${typography.panelMeta} text-text-light mt-1`}>{INLINE_LABELS.basedOnModelStructure}</p>

--- a/src/canvas/ui/inspector-v2/panels/RiskPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/RiskPanel.tsx
@@ -40,6 +40,7 @@ import type { InspectorPanelProps } from '../types'
 import { COACHING } from '../coachingConfig'
 import { RiskAdvancedEditor } from '../editors/RiskAdvancedEditor'
 import { resolveEdgeSignedStrengthDisplay } from '../../../domain/edgeValueProvenance'
+import { resolveElementLabel } from '../../../domain/elementLabel'
 
 /** Impact enum options, ordered low → critical. Labels are the capitalised enum. */
 const IMPACT_OPTIONS: { value: RiskImpact; label: string }[] = [
@@ -93,7 +94,7 @@ export const RiskPanel = memo(function RiskPanel({
           edgeId: e.id,
           nodeId: e.source,
           nodeKind: kind,
-          label: String(src?.data?.label ?? e.source),
+          label: resolveElementLabel(src?.data),
           strength: resolveEdgeSignedStrengthDisplay(e.data as Record<string, unknown> | undefined),
         }
       })
@@ -150,7 +151,7 @@ export const RiskPanel = memo(function RiskPanel({
                     aria-checked={active}
                     data-testid={`risk-impact-${opt.value}`}
                     onClick={() => handleImpactSelect(opt.value)}
-                    className={`${typography.panelMeta} font-medium inline-flex items-center px-2.5 py-1 rounded-full border transition-colors cursor-pointer ${
+                    className={`${typography.panelMeta} inline-flex items-center px-2.5 py-1 rounded-full border transition-colors cursor-pointer ${
                       active
                         ? 'border-primary bg-panel-hover text-text-body'
                         : 'border-panel-border bg-transparent text-text-light hover:bg-panel-hover'

--- a/src/canvas/ui/inspector-v2/shared/AdvancedFieldGroup.tsx
+++ b/src/canvas/ui/inspector-v2/shared/AdvancedFieldGroup.tsx
@@ -1,3 +1,4 @@
+import { typography } from '../../../../styles/typography'
 /**
  * AdvancedFieldGroup — section divider with label for technical detail editor.
  * Renders a card with a sentence-case label header + children.
@@ -11,7 +12,7 @@ interface AdvancedFieldGroupProps {
 export function AdvancedFieldGroup({ title, children }: AdvancedFieldGroupProps) {
   return (
     <div className="mb-2 first:mt-0 mt-2 bg-panel border border-panel-border rounded-lg p-3">
-      <div className="text-[10px] font-semibold text-text-light mb-2 pb-1.5 border-b border-panel-border">
+      <div className={`${typography.panelMeta} text-text-light mb-2 pb-1.5 border-b border-panel-border`}>
         {title}
       </div>
       <div className="space-y-2">

--- a/src/canvas/ui/inspector-v2/shared/ConfidenceBadge.tsx
+++ b/src/canvas/ui/inspector-v2/shared/ConfidenceBadge.tsx
@@ -26,7 +26,7 @@ export function ConfidenceBadge({ level, value }: ConfidenceBadgeProps) {
       className={`${typography.panelMeta} inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-transparent`}
       style={{ border: `1.5px ${cfg.borderStyle} ${cfg.borderColor}` }}
     >
-      <span className={`font-semibold ${cfg.colorClass}`}>{cfg.glyph}</span>
+      <span className={cfg.colorClass}>{cfg.glyph}</span>
       {value != null && (
         <span className="text-text-body">{value}%</span>
       )}

--- a/src/canvas/ui/inspector-v2/shared/EdgeReviewDisagreement.tsx
+++ b/src/canvas/ui/inspector-v2/shared/EdgeReviewDisagreement.tsx
@@ -68,7 +68,7 @@ export function EdgeReviewDisagreement({ validation, techMode }: EdgeReviewDisag
 
   return (
     <div className="bg-panel border border-warning/30 rounded-lg p-2.5">
-      <div className={`${typography.panelBody} font-medium text-warning flex items-center gap-1`}>
+      <div className={`${typography.panelBody} text-warning flex items-center gap-1`}>
         <AlertTriangle size={13} className="text-warning" />
         {EDGE_COPY.needsYourJudgement}
       </div>

--- a/src/canvas/ui/inspector-v2/shared/EditableLabel.tsx
+++ b/src/canvas/ui/inspector-v2/shared/EditableLabel.tsx
@@ -25,6 +25,8 @@
 
 import { useState, useCallback, useRef, useEffect, type KeyboardEvent } from 'react'
 import { Pencil } from 'lucide-react'
+
+import { typography } from '../../../../styles/typography'
 import { NODE_LABEL_MAX_LENGTH } from '../useInspectorMutations'
 
 /** Characters remaining at which the counter appears. */
@@ -178,7 +180,7 @@ export function EditableLabel({
       {remaining <= COUNTER_REVEAL_MARGIN && (
         <span
           data-testid="inspector-rename-counter"
-          className="block text-[11px] leading-snug text-text-light mt-0.5"
+          className={`${typography.panelMeta} block text-text-light mt-0.5`}
         >
           {draft.length}/{maxLength} characters
         </span>

--- a/src/canvas/ui/inspector-v2/shared/ExpertAnnotation.tsx
+++ b/src/canvas/ui/inspector-v2/shared/ExpertAnnotation.tsx
@@ -11,6 +11,7 @@
  */
 
 import type { ReactNode } from 'react'
+import { typography } from '../../../../styles/typography'
 
 interface ExpertAnnotationDisplayProps {
   techMode: boolean
@@ -41,7 +42,7 @@ export function ExpertAnnotation(props: ExpertAnnotationProps) {
       <div className="flex items-center gap-1 mt-1">
         {suffix && (
           <span
-            className="text-[10px] leading-none text-text-light font-mono"
+            className={`${typography.code} leading-none text-text-light`}
           >
             {suffix}
           </span>
@@ -58,7 +59,7 @@ export function ExpertAnnotation(props: ExpertAnnotationProps) {
             const v = Number(raw)
             if (Number.isFinite(v)) onChange(v)
           }}
-          className="text-[10px] leading-none font-mono text-right bg-panel border border-panel-border rounded px-1 py-0.5 w-16 text-text-body focus:outline-none focus:border-primary"
+          className={`${typography.code} leading-none text-right bg-panel border border-panel-border rounded px-1 py-0.5 w-16 text-text-body focus:outline-none focus:border-primary`}
         />
       </div>
     )
@@ -66,7 +67,7 @@ export function ExpertAnnotation(props: ExpertAnnotationProps) {
 
   return (
     <div
-      className="text-[10px] leading-none text-text-light font-mono mt-1"
+      className={`${typography.code} leading-none text-text-light mt-1`}
     >
       {props.children}
     </div>

--- a/src/canvas/ui/inspector-v2/shared/GoalConstraintProvenance.tsx
+++ b/src/canvas/ui/inspector-v2/shared/GoalConstraintProvenance.tsx
@@ -1,0 +1,79 @@
+/**
+ * GoalConstraintProvenance — "You said: …" under a goal constraint.
+ *
+ * ⚠ LEDGER N-20, AND THE PART OF IT THAT WAS TRUE. `source_quote` rides the
+ * wire, is copied onto the persisted `CEEGoalConstraint` by
+ * `applyV5State.ts:421`, and is part of `constraintsDeepEqual` — so it is
+ * AUTHORITATIVE PERSISTED STATE, not a transient echo, which is what entitles
+ * this surface to make a claim about what the user said (P5). It had zero
+ * render consumers, so the user could not see their own words anywhere. This is
+ * that consumer.
+ *
+ * (The ledger row also names `label_authored`. That symbol returns zero hits
+ * anywhere in `src/` at this tip — it is not a UI field here. Reported rather
+ * than invented.)
+ *
+ * ─── WHAT THIS COMPONENT IS ALLOWED TO SAY ──────────────────────────────────
+ *
+ * It prints the stored quote VERBATIM and attributes it to the user. It does
+ * not paraphrase, summarise, tidy or truncate: the value of "you said" is that
+ * it is checkable against the user's memory, and a cleaned-up quote is no
+ * longer evidence of anything.
+ *
+ * ⚠ AND WHAT IT MUST NOT. It renders NOTHING when no quote is stored. A
+ * constraint Olumi inferred carries no `source_quote`, and putting "You said …"
+ * over an inference would fabricate provenance — the most serious defect class
+ * in this estate, and worse here than an ordinary wrong value because it
+ * launders a machine guess as a human statement. The empty and whitespace-only
+ * cases are treated as absent for the same reason: `You said: ""` asserts that
+ * the user said something while showing that they said nothing.
+ *
+ * ─── WHY IT IS QUIET ────────────────────────────────────────────────────────
+ *
+ * "Provenance available without clutter": this is `panelMeta`, muted, one line,
+ * below the constraint it belongs to. It is not a badge, not a pill and not a
+ * disclosure the user has to open — a provenance you have to hunt for is a
+ * provenance nobody checks, and a provenance that shouts competes with the
+ * constraint itself.
+ */
+
+import { typography } from '../../../../styles/typography'
+
+/**
+ * The testid, DERIVED rather than retyped at each call site and each assertion.
+ * Exported so a spec cannot drift from the component about what it is looking
+ * for (trap 12).
+ */
+export const GOAL_CONSTRAINT_PROVENANCE_TESTID = (constraintId: string): string =>
+  `goal-constraint-${constraintId}-source-quote`
+
+export interface GoalConstraintProvenanceProps {
+  /** Identity of the constraint this quote belongs to — ID-addressed. */
+  constraintId: string
+  /**
+   * The persisted `source_quote`, passed through UNCHANGED from the store.
+   * `undefined` on any constraint nobody stated in words, which is the common
+   * case and must render nothing.
+   */
+  sourceQuote?: string
+}
+
+export function GoalConstraintProvenance({
+  constraintId,
+  sourceQuote,
+}: GoalConstraintProvenanceProps) {
+  if (typeof sourceQuote !== 'string' || sourceQuote.trim() === '') return null
+
+  return (
+    <p
+      data-testid={GOAL_CONSTRAINT_PROVENANCE_TESTID(constraintId)}
+      className={`${typography.panelMeta} text-text-light mt-1 italic`}
+    >
+      {/* The attribution and the quote are separate nodes so the quote itself
+          stays byte-for-byte what was stored — no interpolation into a
+          sentence that could later be reworded around it. */}
+      <span className="not-italic">You said: </span>
+      &ldquo;{sourceQuote}&rdquo;
+    </p>
+  )
+}

--- a/src/canvas/ui/inspector-v2/shared/ImportanceBar.tsx
+++ b/src/canvas/ui/inspector-v2/shared/ImportanceBar.tsx
@@ -47,7 +47,7 @@ export function ImportanceBar({ importanceScore, sensitivityRank }: ImportanceBa
       {/* Single row: rank | bar | percentage */}
       <div className="flex items-center gap-2">
         {rankLabel && (
-          <span className="text-base font-semibold text-primary flex-shrink-0">
+          <span className={`${typography.panelHeader} text-primary flex-shrink-0`}>
             {rankLabel}
           </span>
         )}
@@ -64,7 +64,7 @@ export function ImportanceBar({ importanceScore, sensitivityRank }: ImportanceBa
             style={{ width: `${pct}%` }}
           />
         </div>
-        <span className={`${typography.panelMeta} font-medium text-text-body flex-shrink-0`}>
+        <span className={`${typography.panelMeta} text-text-body flex-shrink-0`}>
           {Math.round(pct)}%
         </span>
       </div>

--- a/src/canvas/ui/inspector-v2/shared/InlineNumberEditor.tsx
+++ b/src/canvas/ui/inspector-v2/shared/InlineNumberEditor.tsx
@@ -98,7 +98,7 @@ export function InlineNumberEditor({
       >
         {readout != null
           ? readout
-          : <span className={`${typography.panelMeta} text-text-light italic font-normal text-sm`}>{placeholder}</span>
+          : <span className={`${typography.panelMeta} text-text-light italic`}>{placeholder}</span>
         }
       </button>
     )

--- a/src/canvas/ui/inspector-v2/shared/InterventionRow.tsx
+++ b/src/canvas/ui/inspector-v2/shared/InterventionRow.tsx
@@ -93,7 +93,7 @@ export function InterventionRow({
           <button
             type="button"
             onClick={onNavigate}
-            className={`${typography.panelBody} font-medium text-text-body hover:text-info transition-colors truncate ${onNavigate ? 'cursor-pointer hover:underline' : ''}`}
+            className={`${typography.panelBody} text-text-body hover:text-info transition-colors truncate ${onNavigate ? 'cursor-pointer hover:underline' : ''}`}
             disabled={!onNavigate}
           >
             {factorLabel}
@@ -134,7 +134,7 @@ export function InterventionRow({
             onBlur={handleBlur}
             onKeyDown={handleKeyDown}
             disabled={disabled}
-            className={`${typography.panelHeader} text-xs w-[110px] px-2 py-1 border rounded-lg text-center bg-panel ${
+            className={`${typography.panelBody} w-[110px] px-2 py-1 border rounded-lg text-center bg-panel ${
               disabled ? 'border-panel-border text-text-light' : 'border-info'
             }`}
           />

--- a/src/canvas/ui/inspector-v2/shared/StrengthBandButtons.tsx
+++ b/src/canvas/ui/inspector-v2/shared/StrengthBandButtons.tsx
@@ -67,7 +67,7 @@ export const StrengthBandButtons = memo(function StrengthBandButtons({
             onClick={() => handleClick(band.midpoint)}
             className={`${typography.panelMeta} px-2 py-1 rounded-full bg-transparent border transition-colors cursor-pointer
               ${isActive
-                ? 'border-primary text-primary font-semibold'
+                ? 'border-primary text-primary'
                 : 'border-panel-border text-text-light hover:border-text-light hover:bg-panel-hover'
               }`}
             aria-pressed={isActive}

--- a/tests/ci-guards/shell-conformance.spec.ts
+++ b/tests/ci-guards/shell-conformance.spec.ts
@@ -484,6 +484,28 @@ describe('workspace shell — child surfaces: raw typography, pinned per file', 
   // header rightly calls invisible to every class-based regex — became
   // `panelMeta`, dropping a selected-state weight bump that duplicated the
   // border/background channel.
+  // ⭐ BURNED DOWN TO ZERO, 18 Aug 2026 (B4 Model/Inspector convergence): all
+  // SEVEN `src/canvas/components/model-tab/**` entries are gone from this map
+  // because the measured count for each is now 0 — 21 occurrences retired
+  // (ContestedEdgeCard 5, FactorsSection 7, RelationshipsSection 4,
+  // OptionsSection 2, and 1 each in GoalSection / ReanalyseBar /
+  // SourceProvenancePill). The model-tab child surface now measures ZERO under
+  // this rule.
+  //
+  // How, so the next lane does not re-introduce them: every one was a redundant
+  // WEIGHT stacked on a panel token (`${typography.panelMeta} font-medium`),
+  // which §2.4 bans outright — "each token defines its own weight". The token
+  // stayed and the raw utility went; where the weight was carrying a selected
+  // or emphasised STATE, that state was already signalled by colour and border,
+  // so dropping it also removed a duplicated visual channel (DS §1).
+  //
+  // ⚠ THIS GUARD IS WIDER THAN THE DS RATCHET AND CAUGHT WHAT THE RATCHET COULD
+  // NOT. The same PR widened `check-ds-compliance.mjs`'s `panel-typography-scoped`
+  // scope to include `model-tab/`, `inspector-v2/` and `model-tab-v2/` — but the
+  // ratchet's regex cannot see arbitrary sizes (`text-[10px]`) or inline
+  // `fontSize`/`fontWeight`, and its scope is still narrower than the dock
+  // closure. Two guards over one rule, neither redundant: this one measures the
+  // closure a user actually loads, that one gates the ratchet. Keep both.
   const RAW_TYPOGRAPHY_BY_FILE: Record<string, number> = {
     'src/canvas/compare-tab/CompareFooter.tsx': 2,
     'src/canvas/compare-tab/DotProgression.tsx': 2,
@@ -498,13 +520,6 @@ describe('workspace shell — child surfaces: raw typography, pinned per file', 
     'src/canvas/components/ValidationPanel.tsx': 4,
     'src/canvas/components/WarningBanner.tsx': 1,
     'src/canvas/components/WhatChangedChip.tsx': 1,
-    'src/canvas/components/model-tab/ContestedEdgeCard.tsx': 5,
-    'src/canvas/components/model-tab/FactorsSection.tsx': 7,
-    'src/canvas/components/model-tab/GoalSection.tsx': 1,
-    'src/canvas/components/model-tab/OptionsSection.tsx': 2,
-    'src/canvas/components/model-tab/ReanalyseBar.tsx': 1,
-    'src/canvas/components/model-tab/RelationshipsSection.tsx': 4,
-    'src/canvas/components/model-tab/SourceProvenancePill.tsx': 1,
     'src/canvas/components/pre-analysis/PreAnalysisPanel.tsx': 5,
     'src/canvas/components/pre-analysis/SharpenYourThinking.tsx': 3,
     'src/canvas/conversation/InlineBlocks.tsx': 1,
@@ -573,8 +588,14 @@ describe('workspace shell — child surfaces: raw typography, pinned per file', 
     // measuring almost nothing, which is how this kind of ratchet dies.
     const files = Object.keys(RAW_TYPOGRAPHY_BY_FILE).length
     const total = Object.values(RAW_TYPOGRAPHY_BY_FILE).reduce((a, b) => a + b, 0)
-    expect(files).toBe(37)
-    expect(total).toBe(134)
+    // 18 Aug 2026 (B4): 37 -> 30 files, 134 -> 113 occurrences, as the seven
+    // `model-tab/**` entries above burned to zero. These two numbers are a
+    // hand-maintained mirror OF THE MAP and must be lowered in the same PR as
+    // any burn-down — which is exactly what caught this lane: removing the
+    // entries turned the ratchet green and turned THIS assertion red, so the
+    // pair cannot be quietly hollowed out from either end.
+    expect(files).toBe(30)
+    expect(total).toBe(113)
   })
 })
 

--- a/tools/ci-guards/check-ds-compliance.mjs
+++ b/tools/ci-guards/check-ds-compliance.mjs
@@ -136,10 +136,32 @@ const CLASSES = [
     id: 'panel-typography-scoped',
     mode: 'ratchet',
     description: 'Raw text-/font- utilities in panel scope — must use panelHeader/Body/Meta (DS v5 §2.4)',
+    /*
+     * ⚠ THIS SCOPE WAS A HAND-MAINTAINED MIRROR OF A SCOPE DECLARED IN PROSE
+     * ELSEWHERE, AND IT HAD DRIFTED (widened 18 Aug 2026, B4 lane).
+     *
+     * DS v5 §2.2 declares the rule's scope as "`src/components/results/`,
+     * `src/canvas/panels/`, `src/canvas/ui/EdgeInspector*`, AND ANY COMPONENT
+     * RENDERED INSIDE A SIDE PANEL". The list below implemented the three
+     * literal paths and dropped the clause that carries the actual meaning —
+     * so the gate did not scan the INSPECTOR (`canvas/ui/inspector-v2/`) or the
+     * MODEL EDITOR (`canvas/model-tab-v2/`, `canvas/components/model-tab/`),
+     * which are the side panels the rule exists for. Measured at `dd089a50`:
+     * ZERO baseline signatures in those directories and 67 real occurrences
+     * across 28 files. The gate reported green over the whole surface.
+     *
+     * The three directories are now named. `EdgeInspector` is matched as a
+     * PREFIX, per §2.2's `EdgeInspector*`, rather than the single exact file
+     * the list happened to hold — the stories file beside it was out of scope
+     * for no stated reason.
+     */
     inScope: (p) =>
       !isTest(p) &&
       (under(p, 'components/results') || under(p, 'canvas/panels') ||
-       p === 'canvas/ui/EdgeInspector.tsx'),
+       under(p, 'canvas/ui/inspector-v2') ||
+       under(p, 'canvas/model-tab-v2') ||
+       under(p, 'canvas/components/model-tab') ||
+       p.startsWith('canvas/ui/EdgeInspector')),
     lineTokens: (line) => line.match(PANEL_TYPO) || [],
   },
   {

--- a/tools/ci-guards/ds-compliance-baseline.json
+++ b/tools/ci-guards/ds-compliance-baseline.json
@@ -6173,13 +6173,16 @@
     "panel-typography-scoped": {
       "mode": "ratchet",
       "description": "Raw text-/font- utilities in panel scope — must use panelHeader/Body/Meta (DS v5 §2.4)",
-      "total": 10,
+      "total": 15,
       "byFile": {
         "src/canvas/panels/TemplatesPanel.tsx": 3,
         "src/canvas/ui/EdgeInspector.tsx": 3,
         "src/canvas/panels/AdapterStatusBanner.tsx": 2,
+        "src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx": 2,
+        "src/canvas/ui/inspector-v2/shared/InlineNumberEditor.tsx": 2,
         "src/canvas/panels/InspectorPanel.tsx": 1,
-        "src/canvas/panels/IssuesPanel.tsx": 1
+        "src/canvas/panels/IssuesPanel.tsx": 1,
+        "src/canvas/ui/inspector-v2/panels/OptionPanel.tsx": 1
       },
       "signatures": {
         "panel-typography-scoped :: src/canvas/panels/AdapterStatusBanner.tsx :: text-xs": {
@@ -6223,6 +6226,24 @@
           "file": "src/canvas/ui/EdgeInspector.tsx",
           "token": "font-medium",
           "sample": "<span className=\"font-medium\">{sourceLabel}</span>"
+        },
+        "panel-typography-scoped :: src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx :: text-xl": {
+          "count": 2,
+          "file": "src/canvas/ui/inspector-v2/panels/FactorControllablePanel.tsx",
+          "token": "text-xl",
+          "sample": "<span className={`${typography.panelHeader} text-xl`}>{unit}</span>"
+        },
+        "panel-typography-scoped :: src/canvas/ui/inspector-v2/panels/OptionPanel.tsx :: text-2xl": {
+          "count": 1,
+          "file": "src/canvas/ui/inspector-v2/panels/OptionPanel.tsx",
+          "token": "text-2xl",
+          "sample": "<div className={`${typography.panelHeader} text-2xl`} style={{ color: 'var(--option)' }}>"
+        },
+        "panel-typography-scoped :: src/canvas/ui/inspector-v2/shared/InlineNumberEditor.tsx :: text-xl": {
+          "count": 2,
+          "file": "src/canvas/ui/inspector-v2/shared/InlineNumberEditor.tsx",
+          "token": "text-xl",
+          "sample": "className={`${typography.panelHeader} text-xl text-left w-full cursor-text hover:bg-panel-hover rounded px-0.5 -mx-0.5 t"
         }
       }
     },

--- a/tools/ci-guards/ds-compliance-baseline.json
+++ b/tools/ci-guards/ds-compliance-baseline.json
@@ -5849,7 +5849,7 @@
     "uppercase-text": {
       "mode": "ratchet",
       "description": "Styling-driven all-caps (uppercase class) — sentence case required (DS v5 §2)",
-      "total": 79,
+      "total": 77,
       "byFile": {
         "src/components/decisions/DecisionList.tsx": 7,
         "src/canvas/compare/EdgeDiffTable.tsx": 6,
@@ -5862,7 +5862,6 @@
         "src/canvas/components/ScenarioSwitcher.tsx": 2,
         "src/canvas/help/KeyboardLegend.tsx": 2,
         "src/canvas/ui/inspector/InspectorAccordion.tsx": 2,
-        "src/canvas/ui/inspector-v2/shared/SectionTitle.tsx": 2,
         "src/components/debug/tabs/PipelineTab.tsx": 2,
         "src/pages/sandbox-guide/components/panel/states/EmptyState.tsx": 2,
         "src/canvas/components/CogPopover.tsx": 1,
@@ -6053,12 +6052,6 @@
           "file": "src/canvas/ui/inspector/InspectorAccordion.tsx",
           "token": "uppercase",
           "sample": "/** Section header style: 11px, uppercase, text-text-light, 1px letter-spacing */"
-        },
-        "uppercase-text :: src/canvas/ui/inspector-v2/shared/SectionTitle.tsx :: uppercase": {
-          "count": 2,
-          "file": "src/canvas/ui/inspector-v2/shared/SectionTitle.tsx",
-          "token": "uppercase",
-          "sample": "* SectionTitle — Lucide icon (13px) + uppercase label"
         },
         "uppercase-text :: src/components/Analysis/utils/formatAnalysis.tsx :: uppercase": {
           "count": 1,


### PR DESCRIPTION
**B4 MODEL / INSPECTOR CONVERGENCE — Phase 2 (the non-removal convergence).**
Base `staging` @ `dd089a50`. **Nothing visible is removed here.** Phase 1's KEEP / CUT / REHOME is a report for Paul's veto and is in the lane return, not in this diff.

---

## P-COMPLIANCE BLOCK — read v4, P1–P9

| | |
|---|---|
| **P7** producer semantics from the PRODUCER | `source_quote`'s meaning read at `src/v5/applyV5State.ts:421` (the normaliser that WRITES it onto `CEEGoalConstraint`) and `src/adapters/cee/types.ts:314`, not inferred from a corpus. It is part of `constraintsDeepEqual`, so a quote-only change forces a write — that is what makes it authoritative rather than a transient echo. |
| **P2** behaviour through the MOUNTED consumer | Raw-id fix asserted by rendering `GenericNodePanel` itself (renders `Untitled`, and the id appears nowhere in the panel). Not-set fix asserted by rendering `ModelOutline`. Provenance mount pinned against `GoalPanel`'s own source with positive + contrast controls. |
| **P1** one seam BEYOND the guard | The guard is `resolveElementLabel`. The seam past it is the **panel render with a nameless node in the graph** — a node present, connected, and carrying `data: {}`. The surrounding content survives: the panel renders, the connection row renders, only the name changes. |
| **P5** claims grounded in persisted state | "You said: …" is grounded in the persisted `CEEGoalConstraint.source_quote`. It renders **nothing** when absent, empty or whitespace — pinned in all three directions. |
| **P6** no manufactured obligations | None. Nothing new is required of the user; the unknown summary is descriptive, and the row's existing attention marker is unchanged. |
| **P8** every affordance has a named acceptance path | `Not set` is printed **only** where pressing it opens the live editor. The editable-but-unconnected row keeps its **disabled** control plus `NO_AUTHORITY_REASON` — it explains rather than offers. No affordance was added that terminates in refusal. |
| **P4** mutation harness typechecked the mutated tree | Yes, and it earned its cost. **Mandatory pristine control first: the clean mutant tree passed the typecheck gate (2306 = baseline).** M10 then measured **type-invalid** (`TS6133 'GoalConstraintProvenance' is declared but its value is never read` → 2306 → 2308, `RATCHET FAILED`) — the exact `noUnusedLocals` false-survivor case P4 exists for. |

---

## What changed, and why

### 1 · No raw identifier reaches the user
Fourteen call sites across nine panels resolved a missing element name to the element's **id** — `String(n.data?.label ?? n.id)` — **unconditionally, not behind technical mode**. The panel header three lines above already resolved the same absent label to `Untitled`. One unlabelled node therefore appeared under two different names on one screen, and one of them was a database key.

`src/canvas/domain/elementLabel.ts` is now the one resolver. The id stays where it means something: `Node ID` / `Edge key` in technical mode, and the model outline's Advanced tier. Pinned by a render assertion **and** a derived source scan over the whole panel directory, so a tenth panel added tomorrow is covered without anyone updating a list.

### 2 · The "Not set" wall — and the finding underneath it
`Not set` is now printed only where it is **actionable**; the group heading carries `N of M have no value yet`, derived from the same `primaryValue === null` the cell reads.

⭐ **The more valuable half is what I did *not* change.** My first cut also silenced the editable-but-unconnected row, and it broke `ModelTabV2Panel.spec.tsx`'s pinned invariant that the relationship, option and goal rows show a **disabled** control carrying `NO_AUTHORITY_REASON`. That invariant is right — "editing is not connected yet" is strictly more truthful than an empty cell (P3) — and overturning another lane's deliberate ruling is not this lane's call.

So the remaining repetition **is not a display defect**. It is the visible shape of the edit paths that have no canonical carrier yet (design §2 F6/F9). Suppressing it would have killed the symptom and left the defect alive (trap 23), and destroyed the best available evidence for connecting those edits.

### 3 · Design System v5 §2.4 — and the gate that was blind to it
`panel-typography-scoped` in `check-ds-compliance.mjs` implemented three literal paths from DS v5 §2.2 and **dropped the clause carrying the meaning**: *"and any component rendered inside a side panel"*. So the enforcing gate never scanned the inspector or the model editor — **0 baseline signatures against 67 real occurrences across 28 files**. A hand-maintained mirror of a scope declared in prose somewhere else (trap 12).

Fixed **62 of 67**, including all 5 arbitrary `text-[Npx]` the guard's regex cannot see at all, then widened the scope. **Proved the widened gate bites, with a discriminating pair:** the same violation injected *inside* the new scope exits 1 and names the file; injected *outside* every scope it stays green. A scope, not a blanket.

### 4 · Ledger N-20 — "You said: …"
`source_quote` reaches the UI, is persisted, and had **zero** render consumers (contrast control: `goalThreshold` resolves in 82 files). It now renders verbatim under the constraint it produced — muted, one line, no disclosure to open.

---

## Two things needing a decision, not a silent fix

1. **5 remaining typography occurrences, blessed as recorded debt** (`panel-typography-scoped` 34 → 37, via `--force`). They are `panelHeader text-xl` / `text-2xl` on the **primary numeric displays** (factor value editor, option win-probability). DS v5 sanctions no numeric-emphasis size in a panel — `heroDisplay` is reserved elsewhere — so flattening them to 14px is a **hierarchy decision**, and it works against this lane's own "readable information hierarchy" acceptance. The gap looks real: panels need a sanctioned `panelValue` token. Recorded so no *more* can be added.
2. **The baseline edit is surgical on purpose.** An unforced `--update` would have tightened three unrelated ratchet classes by **567 occurrences** (legacy −515, hex −33, uppercase −19) purely because they had already descended at pristine. That is not this lane's work and would red sibling PRs measured against the old numbers, so those classes are left exactly as they were.

## Ledger correction
**N-20 names two fields; only one exists.** `label_authored` returns **zero** hits anywhere in `src/` at this tip (contrast control in the same sweep: `source_quote` 5 files, `authored_by` non-zero). Its half of the row is not actionable as written.

---

## Evidence

- **Mutants: 10/10 bitten**, leading and trailing controls clean (`applied=0`, green, non-zero collected throughout); applied-check exactly 1 per mutant scoped to `src/`, control exactly 0; **isolation proven by WRITING a sentinel** and asserting the source unchanged (distinct inodes), restores from a pristine archive.
- **Two survivors were found and closed, both defects in my own tests.** Every fixture row was `editable: true`, so the non-editable arm was never exercised and a restore-the-wall mutant walked through the whole suite. And the mount assertion was `toContain('<GoalConstraintProvenance')`, which any **rename** satisfies — `<GoalConstraintProvenanceUNMOUNTED` still contains it. Now a word-boundary regex with a contrast control proving it rejects the lookalike.
- **A broken matcher was caught by its own contrast control before it shipped:** `\s*` before a negative lookahead asserts nothing, because the quantifier yields the position the lookahead wants — it flagged all 36 sites including the 5 already correct.
- **Tests:** 416 files green across `inspector-v2`, `model-tab-v2`, `components/model-tab`, `canvas/components`, `canvas/ui`, `canvas/conversation`, `canvas/domain`. New specs collect **11 / 8 / 8 by name**, asserted non-zero, `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported on every run.
- **Required check, run locally in CI's step order:** `check:vendor` · `schemas-version` · **lint (0 errors)** · **typecheck gate PASSED, 2306 = baseline** · `zustand` · `duplicates` · **`ds:enforce` green**.

Not polled — the orchestrator owns CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

# Rebase onto `3ca238e7` (18 Aug) — one conflict, and it was load-bearing

Rebased from `dd089a50` onto `3ca238e7` after #769 / #770 / #772 landed. **Exactly one file conflicted: `tools/ci-guards/ds-compliance-baseline.json`.** My own three commits came through byte-identical — diffing the rebased branch against the pre-rebase backup shows only staging's own 29 files.

## ⚠ The conflict would have silently undone a sibling lane's fix

**#769 ("burn results-tree raw typography to zero") removed 12 signatures from this baseline.** My baseline was generated by `--update --force` at `dd089a50`, where those violations still existed — so **carrying it forward would have re-added 10 of them**, quietly reversing #769's ratchet tightening under cover of a "my side / their side" conflict resolution. Neither `--ours` nor `--theirs` is correct here: one drops my scope widening, the other drops #769's fix.

**Resolved by re-derivation, not by hand-editing a derived artefact:** take staging's baseline wholesale → regenerate from the actual rebased tree → merge in **only** the signatures under the three directories this PR newly scoped. Verified explicitly:

| check | result |
|---|---|
| signatures added vs staging | **+3**, all under `inspector-v2` / `model-tab-v2` / `components/model-tab` |
| signatures removed vs staging | **0** — every one of #769's 12 removals survives |
| other four ratchet classes | **byte-identical** to staging |
| `ds:enforce` at the rebased tip | green, `panel-typography-scoped` 15 = baseline 15, Δ+0 |

Both lanes' work is kept. Nothing was resolved by taking a side.

## ⚠ Instrument hazard worth keeping: `git merge-base` lies mid-rebase

**Mid-rebase, `git merge-base HEAD origin/staging` resolves to `origin/staging` itself**, because `HEAD` is the partially-replayed state. My first three-way comparison used it and therefore concluded staging's baseline was *unchanged since my base* — byte-identical sha256, empty `git log -- <file>`, the lot. **That is exactly how this collision gets missed:** the probe reports "no sibling work here, take your side" with total confidence. It was caught only by re-deriving against the **explicit base SHA**, at which point the blob SHAs differ and #769's commit appears. Pin the base SHA; never compute a merge-base against a branch you are mid-rebase onto.

## Post-rebase verification

- **Counter-scale census (#772's derived scope): passes.** It derives from `nodeTypes` / `edgeTypes`; no component in this PR goes through a React Flow type registry, so nothing here renders inside the canvas transform. **No pin set widened.**
- **Specs re-asserted BY NAME with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported: 11 / 7 / 9.** The ModelOutline spec collected 7 against an expected 8 — **the expectation was stale, not the file**: 7 declared `it()` blocks, file byte-identical to its commit, and this PR's own third commit had removed one test. Verified rather than assumed.
- **Local Staging Gate steps were NOT run to completion at the rebased tip** and are not claimed. The machine was at load average 281 with 22 concurrent sibling vitest processes; the run was measuring contention, not this code, and was blocking integration. Killed by a PID verified as mine (never by pattern) at the coordinator's instruction. CI on a clean runner is the authority. *(For the record, at the pre-rebase tip all seven `tsc`-job steps were green.)*


---

# Second rebase — onto `9ff14c19` (#775's deletion)

Rebased `3ca238e7` → `9ff14c19`. **Three modify/delete conflicts plus the derived baseline.** `mergeable=MERGEABLE`.

## The conflicts were "my edit vs their deletion" — deletion accepted

#775 deleted `IntelligenceSection.tsx`, `SectionTitle.tsx` and `RangeDerivationPill.tsx`, which this PR had edited for §2.4 conformance. **Confirmed at the tip before deciding anything**: all three absent, the `shared/index.ts` barrel no longer exports them, no live importer remains. Deletion accepted; nothing resurrected.

**No fix is lost.** Those three are exactly the provably-dead components this lane's Phase 1 cut list flagged (0 render sites, verified with contrast controls at 9 / 9 / 2). Deleting them achieves §2.4 conformance more completely than editing them did.

## Baseline re-derived, not carried forward

| check | result |
|---|---|
| `panel-typography-scoped` vs staging | **+3** signatures, all in this PR's newly-scoped dirs |
| signatures removed vs staging | **0** — every sibling fix recorded there survives |
| `legacy-tailwind-token` / `production-hex` / `emoji-icon` | **byte-identical** to staging |
| `uppercase-text` | 79 → 77, retiring the one phantom #775 created |
| `ds:enforce` at the rebased tip | green, `panel-typography-scoped` 15 = baseline 15, Δ+0 |

## ⚠ Finding: this baseline carries 36 rows for files that do not exist

Retiring `SectionTitle`'s row surfaced 35 more phantoms — `DebugDrawer`, the whole `RecommendationCard` subtree, `SequentialView`, `InsightsTab`, `ParetoInsights` and others, all deleted in July. **They are deliberately left in place**: retiring them would tighten three ratchet classes by several hundred occurrences that no live file can reach, which is the overreach refused in the #769 resolution.

**Why 35 accumulated unnoticed, which is the part worth fixing:** a ratchet row for a deleted file is **silent by construction**. It only ever grants headroom, so `--enforce` stays green and nothing ever surfaces it — the hand-maintained-mirror defect in its quietest form. A `--check-phantoms` mode is a one-line derivation over `byFile` and is the right home for this, in its own change.

## Verified at the rebased tip

`ds:enforce` green · `shell-conformance` **49/49** with **0 phantom pin rows** (30 files / 113 occurrences unchanged — #775 deleted nothing in that map) · counter-scale census **8/8** · this lane's specs **11 / 7 / 9 by name** with the Supabase vars exported. Full local gate not run — machine load above 400 measures the machine, not the code.
