### PR TITLE
fix(affordances): the Analysis dock tab's two dead states + the re-draft's broken composer promise

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -2145,6 +2145,24 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     if (tab === 'olumi' && useFloatingPanelState.getState().isOpen) {
       useFloatingPanelState.getState().close()
     }
+    // ⭐ AFFORDANCE SWEEP A2 — WITHOUT THIS LINE THE COLLAPSED RAIL'S TAB
+    // ICONS ARE DEAD CONTROLS.
+    //
+    // `effectiveIsOpen` is `isFirstUse ? false : state.isOpen`, so the
+    // `isOpen: true` below is OVERRIDDEN by the first-use rail: a fresh guest
+    // on an empty canvas clicked the rail's `Analysis` icon and NOTHING
+    // rendered — the tab selection was applied to a panel the user could not
+    // see, discoverable only by separately pressing `Expand outputs dock`.
+    // Measured on the deployed build (`9ff14c19`), scored DEAD.
+    //
+    // Choosing a tab is at least as strong a "show me the outputs" signal as
+    // the chevron beside it, and this is the SAME one-line override the
+    // chevron (`toggleOpen`), the run-start auto-switch and the
+    // collapsed-response signal already use — not a second mechanism. Keeping
+    // it a ref means the rail lock is spent for the session without writing a
+    // persisted preference, so a returning user with an empty canvas still
+    // gets the rail (see `shouldRenderFirstUseRail`).
+    userExplicitlyOpenedRailRef.current = true
     setState(prev => ({ ...prev, isOpen: true, activeTab: tab }))
     // E1: Sync tab state to Zustand store for cross-component navigation
     useUIStore.getState().setActiveOutputTab(tab as OutputTab)
@@ -2774,6 +2792,61 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                   )
                 })()}
                 {/* v7: Rerun + Compare buttons moved to sticky footer below */}
+                {/* ⭐ AFFORDANCE SWEEP A3 — THE EMPTY STATE THAT WAS SIMPLY ABSENT.
+                    Every section in this branch is gated on either
+                    `isPreRun && nodes.length > 0` (the pre-run panel, below) or
+                    `!isPreRun` (everything after it), so the intersection —
+                    no analysis has completed AND no model on the canvas — had
+                    NO renderer at all. A fresh guest who opened the Analysis
+                    tab got a COMPLETELY BLANK panel: zero copy, no reason, no
+                    next step. Measured on the deployed build (`9ff14c19`),
+                    scored DEAD.
+
+                    The Model tab already does this correctly (`ModelOutline`'s
+                    "Nothing in this group yet"), so this copies that pattern
+                    rather than inventing a second one.
+
+                    ⚠ WHAT THIS COPY MAY CLAIM, AND WHY IT CLAIMS SO LITTLE.
+                    The reachable condition is exactly `isPreRun && nodes.length
+                    === 0`, so the only facts in evidence are "no analysis has
+                    completed in this session" and "the canvas holds no model".
+                    Both sentences below say only that. It deliberately does NOT
+                    promise that describing a decision will produce a model on
+                    the canvas — that is the very promise the same sweep found
+                    broken on the `Build the model` chip, and repeating it here
+                    would make this fix another instance of the defect class it
+                    removes. The button's acceptance path is the one thing that
+                    IS proven: the Olumi tab mounts a composer that takes a
+                    description (sweep A5, WORKS), and `handleTabClick('olumi')`
+                    is the same call the tab strip makes. */}
+                {isPreRun && nodes.length === 0 && (
+                  <div
+                    className="flex flex-col items-start gap-2"
+                    data-testid="outputs-analysis-empty"
+                  >
+                    <div className={`${typography.panelHeader} text-text-header`}>
+                      Nothing to analyse yet
+                    </div>
+                    <p className={`${typography.panelBody} text-text-light`}>
+                      This panel reports on a decision model. There isn’t one on the canvas yet.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => handleTabClick('olumi')}
+                      // `py-2` (8px), not the `py-1.5` (6px) the sibling
+                      // buttons in this file use: 6px is OFF the DS spacing
+                      // scale, and `tests/ci-guards/shell-conformance.spec.ts`
+                      // pins `off-scale-spacing` in this file at EXACTLY 6 —
+                      // it REDs on growth as well as on an unrecorded fix. New
+                      // markup in the shell host stays on-scale so the ratchet
+                      // holds without the pin moving.
+                      className={`${typography.panelBody} rounded px-3 py-2 bg-primary text-text-on-color hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-offset-1`}
+                      data-testid="outputs-analysis-empty-describe"
+                    >
+                      Describe your decision to Olumi
+                    </button>
+                  </div>
+                )}
                 {/* Pre-run state: Show consolidated guidance and Run button */}
                 {isPreRun && nodes.length > 0 && (
                   isPreAnalysisV3Enabled() ? (

--- a/src/canvas/components/StarterProvenanceBanner.tsx
+++ b/src/canvas/components/StarterProvenanceBanner.tsx
@@ -32,7 +32,15 @@ import { typography } from '../../styles/typography'
  */
 export function StarterProvenanceBanner() {
   const [dismissed, setDismissed] = useState(false)
-  const { sendMessage } = useConversationContext()
+  // `draft`/`setDraft` are the SHARED composer buffer — `AIInputBar` reads it
+  // from this same context precisely so the text survives a surface switch
+  // (`AIInputBar.tsx:110`, `:140`), and `FirstUseComposer` reads it too
+  // (`:97`). So this is the one write that lands the brief in whichever
+  // composer the user is actually looking at, which is what the confirm
+  // dialog below promises. Destructuring `draft` costs nothing extra: the
+  // context value is `useMemo`'d on `[conversation, draft, …]`, so this
+  // component already re-rendered on every keystroke.
+  const { sendMessage, draft, setDraft } = useConversationContext()
   const showToast = useShowToastSafe()
 
   // `resolveStarterId` is the single shape for this question, shared with the
@@ -50,10 +58,20 @@ export function StarterProvenanceBanner() {
     // model back" is a real outcome the user is entitled to know about first,
     // not a surprise. The last line states the RECOVERY the code below now
     // actually performs; it previously promised only the brief back.
+    // ⚠ THE UNDISCLOSED HALF, ADDED AFTER THE 18 Aug SWEEP SCORED THIS CONTROL
+    // MISLEADING: `resetCanvas()` below does not only clear the graph — for a
+    // decision that is NOT a saved record it also calls
+    // `clearTranscript(scenarioIdBeingReset)` (`store.ts`, resetCanvas), so the
+    // conversation so far is destroyed. The sweep's driver lost its chat here
+    // and this dialog had said nothing about it. The clause is conditional
+    // because the code is: a SAVED record's transcript belongs to the record and
+    // is deliberately left alone, so an unconditional warning would be its own
+    // false claim.
     const confirmed = window.confirm(
       'Re-draft this example live?\n\n' +
         'Olumi will send the original brief to the model and build a fresh graph. ' +
         'This clears the saved example and replaces it with whatever the live draft returns. ' +
+        'If this decision isn’t saved, it also clears the conversation so far. ' +
         'Live drafting can fail or time out; if it does, the saved example is put back and ' +
         'your brief comes back in the composer so you can retry.',
     )
@@ -110,13 +128,43 @@ export function StarterProvenanceBanner() {
       // rather than clobbering it with the old example.
       if (useCanvasStore.getState().nodes.length === 0) {
         useCanvasStore.getState().undoDraft()
+
+        // ⭐ AFFORDANCE SWEEP A13 — THE PROMISE THIS BRANCH DID NOT KEEP.
+        //
+        // The confirm dialog says, of the failure case, *"the saved example is
+        // put back AND YOUR BRIEF COMES BACK IN THE COMPOSER so you can
+        // retry"*, and the toast below repeated the claim. The code above put
+        // the example back and **never touched the composer** — so on the
+        // deployed build (`9ff14c19`) the user was left with the identical
+        // blocked model and an EMPTY composer, told twice that their brief was
+        // in it. Measured, fresh guest, 91 s after the click: canvas restored
+        // to its 20 nodes, banner back, `textarea.value === ""`.
+        //
+        // ⚠ AND THE TWO CLAIMS THE SAME MEASUREMENT REFUTED, recorded because
+        // this branch is the one a later session will read: the brief IS sent
+        // (wire-witnessed, `POST /proxy/v5/turn/stream`, `message` = the
+        // verbatim 385-char brief, 200) and the user's turn IS rendered (it is
+        // in the Olumi tab). The re-draft's only broken promise was this one —
+        // do not "fix" the other two.
+        //
+        // FAIL-SAFE, for the same reason the canvas check above is: if the user
+        // typed into the composer while the draft was in flight, that text is
+        // theirs and outranks the brief. So the restore is conditional — and
+        // the toast then may not claim it happened, which is why the sentence
+        // is chosen from the SAME boolean that performed the write rather than
+        // being asserted alongside it.
+        const composerWasEmpty = draft.trim().length === 0
+        if (composerWasEmpty) setDraft(starter.brief)
+
         showToast(
-          'The live re-draft didn’t return a model, so your saved example has been put back. Your brief is in the composer if you want to try again.',
+          composerWasEmpty
+            ? 'The live re-draft didn’t return a model, so your saved example has been put back. Your brief is in the composer if you want to try again.'
+            : 'The live re-draft didn’t return a model, so your saved example has been put back. What you had typed is still in the composer, so your brief was left out of it.',
           'warning',
         )
       }
     }
-  }, [starterId, sendMessage, showToast])
+  }, [starterId, sendMessage, showToast, draft, setDraft])
 
   if (!starterId || dismissed) return null
   const starter = getStarter(starterId)

--- a/src/canvas/components/__tests__/OutputsDock.analysisEmptyState.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.analysisEmptyState.spec.tsx
@@ -1,0 +1,249 @@
+/**
+ * THE TWO DEAD STATES OF THE `Analysis` DOCK TAB — pinned.
+ *
+ * Both were driven as a fresh guest on the deployed build `9ff14c19`
+ * (18 Aug 2026) and settled against the LIVE DOM, not a screenshot.
+ *
+ * ── A2 · THE COLLAPSED RAIL'S TAB ICONS WERE DEAD CONTROLS ────────────────
+ * Measured: with the dock at its first-use rail, clicking the rail's
+ * `Analysis` icon left `dock-collapse-control` reading `Expand outputs dock`,
+ * `outputs-dock-tab-results` ABSENT and `outputs-dock-body` ABSENT. Zero
+ * observable change. The click had selected a tab inside a panel the user could
+ * not see, discoverable only by separately pressing `Expand outputs dock`.
+ *
+ * Mechanism: `effectiveIsOpen` is `isFirstUse ? false : state.isOpen`, so
+ * `handleTabClick`'s `isOpen: true` was OVERRIDDEN by the rail.
+ * `toggleOpen`, the run-start auto-switch and the collapsed-response signal all
+ * drop the rail lock with `userExplicitlyOpenedRailRef.current = true`;
+ * `handleTabClick` was the one activation path that did not.
+ *
+ * ⚠ TRAP 3b — THE FLAG THAT DECIDES WHETHER THIS TEST IS ABOUT ANYTHING.
+ * The rail only exists when `aiPanelV2` is ON. It is `defaultValue: true` AND
+ * `VITE_FEATURE_AI_PANEL_V2 = "true"` in `netlify.toml`, and the rail was
+ * OBSERVED rendering on staging (three icons: Olumi / Analysis / Model), so the
+ * mounted path is the one under test here. The flag is mocked ON explicitly
+ * rather than left to a default, so this suite fails loudly if that ever moves
+ * instead of passing vacuously against a rail that no longer renders.
+ *
+ * ── A3 · THE EXPANDED PANEL WAS COMPLETELY BLANK ──────────────────────────
+ * Measured: Analysis tab active (`border-info` on `outputs-dock-tab-results`),
+ * `outputs-dock-body` present at 414 x 540 px, and `innerText` exactly `""`.
+ * Zero copy, no reason, no next step.
+ *
+ * Mechanism: every section of the results branch is gated on either
+ * `isPreRun && nodes.length > 0` or `!isPreRun`, so the INTERSECTION — no
+ * analysis has completed AND no model on the canvas — had no renderer at all.
+ * The `Model` tab already does this correctly (`ModelOutline`'s "Nothing in
+ * this group yet"), which is the pattern the fix copies.
+ *
+ * ── WHAT THE EMPTY-STATE COPY MAY CLAIM ───────────────────────────────────
+ * Its reachable condition is exactly `isPreRun && nodes.length === 0`, so the
+ * only facts in evidence are "no analysis has completed" and "no model on the
+ * canvas". It deliberately does NOT promise that describing a decision will
+ * produce a model — the same sweep found that promise broken on the
+ * `Build the model` chip, and repeating it here would make this fix another
+ * instance of the defect class it removes. The one thing it does promise is the
+ * button's destination, and that is asserted below by driving it.
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// OutputsDock's import chain pulls in supabase + dompurify, which break under
+// the test env. Stub both before any module evaluation.
+vi.mock('../../../lib/supabase', () => ({
+  supabase: {
+    from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }),
+  },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) }
+})
+
+// Spread the real module: a hand-listed factory silently drops every export
+// added later, and this repo has shipped that failure (CLAUDE.md trap 12).
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isAiPanelV2Enabled: () => true,
+    isJourneyTabEnabled: () => false,
+    isTelemetryEnabled: () => false,
+  }
+})
+
+// The real readiness hook fetches a relative URL on mount, which jsdom rejects
+// with "Invalid URL" as an unhandled rejection. Nothing here asserts readiness.
+vi.mock('../../hooks/useGraphReadiness', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/useGraphReadiness')>()
+  return {
+    ...actual,
+    useGraphReadiness: () => ({ readiness: null, loading: false, error: null, refresh: vi.fn() }),
+  }
+})
+
+import { OutputsDock } from '../OutputsDock'
+import { useCanvasStore } from '../../store'
+import { ConversationProvider } from '../../conversation/ConversationContext'
+
+function renderDock() {
+  return render(
+    <ConversationProvider>
+      <OutputsDock />
+    </ConversationProvider>,
+  )
+}
+
+/** The collapsed rail's icon buttons, addressed the way the DOM exposes them. */
+function railIcon(label: 'Olumi' | 'Analysis' | 'Model') {
+  const nav = document.querySelector('nav[aria-label="Outputs sections"]')
+  const btns = Array.from(nav?.querySelectorAll('button[aria-label]') ?? [])
+  return btns.find((b) => b.getAttribute('aria-label') === label) as HTMLElement | undefined
+}
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+
+describe('the Analysis dock tab in its two measured-dead states (affordance sweep A2 + A3)', () => {
+  beforeEach(() => {
+    ensureMatchMedia()
+    // A fresh guest: empty canvas, no analysis has ever completed. This is the
+    // exact intersection that had no renderer.
+    useCanvasStore.setState({ nodes: [] as never, edges: [] as never })
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('A2 — starts at the first-use rail, so the icons under test are the mounted ones', () => {
+    renderDock()
+    // PRECONDITION PINNED IN-TEST. Without this the two cases below could pass
+    // on an already-expanded dock, where `handleTabClick` never needed the
+    // override at all — a guard agreeing with itself.
+    expect(screen.getByTestId('dock-collapse-control')).toHaveAttribute(
+      'aria-label',
+      'Expand outputs dock',
+    )
+    expect(screen.queryByTestId('outputs-dock-tab-results')).toBeNull()
+    expect(screen.queryByTestId('outputs-dock-body')).toBeNull()
+    expect(railIcon('Analysis')).toBeTruthy()
+  })
+
+  it('A2 — clicking the collapsed rail’s Analysis icon OPENS the dock on Analysis', async () => {
+    renderDock()
+    const icon = railIcon('Analysis')!
+
+    fireEvent.click(icon)
+
+    // THE assertions that were RED: the dock stayed at 40px and the body never
+    // mounted, so the user saw nothing at all.
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-collapse-control')).toHaveAttribute(
+        'aria-label',
+        'Collapse outputs dock',
+      )
+    })
+    expect(screen.getByTestId('outputs-dock-tab-results')).toBeInTheDocument()
+    expect(screen.getByTestId('outputs-dock-body')).toBeInTheDocument()
+  })
+
+  it('A2 — the fix is on the shared handler, not special-cased to Analysis', async () => {
+    // The defect was in `handleTabClick`, which every rail icon shares, so a
+    // fix that only rescued Analysis would be the wrong shape. Driving a
+    // DIFFERENT icon is the discrimination: it must open the dock too.
+    renderDock()
+    fireEvent.click(railIcon('Model')!)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('dock-collapse-control')).toHaveAttribute(
+        'aria-label',
+        'Collapse outputs dock',
+      )
+    })
+    expect(screen.getByTestId('outputs-dock-tab-diagnostics')).toBeInTheDocument()
+  })
+
+  it('A3 — the expanded Analysis panel says what is going on instead of rendering nothing', async () => {
+    renderDock()
+    fireEvent.click(railIcon('Analysis')!)
+
+    const empty = await screen.findByTestId('outputs-analysis-empty')
+    expect(empty).toBeInTheDocument()
+    // Bound to the sentences, not merely to a non-empty box: the measured
+    // defect was "zero copy", and a container with no text would satisfy a
+    // presence-only assertion.
+    expect(empty).toHaveTextContent('Nothing to analyse yet')
+    expect(empty).toHaveTextContent('This panel reports on a decision model')
+
+    // The measured symptom, asserted directly: the dock body was `innerText`
+    // exactly "". It must not be that any more.
+    expect(screen.getByTestId('outputs-dock-body').textContent).not.toBe('')
+  })
+
+  it('A3 — the empty state’s only promise is its destination, and it keeps it', async () => {
+    // P8: an affordance must have an acceptance path for its direct answer. The
+    // button says "Describe your decision to Olumi", so pressing it must reach
+    // the Olumi surface — which is the one surface measured as WORKING for this
+    // (sweep A5: the chat panel opens with its composer).
+    renderDock()
+    fireEvent.click(railIcon('Analysis')!)
+
+    const cta = await screen.findByTestId('outputs-analysis-empty-describe')
+    fireEvent.click(cta)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('outputs-dock-tab-olumi')).toBeInTheDocument()
+    })
+    // Bound by identity to the ACTIVE tab, not merely to the tab existing: the
+    // strip lights the active tab with `border-info`.
+    await waitFor(() => {
+      expect(screen.getByTestId('outputs-dock-tab-olumi').className).toContain('border-info')
+    })
+    // …and the empty state must be gone, because the Analysis body unmounted.
+    expect(screen.queryByTestId('outputs-analysis-empty')).toBeNull()
+  })
+
+  it('OPPOSITE-DIRECTION TWIN: a canvas WITH a model does not get the empty state', async () => {
+    // Without this, "renders the empty state" is satisfiable by copy that
+    // always renders — which would sit on top of the pre-run readiness panel
+    // and tell a user with 20 nodes that there is no model.
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'n0', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'n0' } },
+      ] as never,
+      edges: [] as never,
+    })
+    renderDock()
+
+    // A populated canvas ends first use, so the dock is already open.
+    await waitFor(() => {
+      expect(screen.getByTestId('outputs-dock-tab-results')).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByTestId('outputs-dock-tab-results'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('outputs-dock-body')).toBeInTheDocument()
+    })
+    expect(screen.queryByTestId('outputs-analysis-empty')).toBeNull()
+  })
+})

--- a/src/canvas/components/__tests__/OutputsDock.analysisEmptyState.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.analysisEmptyState.spec.tsx
@@ -87,6 +87,19 @@ vi.mock('../../hooks/useGraphReadiness', async (importOriginal) => {
   }
 })
 
+// The pre-run readiness panel is stubbed for the same reason the sibling
+// `OutputsDock.analysis-run.spec.tsx` stubs it: the real one calls
+// `useShowToast()`, which THROWS outside a `<ToastProvider>`. Nothing here
+// asserts anything about its contents — the twin case below only needs to know
+// that the EMPTY state is absent once a model exists, so the stub is a marker,
+// not a fixture standing in for behaviour under test.
+vi.mock('../pre-analysis', () => ({
+  PreAnalysisPanel: () => <div data-testid="stub-pre-run" />,
+}))
+vi.mock('../pre-analysis-v3', () => ({
+  default: () => <div data-testid="stub-pre-run-v3" />,
+}))
+
 import { OutputsDock } from '../OutputsDock'
 import { useCanvasStore } from '../../store'
 import { ConversationProvider } from '../../conversation/ConversationContext'

--- a/src/canvas/components/__tests__/OutputsDock.analysisEmptyState.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.analysisEmptyState.spec.tsx
@@ -47,7 +47,7 @@
  */
 
 import '@testing-library/jest-dom/vitest'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // OutputsDock's import chain pulls in supabase + dompurify, which break under
@@ -102,6 +102,8 @@ vi.mock('../pre-analysis-v3', () => ({
 
 import { OutputsDock } from '../OutputsDock'
 import { useCanvasStore } from '../../store'
+import { useUIStore } from '../../../stores/uiStore'
+import { useFloatingPanelState } from '../../hooks/useFloatingPanelState'
 import { ConversationProvider } from '../../conversation/ConversationContext'
 
 function renderDock() {
@@ -117,6 +119,30 @@ function railIcon(label: 'Olumi' | 'Analysis' | 'Model') {
   const nav = document.querySelector('nav[aria-label="Outputs sections"]')
   const btns = Array.from(nav?.querySelectorAll('button[aria-label]') ?? [])
   return btns.find((b) => b.getAttribute('aria-label') === label) as HTMLElement | undefined
+}
+
+/**
+ * Put the dock in "expanded, Analysis fronted" — the state A3 is about —
+ * without going through the collapsed rail.
+ *
+ * Deliberately tolerant of BOTH starting states. The dock may already be open
+ * (see the leak note in the suite below), and a helper that assumed one or the
+ * other would turn an environment difference into a spurious failure. What it
+ * asserts is only its POSTCONDITION, which is the precondition each A3 case
+ * actually needs.
+ */
+async function expandToAnalysis() {
+  if (
+    screen.getByTestId('dock-collapse-control').getAttribute('aria-label') ===
+    'Expand outputs dock'
+  ) {
+    fireEvent.click(screen.getByTestId('dock-collapse-control'))
+  }
+  const tab = await screen.findByTestId('outputs-dock-tab-results')
+  fireEvent.click(tab)
+  await waitFor(() => {
+    expect(screen.getByTestId('outputs-dock-body')).toBeInTheDocument()
+  })
 }
 
 function ensureMatchMedia() {
@@ -139,7 +165,47 @@ function ensureMatchMedia() {
 
 describe('the Analysis dock tab in its two measured-dead states (affordance sweep A2 + A3)', () => {
   beforeEach(() => {
+    // EXPLICIT unmount before each case. RTL's automatic cleanup runs, but a
+    // case that ended inside `waitFor` can leave the previous tree alive long
+    // enough for `document.querySelector` (which, unlike `screen`, is not
+    // scoped to the current container) to find the EXPANDED tab strip's
+    // `<nav aria-label="Outputs sections">` instead of the collapsed rail's.
+    // Measured: cases 3-5 then failed with "Unable to fire a click event" —
+    // a missing element, not a false assertion — while each passed alone.
+    cleanup()
     ensureMatchMedia()
+    // ⚠⚠ WITHOUT THIS RESET ONE CASE BELOW PASSED WITH THE DEFECT STILL IN
+    // PLACE — measured, not theorised. `useUIStore` and the dock's persisted
+    // open-state are MODULE-LEVEL and survive `render`/`cleanup`, so a tab
+    // activation from an earlier case bumped `activeOutputTabVersion`, the
+    // dock's sync effect force-activated on the next mount, and the third case
+    // observed an already-open dock. It therefore asserted nothing about
+    // `handleTabClick` and would have shipped as a discriminator that does not
+    // discriminate (CLAUDE.md trap 13b — a guard whose evidence came from
+    // itself). Proven by re-running the same case FIRST against the pre-fix
+    // tree, where the dock correctly stayed collapsed.
+    //
+    // Resetting here rather than in one case, deliberately: the leak makes
+    // EVERY case order-dependent, so a per-case patch would leave the others
+    // passing by luck.
+    // ⚠ sessionStorage, NOT localStorage — and getting that wrong cost a whole
+    // battery run. `useDockState` persists the dock's `{isOpen, activeTab}`
+    // under `OUTPUTS_DOCK_STORAGE_KEY` in **sessionStorage**, so clearing
+    // localStorage alone left the dock OPEN from the previous case and the
+    // collapsed rail simply did not render — three cases then failed on a
+    // missing element rather than on their own assertion, which reads like a
+    // broken test and is in fact leaked state. Both are cleared because the
+    // component reads both.
+    sessionStorage.clear()
+    localStorage.clear()
+    useUIStore.setState({
+      activeOutputTab: 'results',
+      activeOutputTabVersion: 0,
+      outputSurfaceOrigin: null,
+      outputSurfaceOriginSeq: 0,
+      outputSurfaceOriginAt: null,
+    })
+    useFloatingPanelState.getState().close()
     // A fresh guest: empty canvas, no analysis has ever completed. This is the
     // exact intersection that had no renderer.
     useCanvasStore.setState({ nodes: [] as never, edges: [] as never })
@@ -180,25 +246,34 @@ describe('the Analysis dock tab in its two measured-dead states (affordance swee
     expect(screen.getByTestId('outputs-dock-body')).toBeInTheDocument()
   })
 
-  it('A2 — the fix is on the shared handler, not special-cased to Analysis', async () => {
-    // The defect was in `handleTabClick`, which every rail icon shares, so a
-    // fix that only rescued Analysis would be the wrong shape. Driving a
-    // DIFFERENT icon is the discrimination: it must open the dock too.
-    renderDock()
-    fireEvent.click(railIcon('Model')!)
-
-    await waitFor(() => {
-      expect(screen.getByTestId('dock-collapse-control')).toHaveAttribute(
-        'aria-label',
-        'Collapse outputs dock',
-      )
-    })
-    expect(screen.getByTestId('outputs-dock-tab-diagnostics')).toBeInTheDocument()
-  })
+  /**
+   * ⚠ A CASE WAS REMOVED HERE, AND THE REASON IS THE POINT.
+   *
+   * There was a third A2 case — "the fix is on the shared handler, not
+   * special-cased to Analysis" — that clicked the `Model` rail icon. It
+   * PASSED against the pre-fix tree, i.e. it discriminated nothing (CLAUDE.md
+   * trap 13b). Measured cause: it ran third, and a post-click effect from the
+   * preceding case leaves module-level state that ends the first-use rail, so
+   * by the time it mounted the dock was already open. Re-run FIRST against the
+   * pre-fix tree, the same click correctly left the dock collapsed
+   * (`Expand outputs dock`, no body, no diagnostics tab).
+   *
+   * It is not replaced by a "fixed" version because the property it was
+   * reaching for is STRUCTURAL, not behavioural: the override is one
+   * unconditional line inside `handleTabClick`, which every tab — strip and
+   * rail alike — routes through. There is no tab predicate for a test to
+   * discriminate against. A case that can only pass by luck is worse than a
+   * comment saying where the guarantee comes from.
+   */
 
   it('A3 — the expanded Analysis panel says what is going on instead of rendering nothing', async () => {
+    // Reached through `expandToAnalysis()` rather than the collapsed rail: A3 is
+    // a claim about what the EXPANDED panel RENDERS, and how it got expanded is
+    // irrelevant to it. Keeping the rail out of these two cases also keeps them
+    // immune to the module-state leak documented above, which is what made the
+    // removed case pass for the wrong reason.
     renderDock()
-    fireEvent.click(railIcon('Analysis')!)
+    await expandToAnalysis()
 
     const empty = await screen.findByTestId('outputs-analysis-empty')
     expect(empty).toBeInTheDocument()
@@ -219,7 +294,7 @@ describe('the Analysis dock tab in its two measured-dead states (affordance swee
     // the Olumi surface — which is the one surface measured as WORKING for this
     // (sweep A5: the chat panel opens with its composer).
     renderDock()
-    fireEvent.click(railIcon('Analysis')!)
+    await expandToAnalysis()
 
     const cta = await screen.findByTestId('outputs-analysis-empty-describe')
     fireEvent.click(cta)

--- a/src/canvas/components/__tests__/StarterProvenanceBanner.failedRedraft.spec.tsx
+++ b/src/canvas/components/__tests__/StarterProvenanceBanner.failedRedraft.spec.tsx
@@ -41,8 +41,14 @@ import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const sendMessageMock = vi.fn()
+const setDraftMock = vi.fn()
 vi.mock('../../conversation/ConversationContext', () => ({
-  useConversationContext: () => ({ sendMessage: sendMessageMock }),
+  // `draft`/`setDraft` are part of this context's real shape and the banner's
+  // failure path now writes the brief back through them. A `vi.mock` FACTORY
+  // REPLACES THE MODULE (CLAUDE.md trap 12), so a field omitted here is
+  // `undefined` in the component — which is why they are listed rather than
+  // the component being made defensive against its own test double.
+  useConversationContext: () => ({ sendMessage: sendMessageMock, draft: '', setDraft: setDraftMock }),
 }))
 
 const showToast = vi.fn()

--- a/src/canvas/components/__tests__/StarterProvenanceBanner.redraftComposerRestore.spec.tsx
+++ b/src/canvas/components/__tests__/StarterProvenanceBanner.redraftComposerRestore.spec.tsx
@@ -1,0 +1,196 @@
+/**
+ * THE RE-DRAFT'S FAILURE PROMISE, PINNED — the composer half.
+ *
+ * ── WHAT WAS BROKEN, AND HOW IT WAS MEASURED ──────────────────────────────
+ * `Re-draft this live` raises a confirm that says, of the failure case: *"the
+ * saved example is put back **and your brief comes back in the composer** so
+ * you can retry"*, and its toast repeated the claim. `handleRedraft` put the
+ * example back (`undoDraft`) and **never touched the composer**.
+ *
+ * Driven as a fresh guest on the deployed build `9ff14c19`, 18 Aug 2026: 91 s
+ * after the click the canvas was restored to its 20 nodes, the saved-example
+ * banner was back, and `textarea.value === ""`. The product's own prescribed
+ * remedy for the disabled Analyse button therefore left the user in the
+ * identical blocked state, having told them twice that their brief was waiting
+ * for them.
+ *
+ * ── ⚠ TWO CLAIMS THE SAME MEASUREMENT REFUTED — DO NOT "FIX" THEM ─────────
+ * The 18 Aug affordance sweep recorded that the re-draft sent no brief and
+ * produced no user turn. Both are false, and a lane that believes them will
+ * rebuild working machinery:
+ *
+ *   - THE BRIEF IS SENT, VERBATIM. Wire-witnessed with a `fetch` interceptor:
+ *     `POST https://cee-staging.onrender.com/proxy/v5/turn/stream`, HTTP 200,
+ *     `message` = the full 385-character vendor-selection brief,
+ *     `source: "composer"`, `stage: "frame"`.
+ *   - THE USER'S TURN IS RENDERED. It is in the Olumi dock tab, above CEE's
+ *     reply. The sweep was reading the first-use hero, which by design has NO
+ *     transcript (`OutputsDock.tsx` — *"the floating hero (FirstUseComposer) —
+ *     which has NO transcript"*).
+ *
+ * The re-draft's ONE broken promise was the composer, and that is all this
+ * file pins.
+ *
+ * ── WHY FAILURE IS SIMULATED AS A RESOLVING SEND ──────────────────────────
+ * Inherited from `StarterProvenanceBanner.failedRedraft.spec.tsx`, and it is
+ * load-bearing: a failed USER turn does NOT reject. `sendTurn` catches the
+ * dispatch error, renders the transport-honest bubble and returns normally, so
+ * `sendMessage` RESOLVES on failure. A spec written against a rejection would
+ * pass against a `.catch()` that can never fire in production.
+ *
+ * ── THE OPPOSITE-DIRECTION TWIN ───────────────────────────────────────────
+ * A restore that always runs would clobber text the user typed while the draft
+ * was in flight — trading a broken promise for destroyed input. So every case
+ * here has its twin: empty composer ⇒ brief restored and the toast says so;
+ * NON-empty composer ⇒ the user's text survives untouched and the toast says
+ * THAT instead. The two toast sentences are chosen from the same boolean that
+ * performs the write, so they cannot disagree with what happened.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+const sendMessageMock = vi.fn()
+const setDraftMock = vi.fn()
+// The composer buffer this suite is about. Held in a mutable local so a case
+// can present a NON-empty composer, which is the opposite-direction twin.
+let draftValue = ''
+vi.mock('../../conversation/ConversationContext', () => ({
+  useConversationContext: () => ({
+    sendMessage: sendMessageMock,
+    draft: draftValue,
+    setDraft: setDraftMock,
+  }),
+}))
+
+const showToast = vi.fn()
+vi.mock('../../ToastContext', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, useShowToastSafe: () => showToast }
+})
+
+import { StarterProvenanceBanner } from '../StarterProvenanceBanner'
+import { useCanvasStore } from '../../store'
+import { STARTERS } from '../../starters/loadStarter'
+
+const VENDOR = STARTERS.find((s) => s.id === 'vendor-selection')!
+
+function seedStarterGraph(count = 3) {
+  useCanvasStore.setState({
+    nodes: Array.from({ length: count }, (_, i) => ({
+      id: `n${i}`,
+      type: 'factor',
+      position: { x: 0, y: 0 },
+      data: { label: `n${i}`, starterId: 'vendor-selection', starterTitle: VENDOR.title },
+    })) as never,
+    edges: [{ id: 'e0', source: 'n0', target: 'n1' }] as never,
+  })
+}
+
+describe('a failed starter re-draft returns the brief to the composer (affordance sweep A13)', () => {
+  let confirmSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    draftValue = ''
+    confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true) as never
+    seedStarterGraph()
+    // `resetCanvas` is deliberately NOT mocked: the defect lives in what the
+    // real reset destroys, and a no-op reset makes the restore vacuous.
+  })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('writes the starter brief into the shared composer when the live draft returns no model', async () => {
+    sendMessageMock.mockImplementation(async () => undefined)
+    const user = userEvent.setup()
+    render(<StarterProvenanceBanner />)
+
+    await user.click(screen.getByTestId('starter-redraft'))
+    await waitFor(() => expect(sendMessageMock).toHaveBeenCalledTimes(1))
+
+    // THE assertion that was RED: nothing ever wrote to the composer.
+    //
+    // Bound by IDENTITY, not by a value predicate: the expectation is the
+    // manifest's OWN brief for the starter whose stamp is on the seeded nodes,
+    // so a restore that wrote some other starter's brief (or any non-empty
+    // placeholder) fails here rather than passing on the wrong object.
+    await waitFor(() => expect(setDraftMock).toHaveBeenCalledWith(VENDOR.brief))
+    expect(setDraftMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('says in the toast that the brief is in the composer — and only when it put it there', async () => {
+    sendMessageMock.mockImplementation(async () => undefined)
+    const user = userEvent.setup()
+    render(<StarterProvenanceBanner />)
+
+    await user.click(screen.getByTestId('starter-redraft'))
+    await waitFor(() => expect(showToast).toHaveBeenCalledTimes(1))
+
+    const [message, level] = showToast.mock.calls[0]
+    expect(level).toBe('warning')
+    expect(message).toContain('Your brief is in the composer')
+    // The claim and the write must come from the same decision.
+    expect(setDraftMock).toHaveBeenCalledWith(VENDOR.brief)
+  })
+
+  it('OPPOSITE-DIRECTION TWIN: text the user typed while the draft was in flight is never clobbered', async () => {
+    draftValue = 'my own half-typed question about the CDP shortlist'
+    sendMessageMock.mockImplementation(async () => undefined)
+    const user = userEvent.setup()
+    render(<StarterProvenanceBanner />)
+
+    await user.click(screen.getByTestId('starter-redraft'))
+    await waitFor(() => expect(showToast).toHaveBeenCalledTimes(1))
+
+    // The user's input outranks the brief — the same fail-safe the canvas
+    // restore already applies to a graph that landed mid-flight.
+    expect(setDraftMock).not.toHaveBeenCalled()
+    // …and the toast must NOT then claim the brief is waiting, which is the
+    // whole point of choosing the sentence from the boolean that wrote.
+    const [message] = showToast.mock.calls[0]
+    expect(message).not.toContain('Your brief is in the composer')
+    expect(message).toContain('What you had typed is still in the composer')
+  })
+
+  it('NEGATIVE CONTROL: a SUCCESSFUL re-draft touches neither the composer nor the toast', async () => {
+    // A graph lands, exactly as a successful live draft would leave it.
+    sendMessageMock.mockImplementation(async () => {
+      useCanvasStore.setState({
+        nodes: [
+          { id: 'fresh', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'fresh' } },
+        ] as never,
+        edges: [] as never,
+      })
+    })
+    const user = userEvent.setup()
+    render(<StarterProvenanceBanner />)
+
+    await user.click(screen.getByTestId('starter-redraft'))
+    await waitFor(() => expect(sendMessageMock).toHaveBeenCalledTimes(1))
+
+    // Without this case, the first assertion is satisfiable by a restore that
+    // always runs and overwrites the composer on every successful re-draft.
+    expect(setDraftMock).not.toHaveBeenCalled()
+    expect(showToast).not.toHaveBeenCalled()
+  })
+
+  it('the confirm dialog discloses that an unsaved conversation is cleared', async () => {
+    sendMessageMock.mockImplementation(async () => undefined)
+    const user = userEvent.setup()
+    render(<StarterProvenanceBanner />)
+
+    await user.click(screen.getByTestId('starter-redraft'))
+
+    // `resetCanvas` calls `clearTranscript(scenarioIdBeingReset)` for a
+    // decision that is not a saved record, so the re-draft destroys the
+    // conversation — and this dialog used to say nothing about it. The
+    // sentence is conditional because the code is: a SAVED record's transcript
+    // is deliberately left alone, so an unconditional warning would be its own
+    // false claim.
+    const text = String(confirmSpy.mock.calls[0][0])
+    expect(text).toContain('If this decision isn’t saved, it also clears the conversation so far.')
+  })
+})

--- a/src/canvas/components/__tests__/StarterProvenanceBanner.spec.tsx
+++ b/src/canvas/components/__tests__/StarterProvenanceBanner.spec.tsx
@@ -14,8 +14,14 @@ import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 const sendMessageMock = vi.fn()
+const setDraftMock = vi.fn()
 vi.mock('../../conversation/ConversationContext', () => ({
-  useConversationContext: () => ({ sendMessage: sendMessageMock }),
+  // `draft`/`setDraft` are part of this context's real shape and the banner's
+  // failure path now writes the brief back through them. A `vi.mock` FACTORY
+  // REPLACES THE MODULE (CLAUDE.md trap 12), so a field omitted here is
+  // `undefined` in the component — which is why they are listed rather than
+  // the component being made defensive against its own test double.
+  useConversationContext: () => ({ sendMessage: sendMessageMock, draft: '', setDraft: setDraftMock }),
 }))
 
 import { StarterProvenanceBanner } from '../StarterProvenanceBanner'

--- a/src/canvas/components/__tests__/zz.probe2.spec.tsx
+++ b/src/canvas/components/__tests__/zz.probe2.spec.tsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom/vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+vi.mock('../../../lib/supabase', () => ({ supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) }, isSupabaseAvailable: () => false }))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('react-router-dom', async (io) => ({ ...(await io<any>()), useNavigate: vi.fn(() => vi.fn()) }))
+vi.mock('../../../flags', async (io) => ({ ...(await io<any>()), isAiPanelV2Enabled: () => true, isJourneyTabEnabled: () => false, isTelemetryEnabled: () => false }))
+vi.mock('../../hooks/useGraphReadiness', async (io) => ({ ...(await io<any>()), useGraphReadiness: () => ({ readiness: null, loading: false, error: null, refresh: vi.fn() }) }))
+vi.mock('../pre-analysis', () => ({ PreAnalysisPanel: () => <div data-testid="stub-pre-run" /> }))
+vi.mock('../pre-analysis-v3', () => ({ default: () => <div data-testid="stub-pre-run-v3" /> }))
+import { OutputsDock } from '../OutputsDock'
+import { useCanvasStore } from '../../store'
+import { useUIStore } from '../../../stores/uiStore'
+import { ConversationProvider } from '../../conversation/ConversationContext'
+function snap(tag: string) {
+  const cs: any = useCanvasStore.getState()
+  console.log(tag, JSON.stringify({
+    nodes: cs.nodes.length, resultsStatus: cs.resultsStatus ?? cs.results?.status, showResultsPanel: cs.showResultsPanel,
+    hasCompletedFirstRun: cs.hasCompletedFirstRun,
+    uiTab: useUIStore.getState().activeOutputTab, uiVer: useUIStore.getState().activeOutputTabVersion,
+    ss: sessionStorage.getItem('canvas.outputsDock.v1'),
+    collapse: screen.queryByTestId('dock-collapse-control')?.getAttribute('aria-label'),
+  }))
+}
+describe('probe2', () => {
+  beforeEach(() => {
+    sessionStorage.clear(); localStorage.clear()
+    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0, outputSurfaceOrigin: null, outputSurfaceOriginSeq: 0, outputSurfaceOriginAt: null })
+    useCanvasStore.setState({ nodes: [] as never, edges: [] as never })
+  })
+  it('t1 opens via rail', () => {
+    render(<ConversationProvider><OutputsDock /></ConversationProvider>)
+    snap('T1-PRE ')
+    const nav = document.querySelector('nav[aria-label="Outputs sections"]')
+    const btn = Array.from(nav!.querySelectorAll('button[aria-label]')).find(b => b.getAttribute('aria-label') === 'Analysis') as HTMLElement
+    fireEvent.click(btn); snap('T1-POST')
+    expect(true).toBe(true)
+  })
+  it('t2 should still start collapsed', () => {
+    render(<ConversationProvider><OutputsDock /></ConversationProvider>)
+    snap('T2-PRE ')
+    expect(true).toBe(true)
+  })
+})


### PR DESCRIPTION
Three first-send affordances the 18 Aug sweep scored **DEAD / DEAD / MISLEADING**. Every one was **reproduced on the deployed build `9ff14c19`** as a fresh guest and settled against the **live DOM** (screenshots lag badly on this machine), before being fixed.

## What was measured, and what changed

**A2 — the collapsed rail's tab icons were dead controls.** Clicking the rail's `Analysis` icon left `dock-collapse-control` reading `Expand outputs dock`, `outputs-dock-tab-results` **absent** and `outputs-dock-body` **absent**. Zero observable change: the click selected a tab inside a panel the user could not see.
Mechanism: `effectiveIsOpen` is `isFirstUse ? false : state.isOpen`, so `handleTabClick`'s `isOpen: true` was overridden by the first-use rail. `toggleOpen`, the run-start auto-switch and the collapsed-response signal all drop the rail lock with `userExplicitlyOpenedRailRef.current = true`. `handleTabClick` was the one activation path that did not. Fixed with **that same one line** — not a second mechanism.

**A3 — the expanded Analysis panel rendered completely blank.** `outputs-dock-body` present at **414 × 540 px** with `innerText` exactly `""`. Zero copy, no reason, no next step.
Mechanism: every section of the results branch is gated on `isPreRun && nodes.length > 0` or on `!isPreRun`, so the **intersection** — no analysis yet AND no model — had no renderer at all. Adds an honest empty state modelled on the `Model` tab's existing `Nothing in this group yet`.

**A13 — `Re-draft this live` did not keep its composer promise.** The confirm says that on failure *"your brief comes back in the composer"*; the toast repeated it; the code never touched the composer. Measured 91 s after the click: canvas restored to its 20 nodes, banner back, `textarea.value === ""`. It now writes the starter's own brief into the shared `ConversationContext` buffer, **fail-safe** (text typed mid-flight outranks the brief), with the toast sentence chosen from the *same boolean that performed the write* so the two cannot disagree. The confirm also now discloses that an **unsaved conversation is cleared** — `resetCanvas` calls `clearTranscript` and the dialog said nothing about it.

## ⚠ Two sweep premises REFUTED at the wire

Recorded in the code so a later lane does not rebuild working machinery:

- **The brief IS sent, verbatim.** `POST https://cee-staging.onrender.com/proxy/v5/turn/stream`, HTTP 200, `message` = the full 385-character vendor-selection brief, `source: "composer"`, `stage: "frame"`.
- **The user's turn IS rendered.** It is in the Olumi dock tab, above CEE's reply. The sweep was reading the first-use hero, which **by design has no transcript**.

The re-draft's only broken promise was the composer.

## Copy discipline

The lead question — *could this fix be another instance of the defect class it removes?* — is answered in the diff. The empty state's reachable condition is exactly `isPreRun && nodes.length === 0`, so it claims **only** the two facts in evidence. It deliberately does **not** promise that describing a decision produces a model on the canvas: that is the promise the same sweep found broken on the `Build the model` chip. Its one promise is the button's destination, and that is asserted by driving it.

## Evidence

- **RED-first, both directions, in a worktree outside the repo root** with **sentinel-WRITE isolation** (wrote into the worktree, asserted the source clone unchanged; inodes differ) and **HEAD-relative restores** (trap 9h).
- Pristine control **10/10 green** (P4's mandatory control) with applied-check scoped to `src/` reading **exactly 0**.
- **Mutant A** (revert `OutputsDock.tsx`): **3 of 5 RED** on three distinct assertions — the `aria-label` still `Expand outputs dock`, and both `outputs-analysis-empty*` testids absent. applied-check exactly **1**.
- **Mutant B** (revert `StarterProvenanceBanner.tsx`): **4 of 5 RED** on four distinct assertions. applied-check exactly **1**. The one green case is the negative control, which is pre-fix-true.
- Specs collect their **expected count BY NAME**: `OutputsDock.analysisEmptyState` **5**, `StarterProvenanceBanner.redraftComposerRestore` **5**; the two pre-existing banner specs unchanged at **12** and **5**. 22/22 green.
- `pnpm typecheck` (the repo's own gate, `scripts/ci/typecheck-gate.sh`): **exit 0**, 3503/3543 tracked files loaded.

## A case that discriminated nothing — removed, and why

A third A2 case (`the fix is on the shared handler`) **passed against the pre-fix tree**. Measured cause: it ran third, and a post-click effect from the preceding case leaves module-level state that ends the first-use rail, so it mounted against an already-open dock. Re-run **first** against the pre-fix tree, the same click correctly left the dock collapsed. It is **removed, not "fixed"**: the property it reached for is structural — one unconditional line in the shared handler, no tab predicate to discriminate against. The two A3 cases were moved off the rail for the same reason. Both facts are recorded in the spec.

## Notes for the integrator

- **Small expected conflict.** `StarterProvenanceBanner.spec.tsx` and `StarterProvenanceBanner.failedRedraft.spec.tsx` each gain `draft`/`setDraft` in their `vi.mock` factory (a factory **replaces** the module, so an omitted field is `undefined` — the component is deliberately **not** made defensive against its own test double). A sibling lane was editing the doc comments of those files; the edits do not overlap.
- **`OutputsDock.tsx` regions are disjoint** from the sibling's `blockedReason` work.
- `off-scale-spacing` is pinned at **exactly 6** for `OutputsDock.tsx` and REDs on growth as well as shrinkage, so the new button uses `py-2` (8px, on-scale) rather than the `py-1.5` its siblings use. The pin is untouched.
- **Item 4 of the brief (`Ask Olumi about <node>`) is NOT in this PR** — see the lane report. **UNMEASURED by me:** lint and the full suite (load average 280 on a 10-core machine).

Not merged, CI not polled — per the 18 Aug amendment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)