### PR TITLE
feat(model-tab): rehome every send-to-AI capability onto the canonical editor — step 1 of REHOME → DELETE

### DIFF
--- a/src/canvas/components/ModelTabBody.tsx
+++ b/src/canvas/components/ModelTabBody.tsx
@@ -56,6 +56,10 @@ import { resolveRawFactorConfidenceDisplay, type FactorConfidenceDisplay } from 
 // are retained UNCHANGED — the design's §7 KEEP/CUT removals await Paul's
 // verdict and are deliberately not executed in this train.
 import { ModelTabV2Panel } from '../model-tab-v2/ModelTabV2Panel'
+// THE ONE hand-off for affordances that terminate in a conversation. Built here
+// because this file is the Model tab's only live-app seam; the v2 directory
+// stays free of fronting and store concerns.
+import { createOlumiHandOff } from '../conversation/olumiHandOff'
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -745,6 +749,24 @@ export const ModelTabBody = memo(function ModelTabBody({
     navigator.clipboard?.writeText(json).catch(() => {})
   }, [goalLabel, sortedFactors, sortedEdges])
 
+  /**
+   * The Olumi hand-off for the canonical outline's group affordances.
+   *
+   * ⚠ `null` WHEN THERE IS NO SENDER, and that null travels all the way to the
+   * buttons, which then do not render. The v1 sections each guarded their
+   * send-to-AI controls behind `{onSendMessage && …}`; this preserves that guard
+   * in ONE place instead of eleven, and it is what stops the outline offering an
+   * action whose turn cannot be delivered (preamble P8).
+   */
+  const olumiHandOff = useMemo(() => createOlumiHandOff(onSendMessage), [onSendMessage])
+
+  const handOffToOlumi = useCallback(
+    (message: string, reason: string) => {
+      olumiHandOff?.({ message, reason })
+    },
+    [olumiHandOff],
+  )
+
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
@@ -772,6 +794,7 @@ export const ModelTabBody = memo(function ModelTabBody({
         edges={edges}
         goalThreshold={goalThreshold}
         fragileEdgeIds={hasRobustnessData ? fragileEdgeIds : undefined}
+        onHandOffToOlumi={olumiHandOff ? handOffToOlumi : undefined}
       />
 
       {/* ── Header: factor/edge counts + "Show full detail" toggle ─────────── */}

--- a/src/canvas/components/model-tab/ContestedEdgeCard.tsx
+++ b/src/canvas/components/model-tab/ContestedEdgeCard.tsx
@@ -38,6 +38,7 @@ import {
   directionFromProducerSignedMean,
   type EdgeValueSource,
 } from '../../domain/edgeValueProvenance'
+import { buildCanvasLabelMap, resolveCanvasLabel, UNNAMED_ELEMENT_LABEL } from '../../domain/canvasLabels'
 
 // ── Props ─────────────────────────────────────────────────────────────────────
 
@@ -170,8 +171,14 @@ export function ContestedEdgeCard({
 
   const sourceNode = nodes.find(n => n.id === edge.source)
   const targetNode = nodes.find(n => n.id === edge.target)
-  const fromLabel = String((sourceNode?.data as Record<string, unknown>)?.label ?? edge.source)
-  const toLabel   = String((targetNode?.data as Record<string, unknown>)?.label ?? edge.target)
+  // ⚠ THE ONE id→label policy, not `label ?? edge.source`. This card is KEPT
+  // WHOLESALE by design §7.4 E, so it OUTLIVES the v1 stack's removal — a raw-id
+  // fallback left here would be a permanent leak rather than one the delete
+  // sweeps up. `resolveCanvasLabel` returns null rather than the identifier and
+  // rejects a stored label that is itself id-shaped.
+  const edgeNodeLabels = buildCanvasLabelMap(nodes)
+  const fromLabel = resolveCanvasLabel(edge.source, edgeNodeLabels) ?? UNNAMED_ELEMENT_LABEL
+  const toLabel = resolveCanvasLabel(edge.target, edgeNodeLabels) ?? UNNAMED_ELEMENT_LABEL
 
   // Edge label takes precedence over from → to when present
   const edgeLabel = (data?.label as string | undefined) || null

--- a/src/canvas/components/model-tab/FactorsSection.tsx
+++ b/src/canvas/components/model-tab/FactorsSection.tsx
@@ -18,6 +18,8 @@ import { Check, MessageCircle } from 'lucide-react'
 import { typography } from '../../../styles/typography'
 import { SectionErrorBoundary } from '../GraphTextView'
 import { useNodeMutations } from '../../ui/inspector-v2/useInspectorMutations'
+import { useModelEditAuthority } from '../../hooks/useModelEditAuthority'
+import { factorNeedsVerification } from '../../domain/valueProvenance'
 import { useOptionalConversationContext } from '../../conversation/ConversationContext'
 import { buildFactorValueEditEvent } from '../../conversation/factorValueEdit'
 import { captureOptimisticFactorEdit } from '../../conversation/optimisticFactorEdit'
@@ -163,6 +165,9 @@ function FactorCard({
   // on every commit, and one of them (`handleRawValueSave`) wrote `raw_value`
   // without recomputing the model-scale `value`.
   const mutations = useNodeMutations(node.id)
+  // The ONE transactional authority. This section dispatches; it does not decide
+  // how a confirmation is recorded — see `handleConfirmValue`.
+  const authority = useModelEditAuthority(node.id)
 
   // ROADMAP 2.121 slice 1 / #513 — a Model-tab value commit is a REAL TURN.
   //
@@ -319,19 +324,39 @@ function FactorCard({
   }, [coachingDismissKey])
 
   // Task 8: Verify/confirm button
-  const showConfirmButton = obs.source !== 'user' && (primaryValue !== null || normalisedValue !== null)
+  //
+  // ⚠ THE PREDICATE IS `factorNeedsVerification`, THE SAME ONE THE BADGE COUNTS.
+  // It used to be `obs.source !== 'user'`, which was already loose — it offered
+  // Confirm over a `brief_extraction` the badge did not count — and it becomes
+  // WRONG the moment the gesture stamps `user_confirmed` rather than `user`:
+  // the button would survive its own success and invite the user to confirm the
+  // same number for ever. One question, one predicate.
+  const showConfirmButton =
+    factorNeedsVerification(node.data) && (primaryValue !== null || normalisedValue !== null)
   const [confirmFlash, setConfirmFlash] = useState(false)
   const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => () => { if (flashTimerRef.current) clearTimeout(flashTimerRef.current) }, [])
 
   // Confirm changes the PROVENANCE of the existing number, not the number. It
   // therefore has no value to put on the wire (`factor_value_edit.field` is the
-  // literal `'value'` and the contract carries no confirm event), and routes
-  // through the sanctioned source setter only. Stated plainly rather than
-  // hidden: a confirm is a local annotation today, not a turn.
+  // literal `'value'` and the contract carries no confirm event). Stated plainly
+  // rather than hidden: a confirm is a local annotation today, not a turn.
+  //
+  // ⚠ IT NO LONGER WRITES. It DISPATCHES to `useModelEditAuthority`, the one
+  // transactional authority, which is also what the canonical outline's Confirm
+  // chip calls. Two surfaces, one write, one stamp — and the stamp it writes is
+  // `user_confirmed`, not the `user` this handler used to put there. `user`
+  // classifies as the `edited` kind, so the pill read "User edited" for a
+  // gesture in which the user changed no number at all; pre-analysis, the
+  // outputs dock and the calibrate drill-in have all written `user_confirmed`
+  // for the identical act. This was the last surface asserting otherwise.
+  //
+  // The delegation is deliberately made BEFORE this section is deleted: with it,
+  // the removal drops a rendering and nothing else, which is what makes the
+  // removal reviewable.
   const handleConfirmValue = useCallback((e: React.MouseEvent) => {
     e.stopPropagation()
-    mutations.setObservedSource('user')
+    authority.proposeFactorConfirmation()
     // Flash success
     setConfirmFlash(true)
     flashTimerRef.current = setTimeout(() => setConfirmFlash(false), 300)
@@ -340,7 +365,7 @@ function FactorCard({
       sessionStorage.setItem(coachingDismissKey, '1')
       setCoachingDismissed(true)
     }
-  }, [mutations, isDefaultedControllable, coachingDismissed, coachingDismissKey])
+  }, [authority, isDefaultedControllable, coachingDismissed, coachingDismissKey])
 
   const uncertaintyDrivers = obs.uncertainty_drivers
 

--- a/src/canvas/components/model-tab/OptionsSection.tsx
+++ b/src/canvas/components/model-tab/OptionsSection.tsx
@@ -11,7 +11,7 @@ import { useCallback, useContext, useMemo } from 'react'
 import type { Node } from '@xyflow/react'
 import { ArrowRight, MessageCircle } from 'lucide-react'
 import { typography } from '../../../styles/typography'
-import { useNodeMutations } from '../../ui/inspector-v2/useInspectorMutations'
+import { useModelEditAuthority } from '../../hooks/useModelEditAuthority'
 import { SectionErrorBoundary } from '../GraphTextView'
 import { Accordion } from '../../../components/results/Accordion'
 import { focusNodeById } from '../../utils/focusHelpers'
@@ -19,6 +19,7 @@ import { formatValueWithUnit, formatSmartNumber } from './utils'
 import { InlineEdit } from './InlineEdit'
 import { DetailToggleContext } from './DetailToggleContext'
 import { unwrapInterventionValue, formatRawValueWithUnit } from '../../utils/labelUtils'
+import { interventionTargetValue } from '../../domain/interventions'
 
 /** Conditional winner entry from ISL */
 export interface ConditionalWinner {
@@ -61,48 +62,20 @@ interface InterventionItem {
   displayValue?: string
 }
 
-/**
- * Extract a numeric intervention value, accepting any of these shapes:
- * - plain number (legacy / analysis_ready format)
- * - numeric string (back-compat with hand-edited fixtures)
- * - object with `raw_target` (legacy model-tab response shape)
- * - object with `target_value` (legacy model-tab response shape)
- * - UIInterventionValue / CEEInterventionV3 object with `.value`
- *   (post-`normaliseOptionFromCEE` shape used by inspector panels)
- *
- * Returns undefined when no finite numeric value can be extracted, so
- * callers can `flatMap` to drop unrenderable rows.
- *
- * Note: this helper is intentionally more permissive than `unwrapInterventionValue`
- * in `labelUtils.ts`. The model-tab Options section receives intervention
- * payloads from older CEE response paths that use `raw_target` / `target_value`
- * field names; those paths still need to render correctly.
- */
-function extractInterventionNumeric(value: unknown): number | undefined {
-  // Primary: V3-shape unwrap (handles plain numbers, {value} objects).
-  const unwrapped = unwrapInterventionValue(value).value
-  if (unwrapped != null) return unwrapped
-  // Fallback: numeric string
-  if (typeof value === 'string' && value.trim() !== '') {
-    const n = Number(value)
-    if (Number.isFinite(n)) return n
-  }
-  // Fallback: legacy model-tab object shapes (raw_target / target_value)
-  if (value && typeof value === 'object') {
-    const obj = value as Record<string, unknown>
-    if (typeof obj.raw_target === 'number' && Number.isFinite(obj.raw_target)) return obj.raw_target
-    if (typeof obj.target_value === 'number' && Number.isFinite(obj.target_value)) return obj.target_value
-  }
-  return undefined
-}
+// The private numeric reader that lived here MOVED to
+// `canvas/domain/interventions.ts` as `interventionTargetValue` (18 Aug 2026),
+// with its documentation. The canonical Model editor needs the IDENTICAL
+// reading — including the legacy `raw_target` / `target_value` shapes — and a
+// private reader inside the editor scheduled for deletion is a reader that
+// disappears with it. Moved, not copied: this file imports the one policy.
 
 function buildInterventions(optionNode: Node, allNodes: Node[]): InterventionItem[] {
   const raw = (optionNode.data as Record<string, unknown>)?.interventions as Record<string, unknown> | undefined
   if (!raw) return []
   return Object.entries(raw).flatMap(([factorId, rawValue]) => {
-    const numericValue = extractInterventionNumeric(rawValue)
+    const numericValue = interventionTargetValue(rawValue)
     if (numericValue === undefined) return []
-    // displayValue flows separately: extractInterventionNumeric has legacy
+    // displayValue flows separately: interventionTargetValue has legacy
     // fallbacks (raw_target, target_value) that unwrapInterventionValue does
     // not, so we pull the numeric through that; we extract displayValue via
     // the canonical helper on the same raw input.
@@ -169,9 +142,11 @@ function OptionCard({ option, allNodes, conditionalWinners, hasAnalysisData }: {
   hasAnalysisData?: boolean
 }) {
   const { showDetail } = useContext(DetailToggleContext)
-  // ROADMAP 2.121 slice 1 — sanctioned setter (`NODE_SETTER_FIELDS.setIntervention`),
-  // not a hand-rolled updateNode that spread a render-time `option.data`.
-  const mutations = useNodeMutations(option.id)
+  // ROADMAP 2.121 slice 1 kept this section off a hand-rolled `updateNode` by
+  // routing through the sanctioned setter. The 18 Aug 2026 rehome takes the next
+  // step: the section no longer holds a mutation handle AT ALL. Its only write
+  // goes through the one transactional authority — see `handleInterventionSave`.
+  const authority = useModelEditAuthority(option.id)
 
   const label = String(option.data?.label ?? option.id)
   const interventions = buildInterventions(option, allNodes)
@@ -196,11 +171,19 @@ function OptionCard({ option, allNodes, conditionalWinners, hasAnalysisData }: {
   // edit therefore reaches CEE only as the debounced `direct_graph_edit` ping —
   // stated here rather than implied, and rowed as open question 1 in the design
   // doc. What slice 1 fixes is the WRITE: it goes through the manifest setter.
+  //
+  // ⚠ IT NO LONGER WRITES. It DISPATCHES to `useModelEditAuthority`, the one
+  // transactional authority, which is what the canonical outline's intervention
+  // editor also calls — so the two surfaces cannot record the same gesture two
+  // ways, and deleting this section drops a rendering rather than a write path.
+  // The authority additionally refuses a target keyed to a factor that is not in
+  // the model; this handler wrote one happily, and every list that renders the
+  // result falls back to the raw id when the lookup misses.
   const handleInterventionSave = useCallback((factorId: string, val: string) => {
     const num = parseFloat(val)
     if (isNaN(num)) return
-    mutations.setIntervention(factorId, num)
-  }, [mutations])
+    authority.proposeOptionIntervention(factorId, num)
+  }, [authority])
 
   return (
     <div className="bg-panel-hover rounded-lg p-2.5 mb-2 last:mb-0" data-testid={`option-card-${option.id}`}>

--- a/src/canvas/components/model-tab/__tests__/FactorsSection.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/FactorsSection.spec.tsx
@@ -477,13 +477,39 @@ describe('FactorsSection', () => {
     expect(screen.getByTestId('factor-f1-confirm')).toBeInTheDocument()
   })
 
-  it('writes source: user on confirm click', () => {
+  /**
+   * ⚠ THIS TEST USED TO PIN THE DEFECT. Its name was "writes source: user on
+   * confirm click", and that is exactly what the handler did — so the suite was
+   * GREEN over a surface telling the user "User edited" for a gesture in which
+   * they edited nothing. A test can be correct about the code and wrong about
+   * the product; this one was.
+   *
+   * `'user'` classifies as the `edited` kind. Ratifying somebody else's number
+   * is `user_confirmed` — which is what pre-analysis, the outputs dock and the
+   * calibrate drill-in have always written for the identical act. The Model tab
+   * was the last surface disagreeing, and it disagreed because of this handler.
+   *
+   * The click now dispatches through `useModelEditAuthority`; the assertion is
+   * unchanged in SHAPE (it still watches the store write that reaches the node)
+   * so it still fails if the dispatch stops writing at all.
+   */
+  it('confirm stamps user_confirmed — the ratification stamp, not the edit stamp', () => {
     mockUpdateNode.mockClear()
     const nodes = [makeFactorNode('f1', 'Budget', { value: 0.5, source: 'cee_inference' })]
     mockGraph.nodes = nodes
     render(<FactorsSection factorNodes={nodes} />)
     fireEvent.click(screen.getByTestId('factor-f1-confirm'))
     expect(mockUpdateNode).toHaveBeenCalledWith(
+      'f1',
+      expect.objectContaining({
+        data: expect.objectContaining({
+          observedState: expect.objectContaining({ source: 'user_confirmed' }),
+        }),
+      })
+    )
+    // ⚠ THE FORBIDDEN LITERAL, ASSERTED. Stated so the defect cannot return
+    // under a widened expectation.
+    expect(mockUpdateNode).not.toHaveBeenCalledWith(
       'f1',
       expect.objectContaining({
         data: expect.objectContaining({

--- a/src/canvas/components/model-tab/__tests__/modelTabNoRawIdFallback.sourceScan.spec.ts
+++ b/src/canvas/components/model-tab/__tests__/modelTabNoRawIdFallback.sourceScan.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * NO RAW WIRE ID MAY REACH THE USER FROM THE MODEL TAB — a DERIVED scan over
+ * both editors' directories (18 Aug 2026, the rehome lane).
+ *
+ * ## Why a scan and not a render test
+ *
+ * A render test proves one component is honest about one fixture. The leak class
+ * here is `label ?? node.id` — a one-token fallback that reads as defensive
+ * programming, is invisible in review, and produced `fac_arr → out_uk_arr_retention`
+ * on the CANONICAL editor's relationship rows. There were twelve of them, spread
+ * across seven files, and no test anywhere could see the shape.
+ *
+ * ⚠ THE COMMISSIONED FIGURE WAS EIGHT; THE DERIVED FIGURE IS TWELVE. The brief
+ * that ordered this work counted `label ?? <x>.id` and missed four sites of the
+ * form `label ?? edge.source` / `?? edge.target` (`ContestedEdgeCard.tsx:173-174`,
+ * `RelationshipsSection.tsx:149-150`) — the edge-endpoint variant, which is
+ * exactly the one that renders the arrow string a user sees. A pattern narrower
+ * than the defect class under-reports and reads as a clean result: this scan
+ * matches the CLASS (`?? <expr>.(id|source|target)` beside a `label` read), not
+ * the shape someone happened to write down.
+ *
+ * ## The two directions, and why both
+ *
+ * `model-tab-v2/` — the canonical editor — must be at ZERO, derived, with no
+ * allowance to maintain. `model-tab/` — the duplicate stack, scheduled for
+ * removal in the follow-up commit — carries a PINNED residual with a reason per
+ * entry, asserted for EXACT EQUALITY IN BOTH DIRECTIONS. Growth is a new leak.
+ * SHRINKAGE is the removal landing, and it must red too, so the follow-up commit
+ * has to come here and say so rather than quietly satisfying a `<=`.
+ */
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join, dirname, relative } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { blankNonCode } from '../../../../../tests/helpers/stripSourceComments'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const REPO = join(HERE, '..', '..', '..', '..', '..')
+const V1_DIR = join(HERE, '..')
+const V2_DIR = join(HERE, '..', '..', '..', 'model-tab-v2')
+
+/**
+ * The defect CLASS: a nullish-coalescing fallback whose right-hand side is an
+ * element's `id`, `source` or `target`.
+ *
+ * ⚠ Comments and string literals are BLANKED first (`blankNonCode`) — this file's
+ * own header quotes the pattern, and a scan that matched its own documentation
+ * would report a leak that does not exist.
+ */
+const RAW_ID_FALLBACK = /\?\?\s*[A-Za-z_$][\w$]*(?:\??\.[\w$]+)*\.(?:id|source|target)\b/g
+
+function tsFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true })
+    .filter(e => e.isFile() && /\.tsx?$/.test(e.name))
+    .map(e => join(dir, e.name))
+}
+
+function fallbacksIn(file: string): number {
+  const code = blankNonCode(readFileSync(file, 'utf8'))
+  return [...code.matchAll(RAW_ID_FALLBACK)].length
+}
+
+function scan(dir: string): Record<string, number> {
+  const out: Record<string, number> = {}
+  for (const f of tsFiles(dir)) {
+    const n = fallbacksIn(f)
+    if (n > 0) out[relative(REPO, f)] = n
+  }
+  return out
+}
+
+/**
+ * The v1 residual, PINNED WITH A REASON EACH.
+ *
+ * Every entry here is a file the removal commit deletes. They are not fixed in
+ * place because churning code that is about to be deleted buys nothing and
+ * touches files the DS raw-typography ratchet pins by exact count; they are
+ * PINNED rather than ignored so a NEW leak in the interim cannot hide among them.
+ *
+ * ⚠ `FactorsSection.tsx`'s two are SORT COMPARATOR keys (`:690-691`), not display
+ * — an id used to order a list never reaches the screen. They are counted here
+ * anyway rather than excused by a narrower pattern, because a scan that decides
+ * which matches "don't count" is a scan that can be argued with.
+ */
+const V1_PINNED: Record<string, number> = {
+  // 2 — option card label, and the unmapped-coaching list's per-option label.
+  'src/canvas/components/model-tab/OptionsSection.tsx': 2,
+  // 2 — risk row label, and its trigger-factor list.
+  'src/canvas/components/model-tab/RisksSection.tsx': 2,
+  // 1 — goal heading label.
+  'src/canvas/components/model-tab/GoalSection.tsx': 1,
+  // 3 — factor card label (:180) + two sort comparator keys (:690-691).
+  'src/canvas/components/model-tab/FactorsSection.tsx': 3,
+  // 2 — edge endpoint labels (:149-150), the `from → to` string on screen.
+  'src/canvas/components/model-tab/RelationshipsSection.tsx': 2,
+}
+
+describe('the CANONICAL editor never falls back to a wire id', () => {
+  it('model-tab-v2/ carries ZERO raw-id fallbacks — derived, nothing to maintain', () => {
+    expect(scan(V2_DIR)).toEqual({})
+  })
+
+  it('POSITIVE CONTROL: the pattern DOES detect the shape it bans', () => {
+    // Without this, a broken regex would certify every directory as clean and
+    // the "zero" above would be a statement about the instrument (trap 13).
+    const sample = 'const l = String(node.data?.label ?? node.id)\nconst f = x?.label ?? edge.source\n'
+    expect([...blankNonCode(sample).matchAll(RAW_ID_FALLBACK)]).toHaveLength(2)
+  })
+
+  it('CONTRAST CONTROL: it does NOT fire on an honest resolution', () => {
+    const honest = "const l = resolveCanvasLabel(edge.source, labels) ?? UNNAMED_ELEMENT_LABEL\n"
+    expect([...blankNonCode(honest).matchAll(RAW_ID_FALLBACK)]).toHaveLength(0)
+  })
+
+  it('the scan reads real files, not an empty directory', () => {
+    // A directory that vanished, or a filter that matched nothing, would make
+    // every absence above vacuous. Assert the corpus is non-empty by name.
+    const v2 = tsFiles(V2_DIR).map(f => relative(REPO, f))
+    expect(v2.length).toBeGreaterThan(5)
+    expect(v2).toContain('src/canvas/model-tab-v2/adapters.ts')
+  })
+})
+
+describe('the DUPLICATE stack’s residual is bounded and named', () => {
+  it('matches the pinned set EXACTLY — growth is a leak, shrinkage is the removal', () => {
+    expect(scan(V1_DIR)).toEqual(V1_PINNED)
+  })
+
+  it('ContestedEdgeCard is NOT in the residual — it outlives the removal', () => {
+    // Design §7.4 E keeps this card wholesale, so its two endpoint fallbacks
+    // would have become permanent rather than swept up by the delete. They were
+    // fixed in place for exactly that reason, and this pins the distinction.
+    const v1 = scan(V1_DIR)
+    expect(v1['src/canvas/components/model-tab/ContestedEdgeCard.tsx']).toBeUndefined()
+    // Contrast control: a file that IS in the residual reads non-zero, so the
+    // absence above is a fact about this card and not a dead scan.
+    expect(v1['src/canvas/components/model-tab/GoalSection.tsx']).toBe(1)
+  })
+})

--- a/src/canvas/components/model-tab/utils.ts
+++ b/src/canvas/components/model-tab/utils.ts
@@ -10,6 +10,7 @@
  */
 
 import type { ObservedState } from './types'
+import { factorNeedsVerification } from '../../domain/valueProvenance'
 import { classifyValueProvenance, type ValueProvenanceKind } from '../../domain/valueProvenance'
 import type { EdgeDirectionDisplay } from '../../domain/edgeValueProvenance'
 import { selectDriverDisplayModel, extractPolicyRow } from '../../../components/results/driverDisplayModel'
@@ -106,13 +107,18 @@ export function mapSourceToDisplay(source: string | undefined): string | null {
 
 // ── Factor verification ─────────────────────────────────────────────────────
 
-/** Count factors needing user verification (no source, or AI estimate). */
+/**
+ * Count factors needing user verification (no source, or AI estimate).
+ *
+ * ⚠ THE PREDICATE MOVED OUT (18 Aug 2026) and this function no longer holds a
+ * copy of it. It lived here inline while a second, deliberate port lived in
+ * `model-tab-v2/adapters.ts` — the estate's own documented mirror, pinned by a
+ * corpus that could only prove the two AGREED. Both now import
+ * `factorNeedsVerification` from `domain/valueProvenance`, so the count, the
+ * outline's ⚠ marker and the Confirm affordance cannot disagree about a row.
+ */
 export function countFactorsToVerify(factorNodes: ReadonlyArray<{ data: unknown }>): number {
-  return factorNodes.filter(n => {
-    const data = n.data as Record<string, unknown> | undefined
-    const obs = (data?.observedState ?? data?.observed_state) as Record<string, unknown> | undefined
-    return !obs?.source || obs?.source === 'cee_inference'
-  }).length
+  return factorNodes.filter(n => factorNeedsVerification(n.data)).length
 }
 
 // ── Strength semantic labels ──────────────────────────────────────────────────

--- a/src/canvas/conversation/__tests__/olumiHandOff.spec.ts
+++ b/src/canvas/conversation/__tests__/olumiHandOff.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * olumiHandOff — FRONT FIRST, THEN SEND.
+ *
+ * ## The defect
+ *
+ * Every send-to-AI control on the Model tab called `onSendMessage` directly, so a
+ * real turn was posted into a panel that could stay hidden. The user clicked
+ * "Add a factor" and nothing visibly happened — an affordance terminating in
+ * silence, which is preamble P8's harm and the same family as the Research CTA.
+ *
+ * ## Binding
+ *
+ * ⚠ ORDER IS THE WHOLE POINT, so it is asserted as ORDER, not as "both were
+ * called". A test that only checked both happened would pass on send-then-front,
+ * which is the same defect one frame later. The two mocks write into ONE shared
+ * log and the log's sequence is the object of the assertion.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const log: string[] = []
+const mocks = vi.hoisted(() => ({ fronted: true }))
+
+vi.mock('../revealOlumi', () => ({
+  revealOlumiSurface: () => {
+    log.push('front')
+    return mocks.fronted
+  },
+}))
+
+import { createOlumiHandOff } from '../olumiHandOff'
+
+beforeEach(() => {
+  log.length = 0
+  mocks.fronted = true
+})
+
+describe('createOlumiHandOff — no sender means no affordance', () => {
+  it('returns null when there is no sender, so the caller cannot render a dead end', () => {
+    expect(createOlumiHandOff(undefined)).toBeNull()
+    expect(createOlumiHandOff(null)).toBeNull()
+  })
+
+  it('returns a callable when a sender exists — the contrast control', () => {
+    expect(typeof createOlumiHandOff(vi.fn())).toBe('function')
+  })
+})
+
+describe('createOlumiHandOff — fronts BEFORE it sends', () => {
+  it('the fronting call precedes the send call, in that order', () => {
+    const send = vi.fn(() => {
+      log.push('send')
+    })
+    const handOff = createOlumiHandOff(send)!
+    handOff({ message: 'I want to add a new factor to the model' })
+    expect(log).toEqual(['front', 'send'])
+  })
+
+  it('sends the message verbatim', () => {
+    const send = vi.fn()
+    createOlumiHandOff(send)!({ message: "I'd like to add a causal relationship" })
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send.mock.calls[0][0]).toBe("I'd like to add a causal relationship")
+  })
+
+  it('carries the reason as the debug source, and omits the option when absent', () => {
+    const send = vi.fn()
+    const handOff = createOlumiHandOff(send)!
+    handOff({ message: 'm', reason: 'model-tab-v2:factors-add' })
+    expect(send.mock.calls[0][1]).toEqual({ debugSource: 'model-tab-v2:factors-add' })
+    handOff({ message: 'm' })
+    expect(send.mock.calls[1][1]).toBeUndefined()
+  })
+
+  it('never marks a user gesture hidden — the turn belongs in the transcript', () => {
+    const send = vi.fn()
+    createOlumiHandOff(send)!({ message: 'm', reason: 'r' })
+    expect(send.mock.calls[0][1]).not.toHaveProperty('hidden', true)
+  })
+})
+
+describe('createOlumiHandOff — it reports what the primitive reports', () => {
+  it('"fronted" when a surface came to the front', () => {
+    mocks.fronted = true
+    expect(createOlumiHandOff(vi.fn())!({ message: 'm' })).toBe('fronted')
+  })
+
+  it('"deferred" when nothing did — and the turn is STILL sent', () => {
+    mocks.fronted = false
+    const send = vi.fn()
+    expect(createOlumiHandOff(send)!({ message: 'm' })).toBe('deferred')
+    // The opposite-direction twin: reporting the failure must not also swallow
+    // the turn. A turn the user can find by opening the panel themselves is
+    // strictly better than no turn, and the return value is what keeps the
+    // product from CLAIMING it fronted.
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/canvas/conversation/olumiHandOff.ts
+++ b/src/canvas/conversation/olumiHandOff.ts
@@ -2,9 +2,18 @@
  * olumiHandOff — THE ONE hand-off used by every Model-tab affordance that
  * terminates in a conversation rather than in a mutation.
  *
- * This is the implementation of `model-tab-v2/contracts.ts` §2 `HandOffToOlumi`,
- * which until now was a TYPE WITH NO IMPLEMENTATION anywhere in the tree
- * (derived at `9ff14c19`: one occurrence, the declaration itself).
+ * It implements what `model-tab-v2/contracts.ts` §2 declared as `HandOffToOlumi`
+ * — a type that, derived at `9ff14c19`, had exactly ONE occurrence in the tree:
+ * its own declaration. Nothing was bound to it, and all eleven Model-tab
+ * send-to-AI controls bypassed it entirely.
+ *
+ * ⚠ THE TYPES NOW LIVE HERE, WITH THE CODE THAT SATISFIES THEM. They cannot stay
+ * in `model-tab-v2/` because that directory's boundary scan pins `ModelTabBody`
+ * as the only outside file permitted to reference it — and a type import is a
+ * real reference. Widening that allowlist to accommodate one import would have
+ * spent a structural guarantee on a convenience. Co-locating is also simply
+ * truer: a contract declared where it is CONSUMED has no owner, which is how
+ * this one sat unimplemented while the product shipped the defect it described.
  *
  * ── THE DEFECT IT CLOSES ──────────────────────────────────────────────────
  *
@@ -41,7 +50,42 @@
  */
 
 import { revealOlumiSurface } from './revealOlumi'
-import type { HandOffToOlumi } from '../model-tab-v2/contracts'
+
+/**
+ * Whether the Olumi surface actually came to the front.
+ *
+ * ⚠ THE OUTCOME IS THE POINT. A hand-off that cannot front the panel must be
+ * able to SAY so rather than send into silence — which is what every Model-tab
+ * control did before this module existed.
+ */
+export type PanelFrontingOutcome = 'fronted' | 'deferred'
+
+/**
+ * Front the Olumi conversation wherever the user left it — docked, floating or
+ * collapsed — and report whether a surface came forward.
+ *
+ * ⚠ ORIGIN IS THE USER'S. These are user gestures: they must not stamp
+ * `outputSurfaceOrigin: 'assistant'` or raise the `AssistantOpenedNotice`.
+ * Telling someone Olumi opened something they opened themselves is a lie on the
+ * one channel whose entire purpose is truthfulness.
+ */
+export type FrontOlumiPanel = (opts?: { reason?: string }) => PanelFrontingOutcome
+
+/**
+ * The single hand-off every Model-tab send-to-AI affordance goes through.
+ *
+ * ⚠ THE RULE: no Model-tab control may call `onSendMessage` directly. Fronting
+ * happens FIRST, then the send. It matters most for the STRUCTURAL affordances
+ * ("Add a factor", "Add a relationship", "Explore other strategies", "Identify
+ * potential risks") — they terminate in a conversation rather than a mutation, so
+ * an invisible conversation makes them dead ends. That combination — the tab's
+ * only structural affordances ending in a hidden panel — is the measured
+ * mechanism behind "the less I feel like I can actually directly edit the model".
+ */
+export type HandOffToOlumi = (opts: {
+  message: string
+  reason?: string
+}) => PanelFrontingOutcome
 
 /**
  * The send signature as `ModelTabBody` already receives it. Deliberately the

--- a/src/canvas/conversation/olumiHandOff.ts
+++ b/src/canvas/conversation/olumiHandOff.ts
@@ -1,0 +1,75 @@
+/**
+ * olumiHandOff — THE ONE hand-off used by every Model-tab affordance that
+ * terminates in a conversation rather than in a mutation.
+ *
+ * This is the implementation of `model-tab-v2/contracts.ts` §2 `HandOffToOlumi`,
+ * which until now was a TYPE WITH NO IMPLEMENTATION anywhere in the tree
+ * (derived at `9ff14c19`: one occurrence, the declaration itself).
+ *
+ * ── THE DEFECT IT CLOSES ──────────────────────────────────────────────────
+ *
+ * Every send-to-AI control on the Model tab called `onSendMessage` DIRECTLY,
+ * with no fronting: `FactorsSection.tsx:737` ("Add a factor"),
+ * `RelationshipsSection.tsx:819` ("Add a relationship"),
+ * `OptionsSection.tsx:486`/`:508` ("Explore other strategies"),
+ * `RisksSection.tsx:100` ("Identify risks"), and six "Discuss this with the AI"
+ * buttons. So a real turn was posted into a panel that could stay hidden: the
+ * user clicked, and nothing visibly happened.
+ *
+ * That matters most for the STRUCTURAL controls. They terminate in a
+ * conversation rather than a mutation, so an invisible conversation makes them
+ * dead ends — the product offering an action it does not carry through. That is
+ * preamble P8 (never ask what you cannot accept) and the same family as the
+ * Research-CTA ruling.
+ *
+ * ── THE RULE ──────────────────────────────────────────────────────────────
+ *
+ * FRONT FIRST, THEN SEND. Never the reverse: a send that lands before the
+ * surface is revealed is the defect above with better timing.
+ *
+ * ⚠ THE OUTCOME IS TAKEN FROM `revealOlumiSurface`, NEVER RE-DERIVED HERE.
+ * Modelling "is Olumi visible?" in this module would be a second copy of a rule
+ * the surfaces already implement (trap 12), and #773 rejected precisely that
+ * re-derivation. This module asks; it does not decide.
+ *
+ * ⚠ AND IT IS A FACTORY, NOT A FREE FUNCTION, ON PURPOSE. The sender comes from
+ * the caller's React context. When there is no sender the hand-off CANNOT be
+ * honoured, and `createOlumiHandOff(undefined)` returns `null` rather than a
+ * callable that silently swallows the turn — so a surface with no conversation
+ * cannot render an affordance that does nothing. Not offering is the honest
+ * failure mode; offering-and-dropping is the dead end this file removes.
+ */
+
+import { revealOlumiSurface } from './revealOlumi'
+import type { HandOffToOlumi } from '../model-tab-v2/contracts'
+
+/**
+ * The send signature as `ModelTabBody` already receives it. Deliberately the
+ * live prop's shape rather than a tidier invention — a second shape here would
+ * need an adapter, and the adapter is where the `hidden` option would get lost.
+ */
+export type OlumiSend = (
+  message: string,
+  opts?: { hidden?: boolean; debugSource?: string },
+) => void
+
+/**
+ * Build the hand-off, or `null` when no conversation can receive it.
+ *
+ * `null` is load-bearing: callers render their affordances only when this is
+ * non-null, which is the same `{onSendMessage && …}` guard the v1 sections
+ * already used — preserved rather than dropped, because it is the thing that
+ * stops the button existing when the turn cannot.
+ */
+export function createOlumiHandOff(send: OlumiSend | undefined | null): HandOffToOlumi | null {
+  if (!send) return null
+  return ({ message, reason }) => {
+    // Front FIRST. The outcome is whatever the convergence primitive reports.
+    const fronted = revealOlumiSurface()
+    // Then send — unconditionally. A turn is still worth posting into a panel
+    // the user can open themselves; what must not happen is CLAIMING it was
+    // fronted when it was not, which the return value prevents.
+    send(message, reason ? { debugSource: reason } : undefined)
+    return fronted ? 'fronted' : 'deferred'
+  }
+}

--- a/src/canvas/conversation/revealOlumi.ts
+++ b/src/canvas/conversation/revealOlumi.ts
@@ -57,21 +57,41 @@ import { focusDockedOlumi } from './dockedOlumiFocus'
  * `forceActivateOutputTab` remains the right call on the dock path and does
  * more than switch a tab: it opens a collapsed dock and ends the first-use
  * rail, which is what makes "revealed" true rather than merely selected.
+ *
+ * ── WHY IT NOW REPORTS (18 Aug 2026, the Model-tab rehome lane) ────────────
+ *
+ * It returns whether a surface was actually fronted. The value is additive —
+ * every existing caller ignores it and is unaffected — and it exists because
+ * `model-tab-v2/contracts.ts` §2 needs it: an affordance that hands a turn to
+ * Olumi must be able to SAY it could not front the panel rather than sending
+ * into silence (preamble P8 — never ask what you cannot accept).
+ *
+ * ⚠ THE ANSWER IS DERIVED HERE, INSIDE THE BRANCHES THAT ALREADY KNOW IT, and
+ * must never be re-derived by a caller. A caller modelling "is Olumi visible?"
+ * would be a second copy of this rule (trap 12), and #773 rejected exactly that
+ * re-derivation for exactly that reason.
+ *
+ * What `true` claims, stated narrowly: A SURFACE WAS FRONTED. On the dock path
+ * that is `forceActivateOutputTab`'s own guarantee (it opens a collapsed dock
+ * and ends the first-use rail). It does NOT claim the composer received focus —
+ * that can legitimately land a frame later, and conflating the two would make
+ * this report the thing it cannot see.
  */
-export function revealOlumiSurface(): void {
+export function revealOlumiSurface(): boolean {
   // Flag OFF is the rollback posture: `OutputsDock` redirects an 'olumi'
   // activation to 'results', so claiming the dock would front the WRONG tab.
   // Best-effort floating focus, exactly as before — this path is unchanged.
   if (!isAiPanelV2Enabled()) {
-    focusFloating()
-    return
+    // Best-effort only on the rollback posture: if nothing floating took focus,
+    // there is no surface to front, and saying so is the honest answer.
+    return focusFloating()
   }
 
   // A floating or first-use composer is on screen and has been focused. Do NOT
   // touch the dock: claiming it retires the very surface just revealed, and on
   // an empty canvas it would retire it in favour of a 40px rail that cannot
   // host a composer at all — stranding the user with nowhere to type.
-  if (focusFloating()) return
+  if (focusFloating()) return true
 
   // Nothing floating is visible, so the dock is (or becomes) the host. Force-
   // activate even when the Olumi tab is already selected: the version counter
@@ -84,8 +104,12 @@ export function revealOlumiSurface(): void {
   //
   // ⚠ NO FALLBACK TO `focusFloating()` HERE. It has already returned false, and
   // reaching for it again after claiming the dock is exactly the defect above.
-  if (focusDockedOlumi()) return
+  if (focusDockedOlumi()) return true
   scheduleFrame(() => { focusDockedOlumi() })
+  // The DOCK IS FRONTED — that happened synchronously above. Only the composer
+  // focus is deferred to the next frame, and this return value is about
+  // fronting, not focus.
+  return true
 }
 
 /** rAF where it exists, a macrotask otherwise (jsdom/node without rAF). */

--- a/src/canvas/domain/canvasLabels.ts
+++ b/src/canvas/domain/canvasLabels.ts
@@ -24,6 +24,21 @@
 import { RAW_ID_PATTERN } from '../conversation/friendlyOperation'
 
 /**
+ * What an element is called when the model gives it no honest name.
+ *
+ * ⚠ IT LIVES BESIDE THE POLICY THAT PRODUCES THE `null` IT FILLS, and there is
+ * exactly one of it. It was briefly declared twice — in `model-tab-v2/adapters.ts`
+ * and in `model-tab/ContestedEdgeCard.tsx` — which is the same defect class as the
+ * two editors this work removes, at constant scale: one wording for one situation,
+ * or the two copies drift and the tab calls the same nameless element two things.
+ *
+ * The vocabulary follows the estate's existing choice for this situation
+ * (`V5FlipAnalysisBlock.tsx:30` — "Unnamed factor"), generalised because an
+ * endpoint may be an option or an outcome, not only a factor.
+ */
+export const UNNAMED_ELEMENT_LABEL = 'Unnamed element'
+
+/**
  * Resolve one wire id to a human label, or `null` when no honest label exists.
  *
  * ⚠ RETURNS `null` RATHER THAN THE ID, AND THAT IS THE WHOLE POINT. Callers must

--- a/src/canvas/domain/canvasLabels.ts
+++ b/src/canvas/domain/canvasLabels.ts
@@ -1,0 +1,66 @@
+/**
+ * canvasLabels — THE ONE id → human-label resolution policy for the workspace.
+ *
+ * ⚠ MOVED HERE, NOT COPIED (18 Aug 2026, the Model-tab rehome lane). This
+ * function used to live in `src/v5/blocks/useCanvasLabels.ts` beside the
+ * store-bound hook that feeds it. The Model tab's outline needs the identical
+ * policy, and `canvas/model-tab-v2/adapters.ts` is a PURE projection that
+ * receives its nodes as arguments — so it needs the resolver without the hook.
+ *
+ * The three ways that could have gone wrong, and why this is none of them:
+ *   · a second copy in `canvas/` would be trap 12 — two policies drifting, and
+ *     the drift always reads as green;
+ *   · a re-export left behind in `v5/blocks/` would be a shim: the same thing
+ *     reachable from two places with no single authority;
+ *   · `canvas/` importing from `v5/` would invert the dependency (v5 already
+ *     imports canvas) and closes a real cycle.
+ * So the function moved to the layer it actually belongs to — it depends only on
+ * `RAW_ID_PATTERN`, which is canvas-rooted — and every consumer imports it from
+ * here. `useCanvasNodeLabels` stays in `v5/blocks/`: it is a store subscription,
+ * which is a different concern from the pure policy (trap 21 — two questions
+ * must not share one name).
+ */
+
+import { RAW_ID_PATTERN } from '../conversation/friendlyOperation'
+
+/**
+ * Resolve one wire id to a human label, or `null` when no honest label exists.
+ *
+ * ⚠ RETURNS `null` RATHER THAN THE ID, AND THAT IS THE WHOLE POINT. Callers must
+ * decide what to show instead, and the type makes them decide: there is no way
+ * to accidentally fall through to the identifier. Every `label ?? node.id`
+ * fallback in the estate is this decision made silently and wrongly.
+ *
+ * A stored label that is ITSELF a raw id is rejected via `RAW_ID_PATTERN`.
+ * Upstream sometimes seeds a node's label from its id; without this guard the
+ * leak would simply move one hop upstream and still reach the user.
+ */
+export function resolveCanvasLabel(
+  id: string,
+  labels: ReadonlyMap<string, string>,
+): string | null {
+  const label = labels.get(id)
+  if (label === undefined) return null
+  const trimmed = label.trim()
+  if (trimmed === '') return null
+  if (RAW_ID_PATTERN.test(trimmed)) return null
+  return trimmed
+}
+
+/**
+ * Build the id → label map from a node collection.
+ *
+ * The pure counterpart of `useCanvasNodeLabels` for callers that already hold
+ * the nodes (a projection adapter, a test). Deliberately NOT a second policy:
+ * it only assembles the map; `resolveCanvasLabel` still decides what is honest.
+ */
+export function buildCanvasLabelMap(
+  nodes: readonly { id: string; data?: unknown }[],
+): ReadonlyMap<string, string> {
+  const map = new Map<string, string>()
+  for (const n of nodes) {
+    const label = (n.data as { label?: unknown } | undefined)?.label
+    if (typeof label === 'string' && label.trim() !== '') map.set(n.id, label)
+  }
+  return map
+}

--- a/src/canvas/domain/interventions.ts
+++ b/src/canvas/domain/interventions.ts
@@ -1,0 +1,60 @@
+/**
+ * interventions — THE ONE reading of an option's intervention map.
+ *
+ * ⚠ MOVED HERE, NOT COPIED (18 Aug 2026, the REHOME → DELETE lane). The numeric
+ * reader below used to be `extractInterventionNumeric`, a module-private helper
+ * inside `components/model-tab/OptionsSection.tsx` — i.e. inside the editor
+ * being removed. The canonical editor needs the identical reading, and the
+ * three ways that could have gone wrong are the three this estate keeps paying
+ * for:
+ *
+ *   · a second copy in `model-tab-v2/` would be trap 12 — two readings of one
+ *     map, drifting, and the drift always reads as green;
+ *   · `model-tab-v2/` importing from `components/model-tab/` would bind the
+ *     canonical surface to the one scheduled for deletion, which is how a
+ *     "deleted" editor survives as a dependency;
+ *   · leaving it where it is and narrowing the canonical surface to the shared
+ *     `unwrapInterventionValue` would SILENTLY DROP the legacy shapes below —
+ *     a user whose option carries `raw_target` would watch their number become
+ *     "Not stated" at the moment the old editor went away.
+ *
+ * So it moved to the layer both surfaces can depend on, and the delete step
+ * inherits no hidden reader.
+ */
+
+import { unwrapInterventionValue } from '../utils/labelUtils'
+
+/**
+ * The numeric target an option sets for one factor, across every shape the
+ * store has ever held.
+ *
+ * ⚠ THE CANONICAL PREDICATE IS TRIED FIRST AND IS NEVER WIDENED.
+ * `unwrapInterventionValue` is shared with `flattenInterventions` and the PLoT
+ * request edge, so a display can never consider a value usable that the WIRE
+ * rejects. The fallbacks below run only where it returns nothing, and they
+ * exist because real stored graphs carry these shapes — they are tolerance for
+ * history, not a second opinion about what is valid.
+ *
+ * `undefined` means no number is stated. That is a fact to render as absence,
+ * never a zero to invent.
+ */
+export function interventionTargetValue(raw: unknown): number | undefined {
+  // Primary: the shared V3-shape unwrap (plain numbers, `{ value }` objects).
+  const unwrapped = unwrapInterventionValue(raw).value
+  if (unwrapped != null) return unwrapped
+
+  // Fallback: numeric string.
+  if (typeof raw === 'string' && raw.trim() !== '') {
+    const n = Number(raw)
+    if (Number.isFinite(n)) return n
+  }
+
+  // Fallback: legacy model-tab object shapes.
+  if (raw && typeof raw === 'object') {
+    const obj = raw as Record<string, unknown>
+    if (typeof obj.raw_target === 'number' && Number.isFinite(obj.raw_target)) return obj.raw_target
+    if (typeof obj.target_value === 'number' && Number.isFinite(obj.target_value)) return obj.target_value
+  }
+
+  return undefined
+}

--- a/src/canvas/domain/nodes.ts
+++ b/src/canvas/domain/nodes.ts
@@ -33,6 +33,34 @@ export const NodeTypeEnum = z.enum(['goal', 'decision', 'option', 'factor', 'ris
 export type NodeType = z.infer<typeof NodeTypeEnum>
 
 /**
+ * THE ONE FALLBACK CHAIN for "what kind of element is this node?".
+ *
+ * ⚠ IT LIVES HERE BECAUSE IT IS A DOMAIN QUESTION, NOT A SURFACE ONE. The
+ * chain `node.type ?? data.kind ?? data.type` exists because the store, the
+ * wire and the importers have each seeded the kind in a different place over
+ * time. That is a fact about the DATA, so every surface that asks the question
+ * must get the same answer — a second copy in a hook or a panel would be the
+ * duplicated-helper defect this estate keeps paying for (trap 12), and it would
+ * drift the day a fourth seeding location appears.
+ *
+ * It was MOVED here from `model-tab-v2/adapters.ts` (18 Aug 2026), not copied:
+ * that module's `nodeKind` now calls this and narrows the result to the seven
+ * kinds its outline renders. Two callers, ONE chain, and the narrowing stays
+ * where the narrowing matters — the two functions answer different questions
+ * ("what is this?" vs "does my outline render it?") and are named apart so they
+ * cannot be conflated (trap 21).
+ *
+ * Returns `null` for anything outside the taxonomy, which is a fact to act on
+ * rather than a default to invent.
+ */
+export function resolveNodeTypeLiteral(node: { type?: string; data?: unknown }): NodeType | null {
+  const data = node.data as { kind?: unknown; type?: unknown } | undefined
+  const raw = node.type ?? data?.kind ?? data?.type
+  const parsed = NodeTypeEnum.safeParse(raw)
+  return parsed.success ? parsed.data : null
+}
+
+/**
  * Prior — either a plain probability (0..1) or the CEE distribution object
  * (`{ distribution, range_min, range_max }`) that external factors carry.
  *

--- a/src/canvas/domain/valueProvenance.ts
+++ b/src/canvas/domain/valueProvenance.ts
@@ -197,3 +197,35 @@ export function classifyNodeProvenance(
   if (provenance === 'ai_inferred') return { kind: 'ai', userOwned: false }
   return null
 }
+
+/**
+ * Does this factor's value still need a human to look at it?
+ *
+ * ⚠ MOVED HERE 18 Aug 2026 — IT WAS THE ESTATE'S OWN DOCUMENTED MIRROR. The
+ * predicate existed twice: inline inside `countFactorsToVerify`
+ * (`components/model-tab/utils.ts`), and as a deliberate PORT in
+ * `model-tab-v2/adapters.ts` whose header said so in as many words and pinned
+ * the copy against the live count over a corpus. That pin was honest and it was
+ * still a mirror — it could only prove the two AGREED, never that either was
+ * right, and it needed a hand-written corpus to do even that (trap 12d).
+ *
+ * The REHOME → DELETE lane forced the issue: the Model tab's Confirm ✓ must be
+ * offered by exactly the predicate that counts the factor as unverified, or the
+ * badge and the button disagree about the same row. Three readings of one
+ * question was one too many before; four would have been absurd. So it moved to
+ * the domain layer both surfaces already depend on, and neither keeps a copy.
+ *
+ * ⚠ IT READS BOTH SPELLINGS. Canvas stores `observedState`; the CEE/PLoT wire
+ * uses `observed_state`, and real graphs carry both. Reading one under-counts.
+ *
+ * ⚠ ANY SOURCE OTHER THAN ABSENT-OR-`cee_inference` CLEARS IT — including
+ * `user_confirmed`, which is what ratifying an estimate now stamps. That is the
+ * behaviour the count has always had; it is stated here because the Confirm
+ * gesture is the thing that produces the transition, and a reader of the button
+ * needs to know the badge will clear with it.
+ */
+export function factorNeedsVerification(data: unknown): boolean {
+  const d = data as Record<string, unknown> | undefined
+  const obs = (d?.observedState ?? d?.observed_state) as Record<string, unknown> | undefined
+  return !obs?.source || obs?.source === 'cee_inference'
+}

--- a/src/canvas/hooks/__tests__/useModelEditAuthority.localCommits.spec.tsx
+++ b/src/canvas/hooks/__tests__/useModelEditAuthority.localCommits.spec.tsx
@@ -1,0 +1,171 @@
+/**
+ * `useModelEditAuthority` — the two LOCAL COMMITS, at the authority itself.
+ *
+ * ⚠ WHY THIS FILE EXISTS: A SURVIVING MUTANT SAID IT HAD TO (18 Aug 2026).
+ *
+ * The surface tests in `model-tab-v2/__tests__/rehomedLocalCommits.spec.tsx`
+ * drive these operations through the mounted panel, which is the right place to
+ * pin what a USER gets. But the panel only ever calls them in the states its own
+ * predicates allow — so a mutation that DELETED the authority's value guard
+ * (`M2`, "confirm drops value guard") SURVIVED the entire battery: the UI never
+ * offers Confirm without a value, so nothing reached the guard.
+ *
+ * A survivor is a claim in both directions and must be DEMONSTRATED, never
+ * asserted (trap 13c). The demonstration is that these guards are genuinely
+ * uncovered — the affordance predicate hides them — and the honest response is
+ * to test them where they live rather than to declare the mutant equivalent.
+ *
+ * ⚠ AND THEY ARE NOT REDUNDANT WITH THE UI PREDICATES. The UI predicate decides
+ * whether to OFFER a gesture; these decide whether to HONOUR one. They answer
+ * different questions (trap 21) and the second is what protects the model when a
+ * future caller — the repair queues' "Apply all shown", a keyboard path, a batch
+ * — reaches the authority without the row's predicate in front of it.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+
+vi.mock('../../conversation/ConversationContext', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, useOptionalConversationContext: () => undefined }
+})
+
+import { useModelEditAuthority } from '../useModelEditAuthority'
+import { useCanvasStore } from '../../store'
+
+const FACTOR = 'fac_cost'
+const VALUELESS_FACTOR = 'fac_unknown'
+const OPTION = 'opt_premium'
+const GOAL = 'goal_arr'
+const VALUED_NON_FACTOR = 'risk_supplier'
+
+function seed() {
+  useCanvasStore.setState(
+    {
+      nodes: [
+        {
+          id: FACTOR,
+          type: 'factor',
+          position: { x: 0, y: 0 },
+          data: {
+            label: 'Cost',
+            kind: 'factor',
+            observedState: { value: 0.5, raw_value: 15000, cap: 30000, source: 'cee_inference' },
+          },
+        },
+        {
+          id: VALUELESS_FACTOR,
+          type: 'factor',
+          position: { x: 0, y: 0 },
+          data: { label: 'Churn', kind: 'factor' },
+        },
+        {
+          id: OPTION,
+          type: 'option',
+          position: { x: 0, y: 0 },
+          data: { label: 'Premium', kind: 'option', interventions: { [FACTOR]: 0.2 } },
+        },
+        { id: GOAL, type: 'goal', position: { x: 0, y: 0 }, data: { label: 'ARR', kind: 'goal' } },
+        /*
+         * ⚠ A NON-FACTOR THAT DOES CARRY AN OBSERVED VALUE — and it exists for
+         * one reason: WITHOUT IT THE KIND GUARD IS UNTESTED.
+         *
+         * The first cut of this spec proved "refuses a node that is not a
+         * factor" using the GOAL, which has no observed state — so the VALUE
+         * guard refused it and the KIND guard was never consulted. A mutant
+         * deleting the kind check SURVIVED the whole battery while that test
+         * stayed green: a guard passing because its NEIGHBOUR fired (trap 13b).
+         * Only a node that clears every other guard can discriminate this one.
+         */
+        {
+          id: VALUED_NON_FACTOR,
+          type: 'risk',
+          position: { x: 0, y: 0 },
+          data: {
+            label: 'Supplier failure',
+            kind: 'risk',
+            observedState: { value: 0.3, source: 'cee_inference' },
+          },
+        },
+      ],
+      edges: [],
+    } as never,
+    false,
+  )
+}
+
+const authorityFor = (id: string | null) => renderHook(() => useModelEditAuthority(id)).result
+
+function nodeData(id: string): Record<string, unknown> {
+  return (useCanvasStore.getState().nodes.find(n => n.id === id)?.data ?? {}) as Record<string, unknown>
+}
+const sourceOf = (id: string) =>
+  (nodeData(id).observedState as Record<string, unknown> | undefined)?.source
+const interventionsOf = (id: string) =>
+  (nodeData(id).interventions ?? {}) as Record<string, unknown>
+
+beforeEach(() => seed())
+
+describe('proposeFactorConfirmation — honours only what it can honour', () => {
+  it('POSITIVE CONTROL: it does commit on the case it is FOR, so the refusals below discriminate', () => {
+    expect(authorityFor(FACTOR).current.proposeFactorConfirmation()).toBe('committed')
+    expect(sourceOf(FACTOR)).toBe('user_confirmed')
+  })
+
+  it('refuses a factor with NO value — you cannot ratify a number that is not there (P5)', () => {
+    expect(authorityFor(VALUELESS_FACTOR).current.proposeFactorConfirmation()).toBe('not_encodable')
+    // ⚠ AND NOTHING WAS WRITTEN. The outcome alone would pass on a half-commit.
+    expect(sourceOf(VALUELESS_FACTOR)).toBeUndefined()
+  })
+
+  it('refuses a node that is not a factor — the goal, which also has no value', () => {
+    expect(authorityFor(GOAL).current.proposeFactorConfirmation()).toBe('not_encodable')
+    expect(sourceOf(GOAL)).toBeUndefined()
+  })
+
+  it('⭐ refuses a NON-FACTOR THAT DOES HAVE A VALUE — the kind guard, discriminated', () => {
+    // This case clears every other guard: the node exists, and it carries a
+    // finite observed value. Only the kind check can refuse it, so this is the
+    // one fixture that can tell a live kind guard from a deleted one. Proven by
+    // mutation: deleting the check leaves the test above GREEN and this one RED.
+    expect(authorityFor(VALUED_NON_FACTOR).current.proposeFactorConfirmation()).toBe(
+      'not_encodable',
+    )
+    expect(sourceOf(VALUED_NON_FACTOR)).toBe('cee_inference')
+    expect(sourceOf(VALUED_NON_FACTOR)).not.toBe('user_confirmed')
+  })
+
+  it('refuses when no node is active, and when the id names nothing', () => {
+    expect(authorityFor(null).current.proposeFactorConfirmation()).toBe('not_encodable')
+    expect(authorityFor('nope').current.proposeFactorConfirmation()).toBe('not_encodable')
+  })
+})
+
+describe('proposeOptionIntervention — honours only what it can honour', () => {
+  it('POSITIVE CONTROL: it does commit on the case it is FOR', () => {
+    expect(authorityFor(OPTION).current.proposeOptionIntervention(FACTOR, 0.75)).toBe('committed')
+    expect(interventionsOf(OPTION)[FACTOR]).toBe(0.75)
+  })
+
+  it('refuses a factor that is NOT IN THE MODEL — the entry would surface as a raw id', () => {
+    expect(authorityFor(OPTION).current.proposeOptionIntervention('fac_deleted', 0.5)).toBe(
+      'not_encodable',
+    )
+    expect(Object.keys(interventionsOf(OPTION))).not.toContain('fac_deleted')
+    // The pre-existing entry is untouched — the refusal is a no-op, not a reset.
+    expect(interventionsOf(OPTION)[FACTOR]).toBe(0.2)
+  })
+
+  it('refuses when the ACTIVE node is not an option — interventions belong to options', () => {
+    expect(authorityFor(FACTOR).current.proposeOptionIntervention(FACTOR, 0.5)).toBe('not_encodable')
+    expect(nodeData(FACTOR).interventions).toBeUndefined()
+  })
+
+  it('refuses a non-finite value and an empty factor id', () => {
+    const a = authorityFor(OPTION).current
+    expect(a.proposeOptionIntervention(FACTOR, Number.NaN)).toBe('not_encodable')
+    expect(a.proposeOptionIntervention(FACTOR, Number.POSITIVE_INFINITY)).toBe('not_encodable')
+    expect(a.proposeOptionIntervention('   ', 0.5)).toBe('not_encodable')
+    expect(interventionsOf(OPTION)[FACTOR]).toBe(0.2)
+  })
+})

--- a/src/canvas/hooks/useModelEditAuthority.ts
+++ b/src/canvas/hooks/useModelEditAuthority.ts
@@ -30,22 +30,53 @@
  * render the store, which the central machinery keeps honest. When the
  * receipt-bearing transaction API lands, this seam is where it plugs in.
  *
- * SCOPE AT THIS TIP: `proposeFactorValue` only. The UI's wire vocabulary
+ * ⚠ SCOPE WIDENED 18 Aug 2026 (the REHOME → DELETE lane), and the widening is
+ * the point: the founder's ruling is *"do not preserve the duplicate editor
+ * because some capabilities are still local-only; EXTEND THE CANONICAL
+ * TRANSACTIONAL AUTHORITY WHERE REQUIRED, then remove the duplicate."* So this
+ * hook now owns THREE operations, not one — and it owns them for BOTH editors,
+ * which is what makes the second one deletable.
+ *
+ * The two new ones are LOCAL COMMITS, and they are typed as a different thing
+ * from `proposeFactorValue` on purpose (trap 21 — two questions must not share
+ * one name). `proposeFactorValue` asks *"will the server accept this number?"*.
+ * `proposeOptionIntervention` and `proposeFactorConfirmation` ask *"record this
+ * in the model"*, and there is NO server carrier for either: the wire's only
+ * value-bearing node edit is `factor_value_edit`, whose `field` is the literal
+ * `'value'`. They reach CEE exactly as they always have — through the debounced,
+ * VALUE-LESS `direct_graph_edit` notification that `useGraphEditEvents`
+ * emits off the store. Nothing here claims otherwise, and `LocalCommitOutcome`
+ * has no `dispatched` member so no caller can accidentally report one.
+ *
+ * WHAT THE EXTENSION IS *NOT*: a new writer. Both operations go through the
+ * SANCTIONED SETTERS (`setIntervention`, `setObservedSource`) that the v1
+ * sections already used — the same store write, relocated behind one authority
+ * so the surfaces stop each owning their own copy of it.
+ *
+ * WIRE-CARRIER SCOPE. The UI's wire vocabulary
  * (`WIRE_SYSTEM_EVENT_TYPES`) carries four server-authoritative edit carriers —
  * `factor_value_edit`, `prior_range_edit` (emitted inside the sanctioned
  * `setPriorRange`), `edge_adjudication`, and — since schemas 0.48.0 —
  * `structural_delete`, the durable REMOVAL, which is emitted from the canvas
  * delete gestures via `useStructuralDeleteEvents` and resolves its own receipt
- * inside `sendTurn` (this hook is not on that path). Edge strength /
- * likelihood / direction, option interventions, the goal target and factor
- * confirmation have NO canonical carrier yet; the v2 surface renders those
- * affordances DISABLED with an honest label rather than routing them through a
- * local-only write that would look identical to a server-backed one
- * (design §2 F6).
+ * inside `sendTurn` (this hook is not on that path). Edge strength / likelihood
+ * / direction and the goal target still have NO canonical carrier and NO entry
+ * point here; the v2 surface keeps rendering those affordances DISABLED with an
+ * honest label rather than routing them through a local-only write that would
+ * look identical to a server-backed one (design §2 F6).
+ *
+ * ⚠ AND F6 IS *NOT* RE-OPENED BY THE TWO LOCAL COMMITS. F6's harm is that a
+ * local write and a server-backed one are INDISTINGUISHABLE on screen. These
+ * two are distinguishable by construction: neither renders the value-edit
+ * three-beat, and each is a distinct gesture with its own visible result — a
+ * confirmation flips the provenance pill to "Confirmed by you", and an
+ * intervention target shows the number the user set. Neither ever claims a
+ * server accepted anything, because neither can return an outcome that says so.
  */
 
 import { useCallback } from 'react'
 import { useCanvasStore } from '../store'
+import { resolveNodeTypeLiteral } from '../domain/nodes'
 import { useOptionalConversationContext } from '../conversation/ConversationContext'
 import { useNodeMutations } from '../ui/inspector-v2/useInspectorMutations'
 import { buildFactorValueEditEvent } from '../conversation/factorValueEdit'
@@ -67,8 +98,39 @@ import { captureOptimisticFactorEdit } from '../conversation/optimisticFactorEdi
  */
 export type FactorValueProposalOutcome = 'dispatched' | 'local_only' | 'not_encodable'
 
+/**
+ * How a LOCAL COMMIT left this seam.
+ *
+ * ⚠ THERE IS DELIBERATELY NO `dispatched` MEMBER. These operations have no
+ * value-bearing wire carrier, so a caller cannot report that a server accepted
+ * one — the type makes the honest statement the only statement available.
+ *
+ * - `committed`      — the sanctioned setter wrote the model. CEE learns of it
+ *                      only through the debounced, value-less
+ *                      `direct_graph_edit` notification, exactly as it did from
+ *                      the v1 sections.
+ * - `not_encodable`  — nothing happened anywhere. Fail CLOSED: a dropped edit
+ *                      is a visible "nothing happened"; a half-committed one is
+ *                      a silent split-brain.
+ */
+export type LocalCommitOutcome = 'committed' | 'not_encodable'
+
 export interface ModelEditAuthorityLive {
   proposeFactorValue: (typedValue: number) => FactorValueProposalOutcome
+  /**
+   * Set the ACTIVE OPTION's target value for one factor.
+   *
+   * `activeNodeId` is the OPTION; `factorId` names the factor whose value that
+   * option would move. Both halves are checked — see the implementation for why
+   * an unresolvable `factorId` must fail closed rather than write.
+   */
+  proposeOptionIntervention: (factorId: string, value: number) => LocalCommitOutcome
+  /**
+   * Ratify the ACTIVE FACTOR's existing value as correct.
+   *
+   * ⚠ STAMPS `user_confirmed`, NEVER `user`. See the implementation.
+   */
+  proposeFactorConfirmation: () => LocalCommitOutcome
 }
 
 /**
@@ -120,5 +182,78 @@ export function useModelEditAuthority(activeNodeId: string | null): ModelEditAut
     [activeNodeId, mutations, sendSystemEvent],
   )
 
-  return { proposeFactorValue }
+  /**
+   * ⚠ WHY THE FACTOR MUST EXIST BEFORE AN INTERVENTION IS WRITTEN.
+   *
+   * `interventions` is a map KEYED BY FACTOR ID. Writing a key that resolves to
+   * no node produces an entry nothing can label — and every surface that lists
+   * interventions falls back to the key when the lookup misses
+   * (`OptionsSection.buildInterventions`: `factorNode?.data?.label ?? factorId`).
+   * So an unchecked write here surfaces a RAW WIRE ID to the user, one hop
+   * later, which is the exact leak class this lane's outline work closed. The
+   * guard is at the WRITE because that is the only place it cannot be bypassed.
+   *
+   * It is also preamble P6: an entry the user cannot name is structure the
+   * product invented, and it would go on to manufacture a "set this value" ask
+   * for an element that is not in the model.
+   */
+  const proposeOptionIntervention = useCallback(
+    (factorId: string, value: number): LocalCommitOutcome => {
+      if (!activeNodeId) return 'not_encodable'
+      if (!Number.isFinite(value)) return 'not_encodable'
+      if (typeof factorId !== 'string' || factorId.trim() === '') return 'not_encodable'
+      const state = useCanvasStore.getState()
+      const option = state.nodes.find(n => n.id === activeNodeId)
+      // An intervention belongs to an OPTION. Writing an `interventions` map
+      // onto a factor would be a well-formed store patch that means nothing,
+      // and nothing downstream would ever report it.
+      if (!option || resolveNodeTypeLiteral(option) !== 'option') return 'not_encodable'
+      if (!state.nodes.some(n => n.id === factorId)) return 'not_encodable'
+
+      mutations.setIntervention(factorId, value)
+      return 'committed'
+    },
+    [activeNodeId, mutations],
+  )
+
+  /**
+   * ⚠ THE STAMP IS `user_confirmed`, AND THAT IS THE WHOLE FIX.
+   *
+   * The v1 Model tab wrote `setObservedSource('user')` for this gesture. The
+   * shared classifier (`canvas/domain/valueProvenance.ts`) maps `'user'` to the
+   * `edited` class, so the pill read **"User edited"** for an act in which the
+   * user changed NO number — they ratified Olumi's. Pre-analysis, the outputs
+   * dock and the calibrate drill-in all write `user_confirmed` for the
+   * identical gesture and get "Confirmed by you": one act, two stamps, decided
+   * by which surface the user happened to be standing on.
+   *
+   * ⚠ `source` ALONE — no `extractionType`. The two sibling surfaces also write
+   * `extractionType: 'explicit'`, and copying that would be inventing a claim
+   * this gesture does not establish: confirming a number says nothing about
+   * HOW it was extracted. Ratifying a value may change its provenance and
+   * nothing else, which is precisely why the old handler's baseline sibling was
+   * corrected on the same grounds (see `FactorsSection.handleBaselineSave`).
+   *
+   * ⚠ AND THERE MUST BE A VALUE TO RATIFY. Stamping "confirmed by you" over an
+   * absent number is a claim about the model that the model does not contain
+   * (preamble P5), and it would silently drop the factor out of the verify
+   * count — `countFactorsToVerify` clears on any source that is neither absent
+   * nor `cee_inference`. The gap would stop being reported without being fixed.
+   */
+  const proposeFactorConfirmation = useCallback((): LocalCommitOutcome => {
+    if (!activeNodeId) return 'not_encodable'
+    const node = useCanvasStore.getState().nodes.find(n => n.id === activeNodeId)
+    if (!node || resolveNodeTypeLiteral(node) !== 'factor') return 'not_encodable'
+    const data = node.data as Record<string, unknown> | undefined
+    const obs = (data?.observedState ?? data?.observed_state) as
+      | Record<string, unknown>
+      | undefined
+    const value = obs?.value
+    if (typeof value !== 'number' || !Number.isFinite(value)) return 'not_encodable'
+
+    mutations.setObservedSource('user_confirmed')
+    return 'committed'
+  }, [activeNodeId, mutations])
+
+  return { proposeFactorValue, proposeOptionIntervention, proposeFactorConfirmation }
 }

--- a/src/canvas/model-tab-v2/ModelDetailRegion.tsx
+++ b/src/canvas/model-tab-v2/ModelDetailRegion.tsx
@@ -36,6 +36,21 @@ export interface ModelDetailRegionProps {
   detail: ModelRowDetail
   tier: DetailTier
   onFocusOnCanvas?: (id: string) => void
+  /**
+   * The intervention currently being edited, if any — OWNED BY THE HOST.
+   *
+   * ⚠ THIS COMPONENT HOLDS NO EDIT STATE, deliberately. The panel owns "the one
+   * active edit" for the whole surface, which is what stops the outline and the
+   * detail region each believing they have one. `factorId` identifies the row
+   * BY IDENTITY, never by position in the list (trap 19).
+   */
+  interventionEdit?: { factorId: string; draft: string } | null
+  /** Begin editing one intervention target. Absent ⇒ the list is read-only. */
+  onBeginInterventionEdit?: (factorId: string, seed: string) => void
+  onInterventionDraftChange?: (factorId: string, draft: string) => void
+  /** Commit the draft through the write authority. */
+  onCommitIntervention?: (factorId: string) => void
+  onDiscardInterventionEdit?: () => void
 }
 
 /** Absence is rendered as absence — never as a zero, never as a blank cell. */
@@ -63,6 +78,11 @@ export function ModelDetailRegion({
   detail,
   tier,
   onFocusOnCanvas,
+  interventionEdit = null,
+  onBeginInterventionEdit,
+  onInterventionDraftChange,
+  onCommitIntervention,
+  onDiscardInterventionEdit,
 }: ModelDetailRegionProps) {
   /*
    * The identity gate. This is deliberately a VISIBLE refusal rather than a
@@ -110,6 +130,105 @@ export function ModelDetailRegion({
         </p>
         <FieldList fields={detail.secondaryValues} testid="model-detail-v2-secondary" />
       </section>
+
+      {/*
+        2b — What this option would change (rehomed from `OptionsSection`'s
+        intervention rows, 18 Aug 2026).
+
+        ⚠ IT RENDERS ONLY WHEN THERE IS SOMETHING TO SHOW. An option that sets
+        no targets reports that through its ROW's `missing-intervention` marker
+        and the repair queue that collects it — an empty section here would be a
+        second, quieter rendering of the same fact, and the two would then have
+        to be kept in step.
+      */}
+      {detail.interventions.length > 0 && (
+        <section data-testid="model-detail-v2-interventions">
+          <h4 className={`${typography.label} text-text-header`}>What this would change</h4>
+          <ul>
+            {detail.interventions.map(iv => {
+              const editing = interventionEdit?.factorId === iv.factorId
+              const editable = typeof onBeginInterventionEdit === 'function'
+              return (
+                <li
+                  key={iv.factorId}
+                  data-testid={`model-detail-v2-intervention-${iv.factorId}`}
+                  className="flex items-center gap-2 py-0.5"
+                >
+                  {/*
+                    ⚠ THE FACTOR'S NAME, NEVER ITS ID. The projection drops any
+                    entry it cannot name, so there is no `?? factorId` fallback
+                    to leak one here — see `buildOptionInterventions`.
+                  */}
+                  <span className={`${typography.bodySmall} text-text-body flex-1 truncate`}>
+                    {iv.factorLabel}
+                  </span>
+
+                  {editing ? (
+                    <>
+                      <input
+                        type="number"
+                        autoFocus
+                        data-testid={`model-detail-v2-intervention-${iv.factorId}-input`}
+                        aria-label={`Target value for ${iv.factorLabel}`}
+                        value={interventionEdit.draft}
+                        onChange={e => onInterventionDraftChange?.(iv.factorId, e.target.value)}
+                        onKeyDown={e => {
+                          if (e.key === 'Enter') onCommitIntervention?.(iv.factorId)
+                          if (e.key === 'Escape') onDiscardInterventionEdit?.()
+                        }}
+                        className={`${typography.tabular} w-24 bg-panel-hover border border-panel-border rounded px-1`}
+                      />
+                      <button
+                        type="button"
+                        data-testid={`model-detail-v2-intervention-${iv.factorId}-save`}
+                        onClick={() => onCommitIntervention?.(iv.factorId)}
+                        className={`${typography.buttonSmall} text-info`}
+                      >
+                        Save
+                      </button>
+                      <button
+                        type="button"
+                        data-testid={`model-detail-v2-intervention-${iv.factorId}-cancel`}
+                        onClick={() => onDiscardInterventionEdit?.()}
+                        className={`${typography.buttonSmall} text-text-light`}
+                      >
+                        Cancel
+                      </button>
+                    </>
+                  ) : (
+                    <button
+                      type="button"
+                      disabled={!editable}
+                      data-testid={`model-detail-v2-intervention-${iv.factorId}-value`}
+                      title={editable ? 'Change this target' : undefined}
+                      aria-label={
+                        editable
+                          ? `Change the target for ${iv.factorLabel}`
+                          : `${iv.factorLabel}: ${iv.value ?? 'Not set'}`
+                      }
+                      onClick={() =>
+                        onBeginInterventionEdit?.(
+                          iv.factorId,
+                          // ⚠ SEEDS FROM `numericValue`, NEVER FROM `value`. The
+                          // displayed string may be CEE-authored prose; seeding an
+                          // editor from it would let a label be saved back as if the
+                          // user had typed it.
+                          iv.numericValue === null ? '' : String(iv.numericValue),
+                        )
+                      }
+                      className={`${typography.tabular} ${
+                        editable ? 'underline decoration-dotted' : 'text-text-light'
+                      }`}
+                    >
+                      {iv.value ?? 'Not set'}
+                    </button>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        </section>
+      )}
 
       {/* 3 — Where it came from */}
       <section data-testid="model-detail-v2-provenance">

--- a/src/canvas/model-tab-v2/ModelDetailRegion.tsx
+++ b/src/canvas/model-tab-v2/ModelDetailRegion.tsx
@@ -90,6 +90,23 @@ export function ModelDetailRegion({
    * rendering bug and gets "fixed" by removing the check, whereas a stated
    * mismatch names the defect for whoever sees it.
    */
+  /*
+   * ⚠ READ DEFENSIVELY EVEN THOUGH THE TYPE SAYS IT IS REQUIRED (preamble P1).
+   *
+   * `interventions` is not optional in `ModelRowDetail`, so a producer that
+   * omits it is a contract break — and the type keeps obliging producers. But
+   * the SEAM ONE PAST THAT GUARD is this render, and `detail.interventions.length`
+   * on an absent array throws during render and takes the WHOLE pane with it:
+   * the element's name, its value, its provenance and its "what it affects"
+   * list all disappear because one list is missing. That is #746's exact shape —
+   * malformity must cost the citation, never the attribution.
+   *
+   * Proven, not assumed: twelve existing tests in this file went RED the moment
+   * the field was added, all of them on payloads built before it existed, and
+   * every one of them was asserting something ELSE about the pane.
+   */
+  const interventions = detail.interventions ?? []
+
   if (detail.rowId !== row.id) {
     return (
       <aside data-testid="model-detail-v2" data-mismatch="true">
@@ -141,11 +158,11 @@ export function ModelDetailRegion({
         second, quieter rendering of the same fact, and the two would then have
         to be kept in step.
       */}
-      {detail.interventions.length > 0 && (
+      {interventions.length > 0 && (
         <section data-testid="model-detail-v2-interventions">
           <h4 className={`${typography.label} text-text-header`}>What this would change</h4>
           <ul>
-            {detail.interventions.map(iv => {
+            {interventions.map(iv => {
               const editing = interventionEdit?.factorId === iv.factorId
               const editable = typeof onBeginInterventionEdit === 'function'
               return (

--- a/src/canvas/model-tab-v2/ModelGroupActions.tsx
+++ b/src/canvas/model-tab-v2/ModelGroupActions.tsx
@@ -1,0 +1,70 @@
+/**
+ * ModelGroupActions — the group-level affordances of the canonical outline.
+ *
+ * A PURE PROJECTION, like every other render component in this directory: it
+ * takes the actions and a callback and renders buttons. It performs no fronting,
+ * sends no turn and reads no store — `ModelTabV2Panel` owns the hand-off, and
+ * `ModelTabBody` (the one file here allowed to touch the live app) owns the
+ * sender. Three layers, one write path, no shortcut.
+ *
+ * ⚠ WHY THE `discuss` CONTROLS CARRY VISIBLE TEXT. Their v1 originals were
+ * ICON-ONLY — a 14px `MessageCircle` whose only accessible name was a `title`
+ * attribute (`GoalSection.tsx:243`, `OptionsSection.tsx:521`,
+ * `FactorsSection.tsx:745`, `RelationshipsSection.tsx:827`,
+ * `RisksSection.tsx:143`, `ModelHealthSection.tsx:328`). A `title` is not an
+ * accessible name a screen reader announces reliably and is invisible on touch.
+ * The label is the same DS idiom the v1 STRUCTURAL CTAs already use, so this is
+ * conformance to the existing visual language rather than a new one — no new
+ * token, no new size, no new colour.
+ */
+
+import { typography } from '../../styles/typography'
+import type { GroupAction, GroupActionContext } from './groupActions'
+import type { ModelGroupId } from './types'
+
+export interface ModelGroupActionsProps {
+  groupId: ModelGroupId
+  actions: readonly GroupAction[]
+  context: GroupActionContext
+  /**
+   * Absent when no conversation can receive a turn.
+   *
+   * ⚠ THE CALLER PASSES NOTHING RATHER THAN A NO-OP, and this component renders
+   * nothing in response. That is the v1 `{onSendMessage && …}` guard preserved:
+   * an affordance whose turn cannot be delivered must not be on screen at all
+   * (preamble P8). A no-op callback here would put every button back and make
+   * each one a dead end.
+   */
+  onAction?: (action: GroupAction, message: string) => void
+}
+
+export function ModelGroupActions({
+  groupId,
+  actions,
+  context,
+  onAction,
+}: ModelGroupActionsProps) {
+  if (!onAction || actions.length === 0) return null
+
+  return (
+    <div
+      data-testid={`model-group-v2-${groupId}-actions`}
+      className="flex flex-wrap items-center gap-3 px-4 py-1.5"
+    >
+      {actions.map(action => (
+        <button
+          key={action.id}
+          type="button"
+          data-testid={`model-action-v2-${action.id}`}
+          data-intent={action.intent}
+          onClick={() => onAction(action, action.message(context))}
+          className={`${typography.panelMeta} cursor-pointer hover:underline ${
+            action.intent === 'structural' ? 'text-info' : 'text-text-light hover:text-info'
+          }`}
+        >
+          {action.intent === 'structural' ? `+ ${action.label}` : action.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/canvas/model-tab-v2/ModelOutline.tsx
+++ b/src/canvas/model-tab-v2/ModelOutline.tsx
@@ -28,6 +28,8 @@
 import { useCallback, useMemo, useState } from 'react'
 import { typography } from '../../styles/typography'
 import { ModelRowView } from './ModelRowView'
+import { ModelGroupActions } from './ModelGroupActions'
+import { GROUP_ACTIONS, type GroupAction, type GroupActionContext } from './groupActions'
 import { GROUP_TITLE } from './rowPresentation'
 import {
   MODEL_GROUP_IDS,
@@ -70,6 +72,21 @@ export interface ModelOutlineProps {
   onProposeEdit?: (id: string) => void
   onDiscardEdit?: (id: string) => void
   onConfirmEdit?: (id: string) => void
+  /**
+   * The group-level affordances rehomed from the v1 stack (add a factor, add a
+   * relationship, explore other strategies, identify risks, discuss each group).
+   *
+   * ⚠ ABSENT MEANS THE BUTTONS DO NOT RENDER, not that they render inert. There
+   * is deliberately no default: the v1 sections guarded every send-to-AI control
+   * behind `{onSendMessage && …}`, and dropping that guard would put an
+   * undeliverable affordance on screen (preamble P8).
+   */
+  onGroupAction?: (action: GroupAction, message: string) => void
+  /**
+   * What a group action's message may interpolate. Sourced from the rows this
+   * outline is rendering, so a quoted target is the one the user can see.
+   */
+  groupActionContext?: GroupActionContext
 }
 
 /**
@@ -133,6 +150,8 @@ export function ModelOutline({
   onProposeEdit,
   onDiscardEdit,
   onConfirmEdit,
+  onGroupAction,
+  groupActionContext,
 }: ModelOutlineProps) {
   const [closed, setClosed] = useState<ReadonlySet<ModelGroupId>>(
     () => new Set(initiallyClosedGroups ?? []),
@@ -196,39 +215,55 @@ export function ModelOutline({
             )}
           </button>
 
-          {group.open &&
-            (group.rows.length === 0 ? (
-              <p
-                data-testid={`model-group-v2-${group.id}-empty`}
-                className={`${typography.caption} text-text-light px-4 py-1`}
-              >
-                {filter.trim() === ''
-                  ? 'Nothing in this group yet'
-                  : 'No matches in this group'}
-              </p>
-            ) : (
-              <ul role="listbox" aria-label={GROUP_TITLE[group.id]}>
-                {group.rows.map(row => (
-                  <ModelRowView
-                    key={row.id}
-                    row={row}
-                    tier={tier}
-                    selected={row.id === selectedId}
-                    commit={commitByRowId?.get(row.id)}
-                    editConnected={
-                      editConnectedIds === undefined ? true : editConnectedIds.has(row.id)
-                    }
-                    onSelect={onSelect}
-                    onFocusOnCanvas={onFocusOnCanvas}
-                    onBeginEdit={onBeginEdit}
-                    onDraftChange={onDraftChange}
-                    onProposeEdit={onProposeEdit}
-                    onDiscardEdit={onDiscardEdit}
-                    onConfirmEdit={onConfirmEdit}
-                  />
-                ))}
-              </ul>
-            ))}
+          {group.open && (
+            <>
+              {group.rows.length === 0 ? (
+                <p
+                  data-testid={`model-group-v2-${group.id}-empty`}
+                  className={`${typography.caption} text-text-light px-4 py-1`}
+                >
+                  {filter.trim() === ''
+                    ? 'Nothing in this group yet'
+                    : 'No matches in this group'}
+                </p>
+              ) : (
+                <ul role="listbox" aria-label={GROUP_TITLE[group.id]}>
+                  {group.rows.map(row => (
+                    <ModelRowView
+                      key={row.id}
+                      row={row}
+                      tier={tier}
+                      selected={row.id === selectedId}
+                      commit={commitByRowId?.get(row.id)}
+                      editConnected={
+                        editConnectedIds === undefined ? true : editConnectedIds.has(row.id)
+                      }
+                      onSelect={onSelect}
+                      onFocusOnCanvas={onFocusOnCanvas}
+                      onBeginEdit={onBeginEdit}
+                      onDraftChange={onDraftChange}
+                      onProposeEdit={onProposeEdit}
+                      onDiscardEdit={onDiscardEdit}
+                      onConfirmEdit={onConfirmEdit}
+                    />
+                  ))}
+                </ul>
+              )}
+              {/*
+                THE ACTIONS RENDER EVEN WHEN THE GROUP IS EMPTY, and that is the
+                point of putting them here. "Add a factor" is at its most useful
+                when there are no factors — the v1 risks CTA rendered ONLY in the
+                empty state and the v1 factor CTA only in the populated one, so
+                each was missing exactly where the other proved it was wanted.
+              */}
+              <ModelGroupActions
+                groupId={group.id}
+                actions={GROUP_ACTIONS[group.id]}
+                context={groupActionContext ?? { goalLabel: null, goalTarget: null }}
+                onAction={onGroupAction}
+              />
+            </>
+          )}
         </section>
       ))}
     </div>

--- a/src/canvas/model-tab-v2/ModelOutline.tsx
+++ b/src/canvas/model-tab-v2/ModelOutline.tsx
@@ -72,6 +72,8 @@ export interface ModelOutlineProps {
   onProposeEdit?: (id: string) => void
   onDiscardEdit?: (id: string) => void
   onConfirmEdit?: (id: string) => void
+  /** Ratify an AI estimate as correct — passed straight through to the row. */
+  onConfirmValueAsIs?: (id: string) => void
   /**
    * The group-level affordances rehomed from the v1 stack (add a factor, add a
    * relationship, explore other strategies, identify risks, discuss each group).
@@ -150,6 +152,7 @@ export function ModelOutline({
   onProposeEdit,
   onDiscardEdit,
   onConfirmEdit,
+  onConfirmValueAsIs,
   onGroupAction,
   groupActionContext,
 }: ModelOutlineProps) {
@@ -245,6 +248,7 @@ export function ModelOutline({
                       onProposeEdit={onProposeEdit}
                       onDiscardEdit={onDiscardEdit}
                       onConfirmEdit={onConfirmEdit}
+                      onConfirmValueAsIs={onConfirmValueAsIs}
                     />
                   ))}
                 </ul>

--- a/src/canvas/model-tab-v2/ModelRowView.tsx
+++ b/src/canvas/model-tab-v2/ModelRowView.tsx
@@ -191,10 +191,20 @@ export function ModelRowView({
         </span>
       )}
 
+      {/*
+        ⚠ `-confirm-as-is`, NOT `-confirm`. The three-beat's chip already owns
+        `model-row-v2-<id>-confirm`, and the first cut of this affordance reused
+        it — two DIFFERENT gestures answering to one identity, which broke five
+        existing pins that assert the value-edit chip is absent while typing.
+        The collision was the guard doing its job: an assertion that binds by
+        identity is only as good as the identity being unique (trap 19), and a
+        shared testid is the same "two things, one name" defect this whole lane
+        is removing, at the scale of an attribute.
+      */}
       {canConfirmAsIs && (
         <button
           type="button"
-          data-testid={`model-row-v2-${row.id}-confirm`}
+          data-testid={`model-row-v2-${row.id}-confirm-as-is`}
           title="Confirm this value is correct"
           aria-label={`Confirm ${row.label} is correct`}
           className={`${typography.buttonSmall} text-info underline decoration-dotted`}

--- a/src/canvas/model-tab-v2/ModelRowView.tsx
+++ b/src/canvas/model-tab-v2/ModelRowView.tsx
@@ -21,6 +21,12 @@
  * one: a stub that reported success would be the silent-local-write defect
  * re-created inside the component written to kill it.
  *
+ * ⚠ THE CONFIRM CHIP (`onConfirmValueAsIs`, 18 Aug 2026) IS NOT AN EXCEPTION TO
+ * THAT RULE — it is the rule applied to a different gesture. It has an
+ * authority, so it renders live; and because it changes a value's PROVENANCE
+ * rather than the value, it is deliberately outside the three-beat rather than
+ * a phase of it. See the prop's own note.
+ *
  * THE INLINE-CHIP CONFIRM (ruling R9, 16 Aug 2026). The three-beat renders in
  * the row itself: an input while `editing`, then Confirm / Discard CHIPS while
  * `proposed` — never a modal. Until Confirm, the model is unchanged and the
@@ -71,6 +77,23 @@ export interface ModelRowViewProps {
   onDiscardEdit?: (id: string) => void
   /** The inline confirm chip — dispatches the canonical transaction. */
   onConfirmEdit?: (id: string) => void
+  /**
+   * Ratify this row's AI-estimated value as correct — the v1 Confirm ✓,
+   * rehomed (18 Aug 2026).
+   *
+   * ⚠ IT IS A SEPARATE PROP FROM THE VALUE THREE-BEAT, NOT A PHASE OF IT, and
+   * that separation is load-bearing. Confirming changes the value's PROVENANCE
+   * and not the value, so it has no draft, no `from`/`to` and nothing to
+   * propose — folding it into `EditCommitState` would give the row a "proposed"
+   * state whose `to` equalled its `from`, which reads as an edit that did
+   * nothing. Two gestures, two names (trap 21).
+   *
+   * Absent ⇒ the affordance does not render at all. It never renders disabled:
+   * unlike the value editor, this operation HAS an authority, so an absent
+   * callback means the host chose not to offer it here, not that the estate
+   * cannot honour it.
+   */
+  onConfirmValueAsIs?: (id: string) => void
 }
 
 /** Why the editor is unavailable. Shown on the disabled control, in words. */
@@ -90,9 +113,28 @@ export function ModelRowView({
   onProposeEdit,
   onDiscardEdit,
   onConfirmEdit,
+  onConfirmValueAsIs,
 }: ModelRowViewProps) {
   const phase = commit?.phase ?? 'idle'
   const editorAvailable = row.editable && editConnected && typeof onBeginEdit === 'function'
+
+  /*
+   * ⚠ THE AFFORDANCE IS BOUND TO THE ATTENTION REASON, NOT TO A RE-DERIVED
+   * PREDICATE. `unconfirmed-estimate` is already the one predicate this surface
+   * uses for "an AI estimate nobody has ratified" — it drives the row marker and
+   * the queue counts. Asking the same question a second way here is how the
+   * chip and the ⚠ start disagreeing about the same row (trap 12).
+   *
+   * The value guard is separate and is NOT a duplicate of it: `attention` says
+   * the estimate is unratified; `primaryValue` says there is a number on screen
+   * to ratify. A Confirm button over an empty cell asks the user to endorse
+   * nothing (preamble P8), and the authority would refuse it anyway — so the
+   * button does not appear rather than appearing and failing.
+   */
+  const canConfirmAsIs =
+    typeof onConfirmValueAsIs === 'function' &&
+    row.attention.includes('unconfirmed-estimate') &&
+    row.primaryValue !== null
 
   return (
     <li
@@ -147,6 +189,22 @@ export function ModelRowView({
         <span data-testid={`model-row-v2-${row.id}-provenance`}>
           <SourceProvenancePill source={row.provenanceSource} showWhenAbsent={false} />
         </span>
+      )}
+
+      {canConfirmAsIs && (
+        <button
+          type="button"
+          data-testid={`model-row-v2-${row.id}-confirm`}
+          title="Confirm this value is correct"
+          aria-label={`Confirm ${row.label} is correct`}
+          className={`${typography.buttonSmall} text-info underline decoration-dotted`}
+          onClick={e => {
+            e.stopPropagation()
+            onConfirmValueAsIs?.(row.id)
+          }}
+        >
+          Confirm
+        </button>
       )}
 
       {row.attention.map(reason => (

--- a/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
+++ b/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
@@ -42,6 +42,7 @@ import { resolveValueInputSeed } from '../conversation/factorValueEdit'
 import { useModelEditAuthority } from '../hooks/useModelEditAuthority'
 import { ModelOutline } from './ModelOutline'
 import { ModelDetailRegion } from './ModelDetailRegion'
+import type { GroupAction, GroupActionContext } from './groupActions'
 import { toModelRows, toRowDetail, nodeKind, type ModelProjectionInput } from './adapters'
 import type { DetailTier, EditCommitState } from './types'
 
@@ -56,6 +57,17 @@ export interface ModelTabV2PanelProps {
    * otherwise.
    */
   fragileEdgeIds?: ReadonlySet<string>
+  /**
+   * Hand a turn to Olumi, having FRONTED the conversation first.
+   *
+   * ⚠ ABSENT MEANS THE GROUP AFFORDANCES DO NOT RENDER. `ModelTabBody` builds
+   * this with `createOlumiHandOff`, which returns `null` when no sender exists —
+   * so "no conversation" propagates as "no button", never as a button that
+   * swallows the turn. This panel does NOT import the fronting primitive itself:
+   * the mount host owns every live-app seam, which is what keeps this directory's
+   * boundary guard meaningful.
+   */
+  onHandOffToOlumi?: (message: string, reason: string) => void
 }
 
 /** One active edit at a time — the row the user is currently changing. */
@@ -72,6 +84,7 @@ export function ModelTabV2Panel({
   edges,
   goalThreshold,
   fragileEdgeIds,
+  onHandOffToOlumi,
 }: ModelTabV2PanelProps) {
   const [tier, setTier] = useState<DetailTier>('plain')
   const [filter, setFilter] = useState('')
@@ -109,6 +122,30 @@ export function ModelTabV2Panel({
   const selectedDetail = useMemo(
     () => (selectedId === null ? null : toRowDetail(projection, selectedId)),
     [projection, selectedId],
+  )
+
+  /**
+   * What a group action may quote back to the user.
+   *
+   * ⚠ DERIVED FROM THE RENDERED GOAL ROW, not from `goalThreshold` or the store.
+   * The v1 goal hand-off quoted `displayThreshold` — the value that section was
+   * displaying. The equivalent here is the value THIS outline is displaying, so
+   * the sentence and the screen cannot disagree (preamble P5: a claim about the
+   * model is grounded in the state the user is actually shown).
+   */
+  const groupActionContext: GroupActionContext = useMemo(() => {
+    const goalRow = rows.find(r => r.kind === 'goal') ?? null
+    return {
+      goalLabel: goalRow?.label ?? null,
+      goalTarget: goalRow?.primaryValue ?? null,
+    }
+  }, [rows])
+
+  const handleGroupAction = useCallback(
+    (action: GroupAction, message: string) => {
+      onHandOffToOlumi?.(message, `model-tab-v2:${action.id}`)
+    },
+    [onHandOffToOlumi],
   )
 
   const authority = useModelEditAuthority(edit?.rowId ?? null)
@@ -254,6 +291,8 @@ export function ModelTabV2Panel({
         onProposeEdit={proposeEdit}
         onDiscardEdit={discardEdit}
         onConfirmEdit={confirmEdit}
+        onGroupAction={onHandOffToOlumi ? handleGroupAction : undefined}
+        groupActionContext={groupActionContext}
       />
 
       {selectedRow !== null && selectedDetail !== null && (

--- a/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
+++ b/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
@@ -25,15 +25,22 @@
  * a confirmation (contracts.ts §1 C11). When the receipt-bearing transaction
  * API lands, the three-beat's tail states plug in at `useModelEditAuthority`.
  *
- * EDIT COVERAGE AT THIS TIP: factor values (the reference canonical
- * transaction). Rows whose edit class has NO canonical carrier — edge
- * strength / likelihood / direction, option interventions, the goal target —
- * render the honest disabled affordance (`editConnectedIds`). Wiring them
- * through a local-only write instead would recreate design §2 F6 on the
- * surface built to kill it.
+ * EDIT COVERAGE AT THIS TIP (widened 18 Aug 2026, the REHOME → DELETE lane):
+ *   · FACTOR VALUES — the reference canonical transaction, server-backed.
+ *   · OPTION INTERVENTION TARGETS — in the detail region of the selected option.
+ *   · FACTOR CONFIRMATION — the row's Confirm chip, stamping `user_confirmed`.
+ * The last two are LOCAL COMMITS with no wire carrier, dispatched through the
+ * same authority; see `useModelEditAuthority`'s header for why that does not
+ * re-open design §2 F6 and for the outcome type that makes an over-claim
+ * unrepresentable.
+ *
+ * STILL DISABLED, HONESTLY: edge strength / likelihood / direction and the goal
+ * target. They have no authority entry point, so `editConnectedIds` keeps their
+ * affordances disabled with a label saying so. Wiring them through a local-only
+ * write instead would recreate F6 on the surface built to kill it.
  */
 
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import type { Edge, Node } from '@xyflow/react'
 import { typography } from '../../styles/typography'
 import type { EdgeData } from '../domain/edges'
@@ -90,6 +97,18 @@ export function ModelTabV2Panel({
   const [filter, setFilter] = useState('')
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [edit, setEdit] = useState<ActiveEdit | null>(null)
+  /**
+   * The one intervention target being edited, if any.
+   *
+   * ⚠ IT CARRIES ITS OWN `optionId` AND IS CLEARED ON SELECTION CHANGE. Without
+   * that, selecting a different option while an edit was open would leave a
+   * draft addressed to the previous option's factor — the authority would still
+   * refuse it (the factor is not the new option's), but the user would be
+   * looking at their number in a box that no longer means what it says.
+   */
+  const [interventionEdit, setInterventionEdit] = useState<
+    { optionId: string; factorId: string; draft: string } | null
+  >(null)
 
   const projection: ModelProjectionInput = useMemo(
     () => ({
@@ -148,7 +167,37 @@ export function ModelTabV2Panel({
     [onHandOffToOlumi],
   )
 
-  const authority = useModelEditAuthority(edit?.rowId ?? null)
+  /**
+   * ⚠ ONE AUTHORITY, KEYED ON WHICHEVER NODE THE ACTIVE GESTURE BELONGS TO.
+   *
+   * The value three-beat addresses the row being typed into; an intervention
+   * edit addresses the OPTION that owns it; a confirmation addresses the row
+   * the user pressed Confirm on, which is resolved at the call site. A second
+   * `useModelEditAuthority(...)` call for the second gesture would be a second
+   * writer of the same kind — the defect this whole change removes, recreated
+   * inside the fix. The precedence below is total and the two states are
+   * mutually exclusive in practice: beginning either clears the other.
+   */
+  const activeAuthorityNodeId = edit?.rowId ?? interventionEdit?.optionId ?? null
+  const authority = useModelEditAuthority(activeAuthorityNodeId)
+
+  /**
+   * The confirmation authority for ONE row.
+   *
+   * ⚠ IT IS A SEPARATE HOOK CALL BECAUSE IT ADDRESSES A DIFFERENT NODE, not
+   * because it is a different kind of write. `useModelEditAuthority` is
+   * node-parameterised exactly as `useNodeMutations` is, and Confirm fires on a
+   * row the user has NOT entered an edit on — so there is no active edit whose
+   * node it could borrow. Hooks cannot be called per row, so the host tracks the
+   * row whose confirmation is pending and dispatches on the next render.
+   */
+  const [pendingConfirmId, setPendingConfirmId] = useState<string | null>(null)
+  const confirmAuthority = useModelEditAuthority(pendingConfirmId)
+  useEffect(() => {
+    if (pendingConfirmId === null) return
+    confirmAuthority.proposeFactorConfirmation()
+    setPendingConfirmId(null)
+  }, [pendingConfirmId, confirmAuthority])
 
   /** Rows are nodes OR edges — focus each with the helper that owns its kind. */
   const focusOnCanvas = useCallback(
@@ -224,6 +273,58 @@ export function ModelTabV2Panel({
     [edit, authority],
   )
 
+  /**
+   * Ratify an AI estimate as correct — the v1 Confirm ✓, rehomed.
+   *
+   * Beginning a confirmation CLEARS any open edit: they are two states of one
+   * row and holding both would leave a draft the user can no longer see.
+   */
+  const confirmValueAsIs = useCallback((rowId: string) => {
+    setEdit(null)
+    setInterventionEdit(null)
+    setPendingConfirmId(rowId)
+  }, [])
+
+  const beginInterventionEdit = useCallback(
+    (factorId: string, seed: string) => {
+      if (selectedId === null) return
+      setEdit(null)
+      setInterventionEdit({ optionId: selectedId, factorId, draft: seed })
+    },
+    [selectedId],
+  )
+
+  const changeInterventionDraft = useCallback((factorId: string, draft: string) => {
+    setInterventionEdit(prev => (prev && prev.factorId === factorId ? { ...prev, draft } : prev))
+  }, [])
+
+  const discardInterventionEdit = useCallback(() => setInterventionEdit(null), [])
+
+  const commitIntervention = useCallback(
+    (factorId: string) => {
+      if (!interventionEdit || interventionEdit.factorId !== factorId) return
+      const num = parseFloat(interventionEdit.draft)
+      // Fail CLOSED, exactly as the value three-beat does: an unparseable draft
+      // stays open rather than committing something the user did not state.
+      if (!Number.isFinite(num)) return
+      authority.proposeOptionIntervention(factorId, num)
+      setInterventionEdit(null)
+    },
+    [interventionEdit, authority],
+  )
+
+  /**
+   * ⚠ SELECTING A DIFFERENT ROW ABANDONS AN OPEN INTERVENTION DRAFT. See
+   * `interventionEdit`'s declaration: a draft outliving its option is a number
+   * shown in a box that no longer addresses it.
+   */
+  const selectRow = useCallback((id: string) => {
+    setSelectedId(prev => {
+      if (prev !== id) setInterventionEdit(null)
+      return id
+    })
+  }, [])
+
   return (
     <section
       data-testid="model-tab-v2-panel"
@@ -282,7 +383,7 @@ export function ModelTabV2Panel({
         tier={tier}
         filter={filter}
         selectedId={selectedId}
-        onSelect={setSelectedId}
+        onSelect={selectRow}
         onFocusOnCanvas={focusOnCanvas}
         commitByRowId={commitByRowId}
         editConnectedIds={editConnectedIds}
@@ -291,6 +392,7 @@ export function ModelTabV2Panel({
         onProposeEdit={proposeEdit}
         onDiscardEdit={discardEdit}
         onConfirmEdit={confirmEdit}
+        onConfirmValueAsIs={confirmValueAsIs}
         onGroupAction={onHandOffToOlumi ? handleGroupAction : undefined}
         groupActionContext={groupActionContext}
       />
@@ -301,6 +403,15 @@ export function ModelTabV2Panel({
           detail={selectedDetail}
           tier={tier}
           onFocusOnCanvas={focusOnCanvas}
+          interventionEdit={
+            interventionEdit && interventionEdit.optionId === selectedRow.id
+              ? { factorId: interventionEdit.factorId, draft: interventionEdit.draft }
+              : null
+          }
+          onBeginInterventionEdit={beginInterventionEdit}
+          onInterventionDraftChange={changeInterventionDraft}
+          onCommitIntervention={commitIntervention}
+          onDiscardInterventionEdit={discardInterventionEdit}
         />
       )}
     </section>

--- a/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
+++ b/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
@@ -307,10 +307,35 @@ export function ModelTabV2Panel({
       // Fail CLOSED, exactly as the value three-beat does: an unparseable draft
       // stays open rather than committing something the user did not state.
       if (!Number.isFinite(num)) return
+
+      /*
+       * ⚠ A RE-TYPED IDENTICAL NUMBER IS NOT A CHANGE — and the comparison is
+       * NUMERIC, not lexical.
+       *
+       * This is `InlineEdit.hasChanged` rehomed rather than reinvented. That
+       * guard exists because of a specific adversarial finding: a bare string
+       * compare made `3e4` for `30000`, or `0.40` for `0.4`, read as an edit on
+       * the Model tab and as a no-op in the inspector — two surfaces disagreeing
+       * about whether the user did anything. Here the cost of getting it wrong
+       * is a store write and a `direct_graph_edit` notification for a change
+       * that never happened: the product telling CEE the model moved when it
+       * did not.
+       *
+       * The old editor's intervention rows had this guard because they went
+       * through `InlineEdit`. This editor does not, so it carries the rule
+       * explicitly — otherwise the removal of the old one would quietly delete
+       * a correctness property nobody listed as a capability.
+       */
+      const current = selectedDetail?.interventions?.find(iv => iv.factorId === factorId)
+      if (current?.numericValue !== null && current?.numericValue === num) {
+        setInterventionEdit(null)
+        return
+      }
+
       authority.proposeOptionIntervention(factorId, num)
       setInterventionEdit(null)
     },
-    [interventionEdit, authority],
+    [interventionEdit, authority, selectedDetail],
   )
 
   /**

--- a/src/canvas/model-tab-v2/__tests__/ModelDetailRegion.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/ModelDetailRegion.spec.tsx
@@ -30,6 +30,10 @@ function detail(over: Partial<ModelRowDetail> = {}): ModelRowDetail {
     basis: 'Inferred from model structure',
     adjustments: [],
     affects: [],
+    // A FACTOR has none. Interventions belong to options, so the honest default
+    // here is the empty list, not an omission — `ModelRowDetail` requires the
+    // field precisely so a producer cannot forget it.
+    interventions: [],
     advancedParameters: [
       { label: 'Elasticity', value: '0.42' },
       { label: 'Node ID', value: 'f1' },

--- a/src/canvas/model-tab-v2/__tests__/ModelTabV2Panel.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/ModelTabV2Panel.spec.tsx
@@ -322,3 +322,94 @@ describe('ModelTabV2Panel — rows with no canonical carrier stay honestly disab
     expect(screen.getByTestId(`model-row-v2-${FACTOR_ID}-value`)).not.toBeDisabled()
   })
 })
+
+/**
+ * THE HAND-OFF SEAM — the third of three, and the one a mutation battery found
+ * uncovered (18 Aug 2026, the rehome lane).
+ *
+ * The rehomed affordances pass through three independent gates before a turn can
+ * be sent, and each fails CLOSED on its own:
+ *
+ *   1. `createOlumiHandOff(undefined)` → `null`      (pinned in olumiHandOff.spec)
+ *   2. `ModelOutline` with no `onGroupAction` renders nothing
+ *                                                    (pinned in groupActionsRehome.spec)
+ *   3. THIS PANEL with no `onHandOffToOlumi` passes nothing down  ← was unpinned
+ *
+ * ⚠ WHY THAT MATTERED. A mutant that turned gate 1 into a no-op callable reddened
+ * ONLY gate 1's spec, because the other two specs bypass it. Three gates guarding
+ * one harm, each tested where it sits, and the middle one invisible from either
+ * side — so a regression in the panel's own `onHandOffToOlumi ? … : undefined`
+ * conditional would have shipped under a fully green suite. That is the estate's
+ * "guard agreeing with itself" one layer out: every instrument was correct and
+ * none of them was pointed here.
+ */
+describe('ModelTabV2Panel — the rehomed affordances, at the mounted consumer', () => {
+  beforeEach(() => {
+    seedStore()
+  })
+
+  it('renders the rehomed group actions and hands the EXACT message up', () => {
+    const onHandOffToOlumi = vi.fn()
+    render(
+      <ModelTabV2Panel
+        nodes={allNodes()}
+        edges={[stampedEdge()]}
+        goalThreshold={null}
+        onHandOffToOlumi={onHandOffToOlumi}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('model-action-v2-factors-add'))
+    expect(onHandOffToOlumi).toHaveBeenCalledTimes(1)
+    expect(onHandOffToOlumi.mock.calls[0][0]).toBe('I want to add a new factor to the model')
+    // The reason names the action by ID, so a debug trace can be attributed to
+    // one affordance rather than to "the Model tab".
+    expect(onHandOffToOlumi.mock.calls[0][1]).toBe('model-tab-v2:factors-add')
+  })
+
+  it('GATE 3: with no hand-off, the panel renders NO affordance at all', () => {
+    renderPanel()
+    expect(screen.queryByTestId('model-action-v2-factors-add')).toBeNull()
+    expect(screen.queryByTestId('model-action-v2-relationships-add')).toBeNull()
+    expect(screen.queryByTestId('model-action-v2-risks-add')).toBeNull()
+    expect(screen.queryByTestId('model-action-v2-options-explore')).toBeNull()
+    // CONTRAST CONTROL: the panel and its rows DID render, so the absences above
+    // are about the affordances and not about a render that never happened.
+    expect(screen.getByTestId('model-tab-v2-panel')).toBeInTheDocument()
+    expect(screen.getByTestId(`model-row-v2-${FACTOR_ID}`)).toBeInTheDocument()
+  })
+
+  it('the goal hand-off quotes the goal row THIS PANEL projected (P5)', () => {
+    const onHandOffToOlumi = vi.fn()
+    render(
+      <ModelTabV2Panel
+        nodes={allNodes()}
+        edges={[stampedEdge()]}
+        goalThreshold={null}
+        onHandOffToOlumi={onHandOffToOlumi}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('model-action-v2-goal-discuss'))
+    // The label is the goal NODE's label, taken from the projected row — not a
+    // second read of the store, and not the node id.
+    expect(onHandOffToOlumi.mock.calls[0][0]).toContain("'Hit ARR target'")
+    expect(onHandOffToOlumi.mock.calls[0][0]).not.toContain(GOAL_ID)
+  })
+
+  it('a relationship row reads in English, not in wire ids, at the mounted consumer', () => {
+    // `stampedEdge()` carries its own label, so assert the derived path with an
+    // edge that does NOT — the case that produced `fac_… → goal_…` on screen.
+    const unlabelled = {
+      id: 'e_unlabelled',
+      source: FACTOR_ID,
+      target: GOAL_ID,
+      data: { weight: 0.4, direction: 'positive', weightSource: 'user' },
+    } as unknown as Edge
+    render(
+      <ModelTabV2Panel nodes={allNodes()} edges={[unlabelled]} goalThreshold={null} />,
+    )
+    const row = screen.getByTestId('model-row-v2-e_unlabelled')
+    expect(row.textContent).toContain('Monthly Engineering Cost → Hit ARR target')
+    expect(row.textContent).not.toContain(FACTOR_ID)
+    expect(row.textContent).not.toContain(GOAL_ID)
+  })
+})

--- a/src/canvas/model-tab-v2/__tests__/adapters.spec.ts
+++ b/src/canvas/model-tab-v2/__tests__/adapters.spec.ts
@@ -18,7 +18,10 @@
 import { describe, it, expect } from 'vitest'
 import type { Edge, Node } from '@xyflow/react'
 import type { EdgeData } from '../../domain/edges'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { countFactorsToVerify } from '../../components/model-tab/utils'
+import { factorNeedsVerification } from '../../domain/valueProvenance'
 import {
   edgeIsContested,
   nodeKind,
@@ -155,9 +158,27 @@ describe('toModelRows — factor values and attention', () => {
   })
 })
 
-// ── ⭐ THE PORT PIN ──────────────────────────────────────────────────────────
+// ── ⭐ THE PORT PIN, RETIRED AND REPLACED (18 Aug 2026) ──────────────────────
+//
+// This block used to pin a COPY: `adapters.ts` carried its own
+// `factorNeedsVerification`, ported from the filter body inside
+// `countFactorsToVerify`, and these tests asserted the two agreed over a corpus.
+//
+// ⚠ THE PIN WAS HONEST AND IT WAS STILL A MIRROR. Agreement is all a derived
+// guard can ever prove — never that either side is RIGHT — and it needed a
+// hand-written corpus to prove even that (trap 12d). The REHOME → DELETE lane
+// removed the copy: the predicate now lives once, in `domain/valueProvenance`,
+// and both readers import it.
+//
+// So the corpus-agreement assertions became TAUTOLOGIES — the same function on
+// both sides of the equals sign — and a tautology that reads as a guard is
+// worse than no guard. They are replaced by the claim that actually matters
+// now: THERE IS EXACTLY ONE DEFINITION, and the count still delegates to it.
+// The corpus is kept, because it is the thing that would notice the surviving
+// definition being wrong (trap 12d's other half: derivation and corpus are not
+// redundant — ship both).
 
-describe('⭐ the ported predicate agrees with the live original', () => {
+describe('⭐ ONE definition of "needs verification", and the count delegates to it', () => {
   /**
    * A corpus spanning every shape the live filter distinguishes, INCLUDING the
    * snake_case wire spelling and a factor with no observed state at all.
@@ -178,12 +199,37 @@ describe('⭐ the ported predicate agrees with the live original', () => {
     },
   ]
 
-  it('my per-factor predicate and the live COUNT agree over the corpus', () => {
-    // The live function exports only a count, which is why the predicate had to
-    // be ported at all. Pinning them against each other means the copy cannot
-    // drift from the badge without turning this red.
-    const mine = CORPUS.filter(n => factorNeedsVerification(n.data)).length
-    expect(mine).toBe(countFactorsToVerify(CORPUS))
+  it('the badge COUNT is the domain predicate applied N times — it holds no copy', () => {
+    // Still worth asserting after the move: it goes RED the day
+    // `countFactorsToVerify` grows its own inline predicate back.
+    const viaPredicate = CORPUS.filter(n => factorNeedsVerification(n.data)).length
+    expect(countFactorsToVerify(CORPUS)).toBe(viaPredicate)
+    // ⚠ AND THE COUNT IS NOT TRIVIAL. Without this the line above would pass on
+    // a corpus where nothing needs verification, i.e. on two functions that both
+    // return false for everything (trap 13 — an absence assertion needs a
+    // positive control).
+    expect(viaPredicate).toBeGreaterThan(0)
+    expect(viaPredicate).toBeLessThan(CORPUS.length)
+  })
+
+  it('⭐ the predicate is DEFINED exactly once in the tree — the mirror is gone, not relocated', () => {
+    const read = (rel: string) => readFileSync(join(__dirname, rel), 'utf8')
+    const DEFINITION = /export function factorNeedsVerification\s*\(/
+    const domain = read('../../domain/valueProvenance.ts')
+    const adapters = read('../adapters.ts')
+    const utils = read('../../components/model-tab/utils.ts')
+
+    // POSITIVE CONTROL: the matcher can see a definition when one is present —
+    // otherwise "no definition here" would be reported by a blind regex.
+    expect(DEFINITION.test(domain)).toBe(true)
+
+    // The two former copy sites hold NEITHER a definition NOR a re-export. A
+    // re-export would keep the name reachable from three places with one owner,
+    // which is the shim this lane exists to refuse.
+    for (const [name, src] of [['adapters.ts', adapters], ['model-tab/utils.ts', utils]] as const) {
+      expect(`${name}: ${DEFINITION.test(src)}`).toBe(`${name}: false`)
+      expect(`${name}: ${/export\s*\{[^}]*factorNeedsVerification/.test(src)}`).toBe(`${name}: false`)
+    }
   })
 
   it('and they agree on the empty case', () => {
@@ -191,6 +237,10 @@ describe('⭐ the ported predicate agrees with the live original', () => {
   })
 
   it('the predicate identifies WHICH factors, which is what a queue needs', () => {
+    // The corpus survives the move DELIBERATELY. A single definition cannot be
+    // wrong-and-consistent-with-itself into a red; only a hand-written corpus
+    // notices the surviving definition being wrong. Note `d` (`user_confirmed`)
+    // is absent — which is what makes the rehomed Confirm ✓ clear the badge.
     const flagged = CORPUS.filter(n => factorNeedsVerification(n.data)).map(n => n.id)
     expect(flagged).toEqual(['a', 'b', 'f', 'g'])
   })

--- a/src/canvas/model-tab-v2/__tests__/adapters.spec.ts
+++ b/src/canvas/model-tab-v2/__tests__/adapters.spec.ts
@@ -21,7 +21,6 @@ import type { EdgeData } from '../../domain/edges'
 import { countFactorsToVerify } from '../../components/model-tab/utils'
 import {
   edgeIsContested,
-  factorNeedsVerification,
   nodeKind,
   optionHasNoInterventions,
   toModelRows,

--- a/src/canvas/model-tab-v2/__tests__/groupActionsRehome.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/groupActionsRehome.spec.tsx
@@ -1,0 +1,213 @@
+/**
+ * THE REHOME'S COMPLETENESS PROOF — every send-to-AI capability of the v1 Model
+ * tab, on the canonical outline (founder ruling, 18 Aug 2026: REHOME → DELETE).
+ *
+ * ## What this file is for
+ *
+ * The delete step removes eleven call sites across six components. It is
+ * reviewable ONLY if every one of them has a named successor that carries the
+ * SAME turn text. So the load-bearing test here is not "buttons render" — it is
+ * the MANIFEST below, transcribed from the v1 sources at `9ff14c19`, asserted
+ * for exact set equality in BOTH directions against the rehomed table.
+ *
+ * ⚠ EXACT EQUALITY BOTH WAYS IS DELIBERATE. A subset assertion would pass while
+ * a capability was silently dropped; a superset assertion would pass while the
+ * rehome invented a turn nobody asked for. Both are failures and both are
+ * invisible to a "does it render" test.
+ *
+ * ⚠ THE MANIFEST IS A HAND-TRANSCRIBED RECORD OF THE v1 SOURCE, ON PURPOSE, and
+ * this is the one place in this change where that is right rather than the trap.
+ * Deriving it from `groupActions.ts` would make it a guard agreeing with itself
+ * (platform trap 13b); deriving it from the v1 files would make the test pass
+ * automatically the moment they are deleted, which is precisely the moment it
+ * must still hold. It is pinned to the HISTORIC source (trap 14b) and its
+ * provenance is the `rehomedFrom` field on every action.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ModelOutline } from '../ModelOutline'
+import { ALL_GROUP_ACTIONS, GROUP_ACTIONS } from '../groupActions'
+import { MODEL_GROUP_IDS, type ModelGroupId, type ModelRow } from '../types'
+
+/**
+ * Every message the v1 Model tab could send, transcribed from the source at
+ * `9ff14c19`. Ten distinct turns across eleven call sites — "Explore other
+ * strategies" occupied TWO mutually exclusive branches under ONE testid
+ * (`OptionsSection.tsx:486` and `:508`), which is why a testid census could not
+ * see the duplication and a message census can.
+ *
+ * `Map interventions` (`OptionsSection.tsx:472`) is deliberately ABSENT: it is an
+ * adjudicated CUT (design §7.0 items 2 and 10), not a dropped capability.
+ */
+const V1_MESSAGES = [
+  // GoalSection.tsx:243 — interpolates the goal label and displayed target.
+  "Help me understand my goal 'Grow ARR' and whether the target of 45% is appropriate",
+  // OptionsSection.tsx:486 and :508 — one action, two render sites.
+  'I want to explore other strategies and options',
+  // OptionsSection.tsx:521
+  'Help me review my options and how they compare',
+  // FactorsSection.tsx:737
+  'I want to add a new factor to the model',
+  // FactorsSection.tsx:745
+  'Help me review the factors in my model and whether the values are reasonable',
+  // RisksSection.tsx:100 — THE SEVENTH CAPABILITY the founder's six did not name.
+  'I want to identify potential risks that could cause this decision to fail',
+  // RisksSection.tsx:143
+  'Help me understand the risks in my model and how to mitigate them',
+  // RelationshipsSection.tsx:819
+  "I'd like to add a causal relationship",
+  // RelationshipsSection.tsx:827
+  'Help me review the causal relationships and which ones need attention',
+  // ModelHealthSection.tsx:328
+  'Help me understand the reliability and limitations of my model',
+] as const
+
+/** The context the goal message interpolates, matching the manifest above. */
+const CTX = { goalLabel: 'Grow ARR', goalTarget: '45%' }
+
+function row(id: string, group: ModelGroupId, over: Partial<ModelRow> = {}): ModelRow {
+  return {
+    id,
+    kind: 'factor',
+    group,
+    label: `Label ${id}`,
+    primaryValue: '1',
+    attention: [],
+    editable: true,
+    ...over,
+  }
+}
+
+describe('rehome completeness — every v1 send-to-AI capability has a successor', () => {
+  it('the rehomed messages are EXACTLY the v1 messages, both directions', () => {
+    const rehomed = ALL_GROUP_ACTIONS.map(a => a.message(CTX)).sort()
+    expect(rehomed).toEqual([...V1_MESSAGES].sort())
+  })
+
+  it('carries ten actions — one per distinct v1 turn, no more', () => {
+    expect(ALL_GROUP_ACTIONS).toHaveLength(V1_MESSAGES.length)
+  })
+
+  it('THE SEVENTH CAPABILITY: a structural risk affordance exists, bound by id', () => {
+    const addRisk = ALL_GROUP_ACTIONS.find(a => a.id === 'risks-add')
+    expect(addRisk).toBeDefined()
+    expect(addRisk!.intent).toBe('structural')
+    expect(addRisk!.message(CTX)).toBe(
+      'I want to identify potential risks that could cause this decision to fail',
+    )
+    expect(addRisk!.rehomedFrom).toContain('RisksSection.tsx:100')
+  })
+
+  it('every action names the v1 site it replaces — the delete step’s checklist', () => {
+    for (const action of ALL_GROUP_ACTIONS) {
+      expect(action.rehomedFrom, `${action.id} has no provenance`).toMatch(/\.tsx:\d+/)
+    }
+  })
+
+  it('no two actions share an id — the "one testid, two sites" defect cannot recur', () => {
+    const ids = ALL_GROUP_ACTIONS.map(a => a.id)
+    expect(new Set(ids).size).toBe(ids.length)
+  })
+
+  it('the table is total over the seven groups', () => {
+    expect(Object.keys(GROUP_ACTIONS).sort()).toEqual([...MODEL_GROUP_IDS].sort())
+  })
+
+  it('the four structural capabilities the founder named are structural, by id', () => {
+    const structural = ALL_GROUP_ACTIONS.filter(a => a.intent === 'structural').map(a => a.id).sort()
+    expect(structural).toEqual(['factors-add', 'options-explore', 'relationships-add', 'risks-add'])
+  })
+})
+
+describe('the outline renders the rehomed affordances', () => {
+  it('renders every action as a button, addressed by its own id', () => {
+    render(
+      <ModelOutline
+        rows={[row('f1', 'factors')]}
+        tier="plain"
+        onGroupAction={vi.fn()}
+        groupActionContext={CTX}
+      />,
+    )
+    for (const action of ALL_GROUP_ACTIONS) {
+      expect(
+        screen.getByTestId(`model-action-v2-${action.id}`),
+        `${action.id} is not on the outline`,
+      ).toBeInTheDocument()
+    }
+  })
+
+  it('clicking an action hands its EXACT message to the host', () => {
+    const onGroupAction = vi.fn()
+    render(
+      <ModelOutline
+        rows={[row('f1', 'factors')]}
+        tier="plain"
+        onGroupAction={onGroupAction}
+        groupActionContext={CTX}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('model-action-v2-factors-add'))
+    expect(onGroupAction).toHaveBeenCalledTimes(1)
+    expect(onGroupAction.mock.calls[0][1]).toBe('I want to add a new factor to the model')
+    expect(onGroupAction.mock.calls[0][0].id).toBe('factors-add')
+  })
+
+  it('the goal hand-off quotes the target THIS OUTLINE displays (P5)', () => {
+    const onGroupAction = vi.fn()
+    render(
+      <ModelOutline
+        rows={[row('g1', 'goal', { kind: 'goal', label: 'Grow ARR', primaryValue: '45%' })]}
+        tier="plain"
+        onGroupAction={onGroupAction}
+        groupActionContext={{ goalLabel: 'Grow ARR', goalTarget: '45%' }}
+      />,
+    )
+    fireEvent.click(screen.getByTestId('model-action-v2-goal-discuss'))
+    expect(onGroupAction.mock.calls[0][1]).toBe(
+      "Help me understand my goal 'Grow ARR' and whether the target of 45% is appropriate",
+    )
+  })
+
+  it('"Add a factor" is reachable when the group is EMPTY — the v1 gap', () => {
+    render(
+      <ModelOutline rows={[]} tier="plain" onGroupAction={vi.fn()} groupActionContext={CTX} />,
+    )
+    expect(screen.getByTestId('model-action-v2-factors-add')).toBeInTheDocument()
+    // Its v1 twin's mirror-image gap: the risk CTA existed ONLY when empty.
+    expect(screen.getByTestId('model-action-v2-risks-add')).toBeInTheDocument()
+  })
+
+  it('"Identify potential risks" is reachable when risks ALREADY EXIST — v1 hid it', () => {
+    render(
+      <ModelOutline
+        rows={[row('r1', 'outcomes-risks', { kind: 'risk' })]}
+        tier="plain"
+        onGroupAction={vi.fn()}
+        groupActionContext={CTX}
+      />,
+    )
+    expect(screen.getByTestId('model-action-v2-risks-add')).toBeInTheDocument()
+  })
+
+  it('P8: with no hand-off, NO affordance renders — never an inert button', () => {
+    render(<ModelOutline rows={[row('f1', 'factors')]} tier="plain" groupActionContext={CTX} />)
+    for (const action of ALL_GROUP_ACTIONS) {
+      expect(screen.queryByTestId(`model-action-v2-${action.id}`)).toBeNull()
+    }
+    // Contrast control: the outline itself DID render, so the absence above is
+    // about the affordances and not about a failed render (trap 13).
+    expect(screen.getByTestId('model-outline-v2')).toBeInTheDocument()
+    expect(screen.getByTestId('model-row-v2-f1')).toBeInTheDocument()
+  })
+
+  it('a group with no v1 equivalent offers nothing, and says so by rendering no container', () => {
+    render(
+      <ModelOutline rows={[]} tier="plain" onGroupAction={vi.fn()} groupActionContext={CTX} />,
+    )
+    expect(screen.queryByTestId('model-group-v2-assumptions-provenance-actions')).toBeNull()
+    // Contrast control: a group that DOES have actions renders its container.
+    expect(screen.getByTestId('model-group-v2-factors-actions')).toBeInTheDocument()
+  })
+})

--- a/src/canvas/model-tab-v2/__tests__/rehomedLocalCommits.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/rehomedLocalCommits.spec.tsx
@@ -161,6 +161,11 @@ function storedSource(id: string): unknown {
   return (storedNode(id).observedState as Record<string, unknown> | undefined)?.source
 }
 
+/** The node's `data` OBJECT. A sanctioned write replaces it; a no-op does not. */
+function nodeRef(id: string): unknown {
+  return useCanvasStore.getState().nodes.find(x => x.id === id)?.data
+}
+
 function storedInterventions(id: string): Record<string, unknown> {
   return (storedNode(id).interventions ?? {}) as Record<string, unknown>
 }
@@ -299,12 +304,17 @@ describe('What this would change — the rehomed intervention targets', () => {
   it('commits a new target through the authority, into the OPTION that owns it', () => {
     renderPanel()
     selectOption()
+    const beforeRef = nodeRef(OPTION_ID)
     fireEvent.click(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-value`))
     const input = screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-input`)
     fireEvent.change(input, { target: { value: '0.42' } })
     fireEvent.click(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-save`))
 
     expect(storedInterventions(OPTION_ID)[FACTOR_ID]).toBe(0.42)
+    // POSITIVE CONTROL for the identity instrument used by the no-op test
+    // below: a REAL change DOES replace the node's data object. Without this,
+    // `toBe(before)` there could pass because the setter never replaces it.
+    expect(nodeRef(OPTION_ID)).not.toBe(beforeRef)
     // The ghost entry is untouched: the write is a targeted set, not a rewrite
     // of the map, so an entry the surface cannot render is not silently dropped
     // from the user's model either.
@@ -335,6 +345,42 @@ describe('What this would change — the rehomed intervention targets', () => {
     expect(
       screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-input`),
     ).toBeInTheDocument()
+  })
+
+  it('⭐ re-typing the SAME number in another form is not a change — no write, no notification', () => {
+    renderPanel()
+    selectOption()
+    const before = nodeRef(OPTION_ID)
+    fireEvent.click(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-value`))
+    // 0.6 stored; `6e-1` is the same number in a different lexical form. The v1
+    // rows suppressed this through `InlineEdit.hasChanged`, which compares
+    // PARSED NUMBERS for exactly this case.
+    fireEvent.change(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-input`), {
+      target: { value: '6e-1' },
+    })
+    fireEvent.click(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-save`))
+
+    /*
+     * ⚠ THE ASSERTION IS OBJECT IDENTITY, NOT THE VALUE — and it had to be.
+     *
+     * The first cut asserted `interventions[FACTOR_ID] === 0.6`, and a mutant
+     * that DELETED this guard SURVIVED it: writing 0.6 over 0.6 leaves the value
+     * identical, so a value assertion cannot tell "no write happened" from "a
+     * pointless write happened". That is trap 19 in its purest form — a test
+     * passing on a state another path also produces.
+     *
+     * The sanctioned setter replaces the node's `data` object, so reference
+     * equality is what actually distinguishes them. Proven: with the guard
+     * removed this line goes RED while the value assertion stays green.
+     */
+    expect(nodeRef(OPTION_ID)).toBe(before)
+    expect(storedInterventions(OPTION_ID)[FACTOR_ID]).toBe(0.6)
+    expect(sendSystemEvent).not.toHaveBeenCalled()
+    // The editor closes: the user's intent was honoured, there was simply
+    // nothing to record. Leaving it open would read as a rejected edit.
+    expect(
+      screen.queryByTestId(`model-detail-v2-intervention-${FACTOR_ID}-input`),
+    ).not.toBeInTheDocument()
   })
 
   it('Cancel abandons the draft and writes nothing', () => {

--- a/src/canvas/model-tab-v2/__tests__/rehomedLocalCommits.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/rehomedLocalCommits.spec.tsx
@@ -1,0 +1,370 @@
+/**
+ * The two capabilities #777 could not rehome, rehomed (18 Aug 2026).
+ *
+ * REHOME → DELETE step 2. `useModelEditAuthority` now carries
+ * `proposeOptionIntervention` and `proposeFactorConfirmation`, and this spec
+ * pins what a USER gets from them on the canonical surface — through the
+ * mounted consumer, against the REAL store, never against the hook in isolation
+ * (preamble P2).
+ *
+ * WHAT EACH PIN EXISTS TO CATCH:
+ *
+ *  1. THE STAMP. Confirm must write `user_confirmed`, NEVER `user`. `'user'`
+ *     classifies as the `edited` kind, so the pill said "User edited" for a
+ *     gesture in which the user changed no number. The assertion is written
+ *     BOTH ways — the literal expected AND the literal forbidden — because a
+ *     `toBeTruthy()` on the source would pass on the very value being fixed.
+ *
+ *  2. NO WIRE CLAIM. Neither operation has a value-bearing carrier, so neither
+ *     may emit a turn. A local commit that sent a system event would be
+ *     claiming a server saw a value it never received.
+ *
+ *  3. THE PREDICATE AGREEMENT. The Confirm chip is offered by exactly the
+ *     predicate that counts the factor as unverified, so confirming must make
+ *     the chip GO AWAY. A button that survives its own success is how the badge
+ *     and the affordance start disagreeing about one row.
+ *
+ *  4. NO RAW IDS, AT THE SEAM ONE PAST THE PROJECTION (preamble P1). The
+ *     projection drops an intervention whose factor is not in the model; this
+ *     spec drives a store that CONTAINS such an entry through the real render
+ *     and asserts the id appears nowhere in the detail region's text — the v1
+ *     rows fell back to `factorId` in exactly this case.
+ *
+ *  5. FAIL CLOSED. An unparseable draft, a value with no factor, a confirmation
+ *     over an absent value: nothing may be written anywhere. A dropped edit is
+ *     a visible "nothing happened"; a half-committed one is a split-brain.
+ *
+ * Assertions bind by IDENTITY (testids carrying the element id), never by a
+ * value predicate another element could satisfy (trap 19).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, cleanup, fireEvent, screen } from '@testing-library/react'
+import type { Node, Edge } from '@xyflow/react'
+
+const sendSystemEvent = vi.fn()
+
+// Trap 12: spread the real module rather than hand-listing its exports.
+vi.mock('../../conversation/ConversationContext', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    useOptionalConversationContext: () => ({ sendSystemEvent }),
+  }
+})
+
+vi.mock('../../utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusEdgeById: vi.fn(),
+}))
+
+import { ModelTabV2Panel } from '../ModelTabV2Panel'
+import { useCanvasStore } from '../../store'
+
+const FACTOR_ID = 'fac_monthly_eng_cost'
+const FACTOR_LABEL = 'Monthly Engineering Cost'
+const EMPTY_FACTOR_ID = 'fac_never_estimated'
+const GHOST_FACTOR_ID = 'fac_deleted_last_week'
+const OPTION_ID = 'opt_premium'
+const GOAL_ID = 'goal_arr'
+const EDGE_ID = 'e_cost_to_goal'
+const CAP = 30000
+
+/** An AI estimate nobody has ratified — the row the Confirm chip is FOR. */
+function unconfirmedFactor(): Node {
+  return {
+    id: FACTOR_ID,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: {
+      label: FACTOR_LABEL,
+      kind: 'factor',
+      category: 'observable',
+      observedState: {
+        value: 30000 / CAP,
+        raw_value: 30000,
+        cap: CAP,
+        unit: '£',
+        source: 'cee_inference',
+      },
+    },
+  } as unknown as Node
+}
+
+/** A factor with NO value. There is nothing here to ratify. */
+function valuelessFactor(): Node {
+  return {
+    id: EMPTY_FACTOR_ID,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { label: 'Churn rate', kind: 'factor', category: 'observable' },
+  } as unknown as Node
+}
+
+/**
+ * ⚠ THIS OPTION CARRIES AN INTERVENTION FOR A FACTOR THAT IS NOT IN THE MODEL.
+ * That is not a contrived shape: a factor removed after an option was drafted
+ * leaves exactly this. The v1 rows rendered `GHOST_FACTOR_ID` as the element's
+ * NAME.
+ */
+function optionNode(): Node {
+  return {
+    id: OPTION_ID,
+    type: 'option',
+    position: { x: 0, y: 0 },
+    data: {
+      label: 'Premium-first',
+      kind: 'option',
+      interventions: { [FACTOR_ID]: 0.6, [GHOST_FACTOR_ID]: 0.9 },
+    },
+  } as unknown as Node
+}
+
+function goalNode(): Node {
+  return {
+    id: GOAL_ID,
+    type: 'goal',
+    position: { x: 0, y: 0 },
+    data: { label: 'Hit ARR target', kind: 'goal' },
+  } as unknown as Node
+}
+
+function stampedEdge(): Edge {
+  return {
+    id: EDGE_ID,
+    source: FACTOR_ID,
+    target: GOAL_ID,
+    data: {
+      label: 'Cost affects target',
+      weight: 0.4,
+      direction: 'positive',
+      weightSource: 'user',
+      directionSource: 'user',
+    },
+  } as unknown as Edge
+}
+
+function allNodes(): Node[] {
+  return [goalNode(), optionNode(), unconfirmedFactor(), valuelessFactor()]
+}
+
+function seedStore() {
+  useCanvasStore.setState({ nodes: allNodes(), edges: [stampedEdge()] } as never, false)
+}
+
+function storedNode(id: string): Record<string, unknown> {
+  const n = useCanvasStore.getState().nodes.find(x => x.id === id)
+  return (n?.data ?? {}) as Record<string, unknown>
+}
+
+function storedSource(id: string): unknown {
+  return (storedNode(id).observedState as Record<string, unknown> | undefined)?.source
+}
+
+function storedInterventions(id: string): Record<string, unknown> {
+  return (storedNode(id).interventions ?? {}) as Record<string, unknown>
+}
+
+/**
+ * ⚠ RENDERS FROM THE STORE, NOT FROM THE FIXTURE BUILDERS.
+ *
+ * The panel takes its nodes as PROPS, and `ModelTabBody` — its only mount site
+ * — sources those props from the canvas store. A helper that re-invoked
+ * `allNodes()` would hand the surface pristine fixture data on every render, so
+ * NO write could ever be visible to a re-render. That is exactly the trap this
+ * spec caught on its first run: the "chip goes away" pin failed against
+ * CORRECT code, because the second render was showing the original estimate.
+ * A fixture you wrote yourself is not evidence about the mounted surface
+ * (trap 16, inverse form).
+ */
+function renderPanel() {
+  const { nodes, edges } = useCanvasStore.getState()
+  render(
+    <ModelTabV2Panel
+      nodes={nodes as Node[]}
+      edges={edges as Edge[]}
+      goalThreshold={null}
+    />,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  seedStore()
+})
+afterEach(() => cleanup())
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Factor confirmation — the rehomed Confirm ✓
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Confirm ✓ — rehomed onto the canonical outline', () => {
+  it('is offered on the unratified estimate, and on NO other row', () => {
+    renderPanel()
+    expect(screen.getByTestId(`model-row-v2-${FACTOR_ID}-confirm-as-is`)).toBeInTheDocument()
+    // Bound by identity: each of these is a specific row, not "some other row".
+    expect(screen.queryByTestId(`model-row-v2-${GOAL_ID}-confirm-as-is`)).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`model-row-v2-${OPTION_ID}-confirm-as-is`)).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`model-row-v2-${EDGE_ID}-confirm-as-is`)).not.toBeInTheDocument()
+  })
+
+  it('is NOT offered where there is no value to ratify (P8 — never ask what you cannot accept)', () => {
+    renderPanel()
+    // The row exists; only its Confirm affordance is absent. Asserting the row
+    // is present first stops this passing because the row itself vanished.
+    expect(screen.getByTestId(`model-row-v2-${EMPTY_FACTOR_ID}`)).toBeInTheDocument()
+    expect(screen.queryByTestId(`model-row-v2-${EMPTY_FACTOR_ID}-confirm-as-is`)).not.toBeInTheDocument()
+  })
+
+  it('stamps user_confirmed — and specifically NOT user', () => {
+    renderPanel()
+    expect(storedSource(FACTOR_ID)).toBe('cee_inference')
+
+    fireEvent.click(screen.getByTestId(`model-row-v2-${FACTOR_ID}-confirm-as-is`))
+
+    expect(storedSource(FACTOR_ID)).toBe('user_confirmed')
+    // ⚠ THE FORBIDDEN LITERAL, ASSERTED EXPLICITLY. Without this line a mutant
+    // restoring `'user'` would still have to fail the line above — but this
+    // states the defect being fixed, so a future widening of the expectation
+    // cannot quietly re-admit it.
+    expect(storedSource(FACTOR_ID)).not.toBe('user')
+  })
+
+  it('does not invent an extractionType — confirming a number says nothing about how it was extracted', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTestId(`model-row-v2-${FACTOR_ID}-confirm-as-is`))
+    const obs = storedNode(FACTOR_ID).observedState as Record<string, unknown>
+    expect(obs.extractionType).toBeUndefined()
+  })
+
+  it('leaves the VALUE untouched — a confirmation changes provenance, not the number', () => {
+    renderPanel()
+    const before = (storedNode(FACTOR_ID).observedState as Record<string, unknown>).raw_value
+    fireEvent.click(screen.getByTestId(`model-row-v2-${FACTOR_ID}-confirm-as-is`))
+    const after = (storedNode(FACTOR_ID).observedState as Record<string, unknown>).raw_value
+    expect(after).toBe(before)
+    expect(after).toBe(30000)
+  })
+
+  it('sends NO turn — there is no value-bearing carrier for a confirmation', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTestId(`model-row-v2-${FACTOR_ID}-confirm-as-is`))
+    expect(sendSystemEvent).not.toHaveBeenCalled()
+  })
+
+  it('the chip goes away once confirmed — the affordance and the verify count share ONE predicate', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTestId(`model-row-v2-${FACTOR_ID}-confirm-as-is`))
+    // Re-render from the now-updated store, exactly as the tab does.
+    cleanup()
+    renderPanel()
+    expect(screen.getByTestId(`model-row-v2-${FACTOR_ID}`)).toBeInTheDocument()
+    expect(screen.queryByTestId(`model-row-v2-${FACTOR_ID}-confirm-as-is`)).not.toBeInTheDocument()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Option intervention targets — rehomed into the detail region
+// ─────────────────────────────────────────────────────────────────────────────
+
+function selectOption() {
+  fireEvent.click(screen.getByTestId(`model-row-v2-${OPTION_ID}`))
+}
+
+describe('What this would change — the rehomed intervention targets', () => {
+  it('names the factor in plain English, and never shows its id', () => {
+    renderPanel()
+    selectOption()
+    const row = screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}`)
+    expect(row).toHaveTextContent(FACTOR_LABEL)
+    // The id may legitimately appear as a testid attribute; the assertion is
+    // about what the user READS.
+    expect(row.textContent ?? '').not.toContain(FACTOR_ID)
+  })
+
+  it('DROPS an intervention whose factor is not in the model — no raw id reaches the user (P1)', () => {
+    renderPanel()
+    selectOption()
+    expect(
+      screen.queryByTestId(`model-detail-v2-intervention-${GHOST_FACTOR_ID}`),
+    ).not.toBeInTheDocument()
+    // One seam past the projection: the whole rendered detail region.
+    const detail = screen.getByTestId('model-detail-v2')
+    expect(detail.textContent ?? '').not.toContain(GHOST_FACTOR_ID)
+    // POSITIVE CONTROL — the ghost really IS in the store being rendered, so the
+    // absence above is the projection's doing and not an empty fixture.
+    expect(Object.keys(storedInterventions(OPTION_ID))).toContain(GHOST_FACTOR_ID)
+  })
+
+  it('commits a new target through the authority, into the OPTION that owns it', () => {
+    renderPanel()
+    selectOption()
+    fireEvent.click(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-value`))
+    const input = screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-input`)
+    fireEvent.change(input, { target: { value: '0.42' } })
+    fireEvent.click(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-save`))
+
+    expect(storedInterventions(OPTION_ID)[FACTOR_ID]).toBe(0.42)
+    // The ghost entry is untouched: the write is a targeted set, not a rewrite
+    // of the map, so an entry the surface cannot render is not silently dropped
+    // from the user's model either.
+    expect(storedInterventions(OPTION_ID)[GHOST_FACTOR_ID]).toBe(0.9)
+  })
+
+  it('sends NO turn — an intervention target has no value-bearing carrier', () => {
+    renderPanel()
+    selectOption()
+    fireEvent.click(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-value`))
+    fireEvent.change(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-input`), {
+      target: { value: '0.42' },
+    })
+    fireEvent.click(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-save`))
+    expect(sendSystemEvent).not.toHaveBeenCalled()
+  })
+
+  it('FAILS CLOSED on an unparseable draft — nothing written, the editor stays open', () => {
+    renderPanel()
+    selectOption()
+    fireEvent.click(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-value`))
+    fireEvent.change(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-input`), {
+      target: { value: 'soon' },
+    })
+    fireEvent.click(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-save`))
+
+    expect(storedInterventions(OPTION_ID)[FACTOR_ID]).toBe(0.6)
+    expect(
+      screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-input`),
+    ).toBeInTheDocument()
+  })
+
+  it('Cancel abandons the draft and writes nothing', () => {
+    renderPanel()
+    selectOption()
+    fireEvent.click(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-value`))
+    fireEvent.change(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-input`), {
+      target: { value: '0.99' },
+    })
+    fireEvent.click(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-cancel`))
+
+    expect(storedInterventions(OPTION_ID)[FACTOR_ID]).toBe(0.6)
+    expect(
+      screen.queryByTestId(`model-detail-v2-intervention-${FACTOR_ID}-input`),
+    ).not.toBeInTheDocument()
+  })
+
+  it('an open draft is abandoned when a different element is selected', () => {
+    renderPanel()
+    selectOption()
+    fireEvent.click(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-value`))
+    fireEvent.change(screen.getByTestId(`model-detail-v2-intervention-${FACTOR_ID}-input`), {
+      target: { value: '0.99' },
+    })
+    // Move to another row, then come back.
+    fireEvent.click(screen.getByTestId(`model-row-v2-${FACTOR_ID}`))
+    selectOption()
+    expect(
+      screen.queryByTestId(`model-detail-v2-intervention-${FACTOR_ID}-input`),
+    ).not.toBeInTheDocument()
+    expect(storedInterventions(OPTION_ID)[FACTOR_ID]).toBe(0.6)
+  })
+})

--- a/src/canvas/model-tab-v2/__tests__/relationshipsPlainEnglish.spec.ts
+++ b/src/canvas/model-tab-v2/__tests__/relationshipsPlainEnglish.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * RELATIONSHIPS READ IN ENGLISH — the KEEP-BUT-FIX the dedupe would have lost.
+ *
+ * ## The defect
+ *
+ * `adapters.ts` rendered an edge with no `label` of its own as
+ * `${edge.source} → ${edge.target}` — the RAW WIRE IDS, e.g.
+ * `fac_arr → out_uk_arr_retention`. The v1 stack it is replacing resolved both
+ * endpoints to their node labels (`RelationshipsSection.tsx:149-150`), so the
+ * canonical editor was the LESS readable of the two on the one thing a
+ * relationship exists to state: what affects what. Deduplicating the tab without
+ * this fix would have deleted the readable rendering and kept the identifiers.
+ *
+ * Two more sites leaked the same way and were invisible from the row: the detail
+ * region's "What it affects" list used `e.target` and `edge.target` AS THE LABEL.
+ *
+ * ## Binding
+ *
+ * Every absence assertion here carries a CONTRAST CONTROL that must read
+ * non-zero in the same test — the human labels are asserted PRESENT in the same
+ * breath as the ids are asserted ABSENT. An absence alone is satisfiable by
+ * rendering nothing at all.
+ */
+import { describe, it, expect } from 'vitest'
+import type { Edge, Node } from '@xyflow/react'
+import { toModelRows, toRowDetail, type ModelProjectionInput } from '../adapters'
+
+const SOURCE_ID = 'fac_arr'
+const TARGET_ID = 'out_uk_arr_retention'
+
+function nodes(sourceLabel: string | undefined, targetLabel: string | undefined): Node[] {
+  return [
+    { id: SOURCE_ID, type: 'factor', position: { x: 0, y: 0 }, data: { label: sourceLabel } },
+    { id: TARGET_ID, type: 'outcome', position: { x: 0, y: 0 }, data: { label: targetLabel } },
+  ] as unknown as Node[]
+}
+
+function edge(over: Record<string, unknown> = {}): Edge {
+  return {
+    id: 'e1',
+    source: SOURCE_ID,
+    target: TARGET_ID,
+    data: { ...over },
+  } as unknown as Edge
+}
+
+function project(
+  sourceLabel: string | undefined,
+  targetLabel: string | undefined,
+  edgeData: Record<string, unknown> = {},
+): ModelProjectionInput {
+  return {
+    nodes: nodes(sourceLabel, targetLabel),
+    edges: [edge(edgeData)] as never,
+    goalThreshold: null,
+  }
+}
+
+function relationshipRow(input: ModelProjectionInput) {
+  const row = toModelRows(input).find(r => r.kind === 'relationship')
+  expect(row, 'no relationship row was projected — the fixture is wrong, not the code').toBeDefined()
+  return row!
+}
+
+describe('the relationship row names both endpoints in the user’s words', () => {
+  it('renders "From → To" from the node labels, and NOT the ids', () => {
+    const label = relationshipRow(project('ARR', 'UK ARR retention')).label
+    // Present: the human words.
+    expect(label).toBe('ARR → UK ARR retention')
+    // Absent: the identifiers. Asserted alongside the presence above, so this
+    // cannot pass by rendering nothing.
+    expect(label).not.toContain(SOURCE_ID)
+    expect(label).not.toContain(TARGET_ID)
+  })
+
+  it('an edge that names ITSELF wins over anything derived from its endpoints', () => {
+    expect(
+      relationshipRow(project('ARR', 'UK ARR retention', { label: 'Retention drives ARR' })).label,
+    ).toBe('Retention drives ARR')
+  })
+
+  it('an unnamed endpoint becomes "Unnamed element" — NEVER its identifier', () => {
+    const label = relationshipRow(project(undefined, 'UK ARR retention')).label
+    expect(label).toBe('Unnamed element → UK ARR retention')
+    expect(label).not.toContain(SOURCE_ID)
+  })
+
+  it('a label that is ITSELF id-shaped is rejected, so the leak cannot move upstream', () => {
+    // The shared policy rejects an id-shaped label via RAW_ID_PATTERN. Without
+    // that guard, a node whose label was seeded from its id would leak here.
+    const label = relationshipRow(project('fac_arr', 'UK ARR retention')).label
+    expect(label).toBe('Unnamed element → UK ARR retention')
+    expect(label).not.toContain('fac_arr')
+  })
+
+  it('both endpoints unnamed still yields prose, not a pair of ids', () => {
+    const label = relationshipRow(project(undefined, undefined)).label
+    expect(label).toBe('Unnamed element → Unnamed element')
+    expect(label).not.toMatch(/(?:fac|out)_/)
+  })
+})
+
+describe('the detail region’s "What it affects" list names elements, not ids', () => {
+  it('a factor’s outbound list carries the TARGET’s name and the EDGE’s id', () => {
+    const detail = toRowDetail(project('ARR', 'UK ARR retention'), SOURCE_ID)
+    expect(detail).not.toBeNull()
+    expect(detail!.affects).toEqual([{ id: 'e1', label: 'UK ARR retention' }])
+    // The navigation id is the edge's, deliberately — the label is what the user
+    // reads, the id is what the click resolves. Opposite-direction twin: the
+    // label must NOT be an id and the id must NOT have become a label.
+    expect(detail!.affects[0].label).not.toContain(TARGET_ID)
+  })
+
+  it('an edge row’s affects list names its target', () => {
+    const detail = toRowDetail(project('ARR', 'UK ARR retention'), 'e1')
+    expect(detail).not.toBeNull()
+    expect(detail!.affects).toEqual([{ id: TARGET_ID, label: 'UK ARR retention' }])
+    expect(detail!.affects[0].label).not.toBe(TARGET_ID)
+  })
+
+  it('an unnamed target degrades to prose in the affects list too', () => {
+    const detail = toRowDetail(project('ARR', undefined), 'e1')
+    expect(detail!.affects[0].label).toBe('Unnamed element')
+    expect(detail!.affects[0].label).not.toBe(TARGET_ID)
+  })
+})

--- a/src/canvas/model-tab-v2/adapters.ts
+++ b/src/canvas/model-tab-v2/adapters.ts
@@ -122,7 +122,7 @@ import { getDisplayEdgeId } from '../utils/edgeIdentity'
 // THE ONE id → label policy (`src/canvas/domain/canvasLabels.ts`). It returns
 // `null` rather than the identifier, and rejects a stored label that is itself
 // id-shaped — which is why it is imported here rather than reimplemented.
-import { buildCanvasLabelMap, resolveCanvasLabel } from '../domain/canvasLabels'
+import { buildCanvasLabelMap, resolveCanvasLabel, UNNAMED_ELEMENT_LABEL } from '../domain/canvasLabels'
 import type {
   AttentionReason,
   ModelElementKind,
@@ -268,22 +268,6 @@ export function optionHasNoInterventions(data: unknown): boolean {
 // Relationships in plain English
 // ─────────────────────────────────────────────────────────────────────────────
 
-/**
- * What an endpoint is called when the model gives it no honest name.
- *
- * ⚠ NEVER THE IDENTIFIER. This surface used to render
- * `fac_arr → out_uk_arr_retention` — the raw wire ids, joined by an arrow — for
- * every edge without its own `label`, which is most of them. The v1 stack
- * resolved both endpoints to their node labels
- * (`RelationshipsSection.tsx:149-150`), so the canonical outline was the LESS
- * readable of the two editors on the one thing a relationship is for: saying
- * what affects what.
- *
- * The vocabulary matches the estate's existing choice for the same situation
- * (`V5FlipAnalysisBlock.tsx:30` — "Unnamed factor"), generalised because an
- * endpoint here may be an option or an outcome, not only a factor.
- */
-const UNNAMED_ENDPOINT_LABEL = 'Unnamed element'
 
 /**
  * `From → To`, in the user's words.
@@ -299,14 +283,14 @@ function relationshipLabel(
   labels: ReadonlyMap<string, string>,
 ): string {
   if (typeof data?.label === 'string' && data.label.trim() !== '') return data.label
-  const from = resolveCanvasLabel(sourceId, labels) ?? UNNAMED_ENDPOINT_LABEL
-  const to = resolveCanvasLabel(targetId, labels) ?? UNNAMED_ENDPOINT_LABEL
+  const from = resolveCanvasLabel(sourceId, labels) ?? UNNAMED_ELEMENT_LABEL
+  const to = resolveCanvasLabel(targetId, labels) ?? UNNAMED_ELEMENT_LABEL
   return `${from} → ${to}`
 }
 
 /** One element's name for a navigation target. Never its identifier. */
 function endpointLabel(id: string, labels: ReadonlyMap<string, string>): string {
-  return resolveCanvasLabel(id, labels) ?? UNNAMED_ENDPOINT_LABEL
+  return resolveCanvasLabel(id, labels) ?? UNNAMED_ELEMENT_LABEL
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/canvas/model-tab-v2/adapters.ts
+++ b/src/canvas/model-tab-v2/adapters.ts
@@ -119,6 +119,10 @@ import { resolveEdgeDirectionDisplay, resolveEdgeValueDisplay } from '../domain/
 import { getDirectionalStrengthLabel } from '../components/model-tab/strengthBands'
 import { getPrimaryValue, formatSmartNumber } from '../components/model-tab/utils'
 import { getDisplayEdgeId } from '../utils/edgeIdentity'
+// THE ONE id → label policy (`src/canvas/domain/canvasLabels.ts`). It returns
+// `null` rather than the identifier, and rejects a stored label that is itself
+// id-shaped — which is why it is imported here rather than reimplemented.
+import { buildCanvasLabelMap, resolveCanvasLabel } from '../domain/canvasLabels'
 import type {
   AttentionReason,
   ModelElementKind,
@@ -261,6 +265,51 @@ export function optionHasNoInterventions(data: unknown): boolean {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Relationships in plain English
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * What an endpoint is called when the model gives it no honest name.
+ *
+ * ⚠ NEVER THE IDENTIFIER. This surface used to render
+ * `fac_arr → out_uk_arr_retention` — the raw wire ids, joined by an arrow — for
+ * every edge without its own `label`, which is most of them. The v1 stack
+ * resolved both endpoints to their node labels
+ * (`RelationshipsSection.tsx:149-150`), so the canonical outline was the LESS
+ * readable of the two editors on the one thing a relationship is for: saying
+ * what affects what.
+ *
+ * The vocabulary matches the estate's existing choice for the same situation
+ * (`V5FlipAnalysisBlock.tsx:30` — "Unnamed factor"), generalised because an
+ * endpoint here may be an option or an outcome, not only a factor.
+ */
+const UNNAMED_ENDPOINT_LABEL = 'Unnamed element'
+
+/**
+ * `From → To`, in the user's words.
+ *
+ * The arrow is the v1 separator, kept verbatim. An edge that carries its OWN
+ * `label` still wins — the producer naming a relationship outranks anything
+ * derived from its endpoints.
+ */
+function relationshipLabel(
+  data: Record<string, unknown> | undefined,
+  sourceId: string,
+  targetId: string,
+  labels: ReadonlyMap<string, string>,
+): string {
+  if (typeof data?.label === 'string' && data.label.trim() !== '') return data.label
+  const from = resolveCanvasLabel(sourceId, labels) ?? UNNAMED_ENDPOINT_LABEL
+  const to = resolveCanvasLabel(targetId, labels) ?? UNNAMED_ENDPOINT_LABEL
+  return `${from} → ${to}`
+}
+
+/** One element's name for a navigation target. Never its identifier. */
+function endpointLabel(id: string, labels: ReadonlyMap<string, string>): string {
+  return resolveCanvasLabel(id, labels) ?? UNNAMED_ENDPOINT_LABEL
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Value display
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -356,6 +405,9 @@ function attentionForFactor(data: unknown, value: string | null): AttentionReaso
  */
 export function toModelRows(input: ModelProjectionInput): ModelRow[] {
   const rows: ModelRow[] = []
+  // ONE map per projection — built here, threaded down. Rebuilding it per edge
+  // would be the same work N times and, worse, a second place to get it wrong.
+  const nodeLabels = buildCanvasLabelMap(input.nodes)
 
   for (const node of input.nodes) {
     const kind = nodeKind(node)
@@ -438,7 +490,7 @@ export function toModelRows(input: ModelProjectionInput): ModelRow[] {
       id: edge.id,
       kind: 'relationship',
       group: 'relationships',
-      label: typeof data?.label === 'string' ? data.label : `${edge.source} → ${edge.target}`,
+      label: relationshipLabel(data, edge.source, edge.target, nodeLabels),
       primaryValue: edgeValue(data),
       provenanceSource: typeof data?.weightSource === 'string' ? data.weightSource : undefined,
       attention,
@@ -466,6 +518,7 @@ export function toRepairQueueItems(
   queueId: RepairQueue['id'],
 ): RepairQueueItem[] {
   const factorNodes = input.nodes.filter(n => nodeKind(n) === 'factor')
+  const nodeLabels = buildCanvasLabelMap(input.nodes)
 
   if (queueId === 'confirm-estimates') {
     return factorNodes
@@ -511,7 +564,7 @@ export function toRepairQueueItems(
         const data = e.data as Record<string, unknown> | undefined
         return {
           rowId: e.id,
-          label: typeof data?.label === 'string' ? data.label : `${e.source} → ${e.target}`,
+          label: relationshipLabel(data, e.source, e.target, nodeLabels),
           currentValue: edgeValue(data),
           suggestedValue: null,
           basis: 'Two validation passes disagree',
@@ -552,6 +605,7 @@ export function toRepairQueueItems(
  * visible refusal rather than a confident, wrong pane.
  */
 export function toRowDetail(input: ModelProjectionInput, rowId: string): ModelRowDetail | null {
+  const nodeLabels = buildCanvasLabelMap(input.nodes)
   const node = input.nodes.find(n => n.id === rowId)
   if (node) {
     const data = node.data as Record<string, unknown> | undefined
@@ -566,9 +620,12 @@ export function toRowDetail(input: ModelProjectionInput, rowId: string): ModelRo
       secondaryValues: secondary,
       basis: typeof obs?.source === 'string' ? `Source: ${obs.source}` : null,
       adjustments: [],
+      // ⚠ The NAVIGATION id stays the edge's; the LABEL is the target element's
+      // name. Rendering `e.target` here put a raw wire id in the detail region's
+      // "What it affects" list — an identifier presented as user copy.
       affects: input.edges
         .filter(e => e.source === rowId)
-        .map(e => ({ id: e.id, label: e.target })),
+        .map(e => ({ id: e.id, label: endpointLabel(e.target, nodeLabels) })),
       advancedParameters: buildAdvancedForNode(node.id, obs),
     }
   }
@@ -582,7 +639,9 @@ export function toRowDetail(input: ModelProjectionInput, rowId: string): ModelRo
     secondaryValues: [],
     basis: typeof data?.provenance === 'string' ? `Source: ${data.provenance}` : null,
     adjustments: [],
-    affects: [{ id: edge.target, label: edge.target }],
+    affects: [
+      { id: edge.target, label: endpointLabel(edge.target, nodeLabels) },
+    ],
     advancedParameters: buildAdvancedForEdge(edge.id, data),
   }
 }

--- a/src/canvas/model-tab-v2/adapters.ts
+++ b/src/canvas/model-tab-v2/adapters.ts
@@ -44,13 +44,12 @@
  *   · `getDirectionalStrengthLabel`  — model-tab/strengthBands
  *   · `getPrimaryValue`              — model-tab/utils
  *   · `getDisplayEdgeId`             — utils/edgeIdentity
+ *   · `factorNeedsVerification`      — domain/valueProvenance. ⚠ THIS USED TO BE
+ *     A PORT, with a corpus pinning the copy against `countFactorsToVerify`.
+ *     It MOVED to the domain layer on 18 Aug 2026 and both readers now import
+ *     it, so there is nothing left to pin: agreement is structural, not tested.
  *
  * PORTED, because the live logic is not exported per-item:
- *   · `factorNeedsVerification` ← the filter body inside `countFactorsToVerify`
- *     (`model-tab/utils.ts:118-125`). Only the COUNT is exported, and a queue
- *     needs to know WHICH factors. ⚠ The port is pinned in
- *     `adapters.spec.ts` by asserting my per-factor predicate and the live
- *     COUNT agree over a corpus — so the copy cannot drift without a red.
  *   · `edgeIsContested` ← `RelationshipsSection.tsx:610`.
  *   · `optionHasNoInterventions` ← the `allUnmapped` body in
  *     `OptionsSection.tsx:441-446`.
@@ -123,12 +122,17 @@ import { getDisplayEdgeId } from '../utils/edgeIdentity'
 // `null` rather than the identifier, and rejects a stored label that is itself
 // id-shaped — which is why it is imported here rather than reimplemented.
 import { buildCanvasLabelMap, resolveCanvasLabel, UNNAMED_ELEMENT_LABEL } from '../domain/canvasLabels'
+import { resolveNodeTypeLiteral } from '../domain/nodes'
+import { factorNeedsVerification } from '../domain/valueProvenance'
+import { interventionTargetValue } from '../domain/interventions'
+import { unwrapInterventionValue } from '../utils/labelUtils'
 import type {
   AttentionReason,
   ModelElementKind,
   ModelGroupId,
   ModelRow,
   ModelRowDetail,
+  OptionInterventionField,
   RepairQueue,
   RepairQueueItem,
 } from './types'
@@ -172,8 +176,12 @@ export interface ModelProjectionInput {
  * canvas puts it in.
  */
 export function nodeKind(node: { type?: string; data?: unknown }): ModelElementKind | null {
-  const data = node.data as { kind?: unknown; type?: unknown } | undefined
-  const raw = (node.type ?? data?.kind ?? data?.type) as string | undefined
+  // ⚠ THE FALLBACK CHAIN IS NOT RE-DERIVED HERE. `resolveNodeTypeLiteral`
+  // (canvas/domain/nodes.ts) owns it, because "where is the kind stored?" is a
+  // fact about the data that every surface must answer identically. This
+  // function answers a DIFFERENT question — "does this outline render it?" —
+  // and that narrowing is the only thing it adds.
+  const raw = resolveNodeTypeLiteral(node)
   switch (raw) {
     case 'goal':
     case 'decision':
@@ -205,35 +213,6 @@ const KIND_GROUP: Record<ModelElementKind, ModelGroupId> = {
 // Ported predicates — each pinned against its live original in the specs
 // ─────────────────────────────────────────────────────────────────────────────
 
-/**
- * PORTED from the filter body of `countFactorsToVerify`
- * (`src/canvas/components/model-tab/utils.ts:118-125`), verbatim in behaviour:
- *
- *     const obs = data?.observedState ?? data?.observed_state
- *     return !obs?.source || obs?.source === 'cee_inference'
- *
- * ⚠ WHY A PORT AND NOT AN IMPORT: only the COUNT is exported, and a queue must
- * know WHICH factors, not how many. The copy is pinned in `adapters.spec.ts`
- * against the live `countFactorsToVerify` over a corpus, so a drift in either
- * direction turns that spec red rather than silently disagreeing with the badge.
- *
- * ⚠⚠ IF YOU MUTATION-TEST THIS FUNCTION, ANCHOR ON THE FUNCTION BODY, NOT ON THE
- * PREDICATE LINE. The comment above quotes the live source VERBATIM, so the
- * predicate text appears twice in this file and a first-occurrence replace edits
- * the COMMENT. That produced a FALSE SURVIVOR here once already: the file's hash
- * changed, the applied-check passed, and the mutant was inert — an unapplied
- * mutation is indistinguishable from an equivalent one unless the check proves
- * the CODE moved. Anchoring on the enclosing `export function …` block cannot
- * match a comment, and the mutant then bites six tests.
- *
- * ⚠ IT READS BOTH SPELLINGS. Canvas stores `observedState`; the CEE/PLoT wire
- * uses `observed_state`, and graphs carry both. Reading one would under-count.
- */
-export function factorNeedsVerification(data: unknown): boolean {
-  const d = data as Record<string, unknown> | undefined
-  const obs = (d?.observedState ?? d?.observed_state) as Record<string, unknown> | undefined
-  return !obs?.source || obs?.source === 'cee_inference'
-}
 
 /**
  * PORTED from `RelationshipsSection.tsx:610`:
@@ -610,6 +589,7 @@ export function toRowDetail(input: ModelProjectionInput, rowId: string): ModelRo
       affects: input.edges
         .filter(e => e.source === rowId)
         .map(e => ({ id: e.id, label: endpointLabel(e.target, nodeLabels) })),
+      interventions: buildOptionInterventions(node, nodeLabels),
       advancedParameters: buildAdvancedForNode(node.id, obs),
     }
   }
@@ -626,8 +606,53 @@ export function toRowDetail(input: ModelProjectionInput, rowId: string): ModelRo
     affects: [
       { id: edge.target, label: endpointLabel(edge.target, nodeLabels) },
     ],
+    interventions: [],
     advancedParameters: buildAdvancedForEdge(edge.id, data),
   }
+}
+
+/**
+ * The factors an option would move — the v1 intervention rows, projected.
+ *
+ * ⚠ `[]` FOR EVERY NON-OPTION KIND, decided by the SAME `nodeKind` the outline
+ * groups by rather than by "does this node happen to carry an `interventions`
+ * key". A factor that somehow carried one would otherwise sprout an editor for
+ * a relationship it does not have.
+ *
+ * ⚠ AN ENTRY WHOSE FACTOR IS NOT IN THE MODEL IS DROPPED, NOT RENAMED. The v1
+ * row rendered `factorId` in that case — a raw wire id presented as the name of
+ * a thing the user is asked to set a value for. Showing `UNNAMED_ELEMENT_LABEL`
+ * instead would be honest about the label and still wrong about the offer: the
+ * product would be asking the user to change something that is not in their
+ * model (preamble P8). The write authority refuses these for the same reason,
+ * so the projection and the authority agree by construction.
+ */
+function buildOptionInterventions(
+  node: Node,
+  labels: ReadonlyMap<string, string>,
+): OptionInterventionField[] {
+  if (nodeKind(node) !== 'option') return []
+  const raw = (node.data as Record<string, unknown> | undefined)?.interventions as
+    | Record<string, unknown>
+    | undefined
+  if (!raw) return []
+  return Object.entries(raw).flatMap(([factorId, rawValue]) => {
+    const factorLabel = resolveCanvasLabel(factorId, labels)
+    if (factorLabel === null) return []
+    const numeric = interventionTargetValue(rawValue)
+    const { displayValue } = unwrapInterventionValue(rawValue)
+    // A CEE-authored `display_value` wins the DISPLAY (the F.6 passthrough the
+    // v1 rows already honoured); the numeric half is independent of it.
+    const value = displayValue ?? (numeric === undefined ? null : formatSmartNumber(numeric))
+    return [
+      {
+        factorId,
+        factorLabel,
+        value,
+        numericValue: numeric === undefined ? null : numeric,
+      },
+    ]
+  })
 }
 
 /** Advanced-tier parameters. Absent values render as absence, never as zero. */

--- a/src/canvas/model-tab-v2/contracts.ts
+++ b/src/canvas/model-tab-v2/contracts.ts
@@ -157,50 +157,25 @@ export interface ModelEditAuthority {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// § 2 — From PX-A (panel fronting)
+// § 2 — panel fronting: BUILT, AND ITS TYPES MOVED WITH IT (18 Aug 2026)
 // ─────────────────────────────────────────────────────────────────────────────
-
-/**
- * Whether the Olumi surface actually came to the front.
- *
- * ⚠ THE RETURN VALUE IS THE POINT. All 12 send-to-AI call sites on today's
- * Model tab (6 components, 11 distinct messages, measured at `a3c71513`) post a
- * real turn into a panel that stays `hidden`, so the user clicks "Discuss this
- * with the AI" and nothing visibly happens. A hand-off that cannot front the
- * panel must be able to SAY so rather than send into silence.
- */
-export type PanelFrontingOutcome = 'fronted' | 'deferred'
-
-/**
- * The one call this surface needs from the dock lane.
- *
- * Requirements:
- *   · fronts the Olumi conversation whether it is DOCKED, FLOATING or COLLAPSED
- *     (`revealOlumiSurface()` is the current primitive and the natural basis);
- *   · ⚠ ORIGIN IS `'user'`. These are user gestures. They must not stamp
- *     `outputSurfaceOrigin: 'assistant'` and must not raise the
- *     `AssistantOpenedNotice` — telling the user Olumi opened something they
- *     opened themselves is a lie on the one channel whose purpose is
- *     truthfulness;
- *   · returns the outcome.
- *
- * This lane does NOT build it.
- */
-export type FrontOlumiPanel = (opts?: { reason?: string }) => PanelFrontingOutcome
-
-/**
- * The single hand-off helper every v2 send-to-AI affordance goes through.
- *
- * ⚠ THE RULE: no Model-tab control may call `onSendMessage` directly. Fronting
- * happens FIRST, then the send. It matters most for the structural CTAs ("Add a
- * factor", "Add a relationship", "Map interventions", "Explore other
- * strategies") — those terminate in a conversation rather than a mutation, so
- * an invisible conversation makes them dead ends. That combination — the tab's
- * only structural affordance ending in a hidden panel — is the measured
- * mechanism behind "the less I feel like I can actually directly edit the
- * decision model".
- */
-export type HandOffToOlumi = (opts: {
-  message: string
-  reason?: string
-}) => PanelFrontingOutcome
+//
+// `PanelFrontingOutcome`, `FrontOlumiPanel` and `HandOffToOlumi` used to be
+// declared here, unimplemented, against the day another lane built them. They
+// are now implemented in `src/canvas/conversation/olumiHandOff.ts`, and the
+// types went with the implementation.
+//
+// ⚠ THEY HAD TO MOVE, and the reason is a guard doing its job. This directory's
+// boundary scan pins `ModelTabBody.tsx` as the ONLY file outside it that may
+// reference `model-tab-v2/` at all — one mount path, no second one. An
+// implementation living in the conversation layer and importing its interface
+// from here made that scan RED, correctly: a type import is a real reference,
+// and the alternative — widening the allowlist — would have traded a structural
+// guarantee for one import's convenience.
+//
+// The deeper point, which is why this note stays: a contract declared where it
+// is CONSUMED rather than where it is IMPLEMENTED has no owner. It reads as a
+// commitment while nothing is bound to it — `HandOffToOlumi` sat here with ZERO
+// implementations while all eleven Model-tab send-to-AI controls bypassed it
+// entirely. Now the type and the code that satisfies it cannot drift apart,
+// because they are the same file.

--- a/src/canvas/model-tab-v2/groupActions.ts
+++ b/src/canvas/model-tab-v2/groupActions.ts
@@ -1,0 +1,187 @@
+/**
+ * groupActions — THE ONE table of Model-tab affordances that terminate in a
+ * conversation, rehomed onto the canonical outline (18 Aug 2026).
+ *
+ * ⚠ EVERY MESSAGE STRING HERE IS VERBATIM FROM THE v1 SITE NAMED IN
+ * `rehomedFrom`. Nothing is paraphrased and nothing is invented. A rehome that
+ * rewrote the turn text would change what Olumi is asked while claiming to move
+ * a capability, and the difference would be invisible in review.
+ *
+ * ── WHY A TABLE AND NOT TEN BUTTONS ───────────────────────────────────────
+ *
+ * The v1 stack spread these across six components and eleven call sites, two of
+ * which ("Explore other strategies", `OptionsSection.tsx:486` and `:508`) were
+ * the SAME action under ONE testid on mutually exclusive branches — so the
+ * duplication was already invisible to a testid-based check. One table keyed by
+ * group is the single authority: `Record<ModelGroupId, …>` is TOTAL, so a new
+ * group is a type error rather than a group that silently offers nothing.
+ *
+ * ── THE SEVENTH CAPABILITY (a finding, not part of the commissioned six) ──
+ *
+ * The founder's ruling named six unique old-editor capabilities. Deriving the
+ * set at `9ff14c19` turned up a SEVENTH with no equivalent in the outline:
+ * `RisksSection.tsx:100` — a structural affordance for the RISK entity class,
+ * exactly parallel to "Add a factor" and "Add a relationship". It is rehomed
+ * here as `risks-add`.
+ *
+ * ⚠ AND ITS REACH CHANGES, DELIBERATELY. In v1 that button renders ONLY inside
+ * the empty-state branch (`riskNodes.length === 0`), so a user who already has
+ * one risk cannot ask for another. On the outline it is a group action like the
+ * others. That is a reach INCREASE, stated here so review can see it rather
+ * than discover it: an outline whose "add" affordance disappears once the group
+ * is non-empty would be the undiscoverability defect this surface replaced.
+ *
+ * ── WHAT IS NOT HERE, AND WHY ─────────────────────────────────────────────
+ *
+ * `OptionsSection.tsx:472` ("Map interventions") is NOT rehomed. It is an
+ * adjudicated CUT — design §7.0 items 2 and 10 — because it names a gap and
+ * offers no way to close it; its replacement is the option-value edit path, not
+ * another chat hand-off. Recorded here so its absence reads as a decision.
+ */
+
+import type { ModelGroupId } from './types'
+
+/**
+ * What a message may interpolate.
+ *
+ * ⚠ SOURCED FROM THE OUTLINE ROW THE USER IS LOOKING AT, never from a second
+ * read of the store. The goal hand-off quotes the target back to the user, and
+ * quoting a number the screen does not show would be a claim about the model
+ * that the model's own rendered state contradicts (preamble P5).
+ */
+export interface GroupActionContext {
+  /** The goal row's label, or `null` when the model has no goal row. */
+  goalLabel: string | null
+  /** The goal row's DISPLAYED target — exactly what the outline shows. */
+  goalTarget: string | null
+}
+
+/**
+ * `structural` changes the shape of the model (adds an element, explores new
+ * options); `discuss` asks about what is already there.
+ *
+ * The distinction is not decoration: the structural ones are the affordances
+ * whose dead-endedness was the measured mechanism behind "I don't feel like I
+ * can actually directly edit the model", so they render first and with emphasis.
+ */
+export type GroupActionIntent = 'structural' | 'discuss'
+
+export interface GroupAction {
+  /** Stable id — the testid suffix. NEVER derived from the label (trap 19). */
+  id: string
+  /** Sentence-case British English, as shown to the user. */
+  label: string
+  intent: GroupActionIntent
+  /** The turn text. Verbatim from `rehomedFrom`. */
+  message: (ctx: GroupActionContext) => string
+  /**
+   * `file:line` of the v1 control this replaces.
+   *
+   * ⚠ THIS IS THE DELETE STEP'S CHECKLIST, not a comment. The removal of the v1
+   * stack is reviewable only if every deleted affordance has a named successor;
+   * a rehome that cannot say what it replaced cannot prove it replaced anything.
+   */
+  rehomedFrom: string
+}
+
+const DISCUSS_GOAL: GroupAction = {
+  id: 'goal-discuss',
+  label: 'Discuss the goal with Olumi',
+  intent: 'discuss',
+  message: ctx =>
+    `Help me understand my goal '${ctx.goalLabel ?? 'not set'}' and whether the target of ${ctx.goalTarget ?? 'not set'} is appropriate`,
+  rehomedFrom: 'model-tab/GoalSection.tsx:243',
+}
+
+const EXPLORE_STRATEGIES: GroupAction = {
+  id: 'options-explore',
+  label: 'Explore other strategies',
+  intent: 'structural',
+  message: () => 'I want to explore other strategies and options',
+  rehomedFrom: 'model-tab/OptionsSection.tsx:486 and :508 (one action, two sites)',
+}
+
+const DISCUSS_OPTIONS: GroupAction = {
+  id: 'options-discuss',
+  label: 'Discuss the options with Olumi',
+  intent: 'discuss',
+  message: () => 'Help me review my options and how they compare',
+  rehomedFrom: 'model-tab/OptionsSection.tsx:521',
+}
+
+const ADD_FACTOR: GroupAction = {
+  id: 'factors-add',
+  label: 'Add a factor',
+  intent: 'structural',
+  message: () => 'I want to add a new factor to the model',
+  rehomedFrom: 'model-tab/FactorsSection.tsx:737',
+}
+
+const DISCUSS_FACTORS: GroupAction = {
+  id: 'factors-discuss',
+  label: 'Discuss the factors with Olumi',
+  intent: 'discuss',
+  message: () => 'Help me review the factors in my model and whether the values are reasonable',
+  rehomedFrom: 'model-tab/FactorsSection.tsx:745',
+}
+
+const ADD_RISK: GroupAction = {
+  id: 'risks-add',
+  label: 'Identify potential risks',
+  intent: 'structural',
+  message: () => 'I want to identify potential risks that could cause this decision to fail',
+  rehomedFrom: 'model-tab/RisksSection.tsx:100 (the SEVENTH capability — empty-state only in v1)',
+}
+
+const DISCUSS_RISKS: GroupAction = {
+  id: 'risks-discuss',
+  label: 'Discuss the risks with Olumi',
+  intent: 'discuss',
+  message: () => 'Help me understand the risks in my model and how to mitigate them',
+  rehomedFrom: 'model-tab/RisksSection.tsx:143',
+}
+
+const ADD_RELATIONSHIP: GroupAction = {
+  id: 'relationships-add',
+  label: 'Add a relationship',
+  intent: 'structural',
+  message: () => "I'd like to add a causal relationship",
+  rehomedFrom: 'model-tab/RelationshipsSection.tsx:819',
+}
+
+const DISCUSS_RELATIONSHIPS: GroupAction = {
+  id: 'relationships-discuss',
+  label: 'Discuss the relationships with Olumi',
+  intent: 'discuss',
+  message: () => 'Help me review the causal relationships and which ones need attention',
+  rehomedFrom: 'model-tab/RelationshipsSection.tsx:827',
+}
+
+const DISCUSS_RELIABILITY: GroupAction = {
+  id: 'evidence-discuss',
+  label: "Discuss the model's reliability with Olumi",
+  intent: 'discuss',
+  message: () => 'Help me understand the reliability and limitations of my model',
+  rehomedFrom: 'model-tab/ModelHealthSection.tsx:328',
+}
+
+/**
+ * The actions each outline group offers, structural first.
+ *
+ * ⚠ TOTAL BY CONSTRUCTION. `assumptions-provenance` is `[]` because the v1
+ * stack had NO send-to-AI control for it — an empty array is the derived answer,
+ * not an omission, and the type will not let a future group be forgotten.
+ */
+export const GROUP_ACTIONS: Record<ModelGroupId, readonly GroupAction[]> = {
+  goal: [DISCUSS_GOAL],
+  options: [EXPLORE_STRATEGIES, DISCUSS_OPTIONS],
+  factors: [ADD_FACTOR, DISCUSS_FACTORS],
+  'outcomes-risks': [ADD_RISK, DISCUSS_RISKS],
+  relationships: [ADD_RELATIONSHIP, DISCUSS_RELATIONSHIPS],
+  'assumptions-provenance': [],
+  'evidence-review': [DISCUSS_RELIABILITY],
+}
+
+/** Every action across every group — the flat set, for guards and sweeps. */
+export const ALL_GROUP_ACTIONS: readonly GroupAction[] =
+  Object.values(GROUP_ACTIONS).flat()

--- a/src/canvas/model-tab-v2/types.ts
+++ b/src/canvas/model-tab-v2/types.ts
@@ -217,6 +217,30 @@ export interface DetailField {
 }
 
 /**
+ * ONE factor an option would move, and the target it would move it to
+ * (design §4.4.2, rehomed from `OptionsSection`'s intervention rows 18 Aug 2026).
+ *
+ * ⚠ `factorLabel` IS ALWAYS A HUMAN LABEL, NEVER THE ID. The v1 rows fell back
+ * to `factorId` when the lookup missed (`factorNode?.data?.label ?? factorId`),
+ * which put a raw wire id on screen for exactly the factors a user is least
+ * able to identify. The projection resolves through the one label policy and
+ * names an unresolvable endpoint `UNNAMED_ELEMENT_LABEL` instead.
+ *
+ * ⚠ `value` AND `numericValue` ANSWER DIFFERENT QUESTIONS and are deliberately
+ * both present. `value` is what the row DISPLAYS — it may be a CEE-authored
+ * `display_value` string that no arithmetic produced. `numericValue` is what an
+ * editor SEEDS FROM, and it is `null` whenever no finite number is stated, so a
+ * display string can never be silently reinterpreted as a number the user then
+ * appears to have typed.
+ */
+export interface OptionInterventionField {
+  factorId: string
+  factorLabel: string
+  value: string | null
+  numericValue: number | null
+}
+
+/**
  * Everything the detail region shows for ONE selected row (design §4.4).
  *
  * ⚠ `rowId` IS LOAD-BEARING, NOT BOOKKEEPING. The detail region asserts it
@@ -244,6 +268,14 @@ export interface ModelRowDetail {
   adjustments: readonly string[]
   /** §4.4.4 "What it affects" — related elements, ID-addressed for navigation. */
   affects: readonly { id: string; label: string }[]
+  /**
+   * §4.4.2 — for an OPTION, the factors it would move and the targets it sets.
+   * Empty for every other kind, and empty for an option that sets none: an
+   * option with no interventions reports that through its row's
+   * `missing-intervention` attention, not by this list quietly meaning two
+   * different things.
+   */
+  interventions: readonly OptionInterventionField[]
   /**
    * §4.4.5 — the ONE Advanced block. ⚠ ABSENT ENTIRELY IN PLAIN, and never
    * mixed inline beside a plain value (design §4.3 rule 2). If a "parameter"

--- a/src/telemetry/__tests__/guidanceEvents.spec.tsx
+++ b/src/telemetry/__tests__/guidanceEvents.spec.tsx
@@ -292,9 +292,23 @@ describe('Trust instrumentation', () => {
   it('fires MODEL_CARD_VIEWED on mount of ModelTabBody', async () => {
     // ModelTabBody has heavy canvas deps — mock the store subscriptions
     vi.mock('../../canvas/components/ModelCardLite', () => ({ ModelCardLite: () => null }))
-    vi.mock('../../canvas/adapters/modelCardAdapter', () => ({
-      selectModelCardData: () => ({ nodes: [], edges: [] }),
-    }))
+    // ⚠ `importOriginal`-SPREAD, NOT A HAND-LISTED FACTORY (trap 12).
+    // A bare factory REPLACES the module, so this mock was a hand-maintained
+    // mirror of `modelCardAdapter`'s export list. It broke the moment an
+    // unrelated import chain reached a DIFFERENT export: `friendlyOperation.ts`
+    // derives `RECEIPT_FIELD_ALLOWLIST` from `Object.keys(FIELD_LABELS)` at
+    // module scope, so any spec that transitively imports it through this mock
+    // throws at collection — "No FIELD_LABELS export is defined on the mock".
+    // Spreading the original keeps the stub (`selectModelCardData`, the heavy
+    // canvas read this test is avoiding) while every other export stays real,
+    // so the mock cannot drift from the module again.
+    vi.mock('../../canvas/adapters/modelCardAdapter', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../../canvas/adapters/modelCardAdapter')>()
+      return {
+        ...actual,
+        selectModelCardData: () => ({ nodes: [], edges: [] }),
+      }
+    })
     // Stub useCanvasStore hook (already mocked at top — returns null for selectors)
     const { ModelTabBody } = await import('../../canvas/components/ModelTabBody')
     render(

--- a/src/v5/blocks/V5AnalysisResultBlock.tsx
+++ b/src/v5/blocks/V5AnalysisResultBlock.tsx
@@ -43,7 +43,8 @@ import {
   resolveLeaderKeys,
   resolveOptionLabelById,
 } from '../mapV5AnalysisToReport'
-import { useCanvasNodeLabels, resolveCanvasLabel } from './useCanvasLabels'
+import { useCanvasNodeLabels } from './useCanvasLabels'
+import { resolveCanvasLabel } from '../../canvas/domain/canvasLabels'
 import { deriveDecisionVerdict } from '../../lib/decisionVerdict'
 import { isRecord } from '../../lib/guards'
 import { formatProbabilityWithResolution } from '../../utils/formatPercent'

--- a/src/v5/blocks/V5ExplanationBlock.tsx
+++ b/src/v5/blocks/V5ExplanationBlock.tsx
@@ -18,7 +18,8 @@
 import { useMemo, type ReactElement } from 'react'
 import { typography } from '../../styles/typography'
 import type { V5ExplanationBlock as V5ExplanationBlockType } from '../../canvas/conversation/types'
-import { useCanvasNodeLabels, resolveCanvasLabel } from './useCanvasLabels'
+import { useCanvasNodeLabels } from './useCanvasLabels'
+import { resolveCanvasLabel } from '../../canvas/domain/canvasLabels'
 
 export interface V5ExplanationBlockProps {
   block: V5ExplanationBlockType

--- a/src/v5/blocks/V5FlipAnalysisBlock.tsx
+++ b/src/v5/blocks/V5FlipAnalysisBlock.tsx
@@ -19,7 +19,8 @@
 import { useMemo, type ReactElement } from 'react'
 import { typography } from '../../styles/typography'
 import type { V5FlipAnalysisBlock as V5FlipAnalysisBlockType } from '../../canvas/conversation/types'
-import { useCanvasNodeLabels, resolveCanvasLabel } from './useCanvasLabels'
+import { useCanvasNodeLabels } from './useCanvasLabels'
+import { resolveCanvasLabel } from '../../canvas/domain/canvasLabels'
 
 export interface V5FlipAnalysisBlockProps {
   block: V5FlipAnalysisBlockType

--- a/src/v5/blocks/useCanvasLabels.ts
+++ b/src/v5/blocks/useCanvasLabels.ts
@@ -15,11 +15,17 @@
  *
  * Options are canvas nodes (there is no separate option entity), so one node
  * map resolves both `option_id` and `factor_id`.
+ *
+ * ⚠ `resolveCanvasLabel` NO LONGER LIVES HERE. It moved to
+ * `src/canvas/domain/canvasLabels.ts` (18 Aug 2026) so the Model tab's pure
+ * projection adapter can share the ONE policy without taking this store
+ * subscription with it. There is deliberately NO re-export from this module:
+ * a shim would make the policy reachable from two places, which is the defect
+ * the move exists to avoid. Import it from its new home.
  */
 
 import { useMemo } from 'react'
 import { useCanvasStore } from '../../canvas/store'
-import { RAW_ID_PATTERN } from '../../canvas/conversation/friendlyOperation'
 
 /**
  * Node id → display label for every canvas node that has one.
@@ -41,28 +47,4 @@ export function useCanvasNodeLabels(): ReadonlyMap<string, string> {
     }
     return map
   }, [nodes])
-}
-
-/**
- * Resolve one wire id to a human label, or `null` when no honest label
- * exists.
- *
- * Returns `null` rather than the id — that is the whole point. Callers must
- * decide what to show instead, and the type makes them decide: there is no
- * way to accidentally fall through to the identifier.
- *
- * A stored label that is ITSELF a raw id is rejected via `RAW_ID_PATTERN`.
- * Upstream sometimes seeds a node's label from its id; without this guard the
- * leak would simply move one hop upstream and still reach the user.
- */
-export function resolveCanvasLabel(
-  id: string,
-  labels: ReadonlyMap<string, string>,
-): string | null {
-  const label = labels.get(id)
-  if (label === undefined) return null
-  const trimmed = label.trim()
-  if (trimmed === '') return null
-  if (RAW_ID_PATTERN.test(trimmed)) return null
-  return trimmed
 }


### PR DESCRIPTION
# REHOME → DELETE, steps 1–2. **The delete is step 3 and is BLOCKED — evidence below.**

The Model tab renders TWO complete model editors stacked. The founder's ruling is
REHOME → DELETE, and *"do not preserve the duplicate editor because some capabilities are
still local-only; **extend the canonical transactional authority where required, then remove
the duplicate.**"*

This PR does the rehome and the authority extension. **It deletes nothing.** The removal is a
separate, independently revertable change — and the derivation at the bottom of this
description is why it must be, not a preference.

---

## What landed

**1 · The CI blocker, fixed at source.** `guidanceEvents.spec.tsx` mocked `modelCardAdapter`
with a bare factory listing one export. A `vi.mock` factory REPLACES the module, so that list
was a hand-maintained mirror (trap 12) — and it broke exactly as trap 12 predicts the moment
an unrelated import chain reached a different export (`friendlyOperation`'s module-scope
`Object.keys(FIELD_LABELS)`). Replaced with the `importOriginal` spread. One such factory
repo-wide, swept including `tests/` and `e2e/`.

**2 · `useModelEditAuthority` now owns three operations.**

| operation | carrier | outcome type |
|---|---|---|
| `proposeFactorValue` | `factor_value_edit` — server-backed | `FactorValueProposalOutcome` |
| `proposeOptionIntervention` | none | `LocalCommitOutcome` |
| `proposeFactorConfirmation` | none | `LocalCommitOutcome` |

`LocalCommitOutcome` has **no `dispatched` member**, deliberately: there is no value-bearing
wire carrier for either, so a caller *cannot* report that a server accepted one. They reach CEE
exactly as they always have — the debounced, value-less `direct_graph_edit` notification.
This does not re-open design §2 F6: F6's harm is that local and server-backed writes are
INDISTINGUISHABLE, and these two are distinguishable by construction.

**3 · The honesty defect.** Confirm ✓ wrote `setObservedSource('user')`, which classifies as
the `edited` kind — so the pill read **"User edited"** for a gesture in which the user changed
no number. It now stamps `user_confirmed`, matching pre-analysis, the outputs dock and the
calibrate drill-in. `source` alone — copying their `extractionType: 'explicit'` would invent a
claim this gesture does not establish.

**4 · The old editor stops being a second writer, before it is deleted.**
`FactorsSection.handleConfirmValue` and `OptionsSection.handleInterventionSave` now DISPATCH to
the authority; `OptionsSection` holds no mutation handle at all. The eventual removal drops a
RENDERING and nothing else.

**5 · Four duplicates removed, none replaced by a shim.** (*Could this change be another
instance of the defect class it removes?* — a re-export or a second copy left behind would move
duplication rather than remove it, so:)

- `nodeKind`'s `node.type ?? data.kind ?? data.type` chain → **moved** to `domain/nodes.ts`.
- `OptionsSection.extractInterventionNumeric` → **moved** to `domain/interventions.ts`, WITH its
  legacy `raw_target`/`target_value` tolerance. Narrowing the canonical surface to the shared
  unwrapper instead would have blanked those users' numbers the day the old editor went away.
- `factorNeedsVerification` → **moved** to `domain/valueProvenance.ts`. It existed TWICE — inline
  in `countFactorsToVerify` and as a documented port in `adapters.ts` pinned against a corpus.
  That pin could only prove the two AGREED, never that either was right (trap 12d).
- `InlineEdit`'s numeric no-op suppression → **rehomed** into the canonical intervention editor.

No re-export was left at any old site, and a test asserts that by scanning for both a definition
AND an `export {}` re-export, with a positive control on the matcher.

---

## Evidence

**Mutation battery: 13 of 13 bitten.** Throwaway worktree OUTSIDE the repo root with `HEAD`
asserted equal to the source SHA; isolation proven by WRITING a sentinel and checking the source
md5 (not by inspecting paths); restores from a pristine ARCHIVE; applied-check scoped to `src/`
asserting exactly 1 per mutant and 0 for baseline and trailing controls; every mutated tree
typechecked, clean-tree control first; every spec's collected count asserted BY NAME.

**Three survivors, all of them findings:**
- the authority's value guard is unreachable from the UI → added a direct authority spec;
- the factor-KIND guard then still survived, because the "not a factor" fixture also had no
  value — a guard passing because its NEIGHBOUR fired (trap 13b). Needed a non-factor that DOES
  carry a value;
- the no-op suppression survived a value assertion, because writing 0.6 over 0.6 leaves the value
  identical (trap 19) → the discriminating assertion is node-object identity, with a positive
  control that a real edit DOES replace the object.

A fourth "survival" was an instrument failure: the worktree was not at my HEAD, caught only
because its applied-check read **2 before any mutation** (trap 9f).

| measurement | result |
|---|---|
| `scripts/ci/typecheck-gate.sh` (the repo's named gate) | **PASSES** — drift 2272 → 2263, none added, baseline deliberately NOT regenerated |
| `src/canvas/model-tab-v2` | 13 files / 223 passed |
| model-tab + domain + hooks | 91 files / 1203 passed |
| `src/canvas/__tests__` + ModelTabBody + telemetry | 67 files / 819 passed |
| `rehomedLocalCommits.spec.tsx` | 15 / 15 by name |
| `useModelEditAuthority.localCommits.spec.tsx` | 9 / 9 by name |

**UNMEASURED by this lane:** `lint`, the full suite in the required check's step order, and any
runtime/deployed witness. CI is the authority.

⚠ The named gate caught a real error that `tsc --noEmit -p tsconfig.json` did NOT (a spec fixture
missing the new required `ModelRowDetail.interventions`). Trap 2, live.

Also fixed on the way, a **P1** defect in this PR's own change: adding one required field to
`ModelRowDetail` made twelve existing tests throw during render — one absent list taking down the
element's name, value, provenance and affects list. The render now reads `?? []` while the type
stays required, so malformity costs the list, never the pane.

---

# ⛔ STEP 3 (DELETE) IS BLOCKED — derived, not assumed

A component-by-component derivation of what deleting the sectioned editor would cost **today**.
The MUST-HOLD conditions are not yet met, and this states exactly which:

| MUST HOLD | status |
|---|---|
| one canonical edit path per quantity | ✅ for factor value, option intervention, factor confirmation — both surfaces now dispatch through the ONE authority |
| relationships readable in plain English | ✅ (`relationshipsPlainEnglish.spec.ts`, 8 tests) |
| no raw ids shown to the user | ✅ extended — an intervention whose factor is not in the model is DROPPED, not rendered with its id, and the authority refuses the same case so projection and authority agree by construction |
| all seven rehomed send-to-AI capabilities reachable | ✅ (`groupActionsRehome.spec.tsx`) |
| **one canonical editor** | ❌ two still render |
| **no element rendered twice** | ❌ follows from the above |

**NOT COVERED by the canonical editor — deleting today would remove user capability:**

- **Editing:** the goal success target (`setGoalThresholdAndUpdateNode`, still live only in
  `GoalSection`); factor **prior ranges** + "Refine range" for external factors; factor
  **baseline**; edge **strength**, **direction** and **likelihood** (all three render honestly
  disabled in v2 — they have no authority entry point).
- **Contested-edge resolution** — `ContestedEdgeCard`'s whole accept/override/dismiss vertical.
  v2 shows only a ⚠. (The file itself survives: `pre-analysis/AllImprovements.tsx` imports it.)
- **`ModelAdjustments`** — CEE structural repairs. `ModelRowDetail.adjustments` exists and the
  detail region would render it, but `adapters.ts` sets it to `[]` for every node and edge, so
  it is permanently empty.
- **`ModelHealthSection`** — CEE quality sub-scores and the entire audit trail (seed, response
  hash, simulation count, auto-noise disclosure, stability penalty, inference warnings).
- **Displayed facts:** conditional-winner statements; intervention baseline + delta chips;
  e-value chips; causal claim; repairs-applied; factor influence bar + attribution-stability;
  uncertainty drivers / elasticity / rank-flip rate / confidence; risks' "Triggered by" line
  (v2's `affects` is outbound-only); status-quo and empty-state prose; per-section coaching.
- **`ModelFooter`'s Copy as Text / Copy as JSON.**
- Aggregate header counts, the click-to-scroll StatusBar, and the EntityBar composition bar.

**Must SURVIVE any delete (imported from outside the directory):** `SourceProvenancePill`,
`strengthBands`, `utils`, `types` (all consumed by `model-tab-v2/`), `ContestedEdgeCard` and
`DetailToggleContext` (by `pre-analysis/AllImprovements`), `ReanalyseBar` (by `OutputsDock` —
it is not part of the sectioned stack), plus eight test-only importers.
`model-tab/__tests__/modelTabNoRawStoreWrites.sourceScan.spec.ts` requires four of the section
files to EXIST and must be rehomed with them.

**Also found, and worth a decision:** three v2 paths are **built but unmounted** —
`RepairQueueList` (and its producer `toRepairQueueItems`), `useOutlineKeyboard`, and
`row.deferred` (never populated by `adapters.ts`, so the "Left unresolved" marker cannot render).
The repair queues are the design's answer to Paul's two repair cases; they are the natural home
for several of the NOT-COVERED items above.

**Recommended step 3:** close the NOT-COVERED editing set by extending the authority further
(goal target, prior range, edge strength/likelihood/direction), mount the repair queues, then
delete — in that order. A verified rehome beats a rushed removal.
