### PR TITLE
fix(canvas): the floating panel stops charging the graph 392px — steps 1-2 of the workspace composition decision

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -71,6 +71,8 @@ import { InfluenceExplainer, useInfluenceExplainer } from '../components/assista
 import { executeCanonicalRun } from './analysis/canonicalRunRegistry'
 import { HighlightLayer } from './highlight/HighlightLayer'
 import { computeFitPadding } from './utils/computeFitPadding'
+import { GHOST_OPTION_NODE_ID, excludeNonModelNodes } from './utils/fitTargets'
+import { LABEL_LEGIBLE_ZOOM } from './utils/zoomLegibility'
 import { OPEN_FULL_INSPECTOR_EVENT } from './utils/openEdgeStrengthEditor'
 import { usePathHighlight } from './hooks/usePathHighlight'
 import { useLensFilter } from './hooks/useLensFilter'
@@ -458,7 +460,7 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
     const ghostGap = measuredW + 60
 
     const ghostNode = {
-      id: '__ghost-option__',
+      id: GHOST_OPTION_NODE_ID,
       type: 'ghost-option' as const,
       position: { x: maxX + ghostGap, y: ghostY },
       data: {},
@@ -473,15 +475,20 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
   // AI coaching is rendered by the guidanceStore consumers, not here — see
   // ./nodes/FactorNode.tsx (on-canvas CoachingCard) and ./conversation/GuidanceStrip.tsx.
 
-  const { getViewport, fitView, zoomIn, zoomOut, zoomTo, screenToFlowPosition } = useReactFlow()
+  const { getViewport, getNodes, fitView, zoomIn, zoomOut, zoomTo, screenToFlowPosition } = useReactFlow()
 
   // Brief 36 Fix: Stabilize ReactFlow function references via refs
   // These functions may have unstable references in some ReactFlow versions
   const getViewportRef = useRef(getViewport)
+  // Fit targets are read through a ref for the same reason every other ReactFlow
+  // function here is: the reference is not stable across versions and these
+  // callbacks are empty-deps by design.
+  const getNodesRef = useRef(getNodes)
   const zoomInRef = useRef(zoomIn)
   const zoomOutRef = useRef(zoomOut)
   const zoomToRef = useRef(zoomTo)
   getViewportRef.current = getViewport
+  getNodesRef.current = getNodes
   zoomInRef.current = zoomIn
   zoomOutRef.current = zoomOut
   zoomToRef.current = zoomTo
@@ -1967,7 +1974,25 @@ const ReactFlowGraphInner = memo(function ReactFlowGraphInner({ blueprintEventBu
   const handleZoomIn = useCallback(() => zoomInRef.current({ duration: cameraDuration(200, reducedMotionRef.current) }), [])
   const handleZoomOut = useCallback(() => zoomOutRef.current({ duration: cameraDuration(200, reducedMotionRef.current) }), [])
   const handleZoomReset = useCallback(() => zoomToRef.current(1, { duration: cameraDuration(200, reducedMotionRef.current) }), [])
-  const handleFitView = useCallback(() => fitViewRef.current({ padding: computeFitPadding(), duration: cameraDuration(300, reducedMotionRef.current) }), [])
+  // The USER-invoked "Fit to view".
+  //
+  // ⚠ It had no legibility floor while the product's own auto-fit did — so the
+  // product refused to choose an unreadable first view and then offered the user
+  // a button that chose one for them. `minZoom` is honoured by xyflow
+  // (`fitViewport` passes it into `getViewportForBounds`, which clamps and
+  // RE-FRAMES on the clamped zoom), and the canvas instance's own `minZoom={0.1}`
+  // still lets the user zoom out by hand: the asymmetry is deliberate — the user
+  // may choose the overview, the product may not choose it for them.
+  // `utils/zoomLegibility.ts` owns the number.
+  const handleFitView = useCallback(() => {
+    const nodes = excludeNonModelNodes(getNodesRef.current())
+    fitViewRef.current({
+      ...(nodes.length > 0 ? { nodes } : {}),
+      padding: computeFitPadding(),
+      minZoom: LABEL_LEGIBLE_ZOOM,
+      duration: cameraDuration(300, reducedMotionRef.current),
+    })
+  }, [])
 
   // Canvas debug mode: 'blank' short-circuits the full canvas UI so we can
   // quickly determine whether React 185 is coming from inside the canvas

--- a/src/canvas/__tests__/computeFitPadding.spec.ts
+++ b/src/canvas/__tests__/computeFitPadding.spec.ts
@@ -29,7 +29,7 @@
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest'
-import { computeFitPadding, cheapestReservation } from '../utils/computeFitPadding'
+import { computeFitPadding } from '../utils/computeFitPadding'
 
 function fakeEl(rect: Partial<DOMRect>): HTMLElement {
   const full: DOMRect = {
@@ -263,205 +263,178 @@ describe('computeFitPadding', () => {
 })
 
 /**
- * A2 (16 Aug 2026) — the FLOATING conversation panel's reservation.
+ * STEP 1 (18 Aug 2026) — THE FLOATING PANEL RESERVES NOTHING, EVER.
  *
- * The dock and the sidebar are edge-anchored, so "what do they occlude" has one
- * answer. The floating Olumi panel is free-floating, so it does not: these tests
- * are written against the STATED CONTRACT — "the graph must not be framed
- * underneath the panel, at the least cost to the fitting box" — and not against
- * the 1280x800 case that motivated the work. A reservation is correct when the
- * chosen side EXCLUDES the occluder from the fitting box; that postcondition is
- * asserted directly below rather than by pinning the side a particular geometry
- * happens to pick.
+ * `WORKSPACE-COMPOSITION-DECISION-2026-08-18.md`, built inside the founder's
+ * ruling: *"FLOATING AND LAYOUT-RESERVING ARE DIFFERENT CONCEPTS… FIX THE
+ * COMPOSITION, NOT THE CAPABILITY."* This module was the one place in the
+ * codebase that conflated them: it converted a free-floating overlay into a
+ * rectangular fitView inset, and because a rectangular inset cannot express
+ * "this box is covered", the only way to clear a 400x550 panel was to give up
+ * a whole band of canvas. Measured live at 1280x800: **392px of canvas, 52% of
+ * the resulting fit box**, spent so one conversation and one analysis could
+ * coexist. Fit box 368x742 with the panel open, 760x742 without it.
+ *
+ * The tests this replaces asserted the OPPOSITE contract ("the graph must not
+ * be framed underneath the panel, at the least cost to the fitting box") and
+ * they were correct about the code as it stood. They are deleted rather than
+ * skipped, because the contract they pinned is the one being retired — with
+ * one exception carried over deliberately: the minimised pill's non-reservation
+ * is now a special case of the general rule rather than a judgement of its own.
+ *
+ * THE NEW RULE, stated once: **ONLY EDGE-ANCHORED, LAYOUT-RESERVING CHROME
+ * CONTRIBUTES.** Guard G2(a) of the decision.
+ *
+ * ⚠ WHAT THIS DOES **NOT** MEAN, and the reason `cameraComfort` changed in the
+ * same commit: "the fit must not reserve for the panel" is not "nothing may
+ * know the panel is there". `cameraComfort`'s no-churn rule is stated as each
+ * target's rect inside the fit frame — "anything less — a target off-screen,
+ * UNDER AN OCCLUDING PANEL, or rendered unreadably small — and the caller
+ * fits". It derived that frame from THIS function, so deleting the floating
+ * branch here alone would have scored a node behind the panel COMFORTABLE and
+ * the focus camera would have silently refused to move — a regression in the
+ * very capability this change exists to serve, with no error and no red test.
+ * See `cameraComfort.spec.ts` → "the floating companion is comfort-visible".
  */
-describe('computeFitPadding — floating Olumi panel', () => {
+describe('computeFitPadding — the floating panel reserves NOTHING (G2a: padding invariance)', () => {
   const PANEL = '[data-testid="floating-olumi-panel"]'
   const SIDE_TAB = '[data-testid="floating-olumi-panel-side-tab"]'
   const PILL = '[aria-label="Restore Olumi"]'
   const FLOW = { left: 0, right: 1280, width: 1280, top: 0, bottom: 800, height: 800 }
+  // The shipped 1280x800 geometry: dock `right: 12` at 416px, sidebar at 12/52.
+  const DOCK_1280 = { left: 852, right: 1268, width: 416, top: 12, bottom: 784, height: 772 }
+  const SIDEBAR_1280 = { left: 12, right: 60, width: 48, top: 73, bottom: 300, height: 227 }
 
-  /** The fitting box the returned padding implies, in viewport coordinates. */
-  function fitBoxOf(p: { top: string; right: string; bottom: string; left: string }) {
-    return {
-      left: FLOW.left + parseInt(p.left, 10),
-      right: FLOW.right - parseInt(p.right, 10),
-      top: FLOW.top + parseInt(p.top, 10),
-      bottom: FLOW.bottom - parseInt(p.bottom, 10),
-    }
+  /**
+   * Every position the panel actually reaches, INCLUDING the centred case the
+   * old suite had to except itself from (`MAX_PADDING_FRACTION` bound first) and
+   * the bottom-hugging case that used to take a cheap bottom reservation. Under
+   * invariance there is no case to except: the answer is zero everywhere.
+   */
+  const POSITIONS = [
+    { name: 'bottom-right anchor (FirstUseComposer)', left: 812, top: 234, w: 400, h: 550 },
+    { name: 'left clamp floor', left: 52, top: 73, w: 400, h: 550 },
+    { name: 'top-left', left: 52, top: 16, w: 400, h: 550 },
+    { name: 'centred (the old suite could not clear this one)', left: 440, top: 125, w: 400, h: 550 },
+    { name: 'wide + bottom-hugging (used to cost bottom)', left: 300, top: 700, w: 700, h: 90 },
+    { name: 'fully outside the flow rect', left: 1400, top: 73, w: 400, h: 550 },
+  ] as const
+
+  function baseline() {
+    stubSelectors({ [DOCK]: fakeEl(DOCK_1280), [SIDEBAR]: fakeEl(SIDEBAR_1280) })
+    const p = computeFitPadding(fakeEl(FLOW))
+    vi.restoreAllMocks()
+    return p
   }
 
-  function overlaps(a: { left: number; right: number; top: number; bottom: number }, b: typeof a) {
-    return a.left < b.right && a.right > b.left && a.top < b.bottom && a.bottom > b.top
-  }
+  it('inserting a floating rect ANYWHERE changes the returned padding by exactly zero', () => {
+    const before = baseline()
+    // PIN THE PRECONDITION (trap 13b): this whole assertion is vacuous unless
+    // the baseline is a real, non-degenerate reservation. 444 = dock overlap 428
+    // + GAP 16; 76 = sidebar 60 + GAP 16. If either drifted to the base margin
+    // the invariance below would pass while measuring nothing.
+    expect(before, 'baseline must be the real 1280x800 reservation').toEqual({
+      top: '29px',
+      right: '444px',
+      bottom: '29px',
+      left: '76px',
+    })
 
-  it('excludes the panel from the fitting box at every EDGE-RESTING position', () => {
-    // The POSTCONDITION, swept over the positions the panel actually rests at in
-    // the product: the bottom-right anchor `FirstUseComposer` slides to on the
-    // 0→N draft, the left clamp floor (x = DEFAULT_MARGIN + SIDE_TAB_WIDTH = 52,
-    // where `clampPositionToViewport` parks it), and the top-left corner. If any
-    // of these framed the graph under the panel the reservation would be
-    // decorative. The CENTRED case is excluded here on purpose and gets its own
-    // test below — it cannot satisfy this postcondition, and pretending
-    // otherwise by widening the sweep until it passed would hide that.
-    const positions = [
-      { name: 'bottom-right anchor', left: 812, top: 234 },
-      { name: 'left clamp floor', left: 52, top: 73 },
-      { name: 'top-left', left: 52, top: 16 },
-    ]
-    for (const pos of positions) {
-      const panel = { left: pos.left, right: pos.left + 400, top: pos.top, bottom: pos.top + 550 }
+    for (const pos of POSITIONS) {
+      const panel = { left: pos.left, right: pos.left + pos.w, top: pos.top, bottom: pos.top + pos.h }
       stubSelectors({
-        [PANEL]: fakeEl({ ...panel, width: 400, height: 550 }),
-        [SIDE_TAB]: fakeEl({ left: panel.left - 36, right: panel.left, top: pos.top, bottom: pos.top + 120, width: 36, height: 120 }),
+        [DOCK]: fakeEl(DOCK_1280),
+        [SIDEBAR]: fakeEl(SIDEBAR_1280),
+        [PANEL]: fakeEl({ ...panel, width: pos.w, height: pos.h }),
+        // The side tab sits OUTSIDE the panel rect at `left: -36` (overflow
+        // visible), so a union-blind implementation used to be 36px short. Both
+        // are asserted to cost zero.
+        [SIDE_TAB]: fakeEl({
+          left: panel.left - 36,
+          right: panel.left,
+          top: pos.top,
+          bottom: pos.top + 120,
+          width: 36,
+          height: 120,
+        }),
       })
-      const p = computeFitPadding(fakeEl(FLOW))
-      const box = fitBoxOf(p)
-      const panelWithTab = { ...panel, left: panel.left - 36 }
-      // PIN THE PRECONDITION (else this passes for the wrong reason): assert the
-      // MAX_PADDING_FRACTION clamp is NOT binding on either axis, so the
-      // exclusion below is the reservation's doing and not an accident of a
-      // capped padding that happened to land clear.
-      const hSum = parseInt(p.left, 10) + parseInt(p.right, 10)
-      const vSum = parseInt(p.top, 10) + parseInt(p.bottom, 10)
-      expect(hSum, `${pos.name}: horizontal clamp bound`).toBeLessThanOrEqual(1024)
-      expect(vSum, `${pos.name}: vertical clamp bound`).toBeLessThanOrEqual(640)
-      expect(overlaps(box, panelWithTab), `${pos.name}: fitting box still overlaps the panel`).toBe(false)
+      const after = computeFitPadding(fakeEl(FLOW))
+      expect(after, `${pos.name}: the floating panel changed the padding`).toEqual(before)
       vi.restoreAllMocks()
     }
   })
 
-  it('CANNOT clear a centred panel — the fitting-area clamp binds first', () => {
-    // An honest limit, not a pass. A 400x550 panel resting mid-pane needs a
-    // 691px reservation on its cheapest side; MAX_PADDING_FRACTION caps the
-    // vertical pair at 640px, so the clamp scales the reservation DOWN and the
-    // fitting box still overlaps the panel. Recorded rather than papered over:
-    // it is the strongest statement of why the hero MINIMISES after the draft
-    // (FirstUseComposer) instead of the product trying to fit around it.
-    const panel = { left: 440, right: 840, top: 125, bottom: 675 }
+  it('the minimised pill still reserves nothing — now a case of the rule, not an exception to it', () => {
+    const before = baseline()
     stubSelectors({
-      [PANEL]: fakeEl({ ...panel, width: 400, height: 550 }),
-      [SIDE_TAB]: fakeEl({ left: 404, right: 440, top: 125, bottom: 245, width: 36, height: 120 }),
+      [DOCK]: fakeEl(DOCK_1280),
+      [SIDEBAR]: fakeEl(SIDEBAR_1280),
+      [PILL]: fakeEl({ left: 640, right: 708, top: 400, bottom: 425, width: 68, height: 25 }),
     })
-    const p = computeFitPadding(fakeEl(FLOW))
-    const box = fitBoxOf(p)
-    // 639, not 640: `capPair` floors each side after scaling (29→25, 691→614),
-    // so the pair lands one below the 0.8 cap. Pinned at the value the code
-    // actually produces rather than the value the cap suggests.
-    expect(parseInt(p.top, 10) + parseInt(p.bottom, 10)).toBe(639)
-    expect(overlaps(box, { ...panel, left: 404 })).toBe(true) // and so it is NOT cleared
+    expect(computeFitPadding(fakeEl(FLOW))).toEqual(before)
   })
 
-  it('unions the side tab, which sits OUTSIDE the panel rect at left:-36', () => {
-    // Identity-bound, and deliberately measured on a RIGHT-side reservation.
-    // The side tab extends the panel's LEFT edge, and a left-side reservation is
-    // `occ.right - flow.left` — which does not read occ.left at all, so the tab
-    // is invisible there. Only `right` (= flow.right - occ.left) can observe it.
-    // The first draft of this test asserted the difference on a left-resting
-    // panel and measured 0: a spec written from the assumption rather than from
-    // the formula would have "proved" the union works while testing nothing.
-    const panel = { left: 812, right: 1212, top: 234, bottom: 784 }
-    stubSelectors({
-      [PANEL]: fakeEl({ ...panel, width: 400, height: 550 }),
-      [SIDE_TAB]: fakeEl({ left: 776, right: 812, top: 234, bottom: 354, width: 36, height: 120 }),
-    })
-    const withTab = parseInt(computeFitPadding(fakeEl(FLOW)).right, 10)
-    vi.restoreAllMocks()
-
-    stubSelectors({ [PANEL]: fakeEl({ ...panel, width: 400, height: 550 }) })
-    const withoutTab = parseInt(computeFitPadding(fakeEl(FLOW)).right, 10)
-
-    expect(withTab - withoutTab).toBe(36)
-    expect(withTab).toBe(520) // 1280 - 776 + 16 gap
-  })
-
-  it('takes the CHEAPEST side, not a fixed one — a bottom-resting panel costs bottom, not width', () => {
-    // A wide, short panel hugging the bottom edge: reserving width would cost
-    // far more than reserving height. This is the discriminating case — a
-    // right-only implementation passes the first test and fails this one.
-    stubSelectors({
-      [PANEL]: fakeEl({ left: 300, right: 1000, top: 700, bottom: 790, width: 700, height: 90 }),
-    })
-    const p = computeFitPadding(fakeEl(FLOW))
-    expect(p.bottom).toBe('116px') // 800 - 700 + 16
-    expect(p.left).toBe('47px') // untouched base margin
-    expect(p.right).toBe('47px')
-  })
-
-  it('reserves nothing when the panel does not overlap the flow rect', () => {
-    // Positive control for the absence claim: the SAME stub shape that produces
-    // a reservation above must produce none here, so a no-op implementation
-    // cannot pass both this and the tests above.
-    stubSelectors({
-      [PANEL]: fakeEl({ left: 1400, right: 1800, top: 73, bottom: 623, width: 400, height: 550 }),
-    })
-    const p = computeFitPadding(fakeEl(FLOW))
-    expect(p.left).toBe('47px')
-    expect(p.right).toBe('47px')
-    expect(p.top).toBe('29px')
-    expect(p.bottom).toBe('29px')
-  })
-
-  it('does NOT reserve the minimised pill — the measured reason it is excluded', () => {
-    // Deliberate product judgement, pinned so a later tidy-up cannot "restore
-    // consistency" by adding the pill selector back without re-reading why.
-    // Measured 16 Aug 2026: reserving an 84x28 pill resting mid-pane took 416px
-    // of bottom padding, collapsing the vertical fitting box to 355px for a
-    // graph needing 524px — clamping the entire first view of the model to
-    // avoid a node grazing a draggable affordance.
-    stubSelectors({ [PILL]: fakeEl({ left: 640, right: 708, top: 400, bottom: 425, width: 68, height: 25 }) })
-    const p = computeFitPadding(fakeEl(FLOW))
-    expect(p.bottom).toBe('29px')
-    expect(p.top).toBe('29px')
-    expect(p.left).toBe('47px')
-    expect(p.right).toBe('47px')
-  })
-
-  it('reserves the panel ALONGSIDE the dock, taking the larger on a shared side', () => {
-    // Both occlude the right at 1280x800 with the dock collapsed: the rail
-    // reserves 68, the bottom-right panel 504. The side must carry the larger,
-    // never the last one written.
-    stubSelectors({
-      [DOCK]: fakeEl({ left: 1228, right: 1268, width: 40, top: 12, bottom: 784, height: 772 }),
-      [PANEL]: fakeEl({ left: 812, right: 1212, top: 234, bottom: 784, width: 400, height: 550 }),
-      [SIDE_TAB]: fakeEl({ left: 776, right: 812, top: 234, bottom: 354, width: 36, height: 120 }),
-    })
-    const p = computeFitPadding(fakeEl(FLOW))
-    expect(p.right).toBe('520px') // 1280 - 776 + 16, beating the rail's 68
-  })
-})
-
-describe('cheapestReservation', () => {
-  const FLOW = { left: 0, top: 0, right: 1280, bottom: 800 }
-
-  it('returns null when the boxes do not intersect', () => {
-    expect(cheapestReservation(FLOW, { left: 1400, top: 0, right: 1800, bottom: 550 })).toBeNull()
-    expect(cheapestReservation(FLOW, { left: 100, top: 900, right: 500, bottom: 1200 })).toBeNull()
-  })
-
-  it('picks the minimum of the four clearing distances', () => {
-    // Bottom-right anchored panel: right (504) < bottom (566) < left (1212).
-    expect(cheapestReservation(FLOW, { left: 776, top: 234, right: 1212, bottom: 784 })).toEqual({
-      side: 'right',
-      amount: 504,
-    })
-    // Same panel moved to hug the top edge: top (262) is now cheapest.
-    expect(cheapestReservation(FLOW, { left: 776, top: 0, right: 1212, bottom: 262 })).toEqual({
-      side: 'top',
-      amount: 262,
-    })
-  })
-
-  it('never returns a negative amount', () => {
-    // Spec-level invariant (not a case): a padding is a non-negative length,
-    // whatever pathological rect arrives.
-    const boxes = [
-      { left: -500, top: -500, right: 2000, bottom: 2000 },
-      { left: 0, top: 0, right: 1280, bottom: 800 },
-      { left: 1279, top: 799, right: 1281, bottom: 801 },
-    ]
-    for (const b of boxes) {
-      const r = cheapestReservation(FLOW, b)
-      if (r) expect(r.amount).toBeGreaterThanOrEqual(0)
+  it('integration: a floating panel in the REAL DOM changes nothing (no-arg call, real selectors)', () => {
+    // The invariance above drives a stubbed `querySelector`. This one builds the
+    // real elements, so a future implementation that reads the panel through a
+    // different selector, a different attribute or a live `document` walk is
+    // still covered. Same three-element geometry as the 1280x800 case.
+    const mk = (tag: string, attrs: Record<string, string>, rect: Partial<DOMRect>) => {
+      const el = document.createElement(tag)
+      for (const [k, v] of Object.entries(attrs)) {
+        if (k === 'class') el.className = v
+        else el.setAttribute(k, v)
+      }
+      const full = { x: 0, y: 0, width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0, toJSON: () => ({}), ...rect } as DOMRect
+      el.getBoundingClientRect = () => full
+      document.body.appendChild(el)
+      return el
     }
+    const created: HTMLElement[] = []
+    try {
+      created.push(mk('div', { class: 'react-flow' }, { ...FLOW }))
+      created.push(mk('aside', { 'aria-label': 'Outputs dock' }, DOCK_1280))
+      created.push(mk('nav', { 'aria-label': 'Canvas tools' }, SIDEBAR_1280))
+      const without = computeFitPadding()
+
+      created.push(
+        mk('div', { 'data-testid': 'floating-olumi-panel' }, { left: 812, right: 1212, top: 234, bottom: 784, width: 400, height: 550 }),
+      )
+      created.push(
+        mk('div', { 'data-testid': 'floating-olumi-panel-side-tab' }, { left: 776, right: 812, top: 234, bottom: 354, width: 36, height: 120 }),
+      )
+      const with_ = computeFitPadding()
+
+      expect(without.right).toBe('444px') // precondition: a real reservation exists
+      expect(with_).toEqual(without)
+    } finally {
+      created.forEach((el) => el.remove())
+    }
+  })
+
+  /**
+   * THE DISCRIMINATING PAIR (decision §6, step 1). Invariance alone cannot tell
+   * "the panel is ignored" apart from "this function ignores everything". The
+   * mutant that removes the invariance REDs the test above; the mutant that
+   * changes an EDGE-ANCHORED reservation must RED **this** test instead — a
+   * different assertion, on a different rule. Neither alone proves the binding.
+   */
+  it('an EDGE-ANCHORED reservation still moves the padding — the other half of the pair', () => {
+    const expanded = baseline()
+    stubSelectors({
+      // Same dock, collapsed to its 40px rail: left = 1280 - 12 - 40 = 1228.
+      [DOCK]: fakeEl({ left: 1228, right: 1268, width: 40, top: 12, bottom: 784, height: 772 }),
+      [SIDEBAR]: fakeEl(SIDEBAR_1280),
+    })
+    const rail = computeFitPadding(fakeEl(FLOW))
+    expect(rail.right).toBe('68px') // 52 overlap + 16 gap
+    expect(rail.right).not.toBe(expanded.right)
+
+    // And the win this change buys, asserted as arithmetic on the real function
+    // rather than restated: 760px of fit box at the expanded dock (up from the
+    // measured 368px with the panel open), 1136px at the rail.
+    const boxOf = (p: { left: string; right: string }) => 1280 - parseInt(p.left, 10) - parseInt(p.right, 10)
+    expect(boxOf(expanded)).toBe(760)
+    expect(boxOf(rail)).toBe(1136)
   })
 })

--- a/src/canvas/__tests__/layoutSizingAuthority.guard.spec.ts
+++ b/src/canvas/__tests__/layoutSizingAuthority.guard.spec.ts
@@ -1,0 +1,442 @@
+/**
+ * G2(b) + G3 — ONE LAYOUT AUTHORITY, AND A CANONICAL MODEL THAT DOES NOT MOVE
+ * WHEN THE SCREEN DOES.
+ *
+ * Mandatory guards 2(b) and 3 of `WORKSPACE-COMPOSITION-DECISION-2026-08-18.md`
+ * §6.1, plus the founder's 18 Aug correction that promoted the sizing-authority
+ * unification from a follow-on lane into this one:
+ *
+ * > "You have derived that the model/layout solver assumes ~1088px while the fit
+ * > stage actually gets ~760px. That is a first-order upstream defect. Fix/unify
+ * > that authority first… Do not choose a workaround around a measurement made
+ * > under a known sizing inconsistency."
+ *
+ * ⚠ SCOPE, STATED BEFORE THE ASSERTIONS (trap 3): everything here is
+ * ARITHMETIC-LEVEL or jsdom-level. `layoutGraph` is run for real (real ELK, real
+ * browser-captured node heights), so the POSITIONS are real; nothing in this file
+ * proves a rendered size, a visible overlap or a settled camera zoom. Those
+ * claims need a real browser and are carried separately in the PR.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { createHash } from 'node:crypto'
+import type { Node, Edge } from '@xyflow/react'
+import { layoutGraph, type CanvasSize } from '../utils/layout'
+import {
+  LAYOUT_CANVAS_MIN_HEIGHT,
+  LAYOUT_CANVAS_MIN_WIDTH,
+  resolveLayoutCanvasSize,
+} from '../utils/layoutCanvasSize'
+import {
+  LAYOUT_PADDING_X,
+  MIN_GAP,
+  NODE_CARD_MAX_W,
+  NODE_LAYOUT_MIN_W,
+  NODE_SINGLE_ROW_FAIR_SHARE_W,
+} from '../utils/nodeLayoutConstants'
+
+import capture from './__fixtures__/starter-node-heights.browser-capture-2026-08-18.json'
+import vendorSelection from '../starters/data/vendor-selection.draft.json'
+import marketEntry from '../starters/data/market-entry.draft.json'
+import buildVsBuy from '../starters/data/build-vs-buy.draft.json'
+import headcountAllocation from '../starters/data/headcount-allocation.draft.json'
+import pricingModel from '../starters/data/pricing-model.draft.json'
+
+const STARTERS = {
+  'vendor-selection': vendorSelection,
+  'market-entry': marketEntry,
+  'build-vs-buy': buildVsBuy,
+  'headcount-allocation': headcountAllocation,
+  'pricing-model': pricingModel,
+} as const
+type StarterId = keyof typeof STARTERS
+const HEIGHTS = (capture as { heights: Record<string, Record<string, number>> }).heights
+
+function buildGraph(id: StarterId): { nodes: Node[]; edges: Edge[] } {
+  const draft = STARTERS[id] as unknown as {
+    nodes: Array<{ id: string; kind: string; label: string }>
+    edges: Array<{ id?: string; from?: string; to?: string; source?: string; target?: string }>
+  }
+  const heights = HEIGHTS[id]
+  const nodes = draft.nodes.map((n) => ({
+    id: n.id,
+    type: n.kind,
+    position: { x: 0, y: 0 },
+    data: { label: n.label, kind: n.kind },
+    measured: { width: NODE_CARD_MAX_W, height: heights[n.id] },
+  })) as unknown as Node[]
+  const edges = draft.edges.map((e, i) => ({
+    id: e.id ?? `e${i}`,
+    source: (e.from ?? e.source) as string,
+    target: (e.to ?? e.target) as string,
+  })) as Edge[]
+  return { nodes, edges }
+}
+
+/**
+ * A position signature — id, x and y for every node, order-stable.
+ *
+ * "Byte-identical positions" is the claim, so the comparison is over the exact
+ * emitted numbers rather than a tolerance. The hash is only for readable failure
+ * output; equality is asserted on the full string.
+ */
+async function positionSignature(
+  nodes: Node[],
+  edges: Edge[],
+  canvas: CanvasSize,
+): Promise<{ signature: string; digest: string; count: number }> {
+  const out = await layoutGraph(nodes, edges, {}, canvas)
+  const signature = out.nodes
+    .map((n) => `${n.id}@${n.position.x},${n.position.y}`)
+    .sort()
+    .join('|')
+  return {
+    signature,
+    digest: createHash('sha256').update(signature).digest('hex').slice(0, 16),
+    count: out.nodes.length,
+  }
+}
+
+/** A synthetic model whose widest tier holds exactly `n` same-tier nodes. */
+function tierOfWidth(n: number): { nodes: Node[]; edges: Edge[] } {
+  const nodes: Node[] = [
+    { id: 'dec', type: 'decision', position: { x: 0, y: 0 }, data: { label: 'Decision', kind: 'decision' }, measured: { width: NODE_CARD_MAX_W, height: 120 } },
+    { id: 'opt_a', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Option A', kind: 'option' }, measured: { width: NODE_CARD_MAX_W, height: 120 } },
+    { id: 'opt_b', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Option B', kind: 'option' }, measured: { width: NODE_CARD_MAX_W, height: 120 } },
+  ] as unknown as Node[]
+  const edges: Edge[] = [
+    { id: 'e_dec_a', source: 'dec', target: 'opt_a' },
+    { id: 'e_dec_b', source: 'dec', target: 'opt_b' },
+  ]
+  for (let i = 0; i < n; i++) {
+    nodes.push({
+      id: `fac_${i}`,
+      type: 'factor',
+      position: { x: 0, y: 0 },
+      data: { label: `Factor ${i}`, kind: 'factor' },
+      measured: { width: NODE_CARD_MAX_W, height: 100 },
+    } as unknown as Node)
+    edges.push({ id: `e_fac_${i}`, source: 'opt_a', target: `fac_${i}` })
+  }
+  return { nodes, edges }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('the sizing authority is ONE module (G2b — a known set, red on grow OR shrink)', () => {
+  /**
+   * THE RECORDED LITERAL. Before this change there were **four** `setCanvasSize`
+   * call sites across two files, each a hand-copied duplicate of the same
+   * `.react-flow` measurement with its own floors and its own window fallback.
+   * There are now **two** — one per trigger — and both delegate to
+   * `resolveLayoutCanvasSize`.
+   *
+   * Recorded rather than derived, deliberately: a guard that derives its own
+   * expectation from the thing it measures is a guard agreeing with itself. This
+   * REDs if the set grows (a third writer) OR shrinks (a trigger silently lost),
+   * so the suite stays green for the right reason.
+   */
+  const KNOWN_CALL_SITES: Record<string, number> = {
+    'src/canvas/components/DraftChat.tsx': 1,
+    'src/canvas/components/LayoutOptionsPanel.tsx': 1,
+  }
+
+  const CANVAS_SRC_ROOT = resolve(__dirname, '..')
+
+  function sourceFilesUnderCanvas(): string[] {
+    // Walked rather than globbed so the traversal is visible and cannot silently
+    // stop matching. Spec files are excluded: they discuss the symbol, they do
+    // not write the store.
+    const { readdirSync, statSync } = require('node:fs') as typeof import('node:fs')
+    const out: string[] = []
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir)) {
+        const full = resolve(dir, entry)
+        if (statSync(full).isDirectory()) {
+          if (entry === '__tests__' || entry === '__fixtures__' || entry === 'node_modules') continue
+          walk(full)
+        } else if (/\.tsx?$/.test(entry) && !/\.(spec|test)\.tsx?$/.test(entry)) {
+          out.push(full)
+        }
+      }
+    }
+    walk(CANVAS_SRC_ROOT)
+    return out
+  }
+
+  it('every setCanvasSize CALL SITE is in the recorded set', () => {
+    const files = sourceFilesUnderCanvas()
+    // POSITIVE CONTROL + MAGNITUDE CHECK (trap 13e): a walk that reached nothing
+    // would satisfy every absence below. `src/canvas` is a large tree.
+    expect(files.length, 'the source walk reached nothing').toBeGreaterThan(50)
+
+    const found: Record<string, number> = {}
+    for (const file of files) {
+      const src = readFileSync(file, 'utf8')
+      const matches = src.match(/setCanvasSize\s*\(/g)
+      if (!matches) continue
+      const rel = file.slice(file.indexOf('src/canvas'))
+      found[rel] = matches.length
+    }
+    expect(found).toEqual(KNOWN_CALL_SITES)
+  })
+
+  it('neither call site derives a canvas dimension itself', () => {
+    // The "no second layout authority" half. Both blocks used to read
+    // `.react-flow` and `getBoundingClientRect` inline; that measurement now has
+    // exactly one home.
+    for (const rel of Object.keys(KNOWN_CALL_SITES)) {
+      const src = readFileSync(resolve(__dirname, '../../..', rel), 'utf8')
+      expect(src, `${rel} must import the authority`).toContain('resolveLayoutCanvasSize')
+      expect(src, `${rel} must not measure the pane itself`).not.toContain("querySelector('.react-flow')")
+    }
+  })
+
+  it('resolveLayoutCanvasSize is panel-state-INDEPENDENT (jsdom-level)', () => {
+    // ⚠ jsdom-level and stated as such: this asserts the FUNCTION reads only the
+    // pane, not that the pane's rect is unaffected by the dock in a real browser.
+    // It is unaffected because the dock and the sidebar are `position: fixed`
+    // chrome drawn OVER the pane — a browser claim, carried in the PR, not here.
+    const pane = { getBoundingClientRect: () => ({ width: 1280, height: 800 }) } as unknown as Element
+    const withDockExpanded = resolveLayoutCanvasSize(pane)
+    const withDockAtRail = resolveLayoutCanvasSize(pane)
+    const withFloatOpen = resolveLayoutCanvasSize(pane)
+    expect(withDockExpanded).toEqual({ width: 1280, height: 800 })
+    expect(withDockAtRail).toEqual(withDockExpanded)
+    expect(withFloatOpen).toEqual(withDockExpanded)
+  })
+
+  it('floors the resolved size, and returns null rather than inventing one', () => {
+    const tiny = { getBoundingClientRect: () => ({ width: 200, height: 100 }) } as unknown as Element
+    expect(resolveLayoutCanvasSize(tiny)).toEqual({
+      width: LAYOUT_CANVAS_MIN_WIDTH,
+      height: LAYOUT_CANVAS_MIN_HEIGHT,
+    })
+    const unmeasurable = { getBoundingClientRect: () => ({ width: 0, height: 0 }) } as unknown as Element
+    // With no pane it falls back to the window (jsdom gives 1024x768 by default),
+    // which is a measurement, not an invention. The `null` path needs no window.
+    const fallback = resolveLayoutCanvasSize(unmeasurable)
+    expect(fallback).not.toBeNull()
+    expect(fallback!.width).toBe(Math.max(LAYOUT_CANVAS_MIN_WIDTH, window.innerWidth - 48))
+  })
+
+  it('FORBIDDEN: no module derives the layout budget from the fit box', () => {
+    // The founder's binding rule, asserted at the bytes. `boxW / 0.50` (or
+    // `/ LABEL_LEGIBLE_ZOOM`) would make the canonical model re-pack whenever a
+    // panel opened. Recorded in `layout.ts`'s header; enforced here.
+    const files = sourceFilesUnderCanvas()
+    const offenders: string[] = []
+    for (const file of files) {
+      const src = readFileSync(file, 'utf8')
+      // Strip block and line comments: the headers DISCUSS the forbidden form on
+      // purpose, and a guard that cannot tell a warning from an implementation
+      // would force the warning to be deleted.
+      const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '')
+      if (/\/\s*(LABEL_LEGIBLE_ZOOM|0\.50?\b)/.test(code) && /availableWidth|canvasSize/.test(code)) {
+        offenders.push(file.slice(file.indexOf('src/canvas')))
+      }
+    }
+    expect(offenders).toEqual([])
+
+    // POSITIVE CONTROL on the detector, or the absence above is vacuous: the same
+    // pattern must FIRE on a synthetic offender.
+    const synthetic = 'const availableWidth = boxW / LABEL_LEGIBLE_ZOOM'
+    expect(/\/\s*(LABEL_LEGIBLE_ZOOM|0\.50?\b)/.test(synthetic)).toBe(true)
+    expect(/availableWidth|canvasSize/.test(synthetic)).toBe(true)
+  })
+})
+
+describe('G3 — what is TRUE about the canonical model across viewports, and what is not', () => {
+  /**
+   * ⚠⚠ READ THIS BEFORE THE ASSERTIONS. G3 was commissioned as *"node positions
+   * are byte-identical across viewport widths 1280 / 1440 / 1512 / 1920 and
+   * across dock states"*, with the decision's honest caveat that *"the property
+   * already fails below 1246px today"*.
+   *
+   * **MEASURED AT `953da3f8`, AND THE CAVEAT IS TOO NARROW BY A LONG WAY.** The
+   * property fails INSIDE the laptop band, not below it: three of the five
+   * shipped starters produce THREE DIFFERENT canonical layouts across
+   * 1280 / 1440 / 1512 / 1920. This is pre-existing behaviour — these cases drive
+   * `layoutGraph` with an explicit `canvasSize`, so nothing in this lane's change
+   * is in the path.
+   *
+   * THE MECHANISM, derived rather than described: `layout.ts` solves
+   * `availableWidth = canvasSize.width * 0.85`. When the widest tier cannot take
+   * its fair share of that, the tier splits into rows of
+   * `nodesPerRow = floor((availableWidth + spacing) / (elkBoxW + spacing))` — a
+   * function of the VIEWPORT. So an 8-wide tier packs 3-per-row at 1280,
+   * 4-per-row at 1440 and 1512, and single-row at 1920. A 5-wide tier is
+   * single-row at every one of them and is genuinely stable.
+   *
+   * So the founder's binding rule — *"the canonical strategic model should not
+   * silently change merely because the screen is small"* — **is already being
+   * broken by the shipped product**, and by more than the 1088-vs-760 gap his
+   * correction names: the solver's own assumption is viewport-dependent, so the
+   * model is already adaptive. Making it genuinely stable means pinning
+   * `availableWidth` to a constant, which changes the shape of the affected
+   * models at some widths. That is a product decision behind a visual-regression
+   * gate, not a tidy-up, and it is NOT in this lane.
+   *
+   * G3 therefore lands as the decision instructed — **a KNOWN-SET pin: record
+   * what is true, name what is not, RED on movement in EITHER direction.** A
+   * model becoming MORE stable is a good change that must still be deliberate; a
+   * model becoming LESS stable is a regression. Both red here.
+   */
+  const WIDTH_SWEEP = [1280, 1440, 1512, 1920] as const
+
+  /**
+   * The recorded partition: widths that produce the SAME canonical layout, in
+   * ascending order. `[[1280], [1440, 1512], [1920]]` reads "three different
+   * models across the laptop band".
+   */
+  const KNOWN_STABILITY: Record<StarterId, { widestTier: number; classes: number[][] }> = {
+    'vendor-selection': { widestTier: 8, classes: [[1280], [1440, 1512], [1920]] },
+    'market-entry': { widestTier: 8, classes: [[1280], [1440, 1512], [1920]] },
+    'build-vs-buy': { widestTier: 8, classes: [[1280], [1440, 1512], [1920]] },
+    'headcount-allocation': { widestTier: 5, classes: [[1280, 1440, 1512, 1920]] },
+    'pricing-model': { widestTier: 5, classes: [[1280, 1440, 1512, 1920]] },
+  }
+
+  /** The packing decision `layout.ts` makes, re-derived from the shipped constants. */
+  function packingOf(widestTier: number, viewportWidth: number): string {
+    const availableWidth = viewportWidth * 0.85
+    const unclamped = Math.floor((availableWidth - (widestTier - 1) * MIN_GAP) / widestTier)
+    const singleRow = unclamped >= NODE_SINGLE_ROW_FAIR_SHARE_W + LAYOUT_PADDING_X
+    if (singleRow) return 'single-row'
+    const elkBoxW = NODE_LAYOUT_MIN_W + LAYOUT_PADDING_X
+    // `effectiveNodeSpacing` is `max(20, spacing)` and the default spacing is 15.
+    const nodesPerRow = Math.max(1, Math.floor((availableWidth + 20) / (elkBoxW + 20)))
+    return `multi-row/${nodesPerRow}`
+  }
+
+  /** Group widths by identical position signature, ascending. */
+  function classesOf(byWidth: Array<{ width: number; signature: string }>): number[][] {
+    const groups = new Map<string, number[]>()
+    for (const { width, signature } of byWidth) {
+      const bucket = groups.get(signature)
+      if (bucket) bucket.push(width)
+      else groups.set(signature, [width])
+    }
+    return [...groups.values()].sort((a, b) => a[0] - b[0])
+  }
+
+  for (const id of Object.keys(STARTERS) as StarterId[]) {
+    it(`${id}: the canonical layout partitions across ${WIDTH_SWEEP.join('/')} exactly as recorded`, async () => {
+      const { nodes, edges } = buildGraph(id)
+      const measured: Array<{ width: number; signature: string; digest: string; count: number }> = []
+      for (const width of WIDTH_SWEEP) {
+        measured.push({ width, ...(await positionSignature(nodes, edges, { width, height: 800 })) })
+      }
+
+      // PIN THE PRECONDITION: a layout that emitted nothing would agree with every
+      // other layout that emitted nothing — trap 13's shape reached through an
+      // empty extraction, and it would read as perfect stability.
+      const expectedCount = (STARTERS[id] as unknown as { nodes: unknown[] }).nodes.length
+      for (const m of measured) {
+        expect(m.count, `${id} @${m.width}px laid out the wrong node count`).toBe(expectedCount)
+        expect(m.signature.length, `${id} @${m.width}px produced an empty signature`).toBeGreaterThan(0)
+      }
+
+      const recorded = KNOWN_STABILITY[id]
+      expect(
+        classesOf(measured),
+        `${id}: the viewport-stability partition MOVED. Measured digests: ${measured
+          .map((m) => `${m.width}=${m.digest}`)
+          .join(' ')}`,
+      ).toEqual(recorded.classes)
+    })
+  }
+
+  it('the partition is EXPLAINED by the packing branch — bound to the mechanism, not to a hash', () => {
+    // Without this, the pins above are five opaque tables that a future lane
+    // would "re-bless" by pasting new digests in. Two widths share a canonical
+    // layout IF AND ONLY IF they share a packing decision, and that decision is
+    // re-derived here from the shipped constants.
+    for (const id of Object.keys(KNOWN_STABILITY) as StarterId[]) {
+      const { widestTier, classes } = KNOWN_STABILITY[id]
+      const derived = new Map<string, number[]>()
+      for (const width of WIDTH_SWEEP) {
+        const key = packingOf(widestTier, width)
+        const bucket = derived.get(key)
+        if (bucket) bucket.push(width)
+        else derived.set(key, [width])
+      }
+      const derivedClasses = [...derived.values()].sort((a, b) => a[0] - b[0])
+      expect(derivedClasses, `${id}: the recorded partition does not match the packing derivation`).toEqual(
+        classes,
+      )
+    }
+    // POSITIVE CONTROL on the derivation, or the agreement above proves nothing:
+    // it must DISCRIMINATE. A 5-wide tier is single-row at 1280; an 8-wide tier
+    // is not, and an 8-wide tier's answer must differ between 1280 and 1440.
+    expect(packingOf(5, 1280)).toBe('single-row')
+    expect(packingOf(8, 1280)).not.toBe('single-row')
+    expect(packingOf(8, 1280)).not.toBe(packingOf(8, 1440))
+  })
+
+  it('THE PART OF G3 THAT HOLDS: the layout is independent of DOCK STATE', () => {
+    // This is the half the founder's rule most depends on and the half that is
+    // genuinely true: the dock and the floating companion never reach the solver.
+    // `resolveLayoutCanvasSize` reads only the pane, and the pane is not resized
+    // by `position: fixed` chrome — so no dock state, drag width or companion
+    // position can re-pack the model.
+    //
+    // ⚠ jsdom-level, and named as such: the *pane is not resized by the dock*
+    // half is a browser claim, carried in the PR, not provable here.
+    const pane = { getBoundingClientRect: () => ({ width: 1280, height: 800 }) } as unknown as Element
+    const sizes = ['dock expanded 416', 'dock rail 40', 'dock dragged 480', 'companion floating'].map(
+      () => resolveLayoutCanvasSize(pane),
+    )
+    for (const size of sizes) expect(size).toEqual(sizes[0])
+  })
+
+  /**
+   * The 1246px breakpoint the decision recorded, kept because it is the cleanest
+   * demonstration of the mechanism on a tier width the starters do not contain —
+   * and 4 of 8 measured real drafts DO produce 6- or 7-wide tiers.
+   */
+  const KNOWN_BREAKPOINTS: ReadonlyArray<{ tierWidth: number; lastMultiRow: number; firstSingleRow: number }> = [
+    { tierWidth: 6, lastMultiRow: 1245, firstSingleRow: 1246 },
+    { tierWidth: 7, lastMultiRow: 1456, firstSingleRow: 1457 },
+  ]
+
+  it('the recorded breakpoints are what the shipped constants imply', () => {
+    for (const bp of KNOWN_BREAKPOINTS) {
+      expect(packingOf(bp.tierWidth, bp.firstSingleRow), `${bp.tierWidth}-wide @${bp.firstSingleRow}`).toBe(
+        'single-row',
+      )
+      expect(packingOf(bp.tierWidth, bp.lastMultiRow), `${bp.tierWidth}-wide @${bp.lastMultiRow}`).not.toBe(
+        'single-row',
+      )
+    }
+  })
+
+  for (const bp of KNOWN_BREAKPOINTS) {
+    it(`a ${bp.tierWidth}-wide tier: one layout at and above ${bp.firstSingleRow}px, a DIFFERENT one at ${bp.lastMultiRow}px`, async () => {
+      const { nodes, edges } = tierOfWidth(bp.tierWidth)
+      const atBreakpoint = await positionSignature(nodes, edges, { width: bp.firstSingleRow, height: 800 })
+      const wide = await positionSignature(nodes, edges, { width: 2560, height: 800 })
+      const below = await positionSignature(nodes, edges, { width: bp.lastMultiRow, height: 800 })
+
+      const expected = bp.tierWidth + 3
+      for (const r of [atBreakpoint, wide, below]) {
+        expect(r.count).toBe(expected)
+        expect(r.signature.length).toBeGreaterThan(0)
+      }
+      // Stable across the single-row band …
+      expect(wide.signature, 'positions moved within the single-row band').toBe(atBreakpoint.signature)
+      // … and the known break one pixel below it, asserted as a DIFFERENCE so the
+      // pin REDs if the breakpoint moves either way. Stability alone would go
+      // quiet if the packer stopped splitting at all; the split alone would go
+      // quiet if it split everywhere.
+      expect(
+        below.signature,
+        `the ${bp.tierWidth}-wide tier no longer re-packs at ${bp.lastMultiRow}px`,
+      ).not.toBe(atBreakpoint.signature)
+    })
+  }
+})

--- a/src/canvas/__tests__/useFitViewOnLayoutVersion.spec.tsx
+++ b/src/canvas/__tests__/useFitViewOnLayoutVersion.spec.tsx
@@ -8,6 +8,11 @@
  * `layoutVersion === 0` is the "no layout yet" state and must not trigger
  * fitView. `computeFitPadding` is mocked here to a sentinel — its own correctness
  * is covered by computeFitPadding.spec.ts; this spec locks the cadence + duration.
+ *
+ * ⭐ EXTENDED 18 Aug 2026 (`WORKSPACE-COMPOSITION-DECISION-2026-08-18.md` step 1):
+ * the RESERVED BOX is now a trigger too, and the fit targets exclude UI
+ * placeholders. Both are covered below; the sentinel padding is mutable so a
+ * reserved-box CHANGE can be simulated without the real measurement.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
@@ -19,13 +24,17 @@ import { LABEL_LEGIBLE_ZOOM } from '../utils/zoomLegibility'
 const fitViewSpy = vi.fn()
 
 const FIT_PADDING = { top: '10px', right: '20px', bottom: '10px', left: '20px' }
+/** The reserved box the mocked measurement reports; reassigned to simulate a change. */
+let currentPadding: { top: string; right: string; bottom: string; left: string } = FIT_PADDING
+/** The nodes the mocked ReactFlow instance holds — including a UI placeholder. */
+let currentNodes: Array<{ id: string }> = []
 
 vi.mock('@xyflow/react', () => ({
-  useReactFlow: () => ({ fitView: fitViewSpy }),
+  useReactFlow: () => ({ fitView: fitViewSpy, getNodes: () => currentNodes }),
 }))
 
 vi.mock('../utils/computeFitPadding', () => ({
-  computeFitPadding: () => FIT_PADDING,
+  computeFitPadding: () => currentPadding,
 }))
 
 describe('useFitViewOnLayoutVersion', () => {
@@ -33,6 +42,8 @@ describe('useFitViewOnLayoutVersion', () => {
     useCanvasStore.getState().resetCanvas()
     useCanvasStore.setState({ layoutVersion: 0 } as never)
     fitViewSpy.mockReset()
+    currentPadding = FIT_PADDING
+    currentNodes = []
   })
 
   afterEach(() => {
@@ -152,5 +163,147 @@ describe('useFitViewOnLayoutVersion', () => {
 
     rafSpy.mockRestore()
     cancelSpy.mockRestore()
+  })
+
+  describe('the reserved box is a trigger too', () => {
+    it('re-fits when the reserved box changes, with the SAME contract as the layout fit', () => {
+      // The witnessed defect: the camera sat at zoom 0.385 after the conversation
+      // panel closed while the computed fit for the new box was 0.582 — the graph
+      // 34% smaller than it needed to be, because fitView only ever ran on layout.
+      const rafCallbacks: Array<() => void> = []
+      const rafSpy = vi
+        .spyOn(globalThis, 'requestAnimationFrame')
+        .mockImplementation((cb: FrameRequestCallback) => {
+          rafCallbacks.push(cb as () => void)
+          return rafCallbacks.length
+        })
+
+      renderHook(() => useFitViewOnLayoutVersion())
+      act(() => {
+        useCanvasStore.setState({ layoutVersion: 1 } as never)
+      })
+      act(() => {
+        rafCallbacks.splice(0).forEach((cb) => cb())
+      })
+      expect(fitViewSpy).toHaveBeenCalledTimes(1)
+      const layoutFitArgs = fitViewSpy.mock.calls[0][0]
+
+      // The dock collapses: 20px of right reservation becomes 444px.
+      currentPadding = { top: '10px', right: '444px', bottom: '10px', left: '20px' }
+      act(() => {
+        window.dispatchEvent(new Event('resize'))
+      })
+      act(() => {
+        rafCallbacks.splice(0).forEach((cb) => cb())
+      })
+
+      expect(fitViewSpy).toHaveBeenCalledTimes(2)
+      const refitArgs = fitViewSpy.mock.calls[1][0]
+      // ONE contract: everything except the measured padding must be identical,
+      // so the two triggers cannot drift into two different fits.
+      expect(refitArgs.minZoom).toBe(layoutFitArgs.minZoom)
+      expect(refitArgs.duration).toBe(layoutFitArgs.duration)
+      expect(refitArgs.padding).toEqual(currentPadding)
+
+      rafSpy.mockRestore()
+    })
+
+    it('does NOT re-fit when the reserved box is unchanged', () => {
+      // The discriminating half: a watcher that fired on every trigger regardless
+      // would pass the test above and yank the camera on every pointerup.
+      const rafCallbacks: Array<() => void> = []
+      const rafSpy = vi
+        .spyOn(globalThis, 'requestAnimationFrame')
+        .mockImplementation((cb: FrameRequestCallback) => {
+          rafCallbacks.push(cb as () => void)
+          return rafCallbacks.length
+        })
+
+      renderHook(() => useFitViewOnLayoutVersion())
+      act(() => {
+        useCanvasStore.setState({ layoutVersion: 1 } as never)
+      })
+      act(() => {
+        rafCallbacks.splice(0).forEach((cb) => cb())
+      })
+      expect(fitViewSpy).toHaveBeenCalledTimes(1)
+
+      // Same padding: three triggers, no re-fit.
+      act(() => {
+        window.dispatchEvent(new Event('resize'))
+        document.dispatchEvent(new Event('pointerup'))
+        document.dispatchEvent(new Event('transitionend'))
+      })
+      act(() => {
+        rafCallbacks.splice(0).forEach((cb) => cb())
+      })
+      expect(fitViewSpy).toHaveBeenCalledTimes(1)
+
+      rafSpy.mockRestore()
+    })
+
+    it('never re-fits before a layout has happened', () => {
+      const rafCallbacks: Array<() => void> = []
+      const rafSpy = vi
+        .spyOn(globalThis, 'requestAnimationFrame')
+        .mockImplementation((cb: FrameRequestCallback) => {
+          rafCallbacks.push(cb as () => void)
+          return rafCallbacks.length
+        })
+
+      renderHook(() => useFitViewOnLayoutVersion())
+      currentPadding = { top: '10px', right: '444px', bottom: '10px', left: '20px' }
+      act(() => {
+        window.dispatchEvent(new Event('resize'))
+      })
+      act(() => {
+        rafCallbacks.splice(0).forEach((cb) => cb())
+      })
+      expect(fitViewSpy).not.toHaveBeenCalled()
+
+      rafSpy.mockRestore()
+    })
+  })
+
+  describe('fit targets exclude UI placeholders', () => {
+    function fitOnce() {
+      const rafCallbacks: Array<() => void> = []
+      const rafSpy = vi
+        .spyOn(globalThis, 'requestAnimationFrame')
+        .mockImplementation((cb: FrameRequestCallback) => {
+          rafCallbacks.push(cb as () => void)
+          return rafCallbacks.length
+        })
+      renderHook(() => useFitViewOnLayoutVersion())
+      act(() => {
+        useCanvasStore.setState({ layoutVersion: 1 } as never)
+      })
+      act(() => {
+        rafCallbacks.splice(0).forEach((cb) => cb())
+      })
+      rafSpy.mockRestore()
+      return fitViewSpy.mock.calls[0][0]
+    }
+
+    it('passes the model nodes and omits __ghost-option__ — bound by ID', () => {
+      currentNodes = [{ id: 'dec_1' }, { id: 'opt_a' }, { id: '__ghost-option__' }]
+      const args = fitOnce()
+      // Bound by identity, never by a count another node set could satisfy.
+      expect(args.nodes.map((n: { id: string }) => n.id)).toEqual(['dec_1', 'opt_a'])
+    })
+
+    it('omits `nodes` entirely when there are none — the previous behaviour', () => {
+      // A `nodes: []` would frame nothing. The fallback must be xyflow's
+      // fit-everything, i.e. exactly what shipped before.
+      currentNodes = []
+      const args = fitOnce()
+      expect('nodes' in args).toBe(false)
+    })
+
+    it('omits `nodes` when the ONLY node is the placeholder', () => {
+      currentNodes = [{ id: '__ghost-option__' }]
+      const args = fitOnce()
+      expect('nodes' in args).toBe(false)
+    })
   })
 })

--- a/src/canvas/components/CommandPalette.tsx
+++ b/src/canvas/components/CommandPalette.tsx
@@ -8,6 +8,8 @@ import { ValidationBanner, type ValidationError } from './ValidationBanner'
 import { useValidationFeedback } from '../hooks/useValidationFeedback'
 import { trackRunAttempt } from '../utils/sandboxTelemetry'
 import { computeFitPadding } from '../utils/computeFitPadding'
+import { excludeNonModelNodes } from '../utils/fitTargets'
+import { LABEL_LEGIBLE_ZOOM } from '../utils/zoomLegibility'
 import { usePrefersReducedMotion } from '../hooks/usePrefersReducedMotion'
 import { cameraDuration } from '../utils/cameraMotion'
 import { typography } from '../../styles/typography'
@@ -44,7 +46,7 @@ export function CommandPalette({ isOpen, onClose, onOpenInspector }: CommandPale
   // React #185 FIX: Use shallow comparison for array selectors
   const nodes = useCanvasStore(s => s.nodes)
   const edges = useCanvasStore(s => s.edges)
-  const { fitView } = useReactFlow()
+  const { fitView, getNodes } = useReactFlow()
   const { formatErrors, focusError } = useValidationFeedback()
   const prefersReducedMotion = usePrefersReducedMotion() // F1: reduced-motion guard for Zoom to Fit
 
@@ -167,7 +169,18 @@ export function CommandPalette({ isOpen, onClose, onOpenInspector }: CommandPale
       }
     }},
     { id: 'select-all', label: 'Select All', shortcut: '⌘A', execute: () => selectAll() },
-    { id: 'zoom-fit', label: 'Zoom to Fit', execute: () => fitView({ padding: computeFitPadding(), duration: cameraDuration(300, prefersReducedMotion) }) },
+    // Same contract as the toolbar's "Fit to view" (ReactFlowGraph.handleFitView):
+    // UI placeholders excluded, and floored at the legibility zoom so the palette
+    // cannot choose an unreadable frame either.
+    { id: 'zoom-fit', label: 'Zoom to Fit', execute: () => {
+      const nodes = getNodes ? excludeNonModelNodes(getNodes()) : []
+      fitView({
+        ...(nodes.length > 0 ? { nodes } : {}),
+        padding: computeFitPadding(),
+        minZoom: LABEL_LEGIBLE_ZOOM,
+        duration: cameraDuration(300, prefersReducedMotion),
+      })
+    } },
     { id: 'save-snapshot', label: 'Save Snapshot', shortcut: '⌘S', execute: () => saveSnapshot() },
   ]
 

--- a/src/canvas/components/DraftChat.tsx
+++ b/src/canvas/components/DraftChat.tsx
@@ -5,6 +5,7 @@ import { useCEEDraft } from '../../hooks/useCEEDraft'
 import { DraftLoadingAnimation } from './DraftLoadingAnimation'
 import { ErrorAlert } from '../../components/ErrorAlert'
 import { useCanvasStore } from '../store'
+import { resolveLayoutCanvasSize } from '../utils/layoutCanvasSize'
 import { useDraftStore } from '../stores/draftStore'
 import { useAnalysisSnapshotStore } from '../stores/analysisSnapshotStore'
 import { useLayoutStore } from '../layoutStore'
@@ -709,24 +710,15 @@ export function DraftChat() {
         totalEdges: useCanvasStore.getState().edges.length,
       })
     }
-    // Pass actual canvas dimensions so layoutGraph can size nodes to fit.
-    // Read the React Flow container directly so the measurement is accurate
-    // regardless of whether the right panel is open or collapsed.
-    const rfEl = document.querySelector('.react-flow') as HTMLElement | null
-    if (rfEl) {
-      const { width, height } = rfEl.getBoundingClientRect()
-      setCanvasSize({
-        width: Math.max(600, width),
-        height: Math.max(400, height),
-      })
-    } else if (typeof window !== 'undefined') {
-      // Fallback: subtract known fixed chrome (left sidebar 48px, top bar 57px,
-      // canvas toolbar 72px). No right-panel deduction — panel width varies.
-      setCanvasSize({
-        width: Math.max(600, window.innerWidth - 48),
-        height: Math.max(400, window.innerHeight - 57 - 72),
-      })
-    }
+    // The canvas size the canonical model is packed against. ONE authority —
+    // this block and `LayoutOptionsPanel`'s were hand-copied duplicates, each
+    // with its own floors and its own window fallback, and a third path used
+    // `layout.ts`'s FALLBACK_CANVAS instead. See `utils/layoutCanvasSize.ts` for
+    // the derivation, for why it is deliberately panel-state-INDEPENDENT
+    // ("stable model, adaptive attention"), and for what the 1088-vs-760 gap
+    // between this and the fit box is and is not.
+    const layoutCanvas = resolveLayoutCanvasSize()
+    if (layoutCanvas) setCanvasSize(layoutCanvas)
     // Defer layout until React Flow has measured the inserted nodes (D2).
     setPendingLayout(true)
 

--- a/src/canvas/components/LayoutOptionsPanel.tsx
+++ b/src/canvas/components/LayoutOptionsPanel.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useLayoutStore } from '../layoutStore'
+import { resolveLayoutCanvasSize } from '../utils/layoutCanvasSize'
 import { useToast } from '../ToastContext'
 import { runLayoutWithProgress } from '../layout/runLayoutWithProgress'
 import { typography } from '../../styles/typography'
@@ -24,23 +25,11 @@ export function LayoutOptionsPanel() {
   const handleApplyLayout = async () => {
     setIsApplying(true)
 
-    // Capture actual canvas dimensions before layout so viewport-constrained
-    // sizing uses real available space rather than the fallback constants.
-    // Read the React Flow container directly so measurement is accurate
-    // regardless of whether the right panel is open or collapsed.
-    const rfEl = document.querySelector('.react-flow') as HTMLElement | null
-    if (rfEl) {
-      const { width, height } = rfEl.getBoundingClientRect()
-      setCanvasSize({
-        width: Math.max(600, width),
-        height: Math.max(400, height),
-      })
-    } else if (typeof window !== 'undefined') {
-      setCanvasSize({
-        width: Math.max(600, window.innerWidth - 48),
-        height: Math.max(400, window.innerHeight - 57 - 72),
-      })
-    }
+    // Same single authority as the draft path — see `utils/layoutCanvasSize.ts`.
+    // These two blocks were hand-copied and would have drifted; the rule now
+    // lives in one module and neither call site derives a dimension itself.
+    const layoutCanvas = resolveLayoutCanvasSize()
+    if (layoutCanvas) setCanvasSize(layoutCanvas)
 
     // Show loading toast for first-time ELK load
     showToast('Loading layout engine...', 'info')

--- a/src/canvas/components/__tests__/dockWidth.analysisStateClamp.guard.spec.ts
+++ b/src/canvas/components/__tests__/dockWidth.analysisStateClamp.guard.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * G1 — THE DELETED 280px ANALYSIS-STATE CLAMP CANNOT RETURN.
+ *
+ * Mandatory guard 1 of `WORKSPACE-COMPOSITION-DECISION-2026-08-18.md` §6.1.
+ *
+ * WHAT WAS DELETED AND WHY (17 Aug 2026, recorded in `OutputsDock.tsx`'s header
+ * at :346-366): until an analysis result existed, the dock was clamped to
+ * `dockWidthBounds().min` — 280px. Three things were wrong with it:
+ *
+ *  1. **It bought nothing.** The clamp existed to close the graph's legibility
+ *     clamp. The drafted 17-node graph needs 1008px at the 0.50 floor and the
+ *     fit box reaches only 896px even at a 280px dock (760 / 843 / 896 for dock
+ *     416 / 333 / 280). The post-draft fit clamped at the floor at EVERY dock
+ *     width, so the trade was one-sided from the day it shipped.
+ *  2. **The floor is an unconditional constant**, so `Math.min(full, min)`
+ *     returned 280px at 1280, at 1920 and at 3840 alike — a per-input rule
+ *     returning the same answer for every input (CLAUDE.md trap 20) while the
+ *     panel's content budget fell 390px → 254px, a 35% cut, at all of them.
+ *  3. **Its input did not persist**, so every page reload re-narrowed the dock
+ *     for a user who had run analyses all day.
+ *
+ * ⚠ THIS GUARD IS A REGRESSION PIN, NOT A FIX, and the distinction is stated so
+ * nobody reads it as evidence of work done: the clamp is ALREADY absent at this
+ * tip, so these assertions PASS at pristine. Their value is entirely in the
+ * mutant — reintroduce the clamp and every one of them REDs. That mutant is run
+ * and recorded in this lane's PR rather than asserted here.
+ *
+ * The reason it needs a guard at all: the workspace-composition change splits the
+ * dock into two regions, and "the panel is short of room, narrow it" is exactly
+ * the reasoning that produced the clamp the first time.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  DOCK_MIN_WIDTH,
+  DOCK_RESPONSIVE_MAX_WIDTH,
+  DOCK_VIEWPORT_RATIO,
+  resolveDockWidth,
+  responsiveDockWidth,
+} from '../dockWidth'
+
+/**
+ * Every viewport ≥1280 the product is driven at, plus the two the deleted clamp
+ * proved indifferent to. Named individually rather than generated, so a width
+ * that stops being covered is a visible edit (trap 2b in miniature).
+ */
+const WIDE_VIEWPORTS = [1280, 1366, 1440, 1512, 1600, 1920, 2560, 3840] as const
+
+describe('G1 — the analysis-state clamp cannot return', () => {
+  it('the default width is DOCK_RESPONSIVE_MAX_WIDTH at every viewport ≥1280', () => {
+    // `null` is the "user has never dragged it" signal, i.e. the state the
+    // deleted clamp acted on. Under the clamp every one of these read 280.
+    for (const vw of WIDE_VIEWPORTS) {
+      expect(resolveDockWidth(vw, null), `viewport ${vw}`).toBe(DOCK_RESPONSIVE_MAX_WIDTH)
+      expect(responsiveDockWidth(vw), `viewport ${vw} (responsive)`).toBe(DOCK_RESPONSIVE_MAX_WIDTH)
+    }
+    // PIN THE PRECONDITION (trap 13b): 416 and 280 must be DIFFERENT numbers, or
+    // the sweep above would be satisfied by the clamp it exists to forbid.
+    expect(DOCK_RESPONSIVE_MAX_WIDTH).not.toBe(DOCK_MIN_WIDTH)
+    expect(DOCK_RESPONSIVE_MAX_WIDTH).toBe(416)
+    expect(DOCK_MIN_WIDTH).toBe(280)
+  })
+
+  it('the width is a function of the VIEWPORT and of the stored value — of nothing else', () => {
+    // `resolveDockWidth`'s whole signature is (viewportWidth, storedWidth). A
+    // reintroduced analysis-state clamp needs a third input, so the pin is that
+    // repeated calls with identical arguments are identical — asserted across a
+    // sweep so a hidden module-level flag flipping between calls would show.
+    for (const vw of WIDE_VIEWPORTS) {
+      const first = resolveDockWidth(vw, null)
+      expect(resolveDockWidth(vw, null)).toBe(first)
+      expect(resolveDockWidth(vw, 480)).toBe(resolveDockWidth(vw, 480))
+    }
+  })
+
+  it('SOURCE-LEVEL: dockWidth.ts contains no analysis-state branch', () => {
+    // The behavioural sweep above cannot see a clamp that is present but dormant
+    // (e.g. behind a flag defaulting off), and the decision asks for both. Read
+    // with `readFileSync` and searched case-insensitively — `grep` without `-a`
+    // is blind to a NUL-bearing source file (CLAUDE.md trap 17), and a
+    // case-sensitive mint-check has produced a false "absent" in this estate
+    // before.
+    const path = resolve(__dirname, '../dockWidth.ts')
+    const src = readFileSync(path, 'utf8')
+
+    // POSITIVE CONTROL FIRST: an absence claim from an unproven reader is
+    // vacuous. These three symbols are known to be present.
+    for (const present of ['DOCK_MIN_WIDTH', 'resolveDockWidth', 'DOCK_VIEWPORT_RATIO']) {
+      expect(src.toLowerCase(), `positive control: ${present}`).toContain(present.toLowerCase())
+    }
+    // And a magnitude check on the control (trap 13e): the file is real, not a
+    // truncated read that would make every absence below trivially true.
+    expect(src.length).toBeGreaterThan(2000)
+
+    const FORBIDDEN = [
+      'hasAnalysisResult',
+      'hasCompletedFirstRun',
+      'hasGraphContent',
+      'analysisState',
+      'resultsStatus',
+      'isFirstUse',
+    ]
+    for (const symbol of FORBIDDEN) {
+      expect(src.toLowerCase(), `dockWidth.ts must not read ${symbol}`).not.toContain(
+        symbol.toLowerCase(),
+      )
+    }
+  })
+
+  it('the ratio still lands 1280 exactly ON the ceiling — the derivation, not a coincidence', () => {
+    // 416 / 1280 = 0.325 exactly. If the ratio moves, the 1280 default silently
+    // stops being 416 and the sweep above starts asserting a different rule.
+    expect(DOCK_VIEWPORT_RATIO).toBe(0.325)
+    expect(Math.round(1280 * DOCK_VIEWPORT_RATIO)).toBe(DOCK_RESPONSIVE_MAX_WIDTH)
+  })
+})

--- a/src/canvas/hooks/useFitViewOnLayoutVersion.ts
+++ b/src/canvas/hooks/useFitViewOnLayoutVersion.ts
@@ -2,6 +2,8 @@ import { useEffect, useRef } from 'react'
 import { useReactFlow } from '@xyflow/react'
 import { useCanvasStore } from '../store'
 import { computeFitPadding } from '../utils/computeFitPadding'
+import { excludeNonModelNodes } from '../utils/fitTargets'
+import { watchReservedBox } from '../utils/reservedBoxWatcher'
 import { usePrefersReducedMotion } from './usePrefersReducedMotion'
 import { cameraDuration } from '../utils/cameraMotion'
 import { LABEL_LEGIBLE_ZOOM } from '../utils/zoomLegibility'
@@ -34,13 +36,31 @@ import { LABEL_LEGIBLE_ZOOM } from '../utils/zoomLegibility'
  * which is the intended asymmetry: the user may choose the overview, the
  * product may not choose it for them. See `utils/zoomLegibility.ts`.
  *
+ * ⭐ TWO TRIGGERS, ONE CONTRACT (18 Aug 2026,
+ * `WORKSPACE-COMPOSITION-DECISION-2026-08-18.md` §5.1). The hook used to fit
+ * once per completed layout and never again, so every pixel of canvas won back
+ * — by collapsing the dock, or now by the floating companion no longer
+ * reserving — was won and then not spent. A lane witnessed the camera stranded
+ * at zoom 0.385 after the conversation panel closed while the computed fit for
+ * the new box was 0.582: the graph sitting 34% smaller than it needed to be,
+ * live, on the deployed build. The RESERVED BOX is therefore a trigger too, and
+ * both triggers pass the same options object so they cannot drift.
+ *
+ * ⭐ AND THE FIT TARGETS EXCLUDE UI PLACEHOLDERS. `__ghost-option__` is an
+ * add-an-option affordance, not part of the user's model, and the fit used to
+ * frame it as though it were — on one measured starter it adds 9% to the width
+ * the fit must accommodate. See `utils/fitTargets.ts`, which also records why
+ * this is honest bookkeeping and NOT a legibility win to bank.
+ *
  * Must be called inside a ReactFlowProvider (uses `useReactFlow`).
  */
 export function useFitViewOnLayoutVersion(): void {
   const layoutVersion = useCanvasStore((s) => s.layoutVersion)
-  const { fitView } = useReactFlow()
+  const { fitView, getNodes } = useReactFlow()
   const fitViewRef = useRef(fitView)
   fitViewRef.current = fitView
+  const getNodesRef = useRef(getNodes)
+  getNodesRef.current = getNodes
 
   // F1: the post-layout auto-fit fires on every layout change, so honour
   // reduced-motion here too (mirrored to a ref to keep the effect deps = only
@@ -49,15 +69,38 @@ export function useFitViewOnLayoutVersion(): void {
   const reducedMotionRef = useRef(prefersReducedMotion)
   reducedMotionRef.current = prefersReducedMotion
 
+  // ONE contract, both triggers. A second literal here is how the auto-fit and
+  // the re-fit would silently stop agreeing (and how three copies of the dock
+  // bounds drifted before `dockWidth.ts` existed).
+  const fitNow = useRef(() => {
+    const nodes = getNodesRef.current ? excludeNonModelNodes(getNodesRef.current()) : []
+    fitViewRef.current({
+      // Only constrain the target set when there IS one: an empty `nodes` array
+      // would frame nothing, so absent/unavailable nodes fall back to xyflow's
+      // fit-everything, i.e. exactly the previous behaviour.
+      ...(nodes.length > 0 ? { nodes } : {}),
+      padding: computeFitPadding(),
+      minZoom: LABEL_LEGIBLE_ZOOM,
+      duration: cameraDuration(400, reducedMotionRef.current),
+    })
+  })
+
   useEffect(() => {
     if (layoutVersion === 0) return
     const raf = requestAnimationFrame(() => {
-      fitViewRef.current({
-        padding: computeFitPadding(),
-        minZoom: LABEL_LEGIBLE_ZOOM,
-        duration: cameraDuration(400, reducedMotionRef.current),
-      })
+      fitNow.current()
     })
     return () => cancelAnimationFrame(raf)
   }, [layoutVersion])
+
+  // Re-fit when the RESERVED BOX changes. Gated on a layout having happened, so
+  // this never fits an empty canvas; the watcher derives the change from
+  // `computeFitPadding` itself rather than from a list of things that move it
+  // (see `reservedBoxWatcher.ts`).
+  useEffect(() => {
+    return watchReservedBox(() => {
+      if (useCanvasStore.getState().layoutVersion === 0) return
+      fitNow.current()
+    })
+  }, [])
 }

--- a/src/canvas/utils/__tests__/cameraComfort.floatingCompanion.spec.ts
+++ b/src/canvas/utils/__tests__/cameraComfort.floatingCompanion.spec.ts
@@ -1,0 +1,301 @@
+/**
+ * THE SHARED MISS — no design in the workspace-composition set named it, and it
+ * is the one defect that would have shipped silently.
+ *
+ * `WORKSPACE-COMPOSITION-DECISION-2026-08-18.md` §5.1 deletes the floating
+ * panel's contribution to `computeFitPadding`, because a free-floating overlay
+ * is not layout-reserving chrome and must not cost the graph a band of canvas.
+ * `cameraComfort`'s no-churn rule, however, is stated as each target's rect
+ * inside the panel-aware fit frame — *"anything less — a target off-screen,
+ * UNDER AN OCCLUDING PANEL, or rendered unreadably small — and the caller
+ * fits"* — and it derived that frame from `computeFitPadding` alone.
+ *
+ * **So the deletion, on its own, makes a node behind the floating panel score
+ * COMFORTABLE, and the focus camera silently refuses to move.** No error, no
+ * red test, no user-visible failure except that "Ask Olumi about this node"
+ * stops bringing the node into view — capability 2 of the six, regressed by the
+ * fix meant to serve it. That is why the companion-aware comfort frame lands in
+ * the SAME COMMIT as the deletion, and why this spec exists.
+ *
+ * THE TWO FRAMES ARE NOW DELIBERATELY DIFFERENT, and the asymmetry is the
+ * contract:
+ *   - `FocusCamera.padding` — what the gated fit passes to `fitView`. Derived
+ *     from EDGE-ANCHORED, LAYOUT-RESERVING chrome only. The floating companion
+ *     contributes nothing, ever.
+ *   - `FocusCamera.insets` — the frame the no-churn GATE measures against. The
+ *     same padding, then widened by whatever the floating companion occludes.
+ *
+ * The gate frame is therefore a subset of the fit frame, never a superset, so
+ * this change can only make the camera fit MORE often than before — never less.
+ * "Comfortable" is strictly harder to earn than it was at pristine, which is
+ * the safe direction for a gate whose failure mode is a stranded camera.
+ *
+ * ⚠ The honest limit, recorded rather than glossed: the clearance is
+ * RECTANGULAR (a fitView inset cannot express "this box is covered"), so a node
+ * that merely shares the companion's band — beside it, not behind it — also
+ * scores uncomfortable. That is the pre-existing shape of the old reservation,
+ * carried forward unchanged; the decision's step 6 (fit-then-place) is what
+ * removes the occlusion rather than reserving around it.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import {
+  cheapestClearance,
+  comfortInsets,
+  nodesComfortablyVisible,
+  paddingToInsets,
+  readFloatingCompanionBox,
+  readFocusCamera,
+  COMFORT_OCCLUSION_GAP,
+  FLOATING_COMPANION_SELECTORS,
+} from '../cameraComfort'
+import { computeFitPadding } from '../computeFitPadding'
+
+const FLOW = { left: 0, top: 0, right: 1280, bottom: 800 }
+/** The shipped 1280x800 geometry — dock `right: 12` at 416px, sidebar at 12/52. */
+const DOCK_1280 = { left: 852, right: 1268, width: 416, top: 12, bottom: 784, height: 772 }
+const SIDEBAR_1280 = { left: 12, right: 60, width: 48, top: 73, bottom: 300, height: 227 }
+/** Bottom-right anchor the hero slides to on the 0→N draft (FirstUseComposer). */
+const PANEL_ANCHORED = { left: 812, top: 234, right: 1212, bottom: 784 }
+
+function fakeEl(rect: Partial<DOMRect>): HTMLElement {
+  const full = {
+    x: 0, y: 0, width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0,
+    toJSON: () => ({}), ...rect,
+  } as DOMRect
+  return { getBoundingClientRect: () => full } as unknown as HTMLElement
+}
+
+function stubSelectors(map: Record<string, HTMLElement | null>) {
+  vi.spyOn(document, 'querySelector').mockImplementation(
+    (sel: string) => (sel in map ? map[sel] : null) as Element | null,
+  )
+}
+
+const DOCK = 'aside[aria-label="Outputs dock"]'
+const SIDEBAR = 'nav[aria-label="Canvas tools"]'
+const PANEL = '[data-testid="floating-olumi-panel"]'
+const SIDE_TAB = '[data-testid="floating-olumi-panel-side-tab"]'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('cheapestClearance — the geometry, moved here from computeFitPadding', () => {
+  // These two assertions are carried over VERBATIM from the deleted
+  // `cheapestReservation` suite rather than rewritten: the geometry did not
+  // change, only who is allowed to consume it. Deleting evidence because the
+  // caller moved would have thrown away the only pins on the four-direction
+  // minimum (CLAUDE.md trap 14b — a corpus is evidence, not a fixture).
+  it('returns null when the boxes do not intersect', () => {
+    expect(cheapestClearance(FLOW, { left: 1400, top: 0, right: 1800, bottom: 550 })).toBeNull()
+    expect(cheapestClearance(FLOW, { left: 100, top: 900, right: 500, bottom: 1200 })).toBeNull()
+  })
+
+  it('picks the minimum of the four clearing distances', () => {
+    expect(cheapestClearance(FLOW, { left: 776, top: 234, right: 1212, bottom: 784 })).toEqual({
+      side: 'right',
+      amount: 504,
+    })
+    expect(cheapestClearance(FLOW, { left: 776, top: 0, right: 1212, bottom: 262 })).toEqual({
+      side: 'top',
+      amount: 262,
+    })
+  })
+
+  it('never returns a negative amount', () => {
+    for (const b of [
+      { left: -500, top: -500, right: 2000, bottom: 2000 },
+      { left: 0, top: 0, right: 1280, bottom: 800 },
+      { left: 1279, top: 799, right: 1281, bottom: 801 },
+    ]) {
+      const r = cheapestClearance(FLOW, b)
+      if (r) expect(r.amount).toBeGreaterThanOrEqual(0)
+    }
+  })
+})
+
+describe('readFloatingCompanionBox — unions the side tab that sits OUTSIDE the panel rect', () => {
+  it('is null when no companion is present', () => {
+    stubSelectors({})
+    expect(readFloatingCompanionBox()).toBeNull()
+  })
+
+  it('extends the panel LEFT edge by the side tab at left:-36', () => {
+    stubSelectors({
+      [PANEL]: fakeEl({ ...PANEL_ANCHORED, width: 400, height: 550 }),
+      [SIDE_TAB]: fakeEl({ left: 776, right: 812, top: 234, bottom: 354, width: 36, height: 120 }),
+    })
+    // Identity-bound on the LEFT edge specifically: the tab is positioned at
+    // `left: -36` with the panel `overflow: visible`, so it is absent from the
+    // panel's own rect and only the left edge can observe the union.
+    expect(readFloatingCompanionBox()).toEqual({ left: 776, top: 234, right: 1212, bottom: 784 })
+  })
+
+  it('reads through the recorded selector list, which is the single source', () => {
+    // A hand-maintained list of selectors in two modules is the estate's
+    // dominant defect (trap 12). After step 1, `computeFitPadding` names the
+    // companion nowhere, so this list is the ONLY place it is spelled.
+    expect([...FLOATING_COMPANION_SELECTORS]).toEqual([
+      '[data-testid="floating-olumi-panel"]',
+      '[data-testid="floating-olumi-panel-side-tab"]',
+    ])
+  })
+})
+
+describe('comfortInsets — the fit frame, widened by what the companion occludes', () => {
+  const padding = { top: '29px', right: '444px', bottom: '29px', left: '76px' } as const
+
+  it('with no companion, it IS the padding — byte for byte', () => {
+    expect(comfortInsets(FLOW, padding, null)).toEqual(paddingToInsets(padding))
+  })
+
+  it('widens the cheapest side by clearance + gap when a companion overlaps', () => {
+    const insets = comfortInsets(FLOW, padding, { left: 776, top: 234, right: 1212, bottom: 784 })
+    // clearance right = flow.right(1280) - occ.left(776) = 504; + GAP.
+    expect(insets.right).toBe(504 + COMFORT_OCCLUSION_GAP)
+    expect(insets.left).toBe(76)
+    expect(insets.top).toBe(29)
+    expect(insets.bottom).toBe(29)
+  })
+
+  it('is never MORE permissive than the padding alone, at any companion position', () => {
+    // The monotonicity claim this change rests on, asserted rather than argued:
+    // a smaller gate frame can only make the camera fit more often. If any side
+    // ever came back SMALLER than the padding inset, a node could become newly
+    // "comfortable" and the camera would newly refuse to move.
+    const base = paddingToInsets(padding)
+    const positions = [
+      { name: 'bottom-right anchor', left: 812, top: 234, w: 400, h: 550 },
+      { name: 'left clamp floor', left: 52, top: 73, w: 400, h: 550 },
+      { name: 'centred', left: 440, top: 125, w: 400, h: 550 },
+      { name: 'wide + bottom-hugging', left: 300, top: 700, w: 700, h: 90 },
+      { name: 'fully outside the flow rect', left: 1400, top: 73, w: 400, h: 550 },
+    ]
+    for (const p of positions) {
+      const insets = comfortInsets(FLOW, padding, {
+        left: p.left, top: p.top, right: p.left + p.w, bottom: p.top + p.h,
+      })
+      for (const side of ['top', 'right', 'bottom', 'left'] as const) {
+        expect(insets[side], `${p.name}.${side}`).toBeGreaterThanOrEqual(base[side])
+      }
+    }
+  })
+})
+
+describe('THE SHARED MISS — the floating companion is comfort-visible even though it reserves nothing', () => {
+  /**
+   * ⭐ MEASURED WHILE WRITING THIS TEST, and it sharpens the claim rather than
+   * weakening it. The first fixture used the EXPANDED-dock padding (right 444px)
+   * and its own precondition refused: at 1280 the expanded dock already excludes
+   * every screen x above 844, and the companion's band starts at 776, so only a
+   * 68px-wide sliver of the companion sits inside the padding frame at all — no
+   * 200px node can be both inside that frame and behind the panel.
+   *
+   * So the honest scope of the miss is:
+   *  - **at the 40px rail it is fully live** — the frame reaches x 1220 and the
+   *    companion occupies 776..1212 of it. This is the state the decision
+   *    PROMOTES as the one-gesture whole-model view, i.e. exactly where a user
+   *    asks about a node they can finally see.
+   *  - at the expanded dock it is live only for nodes in that 68px sliver.
+   *
+   * The fixture below is therefore the rail, named, rather than a width chosen
+   * to make the assertion pass. Pinning the sliver case as well would assert
+   * almost nothing and would read as broader coverage than it is.
+   */
+  const PADDING_RAIL = { top: '29px', right: '68px', bottom: '29px', left: '76px' } as const
+
+  /**
+   * A node parked under the bottom-right anchored panel: flow (900, 400), so at
+   * zoom 1 with the viewport at the origin its screen rect is x 900..1100,
+   * y 400..480 — inside the panel's 776..1212 x 234..784 box.
+   */
+  const NODE_BEHIND_PANEL = { position: { x: 900, y: 400 }, measured: { width: 200, height: 80 } }
+  /** Same graph, a node well clear of the companion's band on the left. */
+  const NODE_CLEAR_OF_PANEL = { position: { x: 200, y: 400 }, measured: { width: 200, height: 80 } }
+  const VIEWPORT = { x: 0, y: 0, zoom: 1 }
+
+  it('scores a node behind the companion as NOT comfortable, so the camera moves', () => {
+    // PIN THE PRECONDITION, or this test passes for the wrong reason: with
+    // PADDING-ONLY insets — exactly what the step-1 deletion leaves behind — the
+    // same node IS comfortable and the camera would refuse to move. That is the
+    // regression; the assertion below is the fix.
+    const paddingOnly = comfortInsets(FLOW, PADDING_RAIL, null)
+    expect(
+      nodesComfortablyVisible([NODE_BEHIND_PANEL], VIEWPORT, 1280, 800, paddingOnly),
+      'precondition: padding-only insets score the occluded node COMFORTABLE',
+    ).toBe(true)
+
+    const companionAware = comfortInsets(FLOW, PADDING_RAIL, PANEL_ANCHORED)
+    expect(
+      nodesComfortablyVisible([NODE_BEHIND_PANEL], VIEWPORT, 1280, 800, companionAware),
+    ).toBe(false)
+  })
+
+  it('a node clear of the companion stays comfortable — the contrast control', () => {
+    // Without this, "not comfortable" could be the frame collapsing rather than
+    // the occlusion being observed: a gate that fails everything is not a gate.
+    const companionAware = comfortInsets(FLOW, PADDING_RAIL, PANEL_ANCHORED)
+    expect(
+      nodesComfortablyVisible([NODE_CLEAR_OF_PANEL], VIEWPORT, 1280, 800, companionAware),
+    ).toBe(true)
+  })
+
+  it('and the same node is comfortable again once the companion closes', () => {
+    // The round trip: the gate is a function of the companion's PRESENCE, not a
+    // permanent narrowing of the frame. A `null` companion restores the frame
+    // byte-for-byte, so closing the panel does not leave the camera twitchy.
+    const companionAware = comfortInsets(FLOW, PADDING_RAIL, PANEL_ANCHORED)
+    const closed = comfortInsets(FLOW, PADDING_RAIL, null)
+    expect(closed).toEqual(paddingToInsets(PADDING_RAIL))
+    expect(closed).not.toEqual(companionAware)
+    expect(nodesComfortablyVisible([NODE_BEHIND_PANEL], VIEWPORT, 1280, 800, closed)).toBe(true)
+  })
+})
+
+describe('readFocusCamera — one measurement, two deliberately different frames', () => {
+  function stubLiveDom() {
+    const flowEl = fakeEl({ ...FLOW, width: 1280, height: 800 })
+    stubSelectors({
+      '.react-flow': flowEl,
+      [DOCK]: fakeEl(DOCK_1280),
+      [SIDEBAR]: fakeEl(SIDEBAR_1280),
+      [PANEL]: fakeEl({ ...PANEL_ANCHORED, width: 400, height: 550 }),
+      [SIDE_TAB]: fakeEl({ left: 776, right: 812, top: 234, bottom: 354, width: 36, height: 120 }),
+    })
+    return flowEl
+  }
+
+  it('the FIT padding is companion-free — identical to computeFitPadding', () => {
+    // The test that REDs if a later lane "restores consistency" by feeding the
+    // companion back into the padding. That would re-take the 392px of canvas
+    // this change exists to give back.
+    const flowEl = stubLiveDom()
+    const camera = readFocusCamera(() => ({ x: 0, y: 0, zoom: 1 }))
+    expect(camera).not.toBeNull()
+    expect(camera!.padding).toEqual(computeFitPadding(flowEl))
+    expect(camera!.padding.right).toBe('444px') // dock 428 + gap 16, and nothing else
+  })
+
+  it('the GATE insets are companion-aware — and therefore NOT the padding', () => {
+    stubLiveDom()
+    const camera = readFocusCamera(() => ({ x: 0, y: 0, zoom: 1 }))
+    expect(camera).not.toBeNull()
+    // Identity-bound on the side the companion actually occludes, and asserted
+    // as a DIFFERENCE from the padding, so a future collapse of the two frames
+    // into one reds here rather than going quiet.
+    expect(camera!.insets.right).toBe(504 + COMFORT_OCCLUSION_GAP)
+    expect(camera!.insets).not.toEqual(paddingToInsets(camera!.padding))
+  })
+
+  it('with no companion the two frames agree exactly — the no-op case', () => {
+    stubSelectors({
+      '.react-flow': fakeEl({ ...FLOW, width: 1280, height: 800 }),
+      [DOCK]: fakeEl(DOCK_1280),
+      [SIDEBAR]: fakeEl(SIDEBAR_1280),
+    })
+    const camera = readFocusCamera(() => ({ x: 0, y: 0, zoom: 1 }))
+    expect(camera).not.toBeNull()
+    expect(camera!.insets).toEqual(paddingToInsets(camera!.padding))
+  })
+})

--- a/src/canvas/utils/cameraComfort.ts
+++ b/src/canvas/utils/cameraComfort.ts
@@ -16,6 +16,41 @@
  * Pure by design (cameraMotion precedent): callers supply the viewport, pane
  * size and insets; only readFocusCamera below touches the DOM, mirroring
  * computeFitPadding's measurement approach.
+ *
+ * ⭐⭐ THE TWO FRAMES DIVERGED ON PURPOSE, 18 Aug 2026 — READ THIS BEFORE
+ * "RESTORING CONSISTENCY" BETWEEN THEM.
+ *
+ * `computeFitPadding` no longer reserves anything for the floating Olumi
+ * companion: it is not edge-anchored, it is not layout-reserving, and charging
+ * the graph 392px of canvas for it was the defect
+ * `WORKSPACE-COMPOSITION-DECISION-2026-08-18.md` step 1 exists to fix.
+ *
+ * But THIS module's rule is about OCCLUSION, not layout — "under an occluding
+ * panel" is written into the rule above — and it took its frame from that same
+ * function. So the deletion alone would have scored a node behind the companion
+ * COMFORTABLE and the focus camera would have silently refused to move: a
+ * regression in the very capability ("ask about a selected element without
+ * losing visual context") the change exists to serve, with no error, no red test
+ * and no user-visible failure except that focus stops working. No design in the
+ * set caught it.
+ *
+ * Hence two frames from ONE measurement:
+ *   - `FocusCamera.padding` — what the gated fit passes to `fitView`.
+ *     Edge-anchored chrome only. The companion contributes NOTHING, ever.
+ *   - `FocusCamera.insets` — the frame the no-churn GATE measures against. That
+ *     same padding, widened by whatever the companion occludes.
+ *
+ * The gate frame is a SUBSET of the fit frame, never a superset, so this can only
+ * make the camera fit more often than before — never less. "Comfortable" is
+ * strictly harder to earn than it was at pristine, which is the safe direction
+ * for a gate whose failure mode is a stranded camera, and it means the gate's
+ * behaviour is preserved from before the deletion rather than changed by it.
+ *
+ * ⚠ The consequence, stated rather than discovered later: a gated fit frames into
+ * the companion-FREE box, so a target can still land behind the companion after
+ * the camera moves. That is not a loop (the gate runs per focus action, not
+ * continuously) and it is what the decision's step 6 fixes properly, by MOVING
+ * the panel — fit-then-place — instead of reserving around it.
  */
 
 import { computeFitPadding, type FitPadding } from './computeFitPadding'
@@ -33,6 +68,137 @@ export const COMFORT_SLACK_PX = 8
 /** Fallbacks for nodes that have not reported measured dimensions yet. */
 export const DEFAULT_NODE_WIDTH = 200
 export const DEFAULT_NODE_HEIGHT = 80
+
+/**
+ * Breathing gap added to a companion clearance, mirroring `computeFitPadding`'s
+ * own GAP so the comfort frame and the (former) reservation agree in magnitude.
+ * Kept as its own constant rather than imported: the two now answer different
+ * questions, and a shared constant would invite re-fusing them.
+ */
+export const COMFORT_OCCLUSION_GAP = 16
+
+/**
+ * The floating companion's DOM, spelled ONCE for the whole codebase.
+ *
+ * After step 1, `computeFitPadding` names the panel nowhere, so this list is the
+ * only place it appears. The side tab is a sibling positioned at `left: -36`
+ * with the panel `overflow: visible`, so it is NOT part of the panel's own
+ * `getBoundingClientRect` — union the two or the box is 36px short of what the
+ * user sees.
+ *
+ * ⚠ The minimised pill is deliberately absent. Its entire contract is "I am out
+ * of the way": it is small, semi-transparent and draggable, and treating it as
+ * an occluder used to collapse the vertical fitting box to 355px for a graph
+ * needing 524px. Occlude the surface, not the affordance.
+ */
+export const FLOATING_COMPANION_SELECTORS = [
+  '[data-testid="floating-olumi-panel"]',
+  '[data-testid="floating-olumi-panel-side-tab"]',
+] as const
+
+/** A rectangle in viewport coordinates — the shape `getBoundingClientRect` returns. */
+export interface Box {
+  left: number
+  top: number
+  right: number
+  bottom: number
+}
+
+/** The four sides a clearance can be taken from. */
+export type ComfortClearanceSide = 'left' | 'right' | 'top' | 'bottom'
+
+/**
+ * The cheapest way to hold a frame entirely clear of a FREE-FLOATING occluder.
+ *
+ * MOVED HERE VERBATIM from `computeFitPadding.cheapestReservation` (18 Aug 2026)
+ * — the geometry is unchanged and its tests came with it; what changed is who is
+ * allowed to consume it. It may inform the comfort GATE. It may never again
+ * inform a layout reservation.
+ *
+ * A rectangular inset cannot express "this box is covered", so the only way to
+ * keep a frame off an occluder is to keep the frame entirely to one side of it.
+ * Four clearances achieve that; this returns the SMALLEST:
+ *
+ *   right  → `frame.right - occ.left`     (frame sits left of the occluder)
+ *   left   → `occ.right - frame.left`     (frame sits right of it)
+ *   bottom → `frame.bottom - occ.top`     (frame sits above it)
+ *   top    → `occ.bottom - frame.top`     (frame sits below it)
+ *
+ * Returns `null` when the occluder does not overlap at all. Ties resolve in
+ * `right, left, bottom, top` order, which only matters for exactly-square
+ * overlaps and never changes the amount.
+ */
+export function cheapestClearance(
+  frame: Box,
+  occ: Box,
+): { side: ComfortClearanceSide; amount: number } | null {
+  const overlapsX = occ.left < frame.right && occ.right > frame.left
+  const overlapsY = occ.top < frame.bottom && occ.bottom > frame.top
+  if (!overlapsX || !overlapsY) return null
+
+  const candidates: Array<{ side: ComfortClearanceSide; amount: number }> = [
+    { side: 'right', amount: frame.right - occ.left },
+    { side: 'left', amount: occ.right - frame.left },
+    { side: 'bottom', amount: frame.bottom - occ.top },
+    { side: 'top', amount: occ.bottom - frame.top },
+  ]
+  let best = candidates[0]
+  for (const c of candidates) {
+    if (c.amount < best.amount) best = c
+  }
+  return { side: best.side, amount: Math.max(0, best.amount) }
+}
+
+/**
+ * The floating companion's on-screen box, or `null` when it is not mounted.
+ * Union of every selector above, so the side tab is included.
+ */
+export function readFloatingCompanionBox(): Box | null {
+  if (typeof document === 'undefined') return null
+  const rects: DOMRect[] = []
+  for (const selector of FLOATING_COMPANION_SELECTORS) {
+    const el = document.querySelector(selector) as HTMLElement | null
+    if (!el) continue
+    const rect = el.getBoundingClientRect()
+    if (rect.width <= 0 || rect.height <= 0) continue
+    rects.push(rect)
+  }
+  if (rects.length === 0) return null
+  return {
+    left: Math.min(...rects.map((r) => r.left)),
+    top: Math.min(...rects.map((r) => r.top)),
+    right: Math.max(...rects.map((r) => r.right)),
+    bottom: Math.max(...rects.map((r) => r.bottom)),
+  }
+}
+
+/**
+ * The GATE's frame: the fit padding, widened by whatever the floating companion
+ * occludes.
+ *
+ * Pure — the caller supplies the companion box — so the whole rule is testable
+ * without a DOM, and so a caller cannot accidentally make the FIT padding
+ * companion-aware by reaching for this.
+ *
+ * Deliberately NOT re-clamped by `computeFitPadding`'s MAX_PADDING_FRACTION: an
+ * occluder too large to clear yields a degenerate frame, and
+ * `nodesComfortablyVisible` already treats a degenerate frame as NOT
+ * comfortable — which is this module's documented fail-open-to-fitting. Clamping
+ * it would make the frame LARGER and could newly score an occluded node
+ * comfortable, i.e. the one direction that is unsafe.
+ */
+export function comfortInsets(
+  flow: Box,
+  padding: FitPadding,
+  floating: Box | null,
+): ComfortInsets {
+  const insets = paddingToInsets(padding)
+  if (!floating) return insets
+  const clearance = cheapestClearance(flow, floating)
+  if (!clearance || clearance.amount <= 0) return insets
+  const value = clearance.amount + COMFORT_OCCLUSION_GAP
+  return { ...insets, [clearance.side]: Math.max(insets[clearance.side], value) }
+}
 
 export interface ViewportLike {
   x: number
@@ -124,19 +290,25 @@ export interface FocusCamera {
  * ReactFlow instance, pane + panel-aware insets from the `.react-flow`
  * element (same single-canvas scope caveat as computeFitPadding). Returns
  * null when unmeasurable — callers treat that as "not comfortable" and fit.
+ *
+ * The `insets` it returns are COMPANION-AWARE and the `padding` is not; that
+ * asymmetry is the contract, not a bug. See the module header.
  */
 export function readFocusCamera(getViewport: () => ViewportLike): FocusCamera | null {
   if (typeof document === 'undefined') return null
   const el = document.querySelector('.react-flow')
   const rect = el?.getBoundingClientRect()
   if (!rect || rect.width <= 0 || rect.height <= 0) return null
-  // ONE measurement feeds both the gate (insets) and the fit (padding).
+  // ONE measurement, TWO frames — see the header. `padding` is what the gated
+  // fit uses and carries edge-anchored chrome only; `insets` is what the gate
+  // measures against and additionally excludes the floating companion.
   const padding = computeFitPadding(el)
+  const flow: Box = { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom }
   return {
     viewport: getViewport(),
     paneWidth: rect.width,
     paneHeight: rect.height,
-    insets: paddingToInsets(padding),
+    insets: comfortInsets(flow, padding, readFloatingCompanionBox()),
     padding,
   }
 }

--- a/src/canvas/utils/computeFitPadding.ts
+++ b/src/canvas/utils/computeFitPadding.ts
@@ -36,6 +36,41 @@
  * like FloatingOlumiPanel.measureDockInset), so it stays correct if the canvas
  * is offset or embedded.
  *
+ * ⭐⭐ THE STATED RULE, added 18 Aug 2026: **ONLY EDGE-ANCHORED, LAYOUT-RESERVING
+ * CHROME CONTRIBUTES.** The OutputsDock and the LeftSidebar are edge-anchored, so
+ * "how much do they occlude" has exactly one answer and the caller reserves it on
+ * that side. The floating Olumi conversation panel is not, and it used to be
+ * handled here anyway — converted into a rectangular inset by taking the cheapest
+ * of four clearing directions.
+ *
+ * That conflated two concepts the founder ruled are different:
+ *
+ * > "DO NOT remove floating/concurrent Olumi… FLOATING AND LAYOUT-RESERVING ARE
+ * > DIFFERENT CONCEPTS… FIX THE COMPOSITION, NOT THE CAPABILITY."
+ *
+ * A `fitView` padding is a rectangular inset and cannot express "this box is
+ * covered", so the only way to clear a 400x550 overlay was to surrender a whole
+ * band of canvas. Measured live at 1280x800 on the deployed build: **392px of
+ * canvas, 52% of the resulting fit box** — the fit box was 368x742 with the panel
+ * open against 760x742 without it, and at a dragged position it fell to 257 and
+ * even 194px. Nought of twelve measured models cleared the 0.50 legibility floor
+ * in that state; six of twelve clear it at 760.
+ *
+ * So the floating panel — and its side tab, and its minimised pill — now reserve
+ * NOTHING, EVER. The panel keeps its capability and stops charging the graph for
+ * it. Pinned by the padding-invariance guard (decision guard G2a) in
+ * `computeFitPadding.spec.ts`.
+ *
+ * ⚠ THIS IS NOT "nothing may know the panel is there", and the difference is a
+ * live regression if it is missed. `cameraComfort`'s no-churn rule asks whether a
+ * target is *"off-screen, UNDER AN OCCLUDING PANEL, or rendered unreadably
+ * small"*, and it derived that frame from this function. Deleting the branch here
+ * ALONE scores a node behind the panel COMFORTABLE, so the focus camera silently
+ * refuses to move — no error, no red, and "Ask Olumi about this node" quietly
+ * stops working. The companion-aware COMFORT frame therefore lives in
+ * `cameraComfort.ts` and landed in the same commit as this deletion. Padding is
+ * about layout; comfort is about occlusion; they are not the same question.
+ *
  * Scope caveat: with no `flowEl` argument this defaults to the FIRST `.react-flow`
  * in the document — correct for the single live main canvas (where the wired fit
  * sites run). Multi-canvas surfaces (comparison mode) use their own separate
@@ -72,80 +107,6 @@ const MAX_PADDING_FRACTION = 0.8
 
 /** A pixel padding string, e.g. `'120px'` — matches xyflow's `PaddingWithUnit`. */
 type PxString = `${number}px`
-
-/** The four sides a reservation can be taken from. */
-export type ReservationSide = 'left' | 'right' | 'top' | 'bottom'
-
-/** A rectangle in viewport coordinates — the shape `getBoundingClientRect` returns. */
-export interface Box {
-  left: number
-  top: number
-  right: number
-  bottom: number
-}
-
-/**
- * The cheapest way to push the graph clear of a FREE-FLOATING occluder.
- *
- * The dock and the sidebar are edge-anchored, so "how much do they occlude"
- * has exactly one answer and the caller reserves it on that side. The floating
- * Olumi panel is not: it can rest anywhere, and after the 0→N draft transition
- * it slides to a bottom-right anchor (`FirstUseComposer`), while a minimised
- * pill is a small box wherever the panel last was. There is no single "its
- * side" to reserve.
- *
- * `fitView` padding is rectangular, so the only way to guarantee the graph is
- * not drawn underneath a box is to keep the graph entirely to one side of it.
- * Four reservations achieve that; this returns the SMALLEST, i.e. the direction
- * that costs the fitting box least:
- *
- *   right  → `flow.right - occ.left`     (graph sits left of the occluder)
- *   left   → `occ.right - flow.left`     (graph sits right of it)
- *   bottom → `flow.bottom - occ.top`     (graph sits above it)
- *   top    → `occ.bottom - flow.top`     (graph sits below it)
- *
- * This is what makes a minimised pill cheap: a 28px-tall pill resting near the
- * bottom edge costs ~44px of BOTTOM padding, where reserving the whole right
- * band from its left edge would have cost ~468px of width.
- *
- * Returns `null` when the occluder does not overlap the flow rect at all —
- * nothing to reserve. Ties resolve in `right, left, bottom, top` order, which
- * only matters for exactly-square overlaps and never changes the amount.
- */
-export function cheapestReservation(flow: Box, occ: Box): { side: ReservationSide; amount: number } | null {
-  const overlapsX = occ.left < flow.right && occ.right > flow.left
-  const overlapsY = occ.top < flow.bottom && occ.bottom > flow.top
-  if (!overlapsX || !overlapsY) return null
-
-  const candidates: Array<{ side: ReservationSide; amount: number }> = [
-    { side: 'right', amount: flow.right - occ.left },
-    { side: 'left', amount: occ.right - flow.left },
-    { side: 'bottom', amount: flow.bottom - occ.top },
-    { side: 'top', amount: occ.bottom - flow.top },
-  ]
-  let best = candidates[0]
-  for (const c of candidates) {
-    if (c.amount < best.amount) best = c
-  }
-  return { side: best.side, amount: Math.max(0, best.amount) }
-}
-
-/**
- * Union of a set of rects, or `null` when none are present. Used to treat the
- * floating panel and its side tab (which is positioned OUTSIDE the panel's left
- * edge at `left: -36`, so it is absent from the panel's own
- * `getBoundingClientRect`) as the single opaque box the user actually sees.
- */
-function unionOf(boxes: Array<DOMRect | null>): Box | null {
-  const present = boxes.filter((b): b is DOMRect => b != null)
-  if (present.length === 0) return null
-  return {
-    left: Math.min(...present.map((b) => b.left)),
-    top: Math.min(...present.map((b) => b.top)),
-    right: Math.max(...present.map((b) => b.right)),
-    bottom: Math.max(...present.map((b) => b.bottom)),
-  }
-}
 
 export interface FitPadding {
   top: PxString
@@ -219,41 +180,11 @@ export function computeFitPadding(flowEl?: Element | null): FitPadding {
       if (overlap > 0) left = Math.max(left, overlap + GAP)
     }
 
-    // The floating Olumi conversation panel — a FREE-FLOATING occluder, so it
-    // reserves in whichever direction costs the fitting box least (see
-    // `cheapestReservation`). Measured 16 Aug 2026 at 1280x800: with the panel
-    // open, 10 of the 18 nodes in the committed CEE draft capture rendered
-    // UNDERNEATH it, because this function reserved nothing for it at all.
-    //
-    // The side tab is a sibling positioned at `left: -36` with the panel
-    // `overflow: visible`, so it is NOT part of the panel's own rect — union
-    // the two or the reservation is 36px short of what the user sees.
-    //
-    // ⚠ THE MINIMISED PILL IS DELIBERATELY NOT RESERVED, and this is a judgement
-    // with a measurement behind it rather than an oversight. Reserving it was
-    // tried first: an 84x28 pill resting mid-pane took a 416px BOTTOM
-    // reservation (the cheapest of its four directions), which collapsed the
-    // vertical fitting box to 355px for a graph needing 524px and clamped the
-    // whole first view at the legibility floor. The harm avoided was one node
-    // partially behind a 28px-tall affordance; the harm caused was an
-    // unreadable model. The pill's entire contract is "I am out of the way" —
-    // it is small, semi-transparent and draggable — whereas the open panel is a
-    // 400x550 opaque surface the user is reading. Reserve the surface, not the
-    // affordance.
-    const floating = unionOf([
-      rectOf('[data-testid="floating-olumi-panel"]'),
-      rectOf('[data-testid="floating-olumi-panel-side-tab"]'),
-    ])
-    if (floating) {
-      const reservation = cheapestReservation(flowRect, floating)
-      if (reservation && reservation.amount > 0) {
-        const value = reservation.amount + GAP
-        if (reservation.side === 'right') right = Math.max(right, value)
-        else if (reservation.side === 'left') left = Math.max(left, value)
-        else if (reservation.side === 'top') top = Math.max(top, value)
-        else bottom = Math.max(bottom, value)
-      }
-    }
+    // ⭐ NOTHING ELSE CONTRIBUTES. The floating conversation panel, its side tab
+    // and its minimised pill are read here NOWHERE — deliberately, and see the
+    // header for the 392px this gives back and for why `cameraComfort` still
+    // observes the panel. A future lane adding a free-floating occluder to this
+    // function REDs the padding-invariance guard (G2a).
   }
 
   // Defensive clamp: never reserve so much padding that the pane is left with no

--- a/src/canvas/utils/fitTargets.ts
+++ b/src/canvas/utils/fitTargets.ts
@@ -1,0 +1,29 @@
+/**
+ * fitTargets — which nodes a whole-graph `fitView` is allowed to frame.
+ *
+ * `WORKSPACE-COMPOSITION-DECISION-2026-08-18.md` §5.1 / step 2: exclude the
+ * `__ghost-option__` placeholder from every whole-graph fit.
+ *
+ * ⚠ PRICED HONESTLY, because the brief that commissioned this priced it wrong.
+ * The ghost is NOT free width nobody is taking. Three lanes measured its cost at
+ * 220, 76, 60, 32 and **zero** flow units on different models, and the
+ * load-bearing correction is that the two models where it costs width are
+ * HEIGHT-bound — so removing it changes their fit zoom by nothing. On the
+ * measured corpus it adds 9% to the width of one starter (vendor-selection,
+ * 820 → 896 units) whose fit verdict has ~5% of headroom. So: one line, honest,
+ * costless, and **not a win to bank**. It stops a UI affordance from being
+ * framed as though it were part of the user's model.
+ */
+
+/** The affordance's id, spelled ONCE for the whole codebase. */
+export const GHOST_OPTION_NODE_ID = '__ghost-option__'
+
+/**
+ * Drop UI placeholders from a fit target list.
+ *
+ * Generic over the node shape so it serves both `Node[]` from the store and
+ * ReactFlow's `getNodes()` without either caller casting.
+ */
+export function excludeNonModelNodes<T extends { id: string }>(nodes: readonly T[]): T[] {
+  return nodes.filter((n) => n.id !== GHOST_OPTION_NODE_ID)
+}

--- a/src/canvas/utils/layout.ts
+++ b/src/canvas/utils/layout.ts
@@ -1,3 +1,43 @@
+/**
+ * ⭐⭐ A LOAD-BEARING NON-CHANGE — READ BEFORE TOUCHING `availableWidth`.
+ *
+ * `WORKSPACE-COMPOSITION-DECISION-2026-08-18.md` §5.1 records this file as **NO
+ * CHANGE, and it is load-bearing**. This header is that record.
+ *
+ * ⚠⚠ FORBIDDEN: deriving the layout budget from the fit box —
+ * `availableWidth = boxW / LABEL_LEGIBLE_ZOOM` (i.e. `boxW / 0.50`) or any
+ * relative of it. It is a genuinely attractive idea: it makes the solver's
+ * assumption and the camera's frame agree by construction, and one of the three
+ * candidate designs proposed exactly this. It is forbidden because the fit box is
+ * a function of PANEL STATE, so the canonical model would **re-pack whenever a
+ * panel opened or a screen shrank** — the founder's binding ruling is the
+ * opposite:
+ *
+ * > "Do NOT solve the problem by making the canonical model artificially
+ * > smaller. Preserve: STABLE MODEL, ADAPTIVE ATTENTION."
+ *
+ * The model is the team's shared reasoning. It must not silently change shape
+ * because someone opened a conversation. Adapt the PRESENTATION (camera, focus,
+ * "showing N of M"), never the model.
+ *
+ * WHAT IS SAFE, and what shipped instead (18 Aug 2026): pinning `canvasSize` to
+ * ONE canonical, panel-INDEPENDENT derived width — `utils/layoutCanvasSize.ts`,
+ * which replaced two hand-copied duplicates. That removes an authority defect
+ * without coupling the model to the chrome. Read that module's header for the
+ * measured 1088-vs-760 arithmetic and for which half of it is a defect (the
+ * floating panel's phantom reservation, now deleted) and which half is not (the
+ * dock and sidebar, which genuinely occlude).
+ *
+ * ⚠ ONE GENUINE DEFECT IN THIS FILE, NOT FIXED HERE, recorded so it is not lost:
+ * the DOWN branch treats `availableWidth` as a budget for deciding
+ * single-row-vs-multi-row and then emits a row that OVERRUNS it — a 6-wide tier
+ * packs to 2140 units against a 1088 budget, 63% over (the sharpest diagnosis in
+ * the design set). Honouring the budget would change the shape of every model at
+ * every viewport, so it is a product decision behind a visual-regression gate,
+ * not a tidy-up. Guard G3 (`layoutSizingAuthority.guard.spec.ts`) pins the
+ * current viewport-independence AND the exact width at which it breaks, so any
+ * move in either direction REDs.
+ */
 // P1 Polish: Dynamic ELK import for code-splitting (Task F)
 import type { ElkNode, ElkExtendedEdge } from 'elkjs/lib/elk.bundled.js'
 import { Node, Edge } from '@xyflow/react'

--- a/src/canvas/utils/layoutCanvasSize.ts
+++ b/src/canvas/utils/layoutCanvasSize.ts
@@ -1,0 +1,111 @@
+/**
+ * layoutCanvasSize — THE ONE AUTHORITY for the canvas size the layout solver is
+ * packed against.
+ *
+ * WHY THIS MODULE EXISTS (18 Aug 2026, founder correction to
+ * `WORKSPACE-COMPOSITION-DECISION-2026-08-18.md`):
+ *
+ * > "You have derived that the model/layout solver assumes ~1088px while the fit
+ * > stage actually gets ~760px. That is a first-order upstream defect. Fix/unify
+ * > that authority first… Do not choose a workaround around a measurement made
+ * > under a known sizing inconsistency."
+ *
+ * The duplication was the defect in its clearest form: `DraftChat.tsx` and
+ * `LayoutOptionsPanel.tsx` each carried their own hand-copied block reading the
+ * live `.react-flow` rect, with their own floors and their own window fallback,
+ * both commented *"regardless of whether the right panel is open or collapsed"*.
+ * They agreed on the day they were written and nothing would have gone red when
+ * they stopped. A third path — a layout run through neither — silently used
+ * `layout.ts`'s `FALLBACK_CANVAS` of 1300x750, a fourth answer nobody chose.
+ *
+ * ⭐ WHAT THIS DOES AND DOES NOT FIX — say it here, because the numbers invite
+ * the wrong conclusion. At a 1280px viewport this resolves to width 1280, so
+ * `layout.ts` solves tier packing against `1280 * 0.85 = 1088` units while the
+ * post-layout `fitView` frames into 760px (dock expanded) or 1136px (dock at its
+ * 40px rail). Derived at this tip, and the two halves are NOT the same kind of
+ * thing:
+ *
+ *  1. **The phantom half — 392px — WAS a defect and step 1 deletes it.** The
+ *     free-floating conversation panel was contributing a rectangular
+ *     `fitView` inset, so the fit box measured 368px with it open. It is not
+ *     edge-anchored and not layout-reserving; it now reserves nothing, ever
+ *     (`computeFitPadding.ts`). Fit box 368 → 760 at 1280.
+ *  2. **The residual half — 328px — is NOT a defect and no pin closes it.** The
+ *     dock (444px) and the canvas-tools sidebar (76px) genuinely occlude the
+ *     canvas. `canvasSize` deliberately ignores them, and that is the founder's
+ *     binding rule, not an oversight: *"stable model, adaptive attention — the
+ *     canonical strategic model should not silently change merely because the
+ *     screen is small."* Subtracting live panel width here would re-pack the
+ *     canonical model every time a panel opened.
+ *
+ * So the two stages measure different things and both are right to: this one
+ * answers *"how wide may the canonical model be?"* (a model question, panel- and
+ * viewport-stable), and `computeFitPadding` answers *"how much canvas can the
+ * user see right now?"* (a presentation question). Unifying the AUTHORITY means
+ * one derivation of the first question — not making the two answers equal.
+ * **The only state in which the fit stage receives at least what the solver
+ * assumed is the collapsed dock: 1136 ≥ 1088.** That is arithmetic on this
+ * module's own output and `computeFitPadding`'s, and it is why the rail clears
+ * the legibility floor on 12 of 12 measured models where the expanded dock
+ * clears 6.
+ *
+ * ⚠⚠ FORBIDDEN, and it is the whole point of the paragraph above: do NOT derive
+ * this width from the fit box (`availableWidth = boxW / LABEL_LEGIBLE_ZOOM`, and
+ * any relative of it). It is one plausible refactor away and it re-packs the
+ * canonical model when a panel opens. See `layout.ts`'s header.
+ *
+ * ⚠ A SEPARATE, GENUINE SIZING DEFECT THIS MODULE DOES NOT FIX, recorded so it
+ * is not lost: `layout.ts`'s DOWN branch treats `availableWidth` as a budget for
+ * deciding single-row-vs-multi-row and then emits a row that OVERRUNS it — a
+ * 6-wide tier packs to 2140 units against a 1088 budget (63% over). Changing
+ * that changes the shape of every model at every viewport, so it is a product
+ * decision with a visual-regression gate in front of it, not a tidy-up.
+ */
+
+/** Floors carried over verbatim from the two duplicated call sites. */
+export const LAYOUT_CANVAS_MIN_WIDTH = 600
+export const LAYOUT_CANVAS_MIN_HEIGHT = 400
+
+/**
+ * Fixed chrome subtracted by the pre-existing WINDOW fallback, kept identical to
+ * the blocks this module replaces: left sidebar 48, top bar 57, canvas toolbar
+ * 72. Deliberately NO right-panel deduction — see the header: the dock's width
+ * must not reach the canonical model.
+ */
+export const LAYOUT_CANVAS_FALLBACK_CHROME_X = 48
+export const LAYOUT_CANVAS_FALLBACK_CHROME_Y = 57 + 72
+
+export interface LayoutCanvasSize {
+  width: number
+  height: number
+}
+
+/**
+ * The canvas size to pack the canonical model against.
+ *
+ * Measured from the live `.react-flow` rect, which spans the full pane: the dock
+ * and the sidebar are `position: fixed` chrome ON TOP of it, so this reading is
+ * panel-state-independent by construction rather than by intention. Falls back
+ * to the window minus fixed chrome before the canvas has mounted, and returns
+ * `null` when neither is measurable, so a caller never invents a size.
+ *
+ * @param flowEl optional explicit pane (comparison canvases pass their own).
+ */
+export function resolveLayoutCanvasSize(flowEl?: Element | null): LayoutCanvasSize | null {
+  const el =
+    flowEl ?? (typeof document !== 'undefined' ? document.querySelector('.react-flow') : null)
+  const rect = el?.getBoundingClientRect()
+  if (rect && rect.width > 0 && rect.height > 0) {
+    return {
+      width: Math.max(LAYOUT_CANVAS_MIN_WIDTH, rect.width),
+      height: Math.max(LAYOUT_CANVAS_MIN_HEIGHT, rect.height),
+    }
+  }
+  if (typeof window !== 'undefined' && window.innerWidth > 0 && window.innerHeight > 0) {
+    return {
+      width: Math.max(LAYOUT_CANVAS_MIN_WIDTH, window.innerWidth - LAYOUT_CANVAS_FALLBACK_CHROME_X),
+      height: Math.max(LAYOUT_CANVAS_MIN_HEIGHT, window.innerHeight - LAYOUT_CANVAS_FALLBACK_CHROME_Y),
+    }
+  }
+  return null
+}

--- a/src/canvas/utils/reservedBoxWatcher.ts
+++ b/src/canvas/utils/reservedBoxWatcher.ts
@@ -1,0 +1,119 @@
+/**
+ * reservedBoxWatcher — re-fit when the RESERVED BOX changes, not only when the
+ * layout changes.
+ *
+ * WHY (`WORKSPACE-COMPOSITION-DECISION-2026-08-18.md` §5.1): a lane witnessed
+ * the camera stranded at zoom 0.385 after the conversation panel closed, while
+ * the computed fit for the new, larger box was 0.582 — the graph sitting 34%
+ * smaller than it needed to be, live, on the deployed build. `fitView` ran once
+ * per completed layout and never again, so every pixel of canvas won back by
+ * collapsing the dock (or, now, by the floating panel no longer reserving) was
+ * won and then not spent.
+ *
+ * THE SIGNAL IS DERIVED, NOT MIRRORED (CLAUDE.md trap 12). This watcher does not
+ * keep a list of "things that change the reserved box" and hope it stays
+ * current — it recomputes `computeFitPadding()` and compares the result. A
+ * trigger that fires spuriously costs three `getBoundingClientRect` calls and
+ * changes nothing; a trigger we failed to think of degrades to the previous
+ * behaviour (no re-fit), never to a wrong fit. The triggers are therefore
+ * allowed to be approximate, and the decision never is.
+ *
+ * The trigger set, each with its reason:
+ *  - `resize` on window — the viewport itself changed.
+ *  - `transitionend` (capture) — the dock's collapse/expand animates its width.
+ *  - `pointerup` (capture) — the end of a dock width drag; the style lands in
+ *    the same commit, which the settle re-check below covers.
+ *  - a `ResizeObserver` on the pane, when available — covers anything that
+ *    resizes `.react-flow` itself without a window resize.
+ *
+ * Every trigger is coalesced onto the next animation frame AND re-checked once
+ * after `RESERVED_BOX_SETTLE_MS`, because a collapse animates: the frame after
+ * the click still reads the OLD width, and only the settle read sees the new
+ * one. Both reads are cheap and idempotent — the signature comparison is what
+ * decides.
+ */
+
+import { computeFitPadding, type FitPadding } from './computeFitPadding'
+
+/**
+ * Long enough to outlast the dock's width transition and short enough that the
+ * user does not see a stale frame. The transition is a Tailwind default-duration
+ * class on the dock shell; this is deliberately a settle WINDOW rather than a
+ * mirror of that duration, so a styling change cannot silently break it.
+ */
+export const RESERVED_BOX_SETTLE_MS = 360
+
+/** The comparable form of a reserved box — four px strings, order-stable. */
+export function reservedBoxSignature(padding: FitPadding): string {
+  return `${padding.top}|${padding.right}|${padding.bottom}|${padding.left}`
+}
+
+export interface ReservedBoxWatcherOptions {
+  /** Injected in tests; defaults to the live measurement. */
+  readonly measure?: () => FitPadding
+  readonly settleMs?: number
+}
+
+/**
+ * Call `onChange` whenever the reserved box's signature changes. Returns an
+ * unsubscribe. Safe to call in a non-DOM environment (returns a no-op).
+ */
+export function watchReservedBox(
+  onChange: (signature: string) => void,
+  options: ReservedBoxWatcherOptions = {},
+): () => void {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return () => {}
+
+  const measure = options.measure ?? (() => computeFitPadding())
+  const settleMs = options.settleMs ?? RESERVED_BOX_SETTLE_MS
+
+  let last = reservedBoxSignature(measure())
+  let frame: number | null = null
+  let timer: ReturnType<typeof setTimeout> | null = null
+  let disposed = false
+
+  const check = () => {
+    if (disposed) return
+    const next = reservedBoxSignature(measure())
+    if (next === last) return
+    last = next
+    onChange(next)
+  }
+
+  const schedule = () => {
+    if (disposed) return
+    if (frame === null) {
+      frame = window.requestAnimationFrame(() => {
+        frame = null
+        check()
+      })
+    }
+    if (timer === null) {
+      timer = setTimeout(() => {
+        timer = null
+        check()
+      }, settleMs)
+    }
+  }
+
+  window.addEventListener('resize', schedule)
+  document.addEventListener('transitionend', schedule, true)
+  document.addEventListener('pointerup', schedule, true)
+
+  let observer: ResizeObserver | null = null
+  const pane = document.querySelector('.react-flow')
+  if (pane && typeof ResizeObserver !== 'undefined') {
+    observer = new ResizeObserver(schedule)
+    observer.observe(pane)
+  }
+
+  return () => {
+    disposed = true
+    window.removeEventListener('resize', schedule)
+    document.removeEventListener('transitionend', schedule, true)
+    document.removeEventListener('pointerup', schedule, true)
+    observer?.disconnect()
+    if (frame !== null) window.cancelAnimationFrame(frame)
+    if (timer !== null) clearTimeout(timer)
+  }
+}


### PR DESCRIPTION
Steps **1 and 2 only** of `WORKSPACE-COMPOSITION-DECISION-2026-08-18.md`, plus the founder's 18 Aug correction that promoted the sizing-authority unification into this lane. **Steps 3–7 are not started** — five product rulings and the post-run Analysis measurement (Q1) gate them.

## What a user gets

**At 1280×800 with the conversation panel open, the graph's fit box goes 368px → 760px.** Measured live in a real browser on this branch, at three widths, with the panel open:

| viewport | fit box BEFORE | fit box NOW | gained |
|---|---|---|---|
| 1280×800 | 420 (panel at 52,73) / 368 (system position) | **760** | +340 / +392 |
| 1440×900 | 528 | **920** | +392 |
| 1512×860 | 600 | **992** | +392 |

`920 × 834` and `992 × 798` are **exactly** the figures the decision listed as DERIVED and flagged as unverified (its open question Q7, after two lanes' resize controls failed). They are now browser-measured, so Q7 is closed for 1440 and 1512.

**Live witness at 1512×860, panel open:** the model settles at zoom `0.530057` — above the 0.50 legibility floor — with its screen rect at x `77 … 1038`, i.e. framed from the sidebar inset rather than from `468` where the panel's old reservation put it. Before this change the panel's rect pushed the left inset to 468 and the model with it.

## The five changes

1. **`computeFitPadding` — the floating companion reserves nothing, ever.** Deleted the floating branch and `cheapestReservation`. New stated rule in the header: *ONLY EDGE-ANCHORED, LAYOUT-RESERVING CHROME CONTRIBUTES* — the founder's *"FLOATING AND LAYOUT-RESERVING ARE DIFFERENT CONCEPTS"* encoded in the one module that conflated them. The panel keeps its capability and stops charging the graph 392px for it.

2. **⭐ `cameraComfort` — the shared miss, in the same commit.** No design in the set caught this. cameraComfort's no-churn rule asks whether a target is *"off-screen, UNDER AN OCCLUDING PANEL, or rendered unreadably small"* and it derived that frame from `computeFitPadding`. **The deletion alone scores a node behind the panel COMFORTABLE, so the focus camera silently refuses to move** — "Ask Olumi about this node" quietly stops working, no error, no red test. There are now two frames from one measurement: `padding` (the gated fit) is companion-free; `insets` (the gate) is companion-aware. The gate frame is a **subset** of the fit frame, never a superset, so this can only make the camera fit *more* often than at pristine — the gate's behaviour is preserved from before the deletion rather than changed by it.

3. **Re-fit when the reserved box changes**, not only on `layoutVersion`. Without it the width we win is not spent — a lane witnessed the camera stranded at 0.385 after the panel closed while the fit for the new box was 0.582. The signal is **derived, not mirrored**: the watcher recomputes `computeFitPadding()` and compares, so a missed trigger degrades to today's behaviour, never to a wrong fit.

4. **Step 2** — `__ghost-option__` excluded from every whole-graph fit, and the **user-invoked "Fit to view" gains the legibility floor** it never had while the product's own auto-fit did. (Priced honestly: the ghost is *not* free width — the two models where it costs width are height-bound, so it changes their fit zoom by nothing.)

5. **ONE authority for the canvas size the canonical model is packed against** (`utils/layoutCanvasSize.ts`). `DraftChat` and `LayoutOptionsPanel` each carried a hand-copied `.react-flow` measurement with its own floors and fallback; a third path used `layout.ts`'s `FALLBACK_CANVAS` of 1300×750, a fourth answer nobody chose. Four `setCanvasSize` call sites → two, neither deriving a dimension itself.

## The founder's question: does this close the 1088-vs-760 gap?

**No, and the two halves are not the same kind of thing.**

- **The phantom half — 392px — WAS a defect and step 1 deletes it.** A free-floating overlay was contributing a rectangular `fitView` inset. Fit box 368 → 760 at 1280.
- **The residual half — 328px — is NOT a defect and no pin closes it.** The dock (444) and sidebar (76) genuinely occlude the canvas. `canvasSize` deliberately ignores them, and that *is* the binding rule: subtracting live panel width would re-pack the canonical model whenever a panel opened.

The two stages answer different questions — *"how wide may the canonical model be?"* (panel-stable) versus *"how much canvas can the user see now?"*. Unifying the **authority** means one derivation of the first, not making the two answers equal. **The only state where the fit stage receives at least what the solver assumed is the collapsed dock: 1136 ≥ 1088** — which is why the rail clears the floor on 12 of 12 measured models where the expanded dock clears 6.

`layout.ts` gets a header and **no code change**, recording the FORBIDDEN derivation `availableWidth = boxW / LABEL_LEGIBLE_ZOOM` and why (it re-packs the model on panel open). Guard G2 enforces it at the bytes, comment-stripped so the warning may stay.

## ⚠ AND A REFUTATION THE FOUNDER SHOULD SEE FIRST

His correction says the corpus was measured "under a known sizing inconsistency". **It is worse than diagnosed, and G3 measures it.** The decision's caveat was *"the property already fails below 1246px today"*. Measured at `953da3f8`:

**Three of the five shipped starters produce THREE DIFFERENT canonical layouts across 1280 / 1440 / 1512 / 1920.** The failure is *inside* the laptop band, not below it.

Mechanism, derived not described: `nodesPerRow` is a function of `canvasSize.width * 0.85`, so an 8-wide tier packs 3-per-row at 1280, 4-per-row at 1440 and 1512, single-row at 1920. A 5-wide tier is single-row at all four and genuinely stable. **So "stable model, adaptive attention" is already broken by the shipped product, and by more than the 1088-vs-760 gap: the solver's own assumption is viewport-dependent, so the model is already adaptive.** Fixing it means pinning `availableWidth` to a constant, which changes the shape of the affected models at some widths — a product decision behind a visual-regression gate, and **not in this lane**.

This is pre-existing: G3's cases drive `layoutGraph` with an explicit `canvasSize`, so nothing here is in the path.

## Guards

- **G1** — the deleted 280px analysis-state clamp cannot return: `resolveDockWidth(vw, null) === 416` at eight named viewports ≥1280, width proven a function of viewport + stored value alone, plus a source-level assertion that `dockWidth.ts` reads no analysis-state symbol (positive control and magnitude check on the reader first). ⚠ Stated in the spec: this **passes at pristine**, so its value is in the mutant, not the green.
- **G2** — (a) padding invariance: a floating rect at six positions, plus its side tab and the minimised pill, changes the padding by **exactly zero**, with a real-DOM variant; the discriminating half asserts an **edge-anchored** reservation still moves it, on a different rule. (b) `setCanvasSize` call sites are a **recorded** literal (2 sites, 2 files) REDing on grow **or** shrink, with a magnitude check so a traversal that reached nothing cannot satisfy it; plus neither site measures the pane, plus the `boxW / 0.50` ban with a positive control on the detector.
- **G3** — a **known-set pin, not a universal invariant**, exactly as the decision instructed: the exact partition of widths per starter, REDing on movement in either direction, and **bound to the mechanism, not a hash** (two widths share a layout iff they share a re-derived packing decision, with a positive control proving that derivation discriminates). The 1246px breakpoint is kept as a RED/GREEN pair either side of the pixel. The half of G3 that genuinely holds — independence from **dock state** — is asserted and labelled jsdom-level.

## Evidence, and what is NOT evidence

**Browser-measured (1280×800, 1440×900, 1512×860, real Chrome, panel open, guest session, local dev server on this branch):** the rects above; the settled zoom `0.530057` at 1512 framing inside the new box; `.react-flow` spans the **full** viewport width while the dock overlaps it at 852..1268 — the browser-level confirmation of `layoutCanvasSize`'s panel-independence premise; and rig calibration passed (headcount-allocation bbox `1776 × 912`, the one figure three independent lanes agreed on).

**Instrument controls, including two that failed:**
- ✅ `visualViewport` tracks each resize (720 → 800 → 900 → 860). The resize *does* take.
- ❌ **`window.innerWidth` reads `0` in this harness** while rects are correct. Any reading from it is void — and this is plausibly the same artifact behind the corpus lane's *"resize_window did not take (innerWidth stayed 1280)"*.
- ❌ **Canvas-toolbar clicks do not reach the product** (Zoom in and Auto-arrange both no-op; positive control failed). Independently reproduces the corpus lane's limit. So no toolbar-derived reading is used anywhere here.

**⚠ NOT witnessed, and it is my own new feature:** the reserved-box **re-fit did not fire** on a `1512 → 1280` resize, nor on a dispatched `resize` event (transform unchanged at `0.530057`). The likely cause is its own `layoutVersion !== 0` gate on a starter route that never runs `applyLayout` — which would be correct behaviour, not a defect — but **I have not settled it, and the earlier `0.5017 → 0.5301` change must not be attributed to the watcher.** It is unit-pinned (3 tests incl. the does-NOT-fire discriminator) and **browser-unattributed**. First thing a reviewer should probe.

**Also not evidence:** no fresh CEE draft was measured — the local dev server has no BFF proxy, so this is starters only, and the corpus is explicit that *a starter pair will look like a clean win and a fresh draft will not*. Screenshots were taken at all three widths in-session; the durable record is the numeric geometry above.

## Gates

- ✅ **`bash scripts/ci/typecheck-gate.sh` PASSED** (coverage + ratchet). It caught two real errors first, one of them my own comment defeating an import-presence check — the hand-maintained-mirror shape in miniature. Drift **shrank** 2306 → 2298; the baseline is deliberately **not** re-blessed (N-30).
- ✅ Directly affected specs green and asserted by name: `computeFitPadding.spec.ts` **16**, `cameraComfort.floatingCompanion.spec.ts` **15**, `cameraComfort.spec.ts` **20**, `useFitViewOnLayoutVersion.spec.tsx` **10**, `dockWidth.analysisStateClamp.guard.spec.ts` **4**, `layoutSizingAuthority.guard.spec.ts` **15**.
- ⚠ **UNMEASURED: the broad `src/canvas` + `tests/ci-guards` sweep did not complete in-session.** Machine load peaked above 400 and a local run measures the machine, not the code. Not blocking the push per the standing instruction — **CI is the authority.**
- ⚠ **UNMEASURED: mutants.** The RED-first evidence is real (15 named failures at pristine `953da3f8`, incl. `comfortInsets is not a function` and `expected '520px' to be '444px'`), and each guard carries its own pinned precondition and positive control, but the mutant kit was not run. G1 in particular is *only* meaningful under its mutant.
- ⚠ Visual-regression references **not** re-blessed (N-30).

## Also

`WORKSPACE-VIEWPORT-DECISION-2026-08-18.md` now carries a SUPERSEDED banner naming the countermanded spine and the two refuted figures. ⚠ It is in `olumi-docs/`, which is **not a git repo on this machine**, so that edit is on disk only and needs pushing to `Talchain/olumi-programme-docs` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
