### PR TITLE
fix(analyse): one authority for "analysis is held" — the Analyse control stops stating things that are not true

### DIFF
--- a/DESIGN_SYSTEM.md
+++ b/DESIGN_SYSTEM.md
@@ -297,7 +297,8 @@ same state).
 | Model changed since analysis (CEE verdict) | Model changed since this analysis. Re-run to update. | `FRESHNESS_COPY.stale` |
 | Freshness unknown | Cannot confirm whether this analysis is current. | `FRESHNESS_COPY.unknown` |
 | No analysis yet | No analysis yet. | `FRESHNESS_COPY.none` |
-| Engine cannot see the model | Draft or save a model first, then run analysis. | `CEE_DRAFT_FIRST_REFUSAL` |
+| Analysis held on a bundled starter | Analysis is held on a saved example. Re-draft it live to run one. | `ANALYSIS_HELD_NOTICE.starter` |
+| Analysis held on an inserted template | Analysis is held on an inserted template. Re-draft it live to run one. | `ANALYSIS_HELD_NOTICE.template` |
 | Guest panel constraint not analysed (persistence inactive) | In guest mode, constraints added here aren't included in the analysis. Add them in chat instead. | `GOAL_CONSTRAINT_COPY.guestConstraintsNotInAnalysis` |
 | Template load failed | Failed to load template. | `TEMPLATE_LOAD_FAILED_MESSAGE` |
 

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -107,13 +107,12 @@ import { useConversation } from '../conversation/useConversation'
 import {
   canRunAnalysis as canRunAnalysisUtil,
   getRunButtonTooltip,
-  computeCeeCannotSeeModel,
   readinessObjectsToRun,
   verdictLicenceSuperseded,
   RUN_LICENCE_SUPERSEDED_REFUSAL,
   type ReadinessVerdictLicence,
 } from '../utils/canRunAnalysis'
-import { clientInjectedProvenance } from '../utils/analysisHeldOnInjectedModel'
+import { analysisHeldOn } from '../utils/analysisHeldOnInjectedModel'
 import { selectOptionsNeedingValues } from '../utils/composeBlockedReason'
 import { WarningBanner } from './WarningBanner'
 import { DegradedStateBanner } from './DegradedStateBanner'
@@ -1148,8 +1147,10 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     hasBlockers: hasValidationBlockers,
     nodeCount: nodes.length,
     isRunning,
-    ceeCannotSeeModel: computeCeeCannotSeeModel(nodes),
-    injectedProvenance: clientInjectedProvenance(nodes),
+    // ONE value carries both "is analysis held?" and "what do we call this
+    // model?" — see `analysisHeldOn`. Two parameters here is how the panel and
+    // the composer came within one review of naming the same state differently.
+    analysisHeldOn: analysisHeldOn(nodes),
     draftStreamPhase,
     optionsNeedingValues,
     readinessStale,

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -113,6 +113,7 @@ import {
   RUN_LICENCE_SUPERSEDED_REFUSAL,
   type ReadinessVerdictLicence,
 } from '../utils/canRunAnalysis'
+import { clientInjectedProvenance } from '../utils/analysisHeldOnInjectedModel'
 import { selectOptionsNeedingValues } from '../utils/composeBlockedReason'
 import { WarningBanner } from './WarningBanner'
 import { DegradedStateBanner } from './DegradedStateBanner'
@@ -1148,6 +1149,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     nodeCount: nodes.length,
     isRunning,
     ceeCannotSeeModel: computeCeeCannotSeeModel(nodes),
+    injectedProvenance: clientInjectedProvenance(nodes),
     draftStreamPhase,
     optionsNeedingValues,
     readinessStale,

--- a/src/canvas/components/StarterProvenanceBanner.tsx
+++ b/src/canvas/components/StarterProvenanceBanner.tsx
@@ -5,6 +5,7 @@ import { useCanvasStore } from '../store'
 import { useShowToastSafe } from '../ToastContext'
 import { useConversationContext } from '../conversation/ConversationContext'
 import { getStarter, resolveStarterId } from '../starters/loadStarter'
+import { analysisHeldNotice } from '../utils/analysisHeldOnInjectedModel'
 import { typography } from '../../styles/typography'
 
 /**
@@ -46,6 +47,16 @@ export function StarterProvenanceBanner() {
   // `resolveStarterId` is the single shape for this question, shared with the
   // run gate — see its docstring for why reading nodes[0] alone was wrong.
   const starterId = useCanvasStore((s) => resolveStarterId(s.nodes))
+  /**
+   * ⭐ THE ANALYSIS CLAIM NOW TRACKS THE RUN GATE, rather than the banner's own
+   * mount condition. The 18 Aug affordance sweep found this notice still saying
+   * "Analysis is held on a saved example" while a toast said "Analysis
+   * complete." — because the banner mounted on `starterId` while the gate
+   * refused on a DIFFERENT condition. `analysisHeldNotice` is the gate's own
+   * condition and the gate's own sentence, so the two cannot disagree; `null`
+   * means analysis is not held and the claim is simply not made.
+   */
+  const heldNotice = useCanvasStore((s) => analysisHeldNotice(s.nodes))
 
   const handleRedraft = useCallback(async () => {
     if (!starterId) return
@@ -189,8 +200,7 @@ export function StarterProvenanceBanner() {
             saving does NOT re-enable analysis. Re-drafting is the one route
             that does, because the resulting graph comes from a CEE turn. */}
         <p className={`mt-1 ${typography.caption} text-text-light`}>
-          Edit anything on the canvas. Analysis is held on a saved example — re-draft it live to
-          run one.
+          Edit anything on the canvas.{heldNotice === null ? '' : ` ${heldNotice}`}
         </p>
         <button
           type="button"

--- a/src/canvas/components/StarterProvenanceBanner.tsx
+++ b/src/canvas/components/StarterProvenanceBanner.tsx
@@ -25,7 +25,7 @@ import { typography } from '../../styles/typography'
  *
  * It also names the analysis consequence, because the Analyse button IS
  * disabled for a starter and a user who does not know why will read it as the
- * product being broken. `computeCeeCannotSeeModel` refuses the run for any
+ * product being broken. `analysisHeldOn` refuses the run for any
  * client-injected graph on the V5 canonical path: the V5 turn body carries no
  * graph, so CEE would otherwise answer about a model it never received. The
  * re-draft is the honest route to an analysable model, which is exactly why it

--- a/src/canvas/components/__tests__/OutputsDock.blockedReasonWiring.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.blockedReasonWiring.spec.tsx
@@ -29,6 +29,7 @@ import { useCanvasStore } from '../../store'
 import { useReadinessStore } from '../../stores/readinessStore'
 import { clearInflightCache } from '../../hooks/useGraphReadiness'
 import { BLOCKED_REASON_COPY } from '../../utils/composeBlockedReason'
+import { ANALYSIS_HELD_NOTICE } from '../../utils/analysisHeldOnInjectedModel'
 import { FOOTER_COPY } from '../pre-analysis-v3/constants'
 
 vi.mock('react-router-dom', async (importOriginal) => {
@@ -112,18 +113,27 @@ function ensureMatchMedia() {
   }
 }
 
-/** Pre-run canvas: a decision, a goal and five options — Paul's actual model. */
-function seedPreRunCanvas(overrides: Record<string, unknown> = {}) {
+/**
+ * Pre-run canvas: a decision, a goal and five options — Paul's actual model.
+ *
+ * `stamp` is the client-side injection provenance `applyStarter` writes onto
+ * EVERY node. Passing it is the only difference between the two cases in the
+ * final describe below, which is what makes that pair discriminating.
+ */
+function seedPreRunCanvas(
+  overrides: Record<string, unknown> = {},
+  stamp: Record<string, unknown> = {},
+) {
   const nodes = [
-    { id: 'd1', type: 'decision', position: { x: 0, y: 0 }, data: { kind: 'decision', label: 'Build or buy?' } },
-    { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { kind: 'goal', label: 'Increase delivery output' } },
+    { id: 'd1', type: 'decision', position: { x: 0, y: 0 }, data: { kind: 'decision', label: 'Build or buy?', ...stamp } },
+    { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { kind: 'goal', label: 'Increase delivery output', ...stamp } },
     ...Object.entries(OPTION_LABELS).map(([id, label], i) => ({
       id,
       type: 'option',
       position: { x: 10 * i, y: 0 },
-      data: { kind: 'option', label },
+      data: { kind: 'option', label, ...stamp },
     })),
-    { id: 'f1', type: 'factor', position: { x: 0, y: 0 }, data: { kind: 'factor', label: 'Ramp-up time' } },
+    { id: 'f1', type: 'factor', position: { x: 0, y: 0 }, data: { kind: 'factor', label: 'Ramp-up time', ...stamp } },
   ]
   useCanvasStore.setState({
     nodes: nodes as never,
@@ -196,7 +206,25 @@ beforeEach(() => {
 afterEach(() => {
   useReadinessStore.getState().reset()
   vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+  try { localStorage.removeItem('feature.v5CanonicalAnalysis') } catch { /* jsdom quirk */ }
 })
+
+/**
+ * The DEPLOYED run-path posture: both `VITE_V5_CANONICAL_ANALYSIS` and
+ * `VITE_ENABLE_V5_ORCHESTRATOR` are inlined "true" in the staging bundle, so the
+ * canonical path — the one on which CEE receives no graph — is the one a real
+ * user is on (trap 3b: bind to the surface the deployed flags mount).
+ *
+ * ⚠ The canonical half goes through the documented localStorage override, not
+ * `vi.stubEnv`: `lib/flagFactory.ts` reads env from an EAGERLY-CAPTURED SNAPSHOT
+ * (`envSnapshot`) while it reads `localStorage` per call, so a stub set inside a
+ * test arrives after the snapshot and silently reads OFF.
+ */
+function seedCanonicalRunPath() {
+  try { localStorage.setItem('feature.v5CanonicalAnalysis', '1') } catch { /* jsdom quirk */ }
+  vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'true')
+}
 
 describe('OutputsDock → the blocked footer, through the real wiring', () => {
   it('names the option the user must describe (no prop injection anywhere)', async () => {
@@ -256,5 +284,69 @@ describe('OutputsDock → the blocked footer, through the real wiring', () => {
       'title',
       BLOCKED_REASON_COPY.oneOption('Partner with a consultancy', true),
     )
+  }, 30_000)
+})
+
+/**
+ * ⭐ THE A2 DEFECT, AT THE DOCK — and the mutant that made this necessary.
+ *
+ * The 18 Aug affordance sweep (A7) found `Analyse first pass` disabled under
+ * "Draft or save a model first, then run analysis." on a 20-node bundled
+ * starter, four rows below the same panel's own option/risk/estimate counts.
+ * The gate now refuses with the sentence the provenance banner already shipped.
+ *
+ * WHY IT IS PINNED HERE AND NOT ONLY AT THE GATE: a mutant that deleted
+ * `analysisHeldOn: analysisHeldOn(nodes)` from OutputsDock's `canRunAnalysis`
+ * call SURVIVED a battery of 261 tests across six spec files. Every one of them
+ * tested the gate as a function or the footer as a prop — the WIRING between
+ * them, which is the entire fix, was pinned by nothing. This file exists for
+ * exactly that class (see its header), so the case belongs in it.
+ *
+ * The verdict is deliberately `can_run_analysis: true` so the hold is the ONLY
+ * blocker: with a refusing verdict the footer would print the readiness rung and
+ * this pin would pass without the wiring ever running.
+ */
+describe('OutputsDock → the held-analysis refusal, through the real wiring', () => {
+  it('a bundled starter refuses with the truthful sentence, not "draft or save a model first"', async () => {
+    seedCanonicalRunPath()
+    seedPreRunCanvas({}, { starterId: 'starter-decision-vendor-selection' })
+    seedVerdict({ can_run_analysis: true, options_ready: 5 })
+
+    render(
+      <ToastProvider>
+        <OutputsDock />
+      </ToastProvider>,
+    )
+
+    const footer = await screen.findByTestId('pre-analysis-v3-footer', {}, { timeout: 20_000 })
+    expect(footer).toHaveTextContent(ANALYSIS_HELD_NOTICE.starter)
+    // The witnessed sentence, and the non-committal line an unwired dock gives.
+    expect(footer).not.toHaveTextContent('Draft or save a model first')
+    expect(footer).not.toHaveTextContent(FOOTER_COPY.notReadySubFallback)
+
+    // One state, one story: the button says the same thing as the subline.
+    const analyse = screen.getByTestId('pre-analysis-v3-analyse')
+    expect(analyse).toBeDisabled()
+    expect(analyse).toHaveAttribute('title', ANALYSIS_HELD_NOTICE.starter)
+  }, 30_000)
+
+  it('DISCRIMINATOR: the identical model Olumi drafted ANALYSES — only the stamp differs', async () => {
+    // The founder's other half, at the dock. Same canvas, same verdict, same
+    // flags; the ONLY difference from the case above is the absence of the
+    // starter stamp. Without this twin the pin above would pass against a dock
+    // that had simply stopped enabling the button.
+    seedCanonicalRunPath()
+    seedPreRunCanvas()
+    seedVerdict({ can_run_analysis: true, options_ready: 5 })
+
+    render(
+      <ToastProvider>
+        <OutputsDock />
+      </ToastProvider>,
+    )
+
+    const analyse = await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
+    expect(analyse).toBeEnabled()
+    expect(screen.getByTestId('pre-analysis-v3-footer')).not.toHaveTextContent('Analysis is held')
   }, 30_000)
 })

--- a/src/canvas/components/__tests__/StarterProvenanceBanner.spec.tsx
+++ b/src/canvas/components/__tests__/StarterProvenanceBanner.spec.tsx
@@ -78,7 +78,7 @@ describe('StarterProvenanceBanner', () => {
 
     // ── the two-shapes defect ────────────────────────────────────────────
     //
-    // `computeCeeCannotSeeModel` (canRunAnalysis.ts) refuses the run when ANY
+    // `analysisHeldOn` (canRunAnalysis.ts) refuses the run when ANY
     // node carries starter provenance — `nodes.some(...)`. This banner used to
     // read `nodes[0]?.data?.starterId`, i.e. the FIRST node only. Two shapes
     // for one question, and they disagree exactly when an unstamped node sits

--- a/src/canvas/components/__tests__/StarterProvenanceBanner.spec.tsx
+++ b/src/canvas/components/__tests__/StarterProvenanceBanner.spec.tsx
@@ -7,6 +7,18 @@
  * tests pin the two claims that must never silently regress — that the
  * disclosure renders whenever starter provenance is on the graph, and that the
  * redraft re-sends the VERBATIM brief the shown graph came from.
+ *
+ * ⭐ THE ANALYSIS CLAIM IS NOW CONDITIONAL, AND THAT IS THE POINT (18 Aug
+ * affordance sweep, cross-cutting note 1). The banner used to print "Analysis
+ * is held on a saved example" unconditionally, on its OWN mount condition —
+ * so it kept saying it while a toast said "Analysis complete." It now reads
+ * `analysisHeldNotice`, the run gate's own condition and sentence, which is
+ * `null` off the V5 canonical run path (a V2-direct run carries the graph, so
+ * nothing is held). The DEPLOYED posture bakes that path ON — both
+ * `VITE_V5_CANONICAL_ANALYSIS` and `VITE_ENABLE_V5_ORCHESTRATOR` are inlined
+ * "true" — so the held-claim tests stub it ON to test the surface the
+ * deployment actually mounts (trap 3b), and the twin below proves the claim
+ * DISAPPEARS when the state stops holding.
  */
 
 import { render, screen, waitFor } from '@testing-library/react'
@@ -52,12 +64,29 @@ describe('StarterProvenanceBanner', () => {
     vi.clearAllMocks()
     confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
     resetSpy = vi.spyOn(useCanvasStore.getState(), 'resetCanvas').mockImplementation(() => {})
+    // The deployed flag posture (see the file header). Without it the run gate
+    // does not hold, so the banner correctly declines to say that it does — and
+    // the assertions below would be measuring a posture staging does not serve.
+    //
+    // ⚠ THE CANONICAL HALF GOES THROUGH localStorage, NOT `vi.stubEnv`.
+    // `flags.ts` resolves `VITE_V5_CANONICAL_ANALYSIS` at MODULE LOAD (which is
+    // why `flags.v5CanonicalAnalysis.spec.ts` pairs every `stubEnv` with a
+    // `vi.resetModules()`), so a stub set here arrives too late and reads as
+    // OFF. The documented storage override is evaluated per call and is the one
+    // that works from a component spec. Measured, not assumed: with `stubEnv`
+    // alone these assertions failed while the "STOPS claiming" twin below
+    // passed — i.e. the twin was agreeing for the wrong reason and proving
+    // nothing (trap 13b).
+    try { localStorage.setItem('feature.v5CanonicalAnalysis', '1') } catch { /* ignore */ }
+    vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'true')
     setNodes({ starterId: 'market-entry', starterTitle: MARKET.title })
   })
 
   afterEach(() => {
     confirmSpy.mockRestore()
     resetSpy.mockRestore()
+    vi.unstubAllEnvs()
+    try { localStorage.removeItem('feature.v5CanonicalAnalysis') } catch { /* ignore */ }
   })
 
   describe('disclosure', () => {
@@ -74,6 +103,22 @@ describe('StarterProvenanceBanner', () => {
     it('explains why analysis is held, so a disabled Run does not read as broken', () => {
       render(<StarterProvenanceBanner />)
       expect(screen.getByTestId('starter-provenance-banner')).toHaveTextContent(/analysis is held/i)
+    })
+
+    it('STOPS claiming analysis is held once the run gate no longer holds it', () => {
+      // The staleness the sweep witnessed, pinned from the other side: the
+      // banner still read "Analysis is held on a saved example" beside a toast
+      // that said "Analysis complete." The claim now comes from the gate's own
+      // condition, so when that condition is false the sentence is simply not
+      // made — while the provenance disclosure, which is still true, stays.
+      try { localStorage.setItem('feature.v5CanonicalAnalysis', '0') } catch { /* ignore */ }
+      render(<StarterProvenanceBanner />)
+      const banner = screen.getByTestId('starter-provenance-banner')
+      expect(banner).not.toHaveTextContent(/analysis is held/i)
+      // CONTROL: the banner is still mounted and still discloses provenance, so
+      // the absence above is the CLAIM being dropped, not the component.
+      expect(banner).toHaveTextContent(/saved example/i)
+      expect(banner).toHaveTextContent(/wasn’t generated just now/i)
     })
 
     // ── the two-shapes defect ────────────────────────────────────────────

--- a/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
+++ b/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
@@ -387,7 +387,7 @@ describe('every notice this module exports is governed (trap 12, round 2)', () =
    * module must be under the frame-licence rules.
    *
    * Scoped to that module on purpose. The gate module also exports
-   * `CLIENT_INJECTED_MODEL_REFUSAL`, which predates this lane and is governed
+   * `computeCeeCannotSeeModel`'s refusal, which predates this lane and is governed
    * by its own pins (`utils/__tests__/analyseAffordanceTruthfulness.spec.ts`) —
    * holding another module's copy to this lane's licence model would be the
    * wrong claim, so the two refusals this lane owns are listed explicitly above

--- a/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
+++ b/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
@@ -387,10 +387,17 @@ describe('every notice this module exports is governed (trap 12, round 2)', () =
    * module must be under the frame-licence rules.
    *
    * Scoped to that module on purpose. The gate module also exports
-   * `CEE_DRAFT_FIRST_REFUSAL`, which is CEE's own words quoted verbatim and
-   * predates this lane — holding someone else's copy to this lane's licence model
-   * would be the wrong claim, so the two refusals this lane owns are listed
-   * explicitly above and asserted here by name.
+   * `CLIENT_INJECTED_MODEL_REFUSAL`, which predates this lane and is governed
+   * by its own pins (`utils/__tests__/analyseAffordanceTruthfulness.spec.ts`) —
+   * holding another module's copy to this lane's licence model would be the
+   * wrong claim, so the two refusals this lane owns are listed explicitly above
+   * and asserted here by name.
+   *
+   * ⚠ This note used to justify the exclusion as "CEE's own words quoted
+   * verbatim". That justification was withdrawn when the constant was renamed:
+   * CEE emits that sentence for `NO_GRAPH`, a different question from the one
+   * this rung answers. The EXCLUSION still stands — it was always about
+   * ownership, not about provenance — but the reason given for it did not.
    */
   it('covers every *_NOTICE the narration module exports', () => {
     const exportedNotices = Object.keys(narration).filter((k) => k.endsWith('_NOTICE'))

--- a/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
+++ b/src/canvas/components/__tests__/narrationHonesty.invariant.spec.ts
@@ -387,7 +387,7 @@ describe('every notice this module exports is governed (trap 12, round 2)', () =
    * module must be under the frame-licence rules.
    *
    * Scoped to that module on purpose. The gate module also exports
-   * `computeCeeCannotSeeModel`'s refusal, which predates this lane and is governed
+   * `analysisHeldOn`'s refusal, which predates this lane and is governed
    * by its own pins (`utils/__tests__/analyseAffordanceTruthfulness.spec.ts`) —
    * holding another module's copy to this lane's licence model would be the
    * wrong claim, so the two refusals this lane owns are listed explicitly above

--- a/src/canvas/components/pre-analysis-v3/__tests__/analyseControlHonesty.mounted.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/__tests__/analyseControlHonesty.mounted.spec.tsx
@@ -1,0 +1,119 @@
+/**
+ * THE ANALYSE CONTROL, THROUGH THE SURFACE THE USER ACTUALLY LOADS (P2).
+ *
+ * `canRunAnalysis` returning an honest sentence proves nothing about what the
+ * panel prints. Between the gate and the pixel sits `PanelFooter`'s
+ * `vetBlockedReason`, which routes any non-composed string through
+ * `guardCeeText` — and that guard's whole job is to REPLACE strings it does not
+ * like with `FOOTER_COPY.notReadySubFallback`. A refusal that is true in the
+ * gate and degraded in the footer is the same defect wearing the fix's clothes,
+ * and it is invisible to every pure-function test of the gate.
+ *
+ * P1 — the seam tested one beyond the guard: `vetBlockedReason` → `guardCeeText`
+ * → the rendered `pre-analysis-v3-footer` subline AND the button's `title`.
+ *
+ * Trap 3b — this binds to `PanelFooter`, which is the surface the deployed
+ * flags mount: the 18 Aug affordance sweep read `data-testid`
+ * `pre-analysis-v3-analyse` and `pre-analysis-v3-footer` off the deployed build
+ * `1dec0ad6`, so these are the live ids, not a component the deployment skips.
+ *
+ * Scope (trap 3): PRESENCE and TEXT on the mounted footer. Not layout, not
+ * visibility, not above-the-fold — those need a browser.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { PanelFooter } from '../footer/PanelFooter'
+import { FOOTER_COPY } from '../constants'
+import { ANALYSIS_HELD_NOTICE } from '../../../utils/analysisHeldOnInjectedModel'
+
+/** The open-gate footer the panel supplies when it has nothing to refuse. */
+const openFooter = {
+  dot: 'success' as const,
+  headline: FOOTER_COPY.ready,
+  subline: 'First pass will be provisional until success is defined',
+}
+
+function renderFooter(props: Partial<React.ComponentProps<typeof PanelFooter>> = {}) {
+  return render(
+    <PanelFooter
+      footer={openFooter}
+      onAnalyse={vi.fn()}
+      isAnalysing={false}
+      canRun={false}
+      {...props}
+    />,
+  )
+}
+
+describe('the refusal the user reads is the refusal the gate emitted', () => {
+  it('CONTROL: the held-analysis sentence reaches the footer VERBATIM, not the fallback', () => {
+    renderFooter({ blockedReason: ANALYSIS_HELD_NOTICE.starter })
+
+    const footer = screen.getByTestId('pre-analysis-v3-footer')
+    expect(footer).toHaveTextContent(ANALYSIS_HELD_NOTICE.starter)
+    // The absence half — vacuous without the presence assertion above.
+    expect(footer).not.toHaveTextContent(FOOTER_COPY.notReadySubFallback)
+    // And the sentence the sweep witnessed is gone from this surface entirely.
+    expect(footer).not.toHaveTextContent('Draft or save a model first')
+  })
+
+  it('the button is DISABLED and its tooltip carries the SAME sentence as the subline', () => {
+    renderFooter({ blockedReason: ANALYSIS_HELD_NOTICE.starter })
+
+    const button = screen.getByTestId('pre-analysis-v3-analyse')
+    expect(button).toBeDisabled()
+    // Two consumers of one authority, in one component: the subline and the
+    // title must not be able to say different things about one state.
+    expect(button).toHaveAttribute('title', ANALYSIS_HELD_NOTICE.starter)
+  })
+
+  it('the template variant survives the guard too — both nouns, one seam', () => {
+    renderFooter({ blockedReason: ANALYSIS_HELD_NOTICE.template })
+    expect(screen.getByTestId('pre-analysis-v3-footer')).toHaveTextContent(
+      ANALYSIS_HELD_NOTICE.template,
+    )
+  })
+
+  it('NEGATIVE CONTROL: the degrade path is still alive, so the pins above are not vacuous', () => {
+    // Without this, "the sentence renders verbatim" would also pass against a
+    // guard that had been deleted. `value of information` is in the guard's
+    // extra-terms list with NO approved substitution, so it must degrade.
+    renderFooter({ blockedReason: 'The value of information is too low to analyse.' })
+
+    const footer = screen.getByTestId('pre-analysis-v3-footer')
+    expect(footer).toHaveTextContent(FOOTER_COPY.notReadySubFallback)
+    expect(footer).not.toHaveTextContent('value of information')
+  })
+})
+
+describe('the real journey: the obvious Analyse control works on a live model', () => {
+  it('an open gate ENABLES the button and makes no not-ready claim', () => {
+    // The founder's other half. A fix for a false refusal that quietly left the
+    // control disabled everywhere would satisfy every assertion above.
+    renderFooter({ canRun: true, blockedReason: undefined })
+
+    const button = screen.getByTestId('pre-analysis-v3-analyse')
+    expect(button).toBeEnabled()
+    expect(button).not.toHaveAttribute('title')
+
+    const footer = screen.getByTestId('pre-analysis-v3-footer')
+    expect(footer).toHaveTextContent(FOOTER_COPY.ready)
+    expect(footer).not.toHaveTextContent(FOOTER_COPY.notReady)
+    expect(footer).not.toHaveTextContent('Analysis is held')
+  })
+
+  it('an open gate ignores an advisory blockedReason rather than printing a refusal', () => {
+    // `blockedReason` is documented as advisory while the gate is open. This
+    // pins that an open gate cannot be made to state a refusal by a stale
+    // tooltip string — the failure mode that made an enabled state read as
+    // disabled in the original footer diagnosis.
+    renderFooter({ canRun: true, blockedReason: ANALYSIS_HELD_NOTICE.starter })
+
+    expect(screen.getByTestId('pre-analysis-v3-analyse')).toBeEnabled()
+    expect(screen.getByTestId('pre-analysis-v3-footer')).not.toHaveTextContent(
+      ANALYSIS_HELD_NOTICE.starter,
+    )
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -9,6 +9,7 @@
  */
 
 import type { BarKey, BarState, SparkPrompt } from './types'
+import { BLOCKED_REASON_COPY } from '../../utils/composeBlockedReason'
 
 export type { SparkPrompt } from './types'
 
@@ -289,8 +290,15 @@ export const FOOTER_COPY = {
    * The real reason is now composed from the readiness verdict's structured
    * fields (`utils/composeBlockedReason.ts`) and this string is reached only
    * when even that has nothing specific to say.
+   *
+   * ⚠ REFERENCED, NOT RE-TYPED. This was a VERBATIM SECOND COPY of
+   * `BLOCKED_REASON_COPY.unspecified` — the same sentence, in two files, kept
+   * identical by nobody (trap 12). They answer the same question: "the verdict
+   * refuses and nothing specific can be named." The `guardCeeText` degrade path
+   * lands here, so a drift between the two would show the user one sentence on
+   * the composed path and a different one on the degraded path, for one state.
    */
-  notReadySubFallback: 'Olumi is not able to run this yet. Ask in the chat and it will explain what is missing.',
+  notReadySubFallback: BLOCKED_REASON_COPY.unspecified,
   /**
    * UI-SEM-091: runnable-via-scaffold subline. Shown when readiness reports
    * not-runnable but CEE (#612) will draft the remaining options — replaces the

--- a/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
@@ -240,7 +240,7 @@ export function usePreAnalysisModel(): PreAnalysisModel {
    *
    * Derived from the graph's own stamp via `resolveStarterId` — the SAME
    * predicate the canvas disclosure (`StarterProvenanceBanner`) and the run
-   * gate (`computeCeeCannotSeeModel`) ask. A separate flag would be a second
+   * gate (`analysisHeldOn`) ask. A separate flag would be a second
    * answer to one question, and this panel would eventually contradict the
    * banner sitting directly above it (W-1: it already did).
    */

--- a/src/canvas/components/pre-analysis-v3/signals/__tests__/registry.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/__tests__/registry.spec.ts
@@ -26,6 +26,7 @@ import {
 } from '../../constants'
 import { findBannedTerm } from '../../../../../test/glossaryBannedTerms'
 import { BLOCKED_REASON_COPY } from '../../../../utils/composeBlockedReason'
+import { ANALYSIS_HELD_NOTICE } from '../../../../utils/analysisHeldOnInjectedModel'
 
 function input(overrides: Partial<SignalDetectionInput> = {}): SignalDetectionInput {
   return {
@@ -216,6 +217,14 @@ describe('glossary — every copy string passes the banned-terms scan', () => {
     manyOptions: BLOCKED_REASON_COPY.manyOptions(3, true),
     manyOptionsNoPromise: BLOCKED_REASON_COPY.manyOptions(3, false),
   })
+  // The injected-model refusal (18 Aug affordance sweep A7). It reaches THIS
+  // surface — `canRunAnalysis` hands it to `PanelFooter` as the `blockedReason`
+  // subline — so it belongs under the same copy rules as everything else the
+  // footer prints. Unswept, it was the one user-facing sentence on this panel
+  // that no glossary rule governed, which is how a second set of conventions
+  // gets in: the sweep is the only thing that makes "the product's copy rules"
+  // mean the product's copy rather than one file's.
+  push('ANALYSIS_HELD_NOTICE', ANALYSIS_HELD_NOTICE)
   // ROADMAP 2.376 — the contested surface's own copy, with its one factory invoked so the
   // sentence a user is shown is scanned rather than the function that builds it.
   push('CONTESTED_COPY', { ...CONTESTED_COPY, meta: CONTESTED_COPY.meta(2) })

--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -33,7 +33,8 @@ import { humaniseWireToken } from './friendlyOperation'
 import type { BriefReadiness } from './hooks/useBriefSignals'
 import { useThreadPersistence } from './hooks/useThreadPersistence'
 import { beginInteractionChain, getUiSurfaceState, recordCrossSurfaceEvent, recordInteractionEvent, recordUserAction, type InteractionStateSnapshot } from '../../lib/debug-state'
-import { canRunAnalysis as canRunAnalysisUtil, getRunButtonTooltip, computeCeeCannotSeeModel } from '../utils/canRunAnalysis'
+import { canRunAnalysis as canRunAnalysisUtil, getRunButtonTooltip } from '../utils/canRunAnalysis'
+import { analysisHeldOn } from '../utils/analysisHeldOnInjectedModel'
 import { useGraphReadiness } from '../hooks/useGraphReadiness'
 
 interface ConversationPanelProps {
@@ -497,10 +498,13 @@ export const ConversationPanel = memo(function ConversationPanel({
   })
   const isAnalysisRunning = resultsStatus === 'preparing' || resultsStatus === 'connecting' || resultsStatus === 'streaming'
 
-  // Boolean selector: recomputes on store writes but only re-renders on a
-  // flip. Same honest gate as OutputsDock — without it this surface's run
-  // button re-created the exact panel-vs-engine contradiction #343 fixed.
-  const ceeCannotSeeModel = useCanvasStore((s) => computeCeeCannotSeeModel(s.nodes))
+  // Primitive selector (a provenance string or null): recomputes on store
+  // writes but only re-renders on a flip. Same honest gate as OutputsDock —
+  // without it this surface's run button re-created the exact panel-vs-engine
+  // contradiction #343 fixed. It carries the WORDING too, which is why this
+  // surface's tooltip cannot describe the held model differently from the
+  // Analysis panel's refusal.
+  const heldOn = useCanvasStore((s) => analysisHeldOn(s.nodes))
   // ROADMAP 2.122 — this surface is a run affordance too, so it needs the
   // streamed-draft honesty rung for the same reason OutputsDock does: between
   // GRAPH_READY (~36 s) and COMPLETE (~61 s) the canvas holds a graph whose
@@ -518,10 +522,10 @@ export const ConversationPanel = memo(function ConversationPanel({
     hasBlockers,
     nodeCount,
     isRunning: isAnalysisRunning,
-    ceeCannotSeeModel,
+    analysisHeldOn: heldOn,
     draftStreamPhase,
     readinessStale,
-  }), [graphHealth, readiness, hasBlockers, nodeCount, isAnalysisRunning, ceeCannotSeeModel, draftStreamPhase, readinessStale])
+  }), [graphHealth, readiness, hasBlockers, nodeCount, isAnalysisRunning, heldOn, draftStreamPhase, readinessStale])
 
   // In-flight takes priority over structural reasons: the composer button
   // is disabled for either cause, but the user-visible tooltip should explain

--- a/src/canvas/conversation/__tests__/aiPanelTranche1Hotfix.spec.tsx
+++ b/src/canvas/conversation/__tests__/aiPanelTranche1Hotfix.spec.tsx
@@ -64,7 +64,7 @@ vi.mock('../zones/CoachingTip', () => ({
 
 vi.mock('../../../flags', () => ({
   isBilPreviewEnabled: () => false,
-  // The run gate reaches this via computeCeeCannotSeeModel → isV5CanonicalRunPath;
+  // The run gate reaches this via analysisHeldOn → isV5CanonicalRunPath;
   // false = canonical dispatch off, preserving this suite's pre-gate behaviour.
   // (Hand-listed factory debt: vitest fails loud on any OTHER missing export.)
   isV5CanonicalAnalysisEnabled: () => false,

--- a/src/canvas/conversation/__tests__/generateModelIntegration.spec.tsx
+++ b/src/canvas/conversation/__tests__/generateModelIntegration.spec.tsx
@@ -98,7 +98,7 @@ vi.mock('../zones/CoachingTip', () => ({
 
 vi.mock('../../../flags', () => ({
   isBilPreviewEnabled: () => false,
-  // The run gate reaches this via computeCeeCannotSeeModel → isV5CanonicalRunPath;
+  // The run gate reaches this via analysisHeldOn → isV5CanonicalRunPath;
   // false = canonical dispatch off, preserving this suite's pre-gate behaviour.
   // (Hand-listed factory debt: vitest fails loud on any OTHER missing export.)
   isV5CanonicalAnalysisEnabled: () => false,

--- a/src/canvas/nodes/shared/__tests__/NodeChip.canonicalRun.spec.tsx
+++ b/src/canvas/nodes/shared/__tests__/NodeChip.canonicalRun.spec.tsx
@@ -6,7 +6,7 @@
  * the guidance bridge's `_dispatchAction` DIRECTLY, so a click bypassed
  * everything OutputsDock's `runCanonicalAnalysis` does before dispatching:
  *
- *  1. the readiness gate (`canRunAnalysis`, incl. computeCeeCannotSeeModel) —
+ *  1. the readiness gate (`canRunAnalysis`, incl. analysisHeldOn) —
  *     a graph CEE cannot see could still dispatch a run;
  *  2. the `flushPendingSaves()` barrier — a click inside the 1500ms autosave
  *     debounce resolved against the PREVIOUS persisted graph (edit loss);

--- a/src/canvas/persist/recoveryNotice.ts
+++ b/src/canvas/persist/recoveryNotice.ts
@@ -24,7 +24,7 @@
  * ── HOW THE QUESTION IS ANSWERED ─────────────────────────────────────────────
  * By `resolveStarterId` over the restored nodes — the SAME predicate the canvas
  * disclosure (`StarterProvenanceBanner`) and the run gate
- * (`computeCeeCannotSeeModel`) already use. Not a new "is this a demo" flag: a
+ * (`analysisHeldOn`) already use. Not a new "is this a demo" flag: a
  * second answer to one question is how the disclosure and the gate would come
  * to disagree, and the graph's own stamp is the authoritative persisted read
  * (P5) — it is present exactly when the starter graph is.

--- a/src/canvas/starters/__tests__/applyStarter.spec.ts
+++ b/src/canvas/starters/__tests__/applyStarter.spec.ts
@@ -4,7 +4,7 @@
  * WHY THIS FILE EXISTS. It was added because a mutation check found the gap:
  * commenting out `stampStarterProvenance` left all 27 starter-integrity tests
  * green. That stamp is the single thing that makes
- *   (a) `computeCeeCannotSeeModel` refuse an un-analysable starter run, and
+ *   (a) `analysisHeldOn` refuse an un-analysable starter run, and
  *   (b) the saved-example disclosure render at all.
  * Without it the product would silently dispatch a V5 run against a scenario
  * CEE has no graph for, and would show a cached model with no disclosure —

--- a/src/canvas/starters/__tests__/starterIdentitySurvivesPersistence.spec.ts
+++ b/src/canvas/starters/__tests__/starterIdentitySurvivesPersistence.spec.ts
@@ -18,7 +18,7 @@
  * UNSTAMPED graph. The stamp exists in memory and dies at the page boundary,
  * and with it BOTH honesty mechanisms `starterId` carries: the canvas
  * disclosure (StarterProvenanceBanner) and the run gate
- * (`computeCeeCannotSeeModel`).
+ * (`analysisHeldOn`).
  *
  * The in-memory stamp is already pinned by `applyStarter.spec.ts`. That spec
  * stays green through the whole defect, because it never looks at what was

--- a/src/canvas/starters/loadStarter.ts
+++ b/src/canvas/starters/loadStarter.ts
@@ -67,7 +67,7 @@ export function getStarter(id: string): StarterSummary | undefined {
 /**
  * THE predicate for "is this canvas a starter graph", and which starter.
  *
- * Scans EVERY node, deliberately. `computeCeeCannotSeeModel` (canRunAnalysis)
+ * Scans EVERY node, deliberately. `analysisHeldOn` (canRunAnalysis)
  * refuses the run when ANY node carries the stamp, so a disclosure that read
  * only `nodes[0]` disagreed with the gate the moment an unstamped node sat
  * first — the run stayed refused while the banner explaining the refusal

--- a/src/canvas/ui/inspector-v2/__tests__/InlineRerunPrompt.dispatchesRun.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/InlineRerunPrompt.dispatchesRun.spec.tsx
@@ -63,6 +63,10 @@ import {
   __resetCanonicalRunnerForTests,
   RUNNER_UNAVAILABLE_MESSAGE,
 } from '../../../analysis/canonicalRunRegistry'
+// Bound to the gate's real refusal rather than a hand-typed literal: this spec
+// asserts the toast carries WHATEVER the canonical runner refused with, and a
+// retired sentence frozen here would keep a dead string alive in the suite.
+import { ANALYSIS_HELD_NOTICE } from '../../../utils/analysisHeldOnInjectedModel'
 
 const NODE_ID = 'fac_compliance_readiness'
 const CAP = 1
@@ -149,14 +153,14 @@ describe('post-edit inline Re-run dispatches the canonical run (ROADMAP 2.102)',
   it('surfaces a BLOCKED refusal instead of silently no-opping', async () => {
     const runner = vi
       .fn()
-      .mockResolvedValue({ status: 'blocked', reason: 'Draft or save a model first, then run analysis.' })
+      .mockResolvedValue({ status: 'blocked', reason: ANALYSIS_HELD_NOTICE.starter })
     registerCanonicalRunner(runner)
 
     render(<InlineRerunPrompt visible />)
     fireEvent.click(screen.getByTestId('inline-rerun'))
 
     await waitFor(() =>
-      expect(showToast).toHaveBeenCalledWith('Draft or save a model first, then run analysis.', 'warning'),
+      expect(showToast).toHaveBeenCalledWith(ANALYSIS_HELD_NOTICE.starter, 'warning'),
     )
   })
 

--- a/src/canvas/utils/__tests__/analyseAffordanceTruthfulness.spec.ts
+++ b/src/canvas/utils/__tests__/analyseAffordanceTruthfulness.spec.ts
@@ -1,29 +1,32 @@
 /**
  * ANALYSE-AFFORDANCE TRUTHFULNESS — the first-send blocker, pinned.
  *
- * Witnessed on the DEPLOYED build `d5aa8453` (= this tip; `/version.json`),
- * fresh guest, real browser, `staging--olumi.netlify.app`:
+ * WITNESSED, deployed `1dec0ad6`, fresh guest, real browser,
+ * `staging--olumi.netlify.app`
+ * (`olumi-docs/feedback-2026-08-16/AFFORDANCE-SWEEP-2026-08-18.md`, A7/A15).
+ * Bundled starter "Customer Data Platform Selection", 20 nodes on canvas, and
+ * the Analysis tab read:
  *
- *   Bundled starter "International Expansion Strategy" on screen — 8 nodes,
- *   3 options, 3 risks, 8 estimates, all visible — and the Analysis tab reads
- *
- *       Not ready for analysis yet
- *       Draft or save a model first, then run analysis.        [Analyse first pass]  (disabled)
+ *     Your decision — 4 options · 3 risks · 8 estimates
+ *     …
+ *     Not ready for analysis yet
+ *     Draft or save a model first, then run analysis.   [Analyse first pass] (disabled)
  *
  * BOTH LIMBS OF THAT SENTENCE ARE FALSE AT THE ONLY BRANCH THAT EMITS IT, and
  * that is what this file pins.
  *
  *  - "Draft ... a model first" — `canRunAnalysis` returns at `nodeCount === 0`
  *    BEFORE the injected-model rung is reached, so a model is always on the
- *    canvas when this sentence renders. Pinned by `the rung is unreachable with
- *    an empty canvas` below.
+ *    canvas when this sentence renders. Pinned by "the rung is unreachable with
+ *    an empty canvas" below. The panel counted the model four rows above the
+ *    refusal that denied it.
  *
- *  - "... or save a model first" — `computeCeeCannotSeeModel` is a pure
- *    function of `node.data`, and `applyStarter` stamps `starterId` onto EVERY
- *    node (`starters/loadStarter.ts::stampStarterProvenance`). Persistence
+ *  - "... or save a model first" — the predicate is a pure function of
+ *    `node.data`, and `applyStarter` stamps `starterId` onto EVERY node
+ *    (`starters/loadStarter.ts::stampStarterProvenance`). Persistence
  *    round-trips `node.data`, so a saved starter is still refused. Saving is an
  *    instruction the gate CANNOT ACCEPT — preamble P8, and the exact defect
- *    `StarterProvenanceBanner` already fixed in its own copy:
+ *    `StarterProvenanceBanner` had already fixed in its own copy:
  *
  *       "An earlier draft of this copy read '…drafted or saved into your own
  *        decision', which was a promise the product does not keep: the starter
@@ -44,24 +47,34 @@
  * model on this canvas one the engine can analyse?"* Quoting the right answer
  * to the wrong question is how the false instruction arrived.
  *
- * SECOND DEFECT, SAME CLASS, DIFFERENT SURFACE. `OutputsDock` feeds the SAME
- * `runGateResult.reason` to the POST-analysis footer (`derivePostFooterMeta`'s
- * `blockedReason`, added 18 Aug 2026 to stop a disabled Rerun explaining itself
- * only on hover — the right fix). Consequence: the terminal readiness rung
- * "Olumi is not able to run this yet" renders UNDER a completed analysis's
- * ranked results. Same authority, correctly answering "may a run be dispatched
- * now?", rendered as a claim that analysis is impossible — beside the proof
- * that it is not.
+ * SECOND DEFECT, SAME CLASS, DIFFERENT SURFACE (sweep cross-cutting note 1).
+ * `OutputsDock` feeds the SAME `runGateResult.reason` to the POST-analysis
+ * footer (`derivePostFooterMeta`'s `blockedReason`, added 18 Aug 2026 to stop a
+ * disabled Rerun explaining itself only on hover — the right fix). Consequence:
+ * the terminal readiness rung "Olumi is not able to run this yet" could render
+ * UNDER a completed analysis's ranked results. The rung is not wrong about the
+ * verdict; its wording was scoped to a pre-analysis screen.
+ *
+ * ⭐ WHAT THIS FILE IS FOR, stated so a later reader does not re-scope it. The
+ * founder's 18 Aug ruling is that on a bundled starter the analysis does NOT
+ * need to run — a starter is an onboarding surface, not a second model
+ * architecture. It needs ONE honest refusal naming the real reason, with a
+ * usable route. So these pins are about the REFUSAL being true and the LIVE
+ * path being open; they are not a demand that a starter become analysable.
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { canRunAnalysis, computeCeeCannotSeeModel } from '../canRunAnalysis'
+import fs from 'node:fs'
+import path from 'node:path'
+import { stripComments } from '../../../../tests/helpers/stripSourceComments'
+import { canRunAnalysis, getRunButtonTooltip } from '../canRunAnalysis'
 import {
   ANALYSIS_HELD_NOTICE,
   analysisHeldNotice,
-  clientInjectedProvenance,
+  analysisHeldOn,
 } from '../analysisHeldOnInjectedModel'
 import { composeReadinessBlockedReason, BLOCKED_REASON_COPY } from '../composeBlockedReason'
+import { resolveStarterId } from '../../starters/loadStarter'
 import type { GraphReadiness } from '../../hooks/useGraphReadiness'
 import { derivePostFooterMeta } from '../../components/utils/postAnalysisFooter'
 import { FOOTER_COPY } from '../../components/pre-analysis-v3/constants'
@@ -74,36 +87,35 @@ vi.mock('../../../v5/eligibility', async (importOriginal) => {
 
 /** The witnessed shape: a bundled starter, stamped on every node. */
 const starterNodes = [
-  { data: { starterId: 'international-expansion', label: 'Germany First' } },
-  { data: { starterId: 'international-expansion', label: 'Nordics First' } },
+  { data: { starterId: 'starter-decision-vendor-selection', label: 'Segment' } },
+  { data: { starterId: 'starter-decision-vendor-selection', label: 'RudderStack' } },
 ]
+
+/** The template twin, to prove the wording follows the graph's own provenance. */
+const templateNodes = [{ data: { templateId: 'hiring_strategy_tech_lead' } }]
+
+/** A model Olumi drafted — the real user journey, and the one that must run. */
+const ceeDraftedNodes = [{ data: { label: 'Segment' } }, { data: { label: 'RudderStack' } }]
 
 function gateWith(overrides: Partial<Parameters<typeof canRunAnalysis>[0]> = {}) {
   return canRunAnalysis({
     graphHealth: null,
     readiness: null,
     hasBlockers: false,
-    nodeCount: 8,
-    ceeCannotSeeModel: true,
-    injectedProvenance: 'starter',
+    nodeCount: 20,
+    analysisHeldOn: analysisHeldOn(starterNodes),
     ...overrides,
   })
 }
-
-/** The template twin, to prove the wording follows the graph's own provenance. */
-const templateNodes = [{ data: { templateId: 'hiring_strategy_tech_lead' } }]
 
 describe('the injected-model refusal never asks for an action the gate cannot accept (P8)', () => {
   beforeEach(() => {
     isV5CanonicalRunPathMock.mockReturnValue(true)
   })
 
-  it('CONTROL: the rung is live, and its sentence IS the banner\'s shipped one', () => {
-    const result = gateWith({
-      ceeCannotSeeModel: computeCeeCannotSeeModel(starterNodes),
-      injectedProvenance: clientInjectedProvenance(starterNodes),
-    })
-    expect(computeCeeCannotSeeModel(starterNodes)).toBe(true)
+  it("CONTROL: the rung is live, and its sentence IS the banner's shipped one", () => {
+    const result = gateWith()
+    expect(analysisHeldOn(starterNodes)).toBe('starter')
     expect(result.allowed).toBe(false)
     // ⭐ THE ONE-AUTHORITY PIN, bound BY IDENTITY to the shared notice rather
     // than to a constant this module authors. If the gate ever goes back to
@@ -112,19 +124,23 @@ describe('the injected-model refusal never asks for an action the gate cannot ac
     expect(result.reason).toBe(analysisHeldNotice(starterNodes))
   })
 
-  it('the wording follows the graph\'s own provenance, not the call site\'s guess', () => {
+  it("the wording follows the graph's own provenance, not the call site's guess", () => {
     // Discriminating twin: same rung, different provenance, different sentence —
-    // and neither is chosen by the caller.
-    expect(
-      gateWith({ injectedProvenance: clientInjectedProvenance(templateNodes) }).reason,
-    ).toBe(ANALYSIS_HELD_NOTICE.template)
+    // and neither is chosen by the caller. `analysisHeldOn` returns the gating
+    // answer AND the noun in one value, so a caller cannot supply one without
+    // the other (which is how the first attempt at this fix had OutputsDock and
+    // ConversationPanel describing one state with two different nouns).
+    expect(gateWith({ analysisHeldOn: analysisHeldOn(templateNodes) }).reason).toBe(
+      ANALYSIS_HELD_NOTICE.template,
+    )
     expect(ANALYSIS_HELD_NOTICE.template).not.toBe(ANALYSIS_HELD_NOTICE.starter)
-    // A caller that supplies no provenance states the claim without guessing.
-    expect(gateWith({ injectedProvenance: null }).reason).toBe(ANALYSIS_HELD_NOTICE.unspecified)
-    // Every variant offers the SAME way out — one remedy, three descriptions.
+    // Every variant offers the SAME way out — one remedy, two descriptions.
     for (const notice of Object.values(ANALYSIS_HELD_NOTICE)) {
-      expect(notice).toMatch(/re-draft it live to run one\.$/)
+      expect(notice).toMatch(/Re-draft it live to run one\.$/)
     }
+    // …and there is no third, provenance-less variant to fall back on: a
+    // description the product does not hold is a description it may not state.
+    expect(Object.keys(ANALYSIS_HELD_NOTICE).sort()).toEqual(['starter', 'template'])
   })
 
   it('the notice is NOT made when analysis is not held (it cannot go stale)', () => {
@@ -132,31 +148,65 @@ describe('the injected-model refusal never asks for an action the gate cannot ac
     // "Analysis complete." A null here is what makes that unstateable.
     isV5CanonicalRunPathMock.mockReturnValue(false)
     expect(analysisHeldNotice(starterNodes)).toBeNull()
+    expect(analysisHeldOn(starterNodes)).toBeNull()
     // CONTROL: the same input DOES yield a notice on the canonical path.
     isV5CanonicalRunPathMock.mockReturnValue(true)
     expect(analysisHeldNotice(starterNodes)).toBe(ANALYSIS_HELD_NOTICE.starter)
   })
 
   it('the rung is UNREACHABLE with an empty canvas, so it may not say "draft a model first"', () => {
-    // Opposite-direction twin of the control: same `ceeCannotSeeModel: true`,
-    // only `nodeCount` differs. The empty-canvas rung answers first, so the
+    // Opposite-direction twin of the control: same held provenance, only
+    // `nodeCount` differs. The empty-canvas rung answers first, so the
     // injected-model sentence ONLY ever renders with a model on screen.
     const empty = gateWith({ nodeCount: 0 })
     expect(empty.reason).toBe('Add some nodes to get started')
     expect(empty.reason).not.toBe(ANALYSIS_HELD_NOTICE.starter)
 
-    expect(ANALYSIS_HELD_NOTICE.starter).not.toMatch(/draft[^.]*\bfirst\b/i)
+    for (const notice of Object.values(ANALYSIS_HELD_NOTICE)) {
+      expect(notice).not.toMatch(/draft[^.]*\bfirst\b/i)
+    }
   })
 
   it('saving cannot clear the stamp, so the refusal may not ask the user to save', () => {
     // CONTROL first (trap 13): the predicate fires on this input at all.
-    expect(computeCeeCannotSeeModel(starterNodes)).toBe(true)
+    expect(analysisHeldOn(starterNodes)).toBe('starter')
     // A persistence round-trip preserves `node.data`, which is the predicate's
     // ONLY input — so no save can change this verdict.
     const afterSaveRoundTrip = JSON.parse(JSON.stringify(starterNodes))
-    expect(computeCeeCannotSeeModel(afterSaveRoundTrip)).toBe(true)
+    expect(analysisHeldOn(afterSaveRoundTrip)).toBe('starter')
 
-    expect(ANALYSIS_HELD_NOTICE.starter).not.toMatch(/\bsav(e|ed|ing)\b/i)
+    // ⚠ THE VERB, NOT THE ADJECTIVE — and this assertion was WRONG first time.
+    // It read `/\bsav(e|ed|ing)\b/i`, which fired on "a saved example": the
+    // very phrase the sweep confirmed is TRUE and that the banner already
+    // ships. The property is not "the word save is absent", it is "the refusal
+    // does not INSTRUCT the user to save" — an instruction the gate cannot
+    // accept (P8). Written against the failure mode instead of the spec, the
+    // guard banned the honest description along with the false instruction
+    // (trap 13d).
+    for (const notice of Object.values(ANALYSIS_HELD_NOTICE)) {
+      expect(notice).not.toMatch(/\bsave\b/i)
+      expect(notice).not.toMatch(/\bsaving\b/i)
+    }
+    // CONTROL: the retired sentence WOULD have tripped it, so the pin bites.
+    expect('Draft or save a model first, then run analysis.').toMatch(/\bsave\b/i)
+  })
+
+  it('the named remedy has a MOUNTED control in the same state (P8 acceptance path)', () => {
+    // A truthful refusal is only acceptable if the route it names is reachable.
+    // `StarterProvenanceBanner` mounts on `resolveStarterId(nodes) !== null` and
+    // carries `Re-draft this live`; the gate holds on `analysisHeldOn(nodes)`.
+    // This asserts the two conditions coincide on the witnessed input, so the
+    // refusal cannot name a button that is not on screen.
+    expect(analysisHeldOn(starterNodes)).toBe('starter')
+    expect(resolveStarterId(starterNodes as never)).not.toBeNull()
+    // CONTRAST: a CEE-drafted graph mounts no banner AND is not refused, so the
+    // pin above is a coincidence of state, not of a predicate that is always true.
+    expect(resolveStarterId(ceeDraftedNodes as never)).toBeNull()
+    expect(analysisHeldOn(ceeDraftedNodes)).toBeNull()
+    // ⚠ NOT ASSERTED, and stated rather than implied: a TEMPLATE insert has no
+    // one-click re-draft control. Its route is the composer, which is always on
+    // screen. Pinning a `starter-redraft` button for a template state would pin
+    // a control that does not exist.
   })
 
   it('names the one action that DOES clear the refusal — a live re-draft', () => {
@@ -168,9 +218,66 @@ describe('the injected-model refusal never asks for an action the gate cannot ac
 
     // The twin: a graph Olumi drafted is NOT refused, so the named remedy is
     // one the gate genuinely accepts.
-    const ceeDrafted = [{ data: { label: 'Germany First' } }]
-    expect(computeCeeCannotSeeModel(ceeDrafted)).toBe(false)
-    expect(gateWith({ ceeCannotSeeModel: false }).allowed).toBe(true)
+    expect(analysisHeldOn(ceeDraftedNodes)).toBeNull()
+    expect(gateWith({ analysisHeldOn: analysisHeldOn(ceeDraftedNodes) }).allowed).toBe(true)
+  })
+})
+
+describe('the real journey: a model Olumi drafted must ANALYSE from the obvious control', () => {
+  // The founder's re-scope: a starter need only refuse truthfully — but a live,
+  // user-created model must work from the panel's own button, on the same
+  // readiness authority as everything else. These are the pins for that half,
+  // and they are what stops "fix the refusal" being read as "refuse more".
+  beforeEach(() => {
+    isV5CanonicalRunPathMock.mockReturnValue(true)
+  })
+
+  const readyVerdict = {
+    can_run_analysis: true,
+    options_total: 3,
+    options_ready: 3,
+    goal_node_valid: true,
+  } as unknown as GraphReadiness
+
+  it('a CEE-drafted model with a ready verdict is ALLOWED, with no reason and no tooltip', () => {
+    const result = canRunAnalysis({
+      graphHealth: null,
+      readiness: readyVerdict,
+      hasBlockers: false,
+      nodeCount: 20,
+      analysisHeldOn: analysisHeldOn(ceeDraftedNodes),
+    })
+    expect(result.allowed).toBe(true)
+    expect(result.reason).toBeUndefined()
+    // The button's tooltip is the same authority's output: an open gate must not
+    // hand the surface an explanation for a refusal that is not happening.
+    expect(getRunButtonTooltip(result)).toBeUndefined()
+  })
+
+  it('DISCRIMINATOR: the identical inputs on a STARTER graph are refused — the stamp is what decides', () => {
+    // Without this twin, the pin above would pass against a gate that never
+    // refuses anything. Only the node stamps differ between the two calls.
+    const held = canRunAnalysis({
+      graphHealth: null,
+      readiness: readyVerdict,
+      hasBlockers: false,
+      nodeCount: 20,
+      analysisHeldOn: analysisHeldOn(starterNodes),
+    })
+    expect(held.allowed).toBe(false)
+    expect(held.reason).toBe(ANALYSIS_HELD_NOTICE.starter)
+  })
+
+  it('the hold is scoped to the CEE-routed path — a V2-direct run carries the graph itself', () => {
+    isV5CanonicalRunPathMock.mockReturnValue(false)
+    const result = canRunAnalysis({
+      graphHealth: null,
+      readiness: readyVerdict,
+      hasBlockers: false,
+      nodeCount: 20,
+      analysisHeldOn: analysisHeldOn(starterNodes),
+    })
+    expect(result.allowed).toBe(true)
   })
 })
 
@@ -216,5 +323,58 @@ describe('no surface denies analysability while completed results are on screen'
     // (trap 12). Bound by identity so a future edit to one cannot leave the
     // other behind.
     expect(FOOTER_COPY.notReadySubFallback).toBe(BLOCKED_REASON_COPY.unspecified)
+  })
+})
+
+describe('exactly ONE place in the source writes this sentence', () => {
+  /**
+   * ⭐ THE LEAD QUESTION, PINNED. The defect class here is "a surface states
+   * something about analysability that is not true", and its mechanism is a
+   * second copy of the claim. A fix that leaves a third author of the sentence
+   * has made things worse, so this counts the authors instead of trusting that
+   * nobody adds one.
+   *
+   * Scope, stated (trap 20): `src/**` only, `.ts`/`.tsx`, excluding `__tests__`
+   * — a spec that quotes the sentence is a reader, not an author — and with
+   * COMMENTS STRIPPED, because a docstring that recounts the defect is not a
+   * second author either. (This sweep caught its own first version doing
+   * exactly that: `StarterProvenanceBanner`'s new comment quotes the sentence
+   * while its code no longer writes it. The shared `stripComments` helper is
+   * the repo's existing answer to that footgun; a second hand-rolled one here
+   * would be the mirror this file is about.) The contrast control below is what
+   * makes a low count mean absence rather than blindness.
+   */
+  const SRC = path.resolve(__dirname, '../..', '..')
+
+  function sourceFilesUnder(dir: string, out: string[] = []): string[] {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        if (entry.name === '__tests__' || entry.name === 'node_modules') continue
+        sourceFilesUnder(full, out)
+      } else if (/\.tsx?$/.test(entry.name)) {
+        out.push(full)
+      }
+    }
+    return out
+  }
+
+  it('the held-analysis claim has one author, and the sweep can see one when it is there', () => {
+    const files = sourceFilesUnder(SRC)
+    const code = new Map(
+      files.map((f) => [f, stripComments(fs.readFileSync(f, 'utf8'), f)] as const),
+    )
+
+    // CONTRAST CONTROL (must be NON-ZERO, or the sweep proves nothing): a
+    // sentence we know is WRITTEN in this tree, by a neighbouring surface.
+    const control = files.filter((f) =>
+      code.get(f)!.includes('Saved example — Olumi drafted this model on'),
+    )
+    expect(control.length).toBeGreaterThan(0)
+
+    const authors = files.filter((f) =>
+      code.get(f)!.includes('Analysis is held on a saved example'),
+    )
+    expect(authors.map((f) => path.basename(f))).toEqual(['analysisHeldOnInjectedModel.ts'])
   })
 })

--- a/src/canvas/utils/__tests__/analyseAffordanceTruthfulness.spec.ts
+++ b/src/canvas/utils/__tests__/analyseAffordanceTruthfulness.spec.ts
@@ -1,0 +1,185 @@
+/**
+ * ANALYSE-AFFORDANCE TRUTHFULNESS — the first-send blocker, pinned.
+ *
+ * Witnessed on the DEPLOYED build `d5aa8453` (= this tip; `/version.json`),
+ * fresh guest, real browser, `staging--olumi.netlify.app`:
+ *
+ *   Bundled starter "International Expansion Strategy" on screen — 8 nodes,
+ *   3 options, 3 risks, 8 estimates, all visible — and the Analysis tab reads
+ *
+ *       Not ready for analysis yet
+ *       Draft or save a model first, then run analysis.        [Analyse first pass]  (disabled)
+ *
+ * BOTH LIMBS OF THAT SENTENCE ARE FALSE AT THE ONLY BRANCH THAT EMITS IT, and
+ * that is what this file pins.
+ *
+ *  - "Draft ... a model first" — `canRunAnalysis` returns at `nodeCount === 0`
+ *    BEFORE the injected-model rung is reached, so a model is always on the
+ *    canvas when this sentence renders. Pinned by `the rung is unreachable with
+ *    an empty canvas` below.
+ *
+ *  - "... or save a model first" — `computeCeeCannotSeeModel` is a pure
+ *    function of `node.data`, and `applyStarter` stamps `starterId` onto EVERY
+ *    node (`starters/loadStarter.ts::stampStarterProvenance`). Persistence
+ *    round-trips `node.data`, so a saved starter is still refused. Saving is an
+ *    instruction the gate CANNOT ACCEPT — preamble P8, and the exact defect
+ *    `StarterProvenanceBanner` already fixed in its own copy:
+ *
+ *       "An earlier draft of this copy read '…drafted or saved into your own
+ *        decision', which was a promise the product does not keep: the starter
+ *        stamp rides a save, so saving does NOT re-enable analysis.
+ *        Re-drafting is the one route that does."
+ *
+ *    The banner was corrected; the gate constant beside it was not. One claim,
+ *    two copies, one of them fixed — the estate's hand-maintained mirror
+ *    (trap 12) inside a P8 violation.
+ *
+ * WHY THE SENTENCE WAS WRONG IN THE FIRST PLACE (trap 21 — name the question
+ * each authority answers). The constant was justified as "CEE's refusal
+ * sentence, verbatim". CEE does emit it — at
+ * `analysis-ready-helper.ts::assessCanonicalAnalysisReadiness`, under code
+ * `NO_GRAPH`, when `graph === null || graph === undefined`. That answers
+ * *"is there a model at all?"* — for which "draft or save one" is true and
+ * achievable. The UI borrowed it to answer a DIFFERENT question: *"is the
+ * model on this canvas one the engine can analyse?"* Quoting the right answer
+ * to the wrong question is how the false instruction arrived.
+ *
+ * SECOND DEFECT, SAME CLASS, DIFFERENT SURFACE. `OutputsDock` feeds the SAME
+ * `runGateResult.reason` to the POST-analysis footer (`derivePostFooterMeta`'s
+ * `blockedReason`, added 18 Aug 2026 to stop a disabled Rerun explaining itself
+ * only on hover — the right fix). Consequence: the terminal readiness rung
+ * "Olumi is not able to run this yet" renders UNDER a completed analysis's
+ * ranked results. Same authority, correctly answering "may a run be dispatched
+ * now?", rendered as a claim that analysis is impossible — beside the proof
+ * that it is not.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  canRunAnalysis,
+  computeCeeCannotSeeModel,
+  CLIENT_INJECTED_MODEL_REFUSAL,
+} from '../canRunAnalysis'
+import { composeReadinessBlockedReason, BLOCKED_REASON_COPY } from '../composeBlockedReason'
+import type { GraphReadiness } from '../../hooks/useGraphReadiness'
+import { derivePostFooterMeta } from '../../components/utils/postAnalysisFooter'
+import { FOOTER_COPY } from '../../components/pre-analysis-v3/constants'
+
+const isV5CanonicalRunPathMock = vi.fn(() => true)
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  return { ...actual, isV5CanonicalRunPath: () => isV5CanonicalRunPathMock() }
+})
+
+/** The witnessed shape: a bundled starter, stamped on every node. */
+const starterNodes = [
+  { data: { starterId: 'international-expansion', label: 'Germany First' } },
+  { data: { starterId: 'international-expansion', label: 'Nordics First' } },
+]
+
+function gateWith(overrides: Partial<Parameters<typeof canRunAnalysis>[0]> = {}) {
+  return canRunAnalysis({
+    graphHealth: null,
+    readiness: null,
+    hasBlockers: false,
+    nodeCount: 8,
+    ceeCannotSeeModel: true,
+    ...overrides,
+  })
+}
+
+describe('the injected-model refusal never asks for an action the gate cannot accept (P8)', () => {
+  beforeEach(() => {
+    isV5CanonicalRunPathMock.mockReturnValue(true)
+  })
+
+  it('CONTROL: the injected-model rung is live and owns the refusal', () => {
+    const result = gateWith({ ceeCannotSeeModel: computeCeeCannotSeeModel(starterNodes) })
+    expect(computeCeeCannotSeeModel(starterNodes)).toBe(true)
+    expect(result.allowed).toBe(false)
+    // Bound to the rung BY IDENTITY (the exported constant), never by a
+    // substring another rung's copy could satisfy.
+    expect(result.reason).toBe(CLIENT_INJECTED_MODEL_REFUSAL)
+  })
+
+  it('the rung is UNREACHABLE with an empty canvas, so it may not say "draft a model first"', () => {
+    // Opposite-direction twin of the control: same `ceeCannotSeeModel: true`,
+    // only `nodeCount` differs. The empty-canvas rung answers first, so the
+    // injected-model sentence ONLY ever renders with a model on screen.
+    const empty = gateWith({ nodeCount: 0 })
+    expect(empty.reason).toBe('Add some nodes to get started')
+    expect(empty.reason).not.toBe(CLIENT_INJECTED_MODEL_REFUSAL)
+
+    expect(CLIENT_INJECTED_MODEL_REFUSAL).not.toMatch(/draft[^.]*\bfirst\b/i)
+  })
+
+  it('saving cannot clear the stamp, so the refusal may not ask the user to save', () => {
+    // CONTROL first (trap 13): the predicate fires on this input at all.
+    expect(computeCeeCannotSeeModel(starterNodes)).toBe(true)
+    // A persistence round-trip preserves `node.data`, which is the predicate's
+    // ONLY input — so no save can change this verdict.
+    const afterSaveRoundTrip = JSON.parse(JSON.stringify(starterNodes))
+    expect(computeCeeCannotSeeModel(afterSaveRoundTrip)).toBe(true)
+
+    expect(CLIENT_INJECTED_MODEL_REFUSAL).not.toMatch(/\bsav(e|ed|ing)\b/i)
+  })
+
+  it('names the one action that DOES clear the refusal — a live re-draft', () => {
+    // P8's positive half: the question the product asks must have an acceptance
+    // path. `StarterProvenanceBanner`'s "Re-draft this live" is it, and a
+    // CEE-drafted graph carries no stamp — proven by the twin below.
+    expect(CLIENT_INJECTED_MODEL_REFUSAL).toMatch(/draft/i)
+    expect(CLIENT_INJECTED_MODEL_REFUSAL).toMatch(/\blive\b/i)
+
+    // The twin: a graph Olumi drafted is NOT refused, so the named remedy is
+    // one the gate genuinely accepts.
+    const ceeDrafted = [{ data: { label: 'Germany First' } }]
+    expect(computeCeeCannotSeeModel(ceeDrafted)).toBe(false)
+    expect(gateWith({ ceeCannotSeeModel: false }).allowed).toBe(true)
+  })
+})
+
+describe('no surface denies analysability while completed results are on screen', () => {
+  /** The terminal rung: a refusal carrying no field specific enough to name. */
+  const unspecifiedVerdict = {
+    can_run_analysis: false,
+    options_total: 3,
+    options_ready: 3,
+    goal_node_valid: true,
+  } as unknown as GraphReadiness
+
+  it('CONTROL: the terminal rung is reached, and the post-analysis footer renders it', () => {
+    const reason = composeReadinessBlockedReason(unspecifiedVerdict, [], false)
+    // Identity binding to the rung, not to its wording.
+    expect(reason).toBe(BLOCKED_REASON_COPY.unspecified)
+
+    const meta = derivePostFooterMeta({
+      robustnessVerdict: 'robust',
+      robustnessVerdictReason: 'this result held up under the changes we tested',
+      reviewCards: [{ confidence: 80 }],
+      blockedReason: reason,
+    })
+    // Presence first: without this, the absence assertion below is vacuous.
+    expect(meta).toContain(reason)
+  })
+
+  it('the rung rendered beneath ranked results does not claim Olumi is unable to run one', () => {
+    const reason = composeReadinessBlockedReason(unspecifiedVerdict, [], false)
+    const meta = derivePostFooterMeta({
+      robustnessVerdict: 'robust',
+      robustnessVerdictReason: 'this result held up under the changes we tested',
+      reviewCards: [{ confidence: 80 }],
+      blockedReason: reason,
+    })
+    // The witnessed contradiction, verbatim: this string sat at the foot of an
+    // Analysis tab that was displaying a completed run's ranked results.
+    expect(meta).not.toMatch(/not able to run this/i)
+  })
+
+  it('the pre-analysis degrade fallback is the SAME string, not a copy of it', () => {
+    // Two verbatim literals for one sentence is the mirror that drifts
+    // (trap 12). Bound by identity so a future edit to one cannot leave the
+    // other behind.
+    expect(FOOTER_COPY.notReadySubFallback).toBe(BLOCKED_REASON_COPY.unspecified)
+  })
+})

--- a/src/canvas/utils/__tests__/analyseAffordanceTruthfulness.spec.ts
+++ b/src/canvas/utils/__tests__/analyseAffordanceTruthfulness.spec.ts
@@ -318,10 +318,15 @@ describe('no surface denies analysability while completed results are on screen'
     expect(meta).not.toMatch(/not able to run this/i)
   })
 
-  it('the pre-analysis degrade fallback is the SAME string, not a copy of it', () => {
-    // Two verbatim literals for one sentence is the mirror that drifts
-    // (trap 12). Bound by identity so a future edit to one cannot leave the
-    // other behind.
+  it('the pre-analysis degrade fallback carries the same VALUE as the composed rung', () => {
+    // ⚠ AND THIS ASSERTION CANNOT SEE THE THING ITS OLD NAME CLAIMED. It read
+    // "the SAME string, not a copy of it" — but `toBe` on two primitives is
+    // value equality, so it passes just as happily against two verbatim
+    // literals as against a reference. Measured: it PASSED at pristine
+    // `06f745ba`, where `constants.ts` did hold a second copy. A guard that
+    // agrees with itself (trap 13b). It stays, because the value equality is
+    // worth pinning; the mirror claim is made where it can actually be
+    // measured — in the source sweep below.
     expect(FOOTER_COPY.notReadySubFallback).toBe(BLOCKED_REASON_COPY.unspecified)
   })
 })
@@ -376,5 +381,28 @@ describe('exactly ONE place in the source writes this sentence', () => {
       code.get(f)!.includes('Analysis is held on a saved example'),
     )
     expect(authors.map((f) => path.basename(f))).toEqual(['analysisHeldOnInjectedModel.ts'])
+  })
+
+  it('the terminal readiness rung is written once too — the mirror the value test cannot see', () => {
+    const files = sourceFilesUnder(SRC)
+    const code = new Map(
+      files.map((f) => [f, stripComments(fs.readFileSync(f, 'utf8'), f)] as const),
+    )
+
+    // CONTRAST CONTROL: a neighbouring sentence from the same constant object,
+    // so a zero below means "one author", not "the sweep is blind".
+    const control = files.filter((f) =>
+      code.get(f)!.includes('Ask in the chat and it will explain what is missing'),
+    )
+    expect(control.length).toBeGreaterThan(0)
+
+    // At pristine `06f745ba` this sentence had TWO authors —
+    // `composeBlockedReason.ts` and `pre-analysis-v3/constants.ts` — and the
+    // `toBe` pin above passed anyway, because both literals were identical.
+    // This is where "one home" is actually decidable.
+    const authors = files.filter((f) =>
+      code.get(f)!.includes('Olumi needs something more from this model'),
+    )
+    expect(authors.map((f) => path.basename(f))).toEqual(['composeBlockedReason.ts'])
   })
 })

--- a/src/canvas/utils/__tests__/analyseAffordanceTruthfulness.spec.ts
+++ b/src/canvas/utils/__tests__/analyseAffordanceTruthfulness.spec.ts
@@ -55,11 +55,12 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { canRunAnalysis, computeCeeCannotSeeModel } from '../canRunAnalysis'
 import {
-  canRunAnalysis,
-  computeCeeCannotSeeModel,
-  CLIENT_INJECTED_MODEL_REFUSAL,
-} from '../canRunAnalysis'
+  ANALYSIS_HELD_NOTICE,
+  analysisHeldNotice,
+  clientInjectedProvenance,
+} from '../analysisHeldOnInjectedModel'
 import { composeReadinessBlockedReason, BLOCKED_REASON_COPY } from '../composeBlockedReason'
 import type { GraphReadiness } from '../../hooks/useGraphReadiness'
 import { derivePostFooterMeta } from '../../components/utils/postAnalysisFooter'
@@ -84,22 +85,56 @@ function gateWith(overrides: Partial<Parameters<typeof canRunAnalysis>[0]> = {})
     hasBlockers: false,
     nodeCount: 8,
     ceeCannotSeeModel: true,
+    injectedProvenance: 'starter',
     ...overrides,
   })
 }
+
+/** The template twin, to prove the wording follows the graph's own provenance. */
+const templateNodes = [{ data: { templateId: 'hiring_strategy_tech_lead' } }]
 
 describe('the injected-model refusal never asks for an action the gate cannot accept (P8)', () => {
   beforeEach(() => {
     isV5CanonicalRunPathMock.mockReturnValue(true)
   })
 
-  it('CONTROL: the injected-model rung is live and owns the refusal', () => {
-    const result = gateWith({ ceeCannotSeeModel: computeCeeCannotSeeModel(starterNodes) })
+  it('CONTROL: the rung is live, and its sentence IS the banner\'s shipped one', () => {
+    const result = gateWith({
+      ceeCannotSeeModel: computeCeeCannotSeeModel(starterNodes),
+      injectedProvenance: clientInjectedProvenance(starterNodes),
+    })
     expect(computeCeeCannotSeeModel(starterNodes)).toBe(true)
     expect(result.allowed).toBe(false)
-    // Bound to the rung BY IDENTITY (the exported constant), never by a
-    // substring another rung's copy could satisfy.
-    expect(result.reason).toBe(CLIENT_INJECTED_MODEL_REFUSAL)
+    // ⭐ THE ONE-AUTHORITY PIN, bound BY IDENTITY to the shared notice rather
+    // than to a constant this module authors. If the gate ever goes back to
+    // writing its own sentence, this REDs.
+    expect(result.reason).toBe(ANALYSIS_HELD_NOTICE.starter)
+    expect(result.reason).toBe(analysisHeldNotice(starterNodes))
+  })
+
+  it('the wording follows the graph\'s own provenance, not the call site\'s guess', () => {
+    // Discriminating twin: same rung, different provenance, different sentence —
+    // and neither is chosen by the caller.
+    expect(
+      gateWith({ injectedProvenance: clientInjectedProvenance(templateNodes) }).reason,
+    ).toBe(ANALYSIS_HELD_NOTICE.template)
+    expect(ANALYSIS_HELD_NOTICE.template).not.toBe(ANALYSIS_HELD_NOTICE.starter)
+    // A caller that supplies no provenance states the claim without guessing.
+    expect(gateWith({ injectedProvenance: null }).reason).toBe(ANALYSIS_HELD_NOTICE.unspecified)
+    // Every variant offers the SAME way out — one remedy, three descriptions.
+    for (const notice of Object.values(ANALYSIS_HELD_NOTICE)) {
+      expect(notice).toMatch(/re-draft it live to run one\.$/)
+    }
+  })
+
+  it('the notice is NOT made when analysis is not held (it cannot go stale)', () => {
+    // The sweep found the banner still claiming "analysis is held" beside
+    // "Analysis complete." A null here is what makes that unstateable.
+    isV5CanonicalRunPathMock.mockReturnValue(false)
+    expect(analysisHeldNotice(starterNodes)).toBeNull()
+    // CONTROL: the same input DOES yield a notice on the canonical path.
+    isV5CanonicalRunPathMock.mockReturnValue(true)
+    expect(analysisHeldNotice(starterNodes)).toBe(ANALYSIS_HELD_NOTICE.starter)
   })
 
   it('the rung is UNREACHABLE with an empty canvas, so it may not say "draft a model first"', () => {
@@ -108,9 +143,9 @@ describe('the injected-model refusal never asks for an action the gate cannot ac
     // injected-model sentence ONLY ever renders with a model on screen.
     const empty = gateWith({ nodeCount: 0 })
     expect(empty.reason).toBe('Add some nodes to get started')
-    expect(empty.reason).not.toBe(CLIENT_INJECTED_MODEL_REFUSAL)
+    expect(empty.reason).not.toBe(ANALYSIS_HELD_NOTICE.starter)
 
-    expect(CLIENT_INJECTED_MODEL_REFUSAL).not.toMatch(/draft[^.]*\bfirst\b/i)
+    expect(ANALYSIS_HELD_NOTICE.starter).not.toMatch(/draft[^.]*\bfirst\b/i)
   })
 
   it('saving cannot clear the stamp, so the refusal may not ask the user to save', () => {
@@ -121,15 +156,15 @@ describe('the injected-model refusal never asks for an action the gate cannot ac
     const afterSaveRoundTrip = JSON.parse(JSON.stringify(starterNodes))
     expect(computeCeeCannotSeeModel(afterSaveRoundTrip)).toBe(true)
 
-    expect(CLIENT_INJECTED_MODEL_REFUSAL).not.toMatch(/\bsav(e|ed|ing)\b/i)
+    expect(ANALYSIS_HELD_NOTICE.starter).not.toMatch(/\bsav(e|ed|ing)\b/i)
   })
 
   it('names the one action that DOES clear the refusal — a live re-draft', () => {
     // P8's positive half: the question the product asks must have an acceptance
     // path. `StarterProvenanceBanner`'s "Re-draft this live" is it, and a
     // CEE-drafted graph carries no stamp — proven by the twin below.
-    expect(CLIENT_INJECTED_MODEL_REFUSAL).toMatch(/draft/i)
-    expect(CLIENT_INJECTED_MODEL_REFUSAL).toMatch(/\blive\b/i)
+    expect(ANALYSIS_HELD_NOTICE.starter).toMatch(/draft/i)
+    expect(ANALYSIS_HELD_NOTICE.starter).toMatch(/\blive\b/i)
 
     // The twin: a graph Olumi drafted is NOT refused, so the named remedy is
     // one the gate genuinely accepts.

--- a/src/canvas/utils/__tests__/canRunAnalysis.spec.ts
+++ b/src/canvas/utils/__tests__/canRunAnalysis.spec.ts
@@ -8,9 +8,9 @@ import {
   getRunButtonTooltip,
   getRunButtonAriaLabel,
   computeCeeCannotSeeModel,
-  CLIENT_INJECTED_MODEL_REFUSAL,
-  type CanRunAnalysisParams,
+    type CanRunAnalysisParams,
 } from '../canRunAnalysis'
+import { ANALYSIS_HELD_NOTICE } from '../analysisHeldOnInjectedModel'
 import { BLOCKED_REASON_COPY } from '../composeBlockedReason'
 
 
@@ -440,12 +440,12 @@ describe('canRunAnalysis — #343 honest stopgap (model invisible to CEE)', () =
     // nothing, because the constant was never supposed to track CEE here: CEE
     // emits that sentence for `NO_GRAPH` (no model at all), while this rung
     // fires only with a model on the canvas. Pinning the literal froze the
-    // wrong question's answer in place — see `CLIENT_INJECTED_MODEL_REFUSAL`'s
-    // docstring, and `analyseAffordanceTruthfulness.spec.ts` for the pins that
+    // wrong question's answer in place — see `analysisHeldOnInjectedModel.ts`'s
+    // header, and `analyseAffordanceTruthfulness.spec.ts` for the pins that
     // now hold the sentence to THIS rung's facts.
     const result = canRunAnalysis({ ...base, ceeCannotSeeModel: true })
     expect(result.allowed).toBe(false)
-    expect(result.reason).toBe(CLIENT_INJECTED_MODEL_REFUSAL)
+    expect(result.reason).toBe(ANALYSIS_HELD_NOTICE.starter)
   })
 
   it('does not block when the model is CEE-visible (flag false/omitted)', () => {
@@ -478,6 +478,6 @@ describe('computeCeeCannotSeeModel — the ONE home for the honest-gate predicat
   it('the exported refusal constant IS the sentence the gate emits (one home, no drift)', () => {
     isV5CanonicalRunPathMock.mockReturnValue(true)
     const result = canRunAnalysis({ graphHealth: null, readiness: null, hasBlockers: false, nodeCount: 5, ceeCannotSeeModel: computeCeeCannotSeeModel(templateNodes) })
-    expect(result.reason).toBe(CLIENT_INJECTED_MODEL_REFUSAL)
+    expect(result.reason).toBe(ANALYSIS_HELD_NOTICE.starter)
   })
 })

--- a/src/canvas/utils/__tests__/canRunAnalysis.spec.ts
+++ b/src/canvas/utils/__tests__/canRunAnalysis.spec.ts
@@ -7,10 +7,9 @@ import {
   canRunAnalysis,
   getRunButtonTooltip,
   getRunButtonAriaLabel,
-  computeCeeCannotSeeModel,
-    type CanRunAnalysisParams,
+  type CanRunAnalysisParams,
 } from '../canRunAnalysis'
-import { ANALYSIS_HELD_NOTICE } from '../analysisHeldOnInjectedModel'
+import { ANALYSIS_HELD_NOTICE, analysisHeldOn } from '../analysisHeldOnInjectedModel'
 import { BLOCKED_REASON_COPY } from '../composeBlockedReason'
 
 
@@ -443,41 +442,41 @@ describe('canRunAnalysis — #343 honest stopgap (model invisible to CEE)', () =
     // wrong question's answer in place — see `analysisHeldOnInjectedModel.ts`'s
     // header, and `analyseAffordanceTruthfulness.spec.ts` for the pins that
     // now hold the sentence to THIS rung's facts.
-    const result = canRunAnalysis({ ...base, ceeCannotSeeModel: true })
+    const result = canRunAnalysis({ ...base, analysisHeldOn: 'starter' })
     expect(result.allowed).toBe(false)
     expect(result.reason).toBe(ANALYSIS_HELD_NOTICE.starter)
   })
 
-  it('does not block when the model is CEE-visible (flag false/omitted)', () => {
-    expect(canRunAnalysis({ ...base, ceeCannotSeeModel: false }).allowed).toBe(true)
+  it('does not block when the model is CEE-visible (null/omitted)', () => {
+    expect(canRunAnalysis({ ...base, analysisHeldOn: null }).allowed).toBe(true)
     expect(canRunAnalysis({ ...base }).allowed).toBe(true)
   })
 
   it('empty canvas still wins over the CEE-visibility blocker (more fundamental reason first)', () => {
-    const result = canRunAnalysis({ ...base, nodeCount: 0, ceeCannotSeeModel: true })
+    const result = canRunAnalysis({ ...base, nodeCount: 0, analysisHeldOn: 'starter' })
     expect(result.allowed).toBe(false)
     expect(result.reason).toBe('Add some nodes to get started')
   })
 })
 
-describe('computeCeeCannotSeeModel — the ONE home for the honest-gate predicate', () => {
+describe('analysisHeldOn — the ONE home for the honest-gate predicate', () => {
   const templateNodes = [{ data: { templateId: 'hiring-v1' } }, { data: {} }]
   const draftedNodes = [{ data: {} }, { data: { label: 'x' } }]
 
-  it('true only for template provenance on the CEE-routed path', () => {
+  it('names the provenance only for a client-injected graph on the CEE-routed path', () => {
     isV5CanonicalRunPathMock.mockReturnValue(true)
-    expect(computeCeeCannotSeeModel(templateNodes)).toBe(true)
-    expect(computeCeeCannotSeeModel(draftedNodes)).toBe(false)
+    expect(analysisHeldOn(templateNodes)).toBe('template')
+    expect(analysisHeldOn(draftedNodes)).toBeNull()
   })
 
-  it('false off the canonical path — a V2-direct run CAN analyse canvas graphs', () => {
+  it('null off the canonical path — a V2-direct run CAN analyse canvas graphs', () => {
     isV5CanonicalRunPathMock.mockReturnValue(false)
-    expect(computeCeeCannotSeeModel(templateNodes)).toBe(false)
+    expect(analysisHeldOn(templateNodes)).toBeNull()
   })
 
   it('the exported refusal constant IS the sentence the gate emits (one home, no drift)', () => {
     isV5CanonicalRunPathMock.mockReturnValue(true)
-    const result = canRunAnalysis({ graphHealth: null, readiness: null, hasBlockers: false, nodeCount: 5, ceeCannotSeeModel: computeCeeCannotSeeModel(templateNodes) })
-    expect(result.reason).toBe(ANALYSIS_HELD_NOTICE.starter)
+    const result = canRunAnalysis({ graphHealth: null, readiness: null, hasBlockers: false, nodeCount: 5, analysisHeldOn: analysisHeldOn(templateNodes) })
+    expect(result.reason).toBe(ANALYSIS_HELD_NOTICE.template)
   })
 })

--- a/src/canvas/utils/__tests__/canRunAnalysis.spec.ts
+++ b/src/canvas/utils/__tests__/canRunAnalysis.spec.ts
@@ -8,7 +8,7 @@ import {
   getRunButtonTooltip,
   getRunButtonAriaLabel,
   computeCeeCannotSeeModel,
-  CEE_DRAFT_FIRST_REFUSAL,
+  CLIENT_INJECTED_MODEL_REFUSAL,
   type CanRunAnalysisParams,
 } from '../canRunAnalysis'
 import { BLOCKED_REASON_COPY } from '../composeBlockedReason'
@@ -433,13 +433,19 @@ describe('canRunAnalysis — #343 honest stopgap (model invisible to CEE)', () =
     nodeCount: 5,
   }
 
-  it('blocks with CEE\'s own refusal sentence when the model cannot be seen by CEE', () => {
-    // The reason string must be CEE's own refusal sentence so panel and chat
-    // agree (#343). Deliberately the raw literal, NOT the exported constant:
-    // this pin is what catches the constant drifting from CEE's actual copy.
+  it('blocks with this rung\'s own refusal sentence when the model cannot be seen by CEE', () => {
+    // ⚠ THIS PIN USED TO HOLD THE RAW LITERAL
+    // `'Draft or save a model first, then run analysis.'`, on the grounds that
+    // it "catches the constant drifting from CEE's actual copy". It caught
+    // nothing, because the constant was never supposed to track CEE here: CEE
+    // emits that sentence for `NO_GRAPH` (no model at all), while this rung
+    // fires only with a model on the canvas. Pinning the literal froze the
+    // wrong question's answer in place — see `CLIENT_INJECTED_MODEL_REFUSAL`'s
+    // docstring, and `analyseAffordanceTruthfulness.spec.ts` for the pins that
+    // now hold the sentence to THIS rung's facts.
     const result = canRunAnalysis({ ...base, ceeCannotSeeModel: true })
     expect(result.allowed).toBe(false)
-    expect(result.reason).toBe('Draft or save a model first, then run analysis.')
+    expect(result.reason).toBe(CLIENT_INJECTED_MODEL_REFUSAL)
   })
 
   it('does not block when the model is CEE-visible (flag false/omitted)', () => {
@@ -472,6 +478,6 @@ describe('computeCeeCannotSeeModel — the ONE home for the honest-gate predicat
   it('the exported refusal constant IS the sentence the gate emits (one home, no drift)', () => {
     isV5CanonicalRunPathMock.mockReturnValue(true)
     const result = canRunAnalysis({ graphHealth: null, readiness: null, hasBlockers: false, nodeCount: 5, ceeCannotSeeModel: computeCeeCannotSeeModel(templateNodes) })
-    expect(result.reason).toBe(CEE_DRAFT_FIRST_REFUSAL)
+    expect(result.reason).toBe(CLIENT_INJECTED_MODEL_REFUSAL)
   })
 })

--- a/src/canvas/utils/__tests__/canRunAnalysis.starters.spec.ts
+++ b/src/canvas/utils/__tests__/canRunAnalysis.starters.spec.ts
@@ -15,7 +15,7 @@
  * `VITE_AUTH_MODE = "guest"`.
  *
  * So a graph that was injected client-side and never persisted is INVISIBLE to
- * the analysis engine. Today `computeCeeCannotSeeModel` catches exactly one
+ * the analysis engine. Today `analysisHeldOn` catches exactly one
  * such case — template inserts, sniffed via `data.templateId` — and refuses the
  * run honestly. A pre-drafted starter is the same situation with a different
  * stamp: without this coverage the Run button would go ENABLED and dispatch a
@@ -29,8 +29,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { computeCeeCannotSeeModel, canRunAnalysis } from '../canRunAnalysis'
-import { ANALYSIS_HELD_NOTICE } from '../analysisHeldOnInjectedModel'
+import { canRunAnalysis } from '../canRunAnalysis'
+import { ANALYSIS_HELD_NOTICE, analysisHeldOn } from '../analysisHeldOnInjectedModel'
 
 const isV5CanonicalRunPathMock = vi.fn(() => true)
 vi.mock('../../../v5/eligibility', async (importOriginal) => {
@@ -42,40 +42,54 @@ const starterNodes = [{ data: { starterId: 'market-entry', label: 'Germany First
 const templateNodes = [{ data: { templateId: 'hiring_strategy_tech_lead' } }, { data: {} }]
 const ceeDraftedNodes = [{ data: { label: 'Germany First' } }, { data: {} }]
 
-describe('computeCeeCannotSeeModel — starter provenance', () => {
+describe('analysisHeldOn — starter provenance', () => {
   beforeEach(() => {
     isV5CanonicalRunPathMock.mockReturnValue(true)
   })
 
   it('POSITIVE CONTROL: still fires for template inserts (the predicate is alive)', () => {
-    expect(computeCeeCannotSeeModel(templateNodes)).toBe(true)
+    expect(analysisHeldOn(templateNodes)).toBe('template')
   })
 
   it('fires for a starter graph — CEE has no persisted graph for a client-injected starter', () => {
-    expect(computeCeeCannotSeeModel(starterNodes)).toBe(true)
+    expect(analysisHeldOn(starterNodes)).toBe('starter')
   })
 
   it('does NOT fire for a genuine CEE-drafted graph (the gate stays narrow)', () => {
-    expect(computeCeeCannotSeeModel(ceeDraftedNodes)).toBe(false)
+    expect(analysisHeldOn(ceeDraftedNodes)).toBeNull()
   })
 
   it('does not fire off the V5 canonical path — a V2-direct run sends the graph itself', () => {
     isV5CanonicalRunPathMock.mockReturnValue(false)
     // Presence first: the same input is `true` on-path (asserted above), so a
     // `false` here is the flag doing work, not the predicate being dead.
-    expect(computeCeeCannotSeeModel(starterNodes)).toBe(false)
-    expect(computeCeeCannotSeeModel(templateNodes)).toBe(false)
+    expect(analysisHeldOn(starterNodes)).toBeNull()
+    expect(analysisHeldOn(templateNodes)).toBeNull()
   })
 
-  it('a starter graph refuses the run with the same honest sentence as a template insert', () => {
+  it('a starter graph refuses the run with the sentence for a STARTER, chosen by the graph', () => {
+    // The wording is not supplied by this call site: `analysisHeldOn` returns
+    // the gating answer and the provenance as ONE value, so the sentence is a
+    // function of the nodes. The template twin below is the discriminator —
+    // without it, a rung that hardcoded the starter sentence would pass.
     const result = canRunAnalysis({
       graphHealth: null,
       readiness: null,
       hasBlockers: false,
       nodeCount: 18,
-      ceeCannotSeeModel: computeCeeCannotSeeModel(starterNodes),
+      analysisHeldOn: analysisHeldOn(starterNodes),
     })
     expect(result.allowed).toBe(false)
     expect(result.reason).toBe(ANALYSIS_HELD_NOTICE.starter)
+
+    const templateResult = canRunAnalysis({
+      graphHealth: null,
+      readiness: null,
+      hasBlockers: false,
+      nodeCount: 18,
+      analysisHeldOn: analysisHeldOn(templateNodes),
+    })
+    expect(templateResult.reason).toBe(ANALYSIS_HELD_NOTICE.template)
+    expect(ANALYSIS_HELD_NOTICE.template).not.toBe(ANALYSIS_HELD_NOTICE.starter)
   })
 })

--- a/src/canvas/utils/__tests__/canRunAnalysis.starters.spec.ts
+++ b/src/canvas/utils/__tests__/canRunAnalysis.starters.spec.ts
@@ -29,7 +29,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { computeCeeCannotSeeModel, canRunAnalysis, CEE_DRAFT_FIRST_REFUSAL } from '../canRunAnalysis'
+import { computeCeeCannotSeeModel, canRunAnalysis, CLIENT_INJECTED_MODEL_REFUSAL } from '../canRunAnalysis'
 
 const isV5CanonicalRunPathMock = vi.fn(() => true)
 vi.mock('../../../v5/eligibility', async (importOriginal) => {
@@ -75,6 +75,6 @@ describe('computeCeeCannotSeeModel — starter provenance', () => {
       ceeCannotSeeModel: computeCeeCannotSeeModel(starterNodes),
     })
     expect(result.allowed).toBe(false)
-    expect(result.reason).toBe(CEE_DRAFT_FIRST_REFUSAL)
+    expect(result.reason).toBe(CLIENT_INJECTED_MODEL_REFUSAL)
   })
 })

--- a/src/canvas/utils/__tests__/canRunAnalysis.starters.spec.ts
+++ b/src/canvas/utils/__tests__/canRunAnalysis.starters.spec.ts
@@ -29,7 +29,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { computeCeeCannotSeeModel, canRunAnalysis, CLIENT_INJECTED_MODEL_REFUSAL } from '../canRunAnalysis'
+import { computeCeeCannotSeeModel, canRunAnalysis } from '../canRunAnalysis'
+import { ANALYSIS_HELD_NOTICE } from '../analysisHeldOnInjectedModel'
 
 const isV5CanonicalRunPathMock = vi.fn(() => true)
 vi.mock('../../../v5/eligibility', async (importOriginal) => {
@@ -75,6 +76,6 @@ describe('computeCeeCannotSeeModel — starter provenance', () => {
       ceeCannotSeeModel: computeCeeCannotSeeModel(starterNodes),
     })
     expect(result.allowed).toBe(false)
-    expect(result.reason).toBe(CLIENT_INJECTED_MODEL_REFUSAL)
+    expect(result.reason).toBe(ANALYSIS_HELD_NOTICE.starter)
   })
 })

--- a/src/canvas/utils/analysisHeldOnInjectedModel.ts
+++ b/src/canvas/utils/analysisHeldOnInjectedModel.ts
@@ -1,0 +1,171 @@
+/**
+ * THE ONE AUTHORITY for "analysis is held because Olumi did not draft this
+ * model" — the predicate AND the sentence, in one place, consumed by every
+ * surface that needs to say it.
+ *
+ * ⭐ WHY THIS MODULE EXISTS. The affordance sweep of 18 Aug 2026
+ * (`olumi-docs/feedback-2026-08-16/AFFORDANCE-SWEEP-2026-08-18.md`) found that
+ * on a bundled starter the canvas model and the server-side model are out of
+ * step, and **every surface that needs the server invented its own explanation
+ * instead of saying so**. Two of those surfaces were describing THIS state:
+ *
+ *   - `StarterProvenanceBanner` — "Analysis is held on a saved example —
+ *     re-draft it live to run one."  ← already TRUE, already shipped
+ *   - the run gate (`canRunAnalysis`) — "Draft or save a model first, then run
+ *     analysis."                      ← FALSE in both limbs (see below)
+ *
+ * The honest copy was therefore already written and already correct; the
+ * Analyse control simply did not consume it. That makes this a WIRING problem,
+ * not a copywriting one — so this module is the wire, and neither surface
+ * authors the sentence any more.
+ *
+ * ⚠ AND IT IS A PREDICATE, NOT A STATIC STRING, DELIBERATELY. The sweep's
+ * second finding was that the banner's notice **goes stale**: it kept claiming
+ * analysis was held while a toast said "Analysis complete." That happened
+ * because the banner mounted on `resolveStarterId(nodes) !== null` while the
+ * gate refused on `computeCeeCannotSeeModel(nodes)` — two DIFFERENT conditions
+ * (the gate also requires the V5 canonical run path, and also covers template
+ * inserts). Banner-mounted did not imply gate-blocked, in either direction, so
+ * one could speak while the other disagreed. `analysisHeldOnInjectedModel` is
+ * now the single condition both read, so the claim tracks the state it
+ * describes.
+ *
+ * ⚠ WHAT THE GATE'S OLD SENTENCE GOT WRONG (trap 21 — name the question each
+ * authority answers). It was `CEE_DRAFT_FIRST_REFUSAL`, justified as "CEE's
+ * refusal sentence, verbatim". CEE does emit
+ * `'Draft or save a model first, then run analysis.'` — at
+ * `analysis-ready-helper.ts::assessCanonicalAnalysisReadiness`, under code
+ * `NO_GRAPH`, when `graph === null || graph === undefined`. That answers *"is
+ * there a model at all?"*, for which both limbs are true and achievable. This
+ * rung answers *"is the model on this canvas one the engine can analyse?"*, and
+ * for THAT question both limbs are false:
+ *
+ *   - "Draft ... a model first" — `canRunAnalysis` returns at `nodeCount === 0`
+ *     BEFORE this rung, so a model is always on the canvas when it renders.
+ *     Witnessed on deployed `d5aa8453`: 8 nodes, 3 options, 3 risks and 8
+ *     estimates on screen, beneath this refusal.
+ *   - "... or save a model first" — the predicate reads `node.data` only, and
+ *     `applyStarter` stamps `starterId` onto EVERY node. Persistence
+ *     round-trips `node.data`, so a saved starter is still refused. The product
+ *     was asking for an action it cannot accept (preamble P8) — and
+ *     `StarterProvenanceBanner` had ALREADY corrected exactly this promise in
+ *     its own copy ("the starter stamp rides a save, so saving does NOT
+ *     re-enable analysis. Re-drafting is the one route that does") while the
+ *     gate constant beside it kept carrying it. One claim, two copies, one
+ *     fixed (trap 12).
+ *
+ * ⭐ REUSABLE BY THE SWEEP'S OTHER SURFACES, BY CONSTRUCTION. The sweep found
+ * ZERO honest refusals across 17 primary affordances. The shape that fixes this
+ * one — a named STATE, one predicate over the live graph, one sentence that
+ * names the achievable remedy, both consumed rather than re-authored — is what
+ * the other instances need too. They are dispatched separately and this lane
+ * does not touch them; the point is only that nothing here blocks them from
+ * importing it.
+ */
+
+import { isV5CanonicalRunPath } from '../../v5/eligibility'
+
+/**
+ * Which client-side injection put this graph on the canvas, if any.
+ *
+ * `templateId` — stamped only by insertBlueprint (PLoT template insert).
+ * `starterId`  — stamped only by applyStarter (pre-drafted starter scenario,
+ *                src/canvas/starters/loadStarter.ts).
+ *
+ * No CEE draft path stamps either one, which is exactly what makes them a sound
+ * discriminator. ⚠ There is deliberately NO separate `KEYS` array beside
+ * `clientInjectedProvenance` any more: the old `CLIENT_INJECTED_PROVENANCE_KEYS`
+ * const became a second list of the same two stamps the moment the function
+ * needed to tell them APART rather than treat them alike, and two lists of one
+ * fact is the mirror this estate keeps paying for (trap 12). The function below
+ * is the only place the stamps are named.
+ */
+export type ClientInjectedProvenance = 'starter' | 'template'
+
+export interface NodeLike {
+  data?: Record<string, unknown> | undefined
+}
+
+/**
+ * The provenance of a client-injected graph, or `null` when Olumi drafted it.
+ *
+ * Derived from the graph itself, never from a separate "which starter is
+ * loaded" store slot: the stamp lives on the nodes, so it disappears exactly
+ * when the injected graph does. `starterId` wins when both are present — a
+ * starter is the more specific claim and the one with a re-draft affordance.
+ */
+export function clientInjectedProvenance(
+  nodes: ReadonlyArray<NodeLike>,
+): ClientInjectedProvenance | null {
+  let template: ClientInjectedProvenance | null = null
+  for (const node of nodes) {
+    if (node.data?.starterId != null) return 'starter'
+    if (node.data?.templateId != null) template = 'template'
+  }
+  return template
+}
+
+/**
+ * Is analysis HELD because Olumi did not draft the model on this canvas?
+ *
+ * THE single condition. Both the run gate and the provenance banner read it, so
+ * a surface can no longer claim analysis is held while another disagrees.
+ *
+ * Two conjuncts, and both are load-bearing:
+ *  - the graph was injected client-side (`clientInjectedProvenance`), and
+ *  - the run would route through CEE, which analyses its own scenario state,
+ *    not the canvas (#343). The V5 turn body carries no graph at all
+ *    (`src/v5/buildPayload.ts`; the vendored MessageTurnPayloadSchema is
+ *    `.strict()`), so CEE's only route to the nodes is its persisted scenario
+ *    row. A V2-direct run DOES send the canvas graph, so the hold does not
+ *    apply off the canonical path.
+ */
+export function analysisHeldOnInjectedModel(nodes: ReadonlyArray<NodeLike>): boolean {
+  return isV5CanonicalRunPath() && clientInjectedProvenance(nodes) !== null
+}
+
+/**
+ * THE sentence for that state — the one already shipped in
+ * `StarterProvenanceBanner` and verified true, now owned here so both surfaces
+ * say it rather than each writing its own.
+ *
+ * It names the state and the achievable remedy, and nothing else. The remedy is
+ * reachable from where the user is standing: the composer is always on screen,
+ * and for a starter the banner's "Re-draft this live" does exactly this in one
+ * click (P8 — never ask what you cannot accept).
+ *
+ * The variants exist only because "saved example" is a false description of a
+ * template insert; the CLAIM and the REMEDY are identical in all three, and the
+ * remedy clause is byte-identical by construction (`HELD_REMEDY`), so no variant
+ * can drift into offering a different way out.
+ *
+ * `unspecified` is for a caller that knows analysis is held but was not given
+ * the provenance — it states the claim without guessing which kind of ready-made
+ * model it is. It is NOT a default that fabricates: it describes exactly the
+ * caller's knowledge.
+ */
+const HELD_REMEDY = ' — re-draft it live to run one.'
+
+export const ANALYSIS_HELD_NOTICE: Record<ClientInjectedProvenance | 'unspecified', string> = {
+  starter: `Analysis is held on a saved example${HELD_REMEDY}`,
+  template: `Analysis is held on an inserted template${HELD_REMEDY}`,
+  unspecified: `Analysis is held on a ready-made model${HELD_REMEDY}`,
+} as const
+
+/** The notice for a known-or-unknown provenance, when analysis IS held. */
+export function noticeForProvenance(
+  provenance: ClientInjectedProvenance | null | undefined,
+): string {
+  return ANALYSIS_HELD_NOTICE[provenance ?? 'unspecified']
+}
+
+/**
+ * The notice for the graph on the canvas, or `null` when analysis is not held —
+ * so a caller CANNOT render the claim in a state where it is untrue. Returning
+ * a string unconditionally is what let the banner go stale.
+ */
+export function analysisHeldNotice(nodes: ReadonlyArray<NodeLike>): string | null {
+  if (!analysisHeldOnInjectedModel(nodes)) return null
+  const provenance = clientInjectedProvenance(nodes)
+  return provenance === null ? null : ANALYSIS_HELD_NOTICE[provenance]
+}

--- a/src/canvas/utils/analysisHeldOnInjectedModel.ts
+++ b/src/canvas/utils/analysisHeldOnInjectedModel.ts
@@ -1,7 +1,7 @@
 /**
  * THE ONE AUTHORITY for "analysis is held because Olumi did not draft this
- * model" — the predicate AND the sentence, in one place, consumed by every
- * surface that needs to say it.
+ * model" — one input, one predicate, one sentence, consumed by every surface
+ * that needs to say it.
  *
  * ⭐ WHY THIS MODULE EXISTS. The affordance sweep of 18 Aug 2026
  * (`olumi-docs/feedback-2026-08-16/AFFORDANCE-SWEEP-2026-08-18.md`) found that
@@ -16,19 +16,31 @@
  *
  * The honest copy was therefore already written and already correct; the
  * Analyse control simply did not consume it. That makes this a WIRING problem,
- * not a copywriting one — so this module is the wire, and neither surface
- * authors the sentence any more.
+ * not a copywriting one — so this module is the wire, and no surface authors
+ * the sentence any more.
+ *
+ * ⚠ ONE INPUT, DELIBERATELY — AND THE FIRST ATTEMPT AT THIS FIX GOT IT WRONG.
+ * That attempt kept the gate's existing boolean (`ceeCannotSeeModel`) and added
+ * a SECOND parameter beside it carrying the provenance, both derived from the
+ * same `nodes`. Two parameters for one fact is a hand-maintained pairing, and
+ * it had already drifted before it was finished: `OutputsDock` passed both,
+ * `ConversationPanel` passed only the boolean — so in ONE application state the
+ * Analysis panel would have said "a saved example" while the composer's Run
+ * tooltip said "a ready-made model". A fix for "two surfaces, two sentences,
+ * one state" that creates two surfaces, two sentences, one state.
+ * `analysisHeldOn` is therefore the gate's ONLY input for this rung: it answers
+ * *whether* analysis is held and *what to call the model* in a single value, so
+ * a caller cannot supply one without the other.
  *
  * ⚠ AND IT IS A PREDICATE, NOT A STATIC STRING, DELIBERATELY. The sweep's
  * second finding was that the banner's notice **goes stale**: it kept claiming
  * analysis was held while a toast said "Analysis complete." That happened
  * because the banner mounted on `resolveStarterId(nodes) !== null` while the
- * gate refused on `computeCeeCannotSeeModel(nodes)` — two DIFFERENT conditions
- * (the gate also requires the V5 canonical run path, and also covers template
- * inserts). Banner-mounted did not imply gate-blocked, in either direction, so
- * one could speak while the other disagreed. `analysisHeldOnInjectedModel` is
- * now the single condition both read, so the claim tracks the state it
- * describes.
+ * gate refused on a DIFFERENT condition (which also requires the V5 canonical
+ * run path, and also covers template inserts). Banner-mounted did not imply
+ * gate-blocked, in either direction, so one could speak while the other
+ * disagreed. `analysisHeldOn` is now the single condition both read, so the
+ * claim tracks the state it describes.
  *
  * ⚠ WHAT THE GATE'S OLD SENTENCE GOT WRONG (trap 21 — name the question each
  * authority answers). It was `CEE_DRAFT_FIRST_REFUSAL`, justified as "CEE's
@@ -43,7 +55,9 @@
  *   - "Draft ... a model first" — `canRunAnalysis` returns at `nodeCount === 0`
  *     BEFORE this rung, so a model is always on the canvas when it renders.
  *     Witnessed on deployed `d5aa8453`: 8 nodes, 3 options, 3 risks and 8
- *     estimates on screen, beneath this refusal.
+ *     estimates on screen, beneath this refusal. The 18 Aug sweep witnessed the
+ *     same thing on `1dec0ad6` with the panel's own "4 options · 3 risks ·
+ *     8 estimates" four rows above it.
  *   - "... or save a model first" — the predicate reads `node.data` only, and
  *     `applyStarter` stamps `starterId` onto EVERY node. Persistence
  *     round-trips `node.data`, so a saved starter is still refused. The product
@@ -53,32 +67,25 @@
  *     re-enable analysis. Re-drafting is the one route that does") while the
  *     gate constant beside it kept carrying it. One claim, two copies, one
  *     fixed (trap 12).
- *
- * ⭐ REUSABLE BY THE SWEEP'S OTHER SURFACES, BY CONSTRUCTION. The sweep found
- * ZERO honest refusals across 17 primary affordances. The shape that fixes this
- * one — a named STATE, one predicate over the live graph, one sentence that
- * names the achievable remedy, both consumed rather than re-authored — is what
- * the other instances need too. They are dispatched separately and this lane
- * does not touch them; the point is only that nothing here blocks them from
- * importing it.
  */
 
 import { isV5CanonicalRunPath } from '../../v5/eligibility'
 
 /**
- * Which client-side injection put this graph on the canvas, if any.
+ * Which client-side injection put this graph on the canvas.
  *
- * `templateId` — stamped only by insertBlueprint (PLoT template insert).
- * `starterId`  — stamped only by applyStarter (pre-drafted starter scenario,
- *                src/canvas/starters/loadStarter.ts).
+ * `starterId`  — stamped only by `applyStarter` (pre-drafted starter scenario,
+ *                `src/canvas/starters/loadStarter.ts`).
+ * `templateId` — stamped only by `insertBlueprint` (PLoT template insert,
+ *                `src/canvas/hooks/useBlueprintInsert.ts`).
  *
  * No CEE draft path stamps either one, which is exactly what makes them a sound
  * discriminator. ⚠ There is deliberately NO separate `KEYS` array beside
- * `clientInjectedProvenance` any more: the old `CLIENT_INJECTED_PROVENANCE_KEYS`
- * const became a second list of the same two stamps the moment the function
- * needed to tell them APART rather than treat them alike, and two lists of one
- * fact is the mirror this estate keeps paying for (trap 12). The function below
- * is the only place the stamps are named.
+ * `readInjectionStamp`: the old `CLIENT_INJECTED_PROVENANCE_KEYS` const became a
+ * second list of the same two stamps the moment the function needed to tell
+ * them APART rather than treat them alike, and two lists of one fact is the
+ * mirror this estate keeps paying for (trap 12). The function below is the only
+ * place the stamps are named.
  */
 export type ClientInjectedProvenance = 'starter' | 'template'
 
@@ -87,14 +94,20 @@ export interface NodeLike {
 }
 
 /**
- * The provenance of a client-injected graph, or `null` when Olumi drafted it.
+ * The provenance stamp on the graph, or `null` when Olumi drafted it.
+ *
+ * Module-private on purpose: it is the RAW graph read, without the run-path
+ * conjunct, and a surface that consumed it would be answering "is this a
+ * ready-made model?" while believing it had asked "is analysis held?" — the
+ * two-questions-one-name defect this module exists to end. `analysisHeldOn` is
+ * the only exported way in.
  *
  * Derived from the graph itself, never from a separate "which starter is
  * loaded" store slot: the stamp lives on the nodes, so it disappears exactly
  * when the injected graph does. `starterId` wins when both are present — a
  * starter is the more specific claim and the one with a re-draft affordance.
  */
-export function clientInjectedProvenance(
+function readInjectionStamp(
   nodes: ReadonlyArray<NodeLike>,
 ): ClientInjectedProvenance | null {
   let template: ClientInjectedProvenance | null = null
@@ -106,13 +119,15 @@ export function clientInjectedProvenance(
 }
 
 /**
- * Is analysis HELD because Olumi did not draft the model on this canvas?
+ * ⭐ THE ONE INPUT. Non-null ⇔ analysis is held because Olumi did not draft the
+ * model on this canvas — and the value names WHICH ready-made model it is, so
+ * the refusal can describe it without a second parameter to keep in step.
  *
- * THE single condition. Both the run gate and the provenance banner read it, so
- * a surface can no longer claim analysis is held while another disagrees.
+ * Both the run gate and the provenance banner read this, so a surface can no
+ * longer claim analysis is held while another disagrees.
  *
  * Two conjuncts, and both are load-bearing:
- *  - the graph was injected client-side (`clientInjectedProvenance`), and
+ *  - the graph was injected client-side (`readInjectionStamp`), and
  *  - the run would route through CEE, which analyses its own scenario state,
  *    not the canvas (#343). The V5 turn body carries no graph at all
  *    (`src/v5/buildPayload.ts`; the vendored MessageTurnPayloadSchema is
@@ -120,8 +135,10 @@ export function clientInjectedProvenance(
  *    row. A V2-direct run DOES send the canvas graph, so the hold does not
  *    apply off the canonical path.
  */
-export function analysisHeldOnInjectedModel(nodes: ReadonlyArray<NodeLike>): boolean {
-  return isV5CanonicalRunPath() && clientInjectedProvenance(nodes) !== null
+export function analysisHeldOn(
+  nodes: ReadonlyArray<NodeLike>,
+): ClientInjectedProvenance | null {
+  return isV5CanonicalRunPath() ? readInjectionStamp(nodes) : null
 }
 
 /**
@@ -134,30 +151,43 @@ export function analysisHeldOnInjectedModel(nodes: ReadonlyArray<NodeLike>): boo
  * and for a starter the banner's "Re-draft this live" does exactly this in one
  * click (P8 — never ask what you cannot accept).
  *
- * The variants exist only because "saved example" is a false description of a
- * template insert; the CLAIM and the REMEDY are identical in all three, and the
- * remedy clause is byte-identical by construction (`HELD_REMEDY`), so no variant
+ * ⚠ TWO ENTRIES, AND NO `unspecified` FALLBACK. The first attempt at this fix
+ * carried a third variant ("a ready-made model") for a caller that knew
+ * analysis was held but had not been given the provenance. With one input that
+ * caller cannot exist — and while it did, it was a sentence the product could
+ * emit while describing the model from a guess rather than from the graph. A
+ * default that fabricates a description is the defect class, in miniature.
+ *
+ * The two variants exist only because "saved example" is a false description of
+ * a template insert; the CLAIM and the REMEDY are identical in both, and the
+ * remedy clause is byte-identical by construction (`HELD_REMEDY`), so neither
  * can drift into offering a different way out.
  *
- * `unspecified` is for a caller that knows analysis is held but was not given
- * the provenance — it states the claim without guessing which kind of ready-made
- * model it is. It is NOT a default that fabricates: it describes exactly the
- * caller's knowledge.
+ * ⚠ STATE-CLASS, stated rather than implied: the `starter` sentence is the
+ * shipped, live-witnessed one (18 Aug sweep, `1dec0ad6`). The `template`
+ * variant is NOT witnessed — the template-insert state was reachable at the
+ * bytes (`insertBlueprint` stamps every node; the `T` panel opens it) but was
+ * not driven. Only its noun phrase differs from the witnessed sentence, which
+ * is the least invention available: the alternative was to call a template
+ * insert "a saved example", which is simply untrue.
+ *
+ * ⚠ ONE DEVIATION FROM THE SHIPPED STRING, AND WHY. The banner shipped this as
+ * "…a saved example — re-draft it live to run one." with an EM DASH. Wiring it
+ * into the run gate makes it render in the pre-analysis footer, and that
+ * surface's copy is under an enforced rule — `signals/__tests__/registry.spec.ts`
+ * asserts "no em dashes anywhere in copy" over every constant it sweeps, and
+ * this constant is now swept there (it renders beside `BLOCKED_REASON_COPY`, so
+ * it must live under the same rule rather than beside it). The clause boundary
+ * became a full stop. No word changed, the claim and the remedy are untouched,
+ * and the banner now renders the compliant form too — which is the point of one
+ * authority: fixing the copy in one place fixes it everywhere it is said.
  */
-const HELD_REMEDY = ' — re-draft it live to run one.'
+const HELD_REMEDY = '. Re-draft it live to run one.'
 
-export const ANALYSIS_HELD_NOTICE: Record<ClientInjectedProvenance | 'unspecified', string> = {
+export const ANALYSIS_HELD_NOTICE: Record<ClientInjectedProvenance, string> = {
   starter: `Analysis is held on a saved example${HELD_REMEDY}`,
   template: `Analysis is held on an inserted template${HELD_REMEDY}`,
-  unspecified: `Analysis is held on a ready-made model${HELD_REMEDY}`,
 } as const
-
-/** The notice for a known-or-unknown provenance, when analysis IS held. */
-export function noticeForProvenance(
-  provenance: ClientInjectedProvenance | null | undefined,
-): string {
-  return ANALYSIS_HELD_NOTICE[provenance ?? 'unspecified']
-}
 
 /**
  * The notice for the graph on the canvas, or `null` when analysis is not held —
@@ -165,7 +195,6 @@ export function noticeForProvenance(
  * a string unconditionally is what let the banner go stale.
  */
 export function analysisHeldNotice(nodes: ReadonlyArray<NodeLike>): string | null {
-  if (!analysisHeldOnInjectedModel(nodes)) return null
-  const provenance = clientInjectedProvenance(nodes)
-  return provenance === null ? null : ANALYSIS_HELD_NOTICE[provenance]
+  const held = analysisHeldOn(nodes)
+  return held === null ? null : ANALYSIS_HELD_NOTICE[held]
 }

--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -43,10 +43,8 @@ import {
   type OptionNeedingValues,
 } from './composeBlockedReason'
 import {
-  analysisHeldOnInjectedModel,
-  noticeForProvenance,
+  ANALYSIS_HELD_NOTICE as HELD_NOTICE,
   type ClientInjectedProvenance,
-  type NodeLike,
 } from './analysisHeldOnInjectedModel'
 
 /**
@@ -60,10 +58,16 @@ import {
  * the derivation and for why quoting CEE's `NO_GRAPH` sentence here was the
  * root error (trap 21).
  *
- * Re-exported rather than inlined so existing importers of this module keep
- * working while there remains exactly ONE place the sentence is written.
+ * Re-exported rather than inlined so a reader who arrives at the gate looking
+ * for its refusal finds the one place the sentence is written, instead of a
+ * second copy of it.
  */
-export { ANALYSIS_HELD_NOTICE, analysisHeldNotice } from './analysisHeldOnInjectedModel'
+export {
+  ANALYSIS_HELD_NOTICE,
+  analysisHeldNotice,
+  analysisHeldOn,
+  type ClientInjectedProvenance,
+} from './analysisHeldOnInjectedModel'
 
 /**
  * ROADMAP 2.122 — the refusal shown while a STREAMED draft's structure is on
@@ -97,21 +101,6 @@ export const DRAFT_VALUES_SETTLING_REFUSAL =
 export const DRAFT_VALUES_UNSETTLED_REFUSAL =
   'Drafting ended before this model\u2019s values arrived, so they are not final. Start a new draft to analyse it.'
 
-/**
- * True when the canvas model is invisible to the analysis engine.
- *
- * ⭐ DELEGATES to `analysisHeldOnInjectedModel` — the ONE condition the run
- * gate and the provenance banner both read, so neither can claim analysis is
- * held while the other disagrees (the staleness the 18 Aug affordance sweep
- * found: the banner still saying "analysis is held" beside "Analysis
- * complete."). The predicate, the provenance list and the sentence all live in
- * that module now; this name is kept because it is what the gate's callers and
- * specs already ask for.
- */
-export function computeCeeCannotSeeModel(nodes: ReadonlyArray<NodeLike>): boolean {
-  return analysisHeldOnInjectedModel(nodes)
-}
-
 export interface CanRunAnalysisResult {
   /** Whether analysis can be run */
   allowed: boolean
@@ -143,21 +132,21 @@ export interface CanRunAnalysisParams {
   nodeCount: number
   /** Whether analysis is currently running */
   isRunning?: boolean
-  /** See computeCeeCannotSeeModel — the model exists only client-side and
-   *  the run routes through CEE, so the engine would refuse it (#343). */
-  ceeCannotSeeModel?: boolean
   /**
-   * WHICH client-side injection put the graph on the canvas — passed THROUGH
-   * raw (`clientInjectedProvenance(nodes)`), never pre-worded by the caller,
-   * for the same reason `draftStreamPhase` is: a sentence chosen at the call
-   * site is a hand-maintained mirror, and the mutant that picks the wrong
-   * variant survives.
+   * ⭐ ONE INPUT for the injected-model rung — `analysisHeldOn(nodes)`, passed
+   * THROUGH raw, never pre-worded by the caller (the same rule as
+   * `draftStreamPhase`: a sentence chosen at a call site is a hand-maintained
+   * mirror, and the mutant that picks the wrong variant survives).
    *
-   * It affects ONLY the wording of the refusal, never `allowed` — the gating
-   * answer is `ceeCannotSeeModel`. Omitted ⇒ the provenance-neutral notice,
-   * which states the claim without guessing.
+   * Non-null ⇒ the model exists only client-side while the run routes through
+   * CEE, so the engine would answer about a graph it never received (#343) —
+   * AND the value names which ready-made model it is, so the refusal can
+   * describe it. This used to be two parameters (a gating boolean plus a
+   * provenance), which is how `OutputsDock` and `ConversationPanel` came within
+   * one review of describing the SAME state with two different nouns. One
+   * value cannot half-arrive.
    */
-  injectedProvenance?: ClientInjectedProvenance | null
+  analysisHeldOn?: ClientInjectedProvenance | null
   /**
    * ROADMAP 2.122 — the streamed draft's phase, passed THROUGH rather than
    * pre-derived by the caller.
@@ -306,7 +295,7 @@ export const RUN_LICENCE_SUPERSEDED_REFUSAL =
  * @returns CanRunAnalysisResult with allowed status and reason
  */
 export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResult {
-  const { graphHealth, readiness, hasBlockers, nodeCount, isRunning = false, ceeCannotSeeModel = false, injectedProvenance = null, draftStreamPhase = 'idle', optionsNeedingValues, readinessStale = false } = params
+  const { graphHealth, readiness, hasBlockers, nodeCount, isRunning = false, analysisHeldOn = null, draftStreamPhase = 'idle', optionsNeedingValues, readinessStale = false } = params
 
   const blockingReasons: string[] = []
 
@@ -352,11 +341,13 @@ export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResu
     }
   }
 
-  // 2.5 Model invisible to the analysis engine (see computeCeeCannotSeeModel).
-  if (ceeCannotSeeModel) {
+  // 2.5 Model invisible to the analysis engine (see `analysisHeldOn`). The
+  // gating answer and the sentence come from the SAME value, so this rung
+  // cannot refuse for one reason and explain itself with another.
+  if (analysisHeldOn !== null) {
     return {
       allowed: false,
-      reason: noticeForProvenance(injectedProvenance),
+      reason: HELD_NOTICE[analysisHeldOn],
       blockingReasons: ['Model not in Olumi scenario state (client-injected graph)'],
     }
   }

--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -38,54 +38,32 @@
 
 import { draftValuesAreUnsettled, type DraftStreamPhase } from '../stores/draftStore'
 import type { GraphReadiness } from '../hooks/useGraphReadiness'
-import { isV5CanonicalRunPath } from '../../v5/eligibility'
 import {
   composeReadinessBlockedReason,
   type OptionNeedingValues,
 } from './composeBlockedReason'
+import {
+  analysisHeldOnInjectedModel,
+  noticeForProvenance,
+  type ClientInjectedProvenance,
+  type NodeLike,
+} from './analysisHeldOnInjectedModel'
 
 /**
- * The refusal for a model the engine did not draft (see
- * `computeCeeCannotSeeModel`). It is THIS gate's own sentence, deliberately —
- * and that is a correction, not a drift.
+ * The refusal for a model the engine did not draft.
  *
- * ⚠ IT USED TO BE `CEE_DRAFT_FIRST_REFUSAL`, quoting CEE verbatim on the
- * grounds that "the gate must show the engine's own words so panel and chat
- * never contradict each other". CEE does emit
- * `'Draft or save a model first, then run analysis.'` — at
- * `analysis-ready-helper.ts::assessCanonicalAnalysisReadiness`, under code
- * `NO_GRAPH`, when `graph === null || graph === undefined`. That answers
- * *"is there a model at all?"*, and for THAT question both limbs are true and
- * achievable.
+ * ⭐ NOT AUTHORED HERE, AND THAT IS THE FIX. It is
+ * `analysisHeldOnInjectedModel.ts`'s `ANALYSIS_HELD_NOTICE` — the sentence the
+ * provenance banner already shipped and that was already true. The gate used to
+ * write its own (`CEE_DRAFT_FIRST_REFUSAL`, "Draft or save a model first, then
+ * run analysis."), which was false in both limbs; see that module's header for
+ * the derivation and for why quoting CEE's `NO_GRAPH` sentence here was the
+ * root error (trap 21).
  *
- * This rung answers a different question — *"is the model on this canvas one
- * the engine can analyse?"* — and borrowing the other question's answer made
- * BOTH limbs false here (trap 21: name the question each authority answers
- * before making them agree):
- *
- *   - "Draft ... a model first" — `canRunAnalysis` returns at `nodeCount === 0`
- *     before this rung, so a model is ALWAYS on the canvas when this renders.
- *     Witnessed on deployed `d5aa8453`: 8 nodes, 3 options, 3 risks and 8
- *     estimates on screen, beneath this sentence.
- *   - "... or save a model first" — `computeCeeCannotSeeModel` reads
- *     `node.data` only, and `applyStarter` stamps `starterId` onto EVERY node.
- *     Persistence round-trips `node.data`, so a saved starter is still refused.
- *     The product was asking for an action it could not accept (preamble P8).
- *     `StarterProvenanceBanner` had ALREADY corrected exactly this promise in
- *     its own copy — "the starter stamp rides a save, so saving does NOT
- *     re-enable analysis. Re-drafting is the one route that does" — and this
- *     constant beside it was left carrying it. One claim, two copies, one
- *     fixed (trap 12).
- *
- * So it now states this rung's own fact and names the action that genuinely
- * clears it. The named remedy is reachable from where the user is standing:
- * the composer is always on screen, and for a starter
- * `StarterProvenanceBanner`'s "Re-draft this live" does exactly this in one
- * click.
+ * Re-exported rather than inlined so existing importers of this module keep
+ * working while there remains exactly ONE place the sentence is written.
  */
-export const CLIENT_INJECTED_MODEL_REFUSAL =
-  'Olumi has not drafted this model, so it cannot analyse it yet. ' +
-  'Ask Olumi in the chat to draft it live, then run the analysis.'
+export { ANALYSIS_HELD_NOTICE, analysisHeldNotice } from './analysisHeldOnInjectedModel'
 
 /**
  * ROADMAP 2.122 — the refusal shown while a STREAMED draft's structure is on
@@ -120,44 +98,18 @@ export const DRAFT_VALUES_UNSETTLED_REFUSAL =
   'Drafting ended before this model\u2019s values arrived, so they are not final. Start a new draft to analyse it.'
 
 /**
- * Provenance stamps that mark a graph as INJECTED CLIENT-SIDE rather than
- * produced by a CEE turn.
+ * True when the canvas model is invisible to the analysis engine.
  *
- * `templateId` — stamped only by insertBlueprint (PLoT template insert).
- * `starterId`  — stamped only by applyStarter (pre-drafted starter scenario,
- *                src/canvas/starters/loadStarter.ts).
- *
- * No CEE draft path stamps either one, which is exactly what makes them a
- * sound discriminator. Kept as one named list so a third injection source
- * cannot be added without meeting this decision.
+ * ⭐ DELEGATES to `analysisHeldOnInjectedModel` — the ONE condition the run
+ * gate and the provenance banner both read, so neither can claim analysis is
+ * held while the other disagrees (the staleness the 18 Aug affordance sweep
+ * found: the banner still saying "analysis is held" beside "Analysis
+ * complete."). The predicate, the provenance list and the sentence all live in
+ * that module now; this name is kept because it is what the gate's callers and
+ * specs already ask for.
  */
-const CLIENT_INJECTED_PROVENANCE_KEYS = ['templateId', 'starterId'] as const
-
-/**
- * True when the canvas model is invisible to the analysis engine: the graph was
- * injected client-side (see CLIENT_INJECTED_PROVENANCE_KEYS) AND the run would
- * route through CEE, which analyses its own scenario state — not the canvas
- * (#343). A V2-direct run can analyse canvas graphs, so the gate stays open off
- * the canonical path.
- *
- * The V5 turn body carries no graph at all — `src/v5/buildPayload.ts` emits
- * turn ids/stage/message/source/chip and the vendored MessageTurnPayloadSchema
- * is `.strict()` — so CEE's only route to the nodes is its persisted scenario
- * row, which `flushPendingGraphSave` writes ONLY when persistence is active.
- * A guest session therefore has no server-side graph for an injected model, and
- * refusing the run is the honest outcome: the alternative is dispatching a run
- * that returns an answer about a graph nobody analysed.
- *
- * ONE home for the predicate: both gate callers (OutputsDock,
- * ConversationPanel) consume this instead of re-deriving it.
- */
-export function computeCeeCannotSeeModel(
-  nodes: ReadonlyArray<{ data?: Record<string, unknown> | undefined }>,
-): boolean {
-  return (
-    isV5CanonicalRunPath() &&
-    nodes.some((n) => CLIENT_INJECTED_PROVENANCE_KEYS.some((k) => n.data?.[k] != null))
-  )
+export function computeCeeCannotSeeModel(nodes: ReadonlyArray<NodeLike>): boolean {
+  return analysisHeldOnInjectedModel(nodes)
 }
 
 export interface CanRunAnalysisResult {
@@ -194,6 +146,18 @@ export interface CanRunAnalysisParams {
   /** See computeCeeCannotSeeModel — the model exists only client-side and
    *  the run routes through CEE, so the engine would refuse it (#343). */
   ceeCannotSeeModel?: boolean
+  /**
+   * WHICH client-side injection put the graph on the canvas — passed THROUGH
+   * raw (`clientInjectedProvenance(nodes)`), never pre-worded by the caller,
+   * for the same reason `draftStreamPhase` is: a sentence chosen at the call
+   * site is a hand-maintained mirror, and the mutant that picks the wrong
+   * variant survives.
+   *
+   * It affects ONLY the wording of the refusal, never `allowed` — the gating
+   * answer is `ceeCannotSeeModel`. Omitted ⇒ the provenance-neutral notice,
+   * which states the claim without guessing.
+   */
+  injectedProvenance?: ClientInjectedProvenance | null
   /**
    * ROADMAP 2.122 — the streamed draft's phase, passed THROUGH rather than
    * pre-derived by the caller.
@@ -342,7 +306,7 @@ export const RUN_LICENCE_SUPERSEDED_REFUSAL =
  * @returns CanRunAnalysisResult with allowed status and reason
  */
 export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResult {
-  const { graphHealth, readiness, hasBlockers, nodeCount, isRunning = false, ceeCannotSeeModel = false, draftStreamPhase = 'idle', optionsNeedingValues, readinessStale = false } = params
+  const { graphHealth, readiness, hasBlockers, nodeCount, isRunning = false, ceeCannotSeeModel = false, injectedProvenance = null, draftStreamPhase = 'idle', optionsNeedingValues, readinessStale = false } = params
 
   const blockingReasons: string[] = []
 
@@ -392,8 +356,8 @@ export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResu
   if (ceeCannotSeeModel) {
     return {
       allowed: false,
-      reason: CLIENT_INJECTED_MODEL_REFUSAL,
-      blockingReasons: ['Model not in Olumi scenario state (template insert)'],
+      reason: noticeForProvenance(injectedProvenance),
+      blockingReasons: ['Model not in Olumi scenario state (client-injected graph)'],
     }
   }
 

--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -45,11 +45,47 @@ import {
 } from './composeBlockedReason'
 
 /**
- * CEE's refusal sentence, verbatim — the gate must show the engine's own
- * words so panel and chat never contradict each other. If CEE rewords its
- * refusal, this constant (and the spec pinning the raw literal) must follow.
+ * The refusal for a model the engine did not draft (see
+ * `computeCeeCannotSeeModel`). It is THIS gate's own sentence, deliberately —
+ * and that is a correction, not a drift.
+ *
+ * ⚠ IT USED TO BE `CEE_DRAFT_FIRST_REFUSAL`, quoting CEE verbatim on the
+ * grounds that "the gate must show the engine's own words so panel and chat
+ * never contradict each other". CEE does emit
+ * `'Draft or save a model first, then run analysis.'` — at
+ * `analysis-ready-helper.ts::assessCanonicalAnalysisReadiness`, under code
+ * `NO_GRAPH`, when `graph === null || graph === undefined`. That answers
+ * *"is there a model at all?"*, and for THAT question both limbs are true and
+ * achievable.
+ *
+ * This rung answers a different question — *"is the model on this canvas one
+ * the engine can analyse?"* — and borrowing the other question's answer made
+ * BOTH limbs false here (trap 21: name the question each authority answers
+ * before making them agree):
+ *
+ *   - "Draft ... a model first" — `canRunAnalysis` returns at `nodeCount === 0`
+ *     before this rung, so a model is ALWAYS on the canvas when this renders.
+ *     Witnessed on deployed `d5aa8453`: 8 nodes, 3 options, 3 risks and 8
+ *     estimates on screen, beneath this sentence.
+ *   - "... or save a model first" — `computeCeeCannotSeeModel` reads
+ *     `node.data` only, and `applyStarter` stamps `starterId` onto EVERY node.
+ *     Persistence round-trips `node.data`, so a saved starter is still refused.
+ *     The product was asking for an action it could not accept (preamble P8).
+ *     `StarterProvenanceBanner` had ALREADY corrected exactly this promise in
+ *     its own copy — "the starter stamp rides a save, so saving does NOT
+ *     re-enable analysis. Re-drafting is the one route that does" — and this
+ *     constant beside it was left carrying it. One claim, two copies, one
+ *     fixed (trap 12).
+ *
+ * So it now states this rung's own fact and names the action that genuinely
+ * clears it. The named remedy is reachable from where the user is standing:
+ * the composer is always on screen, and for a starter
+ * `StarterProvenanceBanner`'s "Re-draft this live" does exactly this in one
+ * click.
  */
-export const CEE_DRAFT_FIRST_REFUSAL = 'Draft or save a model first, then run analysis.'
+export const CLIENT_INJECTED_MODEL_REFUSAL =
+  'Olumi has not drafted this model, so it cannot analyse it yet. ' +
+  'Ask Olumi in the chat to draft it live, then run the analysis.'
 
 /**
  * ROADMAP 2.122 — the refusal shown while a STREAMED draft's structure is on
@@ -356,7 +392,7 @@ export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResu
   if (ceeCannotSeeModel) {
     return {
       allowed: false,
-      reason: CEE_DRAFT_FIRST_REFUSAL,
+      reason: CLIENT_INJECTED_MODEL_REFUSAL,
       blockingReasons: ['Model not in Olumi scenario state (template insert)'],
     }
   }

--- a/src/canvas/utils/composeBlockedReason.ts
+++ b/src/canvas/utils/composeBlockedReason.ts
@@ -95,8 +95,29 @@ export const BLOCKED_REASON_COPY = {
    * structured field specific enough to name the cause. Deliberately makes NO
    * claim about the model — the defect this module fixes was a confident false
    * claim in exactly this position.
+   *
+   * ⚠ IT USED TO READ "Olumi is not able to run this yet." — and this file's
+   * own staleness rung already noted that sentence "still asserts the verdict's
+   * `can_run_analysis: false` as a present-tense fact". That assertion became a
+   * visible CONTRADICTION on 18 Aug 2026, when `OutputsDock` began feeding the
+   * run gate's reason to the POST-analysis footer (`derivePostFooterMeta`'s
+   * `blockedReason` — the right fix for a disabled Rerun that explained itself
+   * only on hover). From then on the sentence could render directly beneath a
+   * completed analysis's ranked results: a claim that Olumi cannot run one,
+   * printed next to the output of one it had just run.
+   *
+   * The rung is not wrong about the verdict; the wording was scoped to a
+   * pre-analysis screen. This phrasing carries the SAME information — the
+   * verdict refuses, nothing specific can be named, ask in the chat — while
+   * being true whether or not a run has already happened. "The next analysis"
+   * is the first one on a pre-analysis screen and the rerun on a post-analysis
+   * one, so ONE string stays honest in both places rather than a second copy
+   * being minted for the second surface (which is how this module acquired its
+   * mirrors in the first place).
    */
-  unspecified: 'Olumi is not able to run this yet. Ask in the chat and it will explain what is missing.',
+  unspecified:
+    'Olumi needs something more from this model before the next analysis. ' +
+    'Ask in the chat and it will explain what is missing.',
   /**
    * ROADMAP 2.635 (I-3) — the verdict on screen was not asked about the model
    * on screen.


### PR DESCRIPTION
## A2 — the Analyse control tells the truth, and the live model still runs

**Continues the rescued WIP `66291719`.** Rebased cleanly onto `staging` `06f745ba`; **#779's `draft`/`setDraft` mock additions and the WIP's `heldNotice` edit both survive** in `StarterProvenanceBanner` — neither side taken wholesale.

### The defect, as witnessed

18 Aug affordance sweep (A7/A15, deployed `1dec0ad6`, fresh guest): `Analyse first pass` **disabled** under *"Draft or save a model first, then run analysis."* — four rows below the same panel's *"Your decision — 4 options · 3 risks · 8 estimates"* — while the chat chip ran an analysis to completion in the identical state. Same tab, with ranked results on screen, footer still read *"Olumi is not able to run this yet."*

**Both limbs of that refusal are false at the only branch that emits it.** `canRunAnalysis` returns at `nodeCount === 0` **before** this rung, so a model is always on screen; and the `starterId` stamp rides a save, so saving cannot clear it — the product asked for an action it cannot accept (**P8**). `StarterProvenanceBanner` had already corrected that exact promise in its own copy while the gate constant beside it kept carrying it (trap 12).

Root cause is **trap 21**: the constant was justified as *"CEE's refusal sentence, verbatim"*. CEE does emit it — at `assessCanonicalAnalysisReadiness`, code `NO_GRAPH`, when there is **no model at all**, for which "draft or save one" is true and achievable. This rung answers a different question: *is the model on this canvas one the engine can analyse?*

### What changed

**One authority, one input.** `analysisHeldOn(nodes)` returns the gating answer **and** the noun in a single value; `canRunAnalysis` takes it as its only input for that rung. Both consumers — the Analysis panel's button/footer and the composer's Run tooltip — read it.

**The WIP's plumbing is replaced, because it had already reproduced the defect it removes.** It kept the old boolean and added a provenance parameter beside it: `OutputsDock` passed both, `ConversationPanel` passed only the boolean, so in one application state the panel would have said *"a saved example"* while the composer tooltip said *"a ready-made model"*. Two parameters cannot half-arrive when there is one. `computeCeeCannotSeeModel` and the fabricating `unspecified` variant went with it.

**No graph is plumbed and no copy is invented.** On a starter, analysis still does not run — it refuses with the sentence the banner already shipped and that the sweep confirmed true, naming a remedy with a mounted control (`starter-redraft`, one click away, fixed by #779).

**Punctuation, stated:** the shipped em dash became a full stop. Wiring the sentence into the gate makes it render in the pre-analysis footer, whose copy is under an enforced *"no em dashes"* rule — and the constant is **now swept by that rule** rather than sitting beside it. No word changed.

**The live half is pinned, not assumed:** a CEE-drafted model with a ready verdict is allowed, its tooltip is `undefined`, and at the real dock the button is **ENABLED** — with a discriminating twin whose only difference is the node stamp.

### Evidence

- **RED-first at pristine** (second clone at `06f745ba`, sentinel-WRITE isolation proven, distinct inodes): **5 named signatures failed, 2 controls passed** — save-instruction, draft-first, is-the-banner's-sentence, the MOUNTED footer, and the post-analysis denial.
- **Mutants: 9/9 bitten.** Throwaway clone outside the lane repo, pristine-ARCHIVE restores, applied-check scoped to `src/` exactly 1 per mutant, leading and trailing controls exactly 0 with 266/266 green. Includes the defect-restoring mutant (the witnessed false sentence put back → 9 red).
- **M9 initially SURVIVED** and is the most useful thing here: deleting `analysisHeldOn: analysisHeldOn(nodes)` from `OutputsDock` left **261/261 green** — every spec tested the gate as a function or the footer as a prop, and the **wiring between them, which is the entire fix, was pinned by nothing**. Closed in `OutputsDock.blockedReasonWiring.spec.tsx`, the file created for exactly that class.
- **Three of my own instruments were wrong and are recorded in-file:** a `\bsav(e|ed|ing)\b` guard that banned the true phrase *"a saved example"* (written against the failure mode, not the spec — trap 13d); a *"same string, not a copy"* pin that is `toBe` on primitives and **passed at pristine where the copy existed** (the mirror claim moved to a comment-stripped source sweep that can actually see two authors); and a banner staleness twin that passed for the wrong reason because `flags.ts` reads env from an eagerly-captured snapshot, so `vi.stubEnv` in a component spec reads OFF and **both arms were measuring "off"**.
- **Trap 3b:** the banner and dock specs seed the **deployed** canonical-run-path posture, not the vitest default.

### Measured / unmeasured

MEASURED: `pnpm typecheck` **PASSED** (drift shrank 2272 → 2263; baseline deliberately not regenerated) · `tests/ci-guards` 22 files / 368 tests green · 279 files / 4407 tests green across `canvas/utils`, `pre-analysis-v3`, `starters`, `conversation/__tests__` · the 7-file gate battery 266/266.
UNMEASURED BY ME: `pnpm lint`, the full suite. Pushed anyway per the 18 Aug amendment; CI is the authority.

### Findings for the orchestrator, not fixed here

1. **The `Run analysis` chat chip is a third authority.** `SuggestedChips` gates it on `ceeAnalysisReady.status === 'ready'` — CEE's verdict about **its own** graph — not on the client hold. That is why A15 ran an analysis while A7 refused, and why the sweep's note 3 saw results naming nodes absent from the canvas: CEE analysed a different graph. Deliberately untouched — it is a different question under a similar name (trap 21), and gating chip visibility on the client hold risks suppressing legitimate live runs. Needs its own decision.
2. **The `template` sentence is UNWITNESSED.** The template-insert state is reachable at the bytes (`insertBlueprint` stamps every node; `T` opens the panel) but was not driven, and unlike a starter it has **no one-click re-draft control** — its route is the composer. Stated in the module rather than implied.
