### PR TITLE
fix(olumi): converge every Ask-Olumi action on one surface, and stop log language reaching the user

### DIFF
--- a/src/canvas/components/PersistentInputStrip.tsx
+++ b/src/canvas/components/PersistentInputStrip.tsx
@@ -1,9 +1,10 @@
-import { memo, useCallback } from 'react'
+import { memo, useCallback, useEffect, useRef } from 'react'
 import { ChevronUp } from 'lucide-react'
 import { typo } from '../../styles/typography'
 import { useFloatingPanelState } from '../hooks/useFloatingPanelState'
 import { useStageAwarePlaceholder } from '../hooks/useStageAwarePlaceholder'
-import { AIInputBar } from './AIInputBar'
+import { registerDockedOlumiFocus } from '../conversation/dockedOlumiFocus'
+import { AIInputBar, type AIInputBarHandle } from './AIInputBar'
 
 interface PersistentInputStripProps {
   /** True when the docked Olumi tab is the active dock tab. When true and
@@ -56,6 +57,30 @@ export const PersistentInputStrip = memo(function PersistentInputStrip({
   // nowhere else to type.
   const floatingIsMinimised = useFloatingPanelState((s) => s.isMinimised)
   const placeholder = useStageAwarePlaceholder()
+  const inputBarRef = useRef<AIInputBarHandle | null>(null)
+
+  /**
+   * THE DOCKED OLUMI COMPOSER'S FOCUS CHANNEL.
+   *
+   * `revealOlumiSurface()` — the primitive every Ask-Olumi / chip / coaching
+   * action funnels through — could previously only focus the FLOATING panel,
+   * because that was the only surface with a registered channel. On the
+   * dominant deployed path the dock hosts Olumi and the floating panel has
+   * deliberately deregistered, so a revealed action left the composer
+   * unfocused and the user had to click into the box before typing.
+   *
+   * Registered ONLY in composer mode — the same condition the render below
+   * uses, so the channel exists exactly when there is a textarea to focus.
+   * In status mode the floating panel owns focus; in redirect mode there is no
+   * input at all, and registering there would hand `focusDockedOlumi()` a null
+   * ref that silently succeeds (a focus channel that reports success while
+   * focusing nothing is worse than none).
+   */
+  const isComposerMode = isOlumiTabActive && (!floatingIsOpen || floatingIsMinimised)
+  useEffect(() => {
+    if (!isComposerMode) return
+    return registerDockedOlumiFocus(() => inputBarRef.current?.focus())
+  }, [isComposerMode])
 
   const handleFocus = useCallback(() => {
     onFocusFloating?.()
@@ -117,6 +142,7 @@ export const PersistentInputStrip = memo(function PersistentInputStrip({
   return (
     <div className="border-t border-panel-border bg-panel" data-testid="persistent-strip-composer">
       <AIInputBar
+        ref={inputBarRef}
         variant="strip"
         onCogClick={onCogClick}
         onChevronClick={onOpenFloating}

--- a/src/canvas/components/__tests__/PersistentInputStrip.spec.tsx
+++ b/src/canvas/components/__tests__/PersistentInputStrip.spec.tsx
@@ -15,6 +15,7 @@ import { render, screen, fireEvent, act } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { useFloatingPanelState } from '../../hooks/useFloatingPanelState'
 import { PersistentInputStrip } from '../PersistentInputStrip'
+import { focusDockedOlumi } from '../../conversation/dockedOlumiFocus'
 import {
   ConversationProvider,
   useConversationContext,
@@ -223,5 +224,85 @@ describe('PersistentInputStrip', () => {
       const reborn = screen.getByRole('textbox') as HTMLTextAreaElement
       expect(reborn.value).toBe('half-typed thought')
     })
+  })
+})
+
+/**
+ * THE DOCKED OLUMI FOCUS CHANNEL (B3 convergence).
+ *
+ * `revealOlumiSurface()` focuses the docked composer through
+ * `focusDockedOlumi()`. That only works if this strip registers the channel —
+ * and only while it is actually rendering a textarea. A channel registered in
+ * status or redirect mode would report SUCCESS while focusing a null ref,
+ * which is worse than no channel: the caller stops looking for another surface.
+ *
+ * Bound by identity to the strip's three modes via their own testids, so the
+ * registration cannot be satisfied by "some input somewhere got focus".
+ */
+describe('docked Olumi focus channel', () => {
+  beforeEach(() => {
+    useFloatingPanelState.getState().reset()
+  })
+
+  it('registers in composer mode and focuses the strip textarea', () => {
+    render(
+      <Wrapper>
+        <PersistentInputStrip isOlumiTabActive onOpenFloating={vi.fn()} onCogClick={vi.fn()} />
+      </Wrapper>,
+    )
+    // POSITIVE CONTROL — we are in composer mode, not some other branch.
+    expect(screen.getByTestId('persistent-strip-composer')).toBeInTheDocument()
+    expect(focusDockedOlumi()).toBe(true)
+    const textarea = screen
+      .getByTestId('persistent-strip-composer')
+      .querySelector('textarea')
+    expect(textarea).not.toBeNull()
+    expect(document.activeElement).toBe(textarea)
+  })
+
+  it('⭐ does NOT register in redirect mode (no textarea to focus)', () => {
+    render(
+      <Wrapper>
+        <PersistentInputStrip
+          isOlumiTabActive={false}
+          onOpenFloating={vi.fn()}
+          onCogClick={vi.fn()}
+        />
+      </Wrapper>,
+    )
+    expect(screen.getByTestId('persistent-strip-composer-redirect')).toBeInTheDocument()
+    expect(focusDockedOlumi()).toBe(false)
+  })
+
+  it('⭐ does NOT register in status mode (the floating panel owns focus)', () => {
+    act(() => {
+      useFloatingPanelState.getState().open('user')
+    })
+    render(
+      <Wrapper>
+        <PersistentInputStrip isOlumiTabActive onOpenFloating={vi.fn()} onCogClick={vi.fn()} />
+      </Wrapper>,
+    )
+    expect(screen.getByTestId('persistent-strip-status')).toBeInTheDocument()
+    expect(focusDockedOlumi()).toBe(false)
+  })
+
+  it('re-registers when a minimised floating panel hands composing back', () => {
+    act(() => {
+      useFloatingPanelState.getState().open('user')
+    })
+    render(
+      <Wrapper>
+        <PersistentInputStrip isOlumiTabActive onOpenFloating={vi.fn()} onCogClick={vi.fn()} />
+      </Wrapper>,
+    )
+    expect(focusDockedOlumi()).toBe(false)
+    act(() => {
+      useFloatingPanelState.getState().minimise()
+    })
+    // The pill has no textarea, so the strip takes composing back — and with
+    // it the focus channel.
+    expect(screen.getByTestId('persistent-strip-composer')).toBeInTheDocument()
+    expect(focusDockedOlumi()).toBe(true)
   })
 })

--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -29,6 +29,7 @@ import { ChatThread } from './zones/ChatThread'
 import { ChatComposer, type ChatComposerHandle } from './zones/ChatComposer'
 import { useOptionalConversationContext } from './ConversationContext'
 import { prefillInto } from './prefillTarget'
+import { humaniseWireToken } from './friendlyOperation'
 import type { BriefReadiness } from './hooks/useBriefSignals'
 import { useThreadPersistence } from './hooks/useThreadPersistence'
 import { beginInteractionChain, getUiSurfaceState, recordCrossSurfaceEvent, recordInteractionEvent, recordUserAction, type InteractionStateSnapshot } from '../../lib/debug-state'
@@ -98,6 +99,22 @@ function extractTurnIdFromStateKey(stateKey: string, patchId: string): string {
   const separatorIndex = stateKey.indexOf(':')
   if (separatorIndex === -1) return stateKey
   return stateKey.slice(0, separatorIndex)
+}
+
+/**
+ * The user-facing sentence for a patch operation this build cannot apply.
+ *
+ * ⚠ THE RAW OP MAY NOT RIDE IN `message`. `message` is rendered verbatim in
+ * the rejected-patch card, so embedding `unknownOps[0].op` put `add_node` on
+ * screen. `humaniseWireToken` returns null for anything id-shaped and the
+ * sentence then simply omits the name — the user does not need the token, and
+ * the rejection CODE still carries it for operators.
+ */
+export function unsupportedOperationMessage(op: unknown): string {
+  const named = humaniseWireToken(op)
+  return named
+    ? `This build cannot apply that kind of change yet (${named.toLowerCase()}).`
+    : 'This build cannot apply that kind of change yet.'
 }
 
 export const ConversationPanel = memo(function ConversationPanel({
@@ -265,7 +282,10 @@ export const ConversationPanel = memo(function ConversationPanel({
           setPatchBlockState(stateKey, 'rejected')
           setPatchRejection(stateKey, {
             code: 'UNSUPPORTED_OPERATION',
-            message: `Unsupported operation: ${unknownOps[0].op}`,
+            // `message` is rendered verbatim to the user, so the raw op enum
+            // may not ride inside it. The CODE still carries the token for
+            // operators (GraphPatchBlockRenderer puts it on a data attribute).
+            message: unsupportedOperationMessage(unknownOps[0].op),
           })
           sendSystemEventBestEffort({
             type: 'patch_dismissed',

--- a/src/canvas/conversation/GuidanceStrip.tsx
+++ b/src/canvas/conversation/GuidanceStrip.tsx
@@ -59,6 +59,20 @@ function categoryIcon(cat: GuidanceItem['category']) {
 // Action button label
 // ---------------------------------------------------------------------------
 
+/**
+ * The strip's action-button face and aria-label.
+ *
+ * ⚠ THE `default` ARM IS LOAD-BEARING AND ITS ABSENCE WAS A RUNTIME HOLE.
+ * `primary_action.type` arrives ON THE WIRE, so the union is a claim about
+ * the producer at pin time, not a runtime guarantee. Without a default this
+ * switch returned `undefined` for any type CEE adds — an EMPTY button face
+ * and the aria-label `"undefined: <title>"` read aloud to a screen-reader
+ * user. TypeScript could not see it: the union made the switch exhaustive at
+ * compile time, which is exactly why the hole survived review.
+ *
+ * The fallback is a neutral verb, never the raw token: a button reading
+ * `open_evidence_drawer` is the same log-language defect one level down.
+ */
 function actionLabel(action: GuidanceAction): string {
   switch (action.type) {
     case 'open_inspector': return 'View'
@@ -66,6 +80,7 @@ function actionLabel(action: GuidanceAction): string {
     case 'run_exercise': return 'Try it'
     case 'approve_patch': return 'Review'
     case 'navigate': return 'Go to'
+    default: return 'Open'
   }
 }
 

--- a/src/canvas/conversation/__tests__/GraphPatchBlock.spec.tsx
+++ b/src/canvas/conversation/__tests__/GraphPatchBlock.spec.tsx
@@ -323,9 +323,19 @@ describe('GraphPatchBlock', () => {
     )
 
     expect(screen.getByTestId('patch-status-rejected')).toBeInTheDocument()
-    expect(screen.getByText(/INVALID_NODE/)).toBeInTheDocument()
     expect(screen.getByText(/Node type not supported/)).toBeInTheDocument()
     expect(screen.getByText('Missing label field')).toBeInTheDocument()
+    // ⚠ THIS ASSERTION WAS INVERTED, DELIBERATELY (B3). It used to require
+    // `/INVALID_NODE/` in the rendered text — i.e. it PINNED the rejection code
+    // reaching the user, which is the `VALIDATION_FAILED: …` log-language
+    // defect. The code is an operator's handle, so it moved to a data
+    // attribute; both halves are asserted here so the swap cannot silently
+    // become a deletion.
+    expect(screen.getByTestId('patch-status-rejected').textContent).not.toContain('INVALID_NODE')
+    expect(screen.getByTestId('patch-rejection-detail')).toHaveAttribute(
+      'data-rejection-code',
+      'INVALID_NODE',
+    )
   })
 
   it('shows "Show more" toggle for multiple violations', () => {

--- a/src/canvas/conversation/__tests__/GuidanceStrip.spec.tsx
+++ b/src/canvas/conversation/__tests__/GuidanceStrip.spec.tsx
@@ -308,3 +308,35 @@ describe('GuidanceStrip — category badge', () => {
     expect(screen.getByText(expected)).toBeInTheDocument()
   })
 })
+
+/**
+ * THE RUNTIME HOLE IN `actionLabel` (B3 convergence — no log language).
+ *
+ * `primary_action.type` arrives ON THE WIRE. The label switch had no `default`,
+ * so a type CEE adds returned `undefined`: an EMPTY button face and the
+ * aria-label "undefined: <title>" read aloud to a screen-reader user.
+ * TypeScript could not see it — the union made the switch exhaustive at
+ * compile time, which is exactly why it survived review.
+ */
+describe('an unmodelled wire action type', () => {
+  it('⭐ never renders "undefined", and never the raw token', () => {
+    const item = makeItem({
+      title: 'A new kind of suggestion',
+      // A producer type this build does not model. Cast because the whole
+      // point is that the union is a claim about pin time, not runtime.
+      primary_action: { type: 'open_evidence_drawer' } as unknown as GuidanceItem['primary_action'],
+    })
+    useGuidanceStore.getState().setGuidanceItems([item])
+    render(<GuidanceStrip {...makeProps()} />)
+
+    // POSITIVE CONTROL — the strip rendered this item, so the assertions below
+    // are about a surface that exists.
+    expect(screen.getByTestId('guidance-strip')).toBeInTheDocument()
+    expect(screen.getByText('A new kind of suggestion')).toBeInTheDocument()
+
+    const button = screen.getByRole('button', { name: /A new kind of suggestion/ })
+    expect(button.getAttribute('aria-label')).not.toContain('undefined')
+    expect(button.textContent?.trim().length ?? 0).toBeGreaterThan(0)
+    expect(button.textContent).not.toContain('open_evidence_drawer')
+  })
+})

--- a/src/canvas/conversation/__tests__/ProposalBlock.spec.tsx
+++ b/src/canvas/conversation/__tests__/ProposalBlock.spec.tsx
@@ -144,7 +144,11 @@ describe('ProposalBlockRenderer', () => {
     )
     expect(screen.getByText('Add Regulatory Risk as a new factor')).toBeInTheDocument()
     expect(screen.getByText('New factor node')).toBeInTheDocument()
-    expect(screen.getByText('add')).toBeInTheDocument()
+    // ⚠ WAS `getByText('add')` — it PINNED the raw wire operation token in the
+    // pill. The pill now carries the humanised form; asserting BOTH directions
+    // so the change cannot decay into the pill simply disappearing.
+    expect(screen.getByText('Add')).toBeInTheDocument()
+    expect(screen.queryByText('add')).not.toBeInTheDocument()
     expect(screen.getByText('Regulatory Risk')).toBeInTheDocument()
     expect(screen.getByText(/May increase model complexity/)).toBeInTheDocument()
   })

--- a/src/canvas/conversation/__tests__/revealOlumiSurface.spec.ts
+++ b/src/canvas/conversation/__tests__/revealOlumiSurface.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * ONE OLUMI, WHEREVER THE USER LEFT IT — `revealOlumiSurface` convergence.
+ *
+ * ## The defect
+ *
+ * `revealOlumiSurface()` is THE convergence primitive: every Ask-Olumi, chip,
+ * coaching and rerun action launched from the Graph, the Analysis surface or
+ * the Inspector funnels through it (six direct call sites plus
+ * `withOlumiReveal`, which wraps every guidance-store send). It did two things
+ * unconditionally:
+ *
+ *   forceActivateOutputTab('olumi')   // claim the DOCK
+ *   focusFloating()                   // focus the FLOATING panel
+ *
+ * Those fight each other. Forcing the docked Olumi tab makes `dockHostsOlumi`
+ * true, and `FloatingOlumiPanel` returns null the moment it does. So a user
+ * working in the floating Olumi window who clicked "Ask Olumi" on a node had
+ * that window CLOSED and the conversation relocated to the dock; and the
+ * surface that took over — the docked composer — got no focus, because nothing
+ * had ever registered a channel for it.
+ *
+ * ## Binding
+ *
+ * The two focus channels are DIFFERENT registries, and a test that only
+ * counted "something was focused" would pass on the defect. Every case
+ * therefore asserts BOTH directions: the channel that must fire, and the one
+ * that must not — the opposite-direction twin.
+ *
+ * These tests drive the REAL registries rather than mocking them, because the
+ * production rule is precisely "a registration is the surface's own statement
+ * that it is visible". Mocking that away would test a different function.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  forceActivateOutputTab: vi.fn(),
+  aiPanelV2: true,
+}))
+
+vi.mock('../../../stores/uiStore', () => ({
+  useUIStore: {
+    getState: () => ({ forceActivateOutputTab: mocks.forceActivateOutputTab }),
+  },
+}))
+
+vi.mock('../../../flags', () => ({
+  isAiPanelV2Enabled: () => mocks.aiPanelV2,
+}))
+
+import { revealOlumiSurface } from '../revealOlumi'
+import { registerFloatingFocus } from '../../hooks/useFloatingFocus'
+import { registerDockedOlumiFocus } from '../dockedOlumiFocus'
+
+let floatingFocused = 0
+let dockedFocused = 0
+const unregister: Array<() => void> = []
+
+/** A floating/hero composer is on screen: it has registered its channel. */
+function floatingSurfaceIsVisible(): void {
+  unregister.push(registerFloatingFocus(() => { floatingFocused++ }))
+}
+
+/** The docked composer is rendering a textarea: it has registered its channel. */
+function dockedComposerIsMounted(): void {
+  unregister.push(registerDockedOlumiFocus(() => { dockedFocused++ }))
+}
+
+beforeEach(() => {
+  mocks.forceActivateOutputTab.mockClear()
+  mocks.aiPanelV2 = true
+  floatingFocused = 0
+  dockedFocused = 0
+})
+
+afterEach(async () => {
+  // Unregister FIRST, then drain a frame. `revealOlumiSurface` schedules a
+  // deferred retry on the next animation frame; without this drain a retry
+  // armed by one case fires during the NEXT one and lands on that case's
+  // freshly-registered channel — cross-test contamination that reads as a
+  // real focus call. Draining while nothing is registered makes it a no-op.
+  while (unregister.length > 0) unregister.pop()!()
+  await new Promise<void>((resolve) => setTimeout(resolve, 32))
+})
+
+describe('the user already has a floating or first-use Olumi composer on screen', () => {
+  beforeEach(floatingSurfaceIsVisible)
+
+  it('⭐ does NOT claim the dock — claiming it would close the window it is revealing', () => {
+    revealOlumiSurface()
+    expect(mocks.forceActivateOutputTab).not.toHaveBeenCalled()
+  })
+
+  it('focuses the FLOATING composer and not the docked one', () => {
+    revealOlumiSurface()
+    expect(floatingFocused).toBe(1)
+    expect(dockedFocused).toBe(0)
+  })
+
+  it('still prefers the floating surface even when a docked composer is also registered', () => {
+    // Not reachable on the deployed posture (the two surfaces are mutually
+    // exclusive), but it pins the PREFERENCE rather than an accident of which
+    // registry happened to be empty — otherwise this suite would pass on a
+    // version that simply tried the dock first.
+    dockedComposerIsMounted()
+    revealOlumiSurface()
+    expect(mocks.forceActivateOutputTab).not.toHaveBeenCalled()
+    expect(floatingFocused).toBe(1)
+    expect(dockedFocused).toBe(0)
+  })
+})
+
+describe('no floating composer is on screen', () => {
+  it('claims the docked Olumi tab', () => {
+    dockedComposerIsMounted()
+    revealOlumiSurface()
+    expect(mocks.forceActivateOutputTab).toHaveBeenCalledWith('olumi')
+  })
+
+  it('⭐ focuses the DOCKED composer, not the floating one', () => {
+    dockedComposerIsMounted()
+    revealOlumiSurface()
+    expect(dockedFocused).toBe(1)
+    expect(floatingFocused).toBe(0)
+  })
+
+  it('claims the dock even when no composer is registered anywhere yet', () => {
+    // The dock is always available; force-activating is what makes it appear.
+    revealOlumiSurface()
+    expect(mocks.forceActivateOutputTab).toHaveBeenCalledWith('olumi')
+    expect(floatingFocused).toBe(0)
+  })
+
+  it('⭐ never falls back to the floating channel after claiming the dock', async () => {
+    // The regression guard for the original defect: a floating panel that is
+    // registered when the deferred retry runs (i.e. one that is about to
+    // yield) must NOT receive focus. The retry is scheduled on the next
+    // animation frame, so the assertion waits for that frame to pass — without
+    // the wait this case would assert on a retry that had not run yet, and
+    // would pass whatever the retry did (trap 13: a probe that cannot observe
+    // the thing it names).
+    revealOlumiSurface()
+    floatingSurfaceIsVisible()
+    dockedComposerIsMounted()
+    await new Promise<void>((resolve) => setTimeout(resolve, 32))
+    // POSITIVE CONTROL — the deferred retry DID run, and reached the docked
+    // channel that registered after the first attempt failed.
+    expect(dockedFocused).toBe(1)
+    expect(floatingFocused).toBe(0)
+  })
+})
+
+describe('aiPanelV2 OFF (rollback posture)', () => {
+  beforeEach(() => { mocks.aiPanelV2 = false })
+
+  it('never touches the dock — OutputsDock redirects olumi→results when the flag is off', () => {
+    floatingSurfaceIsVisible()
+    revealOlumiSurface()
+    expect(mocks.forceActivateOutputTab).not.toHaveBeenCalled()
+    // CONTRAST CONTROL: the legacy best-effort floating focus is preserved, so
+    // this case is not passing merely because nothing ran.
+    expect(floatingFocused).toBe(1)
+  })
+
+  it('does not reach for the docked channel on the rollback path', () => {
+    dockedComposerIsMounted()
+    revealOlumiSurface()
+    expect(dockedFocused).toBe(0)
+  })
+})

--- a/src/canvas/conversation/__tests__/wireTokenLeak.spec.tsx
+++ b/src/canvas/conversation/__tests__/wireTokenLeak.spec.tsx
@@ -1,0 +1,245 @@
+/**
+ * NO WIRE TOKEN ON SCREEN — the "log language reaching the user" class.
+ *
+ * Five surfaces in the Olumi conversation rendered a PRODUCER TOKEN straight
+ * into the DOM. Each is small on its own; together they are the reason the
+ * conversation reads like a log file at exactly the moments it is telling the
+ * user something went wrong:
+ *
+ *   1. a rejected patch printed `VALIDATION_FAILED: Patch validation failed`
+ *   2. the unsupported-operation message embedded the raw op enum (`add_node`)
+ *   3. a proposal change printed its raw `operation` token in a pill
+ *   4. a proposal change printed the raw target ENTITY ID (`fac_x7`) as the
+ *      pill's visible label AND inside its aria-label
+ *   5. an unsurfaced V5 block printed its wire `blockType` in a pill
+ *
+ * plus one runtime hole: `GuidanceStrip`'s `actionLabel` switch had no
+ * `default`, so an unmodelled wire `primary_action.type` produced the
+ * aria-label "undefined: <title>" and an empty button face.
+ *
+ * ── HOW THESE ASSERTIONS BIND ──────────────────────────────────────────────
+ * By IDENTITY, never by a value predicate another element could satisfy
+ * (platform trap 19): every case pins its own testid and asserts on THAT
+ * element's text, and every "must not appear" is paired with a POSITIVE
+ * CONTROL asserting the honest replacement IS present — an absence assertion
+ * with nothing proving the surface rendered at all is vacuous (trap 13).
+ *
+ * ⚠ The diagnostic channels are asserted to SURVIVE. Removing a token from
+ * the user's eyes must not remove it from an operator's reach, or the next
+ * lane re-adds the leak to get its diagnosis back. `data-rejection-code` and
+ * `data-block-type` are that channel and are pinned here.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import type { GraphPatchBlock as GraphPatchBlockType, ProposalBlock } from '../types'
+import { humaniseWireToken } from '../friendlyOperation'
+
+const storeMocks = vi.hoisted(() => ({
+  canvasNodes: [] as Array<{ id: string; data?: { label?: string } }>,
+  canvasEdges: [] as Array<{ id: string; source: string; target: string }>,
+  noop: vi.fn(),
+}))
+
+vi.mock('../../store', () => {
+  const mockState = {
+    get nodes() { return storeMocks.canvasNodes },
+    get edges() { return storeMocks.canvasEdges },
+    selectNodeWithoutHistory: storeMocks.noop,
+    selectNodes: storeMocks.noop,
+    setShowInspectorPanel: storeMocks.noop,
+    setHighlightedNodes: storeMocks.noop,
+    setHighlightedEdges: storeMocks.noop,
+    currentScenarioLastResultHash: undefined,
+  }
+  return {
+    useCanvasStore: Object.assign(
+      (selector: (s: unknown) => unknown) => selector(mockState),
+      { getState: () => mockState },
+    ),
+  }
+})
+
+import { GraphPatchBlockRenderer, ProposalBlockRenderer } from '../blocks/GraphPatchBlockRenderer'
+import { V5UnsupportedBlock } from '../../../v5/blocks/V5UnsupportedBlock'
+
+beforeEach(() => {
+  storeMocks.canvasNodes = []
+  storeMocks.canvasEdges = []
+})
+
+// ---------------------------------------------------------------------------
+// The shared authority
+// ---------------------------------------------------------------------------
+
+describe('humaniseWireToken — the one authority', () => {
+  it('folds a SCREAMING_SNAKE code to sentence case', () => {
+    expect(humaniseWireToken('VALIDATION_FAILED')).toBe('Validation failed')
+    expect(humaniseWireToken('UNSUPPORTED_OPERATION')).toBe('Unsupported operation')
+  })
+
+  it('folds a snake_case enum to sentence case', () => {
+    expect(humaniseWireToken('add_node')).toBe('Add node')
+    expect(humaniseWireToken('v5_flip_analysis')).toBe('V5 flip analysis')
+  })
+
+  it('⭐ returns null for an ENTITY ID rather than a prettier leak', () => {
+    // The load-bearing case. `Fac x7` reads as a name the user is meant to
+    // recognise, which is worse than the raw id, so the caller must omit.
+    expect(humaniseWireToken('fac_x7')).toBeNull()
+    expect(humaniseWireToken('option_hire_tech_lead')).toBeNull()
+    expect(humaniseWireToken('opt_a')).toBeNull()
+  })
+
+  it('returns null for anything with no content to show', () => {
+    expect(humaniseWireToken('')).toBeNull()
+    expect(humaniseWireToken('   ')).toBeNull()
+    expect(humaniseWireToken('___')).toBeNull()
+    expect(humaniseWireToken(undefined)).toBeNull()
+    expect(humaniseWireToken(42)).toBeNull()
+  })
+
+  it('leaves mixed-case producer prose alone (never a downgrade)', () => {
+    expect(humaniseWireToken('Patch validation failed')).toBe('Patch validation failed')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 1 + the diagnostic channel
+// ---------------------------------------------------------------------------
+
+function rejectedPatch(): GraphPatchBlockType {
+  return {
+    type: 'graph_patch',
+    patch_id: 'patch-leak-1',
+    summary: 'Add a factor for supplier risk.',
+    operations: [],
+  } as unknown as GraphPatchBlockType
+}
+
+describe('a rejected patch does not print its rejection CODE at the user', () => {
+  it('shows the message and withholds the code', () => {
+    render(
+      <GraphPatchBlockRenderer
+        block={rejectedPatch()}
+        turnId="turn-1"
+        patchBlockStates={new Map([['turn-1:patch-leak-1', 'rejected']])}
+        patchRejections={new Map([[
+          'turn-1:patch-leak-1',
+          { code: 'VALIDATION_FAILED', message: 'Patch validation failed' },
+        ]])}
+      />,
+    )
+    const status = screen.getByTestId('patch-status-rejected')
+    // POSITIVE CONTROL — the surface rendered and still says what happened.
+    expect(status.textContent).toContain('Patch validation failed')
+    // The defect: `VALIDATION_FAILED: Patch validation failed`
+    expect(status.textContent).not.toContain('VALIDATION_FAILED')
+  })
+
+  it('keeps the code reachable for operators on a data attribute', () => {
+    render(
+      <GraphPatchBlockRenderer
+        block={rejectedPatch()}
+        turnId="turn-1"
+        patchBlockStates={new Map([['turn-1:patch-leak-1', 'rejected']])}
+        patchRejections={new Map([[
+          'turn-1:patch-leak-1',
+          { code: 'VALIDATION_FAILED', message: 'Patch validation failed' },
+        ]])}
+      />,
+    )
+    expect(screen.getByTestId('patch-rejection-detail')).toHaveAttribute(
+      'data-rejection-code',
+      'VALIDATION_FAILED',
+    )
+  })
+
+  it('falls back to the HUMANISED code when the producer sent no message', () => {
+    render(
+      <GraphPatchBlockRenderer
+        block={rejectedPatch()}
+        turnId="turn-1"
+        patchBlockStates={new Map([['turn-1:patch-leak-1', 'rejected']])}
+        patchRejections={new Map([[
+          'turn-1:patch-leak-1',
+          { code: 'UNSUPPORTED_OPERATION', message: '' },
+        ]])}
+      />,
+    )
+    const status = screen.getByTestId('patch-status-rejected')
+    expect(status.textContent).toContain('Unsupported operation')
+    expect(status.textContent).not.toContain('UNSUPPORTED_OPERATION')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3 + 4
+// ---------------------------------------------------------------------------
+
+function proposal(changes: ProposalBlock['changes']): ProposalBlock {
+  return {
+    type: 'proposal',
+    action_type: 'edit_graph',
+    description: 'Two changes to the model.',
+    proposal_id: 'prop-leak-1',
+    changes,
+  }
+}
+
+describe('a proposal change does not print raw wire tokens', () => {
+  it('humanises the operation token in its pill', () => {
+    render(<ProposalBlockRenderer block={proposal([
+      { operation: 'add_edge', target: 'Supplier risk', detail: 'Link supplier risk to margin.' },
+    ])} />)
+    const card = screen.getByTestId('block-proposal')
+    // POSITIVE CONTROL — the change itself still renders.
+    expect(card.textContent).toContain('Link supplier risk to margin.')
+    expect(card.textContent).toContain('Add edge')
+    expect(card.textContent).not.toContain('add_edge')
+  })
+
+  it('⭐ withholds an unresolvable ENTITY ID instead of rendering it as a label', () => {
+    // No node matches, so `resolveTarget` returns null and the old code
+    // rendered the bare id.
+    render(<ProposalBlockRenderer block={proposal([
+      { operation: 'update_node', target: 'fac_x7', detail: 'Raise the supplier-risk weight.' },
+    ])} />)
+    const card = screen.getByTestId('block-proposal')
+    expect(card.textContent).toContain('Raise the supplier-risk weight.')
+    expect(card.textContent).not.toContain('fac_x7')
+    expect(card.innerHTML).not.toContain('fac_x7')
+  })
+
+  it('still shows a RESOLVED target by its human label, and never by its id', () => {
+    storeMocks.canvasNodes = [{ id: 'fac_x7', data: { label: 'Supplier risk' } }]
+    render(<ProposalBlockRenderer block={proposal([
+      { operation: 'update_node', target: 'Supplier risk', detail: 'Raise the weight.' },
+    ])} />)
+    const card = screen.getByTestId('block-proposal')
+    // POSITIVE CONTROL for the resolved branch — the pill is present…
+    expect(card.textContent).toContain('Supplier risk')
+    // …and it carries the label, not the id.
+    expect(card.innerHTML).not.toContain('>fac_x7<')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 5
+// ---------------------------------------------------------------------------
+
+describe('an unsurfaced V5 block does not print its wire kind', () => {
+  it('keeps the honest sentence and drops the token pill', () => {
+    render(
+      <V5UnsupportedBlock
+        block={{ type: 'v5_unsupported', blockType: 'v5_flip_analysis', raw: {} } as never}
+      />,
+    )
+    const card = screen.getByTestId('v5-unsupported-block')
+    // POSITIVE CONTROL — the user still gets the explanation.
+    expect(card.textContent).toContain("can't display this part of the response yet")
+    expect(card.textContent).not.toContain('v5_flip_analysis')
+    // Operators keep the kind.
+    expect(card).toHaveAttribute('data-block-type', 'v5_flip_analysis')
+  })
+})

--- a/src/canvas/conversation/blocks/GraphPatchBlockRenderer.tsx
+++ b/src/canvas/conversation/blocks/GraphPatchBlockRenderer.tsx
@@ -34,7 +34,7 @@ import { resolvePatchBlockState } from '../selectors'
 import { resolveCardState, getPatchCardLabels } from '../utils/getPatchCardLabels'
 import { safeRichText, normaliseDashes } from '../../utils/safeRichText'
 import { isOrchestratorRenderingV2Enabled } from '../../../flags'
-import { describeOperation, RAW_ID_PATTERN } from '../friendlyOperation'
+import { describeOperation, humaniseWireToken, RAW_ID_PATTERN } from '../friendlyOperation'
 import type { DescribeOpDeps } from '../friendlyOperation'
 import { BadgeIcon } from './BadgeIcon'
 import styles from '../Conversation.module.css'
@@ -260,7 +260,9 @@ export function GraphPatchBlockRenderer({
             ...item,
             description: op
               ? describeOperation(op, deps)
-              : item.description.replace(new RegExp(RAW_ID_PATTERN.source, 'gi'), '[item]'),
+              // `[item]` read as a broken template to the user; the scrub is
+              // right, its replacement text was not.
+              : item.description.replace(new RegExp(RAW_ID_PATTERN.source, 'gi'), 'this element'),
             elementLabel: labelNeedsClean ? undefined : item.elementLabel,
           }
         })
@@ -268,7 +270,9 @@ export function GraphPatchBlockRenderer({
           const deps: DescribeOpDeps = { relatedElements, nodeLabels, edgeEndpoints }
           return {
             description: describeOperation(op, deps),
-            elementLabel: typeof op.data?.kind === 'string' ? op.data.kind : undefined,
+            // `kind` is a producer token (`intervention`, `outcome`), not a
+            // label the user wrote. Humanised, and DROPPED when it is an id.
+            elementLabel: humaniseWireToken(op.data?.kind) ?? undefined,
             changeLabel: undefined,
           }
         })
@@ -505,8 +509,23 @@ export function GraphPatchBlockRenderer({
         <div className={styles.graphPatchStatusRejected} data-testid="patch-status-rejected">
           {cardBadge && <BadgeIcon badge={cardBadge} />} {cardHeader}
           {rejectionInfo && (
-            <div className={styles.graphPatchError}>
-              {rejectionInfo.code}: {rejectionInfo.message}
+            <div
+              className={styles.graphPatchError}
+              data-testid="patch-rejection-detail"
+              /* ⚠ THE CODE STAYS REACHABLE, JUST NOT ON SCREEN. It used to be
+                 rendered as `CODE: message` — log language at the exact moment
+                 the product is telling the user something failed. The code is
+                 an operator's handle, so it moves to a data attribute rather
+                 than being deleted; deleting it is how the next lane
+                 re-introduces the leak to get its diagnosis back. */
+              data-rejection-code={rejectionInfo.code}
+            >
+              {/* The producer's own sentence when it sent one; otherwise the
+                  humanised code, because a rejection with no explanation at
+                  all is worse than a plain one. Never both, and never raw. */}
+              {rejectionInfo.message?.trim()
+                ? rejectionInfo.message
+                : humaniseWireToken(rejectionInfo.code) ?? 'This change could not be applied.'}
               {rejectionInfo.violations && rejectionInfo.violations.length > 0 && (
                 <>
                   <div className={styles.graphPatchViolations}>
@@ -717,23 +736,39 @@ export function ProposalBlockRenderer({
         <div className={styles.graphPatchProposalList}>
           {block.changes.map((c, i) => {
             const resolved = c.target ? resolveTarget(c.target) : null
+            const operationLabel = humaniseWireToken(c.operation)
+            /**
+             * An UNRESOLVED target is only ever shown when it is already human
+             * text — a label the producer wrote. An entity id resolves to null
+             * and the pill is omitted: the change's own `detail` sentence is
+             * what tells the user what is happening, and a pill reading
+             * `fac_x7` adds nothing but noise. A RESOLVED target keeps its
+             * string (the resolution rule matches on id OR exact label), but
+             * an id-shaped one is still withheld from display.
+             */
+            const targetLabel = c.target && !RAW_ID_PATTERN.test(c.target) ? c.target : null
             return (
               <div key={`${c.target}-${i}`} className={styles.graphPatchProposalItem}>
                 <span className={typography.panelBody}>{c.detail}</span>
                 <div className="flex gap-1">
-                  {c.operation && (
-                    <span className={`${typography.panelMeta} ${styles.outlinedPill}`}>{c.operation}</span>
+                  {/* Raw wire tokens never reach the DOM here. `GraphPatchBlockRenderer`
+                      above already scrubs its half through RAW_ID_PATTERN;
+                      this renderer did not, so `add_edge` and `fac_x7` were
+                      rendering verbatim — in the pill face AND in the pill's
+                      aria-label, i.e. read aloud to a screen-reader user. */}
+                  {operationLabel && (
+                    <span className={`${typography.panelMeta} ${styles.outlinedPill}`}>{operationLabel}</span>
                   )}
-                  {c.target && resolved && (
+                  {resolved && targetLabel && (
                     <TargetRefPill
                       id={resolved.id}
                       kind={resolved.kind}
-                      label={c.target}
+                      label={targetLabel}
                       className={`${typography.panelMeta} ${styles.graphPatchProposalBadge}`}
                     />
                   )}
-                  {c.target && !resolved && (
-                    <span className={`${typography.panelMeta} ${styles.graphPatchProposalBadge}`}>{c.target}</span>
+                  {!resolved && targetLabel && (
+                    <span className={`${typography.panelMeta} ${styles.graphPatchProposalBadge}`}>{targetLabel}</span>
                   )}
                 </div>
               </div>

--- a/src/canvas/conversation/dockedOlumiFocus.ts
+++ b/src/canvas/conversation/dockedOlumiFocus.ts
@@ -1,0 +1,60 @@
+/**
+ * dockedOlumiFocus — the focus channel for the DOCKED Olumi composer.
+ *
+ * ## Why this is a SECOND channel and not a widening of the first
+ *
+ * `useFloatingFocus` already exists and answers "focus the floating/hero
+ * composer". This one answers "focus the DOCKED composer". They look like one
+ * concept and are not: the two surfaces are mutually exclusive by design
+ * (`olumiSurface.resolveOlumiSurface`), they mount in different trees, and at
+ * any moment at most one of them has an input to focus. Folding them into one
+ * registry would mean the last surface to mount silently wins — which is the
+ * "two authorities under one name" defect this estate pays for repeatedly
+ * (platform trap 21). Two named channels, one per surface, and the caller
+ * picks by asking which surface is hosting.
+ *
+ * ## What it fixes
+ *
+ * Nothing registered a focus channel for the docked composer at all, so
+ * `revealOlumiSurface()` — the primitive every Ask-Olumi action funnels
+ * through — could only ever focus the floating panel. On the dominant deployed
+ * path (dock hosting Olumi, floating yielded and therefore NOT registered)
+ * `focusFloating()` returned false and the composer the user was looking at
+ * was never focused. The action "worked" and the user still had to click into
+ * the box.
+ *
+ * Module-level rather than context, for the same reason `useFloatingFocus` is:
+ * the callers are spread across the canvas, the inspector and the analysis
+ * surface, and prop-drilling a ref through them is not worth a re-render.
+ */
+
+type FocusFn = () => void
+
+let registered: FocusFn | null = null
+
+/**
+ * Called by the docked composer while it is actually rendering an input.
+ * Returns its own unregister — and the identity check means a stale cleanup
+ * from a previous mount cannot clear a newer registration.
+ */
+export function registerDockedOlumiFocus(fn: FocusFn): () => void {
+  registered = fn
+  return () => {
+    if (registered === fn) registered = null
+  }
+}
+
+/**
+ * Focus the docked Olumi composer. Returns false when nothing is registered —
+ * the dock is collapsed, on another tab, or in its status/redirect mode.
+ *
+ * ⚠ A false return is NOT an invitation to fall back to `focusFloating()`.
+ * On the docked path the floating panel has deliberately deregistered, and
+ * focusing whatever else happens to be in that slot is how the original defect
+ * worked. No focus is the correct outcome when there is no composer.
+ */
+export function focusDockedOlumi(): boolean {
+  if (!registered) return false
+  registered()
+  return true
+}

--- a/src/canvas/conversation/friendlyOperation.ts
+++ b/src/canvas/conversation/friendlyOperation.ts
@@ -144,6 +144,55 @@ export function friendlyFieldName(key: string): string {
 }
 
 /**
+ * ONE AUTHORITY for turning a raw WIRE TOKEN into user-facing text.
+ *
+ * ## The defect this closes
+ *
+ * Several surfaces rendered a producer token straight into the DOM — a
+ * rejection `code` (`VALIDATION_FAILED: …`), an operation enum (`add_node`), a
+ * block kind (`v5_flip_analysis`), a node `kind`. Each was individually small;
+ * together they are the "log language reaching the user" class, and every one
+ * of them arrived through the same shape: a value the UI does not model, put on
+ * screen because it was a string.
+ *
+ * ## What it does, and what it deliberately does NOT do
+ *
+ * It changes PRESENTATION only: separators to spaces, SCREAMING_SNAKE folded to
+ * sentence case, first letter capitalised. It never maps a token to a different
+ * word, so it cannot invent a meaning the producer did not have (P7 — a lookup
+ * table here would be a hand-maintained mirror of a producer enum, trap 12, and
+ * every entry would be a guess at the producer's semantics).
+ *
+ * ## Returning `null` is the load-bearing case
+ *
+ * An ENTITY ID is not display text at any casing. `Fac x7` is worse than
+ * `fac_x7`, because it reads as a name the user is expected to recognise. So
+ * anything matching {@link RAW_ID_PATTERN} — and anything that normalises to
+ * nothing — returns `null`, and the CALLER omits the element rather than
+ * rendering a prettier leak. Callers must treat `null` as "show nothing here",
+ * never as "fall back to the raw value": a `?? raw` at a call site reinstates
+ * the exact defect this function exists to remove.
+ */
+export function humaniseWireToken(raw: unknown): string | null {
+  if (typeof raw !== 'string') return null
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return null
+  // An entity id is never display text — see the docstring. Checked BEFORE any
+  // normalisation, because normalising first would destroy the very shape the
+  // pattern recognises.
+  if (RAW_ID_PATTERN.test(trimmed)) return null
+  // Already prose (contains a space and no separator) — pass through untouched
+  // rather than re-casing a producer's sentence.
+  const words = trimmed.replace(/[_\-.]+/g, ' ').replace(/\s+/g, ' ').trim()
+  if (words.length === 0) return null
+  // Fold SCREAMING_SNAKE / ALL CAPS to lower case so it stops reading as a log
+  // line. Mixed-case tokens keep their case: `blockType` is the producer's, and
+  // lower-casing `PLoT` or `EVPI` would be a downgrade, not a humanisation.
+  const folded = words === words.toUpperCase() ? words.toLowerCase() : words
+  return folded.charAt(0).toUpperCase() + folded.slice(1)
+}
+
+/**
  * Returns the first changed key from `data` according to UPDATE_FIELD_PRIORITY,
  * then any remaining keys (excluding `id`), sorted for determinism.
  *

--- a/src/canvas/conversation/revealOlumi.ts
+++ b/src/canvas/conversation/revealOlumi.ts
@@ -1,18 +1,98 @@
 import { useUIStore } from '../../stores/uiStore'
 import { focusFloating } from '../hooks/useFloatingFocus'
 import { isAiPanelV2Enabled } from '../../flags'
+import { focusDockedOlumi } from './dockedOlumiFocus'
 
 /**
- * Bring the Olumi chat surface into view after an action sends a message, so the
- * user sees their message land and Olumi's reply. Mirrors the live-diagnosed
- * reveal in useConversationActions: forceActivate the docked Olumi tab (bumps the
- * version so the dock reconciles + opens even when the tab value is unchanged;
- * gated on aiPanelV2 because OutputsDock redirects 'olumi'→'results' otherwise),
- * then best-effort focus a hosting floating panel.
+ * ONE OLUMI, WHEREVER THE USER LEFT IT.
+ *
+ * This is THE convergence primitive for the whole workspace: every Ask-Olumi,
+ * chip, coaching and rerun action launched from the Graph, the Analysis
+ * surface or the Inspector arrives here — six direct call sites plus
+ * `withOlumiReveal`, which wraps every guidance-store send. Whatever this
+ * function does IS what "actions converge on one Olumi interaction model"
+ * means in practice.
+ *
+ * ── WHAT IT USED TO DO, AND WHY THAT WAS TWO DEFECTS ──────────────────────
+ *
+ *   forceActivateOutputTab('olumi')   // claim the DOCK, unconditionally
+ *   focusFloating()                   // focus the FLOATING panel
+ *
+ * Those two lines fight each other, and the fight is visible to the user.
+ * Forcing the docked Olumi tab makes `dockHostsOlumi` true, and
+ * `FloatingOlumiPanel` returns null the moment it does
+ * (`FloatingOlumiPanel.tsx:856`, `yieldToDockedOlumi`). So:
+ *
+ *   1. A user working in the floating Olumi window who clicked "Ask Olumi" on
+ *      a node had that window CLOSED and the conversation relocated to the
+ *      dock. The product overrode the surface the user had chosen — the
+ *      opposite of converging on their interaction model.
+ *   2. `focusFloating()` then focused the panel that was about to unmount,
+ *      while the surface that actually took over — the docked composer in
+ *      `PersistentInputStrip` — got no focus, because nothing had ever
+ *      registered a channel for it. The action "worked" and the user still had
+ *      to click into the box before typing.
+ *
+ * ── THE RULE, AND WHERE ITS EVIDENCE COMES FROM ───────────────────────────
+ *
+ * Reveal the surface the user ALREADY HAS; claim the dock only when no Olumi
+ * composer is on screen.
+ *
+ * ⭐ The test for "is a floating/hero composer on screen?" is
+ * `focusFloating()`'s OWN RETURN VALUE, and that is deliberate. Both floating
+ * surfaces register their focus channel under exactly the condition that makes
+ * them paint — `FloatingOlumiPanel` under `isOpen && !yieldToFirstUse &&
+ * !yieldToDockedOlumi`, `FirstUseComposer` under its `shouldRender` — and
+ * both deregister on cleanup. So a registration IS the surface's own statement
+ * that it is visible, taken from the surface itself.
+ *
+ * The alternative was to re-derive visibility here from the canvas node count,
+ * the dock's persisted open-state and the active tab. That would be a SECOND
+ * copy of a rule the surfaces already implement (platform trap 12 — the two
+ * copies disagree the first time the rail rule moves), and it would have made
+ * this module import `OutputsDock`, closing a real cycle
+ * (`revealOlumi → OutputsDock → guidanceStore → revealOlumi`). Asking the
+ * surface is both cheaper and truer than modelling it.
+ *
+ * `forceActivateOutputTab` remains the right call on the dock path and does
+ * more than switch a tab: it opens a collapsed dock and ends the first-use
+ * rail, which is what makes "revealed" true rather than merely selected.
  */
 export function revealOlumiSurface(): void {
-  if (isAiPanelV2Enabled()) {
-    useUIStore.getState().forceActivateOutputTab('olumi')
+  // Flag OFF is the rollback posture: `OutputsDock` redirects an 'olumi'
+  // activation to 'results', so claiming the dock would front the WRONG tab.
+  // Best-effort floating focus, exactly as before — this path is unchanged.
+  if (!isAiPanelV2Enabled()) {
+    focusFloating()
+    return
   }
-  focusFloating()
+
+  // A floating or first-use composer is on screen and has been focused. Do NOT
+  // touch the dock: claiming it retires the very surface just revealed, and on
+  // an empty canvas it would retire it in favour of a 40px rail that cannot
+  // host a composer at all — stranding the user with nowhere to type.
+  if (focusFloating()) return
+
+  // Nothing floating is visible, so the dock is (or becomes) the host. Force-
+  // activate even when the Olumi tab is already selected: the version counter
+  // is what opens a collapsed dock and ends the first-use rail.
+  useUIStore.getState().forceActivateOutputTab('olumi')
+
+  // The composer may not be in composer mode yet — the activation above is a
+  // store write and `PersistentInputStrip` re-renders after it. Try now (the
+  // already-hosting case) and once more on the next frame.
+  //
+  // ⚠ NO FALLBACK TO `focusFloating()` HERE. It has already returned false, and
+  // reaching for it again after claiming the dock is exactly the defect above.
+  if (focusDockedOlumi()) return
+  scheduleFrame(() => { focusDockedOlumi() })
+}
+
+/** rAF where it exists, a macrotask otherwise (jsdom/node without rAF). */
+function scheduleFrame(fn: () => void): void {
+  if (typeof requestAnimationFrame === 'function') {
+    requestAnimationFrame(() => fn())
+    return
+  }
+  setTimeout(fn, 0)
 }

--- a/src/v5/blocks/V5UnsupportedBlock.tsx
+++ b/src/v5/blocks/V5UnsupportedBlock.tsx
@@ -31,18 +31,16 @@ export function V5UnsupportedBlock({ block }: V5UnsupportedBlockProps): ReactEle
   return (
     <div
       data-testid="v5-unsupported-block"
+      /* THE operator channel for this card, and the reason the visible pill
+         could go. Paired with the DEV console.warn above. */
       data-block-type={block.blockType}
       className="rounded-xl border border-text-light/30 bg-panel p-4 space-y-1"
     >
-      <span
-        className={[
-          'inline-flex items-center rounded-full px-2.5 py-0.5',
-          'bg-transparent border border-text-light/30 text-text-body',
-          typography.panelMeta,
-        ].join(' ')}
-      >
-        {block.blockType}
-      </span>
+      {/* ⚠ NO WIRE KIND ON SCREEN. This used to render `block.blockType` in a
+          pill — `v5_flip_analysis` above a polite sentence, i.e. the product
+          answering "what went wrong?" in log language. The kind means nothing
+          to a user and everything to an operator, so it lives on
+          `data-block-type` and in the DEV warn, not in the card face. */}
       <p className={typography.panelBody}>
         This app version can&apos;t display this part of the response yet.
         The rest of the message is unaffected.


### PR DESCRIPTION
# B3 · Olumi convergence — one Olumi surface, and no log language in it

Base `staging` @ `dd089a50`. Lane B3 of the first-send UX gate. **Phase 2 (non-removal
convergence) only — no visible content block is removed; the Phase-1 KEEP/CUT/REHOME table is in
the lane report and awaits Paul's veto.**

---

## P-COMPLIANCE BLOCK — read **v4, P1–P9**

| Rule | Evidence |
|---|---|
| **P7** producer semantics from the PRODUCER | `humaniseWireToken` deliberately has **no lookup table** — a token→word map would be a hand-maintained mirror of a producer enum and every entry a guess at semantics I did not derive. It changes casing and separators only, so it cannot assert a meaning the producer did not have. The one *semantic* judgement — "an entity id is never display text" — is derived from `friendlyOperation.RAW_ID_PATTERN`, whose header states it is kept in sync with the CEE producer's own `patch-summary.ts:ENTITY_ID_LEAK_RE`. |
| **P2** checked through the MOUNTED consumer | Mount path derived at this tip: `AppPoC.tsx:951/956` → `CanvasMVP.tsx:245` → `ReactFlowGraph.tsx:2105` → **`OutputsDock.tsx:3201 → OlumiTabBody → ConversationPanel`** (docked, always mounted) and **`ReactFlowGraph.tsx:2451 → FloatingOlumiPanel → ConversationPanel`**. Gate is `aiPanelV2`: `defaultValue: true` (`src/flags.ts:357`) **and** `VITE_FEATURE_AI_PANEL_V2="true"` (`netlify.toml:57`) → ON in every deployed context. Every render assertion executes the real component through that path; `DraftChat` is the flag-OFF rollback host and was deliberately **not** used as the consumer under test. |
| **P1** one seam BEYOND the guard | The guard is `humaniseWireToken`. The seam past it is **the render site's null-handling**: a caller that wrote `?? raw` would reinstate the leak with the guard fully intact. So every fix asserts at the DOM — `card.innerHTML` as well as `textContent`, because `TargetRefPill` also put the raw id in an `aria-label`, i.e. past the visible-text seam and into the accessibility tree. |
| **P5** claims grounded in canonical persisted state | n/a — nothing here asserts anything about the user's model, session or history. The one claim added ("This build cannot apply that kind of change yet") is about **this build's own capability**, which is the code path making it. |
| **P6** no manufactured obligations | n/a — no readiness/repair semantics touched; nothing new is required of the user. |
| **P8** every affordance has a pinned acceptance path | The only affordance changed is the guidance strip's action button. Its face was previously **empty** for an unmodelled wire type — an affordance with no readable answer at all. It now always carries a verb, and `GuidanceStrip.spec.tsx` pins that the label is non-empty and never the raw token. |
| **P4** mutation harness typechecked the mutated tree | **Mandatory control first:** the pristine tree passes `pnpm run typecheck` (563 files / 2306 errors). Three mutants of the type-risky shape (two `if (false)` orphan candidates + one widened assignment) were applied **together** and the gate still read **2306** — i.e. type-VALID, so no verdict is a false survivor. Restore control after: exactly **0** dirty files. Note the risk class P4 exists for (a false SURVIVOR) is not reachable here: **10/10 mutants were BITTEN.** |

---

## 1 · Every Ask-Olumi action overrode the surface the user had chosen

`revealOlumiSurface()` is **THE** convergence primitive — six direct call sites plus
`withOlumiReveal`, which wraps every guidance-store send, so Graph, Analysis and Inspector all
arrive here. It did two things unconditionally:

```ts
forceActivateOutputTab('olumi')   // claim the DOCK
focusFloating()                   // focus the FLOATING panel
```

Those fight each other, and the fight is visible. Claiming the docked Olumi tab makes
`dockHostsOlumi` true, and `FloatingOlumiPanel` returns `null` the moment it does
(`FloatingOlumiPanel.tsx:856`, `yieldToDockedOlumi`). So:

1. **A user working in the floating Olumi window who clicked "Ask Olumi" on a node had that window
   closed** and the conversation relocated to the dock. The product overrode their surface choice —
   the exact opposite of converging on one interaction model.
2. `focusFloating()` then focused the panel that was about to unmount, while the surface that
   actually took over — the docked composer in `PersistentInputStrip` — got **no focus at all**,
   because nothing had ever registered a channel for it. The action "worked" and the user still had
   to click into the box before typing.

**Now:** reveal the surface the user already has; claim the dock only when no Olumi composer is on
screen.

⭐ The test for "is a floating/hero composer on screen?" is **`focusFloating()`'s own return
value**. Both floating surfaces register their focus channel under exactly the condition that makes
them paint (`FloatingOlumiPanel.tsx:553`, `FirstUseComposer.tsx:283`) and deregister on cleanup, so
**a registration is the surface's own statement that it is visible** — taken from the surface, not
modelled here.

⚠ **A first draft of this did model it**, deriving visibility from the node count, the persisted
dock-open state and the active tab. Two things were wrong with it, and both are recorded because
they are the interesting part: it was a **second copy of a rule the surfaces already implement**
(trap 12 — the copies disagree the first time the rail rule moves), and it made this module import
`OutputsDock`, closing a real cycle **`revealOlumi → OutputsDock → guidanceStore → revealOlumi`**.
The repo's own typecheck ratchet caught it as **+1 error in a file I had never touched**
(`src/lib/auth/accessValidation.ts` TS7006) — proven pre-existing-clean by a pristine control
worktree. Reverted; the shipped version imports nothing new but the docked channel.

`dockedOlumiFocus.ts` is a **separately named** second channel rather than a widening of
`useFloatingFocus`: the two surfaces answer different questions and folding them into one registry
means the last surface to mount silently wins (trap 21). `PersistentInputStrip` registers it **only
in composer mode**, so the channel exists exactly when there is a textarea to focus — a channel that
reports success while focusing a null ref is worse than none, because the caller stops looking.

## 2 · Raw wire tokens rendered as user copy

Five surfaces put a producer token straight into the DOM, every one of them at the moment the
product is telling the user something went wrong:

| Was | Now |
|---|---|
| `VALIDATION_FAILED: Patch validation failed` | the producer's sentence; the code moves to `data-rejection-code` |
| `Unsupported operation: add_node` | "This build cannot apply that kind of change yet (add node)." |
| proposal pill `add_edge` | `Add edge` |
| proposal pill `fac_x7` — **visible label AND `aria-label`, i.e. read aloud** | omitted; the change's own sentence carries the meaning |
| unsurfaced-block pill `v5_flip_analysis` | omitted; `data-block-type` + the DEV warn keep it for operators |
| `[item]` mid-sentence (a scrub that read as a broken template) | `this element` |

Plus a runtime hole: `GuidanceStrip`'s `actionLabel` switch had **no `default`**, so an unmodelled
wire `primary_action.type` produced the aria-label `"undefined: <title>"` and an **empty button
face**. TypeScript could not see it — the union made the switch exhaustive at compile time, which is
exactly why it survived review. `primary_action.type` arrives on the wire, so the union is a claim
about pin time, not a runtime guarantee.

**Operator diagnosis is preserved, not deleted.** Removing a token from the user's eyes must not
remove it from an operator's reach, or the next lane re-adds the leak to get its diagnosis back —
so both `data-rejection-code` and `data-block-type` are pinned by test.

---

## Evidence

**RED-first at pristine, named signatures, collected counts asserted BY NAME:**

| Spec | RED at pristine | GREEN after |
|---|---|---|
| `wireTokenLeak.spec.tsx` | 6 failed / 6 passed (12) | **12 passed (12)** |
| `revealOlumiSurface.spec.ts` | 4 failed / 3 passed (7) | **9 passed (9)** |
| `PersistentInputStrip.spec.tsx` | — (4 new cases) | **12 passed** (8 pre-existing + 4) |
| `GuidanceStrip.spec.tsx` | — (1 new case) | **23 passed** (22 pre-existing + 1) |

**Mutants — 10/10 BITTEN, 0 void, 0 control failures.** Throwaway worktree OUTSIDE the repo root,
detached at the PR head; **sentinel-WRITE isolation proven with its own positive control** (an
earlier isolation probe of mine reported OK against a worktree that did not exist — trap 13 caught
on myself, hence the control); inodes differ; restores from a **pristine archive**, never from the
other copy; applied-check scoped to `src/` = exactly 1 per mutant, control after restore = exactly 0.

```
M1  unconditional dock claim (the original defect)      BITTEN  2 failed | 7 passed (9)
M2  dock path focuses the floating channel              BITTEN  1 failed | 8 passed (9)
M3  docked channel returns true without focusing        BITTEN  1 failed | 8 passed (9)
M4  strip registers in every mode                       BITTEN  3 failed | 9 passed (12)
M5  rejection-code leak restored                        BITTEN  2 failed | 10 passed (12)
M6  humaniser admits entity ids                         BITTEN  1 failed | 11 passed (12)
M7  proposal pill renders the raw target                BITTEN  1 failed | 11 passed (12)
M8  v5 blockType pill restored                          BITTEN  1 failed | 11 passed (12)
M9  actionLabel loses its default arm                   BITTEN  1 failed | 22 passed (23)
M10 proposal pill renders the raw operation             BITTEN  1 failed | 11 passed (12)
```

**Gate, in the required check's step order** (`Staging Gate` → `TypeScript + Lint` job: lint → typecheck → tests):
- **Lint** — 0 errors on every touched path (pre-existing warnings only).
- **Typecheck** — `pnpm run typecheck`: **563 files / 2306 errors, byte-identical to a pristine
  control worktree at `dd089a50`**.
- **Tests** — the four affected specs are green and mutation-proven above; the wider
  `src/canvas/conversation` sweep was still running when this lane stopped (per the 18 Aug amendment,
  lanes do not poll). **CI is the authority on the full suite.**

Not re-blessed: any visual-regression reference (N-30).
