### PR TITLE
fix(guest): stop presenting Olumi's own saved example as the visitor's recovered work (W-1)

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -29,6 +29,7 @@ import {
   shouldReleaseTextFocusOnCanvasPointerDown,
 } from './useKeyboardShortcuts'
 import { loadState, saveState } from './persist'
+import { armRecoveryNotice, consumeRecoveryNotice } from './persist/recoveryNotice'
 import * as scenarios from './store/scenarios'
 import type { Scenario } from './store/scenarios'
 import { isUUID } from '../services/turn-request-builder'
@@ -1644,11 +1645,18 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
 
       // Show recovery toast if we loaded from autosave
       // Note: Toast will be shown after component mounts via a separate effect
+      //
+      // ⚠ WHAT was restored decides WHAT we are allowed to say about it (W-1).
+      // This used to write a bare `'true'`, and the effect below turned every
+      // restore into "Recovered unsaved changes from your last session." —
+      // including a restore of Olumi's own bundled starter example, which is
+      // neither the visitor's work nor unsaved. `armRecoveryNotice` classifies
+      // by the graph's own starter stamp (the same predicate the canvas
+      // disclosure and the run gate use) and records the kind, not a boolean.
       if (recoveredFromAutosave) {
-        // Store flag for toast effect to pick up
-        try {
-          sessionStorage.setItem('olumi-recovered-from-autosave', 'true')
-        } catch {}
+        // No argument by design — it reads the graph this effect has just
+        // hydrated, so there is no array for a later edit to get wrong.
+        armRecoveryNotice()
       }
 
       // Restore ceeAnalysisReady with source-aligned fallback and validation
@@ -1771,16 +1779,17 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
       currentGraphHash: uiGraphHashSeedless(st.nodes, st.edges),
     })
 
-    try {
-      const recovered = sessionStorage.getItem('olumi-recovered-from-autosave')
-      if (recovered === 'true') {
-        sessionStorage.removeItem('olumi-recovered-from-autosave')
-        // Slight delay to ensure component is fully mounted
-        setTimeout(() => {
-          showToast('Recovered unsaved changes from your last session.', 'info')
-        }, 500)
-      }
-    } catch {}
+    // The sentence comes from `recoveryNotice`, which decided it from what was
+    // actually restored — never from a literal here. See its header for the
+    // measured defect (W-1: a bundled saved example announced as the user's
+    // own unsaved work).
+    const recoveryMessage = consumeRecoveryNotice()
+    if (recoveryMessage) {
+      // Slight delay to ensure component is fully mounted
+      setTimeout(() => {
+        showToast(recoveryMessage, 'info')
+      }, 500)
+    }
 
     // Uninstall the guidance persistence context when this canvas unmounts, so
     // a later mount cannot write under a stale decision identity.

--- a/src/canvas/components/pre-analysis-v3/__tests__/savedExampleAttribution.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/__tests__/savedExampleAttribution.spec.tsx
@@ -1,0 +1,145 @@
+/**
+ * THE MOUNTED PANEL MUST NOT ATTRIBUTE A BUNDLED EXAMPLE TO THE USER'S BRIEF.
+ *
+ * The pure-copy pin lives in `signals/__tests__/estimatesAttribution.spec.ts`.
+ * This file exists because that pin is not evidence that the PRODUCT asks the
+ * question: a mutation making `usePreAnalysisModel` compute `isSavedExample`
+ * as a constant `false` — i.e. the whole W-1 fabrication, restored — survived
+ * the copy spec, the registry spec and the guard, 212/212 green. The same
+ * lesson `reactFlowGraph.restoreFreshnessOnBoot.spec.ts` records: a perfect
+ * unit kit is not evidence that anything calls the unit.
+ *
+ * So this renders the real panel over a real store and reads the sentence off
+ * the screen, in both directions.
+ */
+
+import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { PreAnalysisPanelV3 } from '../PreAnalysisPanelV3'
+import { ToastProvider } from '../../../ToastContext'
+import { useCanvasStore } from '../../../store'
+import { useReadinessStore } from '../../../stores/readinessStore'
+import { useGuidanceStore } from '../../../stores/guidanceStore'
+import { useSignalSessionStore } from '../signals/signalSessionStore'
+import type { PreAnalysisSensitivity } from '../../../../adapters/cee/types'
+
+const SENSITIVITY: PreAnalysisSensitivity = {
+  factor_influence: { f1: 0.9, f2: 0.5, f3: 0.2 },
+  edge_influence: {},
+  method: 'linear',
+}
+
+function node(id: string, kind: string, label: string, data: Record<string, unknown> = {}): Node {
+  return { id, type: kind, position: { x: 0, y: 0 }, data: { kind, label, ...data } } as Node
+}
+
+type StoreEdge = Parameters<typeof useCanvasStore.setState>[0] extends infer S
+  ? S extends { edges?: Array<infer E> | undefined }
+    ? E
+    : never
+  : never
+
+function edge(source: string, target: string): StoreEdge {
+  return { id: `${source}->${target}`, source, target, data: {} } as StoreEdge
+}
+
+/**
+ * One graph, two provenances. `starterStamp` is the ONLY difference between
+ * the two arms, so any behavioural difference below is attributable to it and
+ * to nothing else.
+ */
+function seedGraph(starterStamp: Record<string, unknown>) {
+  const factor = (id: string, label: string, raw: number) =>
+    node(id, 'factor', label, {
+      provenance: 'ai_inferred',
+      observedState: { raw_value: raw, value: raw / 100, unit: '%', source: 'cee_inference' },
+      ...starterStamp,
+    })
+  useCanvasStore.setState({
+    nodes: [
+      node('d1', 'decision', 'Customer Data Platform Selection', starterStamp),
+      node('g1', 'goal', 'Replace CDP within budget', starterStamp),
+      node('o1', 'option', 'Segment', starterStamp),
+      node('o2', 'option', 'Snowflake-native build', starterStamp),
+      factor('f1', 'Snowflake-Native Build Adoption', 30),
+      factor('f2', 'Ramp-up time', 60),
+      factor('f3', 'Coordination overhead', 10),
+    ],
+    edges: [edge('f1', 'g1'), edge('f2', 'g1'), edge('f3', 'g1')],
+    preAnalysisSensitivity: SENSITIVITY,
+    ceeAnalysisReady: null,
+    draftCoaching: null,
+    currentBriefText: null,
+    goalThreshold: null,
+    goalConstraints: null,
+  })
+}
+
+const STARTER_STAMP = {
+  starterId: 'vendor-selection',
+  starterTitle: 'Customer Data Platform Selection',
+}
+
+function renderPanel() {
+  return render(
+    <ToastProvider>
+      <PreAnalysisPanelV3 onAnalyse={vi.fn()} isAnalysing={false} canRun />
+    </ToastProvider>,
+  )
+}
+
+/** The estimates signal sits behind the reveal; open it and return the section. */
+function sharpenSection(): HTMLElement {
+  fireEvent.click(screen.getByTestId('pre-analysis-v3-sharpen-reveal'))
+  return screen.getByTestId('pre-analysis-v3-sharpen')
+}
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) })))
+})
+
+beforeEach(() => {
+  useSignalSessionStore.getState().reset()
+  useGuidanceStore.setState({ _sendChip: null, _prefillChat: null })
+  useReadinessStore.setState({
+    readiness: {
+      readiness_score: 72,
+      readiness_level: 'ready',
+      can_run_analysis: true,
+      confidence_explanation: 'Looks consistent.',
+      improvements: [],
+    },
+    loading: false,
+    error: null,
+  })
+})
+
+describe('pre-analysis panel — whose brief was it', () => {
+  it('does NOT tell a visitor a bundled example came from their brief', () => {
+    seedGraph(STARTER_STAMP)
+    renderPanel()
+    const sharpen = sharpenSection()
+
+    // Precondition pinned in-test: the estimates signal must actually be on
+    // screen, bound to its own factor by name — otherwise the absence of the
+    // false sentence would prove nothing (trap 13).
+    expect(sharpen).toHaveTextContent('Check Snowflake-Native Build Adoption first, it may matter most.')
+
+    expect(sharpen).not.toHaveTextContent('from your brief')
+    expect(sharpen).toHaveTextContent('Olumi estimated 3 values in this saved example.')
+  })
+
+  it('STILL says "from your brief" when the model really came from the user', () => {
+    // Byte-identical graph minus the starter stamp — the discriminating pair.
+    seedGraph({})
+    renderPanel()
+    const sharpen = sharpenSection()
+
+    expect(sharpen).toHaveTextContent('Check Snowflake-Native Build Adoption first, it may matter most.')
+    expect(sharpen).toHaveTextContent('Olumi estimated 3 values from your brief.')
+    expect(sharpen).not.toHaveTextContent('saved example')
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -152,8 +152,24 @@ export const SIGNAL_COPY = {
   }),
   riskRationale:
     'Pre-mortem (Klein): imagine the choice failed, then ask what went wrong. It typically surfaces risks that planning misses.',
-  estimates: (n: number, topLabel: string | null) => ({
-    lead: `Olumi estimated ${n === 1 ? 'one value' : `${n} values`} from your brief.`,
+  /**
+   * ⚠ `isSavedExample` IS AN HONESTY PARAMETER, NOT A STYLE ONE (W-1).
+   *
+   * Measured live on deployed staging `6524caed`, 2026-08-18: a guest who had
+   * written nothing opened the bundled "Customer Data Platform Selection"
+   * example and was told "Olumi estimated 6 values from your brief." The brief
+   * ships inside the app and was drafted on 2026-07-28 — which the canvas
+   * banner two inches away says out loud. One surface knew; this one claimed
+   * authorship on the user's behalf.
+   *
+   * The count and the ranking are unchanged and still true either way; only
+   * the attribution moves. `n === 0` never reaches here (the signal does not
+   * fire), so both branches always name a real quantity.
+   */
+  estimates: (n: number, topLabel: string | null, isSavedExample: boolean) => ({
+    lead: isSavedExample
+      ? `Olumi estimated ${n === 1 ? 'one value' : `${n} values`} in this saved example.`
+      : `Olumi estimated ${n === 1 ? 'one value' : `${n} values`} from your brief.`,
     emphasis: topLabel
       ? `Check ${topLabel} first, it may matter most.`
       : 'Replacing them with your judgement usually helps the analysis.',

--- a/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
@@ -11,6 +11,7 @@ import { useEffect, useMemo } from 'react'
 import { useCanvasStore } from '../../../store'
 import { useGraphReadiness } from '../../../hooks/useGraphReadiness'
 import { readinessWillScaffold } from '../../../utils/canRunAnalysis'
+import { resolveStarterId } from '../../../starters/loadStarter'
 import { isReviewedByUser } from '../../pre-analysis/utils/isReviewedByUser'
 import { computeBars, type BarsModel } from '../selectors/computeBars'
 import { computeContestedRows, type ContestedRowModel } from '../selectors/computeContestedRows'
@@ -234,6 +235,17 @@ export function usePreAnalysisModel(): PreAnalysisModel {
     return guardCeeText(first.explanation, CEE_FALLBACK_COPY.biasRow).text
   }, [analysisReady])
 
+  /**
+   * Is the graph on the canvas one of the bundled starter examples?
+   *
+   * Derived from the graph's own stamp via `resolveStarterId` — the SAME
+   * predicate the canvas disclosure (`StarterProvenanceBanner`) and the run
+   * gate (`computeCeeCannotSeeModel`) ask. A separate flag would be a second
+   * answer to one question, and this panel would eventually contradict the
+   * banner sitting directly above it (W-1: it already did).
+   */
+  const isSavedExample = useMemo(() => resolveStarterId(nodes) != null, [nodes])
+
   const derived = useMemo(
     () =>
       deriveSignalViews(
@@ -245,12 +257,13 @@ export function usePreAnalysisModel(): PreAnalysisModel {
           risksAllOlumi: facts.risksAllOlumi,
           aiEstimatedCount: provenance.aiEstimatedCount,
           topUncalibrated: top,
+          isSavedExample,
           narrowFramingDetail,
           biasFindingExplanation,
         },
         seen,
       ),
-    [facts, success.isSet, provenance.aiEstimatedCount, top, narrowFramingDetail, biasFindingExplanation, seen],
+    [facts, success.isSet, provenance.aiEstimatedCount, top, isSavedExample, narrowFramingDetail, biasFindingExplanation, seen],
   )
 
   useEffect(() => {

--- a/src/canvas/components/pre-analysis-v3/signals/__tests__/estimatesAttribution.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/__tests__/estimatesAttribution.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * OLUMI MUST NOT ATTRIBUTE ITS OWN BUNDLED EXAMPLE TO THE USER'S BRIEF.
+ *
+ * MEASURED DEFECT (W-1, reproduced live on the deployed staging build
+ * `6524caed`, 2026-08-18). A guest with empty storage enters guest mode and
+ * opens the "Customer Data Platform Selection" saved example. The panel says,
+ * verbatim:
+ *
+ *   "Olumi estimated 6 values from your brief. Check Snowflake-Native Build
+ *    Adoption first, it may matter most."
+ *
+ * The visitor has never written a brief. The six values were estimated on
+ * 2026-07-28 from a brief that ships inside the app — which the canvas banner
+ * two inches away says out loud ("Saved example — Olumi drafted this model on
+ * 2026-07-28. It wasn't generated just now."). One surface knows; this one
+ * claims authorship on the user's behalf.
+ *
+ * P5: a claim about the user's own input must be grounded in something that
+ * says the user supplied it. The authoritative read here is the graph itself —
+ * `resolveStarterId(nodes)`, the SAME predicate the disclosure and the run gate
+ * use — not a separate "is this a demo" flag that could drift from either.
+ *
+ * OPPOSITE-DIRECTION TWIN (mandatory): a real user who really did write a brief
+ * must still be told their values came from it. Fixing a false claim by
+ * deleting the true one is the same defect facing the other way.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { SIGNAL_REGISTRY, type SignalDetectionInput } from '../registry'
+
+function input(overrides: Partial<SignalDetectionInput> = {}): SignalDetectionInput {
+  return {
+    goalPresent: true,
+    successSet: true,
+    optionCount: 4,
+    riskCount: 3,
+    risksAllOlumi: true,
+    aiEstimatedCount: 6,
+    // The exact factor the deployed build named in the live capture.
+    topUncalibrated: { id: 'f_snowflake', label: 'Snowflake-Native Build Adoption' },
+    narrowFramingDetail: null,
+    biasFindingExplanation: null,
+    isSavedExample: false,
+    ...overrides,
+  }
+}
+
+const def = SIGNAL_REGISTRY.find(d => d.signal_id === 'sig_estimates')!
+
+describe('estimates signal — attribution of who wrote the brief', () => {
+  it('does NOT claim the values came from the user\'s brief on a saved example', () => {
+    const detection = def.detect(input({ isSavedExample: true }))
+    // Precondition pinned in-test: the signal must actually fire, or the
+    // absence of the false sentence would prove nothing (trap 13).
+    expect(detection, 'precondition: the estimates signal must fire on this input').not.toBeNull()
+
+    expect(
+      detection!.copy.lead,
+      'the panel told a visitor who has never written a brief that Olumi estimated values "from ' +
+        'your brief" — the values came from the example\'s own bundled brief, drafted 2026-07-28',
+    ).not.toMatch(/your brief/i)
+
+    // Still says the true, useful part: how many values Olumi estimated.
+    expect(detection!.copy.lead).toMatch(/\b6\b/)
+    expect(detection!.copy.lead).toMatch(/Olumi estimated/)
+    // And still points at the highest-influence one, bound by its identity.
+    expect(detection!.copy.emphasis).toContain('Snowflake-Native Build Adoption')
+  })
+
+  it('STILL says "from your brief" when the brief really is the user\'s', () => {
+    const detection = def.detect(input({ isSavedExample: false }))
+    expect(detection, 'precondition: the estimates signal must fire on this input').not.toBeNull()
+    expect(detection!.copy.lead).toBe('Olumi estimated 6 values from your brief.')
+  })
+
+  it('the two directions are genuinely different sentences', () => {
+    // Guards against a "fix" that returns the same string either way and
+    // satisfies the negative assertion by accident.
+    const example = def.detect(input({ isSavedExample: true }))!.copy.lead
+    const own = def.detect(input({ isSavedExample: false }))!.copy.lead
+    expect(example).not.toBe(own)
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/signals/__tests__/registry.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/__tests__/registry.spec.ts
@@ -36,6 +36,7 @@ function input(overrides: Partial<SignalDetectionInput> = {}): SignalDetectionIn
     risksAllOlumi: true,
     aiEstimatedCount: 6,
     topUncalibrated: { id: 'f1', label: 'Tech lead impact' },
+    isSavedExample: false,
     narrowFramingDetail: null,
     biasFindingExplanation: null,
     ...overrides,
@@ -185,8 +186,13 @@ describe('glossary — every copy string passes the banned-terms scan', () => {
     ...SIGNAL_COPY,
     optionBreadth: SIGNAL_COPY.optionBreadth(2),
     riskCount: SIGNAL_COPY.riskCount(2, true),
-    estimates: SIGNAL_COPY.estimates(6, 'Tech lead impact'),
-    estimatesNoTop: SIGNAL_COPY.estimates(1, null),
+    // Both attributions are scanned: the saved-example wording is user-facing
+    // copy too, and a glossary scan that saw only one branch would be a guard
+    // watching one door.
+    estimates: SIGNAL_COPY.estimates(6, 'Tech lead impact', false),
+    estimatesNoTop: SIGNAL_COPY.estimates(1, null, false),
+    estimatesSavedExample: SIGNAL_COPY.estimates(6, 'Tech lead impact', true),
+    estimatesSavedExampleNoTop: SIGNAL_COPY.estimates(1, null, true),
   })
   push('ATTRIBUTION_COPY', ATTRIBUTION_COPY)
   push('RANK_LABEL_COPY', RANK_LABEL_COPY)

--- a/src/canvas/components/pre-analysis-v3/signals/__tests__/signalSession.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/__tests__/signalSession.spec.ts
@@ -12,6 +12,7 @@ function input(overrides: Partial<SignalDetectionInput> = {}): SignalDetectionIn
     risksAllOlumi: true,
     aiEstimatedCount: 6,
     topUncalibrated: { id: 'f1', label: 'Tech lead impact' },
+    isSavedExample: false,
     narrowFramingDetail: null,
     biasFindingExplanation: null,
     ...overrides,

--- a/src/canvas/components/pre-analysis-v3/signals/registry.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/registry.ts
@@ -22,6 +22,16 @@ export interface SignalDetectionInput {
   risksAllOlumi: boolean
   aiEstimatedCount: number
   topUncalibrated: { id: string; label: string } | null
+  /**
+   * True when the graph on the canvas is one of the bundled starter examples
+   * (`resolveStarterId(nodes) != null` — the same predicate the canvas
+   * disclosure and the run gate use, never a second answer to one question).
+   *
+   * Required, not optional: a signal that claims the user supplied something
+   * must be told whether they did, and an omitted flag defaulting to `false`
+   * would silently restore the W-1 fabrication at the next call site.
+   */
+  isSavedExample: boolean
   /** draftCoaching narrow_framing detail, verbatim — null when not live. */
   narrowFramingDetail: string | null
   /** First analysis_ready bias finding explanation, verbatim — null when not live. */
@@ -138,7 +148,11 @@ export const SIGNAL_REGISTRY: ReadonlyArray<SignalDef> = [
     resolvedCopy: 'Top estimates checked.',
     detect: input => {
       if (input.aiEstimatedCount === 0 || input.topUncalibrated == null) return null
-      const copy = SIGNAL_COPY.estimates(input.aiEstimatedCount, input.topUncalibrated.label)
+      const copy = SIGNAL_COPY.estimates(
+        input.aiEstimatedCount,
+        input.topUncalibrated.label,
+        input.isSavedExample,
+      )
       return {
         signal_id: 'sig_estimates',
         copy: { lead: copy.lead, emphasis: copy.emphasis },

--- a/src/canvas/persist/__tests__/recoveryNotice.spec.ts
+++ b/src/canvas/persist/__tests__/recoveryNotice.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * The recovery notice may not claim authorship it cannot ground.
+ *
+ * MEASURED DEFECT (W-1) — deployed staging `6524caed`, 2026-08-18, live
+ * browser, storage cleared from `/version.json` so no SPA unload write could
+ * re-seed it. A guest opened the bundled "Customer Data Platform Selection"
+ * saved example and reloaded; the product said "Recovered unsaved changes from
+ * your last session." about Olumi's own demo model.
+ *
+ * BOTH DIRECTIONS ARE PINNED HERE, and the second is not optional. The notice
+ * is CORRECT for the case it was built for — a real user with real unsaved work
+ * — and deleting recovery would be the same defect facing the other way. Every
+ * case below has its opposite-direction twin.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { useCanvasStore } from '../../store'
+import {
+  RECOVERY_NOTICE_COPY,
+  RECOVERY_NOTICE_KEY,
+  armRecoveryNotice,
+  classifyRecoveredGraph,
+  consumeRecoveryNotice,
+} from '../recoveryNotice'
+
+/** A node as the autosave stores it. */
+const node = (id: string, data: Record<string, unknown> = {}) => ({
+  id,
+  data: { label: id, ...data },
+})
+
+/** The shape `applyStarter` persists once its stamp survives the write. */
+const STARTER_GRAPH = [
+  node('dec_cdp', { starterId: 'vendor-selection', starterTitle: 'Customer Data Platform Selection' }),
+  node('fac_snowflake', { starterId: 'vendor-selection', starterTitle: 'Customer Data Platform Selection' }),
+]
+
+/** A model the user actually built. Same shape, no starter stamp. */
+const USER_GRAPH = [node('n1'), node('n2', { provenance: 'brief_extraction' })]
+
+describe('classifyRecoveredGraph', () => {
+  it('calls a restored saved example a saved example', () => {
+    expect(classifyRecoveredGraph(STARTER_GRAPH)).toBe('saved_example')
+  })
+
+  it("calls a restored user model unsaved work — the case the notice was built for", () => {
+    expect(classifyRecoveredGraph(USER_GRAPH)).toBe('unsaved_work')
+  })
+
+  it('finds the stamp wherever it sits, not only on the first node', () => {
+    // The disclosure and the run gate both scan every node; a classification
+    // that read nodes[0] would disagree with them the moment an unstamped node
+    // sat first — the exact split `resolveStarterId` was written to end.
+    expect(classifyRecoveredGraph([node('plain'), ...STARTER_GRAPH])).toBe('saved_example')
+  })
+
+  it('does not treat an empty or unstamped graph as an example', () => {
+    expect(classifyRecoveredGraph([])).toBe('unsaved_work')
+    expect(classifyRecoveredGraph([node('n1', { starterId: '' })])).toBe('unsaved_work')
+  })
+})
+
+/**
+ * `armRecoveryNotice` reads the graph the boot arbiter has just hydrated, so
+ * these drive it the way boot does: put the restored graph in the store, then
+ * arm. Hand-writing the flag instead would test the string, not the decision.
+ */
+function restoreIntoCanvas(nodes: ReadonlyArray<unknown>): void {
+  useCanvasStore.setState({
+    nodes: nodes.map(n => ({ ...(n as object), position: { x: 0, y: 0 } })) as never,
+    edges: [] as never,
+  })
+}
+
+describe('arm → consume, the whole handoff', () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+    useCanvasStore.setState({ nodes: [] as never, edges: [] as never })
+  })
+
+  it('NEVER tells a visitor a bundled example was their own unsaved work', () => {
+    restoreIntoCanvas(STARTER_GRAPH)
+    armRecoveryNotice()
+    // Precondition pinned in-test: a notice must actually be pending, else the
+    // absence of the false sentence would prove nothing (trap 13).
+    expect(sessionStorage.getItem(RECOVERY_NOTICE_KEY), 'precondition: a notice must be armed').toBe(
+      'saved_example',
+    )
+
+    const message = consumeRecoveryNotice()
+    expect(message).not.toBeNull()
+    expect(
+      message,
+      'the product announced Olumi\'s own bundled demo as the visitor\'s recovered unsaved work',
+    ).not.toBe(RECOVERY_NOTICE_COPY.unsaved_work)
+    expect(message).not.toMatch(/your last session/i)
+    expect(message).not.toMatch(/unsaved/i)
+    expect(message).toBe(RECOVERY_NOTICE_COPY.saved_example)
+  })
+
+  it('STILL recovers, and STILL says so, for genuine unsaved work', () => {
+    restoreIntoCanvas(USER_GRAPH)
+    armRecoveryNotice()
+    expect(sessionStorage.getItem(RECOVERY_NOTICE_KEY)).toBe('unsaved_work')
+    expect(consumeRecoveryNotice()).toBe('Recovered unsaved changes from your last session.')
+  })
+
+  it('the two sentences are genuinely different', () => {
+    // Guards a "fix" that returns one string for both and satisfies the
+    // negative assertion by accident.
+    expect(RECOVERY_NOTICE_COPY.saved_example).not.toBe(RECOVERY_NOTICE_COPY.unsaved_work)
+  })
+
+  it('says nothing at all when nothing was restored', () => {
+    expect(consumeRecoveryNotice()).toBeNull()
+  })
+
+  it('is consumed exactly once, so a remount cannot repeat it', () => {
+    restoreIntoCanvas(USER_GRAPH)
+    armRecoveryNotice()
+    expect(consumeRecoveryNotice()).not.toBeNull()
+    expect(consumeRecoveryNotice()).toBeNull()
+    expect(sessionStorage.getItem(RECOVERY_NOTICE_KEY)).toBeNull()
+  })
+
+  it("reads a previous build's bare 'true' as unsaved work rather than falling silent", () => {
+    // A tab that armed the flag before this deploy and consumed it after must
+    // not lose its notice. Read-side alias only — never written.
+    sessionStorage.setItem(RECOVERY_NOTICE_KEY, 'true')
+    expect(consumeRecoveryNotice()).toBe(RECOVERY_NOTICE_COPY.unsaved_work)
+  })
+
+  it('ignores a value it does not recognise instead of guessing', () => {
+    sessionStorage.setItem(RECOVERY_NOTICE_KEY, 'yes-please')
+    expect(consumeRecoveryNotice()).toBeNull()
+  })
+})
+
+describe('storage failures never break the canvas', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('arming survives a throwing sessionStorage', () => {
+    useCanvasStore.setState({
+      nodes: STARTER_GRAPH.map(n => ({ ...n, position: { x: 0, y: 0 } })) as never,
+    })
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError')
+    })
+    expect(() => armRecoveryNotice()).not.toThrow()
+  })
+
+  it('consuming survives a throwing sessionStorage', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError')
+    })
+    expect(consumeRecoveryNotice()).toBeNull()
+  })
+})

--- a/src/canvas/persist/recoveryNotice.ts
+++ b/src/canvas/persist/recoveryNotice.ts
@@ -1,0 +1,138 @@
+/**
+ * What the product is allowed to SAY when the boot arbiter restores a graph.
+ *
+ * ── THE DEFECT THIS EXISTS TO CLOSE (W-1) ────────────────────────────────────
+ * Measured live on the deployed staging build `6524caed`, 2026-08-18, with
+ * storage cleared from `/version.json` so no SPA unload write could re-seed it:
+ * a guest opened the "Customer Data Platform Selection" saved example and
+ * reloaded. The canvas came back announced by
+ *
+ *     "Recovered unsaved changes from your last session."
+ *
+ * The graph was Olumi's own bundled demo, drafted on 2026-07-28 and shipped
+ * inside the app. Two claims in one sentence, both false: that the model was
+ * the visitor's, and that it was unsaved work of theirs.
+ *
+ * ── WHY A SEPARATE MODULE ────────────────────────────────────────────────────
+ * The boot arbiter and the toast that speaks for it live ~200 lines apart in
+ * `ReactFlowGraph.tsx`, joined by a `sessionStorage` flag whose only value was
+ * `'true'` — a boolean cannot carry WHAT was restored, so the copy had nowhere
+ * to come from but a literal at the far end. Both halves live here, so the
+ * question "may we call this the user's own work?" is asked and answered in one
+ * place, and can be tested without mounting a 3,000-line component.
+ *
+ * ── HOW THE QUESTION IS ANSWERED ─────────────────────────────────────────────
+ * By `resolveStarterId` over the restored nodes — the SAME predicate the canvas
+ * disclosure (`StarterProvenanceBanner`) and the run gate
+ * (`computeCeeCannotSeeModel`) already use. Not a new "is this a demo" flag: a
+ * second answer to one question is how the disclosure and the gate would come
+ * to disagree, and the graph's own stamp is the authoritative persisted read
+ * (P5) — it is present exactly when the starter graph is.
+ *
+ * ⚠ This is only sound because `applyStarter` now persists the stamp. Until
+ * 2026-08-18 it stamped AFTER `applyDraftResult` had already written the
+ * autosave, so the restored graph carried no stamp and this classification
+ * would have returned `unsaved_work` for every starter. The two changes are one
+ * fix; see `loadStarter.ts`.
+ */
+
+import { resolveStarterId } from '../starters/loadStarter'
+import { useCanvasStore } from '../store'
+
+/** The cross-effect handoff key. Unchanged — an older build's value still reads. */
+export const RECOVERY_NOTICE_KEY = 'olumi-recovered-from-autosave'
+
+/**
+ * What was restored — NOT how confident we are, and NOT whether to speak.
+ * The kind decides the sentence; the sentences differ in what they CLAIM.
+ */
+export type RecoveryNoticeKind = 'unsaved_work' | 'saved_example'
+
+export const RECOVERY_NOTICE_COPY: Record<RecoveryNoticeKind, string> = {
+  /**
+   * Unchanged, deliberately. This is the case the notice was BUILT for — a
+   * real user with real unsaved work — and it is still true of that case. The
+   * defect was never this sentence; it was this sentence being said about
+   * something else.
+   */
+  unsaved_work: 'Recovered unsaved changes from your last session.',
+  /**
+   * Says only what holds in every sub-case, including a visitor who edited the
+   * example for an hour: the saved example is back on the canvas. It makes no
+   * claim about authorship, and none about how much of the session was theirs
+   * — "nothing of yours was recovered" would be a fresh false claim the moment
+   * they had edited it (one predicate cannot guard both harms).
+   *
+   * The rest of the truth is carried by `StarterProvenanceBanner`, which
+   * renders persistently beside it and names the example and its draft date:
+   * "Saved example — Olumi drafted this model on <date>. It wasn't generated
+   * just now." That banner is the estate's existing, tested disclosure for
+   * exactly this question, and it is back on screen now that the stamp
+   * survives the reload.
+   */
+  saved_example: 'Reopened the saved example.',
+}
+
+/** Minimal shape the classification reads — any node-like will do. */
+type NodeLike = { data?: Record<string, unknown> | undefined }
+
+/**
+ * Which notice a restored graph has earned.
+ *
+ * Bound by IDENTITY (the starter stamp), never by a value predicate another
+ * graph could satisfy — a node count, a title match or a "looks generated"
+ * heuristic would all classify a real user's model as a demo sooner or later.
+ */
+export function classifyRecoveredGraph(nodes: ReadonlyArray<NodeLike>): RecoveryNoticeKind {
+  return resolveStarterId(nodes) != null ? 'saved_example' : 'unsaved_work'
+}
+
+/**
+ * Record, at boot, that a restore happened and what it restored.
+ *
+ * ⚠ TAKES NO ARGUMENT, DELIBERATELY. The boot arbiter hydrates the store from
+ * the chosen source BEFORE it reaches this call, so the canvas already holds
+ * exactly the graph the notice is about. Reading it here rather than accepting
+ * it removes the one way this can silently go wrong: a call site that passes
+ * the wrong array (or an empty one) would classify every restore as
+ * `unsaved_work` and re-open W-1 with nothing red anywhere — and a call site
+ * buried in a 3,000-line effect is not something a unit test can pin. No
+ * argument, no mis-binding. It also makes the classification a statement about
+ * what the user is looking at (P2), which is what the sentence claims to be
+ * about.
+ *
+ * Fail-soft: `sessionStorage` throws in some privacy modes, and a missing
+ * toast must never be the thing that stops a canvas loading.
+ */
+export function armRecoveryNotice(): void {
+  try {
+    sessionStorage.setItem(
+      RECOVERY_NOTICE_KEY,
+      classifyRecoveredGraph(useCanvasStore.getState().nodes),
+    )
+  } catch {
+    /* sessionStorage unavailable — the graph still restores, silently */
+  }
+}
+
+/**
+ * Take the pending notice, if any, and clear it. Returns the sentence to show,
+ * or null when nothing was restored.
+ *
+ * `'true'` is accepted as `unsaved_work` for one reason only: a tab that armed
+ * the flag on the previous build and consumed it after a deploy would otherwise
+ * fall silent. It is a read-side alias, never written.
+ */
+export function consumeRecoveryNotice(): string | null {
+  let raw: string | null = null
+  try {
+    raw = sessionStorage.getItem(RECOVERY_NOTICE_KEY)
+    if (raw != null) sessionStorage.removeItem(RECOVERY_NOTICE_KEY)
+  } catch {
+    return null
+  }
+  if (raw == null) return null
+  if (raw === 'saved_example') return RECOVERY_NOTICE_COPY.saved_example
+  if (raw === 'unsaved_work' || raw === 'true') return RECOVERY_NOTICE_COPY.unsaved_work
+  return null
+}

--- a/src/canvas/starters/__tests__/starterIdentitySurvivesPersistence.spec.ts
+++ b/src/canvas/starters/__tests__/starterIdentitySurvivesPersistence.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * A SAVED EXAMPLE MUST STILL BE A SAVED EXAMPLE AFTER A RELOAD.
+ *
+ * MEASURED DEFECT (W-1, reproduced live on the deployed staging build
+ * `6524caed`, 2026-08-18, storage cleared from `/version.json` so no SPA unload
+ * write could re-seed it). A guest opens the "Customer Data Platform Selection"
+ * starter card and reloads. What comes back is:
+ *   - the toast "Recovered unsaved changes from your last session." — the
+ *     product telling a stranger a bundled demo is their own unsaved work;
+ *   - NO "Saved example — Olumi drafted this model on 2026-07-28" disclosure.
+ * Measured in the browser at that build: the persisted autosave held 19 nodes
+ * and `nodes.filter(n => n.data.starterId).length === 0`.
+ *
+ * ROOT CAUSE, at the bytes. `applyDraftResult` persists the autosave itself
+ * (applyDraftResult.ts, `if (!opts.skipAutosave)`), and `applyStarter` stamps
+ * `starterId`/`starterTitle` only AFTER `applyDraftResult` returns. So the copy
+ * that reaches localStorage — the copy the boot arbiter restores from — is the
+ * UNSTAMPED graph. The stamp exists in memory and dies at the page boundary,
+ * and with it BOTH honesty mechanisms `starterId` carries: the canvas
+ * disclosure (StarterProvenanceBanner) and the run gate
+ * (`computeCeeCannotSeeModel`).
+ *
+ * The in-memory stamp is already pinned by `applyStarter.spec.ts`. That spec
+ * stays green through the whole defect, because it never looks at what was
+ * WRITTEN — which is the seam one past the guard (P1).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { applyStarter, resolveStarterId, STARTERS } from '../loadStarter'
+import { useCanvasStore } from '../../store'
+
+const AUTOSAVE_KEY = 'olumi-canvas-autosave'
+
+function readPersistedNodes(): Array<{ id: string; data?: Record<string, unknown> }> {
+  const raw = localStorage.getItem(AUTOSAVE_KEY)
+  if (raw == null) throw new Error('no autosave was persisted at all')
+  const parsed = JSON.parse(raw) as { nodes?: Array<{ id: string; data?: Record<string, unknown> }> }
+  return parsed.nodes ?? []
+}
+
+describe('starter identity survives the persistence boundary', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    useCanvasStore.setState({ nodes: [] as never, edges: [] as never })
+  })
+
+  it('persists starterId on EVERY node, so a reload still knows this is a saved example', async () => {
+    const meta = STARTERS.find((s) => s.id === 'vendor-selection')!
+    await applyStarter('vendor-selection')
+
+    // Precondition pinned IN-TEST (trap 13b): the stamp must be present in
+    // memory, otherwise this spec could pass by measuring an empty graph.
+    const inMemory = useCanvasStore.getState().nodes
+    expect(inMemory.length, 'precondition: the starter must have applied nodes').toBe(meta.nodeCount)
+    expect(resolveStarterId(inMemory), 'precondition: the in-memory stamp must be present').toBe(
+      'vendor-selection',
+    )
+
+    const persisted = readPersistedNodes()
+    expect(persisted.length, 'precondition: the autosave must hold the starter graph').toBe(
+      meta.nodeCount,
+    )
+
+    // Bound by IDENTITY — the starter's own id, not "some truthy provenance
+    // field" another node could satisfy.
+    const stamped = persisted.filter((n) => n.data?.starterId === 'vendor-selection')
+    expect(
+      stamped.length,
+      'the PERSISTED autosave lost the saved-example stamp, so the next page load restores this ' +
+        'bundled demo as the user\'s own unsaved work: no "Saved example" disclosure, and the ' +
+        'recovery toast claims it came from their last session',
+    ).toBe(meta.nodeCount)
+
+    // The disclosure names the example, so the title must survive too.
+    expect(persisted.every((n) => n.data?.starterTitle === meta.title)).toBe(true)
+
+    // The predicate the product actually asks, run over the restored shape.
+    expect(resolveStarterId(persisted)).toBe('vendor-selection')
+  })
+
+  it('never lets an UNSTAMPED copy reach storage, not even for an instant', async () => {
+    // A mutant that lets `applyDraftResult` persist its own copy first and
+    // relies on the stamped write to supersede it survived the assertion above
+    // — the end state was right. It is still wrong: between the two writes the
+    // stored record is an unstamped starter, and a crash, a navigation or a
+    // second tab reading in that window gets exactly the W-1 state back. So
+    // the pin is on EVERY write, not on the last one.
+    const writes: Array<{ starterId: unknown }> = []
+    const setItem = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation((key: string, value: string) => {
+        if (key === AUTOSAVE_KEY) {
+          const parsed = JSON.parse(value) as { nodes?: Array<{ data?: Record<string, unknown> }> }
+          writes.push({ starterId: parsed.nodes?.[0]?.data?.starterId })
+        }
+      })
+
+    await applyStarter('market-entry')
+    setItem.mockRestore()
+
+    // Positive control: the spy must have SEEN a write, or "no unstamped
+    // write" would be true of an instrument that saw nothing.
+    expect(writes.length, 'precondition: at least one autosave write must be observed').toBeGreaterThan(0)
+    expect(writes.length, 'the starter graph reached storage more than once').toBe(1)
+    expect(writes.every(w => w.starterId === 'market-entry')).toBe(true)
+  })
+})

--- a/src/canvas/starters/loadStarter.ts
+++ b/src/canvas/starters/loadStarter.ts
@@ -19,6 +19,8 @@
 
 import { applyDraftResult } from '../utils/applyDraftResult'
 import { useCanvasStore } from '../store'
+import { saveAutosave } from '../store/scenarios'
+import { autosaveSourceFromStore, projectAutosaveData } from '../store/autosaveProjection'
 import manifest from './starters.manifest.json'
 
 export interface StarterProvenance {
@@ -138,6 +140,12 @@ export async function loadStarterPayload(id: string): Promise<unknown> {
  * `starterId` is load-bearing in two places (canRunAnalysis's honesty gate and
  * the canvas disclosure), so it is applied to EVERY node: a partial stamp
  * would let a single unstamped node silently satisfy an `every()` check.
+ *
+ * ⚠ RUNNING AFTER THE INGESTION IS ONLY SAFE IF NOTHING PERSISTS IN BETWEEN.
+ * It did not use to be: `applyDraftResult` writes the autosave itself, so the
+ * copy that reached `localStorage` — the copy the boot arbiter restores from —
+ * was the UNSTAMPED graph. The stamp lived in memory and died at the page
+ * boundary. See `applyStarter` below for the measured consequence.
  */
 function stampStarterProvenance(id: string, title: string): void {
   const state = useCanvasStore.getState()
@@ -171,10 +179,37 @@ export async function applyStarter(id: string): Promise<ApplyStarterResult> {
   const meta = getStarter(id)
   if (!meta) throw new Error(`[starters] unknown starter id "${id}"`)
   const payload = await loadStarterPayload(id)
-  const result = applyDraftResult(payload as never)
+  // ⚠ `skipAutosave` IS THE FIX, NOT AN OPTIMISATION — W-1, measured live on
+  // the deployed staging build `6524caed` (2026-08-18) with storage cleared
+  // from `/version.json` so no SPA unload write could re-seed it.
+  //
+  // `applyDraftResult` persists the autosave from its own body, BEFORE this
+  // function has stamped anything. So a guest who opened the "Customer Data
+  // Platform Selection" card and reloaded got back an autosave holding 19
+  // nodes and `nodes.filter(n => n.data.starterId).length === 0` — and with
+  // the stamp went every honesty mechanism it carries. The reloaded canvas
+  // showed no "Saved example" disclosure, the run gate stopped refusing on
+  // starter grounds, and the boot arbiter announced Olumi's own bundled demo
+  // as "Recovered unsaved changes from your last session."
+  //
+  // Ingest without persisting, stamp, then persist the STAMPED graph once.
+  const result = applyDraftResult(payload as never, { skipAutosave: true })
   if (result.nodeCount === 0) {
     throw new Error(`[starters] "${id}" applied zero nodes — fixture is not a usable graph`)
   }
   stampStarterProvenance(id, meta.title)
+  // Same projection every other writer uses (autosaveProjection.ts's single
+  // constructor invariant, pinned by tests/ci-guards).
+  //
+  // Fail-soft in the SAFE direction, deliberately. If this write throws
+  // (quota, private mode) the canvas keeps the example and no autosave is
+  // written at all — the next load starts clean. That is strictly better than
+  // the behaviour this replaced, where a failure to stamp still left an
+  // unstamped record behind for the boot arbiter to misattribute.
+  try {
+    saveAutosave(projectAutosaveData(autosaveSourceFromStore(useCanvasStore.getState())))
+  } catch {
+    // Non-critical — the example is on the canvas either way.
+  }
   return result
 }

--- a/tests/ci-guards/recovery-notice-single-writer.spec.ts
+++ b/tests/ci-guards/recovery-notice-single-writer.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * CI guard: ONE module decides what the product says about a restored graph.
+ *
+ * W-1 shipped because the decision and the sentence lived ~200 lines apart in
+ * `ReactFlowGraph.tsx`, joined by a `sessionStorage` flag whose only value was
+ * `'true'`. A boolean cannot carry WHAT was restored, so the copy had nowhere
+ * to come from but a literal at the far end — and that literal claimed the
+ * user's authorship of Olumi's own bundled demo.
+ *
+ * Nothing structural stops the next edit re-introducing a hand-written flag or
+ * a second copy of the sentence somewhere else, and the drift would read green
+ * (a toast that says the wrong thing fails no test). So the invariant is
+ * DERIVED from the filesystem on every run rather than remembered.
+ *
+ * Comments are stripped but string literals are NOT (the opposite of the
+ * autosave guard): the literals ARE the thing being counted here.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+import { stripComments } from '../helpers/stripSourceComments'
+import {
+  RECOVERY_NOTICE_COPY,
+  RECOVERY_NOTICE_KEY,
+} from '../../src/canvas/persist/recoveryNotice'
+
+const SRC = join(process.cwd(), 'src')
+const OWNER = 'canvas/persist/recoveryNotice.ts'
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === 'node_modules' || entry === '__tests__') continue
+      walk(full, out)
+    } else if (/\.tsx?$/.test(entry) && !/\.spec\.tsx?$/.test(entry)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+/**
+ * Read + strip ONCE. The sweep is ~3,500 files; doing it per assertion cost
+ * 30s of shard time for four questions about the same corpus.
+ */
+const CORPUS: ReadonlyArray<readonly [string, string]> = walk(SRC).map(file => {
+  const rel = relative(SRC, file).split('\\').join('/')
+  return [rel, stripComments(readFileSync(file, 'utf8'), file)] as const
+})
+
+/** Production modules whose CODE (not comments) contains `needle`. */
+function filesContaining(needle: string): string[] {
+  return CORPUS.filter(([, code]) => code.includes(needle)).map(([rel]) => rel)
+}
+
+describe('recovery notice — one decider, one sentence', () => {
+  it('finds the owner at all (positive control — an empty sweep proves nothing)', () => {
+    // If the walker or the comment stripper breaks, every assertion below
+    // passes by looking at nothing. Absence claims need a positive control.
+    expect(filesContaining(RECOVERY_NOTICE_KEY)).toContain(OWNER)
+    expect(filesContaining(RECOVERY_NOTICE_COPY.unsaved_work)).toContain(OWNER)
+  })
+
+  it('no other production module writes the handoff key', () => {
+    expect(filesContaining(RECOVERY_NOTICE_KEY)).toEqual([OWNER])
+  })
+
+  it('no other production module carries the recovery sentences', () => {
+    expect(filesContaining(RECOVERY_NOTICE_COPY.unsaved_work)).toEqual([OWNER])
+    expect(filesContaining(RECOVERY_NOTICE_COPY.saved_example)).toEqual([OWNER])
+  })
+
+  it('the sentence a saved example gets claims nothing about the user', () => {
+    // Bound to the words that made W-1 a fabrication, not to the whole string:
+    // the copy may be reworded, it may not start claiming authorship again.
+    expect(RECOVERY_NOTICE_COPY.saved_example).not.toMatch(/your last session/i)
+    expect(RECOVERY_NOTICE_COPY.saved_example).not.toMatch(/unsaved/i)
+    expect(RECOVERY_NOTICE_COPY.saved_example).not.toMatch(/your (work|changes|model)/i)
+    // Opposite direction: the real-work sentence must still make the claim it
+    // is entitled to make. Removing it would be the same defect facing round.
+    expect(RECOVERY_NOTICE_COPY.unsaved_work).toMatch(/your last session/i)
+  })
+})


### PR DESCRIPTION
## The defect, reproduced before it was fixed

**W-1.** Measured live on the **deployed staging build `6524caed`** (2026-08-18), in a real browser, against a genuinely clean origin.

> **Method note, because W-1's own method note was not sufficient.** Clearing `localStorage` and reloading in the same JS tick still risks the SPA rewriting the autosave during unload. I cleared storage while sitting on **`/version.json`** — same origin, no SPA — then navigated to `/`. Nothing is running that can re-seed. That page also confirmed the served bundle is `6524caed`, the same commit this branch is based on.

A guest opens the **"Customer Data Platform Selection"** starter card on the first screen and reloads. What comes back:

| surface | what it says | truth |
|---|---|---|
| toast | *"Recovered unsaved changes from your last session."* | there was no session; the model is Olumi's, shipped in the app |
| pre-analysis panel | *"Olumi estimated 6 values from your brief."* | the visitor has written no brief |
| canvas | **nothing** — the "Saved example" disclosure is gone | it *is* a saved example |

Captured from the live page: `autosaveNodes: 19`, **`nodesCarryingStarterId: 0`**, `bannerPresent: false`, `redraftCta: false`.

## Root cause — one ordering

`applyDraftResult` persists the autosave from its own body (`if (!opts.skipAutosave)`). `applyStarter` stamped `starterId`/`starterTitle` **after** it returned. So the copy that reached `localStorage` — the copy the boot arbiter restores from — was the **unstamped** graph. The stamp existed in memory and died at the page boundary, and with it **both** honesty mechanisms `starterId` carries: the canvas disclosure (`StarterProvenanceBanner`) and the run gate (`computeCeeCannotSeeModel`). The boot arbiter then saw a plain autosave and said the only sentence it knew.

`applyStarter.spec.ts` stayed green through all of it: it asserts the **in-memory** stamp and never looks at what was written. That is the seam one past the guard.

## ⭐ The reported premise is corrected

**A genuinely first-time guest was never shown this.** Measured on the same build with storage empty: **empty canvas, no toast, no autosave written, `localStorage = ["sandbox.help.open","sandbox.mode"]`.** W-1's *"the app minted it at boot"* does not hold — its "fresh" state was seeded, which is exactly the hazard its own method note warns about.

That does not shrink the finding. The reachable path is **one click on the first screen a customer link lands on**, and everything downstream of that click was as reported.

## What changed

**1 · `starters/loadStarter.ts` — the identity survives the write.** Ingest with `skipAutosave`, stamp, then persist the stamped graph once. If that write throws, **no** record is left rather than an unstamped one — the safe direction.

**2 · `persist/recoveryNotice.ts` (new) — the flag carries *what* was restored.** The decision and the sentence used to sit ~200 lines apart in `ReactFlowGraph.tsx`, joined by a `sessionStorage` value of `'true'`; a boolean cannot carry what was restored, so the copy had nowhere to come from but a literal at the far end. Both halves now live in one module. `armRecoveryNotice()` **takes no argument** — it reads the graph the arbiter has just hydrated, so there is no array for a later edit to get wrong in a place no unit test can reach.

**3 · `pre-analysis-v3` — the panel asks whose brief it was.** Via `resolveStarterId`, the **same** predicate the disclosure and the run gate use. Not a second answer to one question: that is how this panel came to contradict the banner directly above it.

### The choice this makes, stated plainly
The bundled example is **deliberately** shown to newcomers — `StarterDecisions` says so in its own copy ("Or open a saved example — a real decision Olumi has modelled") and `StarterProvenanceBanner`'s header calls the disclosure a *"NON-NEGOTIABLE HONESTY REQUIREMENT"*. So it is kept, and made **honestly labelled again**: the disclosure returns on reload because the stamp now survives, and the toast says `"Reopened the saved example."` — true in every sub-case including a visitor who edited it for an hour. *"Nothing of yours was recovered"* would become a fresh false claim the moment they had.

### Recovery is not deleted
`RECOVERY_NOTICE_COPY.unsaved_work` is byte-identical to the sentence that shipped. The defect was never that sentence; it was that sentence being said about something else. Every case here has its **opposite-direction twin**, and mutants M4/M8 exist to prove the twins bite.

## Evidence

**RED-first at pristine** (behavioural, not module-missing):
- `starterIdentitySurvivesPersistence` — `expected 19, received 0` stamped nodes in the persisted autosave. Same number the browser measured.
- `estimatesAttribution` — 3 collected, **2 failed / 1 passed**; the one that passed is the twin ("a real user's brief still says so").

**Mutants — 9/9 bitten.** Throwaway worktree **outside** the repo root, isolation proven by **sentinel WRITE** (sentinel absent from source, SHAs diverged, inodes differ, source `git status` empty), restores from a **pristine archive** (never `git checkout --`, which stages), applied-check scoped to `src/` **= 1** on every mutant, **control = 0**, and a named 7-spec / **214-test** collected baseline asserted non-zero before any verdict.

| # | mutation | bitten by |
|---|---|---|
| M1 | drop `skipAutosave` (unstamped write lands first) | "never lets an UNSTAMPED copy reach storage" |
| M2 | drop the stamped write | persistence spec, 2 tests |
| M3 | classify everything as `unsaved_work` (**the pre-fix behaviour**) | saved-example assertions — twin stays **green** |
| M4 | classify everything as `saved_example` (**opposite direction**) | genuine-work assertions — saved-example test stays **green** |
| M5 | give the example the unsaved-work sentence | notice spec + single-writer guard |
| M6 | classify from `nodes[0]` only | "finds the stamp wherever it sits" |
| M7 | restore "from your brief" for an example (**the W-1 fabrication**) | attribution spec — twin stays **green** |
| M8 | call a real user's brief an example (**opposite direction**) | the twin — saved-example test stays **green** |
| M9 | hook stops asking the graph | mounted-panel spec |

**M3/M4 and M7/M8 fail on *different* assertions** — the discriminating pair, not one biting mutant.

**M1 and M9 both survived the first battery, and both were real findings, not noise.** M1 survived because the spec asserted the *final* persisted state, which a superseding write satisfies — so the assertion moved to **every** write, since between the two writes the stored record is an unstamped starter and a crash or a second tab in that window gets W-1 back. M9 survived because *nothing exercised the hook* — a constant `false` re-opened the whole fabrication under 212/212 green. That is the lesson `reactFlowGraph.restoreFreshnessOnBoot.spec.ts` already records, so M9 is now killed by a spec that **mounts the real panel over a real store and reads the sentence off the screen**, in both directions, with the starter stamp as the only difference between the two arms.

**Gate steps run locally, in the required check's order** (`Staging Gate` = `tsc` → `typecheck-selftest` → `vitest` → `vitest-summary` → `build`):
- `pnpm run lint` — **0 errors**; hooks ratchet **229/13, exactly baseline** (no new conditional hook)
- `pnpm run typecheck` — **PASSED**, baseline **2306 unchanged**, no `--update-baseline`
- `ci:guard:zustand` · `ci:guard:starters` · `check:vendor` · `ci:guard:schemas-version` — all **PASS**
- Three pre-existing spec files needed a real edit, not a suppression: `SignalDetectionInput` gained a **required** field, so the two `input()` helpers and the glossary scan had to state it. The glossary scan now scans **both** attributions — a scan that saw one branch would be a guard watching one door.

Per the 18 Aug amendment: **not polling CI, not merging.**

## For the reviewer

- **`workspaceShell/shellContract.ts` untouched** (shared). No file under `src/components/results/**`, the canvas edges, the inspector, or the conversation surface was modified.
- **Same defect class, left alone because sibling lanes own those files** — reporting, not fixing: `src/canvas/ui/inspector-v2/inspectorStrings.ts:184` maps `brief_extraction` → *"Generated from your brief"*, and `src/canvas/nodes/FactorNode.tsx:598` renders *"Olumi estimated this from your brief."* Both are false over a starter for the same reason, and both now have `resolveStarterId` available to fix it the same way.
- **Residual gap, disclosed:** no test pins the `armRecoveryNotice()` **call site** inside `ReactFlowGraph`'s boot effect — the component is not unit-mountable and extracting the arbiter is out of scope. Mitigated by removing the argument (nothing to mis-bind) and by a filesystem-derived guard, with a positive control, asserting that module is the **only** production writer of the key and the only carrier of either sentence.
- **Not re-blessed:** no visual-regression reference touched (N-30).

## P-COMPLIANCE BLOCK
Read `STANDING-BRIEF-PREAMBLE.md` **v4 · 9 rules (P1–P9)**, plus the 18 Aug amendment (lanes do not poll CI).

- **P7 — producer semantics from the PRODUCER.** `starterId`'s meaning read at `loadStarter.ts`'s own header (*"PROVENANCE IS NOT OPTIONAL… Every node carries `data.starterId`"*) and at `resolveStarterId`'s docstring (scan **every** node; the gate and the disclosure must not disagree). The copy's meaning read at `constants.ts` and at `StarterDecisions`'s header. No predicate inferred from an observed corpus.
- **P2 — the MOUNTED consumer.** Three ways: the deployed build driven in a browser (what it renders, quoted verbatim above); `PreAnalysisPanelV3` mounted over a real store and its sentence read off the DOM; `ReactFlowGraph` wired to the module rather than to a literal.
- **P1 — one seam BEYOND the guard.** The named guard is the in-memory stamp (`applyStarter.spec.ts`, green throughout). The seam past it is **persistence and rehydration** — what reaches `localStorage` and what the boot arbiter says about it.
- **P5 — grounded in canonical persisted state.** Every claim keys off `resolveStarterId` over the **restored graph** — the authoritative persisted read, present exactly when the starter graph is. No parallel flag.
- **P6 — no manufactured obligation.** No structure inferred, none created; only what the product is permitted to *say* changed.
- **P8 — every affordance's answer is acceptable.** No new question is asked. The example's existing affordance ("Re-draft this live") is unchanged and reachable again on reload, because the banner that offers it is back.
- **P4 — the mutation harness typechecks the mutated tree.** Clean tree asserted PASSING first (the mandatory control). Mutants written so none can orphan an import — the `noUnusedLocals` false-survivor case — and the two with genuine type risk (M2, M9) batched into one gate run per the 17 Aug cost refinement. **Result recorded in a follow-up comment; it had not returned when this was written, and a verification result is not written before it is measured.**
