### PR TITLE
Model editor consolidation step 2 — the legacy editor CANNOT yet be deleted, and here is the derived manifest of why

### DIFF
--- a/src/canvas/components/ModelTabBody.tsx
+++ b/src/canvas/components/ModelTabBody.tsx
@@ -22,6 +22,10 @@ import { useAnalysisTrust } from '../hooks/useAnalysisTrust'
 import { AnalysisRunStateCover } from './AnalysisRunStateCover'
 import { useUIStore } from '../../stores/uiStore'
 import { getDisplayEdgeId, buildFragileEdgeLookup } from '../utils/edgeIdentity'
+// THE ONE id → label policy. This container OUTLIVES the duplicate editor, so a
+// raw-id fallback here would have become permanent when the sections go — the
+// same argument that fixed `buildGoalFitRows` in place rather than pinning it.
+import { buildCanvasLabelMap, resolveCanvasLabel, UNNAMED_ELEMENT_LABEL } from '../domain/canvasLabels'
 import { edgeValueSource, resolveEdgeValueDisplay, compareEdgeValueDisplays, type EdgeValueSource } from '../domain/edgeValueProvenance'
 import { getCausalEdges } from '../domain/edgeUtils'
 import { SectionErrorBoundary } from './GraphTextView'
@@ -512,6 +516,11 @@ export const ModelTabBody = memo(function ModelTabBody({
       const needsA = (!srcA || srcA === 'cee_inference' || fullRangeA) ? 0 : 1
       const needsB = (!srcB || srcB === 'cee_inference' || fullRangeB) ? 0 : 1
       if (needsA !== needsB) return needsA - needsB
+      // ⚠ ORDERING KEYS, NOT DISPLAY — an id used to break a tie never reaches
+      // the screen. Kept raw (a resolved label would collapse every unnamed node
+      // to one key and make the order arbitrary) and PINNED in the scan rather
+      // than excused by a narrower pattern: a scan that decides which matches
+      // "don't count" is a scan that can be argued with.
       const labelA = String((a.data as any)?.label ?? a.id)
       const labelB = String((b.data as any)?.label ?? b.id)
       return labelA.localeCompare(labelB)
@@ -559,8 +568,17 @@ export const ModelTabBody = memo(function ModelTabBody({
 
   // ── Goal headline ─────────────────────────────────────────────────────────
 
+  /**
+   * ONE map for every label this container resolves — the goal heading and both
+   * clipboard exports. Built here rather than per call site, which is also what
+   * stops the three of them drifting apart.
+   */
+  const nodeLabels = useMemo(() => buildCanvasLabelMap(nodes), [nodes])
+
   const goalNode = grouped.goal[0]
-  const goalLabel = goalNode ? String((goalNode.data as any)?.label ?? goalNode.id) : null
+  const goalLabel = goalNode
+    ? resolveCanvasLabel(goalNode.id, nodeLabels) ?? UNNAMED_ELEMENT_LABEL
+    : null
 
   // ── Contested pending count (reactive — updates after each resolution) ───
 
@@ -696,30 +714,37 @@ export const ModelTabBody = memo(function ModelTabBody({
     lines.push('')
     lines.push('Factors:')
     for (const n of sortedFactors) {
-      const lbl = String((n.data as any)?.label ?? n.id)
+      const lbl = resolveCanvasLabel(n.id, nodeLabels) ?? UNNAMED_ELEMENT_LABEL
       const obs = (n.data as any)?.observedState ?? (n.data as any)?.observed_state ?? {}
-      const src = obs.source ? ` [${mapSourceToDisplay(obs.source) ?? obs.source}]` : ' [no source]'
+      // ⚠ NO `?? obs.source` TAIL. `mapSourceToDisplay` already returns the raw
+      // token for anything it cannot classify, so the tail added nothing except a
+      // second, unclassified route for `cee_inference` to reach the clipboard —
+      // and `utils.ts:80-83` records this exact leak as having already "left the
+      // estate in what a user pastes into a document".
+      const src = obs.source ? ` [${mapSourceToDisplay(obs.source)}]` : ' [no source]'
       lines.push(`  • ${lbl}${src}`)
     }
     lines.push('')
     lines.push('Edges:')
     for (const e of sortedEdges) {
-      const src = nodes.find(n => n.id === e.source)
-      const tgt = nodes.find(n => n.id === e.target)
-      const fromLbl = String((src?.data as any)?.label ?? e.source)
-      const toLbl = String((tgt?.data as any)?.label ?? e.target)
+      // ⚠ The two `nodes.find` lookups that stood here are gone with the raw
+      // reads that needed them — `nodeLabels` is the one map, built once.
+      const fromLbl = resolveCanvasLabel(e.source, nodeLabels) ?? UNNAMED_ELEMENT_LABEL
+      const toLbl = resolveCanvasLabel(e.target, nodeLabels) ?? UNNAMED_ELEMENT_LABEL
       lines.push(`  • ${fromLbl} → ${toLbl}`)
     }
     const text = lines.join('\n')
     navigator.clipboard?.writeText(text).catch(() => {})
-  }, [goalLabel, sortedFactors, sortedEdges, nodes])
+  }, [goalLabel, sortedFactors, sortedEdges, nodeLabels])
 
   const handleCopyJson = useCallback(() => {
     const payload = {
       goal: goalLabel ?? null,
       factors: sortedFactors.map(n => ({
+        // The id stays, deliberately — an export needs identity. It is the
+        // LABEL that must never silently become one.
         id: n.id,
-        label: String((n.data as any)?.label ?? n.id),
+        label: resolveCanvasLabel(n.id, nodeLabels) ?? UNNAMED_ELEMENT_LABEL,
         category: (n.data as any)?.category ?? null,
         observedState: (n.data as any)?.observedState ?? (n.data as any)?.observed_state ?? null,
         prior: (n.data as any)?.prior ?? null,
@@ -747,7 +772,7 @@ export const ModelTabBody = memo(function ModelTabBody({
     }
     const json = JSON.stringify(payload, null, 2)
     navigator.clipboard?.writeText(json).catch(() => {})
-  }, [goalLabel, sortedFactors, sortedEdges])
+  }, [goalLabel, sortedFactors, sortedEdges, nodeLabels])
 
   /**
    * The Olumi hand-off for the canonical outline's group affordances.

--- a/src/canvas/components/ModelTabBody.tsx
+++ b/src/canvas/components/ModelTabBody.tsx
@@ -125,7 +125,11 @@ export const ModelTabBody = memo(function ModelTabBody({
   expertMode,
   onSendMessage,
 }: ModelTabBodyProps) {
-  const [searchQuery, setSearchQuery] = useState('')
+  // ⚠ THE SEARCH STATE IS GONE, NOT PARKED. It was declared here, threaded to
+  // `ModelFooter`, and consumed by NOTHING — no filter read it anywhere in
+  // `src/`, so the box was an enabled control that silently did nothing. Keeping
+  // the state beside a disabled input would leave the next reader hunting for a
+  // filter that does not exist. See `ModelFooter`'s header.
 
   // Single-open accordion: in default mode, only one section open at a time.
   // In expert mode (showDetail), sections manage their own state independently.
@@ -944,8 +948,6 @@ export const ModelTabBody = memo(function ModelTabBody({
 
       {/* ── Footer: search + copy ─────────────────────────────────────────── */}
       <ModelFooter
-        searchQuery={searchQuery}
-        onSearchChange={setSearchQuery}
         onCopyText={handleCopyText}
         onCopyJson={handleCopyJson}
       />

--- a/src/canvas/components/__tests__/ModelTabBody.spec.tsx
+++ b/src/canvas/components/__tests__/ModelTabBody.spec.tsx
@@ -266,15 +266,56 @@ describe('Inline edit — Enter/Escape/blur (value field)', () => {
   })
 })
 
-describe('Search footer', () => {
-  it('renders the search input', () => {
-    const nodes = [
-      makeFactorNode('f1', 'Market size', { source: 'user' }),
-    ]
+describe('Search footer — an inert control must SAY it is inert', () => {
+  /*
+   * ⚠⚠ THE PREVIOUS TEST HERE ASSERTED ONLY `toBeInTheDocument()`, AND THAT IS
+   * HOW THIS SHIPPED. The search box was enabled, accepted keystrokes, and
+   * filtered NOTHING — `searchQuery` was declared in `ModelTabBody`, threaded to
+   * `ModelFooter`, and read by no consumer anywhere in `src/`. A presence
+   * assertion cannot tell a working control from furniture; the estate's other
+   * five search boxes each have a real filter, and a test shaped like this one
+   * would have passed for any of them equally.
+   *
+   * The control is now disabled WITH A STATED REASON — the pattern the Model tab
+   * already uses honestly for an unbuilt capability (`ModelRowView`'s "Editing
+   * is not connected yet"). These assertions bind to that, so wiring the filter
+   * without re-enabling the input goes red, and re-enabling it without a filter
+   * goes red too.
+   */
+  const renderFooter = () => {
+    const nodes = [makeFactorNode('f1', 'Market size', { source: 'user' })]
     render(<ModelTabBody {...DEFAULT_PROPS} nodes={nodes} edges={[]} />)
+    return screen.getByTestId('model-search')
+  }
 
-    const search = screen.getByTestId('model-search')
-    expect(search).toBeInTheDocument()
+  it('renders the search input', () => {
+    expect(renderFooter()).toBeInTheDocument()
+  })
+
+  it('⚠ is DISABLED — it filters nothing, and must not invite typing', () => {
+    expect(renderFooter()).toBeDisabled()
+  })
+
+  it('⚠ states WHY, to the screen reader and on hover — not just visually', () => {
+    const search = renderFooter()
+    // The exact copy is the contract: an accessible name that says "search"
+    // and nothing else would leave a screen-reader user with no signal at all.
+    expect(search).toHaveAccessibleName(
+      'Search is not connected yet — the list cannot be filtered from here.',
+    )
+    expect(search).toHaveAttribute(
+      'title',
+      'Search is not connected yet — the list cannot be filtered from here.',
+    )
+  })
+
+  it('⚠ POSITIVE CONTROL — the copy buttons in the same footer are NOT disabled', () => {
+    // Otherwise "disabled" above could be satisfied by a footer that failed to
+    // render its controls at all, or by a blanket disable of the whole bar
+    // (trap 13 — an absence assertion needs a presence it can see).
+    renderFooter()
+    expect(screen.getByTestId('model-copy')).toBeEnabled()
+    expect(screen.getByTestId('model-copy-json')).toBeEnabled()
   })
 })
 

--- a/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
@@ -216,14 +216,58 @@ describe('OutputsDock DOM', () => {
     useCanvasStore.setState({
       nodes: [
         { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal' } },
-        { id: 'f1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'A', observedState: { source: 'cee_inference' } } },
-        { id: 'f2', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'B', observedState: { source: 'user' } } },
+        // ⚠ `value` IS PART OF THE FIXTURE NOW, and it is not decoration: the
+        // badge counts factors the user can actually VERIFY, and an AI estimate
+        // with no number carries nothing to verify (`factorIsConfirmable`,
+        // narrowed 19 Aug 2026). This fixture previously carried a bare
+        // `{ source: 'cee_inference' }`, which is not a shape the producer emits
+        // — `setObservedValue` always writes `value` — and it was the shape that
+        // used to inflate this badge.
+        { id: 'f1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'A', observedState: { value: 0.4, raw_value: 40, source: 'cee_inference' } } },
+        { id: 'f2', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'B', observedState: { value: 0.9, raw_value: 90, source: 'user' } } },
       ],
     } as any)
     renderOutputsDock()
     const badge = screen.getByTestId('model-tab-verify-badge')
     expect(badge).toBeInTheDocument()
     expect(badge).toHaveTextContent('1')
+  })
+
+  it('⚠ does NOT count an AI estimate with NO VALUE — there is nothing to verify', () => {
+    /*
+     * The opposite-direction twin of the test above, and the defect the
+     * narrowing closes. `factorNeedsVerification` alone is
+     * `!source || source === 'cee_inference'`, which a factor with no value at
+     * all satisfies — so this badge used to read "1", the user had no way to
+     * drive it to zero, and the Confirm the count implies is one the write
+     * authority declines. `f1` here is in the `no-value` repair queue instead,
+     * which is the repair it actually needs.
+     */
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal' } },
+        { id: 'f1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'A', observedState: { source: 'cee_inference' } } },
+      ],
+    } as any)
+    renderOutputsDock()
+    expect(screen.queryByTestId('model-tab-verify-badge')).not.toBeInTheDocument()
+  })
+
+  it('⚠ DOES count a capped factor carrying `value` and NO `raw_value`', () => {
+    /*
+     * The other direction, and the one a `raw_value` guard silently drops. This
+     * is a staging-witnessed wire shape (`conversation/factorValueEdit.ts:145`):
+     * the write authority accepts it, so the badge must count it and the Confirm
+     * must be offered. Bound to the count, not merely to the badge's presence.
+     */
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal' } },
+        { id: 'f1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'A', observedState: { value: 0.7, source: 'cee_inference' } } },
+      ],
+    } as any)
+    renderOutputsDock()
+    expect(screen.getByTestId('model-tab-verify-badge')).toHaveTextContent('1')
   })
 
   it('hides Model tab verify badge when no factors need verification', () => {

--- a/src/canvas/components/model-tab/FactorsSection.tsx
+++ b/src/canvas/components/model-tab/FactorsSection.tsx
@@ -19,7 +19,7 @@ import { typography } from '../../../styles/typography'
 import { SectionErrorBoundary } from '../GraphTextView'
 import { useNodeMutations } from '../../ui/inspector-v2/useInspectorMutations'
 import { useModelEditAuthority } from '../../hooks/useModelEditAuthority'
-import { factorNeedsVerification } from '../../domain/valueProvenance'
+import { factorIsConfirmable } from '../../domain/valueProvenance'
 import { useOptionalConversationContext } from '../../conversation/ConversationContext'
 import { buildFactorValueEditEvent } from '../../conversation/factorValueEdit'
 import { captureOptimisticFactorEdit } from '../../conversation/optimisticFactorEdit'
@@ -326,14 +326,21 @@ function FactorCard({
 
   // Task 8: Verify/confirm button
   //
-  // ⚠ THE PREDICATE IS `factorNeedsVerification`, THE SAME ONE THE BADGE COUNTS.
+  // ⚠ THE PREDICATE IS `factorIsConfirmable`, THE SAME ONE THE BADGE COUNTS.
   // It used to be `obs.source !== 'user'`, which was already loose — it offered
   // Confirm over a `brief_extraction` the badge did not count — and it becomes
   // WRONG the moment the gesture stamps `user_confirmed` rather than `user`:
   // the button would survive its own success and invite the user to confirm the
   // same number for ever. One question, one predicate.
-  const showConfirmButton =
-    factorNeedsVerification(node.data) && (primaryValue !== null || normalisedValue !== null)
+  //
+  // ⚠⚠ AND THE VALUE GUARD IS NO LONGER THIS SURFACE'S TO WRITE. It read
+  // `(primaryValue !== null || normalisedValue !== null)` — a DISPLAY question
+  // standing in for a WRITE question. The authority refuses unless
+  // `observedState.value` is a finite number, so `raw_value`-only factors got an
+  // enabled Confirm that silently did nothing. `factorIsConfirmable` is that
+  // refusal condition, inverted, and it is the same function the badge counts
+  // with — the button and the number can no longer disagree about a row.
+  const showConfirmButton = factorIsConfirmable(node.data)
   const [confirmFlash, setConfirmFlash] = useState(false)
   const flashTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   useEffect(() => () => { if (flashTimerRef.current) clearTimeout(flashTimerRef.current) }, [])

--- a/src/canvas/components/model-tab/ModelFooter.tsx
+++ b/src/canvas/components/model-tab/ModelFooter.tsx
@@ -1,22 +1,47 @@
 /**
  * ModelFooter — search box + copy-as-text/JSON buttons.
  *
- * Accepts a search query string + setter, plus copy handlers for text and JSON.
  * Renders as a sticky-bottom bar docked to the model tab scroll container.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * ⚠⚠ THE SEARCH BOX IS DISABLED, AND THAT IS THE FIX — IT WAS NEVER WIRED
+ * ─────────────────────────────────────────────────────────────────────────────
+ * It accepted a `searchQuery` + setter, `ModelTabBody` held the state, and
+ * NOTHING FILTERED ON IT: the value was declared, threaded down here, echoed
+ * back up, and read by no consumer anywhere in `src/`. A user typed into it and
+ * the list did not change — and there was no way to tell that from a search that
+ * simply matched everything. The estate's other five search boxes
+ * (`GraphTextView`, `ProvenanceHub`, `ProvenanceHubTab`, `TemplatesPanel`,
+ * `DocumentsManager`) each have a real `filter`/`includes` consumer; this one
+ * had two references, both structural.
+ *
+ * ⚠ THE PROPS ARE GONE, NOT KEPT-AND-IGNORED. Leaving `searchQuery` threaded
+ * through a disabled control preserves the appearance of a wired feature and
+ * invites the next reader to assume the filter exists somewhere. Whoever wires
+ * search adds the props back IN THE SAME CHANGE as the predicate that consumes
+ * them.
+ *
+ * ⚠ DISABLED-WITH-A-REASON, NOT DELETED: the affordance is wanted (design §7.4)
+ * and this is the pattern the Model tab already uses honestly for an unbuilt
+ * capability — `ModelRowView`'s "Editing is not connected yet". A control that
+ * says why it cannot act is a fact; a control that silently does nothing is a
+ * lie the user cannot detect.
  */
 
-import { useState, type ChangeEvent } from 'react'
+import { useState } from 'react'
 import { Copy, ClipboardCopy } from 'lucide-react'
 import { typography } from '../../../styles/typography'
 
 interface ModelFooterProps {
-  searchQuery: string
-  onSearchChange: (q: string) => void
   onCopyText: () => void
   onCopyJson: () => void
 }
 
-export function ModelFooter({ searchQuery, onSearchChange, onCopyText, onCopyJson }: ModelFooterProps) {
+/** Why the search box is inert. Shown on the disabled control, in words. */
+const SEARCH_NOT_CONNECTED_REASON =
+  'Search is not connected yet — the list cannot be filtered from here.'
+
+export function ModelFooter({ onCopyText, onCopyJson }: ModelFooterProps) {
   const [copied, setCopied] = useState<'text' | 'json' | false>(false)
 
   const handleCopyText = () => {
@@ -38,10 +63,15 @@ export function ModelFooter({ searchQuery, onSearchChange, onCopyText, onCopyJso
     >
       <input
         type="search"
-        value={searchQuery}
-        onChange={(e: ChangeEvent<HTMLInputElement>) => onSearchChange(e.target.value)}
-        placeholder="Search factors and edges…"
-        className={`flex-1 ${typography.panelBody} text-text-header px-2 py-1 rounded-sm border border-panel-border bg-panel focus:outline-none focus:ring-1 focus:ring-info/50 placeholder:text-text-light`}
+        value=""
+        readOnly
+        disabled
+        // The reason travels with the control on hover AND to a screen reader —
+        // a `title` alone is invisible to anyone not using a mouse.
+        title={SEARCH_NOT_CONNECTED_REASON}
+        aria-label={SEARCH_NOT_CONNECTED_REASON}
+        placeholder="Search is not connected yet"
+        className={`flex-1 ${typography.panelBody} text-text-header px-2 py-1 rounded-sm border border-panel-border bg-panel placeholder:text-text-light opacity-60 cursor-not-allowed`}
         data-testid="model-search"
       />
       <button

--- a/src/canvas/components/model-tab/__tests__/modelTabNoRawIdFallback.sourceScan.spec.ts
+++ b/src/canvas/components/model-tab/__tests__/modelTabNoRawIdFallback.sourceScan.spec.ts
@@ -34,6 +34,43 @@ import { join, dirname, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { blankNonCode, stripComments } from '../../../../../tests/helpers/stripSourceComments'
 
+/*
+ * ═══════════════════════════════════════════════════════════════════════════
+ * ⚠⚠⚠ MERGE INSTRUCTION FOR PR #790 — THE RESOLUTION IS A **UNION**, NOT A SIDE
+ * ═══════════════════════════════════════════════════════════════════════════
+ * #782 (this file, landing FIRST) and #790 widen THE SAME GUARD ON ORTHOGONAL
+ * AXES. Taking either side wholesale silently NARROWS the guard and the suite
+ * still passes green — which is the only reason this comment exists.
+ *
+ *   #782 widened the PATTERN AND THE REACH:
+ *     · `RAW_ID_TERNARY` — the ternary form (`x ? a : b.id`), alongside the
+ *       original `??` form, plus interpolation.
+ *     · `tsFiles` is RECURSIVE, with `EXCLUDED_DIR_NAMES`.
+ *     · `ModelTabBody.tsx` added as a scan target (the container, which sits
+ *       OUTSIDE both directories and renders the tab).
+ *
+ *   #790 widened the SCOPE:
+ *     · `CONTESTED_DIR` — `canvas/components/contested/`, scanned and pinned
+ *       empty.
+ *
+ * ⚠ #782's RECURSION DOES **NOT** SUBSUME #790's DIRECTORY. `CONTESTED_DIR` is
+ * `join(HERE, '..', '..', 'contested')` — a SIBLING of `model-tab/`, not a
+ * child of it — so the recursive walk of `V1_DIR` never reaches it. Dropping
+ * #790's constant because "the walk is recursive now" removes a whole directory
+ * from the guard, and nothing goes red.
+ *
+ * ⚠ AND THE CONVERSE: keeping #790's non-recursive `tsFiles` reverts the
+ * recursion, the ternary pattern and the container target in one move. Those
+ * three exist because the scan certified this directory at ZERO while a raw
+ * wire id was rendering as a row's NAME.
+ *
+ * SO: keep BOTH `tsFiles` recursion AND `CONTESTED_DIR`; keep BOTH the `??` and
+ * ternary patterns; keep BOTH scan targets AND the contested assertions.
+ * `V1_PINNED` is BYTE-IDENTICAL in both branches (verified 19 Aug, 665 bytes
+ * each) — that half is free, take either.
+ * ═══════════════════════════════════════════════════════════════════════════
+ */
+
 const HERE = dirname(fileURLToPath(import.meta.url))
 const REPO = join(HERE, '..', '..', '..', '..', '..')
 const V1_DIR = join(HERE, '..')

--- a/src/canvas/components/model-tab/__tests__/modelTabNoRawIdFallback.sourceScan.spec.ts
+++ b/src/canvas/components/model-tab/__tests__/modelTabNoRawIdFallback.sourceScan.spec.ts
@@ -49,15 +49,45 @@ const V2_DIR = join(HERE, '..', '..', '..', 'model-tab-v2')
  */
 const RAW_ID_FALLBACK = /\?\?\s*[A-Za-z_$][\w$]*(?:\??\.[\w$]+)*\.(?:id|source|target)\b/g
 
+/**
+ * ⭐⭐ THE SECOND SHAPE — ADDED 18 Aug 2026, AND IT IS WHY THIS FILE'S OWN
+ * "ZERO" WAS A STATEMENT ABOUT THE INSTRUMENT.
+ *
+ * `RAW_ID_FALLBACK` matches `??` and only `??`. The canonical editor's node
+ * rows and all three repair-queue producers wrote the SAME fallback as a
+ * TERNARY:
+ *
+ *     const label = typeof data?.label === 'string' ? data.label : node.id
+ *
+ * Four sites, in `model-tab-v2/adapters.ts` — the directory this spec asserts
+ * carries ZERO. It passed, every time, because the pattern was written from the
+ * shape the author had just fixed rather than from the class. **This file's own
+ * header warned about exactly that** ("a pattern narrower than the defect class
+ * under-reports and reads as a clean result") one screen above a pattern that
+ * was narrower than the defect class. A guard written with the same blind spot
+ * as the code it guards agrees with the code.
+ *
+ * The test is `label`-anchored rather than bare, so an object literal
+ * (`{ rowId: n.id, label: … }`) — a colon beside a raw id that is NOT a
+ * fallback — does not fire. Both directions are controlled below.
+ */
+const RAW_ID_TERNARY =
+  /\blabel\b[^\n;]{0,120}\?[^\n;]{0,120}:\s*[A-Za-z_$][\w$]*(?:\??\.[\w$]+)*\.(?:id|source|target)\b/g
+
 function tsFiles(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true })
     .filter(e => e.isFile() && /\.tsx?$/.test(e.name))
     .map(e => join(dir, e.name))
 }
 
+/** Both shapes, unioned — the CLASS, not whichever spelling was fixed last. */
 function fallbacksIn(file: string): number {
-  const code = blankNonCode(readFileSync(file, 'utf8'))
-  return [...code.matchAll(RAW_ID_FALLBACK)].length
+  return countIn(readFileSync(file, 'utf8'))
+}
+
+function countIn(src: string): number {
+  const code = blankNonCode(src)
+  return [...code.matchAll(RAW_ID_FALLBACK)].length + [...code.matchAll(RAW_ID_TERNARY)].length
 }
 
 function scan(dir: string): Record<string, number> {
@@ -110,6 +140,30 @@ describe('the CANONICAL editor never falls back to a wire id', () => {
   it('CONTRAST CONTROL: it does NOT fire on an honest resolution', () => {
     const honest = "const l = resolveCanvasLabel(edge.source, labels) ?? UNNAMED_ELEMENT_LABEL\n"
     expect([...blankNonCode(honest).matchAll(RAW_ID_FALLBACK)]).toHaveLength(0)
+  })
+
+  it('POSITIVE CONTROL: the TERNARY shape — the one that got past this scan — is detected', () => {
+    // The exact text that stood in `adapters.ts` at four sites while this file
+    // asserted the directory was clean.
+    const ternary = "const label = typeof data?.label === 'string' ? data.label : node.id\n"
+    expect(countIn(ternary)).toBe(1)
+    // …and the queue-producer spelling, which uses a different receiver.
+    expect(countIn("label: typeof data?.label === 'string' ? data.label : n.id,\n")).toBe(1)
+  })
+
+  it('CONTRAST CONTROL: an object literal naming a raw id is NOT a fallback', () => {
+    // `rowId: n.id` beside a label is legitimate — a queue item MUST carry the
+    // element's identity. Without this control the widened pattern would ban
+    // the correct code and get narrowed back to uselessness by the first lane
+    // it inconvenienced.
+    expect(countIn('const item = { rowId: n.id, label: resolved }\n')).toBe(0)
+    expect(countIn('return { rowId: edge.id, label: relationshipLabel(d, s, t, m) }\n')).toBe(0)
+  })
+
+  it('CONTRAST CONTROL: the honest resolution is clean under BOTH patterns', () => {
+    const honest =
+      'const label = resolveCanvasLabel(node.id, nodeLabels) ?? UNNAMED_ELEMENT_LABEL\n'
+    expect(countIn(honest)).toBe(0)
   })
 
   it('the scan reads real files, not an empty directory', () => {

--- a/src/canvas/components/model-tab/__tests__/modelTabNoRawIdFallback.sourceScan.spec.ts
+++ b/src/canvas/components/model-tab/__tests__/modelTabNoRawIdFallback.sourceScan.spec.ts
@@ -32,20 +32,39 @@ import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync } from 'node:fs'
 import { join, dirname, relative } from 'node:path'
 import { fileURLToPath } from 'node:url'
-import { blankNonCode } from '../../../../../tests/helpers/stripSourceComments'
+import { blankNonCode, stripComments } from '../../../../../tests/helpers/stripSourceComments'
 
 const HERE = dirname(fileURLToPath(import.meta.url))
 const REPO = join(HERE, '..', '..', '..', '..', '..')
 const V1_DIR = join(HERE, '..')
 const V2_DIR = join(HERE, '..', '..', '..', 'model-tab-v2')
+/**
+ * ⭐⭐ THE CONTAINER — IN SCOPE SINCE 19 Aug 2026, AND ITS ABSENCE WAS THE
+ * SCAN'S THIRD BLIND SPOT.
+ *
+ * `ModelTabBody.tsx` sits at `canvas/components/`, OUTSIDE both directories
+ * this file walked, and it renders the Model tab. Measured with these same
+ * patterns: SEVEN raw-id fallbacks, of which six reached the user — the goal
+ * heading and both clipboard exports, i.e. the precise leak
+ * `model-tab/utils.ts:80-83` records as having already "left the estate in what
+ * a user pastes into a document".
+ *
+ * ⚠ AND THE ARGUMENT FOR SCOPING IT IN WAS ALREADY WRITTEN, ONE COMMIT EARLIER,
+ * ABOUT SOMETHING ELSE. `buildGoalFitRows` was fixed in place rather than
+ * pinned because "`ModelTabBody` owns it, so the leak would have become
+ * permanent". That applies verbatim to its OWNER, which outlives the duplicate
+ * editor completely — and the argument was not made about the owner.
+ */
+const CONTAINER = join(HERE, '..', '..', 'ModelTabBody.tsx')
 
 /**
  * The defect CLASS: a nullish-coalescing fallback whose right-hand side is an
  * element's `id`, `source` or `target`.
  *
- * ⚠ Comments and string literals are BLANKED first (`blankNonCode`) — this file's
- * own header quotes the pattern, and a scan that matched its own documentation
- * would report a leak that does not exist.
+ * ⚠ Comments are stripped first (`stripComments`) — this file's own header quotes
+ * the patterns, and a scan that matched its own documentation would report a leak
+ * that does not exist. String and template bodies are kept as CODE: the third
+ * pattern's whole target lives inside a template literal.
  */
 const RAW_ID_FALLBACK = /\?\?\s*[A-Za-z_$][\w$]*(?:\??\.[\w$]+)*\.(?:id|source|target)\b/g
 
@@ -74,20 +93,79 @@ const RAW_ID_FALLBACK = /\?\?\s*[A-Za-z_$][\w$]*(?:\??\.[\w$]+)*\.(?:id|source|t
 const RAW_ID_TERNARY =
   /\blabel\b[^\n;]{0,120}\?[^\n;]{0,120}:\s*[A-Za-z_$][\w$]*(?:\??\.[\w$]+)*\.(?:id|source|target)\b/g
 
+/**
+ * ⭐⭐ THE THIRD SHAPE, AND THE REASON THE OTHER TWO WERE NOT ENOUGH.
+ *
+ * A raw PROVENANCE token reaching user copy is a different defect from a raw ID
+ * fallback, and it hid in the gap between them on TWO independent axes:
+ *
+ *   · TRANSFORM. `blankNonCode` blanks template-literal BODIES. Measured:
+ *     `` `Source: ${obs.source}` `` → the transform leaves
+ *     `` `                     ` ``, so the read is erased before any pattern
+ *     runs. The sibling guard in `model-tab-v2/__tests__/` documents this exact
+ *     failure ("two of these guards shipped structurally incapable of firing")
+ *     and switched to `stripComments`. That lesson was not carried across. It is
+ *     now: every scan in this file uses `stripComments`.
+ *
+ *   · PATTERN. Switching the transform alone does NOT catch it — measured, not
+ *     assumed. In `x ? `Source: ${obs.source}` : null` the raw read sits in the
+ *     ternary's CONSEQUENT, so `RAW_ID_TERNARY` (which anchors on the alternate)
+ *     still reads zero. A guard needs both halves right.
+ *
+ * So a live `Source: cee_inference` sat in the INTERSECTION of both blind spots
+ * — in `adapters.ts`, ~80 lines below a commit that fixed the identical
+ * expression elsewhere and announced the class closed.
+ */
+/*
+ * ⚠ THE INTERPOLATION MUST *BE* THE RAW READ — not merely contain one.
+ *
+ * The first cut matched any `${…}` mentioning `.source`, and its own contrast
+ * control caught it firing on `` `Source: ${mapSourceToDisplay(obs.source)}` `` —
+ * i.e. on the HONEST FIX. A guard that reddens the correct code gets narrowed
+ * back to uselessness by the first lane it inconveniences, so it is narrowed
+ * here, deliberately, with both directions pinned.
+ *
+ * A single leading call is allowed (`observedStateOf(data)!.source`) because that
+ * is the shape the repair-queue producer actually used; a call WRAPPING the read
+ * is not, because that is what humanising looks like.
+ */
+const RAW_PROVENANCE_IN_COPY =
+  /`[^`]*\$\{\s*[A-Za-z_$][\w$]*(?:\([^()]*\))?(?:!?\??\.[\w$]+)*!?\??\.(?:source|provenance)!?\s*\}[^`]*`/g
+
+/**
+ * ⚠ RECURSIVE, and `__tests__` excluded — the sibling guard walks this way and
+ * this one did not. Both directories are flat today, so there is no live gap;
+ * the shape is the defect (a subdirectory added later would be silently out of
+ * scope, and the clean result would read exactly like a clean result).
+ */
+const EXCLUDED_DIR_NAMES = new Set(['__tests__', '__fixtures__', '__mocks__', '__snapshots__'])
+
 function tsFiles(dir: string): string[] {
-  return readdirSync(dir, { withFileTypes: true })
-    .filter(e => e.isFile() && /\.tsx?$/.test(e.name))
-    .map(e => join(dir, e.name))
+  const out: string[] = []
+  for (const e of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, e.name)
+    if (e.isDirectory()) {
+      if (!EXCLUDED_DIR_NAMES.has(e.name)) out.push(...tsFiles(full))
+      continue
+    }
+    if (/\.tsx?$/.test(e.name)) out.push(full)
+  }
+  return out
 }
 
 /** Both shapes, unioned — the CLASS, not whichever spelling was fixed last. */
 function fallbacksIn(file: string): number {
-  return countIn(readFileSync(file, 'utf8'))
+  return countIn(readFileSync(file, 'utf8'), file)
 }
 
-function countIn(src: string): number {
-  const code = blankNonCode(src)
-  return [...code.matchAll(RAW_ID_FALLBACK)].length + [...code.matchAll(RAW_ID_TERNARY)].length
+function countIn(src: string, file = 'x.ts'): number {
+  // ⚠ `stripComments`, NOT `blankNonCode` — see `RAW_PROVENANCE_IN_COPY`.
+  const code = stripComments(src, file)
+  return (
+    [...code.matchAll(RAW_ID_FALLBACK)].length +
+    [...code.matchAll(RAW_ID_TERNARY)].length +
+    [...code.matchAll(RAW_PROVENANCE_IN_COPY)].length
+  )
 }
 
 function scan(dir: string): Record<string, number> {
@@ -125,6 +203,18 @@ const V1_PINNED: Record<string, number> = {
   'src/canvas/components/model-tab/RelationshipsSection.tsx': 2,
 }
 
+/**
+ * ⚠ THE CONTAINER'S RESIDUAL — the two `sortedFactors` comparator TIEBREAKS
+ * (`ModelTabBody.tsx:515-516`). An id used to order a list never reaches the
+ * screen, and resolving it would collapse every unnamed node to one key and make
+ * the order arbitrary. Counted anyway rather than excused by a narrower pattern,
+ * for the reason this file already applies to `FactorsSection`: a scan that
+ * decides which matches "don't count" is a scan that can be argued with.
+ *
+ * The other five were DISPLAY and are fixed, not pinned.
+ */
+const CONTAINER_PINNED = 2
+
 describe('the CANONICAL editor never falls back to a wire id', () => {
   it('model-tab-v2/ carries ZERO raw-id fallbacks — derived, nothing to maintain', () => {
     expect(scan(V2_DIR)).toEqual({})
@@ -133,13 +223,17 @@ describe('the CANONICAL editor never falls back to a wire id', () => {
   it('POSITIVE CONTROL: the pattern DOES detect the shape it bans', () => {
     // Without this, a broken regex would certify every directory as clean and
     // the "zero" above would be a statement about the instrument (trap 13).
+    // ⚠ THROUGH `countIn` — the SAME pipeline the claims use. The earlier
+    // version of this control tested the bare regex against a bare string, which
+    // is how the sibling guard once certified a matcher its real scan never got
+    // to run. A control must exercise the transform too.
     const sample = 'const l = String(node.data?.label ?? node.id)\nconst f = x?.label ?? edge.source\n'
-    expect([...blankNonCode(sample).matchAll(RAW_ID_FALLBACK)]).toHaveLength(2)
+    expect(countIn(sample)).toBe(2)
   })
 
   it('CONTRAST CONTROL: it does NOT fire on an honest resolution', () => {
     const honest = "const l = resolveCanvasLabel(edge.source, labels) ?? UNNAMED_ELEMENT_LABEL\n"
-    expect([...blankNonCode(honest).matchAll(RAW_ID_FALLBACK)]).toHaveLength(0)
+    expect(countIn(honest)).toBe(0)
   })
 
   it('POSITIVE CONTROL: the TERNARY shape — the one that got past this scan — is detected', () => {
@@ -149,6 +243,34 @@ describe('the CANONICAL editor never falls back to a wire id', () => {
     expect(countIn(ternary)).toBe(1)
     // …and the queue-producer spelling, which uses a different receiver.
     expect(countIn("label: typeof data?.label === 'string' ? data.label : n.id,\n")).toBe(1)
+  })
+
+  it('⭐ POSITIVE CONTROL: a wire token interpolated into user copy IS detected', () => {
+    // The exact live expression this scan failed to see, in the file it was
+    // pointed at. Proven to read ZERO under the previous transform+pattern pair.
+    expect(
+      countIn("const b = typeof obs?.source === 'string' ? `Source: ${obs.source}` : null\n"),
+    ).toBe(1)
+    expect(countIn('const b = `Source: ${data.provenance}`\n')).toBe(1)
+    // The repair-queue producer's actual pre-fix spelling — a call, then the read.
+    expect(countIn('const b = `Source: ${observedStateOf(data)!.source}`\n')).toBe(1)
+  })
+
+  it('⭐ REGRESSION CONTROL: the OLD transform provably could not see it', () => {
+    // Pins WHY the third pattern needed a transform change too, so nobody
+    // "simplifies" `stripComments` back to `blankNonCode` and silently restores
+    // the blind spot. This is a fact about the instrument, asserted.
+    const live = "const b = typeof obs?.source === 'string' ? `Source: ${obs.source}` : null\n"
+    expect([...blankNonCode(live).matchAll(RAW_PROVENANCE_IN_COPY)]).toHaveLength(0)
+    expect([...stripComments(live, 'x.ts').matchAll(RAW_PROVENANCE_IN_COPY)]).toHaveLength(1)
+  })
+
+  it('CONTRAST CONTROL: an honest interpolation of a RESOLVED label is clean', () => {
+    // The discriminating half: interpolation is not the defect, interpolating a
+    // WIRE TOKEN is. A guard that banned all interpolation would be deleted by
+    // the first lane it inconvenienced.
+    expect(countIn('const b = `Source: ${mapSourceToDisplay(obs.source) ?? ""}`\n')).toBe(0)
+    expect(countIn('const t = `${row.label} → ${target.label}`\n')).toBe(0)
   })
 
   it('CONTRAST CONTROL: an object literal naming a raw id is NOT a fallback', () => {
@@ -189,5 +311,27 @@ describe('the DUPLICATE stack’s residual is bounded and named', () => {
     // Contrast control: a file that IS in the residual reads non-zero, so the
     // absence above is a fact about this card and not a dead scan.
     expect(v1['src/canvas/components/model-tab/GoalSection.tsx']).toBe(1)
+  })
+})
+
+describe('the CONTAINER — which outlives the removal — leaks nothing to the user', () => {
+  it('the file is where this scan thinks it is', () => {
+    // Without this, a moved or renamed container makes every claim below vacuous
+    // by reading an empty string (trap 13).
+    expect(readFileSync(CONTAINER, 'utf8').length).toBeGreaterThan(1000)
+  })
+
+  it('matches the pinned residual EXACTLY — and every entry is an ORDERING key', () => {
+    // Both directions. Growth is a new leak. SHRINKAGE means the two comparator
+    // tiebreaks were changed, which is a decision that must be made here.
+    expect(fallbacksIn(CONTAINER)).toBe(CONTAINER_PINNED)
+  })
+
+  it('CONTRAST CONTROL: the instrument reads this file, and it discriminates', () => {
+    // A magnitude check against a known non-zero, so "2" above cannot be the
+    // output of a scan that silently read nothing. `GoalSection` is pinned at 1
+    // in the residual above and must still read 1 through the same helper.
+    expect(fallbacksIn(join(V1_DIR, 'GoalSection.tsx'))).toBe(1)
+    expect(fallbacksIn(join(V2_DIR, 'adapters.ts'))).toBe(0)
   })
 })

--- a/src/canvas/components/model-tab/buildGoalFitRows.ts
+++ b/src/canvas/components/model-tab/buildGoalFitRows.ts
@@ -41,6 +41,7 @@
  * still yields `null` rather than an empty card.
  */
 
+import { buildCanvasLabelMap, resolveCanvasLabel, UNNAMED_ELEMENT_LABEL } from '../../domain/canvasLabels'
 import type { Node } from '@xyflow/react'
 import {
   selectGoalProbability,
@@ -98,6 +99,8 @@ export function buildGoalFitRows(
   // still the whole-card null.
   const analysedNodes = optionNodes.filter((node) => isAnalysedOption(optionProbabilities, node.id))
   if (analysedNodes.length === 0) return null
+  // ONE map for the whole build — the same policy the canonical outline uses.
+  const optionLabels = buildCanvasLabelMap(optionNodes)
   const rows: GoalFitRow[] = []
   for (const node of analysedNodes) {
     const entry = optionProbabilities[node.id]
@@ -106,13 +109,18 @@ export function buildGoalFitRows(
     if (typeof entry !== 'object') return null
     const decision = selectGoalProbability(entry as GoalProbabilityInput)
     if (decision.goalProbability == null) return null
-    const data = node.data as Record<string, unknown> | undefined
     // Read straight off the producer entry this row was scored from, so the
     // count and the probability cannot come from different options.
     const outcome = (entry as { outcome?: Record<string, unknown> }).outcome
     rows.push({
       id: node.id,
-      label: typeof data?.label === 'string' ? data.label : node.id,
+      // THE ONE id → label policy. This read was `… : node.id`, so an option
+      // whose label is absent (or is itself id-shaped) put a raw wire id —
+      // `opt_hire_two_aes` — into a sentence about the user's goal. Fixed in
+      // place rather than pinned in the removal residual, on the same ground
+      // as `ContestedEdgeCard`: this builder OUTLIVES the duplicate editor
+      // (`ModelTabBody` owns it), so the leak would have become permanent.
+      label: resolveCanvasLabel(node.id, optionLabels) ?? UNNAMED_ELEMENT_LABEL,
       probability: decision.goalProbability,
       // ⭐ L62: always false — the row only exists when a number survived line
       // 75, and every surviving number earns the possessive now that the joint

--- a/src/canvas/components/model-tab/utils.ts
+++ b/src/canvas/components/model-tab/utils.ts
@@ -10,7 +10,7 @@
  */
 
 import type { ObservedState } from './types'
-import { factorNeedsVerification } from '../../domain/valueProvenance'
+import { factorIsConfirmable } from '../../domain/valueProvenance'
 import { classifyValueProvenance, type ValueProvenanceKind } from '../../domain/valueProvenance'
 import type { EdgeDirectionDisplay } from '../../domain/edgeValueProvenance'
 import { selectDriverDisplayModel, extractPolicyRow } from '../../../components/results/driverDisplayModel'
@@ -108,17 +108,23 @@ export function mapSourceToDisplay(source: string | undefined): string | null {
 // ── Factor verification ─────────────────────────────────────────────────────
 
 /**
- * Count factors needing user verification (no source, or AI estimate).
+ * Count factors the user can actually verify — what every "N to verify" surface
+ * renders (`StatusBar`, `WorkspaceShellTabStrip`, `ModelHealthSection`,
+ * `FactorsSection`'s accordion label, and the v2 attention chip).
  *
- * ⚠ THE PREDICATE MOVED OUT (18 Aug 2026) and this function no longer holds a
- * copy of it. It lived here inline while a second, deliberate port lived in
+ * ⚠ IT IS `factorIsConfirmable`, NOT `factorNeedsVerification` (narrowed 19 Aug
+ * 2026). The bare predicate counted factors with NO VALUE AT ALL — nothing to
+ * confirm, an enabled Confirm the authority declines, and a number the user
+ * could never drive to zero. The count and the affordance are now the same
+ * question asked once, and that question is the write authority's own condition.
+ *
+ * ⚠ THE PREDICATE MOVED OUT (18 Aug 2026) and this function holds no copy of it.
+ * It lived here inline while a second, deliberate port lived in
  * `model-tab-v2/adapters.ts` — the estate's own documented mirror, pinned by a
- * corpus that could only prove the two AGREED. Both now import
- * `factorNeedsVerification` from `domain/valueProvenance`, so the count, the
- * outline's ⚠ marker and the Confirm affordance cannot disagree about a row.
+ * corpus that could only prove the two AGREED.
  */
 export function countFactorsToVerify(factorNodes: ReadonlyArray<{ data: unknown }>): number {
-  return factorNodes.filter(n => factorNeedsVerification(n.data)).length
+  return factorNodes.filter(n => factorIsConfirmable(n.data)).length
 }
 
 // ── Strength semantic labels ──────────────────────────────────────────────────

--- a/src/canvas/domain/__tests__/factorConfirmable.spec.ts
+++ b/src/canvas/domain/__tests__/factorConfirmable.spec.ts
@@ -1,0 +1,363 @@
+/**
+ * ⭐⭐ ONE PREDICATE FOR "N TO VERIFY" — and it is the WRITE AUTHORITY'S, not a
+ * display predicate that happens to agree.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHAT THIS FILE EXISTS TO CATCH
+ * ─────────────────────────────────────────────────────────────────────────────
+ * Five surfaces render "N to verify" (`StatusBar`, `WorkspaceShellTabStrip`,
+ * `ModelHealthSection`, `FactorsSection`'s accordion label, and v2's attention
+ * chip) and two offer the Confirm affordance (`FactorCard`, `ModelRowView`).
+ * They were answering ONE question with FOUR predicates, which diverged on two
+ * REACHABLE factor shapes IN OPPOSITE DIRECTIONS:
+ *
+ *   · the bare `factorNeedsVerification` OVER-counts a factor with no value at
+ *     all — an enabled Confirm the authority silently declines;
+ *   · any `raw_value`-based guard (`getPrimaryValue`, `row.primaryValue`)
+ *     UNDER-counts a capped factor carrying only `observedState.value`, which is
+ *     a staging-witnessed wire shape (`conversation/factorValueEdit.ts:145`).
+ *
+ * ⚠⚠ A CORPUS POINTED AT ONE DIRECTION CANNOT SEE BOTH (trap 22b). The fix that
+ * closed the over-count opened the under-count, and every suite stayed green.
+ * So every case below is written as an OPPOSITE-DIRECTION PAIR: `FAC_NO_VALUE`
+ * (only the bare form counts it) against `FAC_MODEL_SCALE` (only the
+ * `raw_value` forms miss it), with `FAC_BOTH` as the agreement control that
+ * stops a predicate returning `false` for everything from passing.
+ *
+ * ⚠ THE ORACLE IS THE PRODUCER, NOT THIS FILE'S OPINION (trap 13c). The
+ * authority pin below does not restate the refusal condition — it DRIVES
+ * `proposeFactorConfirmation` over the same corpus and asserts the predicate
+ * partitions it exactly as the writer does. A mutant kit can only prove a test
+ * DETECTS a change; this is what makes the EXPECTATION right, and it goes red
+ * if the authority's condition ever moves out from under the surfaces.
+ *
+ * Every assertion binds by IDENTITY (factor id), never by a value predicate
+ * another factor could satisfy (trap 19).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { join, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { Node } from '@xyflow/react'
+// ⚠ COMMENTS STRIPPED BEFORE EVERY SCAN BELOW. This file's own prose QUOTES the
+// competitor expressions it forbids, so a raw read matches itself and the guard
+// fails for a reason that has nothing to do with the code (measured, 19 Aug).
+// `stripComments`, not `blankNonCode` — the sibling scan records why.
+import { stripComments } from '../../../../tests/helpers/stripSourceComments'
+
+vi.mock('../../conversation/ConversationContext', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, useOptionalConversationContext: () => undefined }
+})
+
+import {
+  factorHasConfirmableValue,
+  factorIsConfirmable,
+  factorNeedsVerification,
+} from '../valueProvenance'
+import { countFactorsToVerify } from '../../components/model-tab/utils'
+import { toModelRows, toRepairQueueItems } from '../../model-tab-v2/adapters'
+import { useModelEditAuthority } from '../../hooks/useModelEditAuthority'
+import { useCanvasStore } from '../../store'
+
+const HERE = dirname(fileURLToPath(import.meta.url))
+const SRC = join(HERE, '..', '..', '..')
+
+// ── The corpus, by identity ─────────────────────────────────────────────────
+
+/** Agreement control: every predicate ever used here counts this one. */
+const FAC_BOTH = 'fac_both_scales'
+/** ⚠ DIRECTION 1 — only the BARE predicate counts it. Nothing to ratify. */
+const FAC_NO_VALUE = 'fac_no_value_at_all'
+/** ⚠ DIRECTION 2 — only the `raw_value` guards MISS it. Wire-real. */
+const FAC_MODEL_SCALE = 'fac_model_scale_only'
+/** Already ratified — no predicate may count it. */
+const FAC_CONFIRMED = 'fac_already_confirmed'
+/** The WIRE spelling of an unratified estimate. Reading camelCase under-counts. */
+const FAC_SNAKE = 'fac_snake_case_wire'
+/** A value that is present but NOT a finite number — the authority refuses it. */
+const FAC_NAN = 'fac_non_finite'
+
+function factor(id: string, observedState: unknown, snake = false): Node {
+  return {
+    id,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: {
+      label: `Label for ${id}`,
+      type: 'factor',
+      ...(snake ? { observed_state: observedState } : { observedState }),
+    },
+  } as Node
+}
+
+const CORPUS: Node[] = [
+  factor(FAC_BOTH, { value: 0.5, raw_value: 15000, unit: '£', cap: 30000, source: 'cee_inference' }),
+  factor(FAC_NO_VALUE, { source: 'cee_inference' }),
+  factor(FAC_MODEL_SCALE, { value: 0.7, source: 'cee_inference' }),
+  factor(FAC_CONFIRMED, { value: 0.5, raw_value: 15000, source: 'user_confirmed' }),
+  factor(FAC_SNAKE, { value: 0.25, raw_value: 4, source: 'cee_inference' }, true),
+  factor(FAC_NAN, { value: Number.NaN, raw_value: 9, source: 'cee_inference' }),
+]
+
+/** The answer, stated once, by identity. Every surface below must reproduce it. */
+const CONFIRMABLE = [FAC_BOTH, FAC_MODEL_SCALE, FAC_SNAKE]
+
+const ids = (ns: ReadonlyArray<{ id: string }>) => ns.map(n => n.id)
+
+const projection = () => ({
+  nodes: CORPUS,
+  edges: [],
+  goalThreshold: null,
+  robustness: null,
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('⭐⭐ factorIsConfirmable — the canonical "to verify" predicate', () => {
+  it('partitions the corpus by IDENTITY, in both directions at once', () => {
+    expect(ids(CORPUS.filter(n => factorIsConfirmable(n.data)))).toEqual(CONFIRMABLE)
+  })
+
+  it('⚠ DIRECTION 1 — it is NARROWER than the bare predicate (the over-count)', () => {
+    // The bare form counts a factor with nothing to ratify. Named, not implied:
+    // if this ever stops differing, the narrowing has been reverted.
+    expect(factorNeedsVerification(CORPUS.find(n => n.id === FAC_NO_VALUE)!.data)).toBe(true)
+    expect(factorIsConfirmable(CORPUS.find(n => n.id === FAC_NO_VALUE)!.data)).toBe(false)
+    expect(ids(CORPUS.filter(n => factorNeedsVerification(n.data)))).toContain(FAC_NO_VALUE)
+    expect(CONFIRMABLE).not.toContain(FAC_NO_VALUE)
+  })
+
+  it('⚠ DIRECTION 2 — it is WIDER than any `raw_value` guard (the under-count)', () => {
+    const modelScale = CORPUS.find(n => n.id === FAC_MODEL_SCALE)!
+    const obs = (modelScale.data as Record<string, unknown>).observedState as Record<string, unknown>
+    // The shape that makes this reachable, asserted rather than assumed: a
+    // capped factor off the wire carries `value` and no `raw_value`.
+    expect(obs.raw_value).toBeUndefined()
+    expect(obs.value).toBe(0.7)
+    // A `raw_value` guard would drop it. The canonical predicate keeps it.
+    expect(factorIsConfirmable(modelScale.data)).toBe(true)
+    expect(CONFIRMABLE).toContain(FAC_MODEL_SCALE)
+  })
+
+  it('a non-finite value is not a value (the authority refuses it too)', () => {
+    expect(factorHasConfirmableValue(CORPUS.find(n => n.id === FAC_NAN)!.data)).toBe(false)
+    expect(CONFIRMABLE).not.toContain(FAC_NAN)
+  })
+
+  it('reads BOTH spellings — the wire uses snake_case', () => {
+    expect(CONFIRMABLE).toContain(FAC_SNAKE)
+    expect(factorIsConfirmable(CORPUS.find(n => n.id === FAC_SNAKE)!.data)).toBe(true)
+  })
+
+  it('the partition is non-trivial in both directions (positive control)', () => {
+    // Without this, a predicate returning `false` for everything — or `true` for
+    // everything — could satisfy an equality above (trap 13).
+    expect(CONFIRMABLE.length).toBeGreaterThan(0)
+    expect(CONFIRMABLE.length).toBeLessThan(CORPUS.length)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('⭐⭐ THE ORACLE — the predicate IS the write authority, driven', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({ nodes: CORPUS as never, edges: [] as never }, false)
+  })
+
+  /**
+   * ⚠⚠ THE AUTHORITY AND THE OFFER ARE TWO QUESTIONS, AND THIS TEST'S FIRST
+   * VERSION CONFLATED THEM — refuted by driving the producer (trap 13c, on the
+   * author). It asserted the authority honours exactly `factorIsConfirmable`.
+   * It does not: `proposeFactorConfirmation` HONOURED an already-`user_confirmed`
+   * factor, because it asks *"can I record this?"* and never *"does this need
+   * recording?"*. Two questions under similar names (trap 21), so they get two
+   * assertions rather than one averaged expectation:
+   *
+   *   · the authority honours exactly `factorHasConfirmableValue`;
+   *   · `factorIsConfirmable` is a SUBSET of that — which is the property the
+   *     surfaces need, i.e. nothing is ever OFFERED that the writer declines.
+   */
+  const drive = (id: string) =>
+    renderHook(() => useModelEditAuthority(id)).result.current.proposeFactorConfirmation()
+
+  it('the authority HONOURS exactly `factorHasConfirmableValue` — its own condition', () => {
+    const honoured: string[] = []
+    for (const n of CORPUS) {
+      const outcome = drive(n.id)
+      if (outcome === 'committed') honoured.push(n.id)
+      expect(`${n.id}: ${outcome}`).toBe(
+        `${n.id}: ${factorHasConfirmableValue(n.data) ? 'committed' : 'not_encodable'}`,
+      )
+    }
+    // Stated as a set too, so a loop that silently ran zero times cannot pass
+    // (trap 20 — a probe returning the same answer for every item).
+    expect(honoured).toEqual([FAC_BOTH, FAC_MODEL_SCALE, FAC_CONFIRMED, FAC_SNAKE])
+  })
+
+  it('⭐ NOTHING IS OFFERED THAT THE WRITER DECLINES — the property the chips need', () => {
+    for (const n of CORPUS) {
+      if (!factorIsConfirmable(n.data)) continue
+      // Bound by identity, and asserted per factor so a failure names the row.
+      expect(`${n.id}: ${drive(n.id)}`).toBe(`${n.id}: committed`)
+    }
+    // The offered set is a STRICT subset — an equality here would re-introduce
+    // the conflation this pair exists to keep apart.
+    const honoured = CORPUS.filter(n => factorHasConfirmableValue(n.data)).map(n => n.id)
+    expect(honoured.length).toBeGreaterThan(CONFIRMABLE.length)
+    for (const id of CONFIRMABLE) expect(honoured).toContain(id)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('⭐⭐ THE TWO COUNTERS AGREE — one derivation, not two that match today', () => {
+  it('v1 count === v2 queue length === the confirmable set, by identity', () => {
+    const v1Count = countFactorsToVerify(CORPUS)
+    const v2Queue = toRepairQueueItems(projection(), 'confirm-estimates')
+
+    // The NUMBERS, which is what the user reads on two chips saying "N to verify".
+    expect(`v1=${v1Count} v2=${v2Queue.length}`).toBe(
+      `v1=${CONFIRMABLE.length} v2=${CONFIRMABLE.length}`,
+    )
+    // And the IDENTITIES, because two wrong counts can agree (trap 19).
+    expect(v2Queue.map(i => i.rowId)).toEqual(CONFIRMABLE)
+  })
+
+  it('⚠ the OLD bare predicate would have made them disagree — pinned, not assumed', () => {
+    // The concrete divergence the adversarial review named: a graph with a
+    // factor needing verification but no value set. If this ever stops being a
+    // real gap, the corpus has lost the case that makes the convergence mean
+    // something.
+    const bare = CORPUS.filter(n => factorNeedsVerification(n.data)).length
+    expect(bare).toBeGreaterThan(CONFIRMABLE.length)
+    expect(countFactorsToVerify(CORPUS)).not.toBe(bare)
+  })
+
+  it("⚠ and #782's `raw_value` conjunct would have made them disagree the OTHER way", () => {
+    // `getPrimaryValue` reads `raw_value` only, so this is the exact set the
+    // superseded queue filter produced. It is SHORT by a real, confirmable
+    // factor — the direction a one-sided corpus cannot see.
+    const viaRawValue = CORPUS.filter(n => {
+      const d = n.data as Record<string, unknown>
+      const obs = (d.observedState ?? d.observed_state) as Record<string, unknown> | undefined
+      return factorNeedsVerification(n.data) && obs?.raw_value !== undefined
+    })
+    expect(ids(viaRawValue)).not.toEqual(CONFIRMABLE)
+    expect(ids(viaRawValue)).not.toContain(FAC_MODEL_SCALE)
+    expect(CONFIRMABLE).toContain(FAC_MODEL_SCALE)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe("⭐ the outline's row marker is the same predicate, so the chip cannot disagree", () => {
+  it('`unconfirmed-estimate` marks exactly the confirmable rows, by id', () => {
+    const rows = toModelRows(projection())
+    const marked = rows.filter(r => r.attention.includes('unconfirmed-estimate')).map(r => r.id)
+    expect(marked).toEqual(CONFIRMABLE)
+  })
+
+  it('⚠ `no-value` is a DIFFERENT question and keeps its own predicate (trap 21)', () => {
+    // Display vs write. `FAC_MODEL_SCALE` has a confirmable value and NO
+    // displayable one, so it legitimately carries both reasons. Pinned so a
+    // later tidy-up cannot "reconcile" two questions into one.
+    const rows = toModelRows(projection())
+    const modelScale = rows.find(r => r.id === FAC_MODEL_SCALE)!
+    expect(modelScale.attention).toContain('unconfirmed-estimate')
+    expect(modelScale.attention).toContain('no-value')
+
+    const noValue = rows.find(r => r.id === FAC_NO_VALUE)!
+    expect(noValue.attention).toContain('no-value')
+    expect(noValue.attention).not.toContain('unconfirmed-estimate')
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('⭐ ONE definition, and no surface re-expresses the conjunction', () => {
+  const read = (rel: string) => stripComments(readFileSync(join(SRC, rel), 'utf8'), rel)
+  /** Unstripped, for the control that proves the stripper is not blanking everything. */
+  const readRaw = (rel: string) => readFileSync(join(SRC, rel), 'utf8')
+
+  it('the predicate is DEFINED exactly once in the tree', () => {
+    const DEFINITION = /export function factorIsConfirmable\s*\(/
+    const VALUE_GUARD = /export function factorHasConfirmableValue\s*\(/
+    const domain = read('canvas/domain/valueProvenance.ts')
+
+    // POSITIVE CONTROL: the matcher can see a definition when one is present,
+    // otherwise every "absent here" below is reported by a blind regex.
+    expect(DEFINITION.test(domain)).toBe(true)
+    expect(VALUE_GUARD.test(domain)).toBe(true)
+
+    for (const rel of [
+      'canvas/model-tab-v2/adapters.ts',
+      'canvas/model-tab-v2/ModelRowView.tsx',
+      'canvas/components/model-tab/utils.ts',
+      'canvas/components/model-tab/FactorsSection.tsx',
+      'canvas/hooks/useModelEditAuthority.ts',
+    ]) {
+      const src = read(rel)
+      expect(`${rel}: ${DEFINITION.test(src)}`).toBe(`${rel}: false`)
+      expect(`${rel}: ${VALUE_GUARD.test(src)}`).toBe(`${rel}: false`)
+      // A re-export keeps the name reachable from several places with one owner
+      // — the shim this convergence exists to refuse.
+      expect(`${rel}: ${/export\s*\{[^}]*factorIsConfirmable/.test(src)}`).toBe(`${rel}: false`)
+    }
+  })
+
+  it('⚠ the CONSUMERS hold no local value guard beside the predicate', () => {
+    /*
+     * Each row: the file, the COMPETITOR shape that must be gone, and the
+     * CONTRAST that must be present in the same file — the consumption that
+     * replaced it. A per-file contrast, not one shared pattern: `ModelRowView`
+     * consumes the predicate INDIRECTLY, through the `unconfirmed-estimate`
+     * attention reason, and asserting it names `factorIsConfirmable` would be
+     * asserting the wrong thing (it would pass only on a comment).
+     */
+    const COMPETITORS: ReadonlyArray<readonly [string, RegExp, RegExp]> = [
+      [
+        'canvas/model-tab-v2/adapters.ts',
+        /factorValue\(n\.data\)\s*!==\s*null/,
+        /factorIsConfirmable\(/,
+      ],
+      [
+        'canvas/model-tab-v2/ModelRowView.tsx',
+        /row\.primaryValue\s*!==\s*null/,
+        /attention\.includes\('unconfirmed-estimate'\)/,
+      ],
+      [
+        'canvas/components/model-tab/utils.ts',
+        /filter\(n => factorNeedsVerification\(n\.data\)\)/,
+        /factorIsConfirmable\(/,
+      ],
+      [
+        'canvas/components/model-tab/FactorsSection.tsx',
+        /primaryValue\s*!==\s*null\s*\|\|\s*normalisedValue\s*!==\s*null/,
+        /factorIsConfirmable\(/,
+      ],
+    ]
+
+    for (const [rel, competitor, contrast] of COMPETITORS) {
+      const code = read(rel)
+      // The competitor is gone …
+      expect(`${rel} competitor: ${competitor.test(code)}`).toBe(`${rel} competitor: false`)
+      // … and the replacement is there, in the SAME sweep, through the SAME
+      // stripper. An absence is only evidence when a contrast reads non-zero
+      // beside it (trap 13e) — and a stripper that blanked the file would make
+      // every `false` above vacuous.
+      expect(`${rel} contrast: ${contrast.test(code)}`).toBe(`${rel} contrast: true`)
+      expect(`${rel} non-empty: ${code.trim().length > 0}`).toBe(`${rel} non-empty: true`)
+    }
+
+    // ⚠ AND THE STRIPPER IS LOAD-BEARING, PINNED. The competitor shapes are
+    // still QUOTED in this repo's prose (including in this file), so an
+    // UNSTRIPPED read finds them. If a later tidy-up drops `stripComments`, this
+    // goes red rather than the guard reporting a defect that is only a comment.
+    expect(/row\.primaryValue\s*!==\s*null/.test(readRaw('canvas/model-tab-v2/ModelRowView.tsx'))).toBe(
+      true,
+    )
+  })
+})

--- a/src/canvas/domain/canvasLabels.ts
+++ b/src/canvas/domain/canvasLabels.ts
@@ -54,10 +54,28 @@ export function resolveCanvasLabel(
   id: string,
   labels: ReadonlyMap<string, string>,
 ): string | null {
-  const label = labels.get(id)
-  if (label === undefined) return null
+  return honestLabel(labels.get(id))
+}
+
+/**
+ * THE POLICY ITSELF, for callers that already hold the candidate string.
+ *
+ * ⚠ EXTRACTED SO IT CANNOT BE RE-EXPRESSED. An edge carries its OWN `label` (not
+ * one looked up by id), so `model-tab-v2/adapters.ts`'s relationship path had no
+ * map to hand and read it raw — the id-shaped-label rejection was applied on the
+ * node path and not on its neighbour, inside one function. The alternative was a
+ * caller building a one-entry `Map` to borrow the lookup, which is the policy
+ * smuggled through a data structure rather than named.
+ *
+ * `resolveCanvasLabel` is now this function plus a lookup, so there is exactly
+ * one definition of what an honest label is.
+ */
+export function honestLabel(label: unknown): string | null {
+  if (typeof label !== 'string') return null
   const trimmed = label.trim()
   if (trimmed === '') return null
+  // Producers sometimes seed a label from an id; without this the leak just
+  // moves one hop upstream and still reaches the user.
   if (RAW_ID_PATTERN.test(trimmed)) return null
   return trimmed
 }

--- a/src/canvas/domain/valueProvenance.ts
+++ b/src/canvas/domain/valueProvenance.ts
@@ -229,3 +229,77 @@ export function factorNeedsVerification(data: unknown): boolean {
   const obs = (d?.observedState ?? d?.observed_state) as Record<string, unknown> | undefined
   return !obs?.source || obs?.source === 'cee_inference'
 }
+
+/**
+ * Is there a number here that a confirmation could actually ratify?
+ *
+ * ⚠⚠ THIS IS THE AUTHORITY'S OWN REFUSAL CONDITION, INVERTED — NOT A READING OF
+ * IT. `useModelEditAuthority.proposeFactorConfirmation` returns
+ * `'not_encodable'` unless `observedState.value` is a FINITE NUMBER, and it
+ * stamps nothing when it refuses. Every surface that OFFERS a confirmation must
+ * therefore gate on exactly this, or it renders a control the authority will
+ * silently decline (preamble P8 — an enabled button that does nothing).
+ *
+ * The authority imports this rather than keeping its own copy, so the gate and
+ * the refusal cannot drift apart. That is the whole point: a surface asking
+ * "may I offer Confirm?" and the writer answering "no" must be ONE predicate.
+ *
+ * ⚠ IT IS `value`, NOT `raw_value`, AND THE DIFFERENCE IS WIRE-REAL. `value` is
+ * MODEL scale; `raw_value` is the USER-UNIT magnitude, and it is frequently
+ * ABSENT — `conversation/factorValueEdit.ts:145` records the staging-witnessed
+ * shape `{value: 0.7}` with no `raw_value` for a capped factor. A gate written
+ * against `raw_value` (or against `getPrimaryValue`, which reads only
+ * `raw_value`) therefore refuses a whole class of factors the authority would
+ * have accepted — an UNDER-count, the exact mirror of the over-count it was
+ * written to close. Both directions are pinned in
+ * `__tests__/factorConfirmable.spec.ts`.
+ *
+ * ⚠ BOTH SPELLINGS, for the same reason `factorNeedsVerification` reads both:
+ * canvas stores `observedState`, the CEE/PLoT wire uses `observed_state`, and
+ * real graphs carry both.
+ */
+export function factorHasConfirmableValue(data: unknown): boolean {
+  const d = data as Record<string, unknown> | undefined
+  const obs = (d?.observedState ?? d?.observed_state) as Record<string, unknown> | undefined
+  const value = obs?.value
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
+/**
+ * ⭐⭐ THE CANONICAL PREDICATE FOR "N TO VERIFY" — one question, one owner.
+ *
+ * A factor is CONFIRMABLE when it still needs a human to look at it AND there is
+ * a number present that a confirmation can ratify.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY IT EXISTS: FIVE SURFACES WERE ANSWERING ONE QUESTION FOUR WAYS
+ * ─────────────────────────────────────────────────────────────────────────────
+ * "N to verify" is rendered by `StatusBar`, `WorkspaceShellTabStrip`,
+ * `ModelHealthSection`, `FactorsSection`'s accordion tier label and — new — the
+ * v2 attention chip. The Confirm affordance is offered by `FactorCard` (v1) and
+ * `ModelRowView` (v2). Before this predicate existed they used FOUR spellings:
+ *
+ *   · `countFactorsToVerify`        — bare `factorNeedsVerification`
+ *   · v2 repair queue              — `… && getPrimaryValue(…) !== null`
+ *   · `FactorsSection` Confirm ✓   — `… && (primaryValue ?? normalisedValue)`
+ *   · `ModelRowView` Confirm ✓     — `… && row.primaryValue !== null`
+ *
+ * They agreed on the common shapes and diverged on two REACHABLE classes, in
+ * OPPOSITE directions — which is why no single-direction corpus could see both
+ * (trap 22b). The bare form over-counts a factor with no value at all; the
+ * `raw_value` forms under-count a capped factor carrying only `value`.
+ *
+ * ⚠ THE RECONCILIATION IS NOT "PICK THE WIDER" OR "PICK THE NARROWER". It is
+ * the PRODUCER's condition: the only honest answer to "should this row be
+ * counted and offered?" is "will the writer accept it?" (trap 13c — derive the
+ * expectation from the producer's declared semantics, never from your own
+ * reading of what a field ought to mean). Every one of the sites above now
+ * calls this function, and none keeps a copy.
+ *
+ * ⚠ NOT THE SAME QUESTION AS `no-value` (trap 21). `no-value` asks "is there a
+ * number the outline can DISPLAY?", which is `getPrimaryValue` and legitimately
+ * a different predicate. Named apart on purpose rather than aligned.
+ */
+export function factorIsConfirmable(data: unknown): boolean {
+  return factorNeedsVerification(data) && factorHasConfirmableValue(data)
+}

--- a/src/canvas/hooks/useModelEditAuthority.ts
+++ b/src/canvas/hooks/useModelEditAuthority.ts
@@ -77,6 +77,7 @@
 import { useCallback } from 'react'
 import { useCanvasStore } from '../store'
 import { resolveNodeTypeLiteral } from '../domain/nodes'
+import { factorHasConfirmableValue } from '../domain/valueProvenance'
 import { useOptionalConversationContext } from '../conversation/ConversationContext'
 import { useNodeMutations } from '../ui/inspector-v2/useInspectorMutations'
 import { buildFactorValueEditEvent } from '../conversation/factorValueEdit'
@@ -244,12 +245,13 @@ export function useModelEditAuthority(activeNodeId: string | null): ModelEditAut
     if (!activeNodeId) return 'not_encodable'
     const node = useCanvasStore.getState().nodes.find(n => n.id === activeNodeId)
     if (!node || resolveNodeTypeLiteral(node) !== 'factor') return 'not_encodable'
-    const data = node.data as Record<string, unknown> | undefined
-    const obs = (data?.observedState ?? data?.observed_state) as
-      | Record<string, unknown>
-      | undefined
-    const value = obs?.value
-    if (typeof value !== 'number' || !Number.isFinite(value)) return 'not_encodable'
+    // ⚠ THE REFUSAL IS `factorHasConfirmableValue`, NOT A COPY OF IT. This read
+    // its own `observedState.value` finiteness inline, and FOUR surfaces
+    // separately guessed at the same condition to decide whether to OFFER the
+    // control — in three different spellings, two of them wrong on a reachable
+    // class. The gate and the refusal are now the same function, so a surface
+    // cannot offer what this will decline.
+    if (!factorHasConfirmableValue(node.data)) return 'not_encodable'
 
     mutations.setObservedSource('user_confirmed')
     return 'committed'

--- a/src/canvas/model-tab-v2/ModelRowView.tsx
+++ b/src/canvas/model-tab-v2/ModelRowView.tsx
@@ -129,16 +129,21 @@ export function ModelRowView({
    * the queue counts. Asking the same question a second way here is how the
    * chip and the ⚠ start disagreeing about the same row (trap 12).
    *
-   * The value guard is separate and is NOT a duplicate of it: `attention` says
-   * the estimate is unratified; `primaryValue` says there is a number on screen
-   * to ratify. A Confirm button over an empty cell asks the user to endorse
-   * nothing (preamble P8), and the authority would refuse it anyway — so the
-   * button does not appear rather than appearing and failing.
+   * ⚠⚠ AND THE VALUE GUARD IS GONE FROM HERE, WHICH IS THE POINT. It used to
+   * read `&& row.primaryValue !== null` — a second, LOCAL answer to "is there
+   * something to ratify?", written against the DISPLAY value. `primaryValue` is
+   * `getPrimaryValue`, i.e. `raw_value`; the write authority gates on
+   * `observedState.value`, and a capped factor carrying only `value` has one and
+   * not the other. So this chip hid on rows the authority would have accepted
+   * — while `FactorsSection` showed the same rows a button.
+   *
+   * `unconfirmed-estimate` now carries the whole question (`factorIsConfirmable`
+   * in `adapters.ts`), so there is exactly one predicate and this surface reads
+   * it rather than re-deriving half of it.
    */
   const canConfirmAsIs =
     typeof onConfirmValueAsIs === 'function' &&
-    row.attention.includes('unconfirmed-estimate') &&
-    row.primaryValue !== null
+    row.attention.includes('unconfirmed-estimate')
 
   return (
     <li

--- a/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
+++ b/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
@@ -49,9 +49,17 @@ import { resolveValueInputSeed } from '../conversation/factorValueEdit'
 import { useModelEditAuthority } from '../hooks/useModelEditAuthority'
 import { ModelOutline } from './ModelOutline'
 import { ModelDetailRegion } from './ModelDetailRegion'
+import { RepairQueueList } from './RepairQueueList'
+import { REPAIR_QUEUE } from './rowPresentation'
 import type { GroupAction, GroupActionContext } from './groupActions'
-import { toModelRows, toRowDetail, nodeKind, type ModelProjectionInput } from './adapters'
-import type { DetailTier, EditCommitState } from './types'
+import {
+  toModelRows,
+  toRepairQueueItems,
+  toRowDetail,
+  nodeKind,
+  type ModelProjectionInput,
+} from './adapters'
+import type { DetailTier, EditCommitState, RepairQueue } from './types'
 
 export interface ModelTabV2PanelProps {
   nodes: Node[]
@@ -94,6 +102,18 @@ export function ModelTabV2Panel({
   onHandOffToOlumi,
 }: ModelTabV2PanelProps) {
   const [tier, setTier] = useState<DetailTier>('plain')
+  /**
+   * Which repair queue the user is standing in, if any.
+   *
+   * ⚠ A MODE, NOT A SECOND LIST. Design §5.3: a queue is *a filtered view of
+   * the same outline* — "there is only ever one rendering of a row". Rendering
+   * the queue BESIDE the outline would put the same factor on screen twice,
+   * which is precisely the defect this whole consolidation exists to remove;
+   * doing it inside the fix would be the defect class reproduced one layer up.
+   * So the queue REPLACES the outline while it is open, and one control
+   * returns.
+   */
+  const [activeQueue, setActiveQueue] = useState<RepairQueue['id'] | null>(null)
   const [filter, setFilter] = useState('')
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [edit, setEdit] = useState<ActiveEdit | null>(null)
@@ -121,6 +141,18 @@ export function ModelTabV2Panel({
   )
 
   const rows = useMemo(() => toModelRows(projection), [projection])
+
+  /**
+   * ⚠ THE CHIP AND THE QUEUE ARE THE SAME DERIVATION, so they cannot disagree.
+   * The count on the chip IS `confirmItems.length` — not a second predicate
+   * that happens to agree today. The current tab ships the opposite: a
+   * "N to verify" badge whose N counts factors the user has no way to reach.
+   * This is the first time that badge does anything (design §7.2).
+   */
+  const confirmItems = useMemo(
+    () => toRepairQueueItems(projection, 'confirm-estimates'),
+    [projection],
+  )
 
   /**
    * The rows whose edit has a canonical transaction at this tip: factors.
@@ -403,6 +435,49 @@ export function ModelTabV2Panel({
         </div>
       </header>
 
+      {/*
+        THE ATTENTION CHIP — the first time "N to verify" is a control.
+        Rendered only when the count is non-zero: a chip reading "0 to verify"
+        is furniture, and the queue behind it would be empty.
+      */}
+      {confirmItems.length > 0 && activeQueue === null && (
+        <button
+          type="button"
+          data-testid="model-tab-v2-chip-confirm-estimates"
+          onClick={() => setActiveQueue('confirm-estimates')}
+          className={`${typography.buttonSmall} self-start rounded border border-panel-border px-2 py-0.5 text-text-header hover:bg-panel-hover`}
+        >
+          {confirmItems.length === 1 ? '1 to verify' : `${confirmItems.length} to verify`}
+        </button>
+      )}
+
+      {activeQueue === 'confirm-estimates' ? (
+        <>
+          <button
+            type="button"
+            data-testid="model-tab-v2-queue-back"
+            onClick={() => setActiveQueue(null)}
+            className={`${typography.buttonSmall} self-start rounded border border-panel-border px-2 py-0.5 text-text-header hover:bg-panel-hover`}
+          >
+            Back to the model outline
+          </button>
+          <RepairQueueList
+            queue={REPAIR_QUEUE['confirm-estimates']}
+            items={confirmItems}
+            onFocusOnCanvas={focusOnCanvas}
+            /*
+              ⚠ THE SAME AUTHORITY CALL AS THE ROW'S CONFIRM CHIP, not a second
+              implementation of confirming. `confirmValueAsIs` routes to
+              `useModelEditAuthority.proposeFactorConfirmation`, so the queue and
+              the row stamp `user_confirmed` through ONE path. Two entry points
+              to one edit is the design; two implementations of one edit is the
+              defect being removed.
+            */
+            onApply={confirmValueAsIs}
+            applyLabel="Confirm"
+          />
+        </>
+      ) : (
       <ModelOutline
         rows={rows}
         tier={tier}
@@ -421,8 +496,9 @@ export function ModelTabV2Panel({
         onGroupAction={onHandOffToOlumi ? handleGroupAction : undefined}
         groupActionContext={groupActionContext}
       />
+      )}
 
-      {selectedRow !== null && selectedDetail !== null && (
+      {activeQueue === null && selectedRow !== null && selectedDetail !== null && (
         <ModelDetailRegion
           row={selectedRow}
           detail={selectedDetail}

--- a/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
+++ b/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
@@ -85,6 +85,18 @@ export interface ModelTabV2PanelProps {
   onHandOffToOlumi?: (message: string, reason: string) => void
 }
 
+/**
+ * The queues that are actually MOUNTED AND WIRED at this tip.
+ *
+ * ⚠ NARROWER THAN `RepairQueue['id']` ON PURPOSE. `REPAIR_QUEUE` is total over
+ * all four queues — correct for the definitions table — but only
+ * `confirm-estimates` has a write carrier (`proposeFactorConfirmation`). Typing
+ * the panel's state to the total union would make `'contested'` look sanctioned
+ * when nothing renders it. Adding a queue here is a deliberate act, not a
+ * discovery in a diff.
+ */
+type MountedQueueId = Extract<RepairQueue['id'], 'confirm-estimates'>
+
 /** One active edit at a time — the row the user is currently changing. */
 interface ActiveEdit {
   rowId: string
@@ -112,8 +124,34 @@ export function ModelTabV2Panel({
    * doing it inside the fix would be the defect class reproduced one layer up.
    * So the queue REPLACES the outline while it is open, and one control
    * returns.
+   *
+   * ⚠⚠ AND THE SCOPE OF THAT CLAIM, STATED BECAUSE THE COMMIT THAT INTRODUCED
+   * THIS OVERSTATED IT. What is true HERE is that this panel renders a row once:
+   * the branch above is structurally exclusive and the spec pins the outline rows
+   * absent in queue mode, with a before-click contrast control.
+   *
+   * What is NOT yet true is the SURFACE. `ModelTabBody.tsx` renders
+   * `FactorsSection` unconditionally, outside this panel, in the same scroll — so
+   * a queued factor appears in the queue AND in its v1 factor card. The
+   * consolidation's invariant *"there is only ever one rendering of a row"* is a
+   * goal at this tip, not an achieved state, and it stays that way until the
+   * duplicate section stack is deleted.
+   *
+   * A spec that renders THIS COMPONENT can never see that (trap 3b — bound to a
+   * component, not to the surface the deployed tab mounts), which is exactly how
+   * the overstatement passed a green suite.
    */
-  const [activeQueue, setActiveQueue] = useState<RepairQueue['id'] | null>(null)
+  const [activeQueue, setActiveQueue] = useState<MountedQueueId | null>(null)
+  /**
+   * ⚠ ONE PREDICATE, DERIVED ONCE (F7). Two independent tests for "am I in a
+   * queue" (`activeQueue === 'confirm-estimates'` for the body,
+   * `activeQueue === null` for the detail region) were equivalent ONLY because
+   * exactly one id was settable. `REPAIR_QUEUE` is total over four ids, which
+   * makes the other three LOOK sanctioned — and setting one would have rendered
+   * the outline AND suppressed the detail region. `MountedQueueId` narrows the
+   * state to what is actually wired, so the two readings cannot diverge.
+   */
+  const inQueue = activeQueue !== null
   const [filter, setFilter] = useState('')
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [edit, setEdit] = useState<ActiveEdit | null>(null)
@@ -230,6 +268,23 @@ export function ModelTabV2Panel({
     confirmAuthority.proposeFactorConfirmation()
     setPendingConfirmId(null)
   }, [pendingConfirmId, confirmAuthority])
+
+  /**
+   * ⚠ F8 — RESOLVING THE LAST ITEM RETURNS YOU TO THE OUTLINE.
+   *
+   * The chip only renders when the count is non-zero, so an empty queue cannot
+   * be ENTERED; it can only be arrived at by clearing the last item. Leaving the
+   * user there replaces the whole outline with "Nothing needs attention here."
+   * and, because the chip is suppressed while a queue is open, the only way out
+   * is a control they have no reason to look for. Finishing the job should not
+   * look like a dead end.
+   *
+   * The count falls on the HOST's re-render — this panel holds no store
+   * subscription by design — which is exactly when this fires.
+   */
+  useEffect(() => {
+    if (activeQueue === 'confirm-estimates' && confirmItems.length === 0) setActiveQueue(null)
+  }, [activeQueue, confirmItems.length])
 
   /** Rows are nodes OR edges — focus each with the helper that owns its kind. */
   const focusOnCanvas = useCallback(
@@ -440,7 +495,7 @@ export function ModelTabV2Panel({
         Rendered only when the count is non-zero: a chip reading "0 to verify"
         is furniture, and the queue behind it would be empty.
       */}
-      {confirmItems.length > 0 && activeQueue === null && (
+      {confirmItems.length > 0 && !inQueue && (
         <button
           type="button"
           data-testid="model-tab-v2-chip-confirm-estimates"
@@ -451,7 +506,7 @@ export function ModelTabV2Panel({
         </button>
       )}
 
-      {activeQueue === 'confirm-estimates' ? (
+      {inQueue ? (
         <>
           <button
             type="button"
@@ -498,7 +553,7 @@ export function ModelTabV2Panel({
       />
       )}
 
-      {activeQueue === null && selectedRow !== null && selectedDetail !== null && (
+      {!inQueue && selectedRow !== null && selectedDetail !== null && (
         <ModelDetailRegion
           row={selectedRow}
           detail={selectedDetail}

--- a/src/canvas/model-tab-v2/RepairQueueList.tsx
+++ b/src/canvas/model-tab-v2/RepairQueueList.tsx
@@ -1,7 +1,19 @@
 /**
  * Model tab v2 — THE REPAIR QUEUE LIST, RENDER-ONLY (design §5.3).
  *
- * ⚠ DELIBERATELY INERT (and still unmounted by the 16 Aug 2026 mount train,
+ * ⚠⚠ NO LONGER WHOLLY INERT, AND NO LONGER UNMOUNTED (18 Aug 2026, the
+ * REHOME → DELETE lane). Two of the four carriers this file was waiting for
+ * now exist: #777 gave `useModelEditAuthority` `proposeFactorConfirmation`
+ * and `proposeOptionIntervention`. So the CONFIRM-ESTIMATES queue is mounted
+ * and its Confirm resolves, through the SAME authority call as the outline
+ * row's Confirm chip — one edit, one path, two entry points. `proposeBatch`
+ * and `proposeDeferral` still do not exist, so Apply-all, Defer and Resume
+ * remain disabled and still say why. The paragraph below is the ORIGINAL
+ * statement, kept because its reasoning is what governs the parts that are
+ * still inert.
+ *
+ * ⚠ DELIBERATELY INERT (as shipped 16 Aug 2026, and still true of every
+ * control whose carrier is missing;
  * which mounted the outline + detail region only). This renders the queue. It
  * does not apply anything, and it cannot: applying needs write operations the
  * canonical wire does not carry yet (`proposeOptionIntervention`,
@@ -61,6 +73,27 @@ export interface RepairQueueListProps {
   items: readonly RepairQueueItem[]
   /** Focus the element on the canvas — read-only navigation, safe today. */
   onFocusOnCanvas?: (rowId: string) => void
+  /**
+   * Resolve ONE item, through the caller's write authority.
+   *
+   * ⚠ OPTIONAL, AND ITS ABSENCE IS THE HONEST DEFAULT. A queue whose carrier
+   * does not exist yet passes nothing and every Apply stays DISABLED with the
+   * reason on it — the state this component shipped in. A queue whose carrier
+   * DOES exist passes it, and only that queue's button comes alive. So
+   * "connected" is a per-queue fact the type system carries, not a flag someone
+   * has to remember to keep true.
+   *
+   * ⚠ THIS COMPONENT STILL WRITES NOTHING. It calls back; the mount host owns
+   * the authority. Wiring a store setter in here would make the queue a second
+   * writer of the same edit — the defect the whole consolidation removes.
+   */
+  onApply?: (rowId: string) => void
+  /**
+   * What resolving means IN THIS QUEUE. "Apply" is right for a suggested value;
+   * "Confirm" is right for ratifying an estimate that is already in the model,
+   * where "Apply" would imply a change that does not happen.
+   */
+  applyLabel?: string
 }
 
 const NO_AUTHORITY_ITEM =
@@ -119,7 +152,13 @@ function ItemCells({
   )
 }
 
-export function RepairQueueList({ queue, items, onFocusOnCanvas }: RepairQueueListProps) {
+export function RepairQueueList({
+  queue,
+  items,
+  onFocusOnCanvas,
+  onApply,
+  applyLabel = 'Apply',
+}: RepairQueueListProps) {
   // Partition, preserving the caller's order within each group.
   const activeItems = items.filter(i => i.deferred === undefined)
   const deferredItems = items.filter(i => i.deferred !== undefined)
@@ -170,15 +209,30 @@ export function RepairQueueList({ queue, items, onFocusOnCanvas }: RepairQueueLi
             >
               <ItemCells queueId={q} item={item} onFocusOnCanvas={onFocusOnCanvas} />
 
+              {/*
+                ⚠ ONE BUTTON, TWO HONEST STATES — never a third that pretends.
+                With a carrier it resolves the item; without one it is disabled
+                and says why. It never renders enabled-but-inert, which is the
+                shape that would let the queue report a success it never had.
+              */}
               <button
                 type="button"
                 data-testid={`repair-queue-v2-${q}-item-${item.rowId}-apply`}
-                disabled
-                title={NO_AUTHORITY_ITEM}
-                aria-label={`${item.label} — ${NO_AUTHORITY_ITEM}`}
-                className={`${typography.buttonSmall} text-text-light cursor-not-allowed border border-panel-border rounded px-2 py-0.5`}
+                disabled={onApply === undefined}
+                onClick={onApply === undefined ? undefined : () => onApply(item.rowId)}
+                title={onApply === undefined ? NO_AUTHORITY_ITEM : undefined}
+                aria-label={
+                  onApply === undefined
+                    ? `${item.label} — ${NO_AUTHORITY_ITEM}`
+                    : `${applyLabel} ${item.label}`
+                }
+                className={`${typography.buttonSmall} border border-panel-border rounded px-2 py-0.5 ${
+                  onApply === undefined
+                    ? 'text-text-light cursor-not-allowed'
+                    : 'text-text-header hover:bg-panel-hover'
+                }`}
               >
-                Apply
+                {onApply === undefined ? 'Apply' : applyLabel}
               </button>
 
               {/*

--- a/src/canvas/model-tab-v2/RepairQueueList.tsx
+++ b/src/canvas/model-tab-v2/RepairQueueList.tsx
@@ -99,6 +99,15 @@ export interface RepairQueueListProps {
 const NO_AUTHORITY_ITEM =
   'Applying is not connected yet — this cannot be changed from here.'
 
+/**
+ * ⚠ A DIFFERENT REFUSAL FROM `NO_AUTHORITY_ITEM`, AND IT MUST READ THAT WAY.
+ * "Not connected yet" is about the product; this is about THIS ROW. Telling a
+ * user their row is awaiting a carrier when in fact it has no value to act on
+ * sends them to wait for something that will not help them.
+ */
+const NO_REFERENT_ITEM =
+  'There is no value here to act on yet — set one first.'
+
 const NO_AUTHORITY_DEFER =
   'Recording this decision is not connected yet — leaving it unresolved cannot be saved from here.'
 
@@ -109,6 +118,56 @@ const NO_AUTHORITY_BATCH =
   'Applying every row at once needs the batch operation that is still being built. ' +
   'Doing it one row at a time would re-run the analysis after each one. ' +
   'Items left unresolved are never included.'
+
+/**
+ * The resolving control — ONE button, and never a third state that pretends.
+ *
+ * ⚠⚠ IT IS FAIL-CLOSED ON THE ITEM AS WELL AS ON THE CARRIER (F2). An item with
+ * NEITHER a current value nor a suggested one has nothing for Apply to refer
+ * to: the authority fails closed on it, writes nothing, and returns an outcome
+ * both call sites discard — so the user pressed a live button and the model did
+ * not move, with no feedback. That is preamble P8, and it is precisely what the
+ * outline's row chip already refuses (`ModelRowView.tsx:134-136`).
+ *
+ * ⚠ THIS IS NOT A SECOND ANSWER TO THE PRODUCER'S QUESTION (trap 21). The
+ * producer answers *"which elements belong in THIS queue?"* — a per-queue
+ * membership rule. This answers *"does this item carry anything to act on?"* — a
+ * universal property of a queue row, true whichever producer built it. Note the
+ * predicate is deliberately the WEAKER, general one: `set-option-values` items
+ * legitimately have `currentValue === null` and carry a `suggestedValue`, so a
+ * gate copied from the confirm queue's membership rule would have silently
+ * disabled Queue A before it was ever mounted.
+ */
+function ApplyControl({
+  queueId,
+  item,
+  onApply,
+  applyLabel,
+}: {
+  queueId: string
+  item: RepairQueueItem
+  onApply?: (rowId: string) => void
+  applyLabel: string
+}) {
+  const hasReferent = item.currentValue !== null || item.suggestedValue !== null
+  const enabled = onApply !== undefined && hasReferent
+  const reason = onApply === undefined ? NO_AUTHORITY_ITEM : NO_REFERENT_ITEM
+  return (
+    <button
+      type="button"
+      data-testid={`repair-queue-v2-${queueId}-item-${item.rowId}-apply`}
+      disabled={!enabled}
+      onClick={enabled ? () => onApply!(item.rowId) : undefined}
+      title={enabled ? undefined : reason}
+      aria-label={enabled ? `${applyLabel} ${item.label}` : `${item.label} — ${reason}`}
+      className={`${typography.buttonSmall} border border-panel-border rounded px-2 py-0.5 ${
+        enabled ? 'text-text-header hover:bg-panel-hover' : 'text-text-light cursor-not-allowed'
+      }`}
+    >
+      {enabled ? applyLabel : 'Apply'}
+    </button>
+  )
+}
 
 /** The label/value cells, identical in both groups so one item reads one way. */
 function ItemCells({
@@ -210,30 +269,18 @@ export function RepairQueueList({
               <ItemCells queueId={q} item={item} onFocusOnCanvas={onFocusOnCanvas} />
 
               {/*
-                ⚠ ONE BUTTON, TWO HONEST STATES — never a third that pretends.
-                With a carrier it resolves the item; without one it is disabled
-                and says why. It never renders enabled-but-inert, which is the
-                shape that would let the queue report a success it never had.
+                ⚠ THIS COMMENT PREVIOUSLY CLAIMED "it never renders
+                enabled-but-inert". THAT WAS FALSE when written: it gated on the
+                carrier alone, so an item with no value rendered an ENABLED
+                Confirm that wrote nothing. The claim is now true, and it is true
+                because `ApplyControl` gates on the ITEM as well — see its header.
               */}
-              <button
-                type="button"
-                data-testid={`repair-queue-v2-${q}-item-${item.rowId}-apply`}
-                disabled={onApply === undefined}
-                onClick={onApply === undefined ? undefined : () => onApply(item.rowId)}
-                title={onApply === undefined ? NO_AUTHORITY_ITEM : undefined}
-                aria-label={
-                  onApply === undefined
-                    ? `${item.label} — ${NO_AUTHORITY_ITEM}`
-                    : `${applyLabel} ${item.label}`
-                }
-                className={`${typography.buttonSmall} border border-panel-border rounded px-2 py-0.5 ${
-                  onApply === undefined
-                    ? 'text-text-light cursor-not-allowed'
-                    : 'text-text-header hover:bg-panel-hover'
-                }`}
-              >
-                {onApply === undefined ? 'Apply' : applyLabel}
-              </button>
+              <ApplyControl
+                queueId={q}
+                item={item}
+                onApply={onApply}
+                applyLabel={applyLabel}
+              />
 
               {/*
                 The user's other legitimate answer. It sits beside Apply, not

--- a/src/canvas/model-tab-v2/__tests__/ModelRowView.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/ModelRowView.spec.tsx
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { ModelRowView } from '../ModelRowView'
 import type { ModelRow } from '../types'
 
@@ -41,6 +41,55 @@ describe('ModelRowView — renders the model, never its own opinion of it', () =
     expect(screen.getByTestId('model-row-v2-f1-label')).toHaveTextContent('Win rate')
     // Not "0.4" — the producer decided how this reads; the row does not re-derive it.
     expect(screen.getByTestId('model-row-v2-f1-value')).toHaveTextContent('0.40')
+  })
+})
+
+describe('⭐ Confirm ✓ is offered by the ATTENTION REASON alone — no second value guard', () => {
+  /*
+   * ⚠⚠ THIS EXISTS BECAUSE A MUTANT BIT ONLY A SOURCE SCAN (measured, 19 Aug
+   * 2026). Re-adding `&& row.primaryValue !== null` here failed exactly ONE
+   * assertion — the textual guard saying the competitor is gone — and NOTHING
+   * behavioural. A scan proves the line is absent; only a render proves the
+   * chip appears on the row that needs it (trap 13b — presence of a control is
+   * not coverage of the branch).
+   *
+   * The row below is the wire-real shape the old guard hid: a capped factor
+   * carrying `observedState.value` and NO `raw_value`, so it has a value to
+   * CONFIRM and none to DISPLAY. `primaryValue` is null and the chip must still
+   * render, because the write authority accepts it.
+   */
+  it('⚠ renders Confirm on a row with a confirmable value and NO displayable one', () => {
+    const onConfirmValueAsIs = vi.fn()
+    render(
+      <ModelRowView
+        row={row({
+          id: 'f_model_scale',
+          primaryValue: null,
+          attention: ['no-value', 'unconfirmed-estimate'],
+        })}
+        tier="plain"
+        onConfirmValueAsIs={onConfirmValueAsIs}
+      />,
+    )
+    // Bound by IDENTITY — the testid carries the row id, so a sibling row's
+    // chip cannot satisfy this (trap 19).
+    const chip = screen.getByTestId('model-row-v2-f_model_scale-confirm-as-is')
+    expect(chip).toBeInTheDocument()
+    fireEvent.click(chip)
+    expect(onConfirmValueAsIs).toHaveBeenCalledWith('f_model_scale')
+  })
+
+  it('⚠ DISCRIMINATING TWIN — a row WITHOUT the reason gets no chip, same props', () => {
+    // Without this, the assertion above would be satisfied by a chip that
+    // renders unconditionally. The two rows differ in exactly one field.
+    render(
+      <ModelRowView
+        row={row({ id: 'f_confirmed', primaryValue: null, attention: ['no-value'] })}
+        tier="plain"
+        onConfirmValueAsIs={vi.fn()}
+      />,
+    )
+    expect(screen.queryByTestId('model-row-v2-f_confirmed-confirm-as-is')).toBeNull()
   })
 })
 

--- a/src/canvas/model-tab-v2/__tests__/RepairQueueDeferral.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/RepairQueueDeferral.spec.tsx
@@ -22,13 +22,15 @@ import { render, screen } from '@testing-library/react'
 import { RepairQueueList } from '../RepairQueueList'
 import { ModelRowView } from '../ModelRowView'
 import type { DeferralRecord, ModelRow, RepairQueue, RepairQueueItem } from '../types'
+import { REPAIR_QUEUE } from '../rowPresentation'
 
-const QUEUE: RepairQueue = {
-  id: 'confirm-estimates',
-  reason: 'unconfirmed-estimate',
-  title: 'Confirm estimates',
-  supportsApplyAll: true,
-}
+/**
+ * ⚠ THE SHIPPED OBJECT, NOT A LOCAL COPY (F6). `REPAIR_QUEUE` was introduced as
+ * the one definitions table and then became a THIRD copy, because both render
+ * specs kept declaring their own — so the object the product renders was never
+ * exercised by the tests that claim to cover this component.
+ */
+const QUEUE: RepairQueue = REPAIR_QUEUE['confirm-estimates']
 
 const PAUL: DeferralRecord = { by: 'Paul', at: '2026-08-16T10:30:00.000Z' }
 

--- a/src/canvas/model-tab-v2/__tests__/RepairQueueList.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/RepairQueueList.spec.tsx
@@ -12,13 +12,15 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { RepairQueueList } from '../RepairQueueList'
 import type { RepairQueue, RepairQueueItem } from '../types'
+import { REPAIR_QUEUE } from '../rowPresentation'
 
-const QUEUE: RepairQueue = {
-  id: 'confirm-estimates',
-  reason: 'unconfirmed-estimate',
-  title: 'Confirm estimates',
-  supportsApplyAll: true,
-}
+/**
+ * ⚠ THE SHIPPED OBJECT, NOT A LOCAL COPY (F6). `REPAIR_QUEUE` was introduced as
+ * the one definitions table and then became a THIRD copy, because both render
+ * specs kept declaring their own — so the object the product renders was never
+ * exercised by the tests that claim to cover this component.
+ */
+const QUEUE: RepairQueue = REPAIR_QUEUE['confirm-estimates']
 
 function item(rowId: string, over: Partial<RepairQueueItem> = {}): RepairQueueItem {
   return {
@@ -158,5 +160,85 @@ describe('RepairQueueList — navigation is ID-addressed and safe today', () => 
     )
     fireEvent.click(screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-f2-label`))
     expect(onFocusOnCanvas).toHaveBeenCalledWith('f2')
+  })
+})
+
+// ── F2: the control is fail-closed on the ITEM, not only on the carrier ──────
+
+describe('⭐ Apply is offered only when there is something to act on (F2, P8)', () => {
+  const onApply = vi.fn()
+
+  function applyBtn(rowId: string) {
+    return screen.getByTestId(`repair-queue-v2-${QUEUE.id}-item-${rowId}-apply`)
+  }
+
+  it('an item with NEITHER a current nor a suggested value gets a DISABLED Apply', () => {
+    // The live shape: `factorNeedsVerification` admitted factors with no
+    // `observedState`, the row read "No value set", and Confirm was ENABLED and
+    // wrote nothing — the authority fails closed and both call sites discard the
+    // outcome, so the failure was silent.
+    render(
+      <RepairQueueList
+        queue={QUEUE}
+        items={[item('empty', { currentValue: null, suggestedValue: null })]}
+        onApply={onApply}
+      />,
+    )
+    expect(applyBtn('empty')).toBeDisabled()
+    fireEvent.click(applyBtn('empty'))
+    expect(onApply).not.toHaveBeenCalled()
+  })
+
+  it('CONTRAST CONTROL: an item WITH a current value is enabled, same render', () => {
+    // Bound by id and asserted in the same run, so the disable above is about
+    // that item and not about `onApply` being ignored altogether.
+    render(
+      <RepairQueueList
+        queue={QUEUE}
+        items={[
+          item('empty', { currentValue: null, suggestedValue: null }),
+          item('valued'),
+        ]}
+        onApply={onApply}
+      />,
+    )
+    expect(applyBtn('empty')).toBeDisabled()
+    expect(applyBtn('valued')).toBeEnabled()
+  })
+
+  it('⭐ CONTRAST CONTROL: a SUGGESTED value alone is enough — Queue A still works', () => {
+    // The predicate is deliberately the weaker, general one. `set-option-values`
+    // items legitimately have `currentValue === null` and carry a suggestion; a
+    // gate copied from the confirm queue's membership rule would have silently
+    // disabled Queue A before it was ever mounted.
+    render(
+      <RepairQueueList
+        queue={QUEUE}
+        items={[item('suggested', { currentValue: null, suggestedValue: '30 days' })]}
+        onApply={onApply}
+      />,
+    )
+    expect(applyBtn('suggested')).toBeEnabled()
+  })
+
+  it('the two refusals read differently — "no carrier" is not "no value"', () => {
+    // Telling a user their row awaits a carrier, when in fact it has no value to
+    // act on, sends them to wait for something that will not help them.
+    const { unmount } = render(
+      <RepairQueueList queue={QUEUE} items={[item('a')]} />,
+    )
+    const noCarrier = applyBtn('a').getAttribute('title')
+    unmount()
+    render(
+      <RepairQueueList
+        queue={QUEUE}
+        items={[item('a', { currentValue: null, suggestedValue: null })]}
+        onApply={onApply}
+      />,
+    )
+    const noReferent = applyBtn('a').getAttribute('title')
+    expect(noCarrier).toBeTruthy()
+    expect(noReferent).toBeTruthy()
+    expect(noCarrier).not.toBe(noReferent)
   })
 })

--- a/src/canvas/model-tab-v2/__tests__/adapters.spec.ts
+++ b/src/canvas/model-tab-v2/__tests__/adapters.spec.ts
@@ -412,10 +412,26 @@ describe('toRepairQueueItems — each queue derives from the same predicate as i
     optionNode('o2', 'Mapped', { f1: 30 }),
   ]
 
-  it('confirm-estimates returns exactly the unconfirmed factors, in order', () => {
+  it('confirm-estimates returns exactly the unconfirmed factors THAT HAVE A VALUE', () => {
     const items = toRepairQueueItems(input({ nodes }), 'confirm-estimates')
-    // f3 has no source either, so it is also unconfirmed — identity, not count.
-    expect(items.map(i => i.rowId)).toEqual(['f1', 'f3'])
+    /*
+     * ⚠⚠ THIS EXPECTATION USED TO BE `['f1', 'f3']`, AND THE COMMENT BESIDE IT
+     * EXPLAINED WHY: "f3 has no source either, so it is also unconfirmed". That
+     * reading of the predicate was correct and the RESULT was a defect (F2).
+     *
+     * `f3` has NO value at all. In the queue it rendered as "No value set" with
+     * an enabled Confirm beside it — asking the user to endorse nothing, which
+     * the authority then refuses, writing nothing and returning an outcome both
+     * call sites discard. A live button, a silent no-op (preamble P8). The
+     * outline's row chip already refused exactly this case.
+     *
+     * `f3` is not dropped: it is in `no-value`, asserted immediately below, and
+     * that is the repair it actually needs. It was previously in BOTH queues —
+     * two contradictory instructions about one factor.
+     *
+     * Identity, not count: `f1` specifically, and `f3` specifically absent.
+     */
+    expect(items.map(i => i.rowId)).toEqual(['f1'])
   })
 
   it('no-value returns exactly the factors with nothing set', () => {

--- a/src/canvas/model-tab-v2/__tests__/adapters.spec.ts
+++ b/src/canvas/model-tab-v2/__tests__/adapters.spec.ts
@@ -21,7 +21,7 @@ import type { EdgeData } from '../../domain/edges'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { countFactorsToVerify } from '../../components/model-tab/utils'
-import { factorNeedsVerification } from '../../domain/valueProvenance'
+import { factorIsConfirmable, factorNeedsVerification } from '../../domain/valueProvenance'
 import {
   edgeIsContested,
   nodeKind,
@@ -68,8 +68,19 @@ function input(over: Partial<ModelProjectionInput> = {}): ModelProjectionInput {
   return { nodes: [], edges: [], goalThreshold: null, ...over }
 }
 
-/** A factor whose value the user has confirmed — the "no attention" baseline. */
-const CONFIRMED_OBS = { raw_value: 45, unit: 'days', source: 'user_confirmed' }
+/**
+ * A factor whose value the user has confirmed — the "no attention" baseline.
+ *
+ * ⚠ IT CARRIES `value` AS WELL AS `raw_value`, because the producer does and
+ * this fixture previously did not (corrected 19 Aug 2026). `setObservedValue`
+ * writes both, and for an UNCAPPED factor CEE stores them identically
+ * (`conversation/factorValueEdit.ts:138-142`, staging-witnessed
+ * `{value: 40000, unit: '£', raw_value: 40000}`). A `raw_value`-only factor is
+ * outside the producer's output domain — a fixture the author invented — and it
+ * silently exercised the branch where the write authority REFUSES
+ * (trap 16-inverse: a fixture you wrote yourself is not evidence about the wire).
+ */
+const CONFIRMED_OBS = { value: 45, raw_value: 45, unit: 'days', source: 'user_confirmed' }
 
 // ── Kind and grouping ────────────────────────────────────────────────────────
 
@@ -141,7 +152,7 @@ describe('toModelRows — factor values and attention', () => {
     const rows = toModelRows(
       input({
         nodes: [
-          factorNode('f1', 'AI', { raw_value: 45, unit: 'days', source: 'cee_inference' }),
+          factorNode('f1', 'AI', { value: 45, raw_value: 45, unit: 'days', source: 'cee_inference' }),
           factorNode('f2', 'Confirmed', CONFIRMED_OBS),
         ],
       }),
@@ -184,32 +195,43 @@ describe('⭐ ONE definition of "needs verification", and the count delegates to
    * snake_case wire spelling and a factor with no observed state at all.
    */
   const CORPUS: Node[] = [
-    factorNode('a', 'no source', { raw_value: 1 }),
-    factorNode('b', 'cee_inference', { raw_value: 1, source: 'cee_inference' }),
-    factorNode('c', 'user', { raw_value: 1, source: 'user' }),
-    factorNode('d', 'user_confirmed', { raw_value: 1, source: 'user_confirmed' }),
-    factorNode('e', 'brief', { raw_value: 1, source: 'brief_extraction' }),
+    factorNode('a', 'no source', { value: 1, raw_value: 1 }),
+    factorNode('b', 'cee_inference', { value: 1, raw_value: 1, source: 'cee_inference' }),
+    factorNode('c', 'user', { value: 1, raw_value: 1, source: 'user' }),
+    factorNode('d', 'user_confirmed', { value: 1, raw_value: 1, source: 'user_confirmed' }),
+    factorNode('e', 'brief', { value: 1, raw_value: 1, source: 'brief_extraction' }),
     factorNode('f', 'no observed state', null),
     {
       id: 'g',
       type: 'factor',
       position: { x: 0, y: 0 },
       // The WIRE spelling. Reading only camelCase here would under-count.
-      data: { label: 'snake_case', type: 'factor', observed_state: { raw_value: 1, source: 'cee_inference' } },
+      data: {
+        label: 'snake_case',
+        type: 'factor',
+        observed_state: { value: 1, raw_value: 1, source: 'cee_inference' },
+      },
     },
   ]
 
-  it('the badge COUNT is the domain predicate applied N times — it holds no copy', () => {
-    // Still worth asserting after the move: it goes RED the day
-    // `countFactorsToVerify` grows its own inline predicate back.
-    const viaPredicate = CORPUS.filter(n => factorNeedsVerification(n.data)).length
+  it('the badge COUNT is `factorIsConfirmable` applied N times — it holds no copy', () => {
+    // ⚠ NARROWED 19 Aug 2026, AND THE NARROWING IS THE POINT. The count used to
+    // delegate to the BARE `factorNeedsVerification`, which counts a factor with
+    // NOTHING TO CONFIRM — a number the user cannot drive to zero and a Confirm
+    // the write authority declines. The full question ("needs verification AND
+    // has a ratifiable value") now lives once, in `domain/valueProvenance`.
+    const viaPredicate = CORPUS.filter(n => factorIsConfirmable(n.data)).length
     expect(countFactorsToVerify(CORPUS)).toBe(viaPredicate)
-    // ⚠ AND THE COUNT IS NOT TRIVIAL. Without this the line above would pass on
-    // a corpus where nothing needs verification, i.e. on two functions that both
-    // return false for everything (trap 13 — an absence assertion needs a
-    // positive control).
+    // ⚠ AND THE COUNT IS NOT TRIVIAL — otherwise the line above would pass on
+    // two functions that both return false for everything (trap 13).
     expect(viaPredicate).toBeGreaterThan(0)
     expect(viaPredicate).toBeLessThan(CORPUS.length)
+    // ⚠ AND IT IS GENUINELY NARROWER THAN THE BARE PREDICATE ON THIS CORPUS. `f`
+    // has no observed state at all: unverified, and nothing to verify. Without
+    // this the delegation above would be satisfied by re-widening the count.
+    expect(countFactorsToVerify(CORPUS)).toBeLessThan(
+      CORPUS.filter(n => factorNeedsVerification(n.data)).length,
+    )
   })
 
   it('⭐ the predicate is DEFINED exactly once in the tree — the mirror is gone, not relocated', () => {
@@ -377,7 +399,7 @@ describe('⭐ the projection tracks the store — and only where it should', () 
         nodes: [
           factorNode('f1', 'Sales cycle', { raw_value: 45, unit: 'days', source: 'user_confirmed' }),
           // f2 changed in both value and label.
-          factorNode('f2', 'Renamed', { raw_value: 99, unit: '%', source: 'cee_inference' }),
+          factorNode('f2', 'Renamed', { value: 99, raw_value: 99, unit: '%', source: 'cee_inference' }),
         ],
       }),
     ).find(r => r.id === 'f1')!
@@ -392,7 +414,7 @@ describe('⭐ the projection tracks the store — and only where it should', () 
       input({
         nodes: [
           factorNode('f1', 'Sales cycle', { raw_value: 45, unit: 'days', source: 'user_confirmed' }),
-          factorNode('f2', 'Renamed', { raw_value: 99, unit: '%', source: 'cee_inference' }),
+          factorNode('f2', 'Renamed', { value: 99, raw_value: 99, unit: '%', source: 'cee_inference' }),
         ],
       }),
     ).find(r => r.id === 'f2')!
@@ -405,9 +427,12 @@ describe('⭐ the projection tracks the store — and only where it should', () 
 
 describe('toRepairQueueItems — each queue derives from the same predicate as its chip', () => {
   const nodes = [
-    factorNode('f1', 'Unconfirmed', { raw_value: 45, unit: 'days', source: 'cee_inference' }),
+    factorNode('f1', 'Unconfirmed', { value: 45, raw_value: 45, unit: 'days', source: 'cee_inference' }),
     factorNode('f2', 'Confirmed', CONFIRMED_OBS),
     factorNode('f3', 'No value', null),
+    // ⚠ THE WIRE SHAPE A `raw_value` GUARD DROPS: model scale only, no
+    // `raw_value`. Confirmable — the write authority accepts it.
+    factorNode('f4', 'Model scale only', { value: 0.7, source: 'cee_inference' }),
     optionNode('o1', 'Unmapped'),
     optionNode('o2', 'Mapped', { f1: 30 }),
   ]
@@ -426,17 +451,37 @@ describe('toRepairQueueItems — each queue derives from the same predicate as i
      * outline's row chip already refused exactly this case.
      *
      * `f3` is not dropped: it is in `no-value`, asserted immediately below, and
-     * that is the repair it actually needs. It was previously in BOTH queues —
-     * two contradictory instructions about one factor.
+     * that is the repair it actually needs.
      *
-     * Identity, not count: `f1` specifically, and `f3` specifically absent.
+     * ⚠⚠ AND THE VALUE GUARD IS `observedState.value`, NOT `raw_value`
+     * (corrected 19 Aug 2026). The first fix for F2 wrote
+     * `factorValue(n.data) !== null` — `getPrimaryValue`, which reads `raw_value`
+     * only — and so closed the over-count while opening an UNDER-count: `f4`
+     * below is a capped factor off the wire carrying `{value}` and NO
+     * `raw_value` (`conversation/factorValueEdit.ts:145`, staging-witnessed). It
+     * is confirmable, the write authority accepts it, and it had silently
+     * dropped out of this queue and lost its chip. The predicate is now the
+     * authority's own condition (`factorIsConfirmable`), so neither direction
+     * can drift.
+     *
+     * ⚠ `f4` IS IN BOTH QUEUES, AND THAT IS CORRECT. It has a value to CONFIRM
+     * and no value to DISPLAY — two different questions with two different
+     * predicates (trap 21). An earlier comment here claimed this fix closed a
+     * both-queues duplication outright; that was an over-read, corrected rather
+     * than quietly left standing.
+     *
+     * Identity, not count: `f1` and `f4` specifically, `f3` specifically absent.
      */
-    expect(items.map(i => i.rowId)).toEqual(['f1'])
+    expect(items.map(i => i.rowId)).toEqual(['f1', 'f4'])
   })
 
-  it('no-value returns exactly the factors with nothing set', () => {
+  it('no-value returns exactly the factors with nothing DISPLAYABLE set', () => {
     const items = toRepairQueueItems(input({ nodes }), 'no-value')
-    expect(items.map(i => i.rowId)).toEqual(['f3'])
+    // `f4` is here as well as in `confirm-estimates`: nothing to show, something
+    // to ratify. The two queues answer different questions and keep different
+    // predicates — asserted by identity so a later "reconciliation" of the two
+    // goes red instead of silently collapsing them.
+    expect(items.map(i => i.rowId)).toEqual(['f3', 'f4'])
   })
 
   it('set-option-values returns exactly the options that change nothing', () => {

--- a/src/canvas/model-tab-v2/__tests__/adaptersStopSpeakingInWireTokens.spec.ts
+++ b/src/canvas/model-tab-v2/__tests__/adaptersStopSpeakingInWireTokens.spec.ts
@@ -45,6 +45,14 @@ import { UNNAMED_ELEMENT_LABEL } from '../../domain/canvasLabels'
 
 const RAW_ID = 'fac_uk_arr_retention'
 
+/**
+ * ⚠ CONFIRM-QUEUE FIXTURES CARRY `raw_value`, AND THAT IS NOT DECORATION.
+ * `getPrimaryValue` (the live displayed-value rule) returns `null` without it,
+ * so a factor lacking it shows "No value set" and is — correctly — not a
+ * confirmation candidate. A fixture without `raw_value` would silently test the
+ * empty queue while appearing to test a populated one.
+ */
+
 function factorNode(id: string, label: unknown, observedState?: Record<string, unknown>): Node {
   return {
     id,
@@ -105,7 +113,7 @@ describe('the canonical editor names elements in the user’s words, never by wi
 
   it('repair-queue items name their element the same way — all three producers', () => {
     // Bound by rowId, so each assertion is about the element it names.
-    const unverified = factorNode(RAW_ID, undefined, { value: 0.4, source: 'cee_inference' })
+    const unverified = factorNode(RAW_ID, undefined, { value: 0.4, raw_value: 40, source: 'cee_inference' })
     const confirm = toRepairQueueItems(project([unverified]), 'confirm-estimates')
     expect(confirm.map(i => i.rowId)).toContain(RAW_ID)
     expect(confirm.find(i => i.rowId === RAW_ID)!.label).toBe(UNNAMED_ELEMENT_LABEL)
@@ -122,7 +130,7 @@ describe('the canonical editor names elements in the user’s words, never by wi
 
     // CONTRAST CONTROL, same shape, same run: a labelled element reads its label.
     const named = toRepairQueueItems(
-      project([factorNode(RAW_ID, 'UK ARR retention', { value: 0.4, source: 'cee_inference' })]),
+      project([factorNode(RAW_ID, 'UK ARR retention', { value: 0.4, raw_value: 40, source: 'cee_inference' })]),
       'confirm-estimates',
     )
     expect(named.find(i => i.rowId === RAW_ID)!.label).toBe('UK ARR retention')
@@ -134,7 +142,7 @@ describe('the canonical editor names elements in the user’s words, never by wi
 describe('provenance reaches the user as a label, never as the wire token', () => {
   it('the confirm queue’s basis reads "AI estimate", not "cee_inference"', () => {
     const items = toRepairQueueItems(
-      project([factorNode(RAW_ID, 'UK ARR retention', { value: 0.4, source: 'cee_inference' })]),
+      project([factorNode(RAW_ID, 'UK ARR retention', { value: 0.4, raw_value: 40, source: 'cee_inference' })]),
       'confirm-estimates',
     )
     const basis = items.find(i => i.rowId === RAW_ID)!.basis
@@ -142,6 +150,83 @@ describe('provenance reaches the user as a label, never as the wire token', () =
     expect(basis).toBe('Source: AI estimate')
     // Absent: the enum. Beside the presence, so it cannot pass on null.
     expect(basis).not.toContain('cee_inference')
+  })
+
+  it('⭐ F1 — the NODE DETAIL pane reads the label too, not just the queue', () => {
+    /*
+     * The instance the previous commit MISSED while announcing the class fixed.
+     * `toRowDetail`'s node branch carried the identical expression 82 lines
+     * below the one that was repaired, and it renders at
+     * `ModelDetailRegion.tsx:250-263` under "Where it came from" — DIRECTLY
+     * BENEATH the `SourceProvenancePill` humanising the same field. The panel
+     * said both.
+     */
+    const node = factorNode(RAW_ID, 'UK ARR retention', { value: 0.4, raw_value: 40, source: 'cee_inference' })
+    const detail = toRowDetail(project([node]), RAW_ID)
+    expect(detail, 'no detail projected — the fixture is wrong, not the code').not.toBeNull()
+    expect(detail!.basis).toBe('Source: AI estimate')
+    expect(detail!.basis).not.toContain('cee_inference')
+  })
+
+  it('⭐ the detail pane and the queue agree — the same node, the same words', () => {
+    /*
+     * The contrast control that makes the pin above about the CLASS rather than
+     * one call site. Two independent producers, one node, one sentence: if a
+     * future change repairs one and not the other, this fails where a
+     * single-path assertion would not.
+     */
+    const node = factorNode(RAW_ID, 'UK ARR retention', { value: 0.4, raw_value: 40, source: 'cee_inference' })
+    const input = project([node])
+    const fromDetail = toRowDetail(input, RAW_ID)!.basis
+    const fromQueue = toRepairQueueItems(input, 'confirm-estimates').find(
+      i => i.rowId === RAW_ID,
+    )!.basis
+    expect(fromDetail).toBe(fromQueue)
+    // …and non-null, so the equality above cannot be satisfied by two nulls.
+    expect(fromDetail).toBe('Source: AI estimate')
+  })
+})
+
+// ── 2b. F2 — a factor with no value is not a confirmation candidate ──────────
+
+describe('a factor with NO VALUE cannot be confirmed, and is not offered as if it could', () => {
+  const VALUELESS = 'fac_no_value_yet'
+
+  it('⭐ it is ABSENT from confirm-estimates — confirming endorses nothing', () => {
+    // `factorNeedsVerification` is `!source || source === 'cee_inference'`, which
+    // a factor with no `observedState` at all satisfies. It was entering this
+    // queue and rendering an enabled Confirm over "No value set" (P8).
+    const input = project([factorNode(VALUELESS, 'Churn rate')])
+    expect(toRepairQueueItems(input, 'confirm-estimates').map(i => i.rowId)).not.toContain(
+      VALUELESS,
+    )
+  })
+
+  it('CONTRAST CONTROL: it is still surfaced — in the queue that describes it', () => {
+    // The absence above must be a re-homing, not a drop. Without this the fix
+    // could have been "filter it out everywhere" and the gap would vanish.
+    const input = project([factorNode(VALUELESS, 'Churn rate')])
+    expect(toRepairQueueItems(input, 'no-value').map(i => i.rowId)).toContain(VALUELESS)
+  })
+
+  it('CONTRAST CONTROL: a factor WITH a value is still a confirmation candidate', () => {
+    // The discriminating half — proves the new conjunct did not empty the queue.
+    const input = project([
+      factorNode(RAW_ID, 'UK ARR retention', { value: 0.4, raw_value: 40, source: 'cee_inference' }),
+    ])
+    expect(toRepairQueueItems(input, 'confirm-estimates').map(i => i.rowId)).toContain(RAW_ID)
+  })
+
+  it('⭐ it no longer stands in TWO queues at once', () => {
+    // It satisfied both predicates, so it was simultaneously "confirm this
+    // estimate" and "this has no value" — two contradictory instructions about
+    // one factor.
+    const input = project([factorNode(VALUELESS, 'Churn rate')])
+    const inConfirm = toRepairQueueItems(input, 'confirm-estimates').some(
+      i => i.rowId === VALUELESS,
+    )
+    const inNoValue = toRepairQueueItems(input, 'no-value').some(i => i.rowId === VALUELESS)
+    expect([inConfirm, inNoValue]).toEqual([false, true])
   })
 })
 
@@ -159,9 +244,23 @@ describe('an edge states a source only when it HAS one', () => {
     }
   })
 
-  it('CONTRAST CONTROL: a real evidence provenance IS stated', () => {
-    // The discriminating half. Without it, the gate could be a hard `null` and
-    // every assertion above would still pass.
+  it('CONTRAST CONTROL: a real evidence provenance IS stated — VERBATIM, and that is the honest limit', () => {
+    /*
+     * ⚠ F4 — THIS PINS A WIRE-ISH TOKEN AS EXPECTED OUTPUT, DELIBERATELY, AND
+     * THAT IS A NARROWER PROPERTY THAN THIS FILE'S §2 HEADING CLAIMS.
+     *
+     * What was ported from v1 is the GATE (evidence vs placeholder), not a
+     * vocabulary. A factor's `source` is a closed enum with a classifier; an
+     * edge's `provenance` is `z.string().max(100)` (`edges.ts:198`) with no
+     * classifier anywhere in the estate. So an evidence provenance reaches the
+     * user verbatim — v1's behaviour, preserved on purpose.
+     *
+     * Recorded rather than quietly asserted, because "the canonical editor never
+     * shows a wire token" is TRUE of factor provenance and NOT YET TRUE of edge
+     * provenance, and a reader who takes the heading at face value would be
+     * wrong. Closing it needs an edge-provenance vocabulary — a product
+     * decision, not a scan fix.
+     */
     const input = project(nodes, [edgeBetween({ provenance: 'customer_interviews' })])
     expect(toRowDetail(input, 'e1')!.basis).toBe('Source: customer_interviews')
   })

--- a/src/canvas/model-tab-v2/__tests__/adaptersStopSpeakingInWireTokens.spec.ts
+++ b/src/canvas/model-tab-v2/__tests__/adaptersStopSpeakingInWireTokens.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * THE CANONICAL EDITOR STOPS SPEAKING IN WIRE TOKENS — and stops laundering a
+ * default it never measured (18 Aug 2026, the REHOME → DELETE lane).
+ *
+ * ## Why these four, together
+ *
+ * The consolidation's acceptance conditions include *"relationships readable in
+ * plain English"* and *"no raw ids shown to the user"*. Deriving them at the
+ * bytes found the CANONICAL editor — the one that survives — failing all four
+ * of the following, while the DUPLICATE it replaces got each of them right.
+ * Deleting the duplicate first would have made every one of them permanent.
+ *
+ *   1. NODE ROWS AND REPAIR-QUEUE ITEMS NAMED THE USER'S ELEMENTS BY WIRE ID.
+ *      `typeof data?.label === 'string' ? data.label : node.id` — four sites.
+ *      ⭐ The directory's own raw-id scan certified it at ZERO, because that
+ *      scan matched `??` and this is a TERNARY. Measured against the pristine
+ *      file: `??` shape 0, ternary shape 4. The guard had the code's blind spot.
+ *   2. `Source: cee_inference` WAS RENDERED AS BODY COPY. v1 never showed the
+ *      enum: `SourceProvenancePill` renders `mapSourceToDisplay` ("AI
+ *      estimate") and the raw token lives only in a `title`.
+ *   3. EDGE PROVENANCE WAS UNGATED. v1 prints a source only when it is
+ *      EVIDENCE (`RelationshipsSection.tsx:213`); `assumption` / `template` /
+ *      `ai-suggested` are placeholders, and "Source: assumption" announces a
+ *      basis that does not exist.
+ *   4. THE ADVANCED EDGE PARAMETERS READ RAW, AND ONE READ THE WRONG FIELD.
+ *      Unstamped `strengthStd` is `USER_EDGE_DEFAULTS.strengthStd = 0.15` — the
+ *      exact default v1 suppresses under ROADMAP 2.296 C4 — and the likelihood
+ *      row read `exists_probability` while every write in the product lands on
+ *      `beliefExists` (`useInspectorMutations.ts:429-435`).
+ *
+ * ## Binding
+ *
+ * Every absence assertion carries a CONTRAST CONTROL that must read non-zero in
+ * the same test — an absence alone is satisfiable by projecting nothing. Values
+ * are bound to their row BY ID, never by a value predicate another row could
+ * satisfy.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { Edge, Node } from '@xyflow/react'
+import { toModelRows, toRepairQueueItems, toRowDetail, type ModelProjectionInput } from '../adapters'
+import { UNNAMED_ELEMENT_LABEL } from '../../domain/canvasLabels'
+
+// ── Fixtures, shaped like the producer ───────────────────────────────────────
+
+const RAW_ID = 'fac_uk_arr_retention'
+
+function factorNode(id: string, label: unknown, observedState?: Record<string, unknown>): Node {
+  return {
+    id,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { ...(label === undefined ? {} : { label }), type: 'factor', observedState },
+  } as unknown as Node
+}
+
+function optionNode(id: string, label: unknown): Node {
+  return {
+    id,
+    type: 'option',
+    position: { x: 0, y: 0 },
+    data: { ...(label === undefined ? {} : { label }), type: 'option' },
+  } as unknown as Node
+}
+
+function edgeBetween(data: Record<string, unknown>): Edge {
+  return { id: 'e1', source: 'a', target: 'b', data } as unknown as Edge
+}
+
+function project(nodes: Node[], edges: Edge[] = []): ModelProjectionInput {
+  return { nodes, edges: edges as never, goalThreshold: null }
+}
+
+function rowById(input: ModelProjectionInput, id: string) {
+  const row = toModelRows(input).find(r => r.id === id)
+  expect(row, `no row projected for ${id} — the fixture is wrong, not the code`).toBeDefined()
+  return row!
+}
+
+// ── 1. Element names ─────────────────────────────────────────────────────────
+
+describe('the canonical editor names elements in the user’s words, never by wire id', () => {
+  it('a factor with no label renders the unnamed placeholder — NOT its id', () => {
+    const row = rowById(project([factorNode(RAW_ID, undefined)]), RAW_ID)
+    // Present: an honest placeholder.
+    expect(row.label).toBe(UNNAMED_ELEMENT_LABEL)
+    // Absent: the identifier. Asserted beside the presence above, so this
+    // cannot pass by projecting nothing.
+    expect(row.label).not.toContain(RAW_ID)
+  })
+
+  it('a factor whose stored label IS id-shaped is still not shown as an id', () => {
+    // The leak one hop upstream: producers sometimes seed `label` from the id.
+    // `resolveCanvasLabel` rejects it; a bare `data.label` read would not.
+    const row = rowById(project([factorNode(RAW_ID, RAW_ID)]), RAW_ID)
+    expect(row.label).toBe(UNNAMED_ELEMENT_LABEL)
+  })
+
+  it('CONTRAST CONTROL: a real label survives verbatim', () => {
+    // Without this, every assertion above is satisfied by returning a constant.
+    expect(rowById(project([factorNode(RAW_ID, 'UK ARR retention')]), RAW_ID).label).toBe(
+      'UK ARR retention',
+    )
+  })
+
+  it('repair-queue items name their element the same way — all three producers', () => {
+    // Bound by rowId, so each assertion is about the element it names.
+    const unverified = factorNode(RAW_ID, undefined, { value: 0.4, source: 'cee_inference' })
+    const confirm = toRepairQueueItems(project([unverified]), 'confirm-estimates')
+    expect(confirm.map(i => i.rowId)).toContain(RAW_ID)
+    expect(confirm.find(i => i.rowId === RAW_ID)!.label).toBe(UNNAMED_ELEMENT_LABEL)
+
+    const valueless = factorNode(RAW_ID, undefined)
+    const noValue = toRepairQueueItems(project([valueless]), 'no-value')
+    expect(noValue.map(i => i.rowId)).toContain(RAW_ID)
+    expect(noValue.find(i => i.rowId === RAW_ID)!.label).toBe(UNNAMED_ELEMENT_LABEL)
+
+    const opt = optionNode('opt_hire_two_aes', undefined)
+    const setValues = toRepairQueueItems(project([opt]), 'set-option-values')
+    expect(setValues.map(i => i.rowId)).toContain('opt_hire_two_aes')
+    expect(setValues.find(i => i.rowId === 'opt_hire_two_aes')!.label).toBe(UNNAMED_ELEMENT_LABEL)
+
+    // CONTRAST CONTROL, same shape, same run: a labelled element reads its label.
+    const named = toRepairQueueItems(
+      project([factorNode(RAW_ID, 'UK ARR retention', { value: 0.4, source: 'cee_inference' })]),
+      'confirm-estimates',
+    )
+    expect(named.find(i => i.rowId === RAW_ID)!.label).toBe('UK ARR retention')
+  })
+})
+
+// ── 2. Provenance is a label, not an enum ────────────────────────────────────
+
+describe('provenance reaches the user as a label, never as the wire token', () => {
+  it('the confirm queue’s basis reads "AI estimate", not "cee_inference"', () => {
+    const items = toRepairQueueItems(
+      project([factorNode(RAW_ID, 'UK ARR retention', { value: 0.4, source: 'cee_inference' })]),
+      'confirm-estimates',
+    )
+    const basis = items.find(i => i.rowId === RAW_ID)!.basis
+    // Present: the classified label — the same policy the pill renders.
+    expect(basis).toBe('Source: AI estimate')
+    // Absent: the enum. Beside the presence, so it cannot pass on null.
+    expect(basis).not.toContain('cee_inference')
+  })
+})
+
+// ── 3. The edge provenance gate ──────────────────────────────────────────────
+
+describe('an edge states a source only when it HAS one', () => {
+  const nodes = [factorNode('a', 'ARR'), factorNode('b', 'Retention')]
+
+  it('a placeholder provenance states nothing — all three non-evidence markers', () => {
+    for (const placeholder of ['assumption', 'template', 'ai-suggested']) {
+      const input = project(nodes, [edgeBetween({ provenance: placeholder })])
+      const detail = toRowDetail(input, 'e1')
+      expect(detail, `no detail projected for the ${placeholder} edge`).not.toBeNull()
+      expect(detail!.basis, `"${placeholder}" is a placeholder, not a basis`).toBeNull()
+    }
+  })
+
+  it('CONTRAST CONTROL: a real evidence provenance IS stated', () => {
+    // The discriminating half. Without it, the gate could be a hard `null` and
+    // every assertion above would still pass.
+    const input = project(nodes, [edgeBetween({ provenance: 'customer_interviews' })])
+    expect(toRowDetail(input, 'e1')!.basis).toBe('Source: customer_interviews')
+  })
+})
+
+// ── 4. Advanced edge parameters: gated, and on the edited field ──────────────
+
+describe('the advanced edge parameters never launder a default', () => {
+  const nodes = [factorNode('a', 'ARR'), factorNode('b', 'Retention')]
+
+  function advanced(data: Record<string, unknown>) {
+    const detail = toRowDetail(project(nodes, [edgeBetween(data)]), 'e1')
+    expect(detail, 'no detail projected — the fixture is wrong, not the code').not.toBeNull()
+    const out = new Map<string, string | null>()
+    for (const p of detail!.advancedParameters) out.set(p.label, p.value)
+    return out
+  }
+
+  it('an UNSTAMPED strengthStd is withheld — 0.15 is the default, not a measurement', () => {
+    // USER_EDGE_DEFAULTS.strengthStd. Printing it asserts an uncertainty
+    // nobody computed (ROADMAP 2.296 C4).
+    expect(advanced({ strengthStd: 0.15 }).get('Std')).toBeNull()
+  })
+
+  it('CONTRAST CONTROL: a STAMPED strengthStd is shown', () => {
+    // Same field, same value, one stamp different — so the assertion above is
+    // about provenance and not about the number being unreachable.
+    expect(advanced({ strengthStd: 0.15, strengthStdSource: 'user' }).get('Std')).toBe('0.15')
+  })
+
+  it('the likelihood row reads `beliefExists` — the field every write lands on', () => {
+    // A user who set a likelihood wrote `beliefExists` via `setExistsProbability`.
+    // The read this replaces was `exists_probability`, so their own number was
+    // invisible here.
+    expect(
+      advanced({ beliefExists: 0.8, beliefExistsSource: 'user' }).get('Exists probability'),
+    ).toBe('0.8')
+  })
+
+  it('CONTRAST CONTROL: an unstamped likelihood is withheld, so the row is gated too', () => {
+    expect(advanced({ beliefExists: 0.8 }).get('Exists probability')).toBeNull()
+  })
+
+  it('the Edge ID row still renders — the advanced grid itself is not empty', () => {
+    // Guards the four absences above against a projection that returns no
+    // parameters at all, which would satisfy every one of them.
+    expect(advanced({ strengthStd: 0.15 }).get('Edge ID')).toBe('e1')
+  })
+})

--- a/src/canvas/model-tab-v2/__tests__/confirmEstimatesQueueMounted.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/confirmEstimatesQueueMounted.spec.tsx
@@ -247,3 +247,35 @@ describe('Confirm in the queue commits through the ONE authority', () => {
     expect(screen.getByTestId(`${QUEUE}-item-${UNVERIFIED_A}`)).toBeInTheDocument()
   })
 })
+
+// ── F8: finishing the job must not look like a dead end ─────────────────────
+
+describe('⭐ resolving the LAST item returns you to the outline (F8)', () => {
+  it('does not strand the user in an empty queue', () => {
+    // The chip renders only on a non-zero count, so an empty queue cannot be
+    // ENTERED — only arrived at. Left as it was, the outline stayed replaced by
+    // "Nothing needs attention here." and the chip that would bring it back is
+    // suppressed while a queue is open.
+    const only = [
+      factor(UNVERIFIED_A, 'Sales cycle length', 'cee_inference'),
+      factor(VERIFIED, 'Headcount', 'user_confirmed'),
+    ]
+    renderPanel(only)
+    fireEvent.click(screen.getByTestId(CHIP))
+    fireEvent.click(screen.getByTestId(`${QUEUE}-item-${UNVERIFIED_A}-apply`))
+
+    // The host's re-render — this panel holds no store subscription by design.
+    const fresh = useCanvasStore.getState().nodes as Node[]
+    cleanup()
+    render(<ModelTabV2Panel nodes={fresh} edges={[]} goalThreshold={null} />)
+
+    // The outline is back…
+    expect(screen.getByTestId(`model-row-v2-${UNVERIFIED_A}`)).toBeInTheDocument()
+    // …the queue is gone, and so is the empty-state text that would have been
+    // the only thing on screen.
+    expect(screen.queryByTestId(QUEUE)).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`${QUEUE}-empty`)).not.toBeInTheDocument()
+    // …and there is nothing left to verify, so no chip either.
+    expect(screen.queryByTestId(CHIP)).not.toBeInTheDocument()
+  })
+})

--- a/src/canvas/model-tab-v2/__tests__/confirmEstimatesQueueMounted.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/confirmEstimatesQueueMounted.spec.tsx
@@ -1,0 +1,249 @@
+/**
+ * QUEUE B IS MOUNTED, AND "N TO VERIFY" IS A CONTROL FOR THE FIRST TIME
+ * (18 Aug 2026, the REHOME → DELETE lane).
+ *
+ * ## What changed and why it could change now
+ *
+ * `RepairQueueList` and all four queue producers have existed, correct and
+ * unmounted, since the 16 Aug mount train. They were inert for a stated reason:
+ * applying needed write carriers that did not exist. #777 landed two of them —
+ * `proposeFactorConfirmation` and `proposeOptionIntervention`. So the
+ * confirm-estimates queue is no longer blocked, and mounting what already
+ * exists closes design F2 rather than building new UI for it.
+ *
+ * Today the v1 tab renders a "N to verify" badge that scrolls somewhere. The
+ * queue behind this chip is the first time that number can be acted on.
+ *
+ * ## The invariant this spec exists to protect, above all others
+ *
+ * ⭐ THE QUEUE REPLACES THE OUTLINE; IT NEVER SITS BESIDE IT. Design §5.3: a
+ * queue is *a filtered view of the same outline* — "there is only ever one
+ * rendering of a row". This whole consolidation exists because the Model tab
+ * renders every element twice; a queue rendered alongside the outline would
+ * reproduce that defect INSIDE the fix. So the outline's absence in queue mode
+ * is asserted directly, with a contrast control in the same test.
+ *
+ * ## Binding
+ *
+ * The store is REAL — the sanctioned setter reads the node back out of
+ * `useCanvasStore.getState()` — so Confirm is proven by the MODEL CHANGING, not
+ * by a spy agreeing with itself. Two unverified factors are seeded and only one
+ * is confirmed, so every assertion binds to its node BY ID and a handler wired
+ * to the wrong row fails (trap 19).
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, cleanup, fireEvent, screen } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+
+const sendSystemEvent = vi.fn()
+
+// Trap 12: spread the real module rather than hand-listing its exports.
+vi.mock('../../conversation/ConversationContext', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, useOptionalConversationContext: () => ({ sendSystemEvent }) }
+})
+
+vi.mock('../../utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusEdgeById: vi.fn(),
+}))
+
+import { ModelTabV2Panel } from '../ModelTabV2Panel'
+import { useCanvasStore } from '../../store'
+
+const UNVERIFIED_A = 'fac_sales_cycle_length'
+const UNVERIFIED_B = 'fac_win_rate'
+const VERIFIED = 'fac_headcount'
+
+function factor(id: string, label: string, source: string | undefined): Node {
+  return {
+    id,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: {
+      label,
+      kind: 'factor',
+      observedState: { value: 0.45, raw_value: 45, cap: 100, ...(source ? { source } : {}) },
+    },
+  } as unknown as Node
+}
+
+/** Two unverified factors and one already-confirmed — the discriminating set. */
+function allNodes(): Node[] {
+  return [
+    factor(UNVERIFIED_A, 'Sales cycle length', 'cee_inference'),
+    factor(UNVERIFIED_B, 'Win rate', 'cee_inference'),
+    factor(VERIFIED, 'Headcount', 'user_confirmed'),
+  ]
+}
+
+function storedSource(id: string): unknown {
+  const n = useCanvasStore.getState().nodes.find(x => x.id === id)
+  return (
+    ((n?.data as Record<string, unknown> | undefined)?.observedState as
+      | Record<string, unknown>
+      | undefined)?.source
+  )
+}
+
+function renderPanel(nodes: Node[] = allNodes()) {
+  useCanvasStore.setState({ nodes, edges: [] } as never, false)
+  render(<ModelTabV2Panel nodes={nodes} edges={[]} goalThreshold={null} />)
+}
+
+const CHIP = 'model-tab-v2-chip-confirm-estimates'
+const QUEUE = 'repair-queue-v2-confirm-estimates'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+afterEach(() => cleanup())
+
+// ── The chip ─────────────────────────────────────────────────────────────────
+
+describe('the "N to verify" chip is derived from the queue it opens', () => {
+  it('states the count of unverified factors — two, not three', () => {
+    renderPanel()
+    // Bound to the derivation: three factors are seeded, one is already
+    // confirmed, so a chip reading "3" would mean the chip and the queue
+    // disagree — the exact defect the v1 badge ships.
+    expect(screen.getByTestId(CHIP)).toHaveTextContent('2 to verify')
+  })
+
+  it('CONTRAST CONTROL: with nothing to verify there is no chip at all', () => {
+    // Without this, "renders a chip" would pass on a chip that always renders.
+    renderPanel([factor(VERIFIED, 'Headcount', 'user_confirmed')])
+    expect(screen.queryByTestId(CHIP)).not.toBeInTheDocument()
+    // …and the outline is still there, so the absence above is about the chip
+    // and not about the panel failing to render.
+    expect(screen.getByTestId(`model-row-v2-${VERIFIED}`)).toBeInTheDocument()
+  })
+
+  it('singularises honestly', () => {
+    renderPanel([
+      factor(UNVERIFIED_A, 'Sales cycle length', 'cee_inference'),
+      factor(VERIFIED, 'Headcount', 'user_confirmed'),
+    ])
+    expect(screen.getByTestId(CHIP)).toHaveTextContent('1 to verify')
+  })
+})
+
+// ── The mode ─────────────────────────────────────────────────────────────────
+
+describe('⭐ the queue REPLACES the outline — never a second rendering of a row', () => {
+  it('opening the queue removes the outline rows', () => {
+    renderPanel()
+    // Contrast control, first: the rows ARE on screen before the click, so the
+    // absence asserted below is a change and not a permanently empty outline.
+    expect(screen.getByTestId(`model-row-v2-${UNVERIFIED_A}`)).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId(CHIP))
+
+    // The queue is up…
+    expect(screen.getByTestId(QUEUE)).toBeInTheDocument()
+    expect(screen.getByTestId(`${QUEUE}-item-${UNVERIFIED_A}`)).toBeInTheDocument()
+    // …and the element is rendered ONCE. This is the consolidation's whole
+    // point: the same factor must not appear in an outline row AND a queue row.
+    expect(screen.queryByTestId(`model-row-v2-${UNVERIFIED_A}`)).not.toBeInTheDocument()
+    expect(screen.queryByTestId(`model-row-v2-${VERIFIED}`)).not.toBeInTheDocument()
+  })
+
+  it('the queue holds exactly the unverified factors — the confirmed one is absent', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTestId(CHIP))
+    expect(screen.getByTestId(`${QUEUE}-item-${UNVERIFIED_A}`)).toBeInTheDocument()
+    expect(screen.getByTestId(`${QUEUE}-item-${UNVERIFIED_B}`)).toBeInTheDocument()
+    expect(screen.queryByTestId(`${QUEUE}-item-${VERIFIED}`)).not.toBeInTheDocument()
+  })
+
+  it('Back returns to the outline, and the queue goes', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTestId(CHIP))
+    fireEvent.click(screen.getByTestId('model-tab-v2-queue-back'))
+    expect(screen.getByTestId(`model-row-v2-${UNVERIFIED_A}`)).toBeInTheDocument()
+    expect(screen.queryByTestId(QUEUE)).not.toBeInTheDocument()
+  })
+})
+
+// ── The write ────────────────────────────────────────────────────────────────
+
+describe('Confirm in the queue commits through the ONE authority', () => {
+  it('stamps user_confirmed on the row confirmed — and specifically NOT user', () => {
+    renderPanel()
+    expect(storedSource(UNVERIFIED_B)).toBe('cee_inference')
+
+    fireEvent.click(screen.getByTestId(CHIP))
+    fireEvent.click(screen.getByTestId(`${QUEUE}-item-${UNVERIFIED_B}-apply`))
+
+    expect(storedSource(UNVERIFIED_B)).toBe('user_confirmed')
+    // The forbidden literal, stated explicitly: `'user'` classifies as the
+    // `edited` kind, so the pill would read "User edited" for a gesture in
+    // which the user changed no number (F8).
+    expect(storedSource(UNVERIFIED_B)).not.toBe('user')
+  })
+
+  it('⭐ confirms ONLY the row clicked — the other unverified factor is untouched', () => {
+    // The discriminating half. A handler wired to the wrong row, or to "all
+    // shown", passes every assertion above and fails this one.
+    renderPanel()
+    fireEvent.click(screen.getByTestId(CHIP))
+    fireEvent.click(screen.getByTestId(`${QUEUE}-item-${UNVERIFIED_B}-apply`))
+
+    expect(storedSource(UNVERIFIED_B)).toBe('user_confirmed')
+    expect(storedSource(UNVERIFIED_A)).toBe('cee_inference')
+  })
+
+  it('the confirm button is ENABLED here, because its carrier exists', () => {
+    renderPanel()
+    fireEvent.click(screen.getByTestId(CHIP))
+    const apply = screen.getByTestId(`${QUEUE}-item-${UNVERIFIED_A}-apply`)
+    expect(apply).toBeEnabled()
+    // …and it says Confirm, not Apply: this queue ratifies a number that is
+    // already in the model, and "Apply" would imply a change that never happens.
+    expect(apply).toHaveTextContent('Confirm')
+  })
+
+  it('⭐ the controls whose carriers do NOT exist are still disabled, and still say why', () => {
+    // The honesty half of the mount. `proposeDeferral` and `proposeBatch` do
+    // not exist, so enabling Defer or Apply-all would report a decision the
+    // product cannot persist. Mounting the queue must not quietly turn the
+    // whole component live.
+    renderPanel()
+    fireEvent.click(screen.getByTestId(CHIP))
+    expect(screen.getByTestId(`${QUEUE}-item-${UNVERIFIED_A}-defer`)).toBeDisabled()
+    expect(screen.getByTestId(`${QUEUE}-apply-all`)).toBeDisabled()
+  })
+
+  it('a confirmed row leaves the queue once the host re-renders — chip and list stay in step', () => {
+    /*
+     * ⚠ THE RE-RENDER IS SUPPLIED DELIBERATELY, AND SAYING SO IS THE POINT.
+     * This panel takes the model AS PROPS and holds no store subscription of
+     * its own — that is a stated design property (a second subscription would
+     * be a second render authority). So the queue refreshes when `ModelTabBody`
+     * re-renders it from the store, exactly as every other row on the tab does.
+     *
+     * The first version of this test asserted the count fell WITHOUT a
+     * re-render and failed. That failure was the test being wrong about the
+     * architecture, not the product being wrong — and it is recorded here
+     * rather than quietly deleted, because "the count did not update" is
+     * exactly the shape of a real defect and a future reader must be able to
+     * tell the two apart.
+     */
+    renderPanel()
+    fireEvent.click(screen.getByTestId(CHIP))
+    fireEvent.click(screen.getByTestId(`${QUEUE}-item-${UNVERIFIED_B}-apply`))
+
+    // The host's re-render: the store is the source, as in the live app.
+    const fresh = useCanvasStore.getState().nodes as Node[]
+    cleanup()
+    render(<ModelTabV2Panel nodes={fresh} edges={[]} goalThreshold={null} />)
+
+    // Derived from the same predicate as the queue, so they cannot disagree.
+    expect(screen.getByTestId(CHIP)).toHaveTextContent('1 to verify')
+    // Bound by identity: it is specifically the confirmed row that left.
+    fireEvent.click(screen.getByTestId(CHIP))
+    expect(screen.queryByTestId(`${QUEUE}-item-${UNVERIFIED_B}`)).not.toBeInTheDocument()
+    expect(screen.getByTestId(`${QUEUE}-item-${UNVERIFIED_A}`)).toBeInTheDocument()
+  })
+})

--- a/src/canvas/model-tab-v2/adapters.ts
+++ b/src/canvas/model-tab-v2/adapters.ts
@@ -498,8 +498,8 @@ export function toModelRows(input: ModelProjectionInput): ModelRow[] {
  * by you"); this surface reuses it rather than printing the enum, so the pill
  * and the queue cannot disagree about what a source is called.
  */
-function sourceBasis(source: string | undefined): string | null {
-  const label = mapSourceToDisplay(source)
+function sourceBasis(source: string | null | undefined): string | null {
+  const label = mapSourceToDisplay(source ?? undefined)
   return label === null ? null : `Source: ${label}`
 }
 
@@ -550,7 +550,6 @@ export function toRepairQueueItems(
     return factorNodes
       .filter(n => factorValue(n.data) === null)
       .map(n => {
-        const data = n.data as Record<string, unknown> | undefined
         return {
           rowId: n.id,
           label: resolveCanvasLabel(n.id, nodeLabels) ?? UNNAMED_ELEMENT_LABEL,
@@ -587,7 +586,6 @@ export function toRepairQueueItems(
   return input.nodes
     .filter(n => nodeKind(n) === 'option' && optionHasNoInterventions(n.data))
     .map(n => {
-      const data = n.data as Record<string, unknown> | undefined
       return {
         rowId: n.id,
         label: resolveCanvasLabel(n.id, nodeLabels) ?? UNNAMED_ELEMENT_LABEL,

--- a/src/canvas/model-tab-v2/adapters.ts
+++ b/src/canvas/model-tab-v2/adapters.ts
@@ -128,7 +128,12 @@ import { getDisplayEdgeId } from '../utils/edgeIdentity'
 // THE ONE id → label policy (`src/canvas/domain/canvasLabels.ts`). It returns
 // `null` rather than the identifier, and rejects a stored label that is itself
 // id-shaped — which is why it is imported here rather than reimplemented.
-import { buildCanvasLabelMap, resolveCanvasLabel, UNNAMED_ELEMENT_LABEL } from '../domain/canvasLabels'
+import {
+  buildCanvasLabelMap,
+  honestLabel,
+  resolveCanvasLabel,
+  UNNAMED_ELEMENT_LABEL,
+} from '../domain/canvasLabels'
 import { resolveNodeTypeLiteral } from '../domain/nodes'
 import { factorNeedsVerification } from '../domain/valueProvenance'
 import { interventionTargetValue } from '../domain/interventions'
@@ -268,7 +273,21 @@ function relationshipLabel(
   targetId: string,
   labels: ReadonlyMap<string, string>,
 ): string {
-  if (typeof data?.label === 'string' && data.label.trim() !== '') return data.label
+  /*
+   * ⚠ F5 — THE SAME REJECTION THE NODE PATH GETS. `resolveCanvasLabel` refuses
+   * a stored label that is ITSELF id-shaped, because producers sometimes seed a
+   * label from an id and the leak would simply move one hop upstream. That
+   * reasoning does not stop at nodes, and this branch was reading the edge's own
+   * `data.label` raw — so the policy was applied on one path and not its
+   * neighbour, in one function.
+   *
+   * Reachability was NOT established in either direction, and that is exactly
+   * why the policy is applied rather than argued about: it costs one call, and
+   * an id-shaped edge label falls back to the endpoint pair — which reads
+   * better than the id whether or not the case occurs.
+   */
+  const own = honestLabel(data?.label)
+  if (own !== null) return own
   const from = resolveCanvasLabel(sourceId, labels) ?? UNNAMED_ELEMENT_LABEL
   const to = resolveCanvasLabel(targetId, labels) ?? UNNAMED_ELEMENT_LABEL
   return `${from} → ${to}`
@@ -506,6 +525,19 @@ function sourceBasis(source: string | null | undefined): string | null {
 /**
  * An edge's provenance, gated exactly as v1 gates it.
  *
+ * ⚠⚠ F4 — WHAT WAS PORTED IS THE GATE, NOT THE VOCABULARY, AND THE DIFFERENCE
+ * MATTERS. A factor's `observedState.source` is a closed enum with a classifier
+ * (`mapSourceToDisplay` → "AI estimate"). An edge's `provenance` is
+ * `z.string().max(100)` (`edges.ts:198`) — free-form, no classifier exists, and
+ * its own schema doc examples are wire-ish tokens. So this function CANNOT
+ * humanise; it can only decide whether a source is worth stating at all.
+ *
+ * Stated plainly so nobody reads the sibling `sourceBasis` and assumes parity:
+ * an evidence provenance still reaches the user VERBATIM. That is the v1
+ * behaviour, deliberately preserved, and it is a narrower property than "no wire
+ * token reaches the user". Closing it needs an edge-provenance vocabulary, which
+ * is a product decision and not this lane's to invent.
+ *
  * ⚠ THE GATE IS THE POINT. `RelationshipsSection.tsx:213` prints a provenance
  * only when it is EVIDENCE — `assumption`, `template` and `ai-suggested` are
  * placeholders, and announcing "Source: assumption" states a basis that does
@@ -526,7 +558,24 @@ export function toRepairQueueItems(
 
   if (queueId === 'confirm-estimates') {
     return factorNodes
-      .filter(n => factorNeedsVerification(n.data))
+      /*
+       * ⚠⚠ F2 — `factorNeedsVerification` IS `!source || source === 'cee_inference'`
+       * (`valueProvenance.ts:227-231`), which a factor with NO `observedState` at
+       * all satisfies. Those factors were entering this queue, where Confirm
+       * rendered over "No value set": an enabled button asking the user to endorse
+       * nothing, which the authority then refuses — a silent no-op (preamble P8).
+       *
+       * ⭐ THE OUTLINE'S ROW CHIP ALREADY REFUSED EXACTLY THIS, with the reasoning
+       * written out (`ModelRowView.tsx:134-136`): `…&& row.primaryValue !== null`.
+       * Two surfaces answering ONE question — "may this be confirmed?" — and the
+       * queue was the weaker one. The rule now lives at the PRODUCER, so the queue
+       * cannot contain an item the row would have refused.
+       *
+       * It also closes a duplication: a value-less factor satisfied BOTH this
+       * predicate and `no-value`'s, so it stood in two queues at once. `no-value`
+       * is the one that describes it, and confirming is not the repair it needs.
+       */
+      .filter(n => factorNeedsVerification(n.data) && factorValue(n.data) !== null)
       .map(n => {
         const data = n.data as Record<string, unknown> | undefined
         return {
@@ -623,7 +672,16 @@ export function toRowDetail(input: ModelProjectionInput, rowId: string): ModelRo
       rowId,
       description: typeof data?.description === 'string' ? data.description : null,
       secondaryValues: secondary,
-      basis: typeof obs?.source === 'string' ? `Source: ${obs.source}` : null,
+      // ⚠⚠ F1, AND IT IS THIS COMMIT'S OWN THESIS TURNED ON ITSELF. The
+      // previous commit fixed the IDENTICAL expression in the repair-queue
+      // producer and left this one raw — so the detail pane printed
+      // `Source: cee_inference` under "Where it came from", DIRECTLY BENEATH
+      // the `SourceProvenancePill` that humanises the same field to "AI
+      // estimate" (`ModelDetailRegion.tsx:250-263`). The panel said both.
+      // Catching one instance of a class and announcing the class is fixed is
+      // the defect; the scan that should have caught it was blind twice over
+      // (see `modelTabNoRawIdFallback.sourceScan.spec.ts`).
+      basis: sourceBasis(obs?.source),
       adjustments: [],
       // ⚠ The NAVIGATION id stays the edge's; the LABEL is the target element's
       // name. Rendering `e.target` here put a raw wire id in the detail region's

--- a/src/canvas/model-tab-v2/adapters.ts
+++ b/src/canvas/model-tab-v2/adapters.ts
@@ -118,6 +118,12 @@ import { getCausalEdges } from '../domain/edgeUtils'
 import { resolveEdgeDirectionDisplay, resolveEdgeValueDisplay } from '../domain/edgeValueProvenance'
 import { getDirectionalStrengthLabel } from '../components/model-tab/strengthBands'
 import { getPrimaryValue, formatSmartNumber } from '../components/model-tab/utils'
+// THE ONE raw-source → human-label policy, the same one `SourceProvenancePill`
+// renders. Imported, never re-expressed: a second copy is how the pill and the
+// outline start disagreeing about what `cee_inference` is called.
+import { mapSourceToDisplay } from '../components/model-tab/utils'
+// The evidence gate v1 applies before it will print a provenance at all.
+import { NON_EVIDENCE_PROVENANCE } from '../utils/evidenceCoverage'
 import { getDisplayEdgeId } from '../utils/edgeIdentity'
 // THE ONE id → label policy (`src/canvas/domain/canvasLabels.ts`). It returns
 // `null` rather than the identifier, and rejects a stored label that is itself
@@ -377,7 +383,13 @@ export function toModelRows(input: ModelProjectionInput): ModelRow[] {
     const kind = nodeKind(node)
     if (kind === null) continue
     const data = node.data as Record<string, unknown> | undefined
-    const label = typeof data?.label === 'string' ? data.label : node.id
+    // THE ONE id → label policy, same as the relationship rows below.
+    // ⚠ NOT `typeof data?.label === 'string' ? data.label : node.id`, which is
+    // what stood here: a raw wire id (`fac_arr`) rendered as the row's NAME.
+    // That is the same leak #777 fixed on the relationship path, wearing a
+    // ternary instead of a `??` — which is precisely why the source scan that
+    // certified this directory at ZERO could not see it.
+    const label = resolveCanvasLabel(node.id, nodeLabels) ?? UNNAMED_ELEMENT_LABEL
 
     if (kind === 'factor') {
       const value = factorValue(data)
@@ -478,6 +490,33 @@ export function toModelRows(input: ModelProjectionInput): ModelRow[] {
  * queue: a badge and its queue that disagree is the defect the current tab
  * already ships, where "N to verify" counts factors the user cannot reach.
  */
+/**
+ * A factor's provenance, in the user's words.
+ *
+ * ⚠ `Source: cee_inference` IS A WIRE TOKEN, NOT COPY. `mapSourceToDisplay` is
+ * the policy `SourceProvenancePill` already renders ("AI estimate", "Confirmed
+ * by you"); this surface reuses it rather than printing the enum, so the pill
+ * and the queue cannot disagree about what a source is called.
+ */
+function sourceBasis(source: string | undefined): string | null {
+  const label = mapSourceToDisplay(source)
+  return label === null ? null : `Source: ${label}`
+}
+
+/**
+ * An edge's provenance, gated exactly as v1 gates it.
+ *
+ * ⚠ THE GATE IS THE POINT. `RelationshipsSection.tsx:213` prints a provenance
+ * only when it is EVIDENCE — `assumption`, `template` and `ai-suggested` are
+ * placeholders, and announcing "Source: assumption" states a basis that does
+ * not exist. The ungated read this replaces printed all three.
+ */
+function edgeProvenanceBasis(provenance: unknown): string | null {
+  if (typeof provenance !== 'string' || provenance.trim() === '') return null
+  if (NON_EVIDENCE_PROVENANCE.includes(provenance)) return null
+  return `Source: ${provenance}`
+}
+
 export function toRepairQueueItems(
   input: ModelProjectionInput,
   queueId: RepairQueue['id'],
@@ -492,14 +531,17 @@ export function toRepairQueueItems(
         const data = n.data as Record<string, unknown> | undefined
         return {
           rowId: n.id,
-          label: typeof data?.label === 'string' ? data.label : n.id,
+          label: resolveCanvasLabel(n.id, nodeLabels) ?? UNNAMED_ELEMENT_LABEL,
           currentValue: factorValue(data),
           // Confirming ratifies the value that is already there; it does not
           // propose a different one.
           suggestedValue: null,
-          basis: typeof observedStateOf(data)?.source === 'string'
-            ? `Source: ${observedStateOf(data)!.source}`
-            : null,
+          // ⚠ THE CLASSIFIED LABEL, NEVER THE WIRE TOKEN. This read
+          // `Source: ${obs.source}` and put `Source: cee_inference` on screen
+          // as body copy. v1 never did: `SourceProvenancePill` renders
+          // `mapSourceToDisplay` ("AI estimate"), and the raw token appears
+          // only in a `title`. Same policy imported, not a second copy.
+          basis: sourceBasis(observedStateOf(data)?.source),
         }
       })
   }
@@ -511,7 +553,7 @@ export function toRepairQueueItems(
         const data = n.data as Record<string, unknown> | undefined
         return {
           rowId: n.id,
-          label: typeof data?.label === 'string' ? data.label : n.id,
+          label: resolveCanvasLabel(n.id, nodeLabels) ?? UNNAMED_ELEMENT_LABEL,
           currentValue: null,
           suggestedValue: null,
           basis: null,
@@ -548,7 +590,7 @@ export function toRepairQueueItems(
       const data = n.data as Record<string, unknown> | undefined
       return {
         rowId: n.id,
-        label: typeof data?.label === 'string' ? data.label : n.id,
+        label: resolveCanvasLabel(n.id, nodeLabels) ?? UNNAMED_ELEMENT_LABEL,
         currentValue: null,
         suggestedValue: null,
         basis: 'This option does not change any factor yet',
@@ -603,7 +645,7 @@ export function toRowDetail(input: ModelProjectionInput, rowId: string): ModelRo
     rowId,
     description: typeof data?.label === 'string' ? data.label : null,
     secondaryValues: [],
-    basis: typeof data?.provenance === 'string' ? `Source: ${data.provenance}` : null,
+    basis: edgeProvenanceBasis(data?.provenance),
     adjustments: [],
     affects: [
       { id: edge.target, label: endpointLabel(edge.target, nodeLabels) },
@@ -669,12 +711,28 @@ function buildAdvancedForNode(id: string, obs: ObservedState | undefined) {
   ]
 }
 
+/**
+ * ⚠ BOTH NUMBERS ARE PROVENANCE-GATED, AND ONE OF THEM WAS READING THE WRONG
+ * FIELD. The raw reads this replaces had two independent defects:
+ *
+ *  1. `data.strengthStd` unstamped is `USER_EDGE_DEFAULTS.strengthStd = 0.15` —
+ *     a constant nobody measured, printed as a measured uncertainty. v1 closed
+ *     exactly this (ROADMAP 2.296 C4, `RelationshipsSection.tsx:183-197`) by
+ *     routing through `resolveEdgeValueDisplay`, which shows a number only once
+ *     its ingestion site has stamped a source. This surface did not, so the
+ *     canonical editor was laundering a default the duplicate editor suppresses.
+ *  2. `data.exists_probability` IS NOT THE EDITED FIELD. Every likelihood write
+ *     in the product lands on `beliefExists` (`useInspectorMutations.ts:429-435`,
+ *     via `setExistsProbability`), so a user who set a likelihood saw this row
+ *     read empty. `resolveEdgeValueDisplay(data, 'beliefExists')` owns that
+ *     spelling — including the legacy `belief` leg — in one place.
+ */
 function buildAdvancedForEdge(id: string, data: Record<string, unknown> | undefined) {
-  const std = data?.strengthStd
-  const ep = data?.exists_probability
+  const std = resolveEdgeValueDisplay(data, 'strengthStd')
+  const ep = resolveEdgeValueDisplay(data, 'beliefExists')
   return [
     { label: 'Edge ID', value: id },
-    { label: 'Std', value: typeof std === 'number' ? String(std) : null },
-    { label: 'Exists probability', value: typeof ep === 'number' ? String(ep) : null },
+    { label: 'Std', value: std.show ? String(std.value) : null },
+    { label: 'Exists probability', value: ep.show ? String(ep.value) : null },
   ]
 }

--- a/src/canvas/model-tab-v2/adapters.ts
+++ b/src/canvas/model-tab-v2/adapters.ts
@@ -44,10 +44,15 @@
  *   · `getDirectionalStrengthLabel`  — model-tab/strengthBands
  *   · `getPrimaryValue`              — model-tab/utils
  *   · `getDisplayEdgeId`             — utils/edgeIdentity
- *   · `factorNeedsVerification`      — domain/valueProvenance. ⚠ THIS USED TO BE
- *     A PORT, with a corpus pinning the copy against `countFactorsToVerify`.
- *     It MOVED to the domain layer on 18 Aug 2026 and both readers now import
- *     it, so there is nothing left to pin: agreement is structural, not tested.
+ *   · `factorIsConfirmable`          — domain/valueProvenance. ⚠ THE CANONICAL
+ *     "N to verify" PREDICATE, and the only one. `factorNeedsVerification` was
+ *     ported here once, then moved to the domain layer (18 Aug); the FULL
+ *     question — needs verification AND has a ratifiable value — was still being
+ *     answered four ways across five surfaces until 19 Aug. It is now one
+ *     function, defined as the write authority's own refusal condition inverted,
+ *     so agreement is structural. The corpus that would notice the surviving
+ *     definition being WRONG lives in `__tests__/factorConfirmable.spec.ts`
+ *     (trap 12d — derivation and corpus are not redundant; ship both).
  *
  * PORTED, because the live logic is not exported per-item:
  *   · `edgeIsContested` ← `RelationshipsSection.tsx:610`.
@@ -65,13 +70,17 @@
  * Naming them is the point: an unnamed divergence is how two surfaces end up
  * quietly disagreeing about the same model.
  *
- * D1 — TWO LIVE "NEEDS VERIFICATION" PREDICATES EXIST, AND THEY DISAGREE.
- *      `countFactorsToVerify` (utils.ts:118) is `!source || source ===
- *      'cee_inference'`. The factor SORT KEY in `ModelTabBody.tsx:492-493` is
- *      wider — it also flags an `external` factor carrying a full 0–1 prior
- *      range. Nothing reconciles them. This adapter follows the FIRST, because
- *      that is the one the "N to verify" badge and Queue B are counted from, and
- *      a queue that disagreed with its own chip is the defect being closed.
+ * D1 — ⭐ SETTLED 19 Aug 2026: ONE PREDICATE, `factorIsConfirmable`, OWNED BY
+ *      `domain/valueProvenance`. `countFactorsToVerify`, this adapter's queue,
+ *      the outline's `unconfirmed-estimate` marker, `ModelRowView`'s Confirm chip
+ *      and `FactorsSection`'s Confirm ✓ all call it; none keeps a copy, and the
+ *      write authority gates on its `factorHasConfirmableValue` half — so a
+ *      surface cannot offer a confirmation the writer will decline.
+ *      ⚠ STILL UNRECONCILED, AND DELIBERATELY SO: the factor SORT KEY in
+ *      `ModelTabBody.tsx` is wider (it also flags an `external` factor carrying a
+ *      full 0–1 prior range). That is an ORDERING key, not a count and not an
+ *      affordance — a different question (trap 21), left alone rather than
+ *      aligned into a fifth reading of this one.
  *
  * D2 — `'no-value'` IS AUTHORED FRESH, NOT PORTED. There is no per-factor
  *      "has no value" predicate anywhere in the live tree. The Model card's
@@ -135,7 +144,7 @@ import {
   UNNAMED_ELEMENT_LABEL,
 } from '../domain/canvasLabels'
 import { resolveNodeTypeLiteral } from '../domain/nodes'
-import { factorNeedsVerification } from '../domain/valueProvenance'
+import { factorIsConfirmable } from '../domain/valueProvenance'
 import { interventionTargetValue } from '../domain/interventions'
 import { unwrapInterventionValue } from '../utils/labelUtils'
 import type {
@@ -378,10 +387,25 @@ function edgeValue(data: unknown): string | null {
 // Rows
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * ⚠ THE TWO REASONS ANSWER DIFFERENT QUESTIONS AND KEEP DIFFERENT PREDICATES
+ * (trap 21). `no-value` asks *"is there a number this outline can DISPLAY?"* —
+ * `getPrimaryValue`, i.e. `raw_value`. `unconfirmed-estimate` asks *"may this be
+ * CONFIRMED?"* — `factorIsConfirmable`, i.e. the write authority's own condition
+ * on `observedState.value`. They are not spellings of one rule and they are
+ * deliberately not aligned.
+ *
+ * ⚠ `unconfirmed-estimate` CARRIES THE VALUE GUARD NOW, so `ModelRowView` no
+ * longer re-derives one. It used to be the bare `factorNeedsVerification`, which
+ * marked a factor with no value at all as an unratified ESTIMATE — there was no
+ * estimate to ratify, and the row's Confirm chip then had to bolt its own
+ * `row.primaryValue !== null` on top. One question was being answered twice, in
+ * two files, with two different fields.
+ */
 function attentionForFactor(data: unknown, value: string | null): AttentionReason[] {
   const out: AttentionReason[] = []
   if (value === null) out.push('no-value')
-  if (factorNeedsVerification(data)) out.push('unconfirmed-estimate')
+  if (factorIsConfirmable(data)) out.push('unconfirmed-estimate')
   return out
 }
 
@@ -559,23 +583,37 @@ export function toRepairQueueItems(
   if (queueId === 'confirm-estimates') {
     return factorNodes
       /*
-       * ⚠⚠ F2 — `factorNeedsVerification` IS `!source || source === 'cee_inference'`
-       * (`valueProvenance.ts:227-231`), which a factor with NO `observedState` at
-       * all satisfies. Those factors were entering this queue, where Confirm
-       * rendered over "No value set": an enabled button asking the user to endorse
-       * nothing, which the authority then refuses — a silent no-op (preamble P8).
+       * ⚠⚠ F2 — `factorNeedsVerification` ALONE IS `!source || source ===
+       * 'cee_inference'`, which a factor with NO `observedState` at all satisfies.
+       * Those factors were entering this queue, where Confirm rendered over "No
+       * value set": an enabled button asking the user to endorse nothing, which
+       * the authority then refuses — a silent no-op (preamble P8).
        *
-       * ⭐ THE OUTLINE'S ROW CHIP ALREADY REFUSED EXACTLY THIS, with the reasoning
-       * written out (`ModelRowView.tsx:134-136`): `…&& row.primaryValue !== null`.
-       * Two surfaces answering ONE question — "may this be confirmed?" — and the
-       * queue was the weaker one. The rule now lives at the PRODUCER, so the queue
-       * cannot contain an item the row would have refused.
+       * ⚠⚠ AND THE FIRST FIX FOR IT WAS WRONG IN THE OPPOSITE DIRECTION, which is
+       * why this reads `factorIsConfirmable` and not a local conjunction. It was
+       * `… && factorValue(n.data) !== null` — `getPrimaryValue`, i.e. `raw_value`
+       * — copied from `ModelRowView`'s `row.primaryValue !== null`. But the write
+       * authority gates on `observedState.value`, and a capped factor off the wire
+       * carries `{value: 0.7}` with NO `raw_value`
+       * (`conversation/factorValueEdit.ts:145`, staging-witnessed). So the
+       * over-count closed and an UNDER-count opened: a real, confirmable factor
+       * dropped out of the queue AND lost its chip, while `FactorsSection` went on
+       * offering the same row a working button. One direction of corpus could not
+       * see both (trap 22b).
        *
-       * It also closes a duplication: a value-less factor satisfied BOTH this
-       * predicate and `no-value`'s, so it stood in two queues at once. `no-value`
-       * is the one that describes it, and confirming is not the repair it needs.
+       * ⭐ THE RECONCILIATION IS THE PRODUCER'S CONDITION, NOT THE WIDER OR THE
+       * NARROWER OF TWO GUESSES (trap 13c). `factorIsConfirmable` IS
+       * `proposeFactorConfirmation`'s refusal, inverted, and the authority imports
+       * the same half — so this queue holds exactly the rows the writer accepts.
+       *
+       * ⚠ WHAT IT DOES *NOT* CLAIM: that `no-value` and this are disjoint. They
+       * answer different questions (display vs write) and keep different
+       * predicates on purpose, so a factor with a model-scale `value` and no
+       * displayable `raw_value` legitimately appears in both. Stated rather than
+       * quietly aligned — the earlier text here claimed the duplication was closed,
+       * and that was the over-read.
        */
-      .filter(n => factorNeedsVerification(n.data) && factorValue(n.data) !== null)
+      .filter(n => factorIsConfirmable(n.data))
       .map(n => {
         const data = n.data as Record<string, unknown> | undefined
         return {

--- a/src/canvas/model-tab-v2/rowPresentation.ts
+++ b/src/canvas/model-tab-v2/rowPresentation.ts
@@ -12,7 +12,13 @@
  * NOTHING HERE IS MOUNTED. See `types.ts` for the directory-level statement.
  */
 
-import type { AttentionReason, DeferralRecord, ModelElementKind, ModelGroupId } from './types'
+import type {
+  AttentionReason,
+  DeferralRecord,
+  ModelElementKind,
+  ModelGroupId,
+  RepairQueue,
+} from './types'
 
 /**
  * How a deferral reads on screen (design §5.3, Paul's ruling 16 Aug 2026).
@@ -47,6 +53,48 @@ function formatDeferralDate(iso: string): string {
  * The seven group headings, mapping 1:1 onto the brief's IA (design §4.1).
  * Total over `ModelGroupId` — a new group cannot render as an untitled section.
  */
+/**
+ * THE FOUR REPAIR QUEUES, TOTAL BY CONSTRUCTION (design §5.3).
+ *
+ * ⚠ A `Record` over `RepairQueue['id']`, for the same reason as every other map
+ * in this file: adding a queue id becomes a TYPE ERROR here rather than a queue
+ * that renders with no title. The definitions were previously inline in the
+ * queue's own spec — i.e. the only place a queue existed was a test fixture,
+ * which is how a surface stays unmountable without anyone noticing.
+ *
+ * ⚠ `supportsApplyAll` IS A CLAIM ABOUT THE BATCH CARRIER, NOT A PREFERENCE.
+ * It stays `true` where the design wants the affordance; the affordance itself
+ * still renders DISABLED until `proposeBatch` exists, because N single
+ * proposals is N turns, N undo steps and N analysis invalidations for one
+ * gesture (`contracts.ts` §1).
+ */
+export const REPAIR_QUEUE: Record<RepairQueue['id'], RepairQueue> = {
+  'confirm-estimates': {
+    id: 'confirm-estimates',
+    reason: 'unconfirmed-estimate',
+    title: 'Confirm estimates',
+    supportsApplyAll: true,
+  },
+  'set-option-values': {
+    id: 'set-option-values',
+    reason: 'missing-intervention',
+    title: 'Set option values',
+    supportsApplyAll: true,
+  },
+  contested: {
+    id: 'contested',
+    reason: 'contested',
+    title: 'Contested relationships',
+    supportsApplyAll: false,
+  },
+  'no-value': {
+    id: 'no-value',
+    reason: 'no-value',
+    title: 'Factors with no value',
+    supportsApplyAll: false,
+  },
+}
+
 export const GROUP_TITLE: Record<ModelGroupId, string> = {
   goal: 'Goal',
   options: 'Options',


### PR DESCRIPTION
## Verdict first

**NO — the legacy editor cannot be deleted at `4d1e650b`, and it is not close.** The ruling anticipated *"one genuinely unique advanced capability"*. Derived component by component at the tip, there are **roughly forty**, including one whole vertical that is the product's ONLY path for what it does.

Per the scope-expansion rule this lane stopped at that boundary rather than deleting into capability loss. It landed the two things that are unambiguously right and that a deletion would otherwise have made permanent. **Nothing is deleted in this PR.**

## What actually blocks the delete

Derived by reading all 19 `model-tab/` files plus `ModelTabBody.tsx` against the whole of `model-tab-v2/`.

**1 · The contested-edge adjudication vertical — the sharpest blocker.**
`RelationshipsSection` → `ContestedEdgeCard` → `ModelTabBody.handleResolveContested` is **the only live adjudication surface in the product**, and it is the only emitter of the `edge_adjudication` wire event. Six user gestures, four verdicts, three `updateEdge` branches. `pre-analysis-v3/ContestedSection` says so itself in prose and is deliberately display-only; `AllImprovements`' copy is dead (no JSX render site anywhere). v2 has a `⚠` glyph. `RepairQueueList`'s `contested` producer exists but is uncalled, and its four cells cannot express a two-pass comparison. **Deleting `RelationshipsSection` deletes the capability outright.**

**2 · The model card / audit trail.** Seed, response hash, simulation count, auto-noise adjustment, stability penalty, repairs-applied, inference warnings. A sweep for every one of those terms across `model-tab-v2/` returns zero — `rawV2Response`, `repairsApplied` and `ceeQuality` never reach the v2 subtree at all.

**3 · `ModelAdjustments`.** CEE structural-repair receipts. Not a repair-queue candidate: its semantics are the inverse (a receipt of what was already applied, versus proposals awaiting a decision), and `repairActions` are bare strings with no id, so they cannot populate `rowId`.

**4 · Copy-as-text / copy-as-JSON with provenance stamps.** No export path in v2.

**5 · ~30 analysis-derived facts** the v2 projection cannot even see: `ModelProjectionInput` takes only nodes, edges, goal threshold and fragile ids. Influence, elasticity, rank-flip, confidence, attribution stability, goal-fit rows, conditional winners, EVOI, e-value, switch probability, prior ranges, baselines, factor category, "triggered by". Plus influence ordering — v2 never sorts.

## What SHRANK the blocking set, and is worth the founder's attention

⭐ **Four of the five "legacy-only edits" are not legacy-only. They are a THIRD copy.** Every one already has a canonical owner on the inspector:

| Quantity | Model tab (v1) | Canonical owner |
|---|---|---|
| edge strength / direction / likelihood | `RelationshipsSection:250/254/260` | `EdgeAdvancedEditor`, `EdgePanel` |
| factor baseline | `FactorsSection:288` | `FactorControllableEditor`, `FactorObservableEditor` |
| factor prior range | `FactorsSection:301/307` | `FactorExternalEditor`, `FactorExternalPanel` |
| goal target | `GoalSection:130` | `GoalThresholdEditor`, `PreAnalysisPanel`, `DefineSuccessModal` |

So for these, the Model tab is duplication to remove, not capability to rehome — and `openEdgeStrengthEditor` / `openNodeInspector` are the existing, documented routes to the owner. That is the cheapest available progress on *one canonical edit path per quantity*, and it is the recommended next slice. (`openNodeInspector` lacks the dock stand-down its twin has — an inconsistency in shared canvas arbitration, flagged rather than changed here.)

Separately: `FactorsSection:254` still runs its **own** copy of the factor-value commit alongside `useModelEditAuthority.proposeFactorValue`. That duplicate dies with the section.

## What this PR lands

### 1 · The canonical editor stops speaking in wire tokens (`23e86998`)

Four defects in the editor that **survives**, each of which the duplicate got right — so deleting first would have made all four permanent.

⭐ **The directory's own raw-id guard had the code's blind spot.** `modelTabNoRawIdFallback.sourceScan` asserts `model-tab-v2/` is at ZERO. It passed. Its pattern matches `??` and only `??`; the canonical editor wrote the same fallback as a **ternary**, at four sites. Measured against the pristine file: `??` shape **0**, ternary shape **4**. That file's own header warns that a pattern narrower than the defect class reads as a clean result — one screen above a pattern narrower than the defect class. An unlabelled factor rendered as `fac_uk_arr_retention`.

The scan now matches both shapes, `label`-anchored so a legitimate `{ rowId: n.id, label: … }` does not fire. Widening it immediately found a **sixth** site (`buildGoalFitRows:115`) putting a raw option id into a sentence about the user's goal — fixed in place, not pinned, because `ModelTabBody` owns that builder and it outlives the deletion.

Also fixed: `Source: cee_inference` rendered as body copy (now the classified label, policy imported not copied); edge provenance printed ungated, so "Source: assumption" announced a basis that does not exist; and the advanced edge parameters reading raw — unstamped `strengthStd` is `USER_EDGE_DEFAULTS.strengthStd = 0.15`, printed as a measured uncertainty, the exact default v1 suppresses — while the likelihood row read `exists_probability` when every write in the product lands on `beliefExists`.

### 2 · The confirm-estimates repair queue is mounted (`c32e2a54`)

#777 landed two of the four carriers `RepairQueueList` was waiting for. **"N to verify" is a control for the first time** — closing the gap by mounting code that already existed, exactly as the brief suggested, rather than building new UI.

⭐ **The queue REPLACES the outline.** A queue beside the outline would render the same factor twice — the defect this consolidation exists to remove, reproduced inside the fix. ⚠ **Scope corrected after review:** that is true of the PANEL, not yet of the SURFACE — `ModelTabBody` renders `FactorsSection` unconditionally outside the panel, so *"only ever one rendering of a row"* is a goal at this tip, not an achieved state, until the duplicate stack is deleted. A component-level spec cannot see that (trap 3b), which is how the overstatement passed a green suite. Confirm routes to the same `proposeFactorConfirmation` the row chip uses: two entry points, one implementation. The chip's count IS the queue's derivation, so they cannot disagree. **Apply-all, Defer and Resume stay disabled and still say why** — `onApply` is optional precisely so absence keeps the honest state.

### 3 · Review round 2 — three P1s closed (`45e91182`)

An independent adversarial review found the previous commit's own thesis turned on it: **it widened the PATTERN and left the SCOPE narrow on two independent axes, and a live `Source: cee_inference` sat in the intersection — same file, ~80 lines below the fix.**

- **F1** — `toRowDetail`'s NODE branch still printed the wire token, rendering under "Where it came from" *directly beneath* the pill humanising the same field. The panel said both. Now pinned with the queue path as its contrast control.
- **F2** — the queue offered an **enabled, inert Confirm over "No value set"**: `factorNeedsVerification` admits factors with no `observedState`, and both call sites discard `LocalCommitOutcome`, so the no-op was silent. ⭐ The outline's row chip already refused exactly this, with the reasoning written out. Fixed at the producer (which also ends a value-less factor standing in **two** queues), plus a *different*, weaker fail-closed guard in the control. My own comment claiming it "never renders enabled-but-inert" was **false when written** and is corrected in place. The corpus excluded the class the predicate admits; the `adapters.spec.ts` case asserting `['f1','f3']` **encoded the defect** and is corrected with its reasoning kept.
- **F3** — the scan's scope was narrow three ways: `blankNonCode` blanks template bodies; `ModelTabBody.tsx` was outside both scanned directories (**7 fallbacks, 6 user-facing** — the goal heading and both clipboard exports); the walk was non-recursive. ⚠ Switching the transform alone does **not** catch it — measured — so a third pattern was needed, and its first cut fired on the honest fix and was narrowed by its own contrast control.
- Also: F4 (edge-provenance vocabulary was never ported — stated plainly rather than implied), F5 (`honestLabel` extracted so there is one definition), F6 (`REPAIR_QUEUE` had become a third copy), F7 (one `inQueue` predicate, `MountedQueueId`), F8 (empty-queue dead end).

⚠ **A void measurement, reported rather than dropped:** the first mutation harness run produced no result for any arm — zsh does not word-split, so an unquoted spec list reached vitest as one argument and it found no files. Re-run with explicit arguments and a non-zero collected count asserted.

## Evidence

Round 1: 23 new tests + 6 widened-scan tests. Round 2: 63 tests across the four affected specs, collected by name; **61 files / 1215 tests** green across `model-tab-v2/`, `model-tab/`, `canvas/domain/` and the `ModelTabBody` specs. Every absence assertion carries a contrast control reading non-zero in the same test; assertions bind by identity.

**Mutation checks** — throwaway trees at absolute paths outside the repo root, isolation proven by **writing** a sentinel and asserting the source did not change (inodes compared), pristine-archive restores, applied-checks, controls before and after:
- against pristine `4d1e650b`: **8 defect pins RED, all 6 contrast controls GREEN** (the controls staying green is the load-bearing half — it proves the reds are the defect, not a broken fixture)
- queue-beside-outline mutant → the no-double-render pin REDs, alone
- Confirm-wired-to-a-fixed-row mutant → the identity pin REDs
- trailing controls clean, applied-diff 0

Round 2, same discipline: control 63 passed · F1 detail-basis reverted **4 RED** · F2a producer conjunct removed **2 RED** · F2b control gates on the carrier only **3 RED** · F3 transform back to `blankNonCode` **1 RED** · trailing control 63 passed.

**Gates:** `pnpm run typecheck` PASSES. It caught a TS2322 **in a spec** that a tests-excluding project config cannot see (the UI gate is `scripts/ci/typecheck-gate.sh`; `tsconfig.build.json` is CEE's — misnamed in the first version of this description) — the reason the ratchet was run before pushing. Baseline deliberately not regenerated despite a reported shrink (2272 → 2263). 45 files / 701 tests green across `model-tab-v2/`, `model-tab/` and the `ModelTabBody` specs. ESLint clean.

**Not measured:** no CI run polled, no deployed or browser witness, no visual-regression references touched.

## Lead question — is this change an instance of the defect class it removes?

Checked deliberately at each step. No shim, no re-export, no flag branch. The provenance-label policy and the id→label policy are **imported**, never re-expressed. `REPAIR_QUEUE` is a `Record` over the queue-id union — total by construction. The queue's Confirm calls the row chip's existing callback rather than a second confirmation path. And the queue is a **mode**, not a second list, specifically so consolidating the tab does not itself render an element twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

