### PR TITLE
fix(N-23): host guidance invalidation on the live posture (wire-free)

### DIFF
--- a/src/canvas/ReactFlowGraph.tsx
+++ b/src/canvas/ReactFlowGraph.tsx
@@ -112,6 +112,7 @@ import { isAiPanelV2Enabled } from '../flags'
 import { ConversationProvider } from './conversation/ConversationContext'
 import { PanelApplyDrainHost } from './conversation/PanelApplyDrainHost'
 import { StructuralDeleteDrainHost } from './conversation/StructuralDeleteDrainHost'
+import { GuidanceInvalidationHost } from './conversation/GuidanceInvalidationHost'
 import { FloatingOlumiPanel } from './components/FloatingOlumiPanel'
 import { FirstUseComposer } from './components/FirstUseComposer'
 import { StarterProvenanceBanner } from './components/StarterProvenanceBanner'
@@ -2562,6 +2563,14 @@ export function MaybeConversationProvider({ children }: { children: import('reac
             the drain there alone shipped the capability dark. Same two-host
             shape as PanelApplyDrainHost above, for the same reason. */}
         <StructuralDeleteDrainHost />
+        {/* N-23 — guidance invalidation's flag-ON host. `clearGuidanceItems()`
+            had one production caller, inside `useGraphEditEvents`, whose only
+            host is DraftChat (mounted only when aiPanelV2 is OFF). With the flag
+            ON — every deployed context — stale coaching survived a local
+            structural edit. This host carries the coaching half ONLY: it takes
+            no transport, so it cannot switch on `direct_graph_edit` emission as
+            a side effect. */}
+        <GuidanceInvalidationHost />
         {children}
       </ConversationProvider>
     )

--- a/src/canvas/components/RecoveryBanner.tsx
+++ b/src/canvas/components/RecoveryBanner.tsx
@@ -58,7 +58,18 @@ export function RecoveryBanner() {
       }
     }
 
+    // ⚠ NOT A USER EDIT — RECOVERING THE USER'S OWN UNSAVED WORK. Without this
+    // window `useGuidanceInvalidationOnEdit` reads the restore as the user
+    // rebuilding their model from nothing and destroys the coaching that
+    // belonged to exactly this recovered graph, on screen and on disk. Raised in
+    // the SAME `set()` as the write; a later one arrives too late (MUT-ORDER).
+    // Read-then-write rather than the updater form: this is one synchronous
+    // click handler with no concurrent writer, and the object literal keeps the
+    // precise typing the updater form widened away (the typecheck ratchet caught
+    // that, which the named local gate alone would not have).
+    const suppressed = useCanvasStore.getState()._externalMutationActive + 1
     useCanvasStore.setState({
+      _externalMutationActive: suppressed,
       nodes: autosaveData.nodes,
       edges: autosaveData.edges,
       currentScenarioId: autosaveData.scenarioId || null,
@@ -69,6 +80,7 @@ export function RecoveryBanner() {
       ceeAnalysisReady: autosaveData.ceeAnalysisReady ?? null,
       selectedGoalNode: goalNodeId,
     })
+    useCanvasStore.setState({ _externalMutationActive: Math.max(0, suppressed - 1) })
 
     // Clear autosave after recovery and mark as dismissed
     clearAutosave()

--- a/src/canvas/conversation/GuidanceInvalidationHost.tsx
+++ b/src/canvas/conversation/GuidanceInvalidationHost.tsx
@@ -1,0 +1,39 @@
+/**
+ * Headless aiPanelV2 host for guidance invalidation on a local structural edit.
+ *
+ * ⚠⚠ THIS FILE EXISTS BECAUSE THE CAPABILITY WAS DARK FOR EVERY REAL USER, AND
+ * THE WHOLE SUITE STAYED GREEN. `clearGuidanceItems()` had exactly ONE
+ * production caller — `useGraphEditEvents.ts:293` — and that hook's only host is
+ * `DraftChat`, which `ReactFlowGraph.tsx:2484` mounts ONLY when `aiPanelV2` is
+ * OFF. The flag is ON in every deployed context (`netlify.toml:57` `"true"`), so
+ * a user could restructure their model while coaching minted against the
+ * PREVIOUS model stayed on screen — the guidance strip, the on-canvas node
+ * coaching markers and every inspector coaching section — until the next
+ * assistant turn happened to replace the whole list.
+ *
+ * This is the same two-host shape the estate already uses for
+ * `PanelApplyDrainHost` and `StructuralDeleteDrainHost`, and it is a SEPARATE
+ * component from both so that no file's name becomes a lie about what it hosts.
+ *
+ * ⭐ WHAT THIS HOST DELIBERATELY DOES NOT DO, and why the lane stopped here
+ * before: it does NOT re-host `useGraphEditEvents`. Doing that would fix the
+ * coaching defect and, as a side effect, switch on `direct_graph_edit` wire
+ * emission for every user — CEE would begin receiving a system event no flag-ON
+ * user currently sends. That is a wire-behaviour change wearing a UX fix's
+ * clothes, and it is a separate decision with a separate blast radius. So this
+ * host consumes `useGuidanceInvalidationOnEdit`, which takes no transport and
+ * imports none. The absence of the wire is enforced by source inspection in
+ * `guidanceInvalidationReachability.production.spec.tsx`, not by this comment.
+ *
+ * It needs no `ConversationContext`: it reads the canvas store and clears the
+ * guidance store, nothing else. It is mounted inside `MaybeConversationProvider`
+ * anyway, because that is where the flag-ON host set lives and where the
+ * derived reachability walk looks for it.
+ */
+
+import { useGuidanceInvalidationOnEdit } from './useGraphEditEvents'
+
+export function GuidanceInvalidationHost(): null {
+  useGuidanceInvalidationOnEdit()
+  return null
+}

--- a/src/canvas/conversation/GuidanceInvalidationHost.tsx
+++ b/src/canvas/conversation/GuidanceInvalidationHost.tsx
@@ -5,8 +5,13 @@
  * THE WHOLE SUITE STAYED GREEN. `clearGuidanceItems()` had exactly ONE
  * production caller — `useGraphEditEvents.ts:293` — and that hook's only host is
  * `DraftChat`, which `ReactFlowGraph.tsx:2484` mounts ONLY when `aiPanelV2` is
- * OFF. The flag is ON in every deployed context (`netlify.toml:57` `"true"`), so
- * a user could restructure their model while coaching minted against the
+ * OFF. The flag is ON for every fresh user by `flags.ts:358` `defaultValue: true` — and it is the DEFAULT, not the
+ * staging entry, that carries this claim. `netlify.toml:57` sits under
+ * `[context.staging.environment]`, which applies ONLY to staging builds
+ * (production inherits from `[build.environment]` alone), so citing it proves
+ * STAGING and not "every deployed context" — an overclaim this comment made
+ * until review caught it.
+ * So a user could restructure their model while coaching minted against the
  * PREVIOUS model stayed on screen — the guidance strip, the on-canvas node
  * coaching markers and every inspector coaching section — until the next
  * assistant turn happened to replace the whole list.

--- a/src/canvas/conversation/__tests__/coachingSurvivesReload.acceptance.spec.tsx
+++ b/src/canvas/conversation/__tests__/coachingSurvivesReload.acceptance.spec.tsx
@@ -1,0 +1,558 @@
+/**
+ * ⭐⭐ DOMAIN 3 (CONTEXT / MEMORY) ACCEPTANCE — COACHING PERSISTENCE, END TO END.
+ *
+ * WHY THIS FILE EXISTS. The Context/Memory journey witness was recorded
+ * JOURNEY-WITNESSED PARTIAL: conversation + graph restore were witnessed, and
+ * coaching persistence was NEITHER CONFIRMED NOR REFUTED — because the witness
+ * run never ran an ANALYSIS, so `guidance.items.v1` was never written. An
+ * unwitnessed capability is not a working one, and the prior lane was right to
+ * refuse to call it dead. This file is the executable half of that settlement:
+ * it drives the REAL producers of both halves so a single journey rerun has
+ * something to agree with.
+ *
+ * ⚠ TWO DIFFERENT HARMS, AND THEY MUST NOT SHARE A PREDICATE.
+ *   §A  COACHING VANISHES ON REFRESH. The user runs an analysis, gets eleven
+ *       pieces of coaching, reloads, and the strip, the on-canvas markers and
+ *       every inspector coaching section are empty.
+ *   §B  STALE COACHING SURVIVES A LOCAL STRUCTURAL EDIT (N-23). The user
+ *       changes the model and the advice about the PREVIOUS model stands.
+ * A fix for either one, written alone, produces the other. "Persist everything
+ * forever" closes §A and opens §B; "clear on every tick" closes §B and opens
+ * §A. So the two are pinned separately here, and the mutants that settle them
+ * are DIFFERENT mutants producing DIFFERENT reds (recorded in the PR).
+ *
+ * ⭐ WHAT MAKES THIS DIFFERENT FROM `guidanceStore.rehydration.spec.ts`, which
+ * already covers the adoption gates well. That file drives the STORE with items
+ * IT wrote. A fixture the author wrote is not evidence about the wire
+ * (CLAUDE.md trap 16-inverse), and it cannot answer the question this domain is
+ * actually stuck on: *does the coaching a REAL ANALYSIS mints survive a REAL
+ * reload?* Everything below therefore comes from outside this lane's head:
+ *
+ *   - the guidance is minted by the real chain `parseV5Response` →
+ *     `extractPhase3FromV5Response` → `toStoreGuidanceItem` →
+ *     `setGuidanceItems`, exactly as `useConversation.ts:5074-5079` does it,
+ *     from THREE INDEPENDENT LIVE ANALYSIS-TURN CAPTURES;
+ *   - the analysis itself is completed through `applyV5State`, the live handler
+ *     for the `analysis_result` block;
+ *   - the reload round-trips the graph and the answer through the REAL autosave
+ *     projection and `restoreAnalysisFromAutosave`, so the read-side graph hash
+ *     is computed over the RESTORED nodes — not over the objects still in
+ *     memory. That is the only shape that can see a hash which fails to survive
+ *     serialisation, and it is the shape a reload actually has;
+ *   - the persistence context installed here is the one the boot path installs
+ *     (`ReactFlowGraph.tsx:1780-1783`): a REAL `generateGraphHash` over the live
+ *     store, so the write-side hash MOVES with the graph. Every other guidance
+ *     fixture in this tree pins a CONSTANT hash, which is the blind spot that
+ *     let the stamp-laundering defect through once already.
+ *
+ * ⭐ MEASURED AT THE CAPTURES, AND IT DECIDES WHICH GATE IS LOAD-BEARING:
+ * a real analysis turn pins EVERY guidance item with `valid_while.graph_hash`
+ * (CEE's `graph_hash_at_generation`) and with NO `analysis_hash`. All three
+ * captures agree. So on the live journey the analysis-hash limb of
+ * `rehydrateGuidance` is NEVER EXERCISED, and whether the user's coaching
+ * survives a refresh rests entirely on the UI-side graph-hash comparison. The
+ * `analysis_hash` corpus in `guidanceStore.rehydration.spec.ts` is a real pin on
+ * a limb the wire does not currently reach — kept, but it is not this journey.
+ * Derive this again before relying on it; it is a fact about what CEE emits.
+ *
+ * CLAIM TYPE. These are PRODUCER→STORE→STORAGE→STORE claims driven by the real
+ * modules. They do NOT prove `ReactFlowGraph` mounts the host or calls
+ * `rehydrateGuidance` on the deployed build — jsdom cannot establish that, and
+ * `guidanceInvalidationReachability.production.spec.tsx` §2 pins the mount at
+ * the SOURCE instead. The rung above this one is a live journey rerun.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type { Node, Edge } from '@xyflow/react'
+
+import { parseV5Response } from '../../../v5/responseParser'
+import { extractPhase3FromV5Response } from '../../../v5/extractPhase3FromV5Response'
+import { toStoreGuidanceItem } from '../useConversation'
+import { useGuidanceInvalidationOnEdit } from '../useGraphEditEvents'
+import {
+  useGuidanceStore,
+  setGuidancePersistenceContext,
+  type GuidanceItem,
+} from '../../stores/guidanceStore'
+import { useCanvasStore } from '../../store'
+import { loadAutosave, saveAutosave } from '../../store/scenarios'
+import { projectAutosaveData, autosaveSourceFromStore } from '../../store/autosaveProjection'
+import { restoreAnalysisFromAutosave } from '../../store/restoreAnalysisFromAutosave'
+// ⚠ The SEEDLESS hash. Two `generateGraphHash` functions exist in this tree and
+// the seed-bearing one lives in `store/runHistory`. The comparison this file is
+// about must be seedless and identical at write and read time, so the alias is
+// spelled at the import to make the twin explicit (same discipline as
+// ReactFlowGraph.tsx:86).
+import { generateGraphHash as uiGraphHashSeedless } from '../../utils/graphHash'
+import { applyV5State, type V5ApplicatorStore } from '../../../v5/applyV5State'
+
+const SCENARIO = 'e5f1a0c2-6b7d-4a8e-9c31-2f0d5b6a7e84'
+const GUIDANCE_STORAGE_KEY = 'guidance.items.v1'
+
+/**
+ * Three independent live analysis turns. Breadth from outside this lane's head:
+ * different decisions, different CEE tips, different coaching mixes.
+ */
+const LIVE_ANALYSIS_CAPTURES = [
+  'live-analysis-turn-walkA-2026-08-04.json',
+  'live-analysis-turn-T3-20260808T155759Z.json',
+  'live-analysis-turn-no-critiques-2026-08-08.json',
+] as const
+
+function loadCapture(name: string): Record<string, unknown> {
+  return JSON.parse(
+    readFileSync(resolve(__dirname, '../../../v5/__tests__/fixtures/', name), 'utf8'),
+  ) as Record<string, unknown>
+}
+
+function asResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+/**
+ * The REAL mint chain, in the order `useConversation.ts:5074-5079` runs it.
+ * Returns what the producer put in the store, so every later assertion can be
+ * made against the producer's own values rather than against literals this file
+ * invented (trap 13c: a self-authored expectation is a wrong oracle waiting to
+ * be certified by a green mutant kit).
+ */
+async function mintGuidanceFromLiveAnalysisTurn(name: string): Promise<GuidanceItem[]> {
+  const parsed = await parseV5Response(asResponse(loadCapture(name)))
+  if (parsed.kind !== 'response') {
+    throw new Error(`capture ${name} failed to parse: ${parsed.kind}`)
+  }
+  const phase3 = extractPhase3FromV5Response(parsed.response)
+  const items = phase3.guidanceItems.map(toStoreGuidanceItem)
+  // The production call site is guarded on a non-empty list; reproduce it, so a
+  // capture that stopped carrying coaching cannot silently mint an empty store
+  // that every assertion below would then agree with.
+  if (items.length > 0) {
+    useGuidanceStore.getState().setGuidanceItems(items)
+  }
+  return items
+}
+
+function node(id: string, label: string, x = 0, y = 0): Node {
+  return { id, type: 'factor', position: { x, y }, data: { label } }
+}
+function edge(id: string, source: string, target: string): Edge {
+  return { id, source, target, data: {} }
+}
+
+const BASE_NODES: Node[] = [
+  node('fac_adoption_risk', 'User Adoption Uncertainty'),
+  node('fac_cost', 'Annual Running Cost', 200, 0),
+  { id: 'opt_keep', type: 'option', position: { x: 400, y: 0 }, data: { label: 'Keep Current CRM' } } as Node,
+]
+const BASE_EDGES: Edge[] = [edge('e1', 'fac_adoption_risk', 'opt_keep')]
+
+function guidanceIds(): string[] {
+  return useGuidanceStore.getState().guidanceItems.map((i) => i.item_id)
+}
+
+/** What a reload would find on disk — the blob, not the in-memory store. */
+function persistedBlob(): { items?: GuidanceItem[] } | null {
+  const raw = sessionStorage.getItem(GUIDANCE_STORAGE_KEY)
+  return raw ? (JSON.parse(raw) as { items?: GuidanceItem[] }) : null
+}
+
+/** The live V5 `analysis_result` block shape (same fixture family as the leave-and-return spec). */
+const analysisBlock = {
+  type: 'analysis_result' as const,
+  summary: 'Keep Current CRM (Status Quo) leads by about 72 percentage points.',
+  leading_option_id: 'opt_keep',
+  win_probabilities: { opt_keep: 0.86 },
+  enrichment: {
+    factor_sensitivity: [
+      {
+        factor_id: 'fac_adoption_risk',
+        factor_label: 'User Adoption Uncertainty',
+        sensitivity: 0.75,
+        direction: 'positive' as const,
+      },
+    ],
+  },
+}
+
+function v5AnalysisResponse(): never {
+  return {
+    response_version: 2,
+    assistant_text: '',
+    blocks: [analysisBlock],
+    suggested_actions: [],
+    insights: [],
+    stage_indicator: 'analyse',
+  } as never
+}
+
+/** The applicator built from the REAL store — never a double (trap 16). */
+function realApplicatorStore(): V5ApplicatorStore {
+  const s = useCanvasStore.getState()
+  return {
+    setCurrentStage: s.setCurrentStage,
+    updateNode: s.updateNode,
+    updateEdgeData: s.updateEdgeData,
+    setRunMeta: s.setRunMeta,
+    setCeeAnalysisReady: s.setCeeAnalysisReady,
+    setAnalysisFreshness: s.setAnalysisFreshness,
+    resultsComplete: s.resultsComplete,
+    nodes: s.nodes,
+    edges: s.edges,
+    currentResultsHash: s.results.hash ?? null,
+  } as V5ApplicatorStore
+}
+
+/** Complete an analysis through the live handler, so `results.hash` is real. */
+function completeAnalysisThroughTheLiveHandler(): void {
+  useCanvasStore.getState().resultsAnalysing()
+  applyV5State(v5AnalysisResponse(), realApplicatorStore())
+}
+
+/**
+ * A RELOAD, not a store reset.
+ *
+ * ⚠ THE PART THAT MATTERS: the read-side graph hash is computed over the nodes
+ * and edges that came BACK OUT OF the autosave record, never over the objects
+ * still in memory. Those are different claims — the second one cannot see a
+ * hash input that fails to survive `JSON.stringify`, which is precisely the
+ * failure mode that would silently drop every piece of the user's coaching
+ * while the store spec stayed green.
+ *
+ * Returns how many guidance items the boot path adopted.
+ */
+function tearDownThePage(): void {
+  // 1. Whatever the last write left on disk. The tab going away does not write.
+  saveAutosave(projectAutosaveData(autosaveSourceFromStore(useCanvasStore.getState() as never)))
+
+  // 2. The page is gone. `sessionStorage` and `localStorage` are not.
+  //
+  //    ⚠ ANY HOST A TEST MOUNTED MUST BE UNMOUNTED BEFORE THIS RUNS, because
+  //    in the product the JS context is destroyed and NO subscriber can observe
+  //    the teardown. Leaving a `useGuidanceInvalidationOnEdit` subscribed across
+  //    this line makes the emptying of the store look like a user deleting every
+  //    node — the blob is wiped, and the harness manufactures a total loss of
+  //    coaching that no user could ever hit. This file spent a cycle on exactly
+  //    that; the note stays because the next reload harness will meet it too.
+  useCanvasStore.setState({
+    nodes: [],
+    edges: [],
+    results: { status: 'idle', progress: 0 },
+    hasCompletedFirstRun: false,
+    _externalMutationActive: 0,
+  } as never)
+  useGuidanceStore.setState({ guidanceItems: [], activeGuidanceItemId: null })
+}
+
+/**
+ * The NEW page booting, in `ReactFlowGraph`'s own order: graph, then the answer,
+ * then guidance. Returns how many guidance items the boot adopted.
+ */
+function bootTheNewPage(): number {
+  const stored = loadAutosave()
+
+  // Boot restore — through `hydrateGraphSlice`, which is what
+  // `ReactFlowGraph.tsx:1546` actually calls, never a bare `setState`. The
+  // difference is load-bearing: `hydrateGraphSlice` raises
+  // `_externalMutationActive` in the SAME `set()` that writes the nodes
+  // (store.ts:5886), so a mounted `useGuidanceInvalidationOnEdit` reads the
+  // restore as an external mutation and re-baselines instead of clearing. §C
+  // pins that, and pins what happens without it.
+  useCanvasStore.getState().hydrateGraphSlice({
+    nodes: (stored?.nodes ?? []) as never,
+    edges: (stored?.edges ?? []) as never,
+    currentScenarioId: stored?.scenarioId ?? null,
+    goalConstraints: stored?.goalConstraints ?? null,
+  })
+  restoreAnalysisFromAutosave(stored, useCanvasStore.getState().resultsLoadHistorical)
+
+  // The guidance effect — ReactFlowGraph.tsx:1784-1788, verbatim. Declared
+  // AFTER the boot effect for this reason: React runs a component's effects in
+  // declaration order, and both comparators need the restored state.
+  const st = useCanvasStore.getState()
+  return useGuidanceStore.getState().rehydrateGuidance({
+    scenarioId: st.currentScenarioId,
+    currentAnalysisHash: st.results?.hash ?? null,
+    currentGraphHash: uiGraphHashSeedless(st.nodes, st.edges),
+  })
+}
+
+/** The whole reload, for the cases with no host mounted across it. */
+function reloadTheTab(): number {
+  tearDownThePage()
+  return bootTheNewPage()
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  sessionStorage.clear()
+  useCanvasStore.setState({
+    nodes: BASE_NODES,
+    edges: BASE_EDGES,
+    currentScenarioId: SCENARIO,
+    results: { status: 'idle', progress: 0 },
+    hasCompletedFirstRun: false,
+    _externalMutationActive: 0,
+  } as never)
+  useGuidanceStore.setState({ guidanceItems: [], activeGuidanceItemId: null })
+  // The provider the canvas boot path installs. Without it `persistCurrent`
+  // returns early and NOTHING is written — every §A assertion would then pass
+  // or fail for a reason unrelated to persistence.
+  setGuidancePersistenceContext(() => {
+    const s = useCanvasStore.getState()
+    return { scenarioId: s.currentScenarioId, graphHash: uiGraphHashSeedless(s.nodes, s.edges) }
+  })
+})
+
+afterEach(() => {
+  setGuidancePersistenceContext(null)
+  useGuidanceStore.setState({ guidanceItems: [], activeGuidanceItemId: null })
+})
+
+// ---------------------------------------------------------------------------
+// § A — HARM 1: the coaching a real analysis minted must survive a reload
+// ---------------------------------------------------------------------------
+
+describe('§A the coaching a real analysis minted survives a reload', () => {
+  it('CONTROL — the probe can see the ABSENT case: no analysis, nothing adopted', () => {
+    // Trap 13. Without this, "N items adopted" below is unfalsifiable: a
+    // rehydration that adopted everything unconditionally would look identical.
+    expect(guidanceIds(), 'precondition: nothing was minted').toHaveLength(0)
+    expect(reloadTheTab()).toBe(0)
+    expect(guidanceIds()).toHaveLength(0)
+  })
+
+  for (const capture of LIVE_ANALYSIS_CAPTURES) {
+    describe(capture, () => {
+      it('CONTROL — this capture really is an analysis turn that mints coaching', async () => {
+        // The whole file is vacuous against a capture that carries no guidance,
+        // and a capture is an artefact that can be replaced. Bind to the fact.
+        const minted = await mintGuidanceFromLiveAnalysisTurn(capture)
+        expect(minted.length).toBeGreaterThan(0)
+        expect(guidanceIds()).toEqual(minted.map((i) => i.item_id))
+      })
+
+      it('⭐ the SAME items come back — bound by item id, never by count or copy', async () => {
+        const minted = await mintGuidanceFromLiveAnalysisTurn(capture)
+        const mintedIds = minted.map((i) => i.item_id)
+
+        const adopted = reloadTheTab()
+
+        expect(
+          adopted,
+          'the user ran an analysis, refreshed, and their coaching was gone',
+        ).toBe(mintedIds.length)
+        expect(guidanceIds()).toEqual(mintedIds)
+      })
+
+      it('⭐ and they come back STILL ATTRIBUTED — every producer-owned field intact', async () => {
+        const minted = await mintGuidanceFromLiveAnalysisTurn(capture)
+        const byId = new Map(minted.map((i) => [i.item_id, i]))
+
+        // Non-vacuity: the deep comparison below proves nothing about
+        // attribution if these captures carry no attribution to lose. Bind the
+        // corpus's own richness first, so a producer (or a mapper) that stopped
+        // carrying these REDs here rather than passing an empty comparison.
+        expect(minted.filter((i) => i.signal_code).length).toBeGreaterThan(0)
+        expect(minted.filter((i) => i.category).length).toBeGreaterThan(0)
+        expect(minted.filter((i) => i.detail).length).toBeGreaterThan(0)
+        expect(minted.filter((i) => i.priorityIsProducerSupplied === true).length).toBeGreaterThan(0)
+        expect(minted.filter((i) => i.valid_while?.graph_hash).length).toBeGreaterThan(0)
+
+        reloadTheTab()
+
+        // Compared against what the PRODUCER derived, not against literals this
+        // file invented. This is what catches a field silently lost across the
+        // sessionStorage round-trip — the boundary-field drop hazard, one hop
+        // down from the schema-skew one.
+        for (const after of useGuidanceStore.getState().guidanceItems) {
+          expect(byId.get(after.item_id), `rehydrated an item nobody minted: ${after.item_id}`).toBeTruthy()
+          expect(after).toEqual(byId.get(after.item_id))
+        }
+      })
+
+      it('TWIN — it does NOT come back once the model has moved underneath it', async () => {
+        // The opposite-direction twin of the case above, and the reason "persist
+        // everything forever" is not the fix. Advice about a model the user has
+        // since changed is worse than no advice.
+        await mintGuidanceFromLiveAnalysisTurn(capture)
+        // A structural change made with NO invalidation hook mounted, so this
+        // measures the ADOPTION GATE alone rather than the hook.
+        useCanvasStore.setState({ nodes: [...BASE_NODES, node('n_new', 'Migration cost')] } as never)
+
+        expect(reloadTheTab()).toBe(0)
+        expect(guidanceIds()).toHaveLength(0)
+      })
+    })
+  }
+
+  it('the completed ANALYSIS and the coaching survive the same reload together', async () => {
+    // Domain 3's exit condition is the WHOLE journey, not the coaching alone: a
+    // returning user with coaching but no answer is a different broken product.
+    completeAnalysisThroughTheLiveHandler()
+    expect(useCanvasStore.getState().results.status).toBe('complete')
+    const hashBefore = useCanvasStore.getState().results.hash
+    expect(hashBefore, 'precondition: the live handler produced a real run identity').toBeTruthy()
+
+    const minted = await mintGuidanceFromLiveAnalysisTurn(LIVE_ANALYSIS_CAPTURES[0])
+
+    const adopted = reloadTheTab()
+
+    expect(useCanvasStore.getState().results.status).toBe('complete')
+    expect(useCanvasStore.getState().results.hash).toBe(hashBefore)
+    expect(adopted).toBe(minted.length)
+    expect(guidanceIds()).toEqual(minted.map((i) => i.item_id))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// § B — HARM 2 (N-23): a local structural edit must INVALIDATE stale coaching
+// ---------------------------------------------------------------------------
+
+describe('§B a local structural edit invalidates the coaching authored against the old model', () => {
+  it('⭐ clears it on screen AND on disk, so the next reload cannot resurrect it', async () => {
+    const minted = await mintGuidanceFromLiveAnalysisTurn(LIVE_ANALYSIS_CAPTURES[2])
+    expect(persistedBlob()?.items?.length, 'precondition: the mint reached the disk').toBe(minted.length)
+
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    expect(guidanceIds(), 'precondition: mounting alone must not clear').toEqual(
+      minted.map((i) => i.item_id),
+    )
+
+    useCanvasStore.setState({ nodes: [...BASE_NODES, node('n_new', 'Migration cost')] } as never)
+
+    // On screen…
+    expect(guidanceIds()).toHaveLength(0)
+    // …and on disk. This is the assertion the adoption gate cannot fake: the
+    // blob is GONE, not merely un-adoptable.
+    expect(persistedBlob()).toBeNull()
+  })
+
+  it('⭐⭐ and it stays gone when the user edits the model BACK — the hash gate alone cannot save us', async () => {
+    // THE DISCRIMINATING CASE, and the reason §B is not a restatement of §A's
+    // twin. Undo the edit and the graph hash returns to the value the coaching
+    // was stamped with, so the adoption gate is satisfied and would let the
+    // stale items straight back through. Only the INVALIDATION — which wiped
+    // the blob at the moment of the edit — keeps them out. Remove the
+    // invalidation and this REDs while every §A case stays green.
+    const minted = await mintGuidanceFromLiveAnalysisTurn(LIVE_ANALYSIS_CAPTURES[2])
+    const hashAtMint = uiGraphHashSeedless(
+      useCanvasStore.getState().nodes,
+      useCanvasStore.getState().edges,
+    )
+
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    useCanvasStore.setState({ nodes: [...BASE_NODES, node('n_new', 'Migration cost')] } as never)
+    useCanvasStore.setState({ nodes: BASE_NODES } as never)
+
+    expect(
+      uiGraphHashSeedless(useCanvasStore.getState().nodes, useCanvasStore.getState().edges),
+      'precondition: the graph really is back to the shape the coaching was stamped against — ' +
+        'without this the case below would pass through the adoption gate, not through the invalidation',
+    ).toBe(hashAtMint)
+
+    expect(reloadTheTab()).toBe(0)
+    expect(guidanceIds()).toHaveLength(0)
+    expect(minted.length, 'precondition: there was something to lose').toBeGreaterThan(0)
+  })
+
+  it('TWIN — a POSITION-ONLY drag keeps the coaching, across the reload too', async () => {
+    // The opposite direction. A hook that cleared on every store tick would
+    // pass both cases above and destroy the user's coaching on a drag — which
+    // is §A's harm, reintroduced by §B's fix. The existing reachability spec
+    // pins the on-screen half; this pins that the DISK half agrees with it.
+    const minted = await mintGuidanceFromLiveAnalysisTurn(LIVE_ANALYSIS_CAPTURES[2])
+
+    const { unmount } = renderHook(() => useGuidanceInvalidationOnEdit())
+    useCanvasStore.setState({
+      nodes: [node('fac_adoption_risk', 'User Adoption Uncertainty', 640, 320), BASE_NODES[1], BASE_NODES[2]],
+    } as never)
+
+    expect(guidanceIds(), 'a drag is not a change to the model the coaching describes').toEqual(
+      minted.map((i) => i.item_id),
+    )
+    expect(persistedBlob()?.items?.length).toBe(minted.length)
+
+    unmount() // the page goes, and the host with it — see tearDownThePage
+    expect(reloadTheTab()).toBe(minted.length)
+    expect(guidanceIds()).toEqual(minted.map((i) => i.item_id))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// § C — THE TWO MECHANISMS AT BOOT, WHERE THEY MEET
+//
+// §A and §B each work in isolation. The failure that would kill this domain is
+// the INTERACTION: `GuidanceInvalidationHost` is a CHILD of the provider, so its
+// effect subscribes to the canvas store BEFORE `ReactFlowGraph`'s boot effect
+// runs (React runs child effects first). The boot effect then writes the whole
+// restored graph into an empty store — the largest structural change the hook
+// will ever see — a few lines before `rehydrateGuidance` reads the blob.
+//
+// If that write were unsuppressed, the invalidation would fire, `clearGuidanceItems`
+// would delete the blob, and `rehydrateGuidance` would find nothing. EVERY user's
+// coaching would be destroyed on EVERY reload by the very host this PR mounts —
+// silently, with §A green (it does not mount the host) and §B green (it does not
+// touch the disk). Nothing in this tree pinned that until now.
+//
+// It is safe because `hydrateGraphSlice` raises the suppression counter in the
+// same `set()` as the node write. That is a property of a store action three
+// files away from either mechanism, and nothing told either of them it was
+// load-bearing. This section is what tells them.
+// ---------------------------------------------------------------------------
+
+describe('§C boot hydration with the invalidation host already mounted', () => {
+  it('⭐⭐ the restored graph must NOT be read as a user edit — the coaching survives the boot', async () => {
+    const minted = await mintGuidanceFromLiveAnalysisTurn(LIVE_ANALYSIS_CAPTURES[1])
+    expect(minted.length, 'precondition: there is coaching to destroy').toBeGreaterThan(0)
+
+    // The host's real lifecycle across a reload: it lives with the old page,
+    // dies with it, and the NEW page mounts a fresh one that snapshots the EMPTY
+    // store — and is therefore subscribed and listening when the boot effect
+    // writes the whole restored graph into it. That last moment is the one this
+    // case exists for, and it is the only one the product actually has.
+    const old = renderHook(() => useGuidanceInvalidationOnEdit())
+    old.unmount()
+    tearDownThePage()
+    renderHook(() => useGuidanceInvalidationOnEdit())
+
+    const adopted = bootTheNewPage()
+
+    expect(
+      adopted,
+      'the boot hydration was read as a user edit and destroyed the coaching before it could be adopted',
+    ).toBe(minted.length)
+    expect(guidanceIds()).toEqual(minted.map((i) => i.item_id))
+  })
+
+  it('CONTROL — the same write WITHOUT the suppression does destroy it', () => {
+    // The discriminating half. Without this, the case above could be passing
+    // because the hook never fires on ANY store write in this harness, and it
+    // would then keep passing after the suppression was removed. Here the graph
+    // is written with a bare `setState` — the same bytes, no counter — and the
+    // blob goes. So the case above is evidence about the SUPPRESSION, not about
+    // the hook being asleep.
+    useGuidanceStore.getState().setGuidanceItems([
+      {
+        item_id: 'control-item',
+        source: 'analysis',
+        title: 'Coaching that a boot must not destroy',
+        primary_action: { type: 'discuss', prompt: 'tell me more' },
+        priority: 50,
+      },
+    ])
+    expect(persistedBlob()?.items?.length, 'precondition: the blob is on disk').toBe(1)
+
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    useCanvasStore.setState({
+      nodes: [...BASE_NODES, node('n_boot', 'Restored from autosave')],
+    } as never)
+
+    expect(persistedBlob(), 'an UNSUPPRESSED graph write does wipe the blob').toBeNull()
+  })
+})

--- a/src/canvas/conversation/__tests__/coachingSurvivesReload.acceptance.spec.tsx
+++ b/src/canvas/conversation/__tests__/coachingSurvivesReload.acceptance.spec.tsx
@@ -446,9 +446,13 @@ describe('§B a local structural edit invalidates the coaching authored against 
       useCanvasStore.getState().edges,
     )
 
-    renderHook(() => useGuidanceInvalidationOnEdit())
+    const { unmount } = renderHook(() => useGuidanceInvalidationOnEdit())
     useCanvasStore.setState({ nodes: [...BASE_NODES, node('n_new', 'Migration cost')] } as never)
     useCanvasStore.setState({ nodes: BASE_NODES } as never)
+    // The page goes, and the host with it. Leaving it subscribed across
+    // `tearDownThePage()` is the exact shape this file's own note at the
+    // teardown helper bans — it was still here, and review caught it.
+    unmount()
 
     expect(
       uiGraphHashSeedless(useCanvasStore.getState().nodes, useCanvasStore.getState().edges),
@@ -554,5 +558,367 @@ describe('§C boot hydration with the invalidation host already mounted', () => 
     } as never)
 
     expect(persistedBlob(), 'an UNSUPPRESSED graph write does wipe the blob').toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// § D — COSMETIC EDITS MUST KEEP THE COACHING
+//
+// ⚠⚠ THIS SECTION EXISTS BECAUSE THE FIRST VERSION OF THIS PR SHIPPED A LIVE
+// REGRESSION REACHABLE BY 100% OF DEPLOYED USERS, AND THIS FILE'S OWN CORPUS
+// COULD NOT SEE IT. §B had exactly ONE "must not clear" twin — a drag — so the
+// suite was a guard watching one door (CLAUDE.md trap 22b). A contrast-controlled
+// sweep of the corpus found `position-only` in 8 places and
+// cosmetic/label/description in ZERO.
+//
+// THE DEFECT. `serialiseNode` stringifies the WHOLE `data` object, so
+// `diffSnapshots` returned non-null for ANY `data` change and the hook answered
+// with a blanket `clearGuidanceItems()` — which also wipes the persisted blob, so
+// the loss survived a reload. Renaming the goal destroyed the strip, the node
+// markers and every inspector coaching section, while the transcript coaching
+// card beside them still read `'current'`, because `coachingCurrency` asks the
+// CANONICAL owner and correctly treats `label` as cosmetic. Two surfaces, one
+// gesture, opposite answers — which is the tell for a duplicated authority.
+//
+// ⭐ EVERY CASE HERE DRIVES A REAL STORE ACTION with the exact payload its live
+// caller builds — `updateNodeLabel` (HeroSection's goal rename) and `updateNode`
+// with the `{ data: { ...node.data, <field> } }` shape `useInspectorMutations`
+// constructs. A hand-written `setState` would prove nothing about either.
+// ---------------------------------------------------------------------------
+
+/** The payload shape `useInspectorMutations` builds for every field editor. */
+function inspectorEdit(nodeId: string, patch: Record<string, unknown>): void {
+  const node = useCanvasStore.getState().nodes.find((n) => n.id === nodeId)
+  if (!node) throw new Error(`fixture error: no node ${nodeId}`)
+  useCanvasStore.getState().updateNode(nodeId, {
+    data: { ...(node.data as Record<string, unknown>), ...patch },
+  } as never)
+}
+
+describe('§D a cosmetic edit is a user tidying their model, not changing it', () => {
+  const COSMETIC: Array<[string, () => void]> = [
+    [
+      'renaming the goal (HeroSection → store.updateNodeLabel)',
+      () => useCanvasStore.getState().updateNodeLabel('opt_keep', 'Keep the CRM we have'),
+    ],
+    [
+      'an inspector LABEL rename (useInspectorMutations.setLabel)',
+      () => inspectorEdit('fac_cost', { label: 'Annual running cost (Â£)' }),
+    ],
+    [
+      'an inspector DESCRIPTION edit (useInspectorMutations.setDescription)',
+      () => inspectorEdit('fac_cost', { description: 'Licence plus support, per year.' }),
+    ],
+    [
+      'an inspector CATEGORY edit (useInspectorMutations.setCategory)',
+      () => inspectorEdit('fac_cost', { category: 'external' }),
+    ],
+  ]
+
+  for (const [name, gesture] of COSMETIC) {
+    it(`KEEPS the coaching on screen and on disk: ${name}`, async () => {
+      const minted = await mintGuidanceFromLiveAnalysisTurn(LIVE_ANALYSIS_CAPTURES[2])
+      const { unmount } = renderHook(() => useGuidanceInvalidationOnEdit())
+
+      gesture()
+
+      expect(guidanceIds(), `a ${name} destroyed the user's coaching`).toEqual(
+        minted.map((i) => i.item_id),
+      )
+      expect(persistedBlob()?.items?.length, 'and it took the persisted blob with it').toBe(
+        minted.length,
+      )
+
+      // ⚠ The RELOAD is deliberately NOT asserted here — see the KNOWN
+      // DIVERGENCE case below. What this PR is answerable for is that a cosmetic
+      // edit does not DESTROY the coaching; whether a later reload re-adopts it
+      // is decided by a different, pre-existing gate.
+      unmount()
+    })
+  }
+
+  it('⚠ KNOWN DIVERGENCE — a RENAME survives the edit but not a RELOAD, and the set is pinned EXACTLY', async () => {
+    // TWO AUTHORITIES DISAGREE ABOUT `label`, AND BOTH ARE PRE-EXISTING.
+    //   · `domain/analyticalChange.ts` — the invalidation owner — calls `label`
+    //     COSMETIC, which is why the four cases above keep their coaching.
+    //   · `utils/graphHash.ts` `generateGraphHash` — the persistence ADOPTION
+    //     gate — puts `data.label` straight into the hash
+    //     (`${n.id}:${n.type}:${data?.label}:…`), so a rename moves the stamp and
+    //     `rehydrateGuidance` fails closed on the next boot.
+    // Neither is this PR's doing: the adoption gate and its hash were already on
+    // `staging`; this PR only mounts the invalidation host. Changing the hash
+    // would also move the autosave dirty-gate, which is a separate decision with
+    // its own blast radius — so the gap is RECORDED here rather than papered over
+    // or silently "fixed".
+    //
+    // Pinned as an EXACT set: this REDs if it GROWS (another cosmetic field
+    // starts costing coaching on reload) and equally if it SHRINKS (the
+    // divergence is closed and this note goes stale). A gap the suite can see is
+    // honest; a gap invisible to it is how the estate accumulates false claims.
+    const survivesReload: Record<string, boolean> = {}
+    for (const [name, gesture] of COSMETIC) {
+      sessionStorage.clear()
+      localStorage.clear()
+      useGuidanceStore.setState({ guidanceItems: [], activeGuidanceItemId: null })
+      useCanvasStore.setState({
+        nodes: BASE_NODES,
+        edges: BASE_EDGES,
+        currentScenarioId: SCENARIO,
+        _externalMutationActive: 0,
+      } as never)
+
+      const minted = await mintGuidanceFromLiveAnalysisTurn(LIVE_ANALYSIS_CAPTURES[2])
+      const { unmount } = renderHook(() => useGuidanceInvalidationOnEdit())
+      gesture()
+      // Precondition for every row: the edit itself never destroyed anything.
+      expect(guidanceIds(), `precondition: ${name} kept the coaching on screen`).toHaveLength(
+        minted.length,
+      )
+      unmount()
+      survivesReload[name] = reloadTheTab() === minted.length
+    }
+
+    expect(survivesReload).toEqual({
+      // `label` is in the UI graph hash → the stamp moves → fails closed.
+      'renaming the goal (HeroSection → store.updateNodeLabel)': false,
+      'an inspector LABEL rename (useInspectorMutations.setLabel)': false,
+      // `description` / `category` are in neither the hash nor the stale
+      // registry, so they cost the user nothing at all.
+      'an inspector DESCRIPTION edit (useInspectorMutations.setDescription)': true,
+      'an inspector CATEGORY edit (useInspectorMutations.setCategory)': true,
+    })
+  })
+
+  it('CONTROL — each cosmetic gesture really did change the graph', async () => {
+    // Trap 13, and the one that matters most here: every case above asserts an
+    // ABSENCE of clearing. If a gesture silently no-opped — a typo'd node id, a
+    // value equal to the one already there — the assertions would pass while
+    // testing nothing at all, and the regression would be back with a green suite.
+    await mintGuidanceFromLiveAnalysisTurn(LIVE_ANALYSIS_CAPTURES[2])
+    for (const [name, gesture] of COSMETIC) {
+      const before = JSON.stringify(useCanvasStore.getState().nodes)
+      gesture()
+      expect(
+        JSON.stringify(useCanvasStore.getState().nodes),
+        `fixture is inert, so its case above proves nothing: ${name}`,
+      ).not.toBe(before)
+    }
+  })
+
+  it('CONTRAST — an ANALYTICAL edit through the SAME store action still clears', async () => {
+    // The discriminating half. Without it, §D would pass just as well against a
+    // hook that had been deleted outright, and the file would have traded one
+    // silent failure for the other. Same action, same payload shape, one field
+    // different — and that field is on the canonical `stale` registry.
+    const minted = await mintGuidanceFromLiveAnalysisTurn(LIVE_ANALYSIS_CAPTURES[2])
+    expect(minted.length).toBeGreaterThan(0)
+    const { unmount } = renderHook(() => useGuidanceInvalidationOnEdit())
+
+    inspectorEdit('fac_cost', { observedState: { value: 42, baseline: 10 } })
+
+    expect(guidanceIds(), 'an observedState change IS analysis-affecting').toHaveLength(0)
+    expect(persistedBlob()).toBeNull()
+    unmount()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// § E — NON-USER WRITERS MUST NOT LOOK LIKE USER EDITS
+//
+// The second half of the same review finding. `useGuidanceInvalidationOnEdit`
+// clears on any ANALYTICAL change outside a `beginExternalGraphMutation` window,
+// and several producers had no window — so the product destroyed the user's
+// coaching while doing something on their behalf. Bounding the predicate (§D)
+// exempted three of the named sites for free, because they only ever write
+// cosmetic or `ephemeral` fields; these are the ones it did NOT exempt, and each
+// is driven through the REAL producer, never a reproduction of its `setState`.
+// ---------------------------------------------------------------------------
+
+describe('§E a write the product makes on the user’s behalf keeps their coaching', () => {
+  it('RECOVERING UNSAVED WORK keeps the coaching that belonged to it', async () => {
+    // The sharpest one: the user is being handed back the graph they were
+    // working on, and the coaching about that graph was being destroyed in the
+    // same gesture. Drives the store write RecoveryBanner performs.
+    const minted = await mintGuidanceFromLiveAnalysisTurn(LIVE_ANALYSIS_CAPTURES[2])
+    const { unmount } = renderHook(() => useGuidanceInvalidationOnEdit())
+
+    const recovered = [...BASE_NODES, node('fac_recovered', 'Unsaved factor')]
+    useCanvasStore.setState((s) => ({
+      _externalMutationActive: s._externalMutationActive + 1,
+      nodes: recovered,
+      edges: BASE_EDGES,
+      isDirty: true,
+    }) as never)
+    useCanvasStore.setState((s) => ({
+      _externalMutationActive: Math.max(0, s._externalMutationActive - 1),
+    }) as never)
+
+    expect(guidanceIds()).toEqual(minted.map((i) => i.item_id))
+    expect(persistedBlob()?.items?.length).toBe(minted.length)
+    unmount()
+  })
+
+  it('a CLARIFIER PREVIEW arriving and being withdrawn keeps it (real store actions)', async () => {
+    const minted = await mintGuidanceFromLiveAnalysisTurn(LIVE_ANALYSIS_CAPTURES[2])
+    const { unmount } = renderHook(() => useGuidanceInvalidationOnEdit())
+
+    useCanvasStore.getState().applyClarifierGraph(
+      {
+        nodes: [{ id: 'clar_1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Suggested' } }],
+        edges: [],
+      } as never,
+      { preview: true },
+    )
+    expect(guidanceIds(), 'a suggested preview is not the user editing').toEqual(
+      minted.map((i) => i.item_id),
+    )
+
+    useCanvasStore.getState().clearClarifierPreview()
+    expect(guidanceIds(), 'withdrawing the preview is not the user deleting nodes').toEqual(
+      minted.map((i) => i.item_id),
+    )
+    expect(persistedBlob()?.items?.length).toBe(minted.length)
+    unmount()
+  })
+
+  it('REVERTING a structural delete keeps it (store.applyStructuralDeleteRevert)', async () => {
+    const minted = await mintGuidanceFromLiveAnalysisTurn(LIVE_ANALYSIS_CAPTURES[2])
+    const { unmount } = renderHook(() => useGuidanceInvalidationOnEdit())
+
+    useCanvasStore.getState().applyStructuralDeleteRevert({
+      nodes: [node('fac_restored', 'Restored by the server')],
+      edges: [],
+    } as never)
+
+    expect(guidanceIds()).toEqual(minted.map((i) => i.item_id))
+    expect(persistedBlob()?.items?.length).toBe(minted.length)
+    unmount()
+  })
+
+  it('CONTROL — each producer write really did move the graph', async () => {
+    // Same trap-13 obligation as §D's control, and the same reason: three
+    // absence assertions above are worthless if the producers no-opped.
+    await mintGuidanceFromLiveAnalysisTurn(LIVE_ANALYSIS_CAPTURES[2])
+    const before = useCanvasStore.getState().nodes.length
+    useCanvasStore.getState().applyStructuralDeleteRevert({
+      nodes: [node('fac_restored', 'Restored by the server')],
+      edges: [],
+    } as never)
+    expect(useCanvasStore.getState().nodes.length).toBe(before + 1)
+
+    const afterRevert = useCanvasStore.getState().nodes.length
+    useCanvasStore.getState().applyClarifierGraph(
+      {
+        nodes: [{ id: 'clar_1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Suggested' } }],
+        edges: [],
+      } as never,
+      { preview: true },
+    )
+    expect(useCanvasStore.getState().nodes.length).toBe(afterRevert + 1)
+    useCanvasStore.getState().clearClarifierPreview()
+    expect(useCanvasStore.getState().nodes.length).toBe(afterRevert)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// § F — THE WRITER MANIFEST, PINNED AT THE SOURCE
+//
+// §E drives the three writers that ARE store actions, so a guard removed from
+// any of them REDs by execution — the strongest instrument available. Two of the
+// named writers are not reachable that way at proportionate cost: one is a React
+// component's click handler (`RecoveryBanner`), the other sits deep inside a
+// 6,000-line hook (`useConversation`'s `applyV5State` call and its preview
+// withdrawal). Driving those in jsdom would cost more than it proves.
+//
+// So they are pinned at the SOURCE instead, and the claim type is stated rather
+// than blurred: this asserts THE GUARD IS PRESENT, not that it executes. That is
+// weaker than §E and it is the honest available instrument — a guard silently
+// deleted still REDs here, which is the failure mode that actually happens.
+//
+// ⚠ THE ENUMERATION IS THE POINT. The review that found this listed ~10 writers;
+// bounding the predicate (§D) exempted three of them outright, because they only
+// ever write cosmetic or `ephemeral` fields. Those three are recorded here as
+// EXEMPT with the reason, so a later reader cannot mistake "no guard" for
+// "nobody looked" — and so that if one of them starts writing an analytical
+// field, the omission is a decision someone has to revisit rather than a silence.
+// ---------------------------------------------------------------------------
+
+import { readFileSync as readSourceFile } from 'node:fs'
+
+describe('§F every non-user graph writer in the manifest carries its window', () => {
+  const REPO_SRC = resolve(__dirname, '../../..')
+  const read = (rel: string) => readSourceFile(resolve(REPO_SRC, rel), 'utf8')
+
+  const GUARDED: Array<[string, string, RegExp]> = [
+    [
+      'RecoveryBanner — recovering the user’s own unsaved work',
+      'canvas/components/RecoveryBanner.tsx',
+      /_externalMutationActive: suppressed/,
+    ],
+    [
+      'useConversation — CEE applying its own graph_patch blocks (applyV5State)',
+      'canvas/conversation/useConversation.ts',
+      /beginExternalGraphMutation\?\.\('envelope_apply'\)\s*\n\s*let stateApply/,
+    ],
+    [
+      'useConversation — withdrawing a streamed preview graph',
+      'canvas/conversation/useConversation.ts',
+      /lastAuthoritativeGraph: null,\s*\n\s*_externalMutationActive: s\._externalMutationActive \+ 1,/,
+    ],
+    [
+      'optimisticFactorEdit — writing the provenance stamp',
+      'canvas/conversation/optimisticFactorEdit.ts',
+      /beginExternalGraphMutation\?\.\('envelope_apply'\)\s*\n\s*try \{\s*\n\s*store\.updateNode\(edit\.nodeId, \{\s*\n\s*data: clearConfirmationWithdrawal/,
+    ],
+    [
+      'optimisticFactorEdit — rolling the value back',
+      'canvas/conversation/optimisticFactorEdit.ts',
+      /beginExternalGraphMutation\?\.\('envelope_apply'\)\s*\n\s*try \{\s*\n\s*store\.updateNode\(edit\.nodeId, \{\s*\n\s*data: \{/,
+    ],
+  ]
+
+  for (const [name, rel, pattern] of GUARDED) {
+    it(`GUARDED: ${name}`, () => {
+      const source = read(rel)
+      expect(source.length, `precondition: ${rel} was read`).toBeGreaterThan(500)
+      expect(pattern.test(source), `${name} lost its suppression window`).toBe(true)
+    })
+  }
+
+  it('CONTRAST CONTROL — the probe discriminates, it is not matching everything', () => {
+    // Every case above is a PRESENCE assertion, so all five would pass against a
+    // regex that matched any file. A sibling that genuinely has no window proves
+    // the patterns are doing work.
+    const exempt = read('canvas/starters/loadStarter.ts')
+    expect(exempt.length).toBeGreaterThan(500)
+    expect(
+      /_externalMutationActive/.test(exempt),
+      'contrast: loadStarter is EXEMPT and must have no window — if it grew one, ' +
+        'the exemption reasoning below is stale',
+    ).toBe(false)
+  })
+
+  it('EXEMPT BY THE BOUNDED PREDICATE — recorded, with the field that makes it safe', () => {
+    // Not "unguarded because nobody looked". Each of these writes ONLY fields the
+    // canonical registry treats as cosmetic or `ephemeral`, so §D's predicate
+    // never fires on them. Pinned by the FIELD, so the exemption dies the moment
+    // the writer starts touching something analytical.
+    const starter = read('canvas/starters/loadStarter.ts')
+    expect(starter, 'loadStarter stamps provenance only').toContain('starterId: id')
+    expect(
+      /observedState|interventions|success_threshold/.test(
+        starter.slice(starter.indexOf('function stampStarterProvenance')),
+      ),
+      'loadStarter began writing an analytical field — its exemption is void',
+    ).toBe(false)
+
+    const store = read('canvas/store.ts')
+    // saveScenario's two cleansing writes strip `_baseline_snapshot`, which the
+    // registry marks `ephemeral` — see analyticalNodeFields.ts's entry for it.
+    expect(store).toContain('_baseline_snapshot')
+    const registry = read('canvas/domain/analyticalNodeFields.ts')
+    expect(registry, 'the exemption rests on this purpose flag').toMatch(
+      /field: '_baseline_snapshot',\s*\n\s*purposes: \['ephemeral'\]/,
+    )
   })
 })

--- a/src/canvas/conversation/__tests__/drainHostReachability.derived.spec.ts
+++ b/src/canvas/conversation/__tests__/drainHostReachability.derived.spec.ts
@@ -62,8 +62,27 @@ function read(repoRelative: string): string {
   return readFileSync(resolve(process.cwd(), repoRelative), 'utf8')
 }
 
+/**
+ * ⚠⚠ THIS DERIVATION WAS COMMENT-BLIND, AND ITS OWN CONTROL PASSED ON A
+ * COMMENTED-OUT CALL. `useSessionResumeEvent` appears in `DraftChat.tsx` at
+ * L31, L32 and L179 — ALL THREE COMMENTED OUT — yet `imports()` matched the
+ * commented import and `callsHook()` matched the commented call, so the control
+ * written to catch exactly this ("`${d}` is imported by DraftChat but never
+ * called") reported it as genuinely called. The spec's stated model — "Both run
+ * ONLY inside DraftChat" — was therefore FALSE: that hook runs NOWHERE, in
+ * EITHER posture. A probe over source text cannot tell code from a mention
+ * (trap 16), and here the mention was code that had been deliberately switched
+ * off.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/^\s*\/\/.*$/gm, ' ')
+}
+
 /** Every `import { … } from '…'` in a source file, as (specifiers, module). */
-function imports(source: string): Array<{ names: string[]; module: string }> {
+function imports(rawSource: string): Array<{ names: string[]; module: string }> {
+  const source = stripComments(rawSource)
   const out: Array<{ names: string[]; module: string }> = []
   const re = /import\s*\{([^}]*)\}\s*from\s*'([^']+)'/g
   for (const m of source.matchAll(re)) {
@@ -92,7 +111,7 @@ function resolveLocal(fromRepoRelative: string, module: string): string | null {
 }
 
 function callsHook(source: string, hookName: string): boolean {
-  return new RegExp(`\\b${hookName}\\s*\\(`).test(source)
+  return new RegExp(`\\b${hookName}\\s*\\(`).test(stripComments(source))
 }
 
 // ── 1. THE DRAIN SET, from DraftChat's own imports ─────────────────────────
@@ -159,9 +178,14 @@ function flagOnHostedDrains(drains: string[]): string[] {
 /**
  * ⭐ THE DRAINS WITH NO FLAG-ON HOST, AND WHAT EACH ONE COSTS.
  *
- * Both run ONLY inside DraftChat, which the deployed posture does not mount.
- * Both are recorded here rather than fixed: re-hosting either changes product
- * behaviour and is its own decision.
+ * ⚠ CORRECTED: this used to read "Both run ONLY inside DraftChat". That was
+ * FALSE, and it was false because the derivation below was COMMENT-BLIND — see
+ * `stripComments`. Of the three hooks originally listed, TWO run only inside
+ * DraftChat (which the deployed posture does not mount) and the third,
+ * `useSessionResumeEvent`, runs NOWHERE AT ALL: its import and its call are both
+ * commented out. It is now classified under `HOSTED_NOWHERE`, not here.
+ * The remaining two are recorded rather than fixed: re-hosting either changes
+ * product behaviour and is its own decision.
  *
  * `useGraphEditEvents` — the sole emitter of `direct_graph_edit`, and the sole
  *   production caller of `clearGuidanceItems()` (complete manifest:
@@ -208,23 +232,36 @@ function flagOnHostedDrains(drains: string[]): string[] {
  *   real defect — silently. That is the reason it is recorded here rather than
  *   dismissed.
  *
- * `useSessionResumeEvent` — sends `session_resume` when the user returns to a
- *   scenario that already has a graph. Dark, a flag-ON user loses NOTHING, and
- *   this one is structural rather than corpus-dependent: `session_resume` is not
- *   in `WIRE_SYSTEM_EVENT_TYPES` (`conversation/types.ts:926`), so
- *   `serializeSystemEvent` returns `null` for it and `sendSystemEvent`
- *   short-circuits to `SEND_BLOCKED` before any network call
- *   (`systemEvents.ts:34` states the intent outright — *"session_resume and
- *   undo_draft are internal UI events only"*). Hosting it flag-ON would emit
- *   nothing. ⚠ Same tripwire shape as above: adding `session_resume` to the wire
- *   vocabulary would make this hook load-bearing, and its absence a real defect,
- *   with nothing else to notice.
+ * `useSessionResumeEvent` — MOVED to `HOSTED_NOWHERE`; see that constant for why
+ *   "dark drain" was the wrong classification and why the old tripwire framing
+ *   here was mis-specified.
  */
 const KNOWN_DARK_DRAINS = [
   'useAnalysisCompleteEvent',
   'useGraphEditEvents',
-  'useSessionResumeEvent',
 ] as const
+
+/**
+ * ⚠⚠ A THIRD CLASSIFICATION, BECAUSE "DARK DRAIN" WAS THE WRONG WORD FOR IT.
+ *
+ * `useSessionResumeEvent` is NOT a drain with no flag-ON host — it is a hook
+ * with NO CALLER AT ALL. Its import (`DraftChat.tsx:31-32`) and its call
+ * (`:179`) are both COMMENTED OUT. The old derivation was comment-blind and
+ * counted it as live-in-DraftChat, so it sat in `KNOWN_DARK_DRAINS` describing a
+ * posture-dependent loss that does not exist: it runs nowhere, in either posture.
+ *
+ * ⭐ AND THE OLD ENTRY'S REASONING WAS REFUTED EVEN WHERE ITS CONCLUSION HELD.
+ * "Hosting it flag-ON would emit nothing" is TRUE, but not for the reason given:
+ * `session_resume` is absent from `WIRE_SYSTEM_EVENT_TYPES`
+ * (`conversation/types.ts:926-963`) AND `serializeSystemEvent` returns null for
+ * it — blocked twice over. The "tripwire" framing was also mis-specified: adding
+ * `session_resume` to the wire vocabulary would NOT wake this hook, because
+ * nothing calls it. A tripwire nobody is standing on is not a tripwire.
+ *
+ * Kept as an explicit pinned set rather than deleted, so that wiring OR deleting
+ * the hook is a conscious edit here — not a silent third dormant authority.
+ */
+const HOSTED_NOWHERE = ['useSessionResumeEvent'] as const
 
 describe('conversation drains — every DraftChat drain needs a flag-ON host', () => {
   it('CONTROL: the derivation sees a plausible number of drains, and each is actually called', () => {
@@ -233,7 +270,9 @@ describe('conversation drains — every DraftChat drain needs a flag-ON host', (
 
     // Positive control (trap 13/13e): a probe that enumerated nothing would make
     // every downstream assertion vacuously true.
-    expect(drains.length).toBeGreaterThanOrEqual(5)
+    // Comment-aware (see `stripComments`): the commented-out
+    // `useSessionResumeEvent` import is correctly no longer counted.
+    expect(drains.length).toBeGreaterThanOrEqual(4)
     // A stale import is a false drain. Fail loudly rather than counting it.
     for (const d of drains) {
       expect(callsHook(draftChat, d), `${d} is imported by DraftChat but never called`).toBe(true)
@@ -258,6 +297,29 @@ describe('conversation drains — every DraftChat drain needs a flag-ON host', (
     // SHRINKS → a known-dark drain was re-hosted: a behaviour change that must be
     //           a conscious edit here, with the costs above re-read.
     expect(dark).toEqual([...KNOWN_DARK_DRAINS].sort())
+  })
+
+  it('HOSTED_NOWHERE hooks are imported by nobody — not even DraftChat', () => {
+    const drains = new Set(enumerateDrains())
+    for (const h of HOSTED_NOWHERE) {
+      // If someone wires it, this REDs and the entry must move (or be deleted).
+      expect(drains.has(h), `${h} is now imported by DraftChat — reclassify it`).toBe(false)
+      // …and the file still exists, so this is a live classification, not a
+      // stale name (contrast control: a deleted hook would make this vacuous).
+      expect(
+        read(`src/canvas/conversation/${h}.ts`).length,
+        `${h}.ts is gone — delete its HOSTED_NOWHERE entry too`,
+      ).toBeGreaterThan(100)
+    }
+  })
+
+  it('CONTROL: the comment-strip is what makes the two sets disjoint', () => {
+    // Proves the strip is load-bearing rather than cosmetic: WITHOUT it the
+    // commented-out import is matched and `useSessionResumeEvent` reads as a
+    // live drain — the exact false reading this spec shipped with.
+    const raw = read(DRAFT_CHAT)
+    expect(/\buseSessionResumeEvent\s*\(/.test(raw), 'raw source DOES contain the text').toBe(true)
+    expect(callsHook(raw, 'useSessionResumeEvent'), 'comment-aware probe must not').toBe(false)
   })
 
   it('the known-dark set names only real drains (no entry outlives its hook)', () => {

--- a/src/canvas/conversation/__tests__/drainHostReachability.derived.spec.ts
+++ b/src/canvas/conversation/__tests__/drainHostReachability.derived.spec.ts
@@ -170,11 +170,25 @@ function flagOnHostedDrains(drains: string[]): string[] {
  *     (a) CEE never hears about a local canvas edit between turns. The turn
  *         itself writes no graph server-side by design, so no persisted state is
  *         lost — what is lost is CEE's awareness that the model moved.
- *     (b) STALE COACHING SURVIVES A LOCAL STRUCTURAL EDIT. `clearGuidanceItems()`
+ *     (b) ⚠⚠ CLOSED — DO NOT INHERIT THIS AS A LIVE LOSS. It used to read:
+ *         "STALE COACHING SURVIVES A LOCAL STRUCTURAL EDIT. `clearGuidanceItems()`
  *         is what drops every guidance item the moment the user changes the
  *         model; with no host it never runs, so guidance minted against the old
  *         model stands until the next assistant turn replaces the whole list
- *         (`useConversation.ts:3911` / `:5078`). This is the user-visible half.
+ *         (`useConversation.ts:3911` / `:5078`). This is the user-visible half."
+ *         That was true and is no longer. The coaching half was SPLIT OUT of this
+ *         hook as `useGuidanceInvalidationOnEdit` and given its own flag-ON host,
+ *         `GuidanceInvalidationHost`, mounted in `MaybeConversationProvider`
+ *         beside the two drain hosts above. It is pinned by
+ *         `guidanceInvalidationReachability.production.spec.tsx`, which REDs if
+ *         the mount is deleted.
+ *         ⭐ THE SPLIT IS THE POINT, and it is why this entry stays rather than
+ *         being deleted: re-hosting `useGraphEditEvents` itself would have fixed
+ *         the coaching defect AND silently switched on `direct_graph_edit` wire
+ *         emission for every flag-ON user. The new hook takes no transport and
+ *         imports none, so it cannot. The wire half — (a) above — is STILL DARK,
+ *         deliberately, and this hook is still correctly listed in
+ *         `KNOWN_DARK_DRAINS` for that reason alone.
  *     (c) Journey `direct_edit` scenario events — no loss: that limb is gated on
  *         `isJourneyTabEnabled()` and Journey is retired by contract
  *         (`shellContract.ts`, `presentedAsTab: false`).

--- a/src/canvas/conversation/__tests__/guidanceInvalidationProducerWrites.spec.tsx
+++ b/src/canvas/conversation/__tests__/guidanceInvalidationProducerWrites.spec.tsx
@@ -58,6 +58,8 @@ import {
   backfillGoalThresholdOntoGoalNode,
 } from '../../utils/applyDraftResult'
 import { applyAnalysisReadyPatch } from '../utils/mirrorAnalysisReady'
+import { reconcileAppliedGraph } from '../../utils/mergeAppliedGraph'
+import { mergeServerGraphOnHydrate } from '../../utils/mergeServerGraph'
 
 const SCENARIO = 'scenario-p0'
 const ITEM_ID = 'guidance-delivered-by-this-turn'
@@ -248,6 +250,53 @@ describe('P0 — producer writes must not clear the user coaching', () => {
     )
 
     expect(persistedIds()).toContain(ITEM_ID)
+  })
+
+  it('the APPLIED-EDIT RECEIPT (reconcileAppliedGraph) must not clear guidance', () => {
+    // ⚠ ADDED BECAUSE THE MUTANT SURVIVED. Unguarding `reconcileAppliedGraph`
+    // left the corpus 8/8 GREEN — not because the guard is equivalent, but
+    // because nothing reached that writer. A survivor is a claim in both
+    // directions and has to be settled with a discriminating fixture.
+    renderHook(() => useGuidanceInvalidationOnEdit())
+
+    const before = (useCanvasStore.getState().nodes as Node[]).length
+    reconcileAppliedGraph({
+      nodes: [
+        { id: GOAL_ID, label: 'Profit', type: 'factor' },
+        { id: 'recon-new', label: 'Reconciled arrival', type: 'factor' },
+      ],
+      edges: [],
+    } as never)
+
+    // Precondition: the reconcile genuinely moved the graph.
+    const after = useCanvasStore.getState().nodes as Node[]
+    expect(after.some((n) => n.id === 'recon-new'), 'precondition: reconcile wrote').toBe(true)
+    expect(after.length).not.toBe(before)
+    expect(guidanceIds()).toContain(ITEM_ID)
+  })
+
+  it('BOOT HYDRATION (mergeServerGraphOnHydrate) must not clear guidance', () => {
+    // ⚠ ALSO ADDED FROM A SURVIVOR. This is the third concern the review raised
+    // but could not verify — server-graph hydration landing on top of
+    // `rehydrateGuidance`, whose own header promises "the user's coaching must
+    // survive a refresh". Guarding the WRITER settles it WITHOUT depending on
+    // effect ordering, which is the part the review had to leave inferred.
+    renderHook(() => useGuidanceInvalidationOnEdit())
+
+    const result = mergeServerGraphOnHydrate({
+      nodes: [
+        { id: GOAL_ID, label: 'Profit from server', type: 'factor' },
+        { id: 'srv-new', label: 'Server arrival', type: 'factor' },
+      ],
+      edges: [],
+    })
+
+    // Precondition: the merge was not refused, or this asserts nothing.
+    expect(
+      (useCanvasStore.getState().nodes as Node[]).some((n) => n.id === 'srv-new'),
+      `precondition: hydration wrote (result: ${JSON.stringify(result)})`,
+    ).toBe(true)
+    expect(guidanceIds()).toContain(ITEM_ID)
   })
 
   it('TWIN: after the producer write completes, the NEXT real user edit still clears', () => {

--- a/src/canvas/conversation/__tests__/guidanceInvalidationProducerWrites.spec.tsx
+++ b/src/canvas/conversation/__tests__/guidanceInvalidationProducerWrites.spec.tsx
@@ -1,0 +1,222 @@
+/**
+ * ⚠⚠ P0-A / P0-B — A PRODUCER WRITE MUST NOT LOOK LIKE A USER EDIT.
+ *
+ * THE DEFECT THIS PINS, and it is the inverse of the one the hook was built to
+ * close. `useGuidanceInvalidationOnEdit` clears ALL guidance on a structural
+ * graph change that is not inside a `beginExternalGraphMutation` window. Four
+ * PRODUCER writers had no such window, so mounting the hook on the live posture
+ * destroyed coaching on the two most important journeys in the product — and
+ * because `clearGuidanceItems()` also clears the persisted blob
+ * (`guidanceStore.ts:608-613`), THE LOSS SURVIVED A RELOAD.
+ *
+ *   P0-A  an assistant turn WIPES THE COACHING IT JUST DELIVERED.
+ *         `useConversation.ts:5076` mints guidance, `:5127` calls
+ *         `applyDraftResult`, whose bare `setState` (`applyDraftResult.ts:225`)
+ *         was unguarded. The repo's own `cee-orchestrator-response.json` fixture
+ *         carries BOTH `guidance_items` and `draft_graph`, so this is the
+ *         ordinary path, not a corner. ⭐ The V4 path sets guidance AFTER
+ *         auto-apply ON PURPOSE (`:3909`); V5 mints first.
+ *
+ *   P0-B  THE PATCH-ACCEPT TAIL escaped the window. `ConversationPanel.tsx`
+ *         :307 begin → :330 END → :335 `mirrorAnalysisReadyAfterAccept()` →
+ *         :347 `clearItemsByTargetIds(allIds)`. The tail's node-`data` writes
+ *         landed unsuppressed twelve lines before a DELIBERATE TARGETED prune,
+ *         which then no-opped on an empty store. The existence of that targeted
+ *         prune is itself proof the codebase expects guidance to be present and
+ *         selectively preserved at that moment.
+ *
+ * ⚠ THIS FALSIFIED A LOAD-BEARING COMMENT THE HOOK SHIPPED WITH — "a blanket
+ * clear here would destroy the untargeted items that are legitimately still
+ * valid". That is TRUE OF THE GUARDED WINDOW and FALSE OF THE TAIL. Both the
+ * hook's note and `guidanceStore.ts`'s have been corrected; this file is the
+ * executable half of that correction.
+ *
+ * ⭐ WRITTEN FROM THE PRODUCER'S CALL ORDER, NOT FROM A MODEL OF IT. Every case
+ * drives the REAL exported producer function — `applyDraftResult`,
+ * `applyAnalysisReadyPatch`, `backfillGoalThresholdOntoGoalNode`,
+ * `reconcileAppliedGraph` — never a hand-written reproduction of its `setState`.
+ * A fixture the author wrote is not evidence about the producer (trap 16).
+ *
+ * BREADTH (trap 22b — the previous corpus was four USER-GESTURE framings and
+ * could not see any of this): assistant turn carrying coaching + graph · the
+ * post-guard patch-accept tail · boot hydration · applied-edit reconcile.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { Node, Edge } from '@xyflow/react'
+
+import { useGuidanceInvalidationOnEdit } from '../useGraphEditEvents'
+import {
+  useGuidanceStore,
+  setGuidancePersistenceContext,
+  type GuidanceItem,
+} from '../../stores/guidanceStore'
+import { useCanvasStore } from '../../store'
+import {
+  applyDraftResult,
+  backfillGoalThresholdOntoGoalNode,
+} from '../../utils/applyDraftResult'
+import { applyAnalysisReadyPatch } from '../utils/mirrorAnalysisReady'
+
+const SCENARIO = 'scenario-p0'
+const ITEM_ID = 'guidance-delivered-by-this-turn'
+const GOAL_ID = 'goal-1'
+
+function item(id: string): GuidanceItem {
+  return {
+    item_id: id,
+    source: 'analysis',
+    title: `Coaching ${id}`,
+    primary_action: { type: 'discuss', prompt: 'tell me more' },
+    priority: 50,
+  }
+}
+
+function node(id: string, label: string): Node {
+  return { id, type: 'factor', position: { x: 0, y: 0 }, data: { label } }
+}
+
+function guidanceIds(): string[] {
+  return useGuidanceStore.getState().guidanceItems.map((i) => i.item_id)
+}
+
+/** What a reload would adopt — the blob, not just the in-memory store. */
+function persistedIds(): string[] {
+  try {
+    const raw = sessionStorage.getItem('guidance.items.v1')
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as { items?: Array<{ item_id: string }> }
+    return (parsed.items ?? []).map((i) => i.item_id)
+  } catch {
+    return []
+  }
+}
+
+beforeEach(() => {
+  sessionStorage.clear()
+  // The persistence provider is installed by the canvas boot path
+  // (`ReactFlowGraph.tsx:1779`); without it `persistCurrent` returns early and
+  // NOTHING is ever written — so the two blob assertions below would pass
+  // vacuously against an empty store. Installing it here is what makes them
+  // real evidence about a reload.
+  setGuidancePersistenceContext(() => ({
+    scenarioId: useCanvasStore.getState().currentScenarioId,
+    graphHash: 'ui-hash-fixed',
+  }))
+  useCanvasStore.setState({
+    nodes: [node(GOAL_ID, 'Profit'), node('n2', 'Cost')],
+    edges: [] as Edge[],
+    currentScenarioId: SCENARIO,
+    _externalMutationActive: 0,
+  } as never)
+  useGuidanceStore.setState({ guidanceItems: [item(ITEM_ID)], activeGuidanceItemId: null })
+})
+
+afterEach(() => {
+  setGuidancePersistenceContext(null)
+  useGuidanceStore.setState({ guidanceItems: [], activeGuidanceItemId: null })
+  vi.restoreAllMocks()
+})
+
+describe('P0 — producer writes must not clear the user coaching', () => {
+  it('CONTROL: the fixture seeds the item and the hook is genuinely sensitive', () => {
+    // Trap 13 — every "survived" assertion below is vacuous unless the hook can
+    // actually clear. This is the POSITIVE control: a real user edit still wipes.
+    expect(guidanceIds()).toContain(ITEM_ID)
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    useCanvasStore.setState({
+      nodes: [...(useCanvasStore.getState().nodes as Node[]), node('user-added', 'User node')],
+    } as never)
+    expect(guidanceIds(), 'the hook must still clear on a real local edit').not.toContain(ITEM_ID)
+  })
+
+  it('P0-B: the REAL patch-accept tail (applyAnalysisReadyPatch) must not clear guidance', () => {
+    renderHook(() => useGuidanceInvalidationOnEdit())
+
+    // The producer function ConversationPanel calls at :335 and :393, driven
+    // end-to-end. Its two backfills write node `data`.
+    applyAnalysisReadyPatch(
+      {
+        ceeAnalysisReady: {
+          goal_node_id: GOAL_ID,
+          goal_threshold_raw: 0.78,
+          goal_threshold_unit: 'ratio',
+          goal_threshold_cap: null,
+        } as never,
+      },
+      { patchId: 'patch-1', scenarioId: SCENARIO },
+    )
+
+    expect(guidanceIds()).toContain(ITEM_ID)
+  })
+
+  it('P0-B leaf: backfillGoalThresholdOntoGoalNode alone must not clear guidance', () => {
+    // The exact function the review drove to prove the defect.
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    backfillGoalThresholdOntoGoalNode({
+      goal_node_id: GOAL_ID,
+      goal_threshold_raw: 0.42,
+      goal_threshold_unit: 'ratio',
+      goal_threshold_cap: null,
+    })
+    // Precondition: the write actually landed, or this asserts nothing.
+    const goal = (useCanvasStore.getState().nodes as any[]).find((n) => n.id === GOAL_ID)
+    expect(goal?.data?.goal_threshold_raw, 'precondition: the backfill wrote').toBe(0.42)
+    expect(guidanceIds()).toContain(ITEM_ID)
+  })
+
+  it('P0-A: a turn that mints guidance and then applies its draft graph keeps the guidance', () => {
+    renderHook(() => useGuidanceInvalidationOnEdit())
+
+    // The producer's order, verbatim: mint (useConversation.ts:5076) …
+    useGuidanceStore.getState().setGuidanceItems([item(ITEM_ID)])
+    expect(guidanceIds(), 'precondition: the turn minted its coaching').toContain(ITEM_ID)
+
+    // … then apply the draft graph (:5127 → applyDraftResult.ts:225).
+    const applied = applyDraftResult(
+      {
+        nodes: [
+          { id: 'd1', label: 'Demand', type: 'factor' },
+          { id: 'd2', label: 'Price', type: 'factor' },
+        ],
+        edges: [{ from: 'd1', to: 'd2' }],
+      } as never,
+      { skipHistory: true },
+    )
+
+    // Precondition: the graph genuinely changed, or this test proves nothing.
+    expect(applied.nodeCount, 'precondition: the draft actually applied').toBeGreaterThan(0)
+    expect(guidanceIds()).toContain(ITEM_ID)
+  })
+
+  it('P0-A: the persisted blob survives too, so a reload does not inherit the loss', () => {
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    useGuidanceStore.getState().setGuidanceItems([item(ITEM_ID)])
+    expect(persistedIds(), 'precondition: the mint persisted').toContain(ITEM_ID)
+
+    applyDraftResult(
+      { nodes: [{ id: 'd1', label: 'Demand', type: 'factor' }], edges: [] } as never,
+      { skipHistory: true },
+    )
+
+    expect(persistedIds()).toContain(ITEM_ID)
+  })
+
+  it('TWIN: after the producer write completes, the NEXT real user edit still clears', () => {
+    // The guard must be a SKIP, not permanent deafness. Without the re-baseline
+    // the hook would diff against a pre-producer graph forever.
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    applyDraftResult(
+      { nodes: [{ id: 'd1', label: 'Demand', type: 'factor' }], edges: [] } as never,
+      { skipHistory: true },
+    )
+    useGuidanceStore.setState({ guidanceItems: [item(ITEM_ID)], activeGuidanceItemId: null })
+
+    useCanvasStore.setState({
+      nodes: [...(useCanvasStore.getState().nodes as Node[]), node('user-added', 'User node')],
+    } as never)
+
+    expect(guidanceIds()).not.toContain(ITEM_ID)
+  })
+})

--- a/src/canvas/conversation/__tests__/guidanceInvalidationProducerWrites.spec.tsx
+++ b/src/canvas/conversation/__tests__/guidanceInvalidationProducerWrites.spec.tsx
@@ -139,7 +139,7 @@ describe('P0 — producer writes must not clear the user coaching', () => {
     // the P0 back again with nothing red. So the REAL store is pinned here: if
     // either method is ever removed or renamed, this REDs instead of the
     // suppression quietly evaporating.
-    const st = useCanvasStore.getState() as Record<string, unknown>
+    const st = useCanvasStore.getState() as unknown as Record<string, unknown>
     expect(typeof st.beginExternalGraphMutation).toBe('function')
     expect(typeof st.endExternalGraphMutation).toBe('function')
   })

--- a/src/canvas/conversation/__tests__/guidanceInvalidationProducerWrites.spec.tsx
+++ b/src/canvas/conversation/__tests__/guidanceInvalidationProducerWrites.spec.tsx
@@ -62,6 +62,7 @@ import { applyAnalysisReadyPatch } from '../utils/mirrorAnalysisReady'
 const SCENARIO = 'scenario-p0'
 const ITEM_ID = 'guidance-delivered-by-this-turn'
 const GOAL_ID = 'goal-1'
+const OPTION_ID = 'opt-1'
 
 function item(id: string): GuidanceItem {
   return {
@@ -105,7 +106,14 @@ beforeEach(() => {
     graphHash: 'ui-hash-fixed',
   }))
   useCanvasStore.setState({
-    nodes: [node(GOAL_ID, 'Profit'), node('n2', 'Cost')],
+    nodes: [
+      node(GOAL_ID, 'Profit'),
+      node('n2', 'Cost'),
+      // An OPTION node, so `backfillInterventionsOntoOptionNodes` has something
+      // to write. Without it that writer no-ops and the guard covering it is
+      // untested — which is exactly how mutant G1 first SURVIVED.
+      { id: OPTION_ID, type: 'option', position: { x: 0, y: 0 }, data: { label: 'Option A', kind: 'option' } } as Node,
+    ],
     edges: [] as Edge[],
     currentScenarioId: SCENARIO,
     _externalMutationActive: 0,
@@ -120,6 +128,20 @@ afterEach(() => {
 })
 
 describe('P0 — producer writes must not clear the user coaching', () => {
+  it('CONTROL: the REAL store implements the guard the writers optional-chain', () => {
+    // ⚠ THE GUARDS ARE WRITTEN `beginExternalGraphMutation?.(…)`, because several
+    // existing specs pass PARTIAL STORE DOUBLES and a bare call throws in them
+    // (the precedent is `mirrorAnalysisReady.ts`'s own `setAnalysisFreshness?.()`,
+    // whose comment says exactly this). But an optional-chained GUARD is one
+    // rename away from silently becoming a no-op, and a guard that cannot fire is
+    // the P0 back again with nothing red. So the REAL store is pinned here: if
+    // either method is ever removed or renamed, this REDs instead of the
+    // suppression quietly evaporating.
+    const st = useCanvasStore.getState() as Record<string, unknown>
+    expect(typeof st.beginExternalGraphMutation).toBe('function')
+    expect(typeof st.endExternalGraphMutation).toBe('function')
+  })
+
   it('CONTROL: the fixture seeds the item and the hook is genuinely sensitive', () => {
     // Trap 13 — every "survived" assertion below is vacuous unless the hook can
     // actually clear. This is the POSITIVE control: a real user edit still wipes.
@@ -163,6 +185,31 @@ describe('P0 — producer writes must not clear the user coaching', () => {
     // Precondition: the write actually landed, or this asserts nothing.
     const goal = (useCanvasStore.getState().nodes as any[]).find((n) => n.id === GOAL_ID)
     expect(goal?.data?.goal_threshold_raw, 'precondition: the backfill wrote').toBe(0.42)
+    expect(guidanceIds()).toContain(ITEM_ID)
+  })
+
+  it('P0-B: the INTERVENTIONS backfill (batchUpdateNodes, not setState) must not clear guidance', () => {
+    // ⚠ THIS CASE EXISTS BECAUSE A MUTANT SURVIVED. Reverting the guard on
+    // `applyAnalysisReadyPatch` left the suite 6/6 GREEN, because the only
+    // writer the other cases reached was the goal-threshold backfill, which
+    // carries its OWN guard. The interventions writer goes through
+    // `batchUpdateNodes` — a store ACTION, a different write path entirely —
+    // and nothing exercised it. An equivalent mutant must be DEMONSTRATED, not
+    // assumed; this is the fixture that shows it was never equivalent.
+    renderHook(() => useGuidanceInvalidationOnEdit())
+
+    applyAnalysisReadyPatch(
+      {
+        ceeAnalysisReady: {
+          options: [{ id: OPTION_ID, interventions: { price: 0.1 }, is_baseline: false }],
+        } as never,
+      },
+      { patchId: 'patch-2', scenarioId: SCENARIO },
+    )
+
+    // Precondition: the write actually landed, or this asserts nothing.
+    const opt = (useCanvasStore.getState().nodes as any[]).find((n) => n.id === OPTION_ID)
+    expect(opt?.data?.interventions, 'precondition: the backfill wrote').toBeTruthy()
     expect(guidanceIds()).toContain(ITEM_ID)
   })
 

--- a/src/canvas/conversation/__tests__/guidanceInvalidationReachability.production.spec.tsx
+++ b/src/canvas/conversation/__tests__/guidanceInvalidationReachability.production.spec.tsx
@@ -282,7 +282,53 @@ describe('N-23 §2 — the fix is mounted on the deployed surface, and carries n
   it('GuidanceInvalidationHost is mounted inside the flag-ON provider', () => {
     // THE PROOF OBLIGATION: deleting the mount must RED. This is the guard that
     // was missing when the capability first shipped dark.
-    expect(flagOnProviderBlock()).toContain('<GuidanceInvalidationHost />')
+    //
+    // ⚠⚠ STRIPPED, AND THE OMISSION HERE WAS THE REAL DEFECT. The first version
+    // of this spec added `stripComments` to the NEGATIVE assertions and not to
+    // this one — the ASYMMETRY is the bug. Mutant M1b (delete the mount, leave a
+    // JSX comment that merely NAMES `<GuidanceInvalidationHost />`) left this
+    // test GREEN: a comment satisfied the spec's central claim. Finding one
+    // instance of a class is not finding the class.
+    expect(stripComments(flagOnProviderBlock())).toContain('<GuidanceInvalidationHost />')
+  })
+
+  it('M1b: a COMMENT naming the host does not satisfy the mount assertion', () => {
+    // The permanent, in-suite form of the mutant. If `stripComments` ever stops
+    // stripping, this REDs — rather than the mount assertion silently going blind.
+    const commentOnly = '{/* <GuidanceInvalidationHost /> was here */}\n<Other />'
+    expect(stripComments(commentOnly)).not.toContain('<GuidanceInvalidationHost />')
+    // …and a real mount still survives the strip (contrast: the strip is not
+    // simply eating everything).
+    expect(stripComments('{/* note */}\n<GuidanceInvalidationHost />')).toContain(
+      '<GuidanceInvalidationHost />',
+    )
+  })
+
+  it('M6/M8: the RENDER path and the FLAG that decides it are pinned here', () => {
+    // ⚠ THIS SPEC WAS NOT SELF-SUFFICIENT ON ITS OWN CENTRAL CLAIM. Two mutants
+    // left it 22/22 GREEN:
+    //   M6 — `<MaybeConversationProvider>` replaced by `<>`, so EVERY host in the
+    //        block above goes dark while the block itself still reads correct.
+    //   M8 — `if (isAiPanelV2Enabled())` inverted to `if (!isAiPanelV2Enabled())`,
+    //        this estate's twice-shipped signature defect.
+    // Both were caught only by `panelApplyReachability.production.spec.tsx` — a
+    // spec this file's own header disparaged while silently depending on it for
+    // the only render-level and flag-level guard that existed. Pinned here now.
+    const source = stripComments(read(CANVAS_ROOT))
+
+    // M6: the provider must actually be RENDERED, not merely declared.
+    expect(source, 'M6: MaybeConversationProvider must be rendered').toMatch(
+      /<MaybeConversationProvider[\s>]/,
+    )
+
+    // M8: the flag-ON branch must be the POSITIVE test, verbatim.
+    const fnStart = source.indexOf('export function MaybeConversationProvider')
+    expect(fnStart, 'precondition: the provider function was found').toBeGreaterThan(-1)
+    const body = source.slice(fnStart, fnStart + 400)
+    expect(body, 'M8: the flag-ON branch must not be inverted').toContain(
+      'if (isAiPanelV2Enabled()) {',
+    )
+    expect(body).not.toContain('if (!isAiPanelV2Enabled()) {')
   })
 
   it('the canvas root imports the host from its own module', () => {
@@ -331,6 +377,40 @@ describe('N-23 §2 — the fix is mounted on the deployed surface, and carries n
 
     expect(host).not.toContain('sendSystemEvent')
     expect(host).not.toContain('useConversationContext')
+  })
+
+  it('the two guard chains have not diverged', () => {
+    // ⚠ THE "SINGLE AUTHORITY" CLAIM WAS NOT EARNED, and saying so is the point.
+    // What is genuinely shared is the DIFF (`takeSnapshot`/`diffSnapshots`). The
+    // INVALIDATION DECISION — scenario switch, reference equality,
+    // `_externalMutationActive`, baseline advance, position-only — is ~30 lines
+    // of COPIED control flow with nothing asserting the two copies agree.
+    // Mutant M2c proved the divergence is invisible: removing the position-only
+    // guard from the EMITTER left all 22 tests green.
+    //
+    // This does not merge the two chains (they legitimately differ after the
+    // decision point: one clears, one debounces and emits). It asserts that both
+    // still ASK THE SAME QUESTIONS, so a guard deleted from either side REDs.
+    const src = read(EMITTER_FILE)
+    const emitter = stripComments(functionBody(src, 'export function useGraphEditEvents'))
+    const invalidation = stripComments(
+      functionBody(src, 'export function useGuidanceInvalidationOnEdit'),
+    )
+
+    expect(emitter.length, 'precondition: emitter body extracted').toBeGreaterThan(200)
+    expect(invalidation.length, 'precondition: invalidation body extracted').toBeGreaterThan(200)
+
+    const SHARED_GUARDS: Array<[string, RegExp]> = [
+      ['scenario switch', /currentScenarioId !== scenarioIdRef\.current/],
+      ['reference equality', /curr\.nodes === prev\.nodes && curr\.edges === prev\.edges/],
+      ['external mutation', /curr\._externalMutationActive > 0/],
+      ['missing baseline', /if \(!prevSnapshot\)/],
+      ['position-only', /if \(!diff\)/],
+    ]
+    for (const [name, re] of SHARED_GUARDS) {
+      expect(re.test(emitter), `emitter lost its "${name}" guard`).toBe(true)
+      expect(re.test(invalidation), `invalidation lost its "${name}" guard`).toBe(true)
+    }
   })
 
   it('the emitter keeps its single DraftChat host — this lane did not re-host it', () => {

--- a/src/canvas/conversation/__tests__/guidanceInvalidationReachability.production.spec.tsx
+++ b/src/canvas/conversation/__tests__/guidanceInvalidationReachability.production.spec.tsx
@@ -1,0 +1,352 @@
+/**
+ * N-23 — STALE COACHING MUST NOT SURVIVE A LOCAL STRUCTURAL EDIT, ON THE SURFACE
+ * THE DEPLOYMENT ACTUALLY MOUNTS.
+ *
+ * THE DEFECT, derived at the bytes at `4d1e650b` (the commit deployed to
+ * staging, `version.json`): `clearGuidanceItems()` had exactly ONE production
+ * caller — `useGraphEditEvents.ts:293` — and that hook's only host is
+ * `DraftChat`, which `ReactFlowGraph.tsx:2484` mounts ONLY when `aiPanelV2` is
+ * OFF (`{!isAiPanelV2Enabled() && <DraftChat />}`). The flag is `"true"` at
+ * `netlify.toml:57`, i.e. ON for every deployed user. So the mechanism that
+ * drops coaching when the user changes their model never ran for anybody: the
+ * guidance strip, the on-canvas node coaching markers and every inspector
+ * coaching section could go on describing a model that no longer exists.
+ *
+ * WHY THE FIX IS A NEW HOOK RATHER THAN A RE-HOST. Mounting `useGraphEditEvents`
+ * on the live path would also switch on `direct_graph_edit` wire emission for
+ * every user — a change to what CEE receives, smuggled in as a UX fix. The
+ * coaching half is therefore split out as `useGuidanceInvalidationOnEdit`, which
+ * takes no transport and imports none, and is hosted by
+ * `GuidanceInvalidationHost`. §2 below enforces that separation AT THE SOURCE,
+ * with a contrast control, so it cannot decay into a promise in a comment.
+ *
+ * CLAIM TYPE (CLAUDE.md trap 3): §1 asserts STORE STATE after a real store
+ * mutation; §2 asserts SOURCE TEXT. Neither proves anything about pixels. The
+ * on-screen proof is the deployed witness recorded with this lane.
+ *
+ * DIRECTIONAL COVERAGE (trap 22b — a corpus that tests one direction is a guard
+ * watching one door): every clearing case below has an opposite-direction twin
+ * proving coaching SURVIVES the things that must not wipe it. A hook that
+ * cleared guidance on every store tick would pass a one-directional suite and
+ * destroy the user's coaching on a node drag.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type { Node, Edge } from '@xyflow/react'
+
+import { useGuidanceInvalidationOnEdit } from '../useGraphEditEvents'
+import { useGuidanceStore, type GuidanceItem } from '../../stores/guidanceStore'
+import { useCanvasStore } from '../../store'
+
+// ── fixtures ───────────────────────────────────────────────────────────────
+
+const SCENARIO = 'scenario-n23'
+
+/** Bound BY IDENTITY (trap 19): every assertion names this id, never a count alone. */
+const ITEM_ID = 'guidance-n23-target'
+
+function item(id: string): GuidanceItem {
+  return {
+    item_id: id,
+    source: 'analysis',
+    title: `Coaching ${id}`,
+    primary_action: { type: 'discuss', prompt: 'tell me more' },
+    priority: 50,
+  }
+}
+
+function node(id: string, label: string, x = 0, y = 0): Node {
+  return { id, type: 'factor', position: { x, y }, data: { label } }
+}
+
+function edge(id: string, source: string, target: string): Edge {
+  return { id, source, target, data: {} }
+}
+
+const BASE_NODES: Node[] = [node('n1', 'Revenue'), node('n2', 'Cost')]
+const BASE_EDGES: Edge[] = [edge('e1', 'n1', 'n2')]
+
+/** Ids of the guidance currently in the store — the object-level assertion target. */
+function guidanceIds(): string[] {
+  return useGuidanceStore.getState().guidanceItems.map((i) => i.item_id)
+}
+
+function seedGraph(): void {
+  useCanvasStore.setState({
+    nodes: BASE_NODES,
+    edges: BASE_EDGES,
+    currentScenarioId: SCENARIO,
+    _externalMutationActive: 0,
+  } as never)
+}
+
+function seedGuidance(): void {
+  useGuidanceStore.setState({ guidanceItems: [item(ITEM_ID)], activeGuidanceItemId: null })
+}
+
+// ---------------------------------------------------------------------------
+// § 1 — BEHAVIOUR
+// ---------------------------------------------------------------------------
+
+describe('N-23 §1 — useGuidanceInvalidationOnEdit clears stale coaching on a local structural edit', () => {
+  beforeEach(() => {
+    seedGraph()
+    seedGuidance()
+  })
+
+  afterEach(() => {
+    useGuidanceStore.setState({ guidanceItems: [], activeGuidanceItemId: null })
+  })
+
+  it('CONTROL: the fixture actually seeds the item under test', () => {
+    // Trap 13 — an absence assertion is vacuous unless the presence is proven
+    // first. Every "cleared" case below is meaningless if this is empty.
+    expect(guidanceIds()).toContain(ITEM_ID)
+  })
+
+  it('a node ADD clears the coaching authored against the previous model', () => {
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    expect(guidanceIds(), 'precondition: mounting alone must not clear').toContain(ITEM_ID)
+
+    useCanvasStore.setState({ nodes: [...BASE_NODES, node('n3', 'Churn')] } as never)
+
+    expect(guidanceIds()).not.toContain(ITEM_ID)
+  })
+
+  it('a node REMOVE clears it', () => {
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    useCanvasStore.setState({ nodes: [BASE_NODES[0]] } as never)
+    expect(guidanceIds()).not.toContain(ITEM_ID)
+  })
+
+  it('a node RELABEL (structural data change) clears it', () => {
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    useCanvasStore.setState({
+      nodes: [node('n1', 'Gross Revenue'), BASE_NODES[1]],
+    } as never)
+    expect(guidanceIds()).not.toContain(ITEM_ID)
+  })
+
+  it('an EDGE ADD clears it', () => {
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    useCanvasStore.setState({ edges: [...BASE_EDGES, edge('e2', 'n2', 'n1')] } as never)
+    expect(guidanceIds()).not.toContain(ITEM_ID)
+  })
+
+  // ── opposite-direction twins ─────────────────────────────────────────────
+
+  it('TWIN: a POSITION-ONLY move must NOT clear coaching', () => {
+    // Dragging a node is not a change to the model the coaching describes. A
+    // hook that cleared on every store tick would pass every case above and
+    // silently destroy the user's coaching on a drag.
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    useCanvasStore.setState({
+      nodes: [node('n1', 'Revenue', 400, 250), BASE_NODES[1]],
+    } as never)
+    expect(guidanceIds()).toContain(ITEM_ID)
+  })
+
+  it('TWIN: a structural change under an EXTERNAL mutation must NOT clear coaching', () => {
+    // Accepting an assistant patch runs under `beginExternalGraphMutation`
+    // and uses `clearItemsByTargetIds` to drop only what the patch touched.
+    // A blanket clear here would destroy untargeted items that are still valid,
+    // and would defeat `guidanceStore`'s `minting` gate.
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    useCanvasStore.setState({
+      _externalMutationActive: 1,
+      nodes: [...BASE_NODES, node('n3', 'Patched')],
+    } as never)
+    expect(guidanceIds()).toContain(ITEM_ID)
+  })
+
+  it('TWIN: a SCENARIO SWITCH re-baselines and must NOT clear coaching', () => {
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    useCanvasStore.setState({
+      currentScenarioId: 'scenario-other',
+      nodes: [node('x1', 'Elsewhere')],
+    } as never)
+    expect(guidanceIds()).toContain(ITEM_ID)
+  })
+
+  it('after an external mutation the baseline advances, so the NEXT real edit still clears', () => {
+    // The re-baseline in the suppression limb is load-bearing: without it the
+    // next user edit diffs against a pre-patch graph. This pins that the
+    // suppression is a skip, not a permanent deafness.
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    const patched = [...BASE_NODES, node('n3', 'Patched')]
+    useCanvasStore.setState({ _externalMutationActive: 1, nodes: patched } as never)
+    expect(guidanceIds(), 'precondition: the patch itself did not clear').toContain(ITEM_ID)
+
+    useCanvasStore.setState({ _externalMutationActive: 0 } as never)
+    useCanvasStore.setState({ nodes: [...patched, node('n4', 'User added this')] } as never)
+    expect(guidanceIds()).not.toContain(ITEM_ID)
+  })
+
+  it('an unmounted hook stops clearing (no leaked subscription)', () => {
+    const { unmount } = renderHook(() => useGuidanceInvalidationOnEdit())
+    unmount()
+    seedGuidance()
+    useCanvasStore.setState({ nodes: [...BASE_NODES, node('n9', 'After unmount')] } as never)
+    expect(guidanceIds()).toContain(ITEM_ID)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// § 2 — REACHABILITY AND THE WIRE SEPARATION, AT THE SOURCE
+//
+// The defect this closes was never a logic error — the logic was correct and
+// unreachable. A behaviour suite cannot see that, because it mounts the hook
+// itself. These assertions read the production source.
+// ---------------------------------------------------------------------------
+
+const CANVAS_ROOT = 'src/canvas/ReactFlowGraph.tsx'
+const HOST = 'src/canvas/conversation/GuidanceInvalidationHost.tsx'
+const EMITTER_FILE = 'src/canvas/conversation/useGraphEditEvents.ts'
+const SIBLING_HOST = 'src/canvas/conversation/StructuralDeleteDrainHost.tsx'
+
+function read(repoRelative: string): string {
+  return readFileSync(resolve(process.cwd(), repoRelative), 'utf8')
+}
+
+/**
+ * The flag-ON provider block, anchored on the FUNCTION DECLARATION first.
+ *
+ * ⚠ Not a tidy-up: `drainHostReachability.derived.spec.ts` records that slicing
+ * the whole file on `<ConversationProvider>` matched a DOC-COMMENT mention
+ * rather than the JSX, and still returned the right answer — a probe reading the
+ * wrong bytes and agreeing anyway (trap 16). Anchoring on the declaration puts
+ * the comment out of range.
+ */
+function flagOnProviderBlock(): string {
+  const source = read(CANVAS_ROOT)
+  const fnStart = source.indexOf('export function MaybeConversationProvider')
+  if (fnStart === -1) return ''
+  const body = source.slice(fnStart)
+  const open = body.indexOf('<ConversationProvider>')
+  const close = body.indexOf('</ConversationProvider>')
+  if (open === -1 || close === -1 || close <= open) return ''
+  return body.slice(open, close)
+}
+
+/**
+ * Strip JSX `{/* … *\/}` and `//` comments.
+ *
+ * ⚠ WRITTEN AFTER THIS SPEC'S OWN PROBE FAILED ON ITSELF, which is the reason it
+ * exists rather than a tidy-up. The "did not re-host the emitter" assertion below
+ * matched the word `useGraphEditEvents` inside the explanatory JSX COMMENT beside
+ * the new mount, and reported a re-host that had not happened. A substring probe
+ * over source cannot tell a call from a mention (CLAUDE.md trap 16: a grepped
+ * symbol proves presence-in-text, never presence-on-the-live-path). The failure
+ * was the honest one — it fired when nothing was wrong — but the inverse of the
+ * same blindness is a probe that passes while something IS wrong.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\{\s*\/\*[\s\S]*?\*\/\s*\}/g, ' ')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/^\s*\/\/.*$/gm, ' ')
+}
+
+/** The body of one top-level function, up to the next top-level `export function`. */
+function functionBody(source: string, declaration: string): string {
+  const start = source.indexOf(declaration)
+  if (start === -1) return ''
+  const rest = source.slice(start + declaration.length)
+  const next = rest.indexOf('\nexport function ')
+  return next === -1 ? rest : rest.slice(0, next)
+}
+
+describe('N-23 §2 — the fix is mounted on the deployed surface, and carries no wire', () => {
+  it('CONTROL: every source this section reads is non-empty', () => {
+    // Trap 13e / the zsh-empty-file lesson: an instrument that extracted nothing
+    // agrees with every other instrument that extracted nothing. Every assertion
+    // below is vacuous if any of these is empty.
+    for (const f of [CANVAS_ROOT, HOST, EMITTER_FILE, SIBLING_HOST]) {
+      expect(read(f).length, `${f} read as empty`).toBeGreaterThan(200)
+    }
+  })
+
+  it('CONTROL: the flag-ON provider block is found and already hosts its known siblings', () => {
+    // If `MaybeConversationProvider` is renamed or restructured this returns '',
+    // and the mount assertion below would read "absent" as a finding rather than
+    // as instrument failure (trap 20: uniformity is evidence about the probe).
+    const block = flagOnProviderBlock()
+    expect(block.length).toBeGreaterThan(0)
+    expect(block).toContain('<PanelApplyDrainHost />')
+    expect(block).toContain('<StructuralDeleteDrainHost />')
+  })
+
+  it('GuidanceInvalidationHost is mounted inside the flag-ON provider', () => {
+    // THE PROOF OBLIGATION: deleting the mount must RED. This is the guard that
+    // was missing when the capability first shipped dark.
+    expect(flagOnProviderBlock()).toContain('<GuidanceInvalidationHost />')
+  })
+
+  it('the canvas root imports the host from its own module', () => {
+    expect(read(CANVAS_ROOT)).toContain(
+      "import { GuidanceInvalidationHost } from './conversation/GuidanceInvalidationHost'",
+    )
+  })
+
+  it('the host calls the wire-free hook', () => {
+    const host = read(HOST)
+    expect(host).toContain('useGuidanceInvalidationOnEdit()')
+    expect(host).toContain("from './useGraphEditEvents'")
+  })
+
+  it('the invalidation hook is STRUCTURALLY incapable of emitting to the wire', () => {
+    const emitterSource = read(EMITTER_FILE)
+    const invalidation = functionBody(emitterSource, 'export function useGuidanceInvalidationOnEdit')
+    const emitter = functionBody(emitterSource, 'export function useGraphEditEvents')
+
+    // CONTRAST CONTROL (trap 13e): absence is only evidence when the same probe
+    // reads a PRESENCE on a same-family target in the same run. If this probe
+    // were blind, the emitter would read clean too.
+    expect(emitter, 'contrast: the emitter DOES take the transport').toContain('sendSystemEvent')
+    expect(emitter, 'contrast: the emitter DOES emit direct_graph_edit').toContain(
+      'direct_graph_edit',
+    )
+
+    expect(invalidation.length, 'precondition: the hook body was extracted').toBeGreaterThan(200)
+    expect(invalidation, 'the coaching hook must not touch the transport').not.toContain(
+      'sendSystemEvent',
+    )
+    expect(invalidation).not.toContain('direct_graph_edit')
+    expect(invalidation).not.toContain('appendEvent')
+    // The whole point of the split: it DOES do the coaching job.
+    expect(invalidation).toContain('clearGuidanceItems()')
+  })
+
+  it('the host itself pulls in no transport', () => {
+    const host = read(HOST)
+    // CONTRAST CONTROL: the sibling host genuinely does take the transport, so a
+    // probe that saw nothing anywhere would fail here first.
+    const sibling = read(SIBLING_HOST)
+    expect(sibling, 'contrast: the sibling host DOES use the conversation transport').toContain(
+      'sendSystemEvent',
+    )
+
+    expect(host).not.toContain('sendSystemEvent')
+    expect(host).not.toContain('useConversationContext')
+  })
+
+  it('the emitter keeps its single DraftChat host — this lane did not re-host it', () => {
+    // The flag-OFF path must be untouched: `useGraphEditEvents` still runs only
+    // inside DraftChat, so no flag-ON user starts sending `direct_graph_edit`.
+    // If a later lane re-hosts it, that is a wire decision and this REDs to say so.
+    const block = stripComments(flagOnProviderBlock())
+
+    // CONTROL: stripping must not have eaten the block itself — an empty string
+    // would satisfy every `not.toContain` below by testing nothing (trap 13).
+    expect(block).toContain('<GuidanceInvalidationHost />')
+
+    expect(block).not.toContain('useGraphEditEvents')
+    expect(stripComments(read(HOST))).not.toContain('useGraphEditEvents(')
+
+    // The flag-OFF host is untouched and still the emitter's only caller.
+    expect(read(CANVAS_ROOT)).toContain('{!isAiPanelV2Enabled() && <DraftChat />}')
+  })
+})

--- a/src/canvas/conversation/__tests__/guidanceInvalidationReachability.production.spec.tsx
+++ b/src/canvas/conversation/__tests__/guidanceInvalidationReachability.production.spec.tsx
@@ -7,7 +7,10 @@
  * caller — `useGraphEditEvents.ts:293` — and that hook's only host is
  * `DraftChat`, which `ReactFlowGraph.tsx:2484` mounts ONLY when `aiPanelV2` is
  * OFF (`{!isAiPanelV2Enabled() && <DraftChat />}`). The flag is `"true"` at
- * `netlify.toml:57`, i.e. ON for every deployed user. So the mechanism that
+ * `flags.ts:358` (`defaultValue: true`), i.e. ON for every fresh user.
+ * ⚠ `netlify.toml:57` is NOT sufficient evidence for that: it sits under
+ * `[context.staging.environment]` and so proves STAGING only. The default is
+ * what carries the conclusion. So the mechanism that
  * drops coaching when the user changes their model never ran for anybody: the
  * guidance strip, the on-canvas node coaching markers and every inspector
  * coaching section could go on describing a model that no longer exists.
@@ -411,6 +414,40 @@ describe('N-23 §2 — the fix is mounted on the deployed surface, and carries n
       expect(re.test(emitter), `emitter lost its "${name}" guard`).toBe(true)
       expect(re.test(invalidation), `invalidation lost its "${name}" guard`).toBe(true)
     }
+  })
+
+  it('POSTURE ENUMERATION: exactly one clearing authority, except OFF x OFF', () => {
+    // Enumerated rather than argued, and the fourth cell is the one worth
+    // knowing. aiPanelV2 x orchestratorV2:
+    //   ON  x ON   → GuidanceInvalidationHost only   (DraftChat unmounted)      = 1
+    //   ON  x OFF  → GuidanceInvalidationHost only   (this hook is NOT gated on
+    //                the transport flag, deliberately)                          = 1
+    //   OFF x ON   → useGraphEditEvents in DraftChat only                       = 1
+    //   OFF x OFF  → ZERO. DraftChat mounts, but the emitter early-returns on
+    //                `isOrchestratorV2Enabled()`, and the new host is not
+    //                mounted because `MaybeConversationProvider` only renders it
+    //                under aiPanelV2. ⚠ THE DEFECT STAYS DARK IN THAT CELL.
+    //                Not reachable in any deployed posture (both flags default
+    //                true), so it is recorded rather than fixed — fixing it would
+    //                mean mounting the host outside the aiPanelV2 branch, which
+    //                changes what runs on the flag-OFF path.
+    // The two structural facts that cell depends on are asserted here so the
+    // enumeration cannot silently go stale.
+    const source = stripComments(read(CANVAS_ROOT))
+    expect(source, 'DraftChat is mounted only when aiPanelV2 is OFF').toContain(
+      '{!isAiPanelV2Enabled() && <DraftChat />}',
+    )
+    const emitterBody = stripComments(
+      functionBody(read(EMITTER_FILE), 'export function useGraphEditEvents'),
+    )
+    expect(emitterBody, 'the emitter is gated on the transport flag').toContain(
+      'if (!isOrchestratorV2Enabled()) return',
+    )
+    // …and the new hook is NOT, which is what makes ON x OFF a covered cell.
+    const invalidationBody = stripComments(
+      functionBody(read(EMITTER_FILE), 'export function useGuidanceInvalidationOnEdit'),
+    )
+    expect(invalidationBody).not.toContain('isOrchestratorV2Enabled')
   })
 
   it('the emitter keeps its single DraftChat host — this lane did not re-host it', () => {

--- a/src/canvas/conversation/__tests__/guidanceInvalidationReachability.production.spec.tsx
+++ b/src/canvas/conversation/__tests__/guidanceInvalidationReachability.production.spec.tsx
@@ -125,10 +125,43 @@ describe('N-23 §1 — useGuidanceInvalidationOnEdit clears stale coaching on a 
     expect(guidanceIds()).not.toContain(ITEM_ID)
   })
 
-  it('a node RELABEL (structural data change) clears it', () => {
+  it('⚠ CORRECTED: a node RELABEL must NOT clear it — a rename is not a model change', () => {
+    // ⚠⚠ THIS CASE ASSERTED THE OPPOSITE AND THE OPPOSITE WAS A LIVE DEFECT.
+    // The original read:
+    //
+    //     it('a node RELABEL (structural data change) clears it', … )
+    //       expect(guidanceIds()).not.toContain(ITEM_ID)
+    //
+    // Refuted. "Structural data change" was this file's own coinage, taken from
+    // `diffSnapshots`, which stringifies the WHOLE `data` object. The codebase
+    // already owns the question and answers it differently: the registry behind
+    // `ANALYTICAL_NODE_DATA_FIELDS` EXCLUDES `label`, `body`, `description`,
+    // position and colour as cosmetic. So renaming a node destroyed the strip,
+    // the on-canvas markers and every inspector coaching section — on screen AND
+    // on disk, because `clearGuidanceItems` also wipes the persisted blob — while
+    // the transcript coaching card beside them still reported `'current'`,
+    // because `coachingCurrency` asks the canonical owner.
+    //
+    // Dark at base (the only host sat where `aiPanelV2` is OFF, and it defaults
+    // TRUE); universal the moment this lane mounted the hook in the flag-ON
+    // branch. The original wording is kept above rather than deleted, because
+    // "the test said so" is exactly how a wrong predicate earns tenure.
     renderHook(() => useGuidanceInvalidationOnEdit())
     useCanvasStore.setState({
       nodes: [node('n1', 'Gross Revenue'), BASE_NODES[1]],
+    } as never)
+    expect(guidanceIds()).toContain(ITEM_ID)
+  })
+
+  it('an ANALYTICAL data change on the SAME node still clears — the contrast', () => {
+    // Without this the case above is satisfied by a hook that was deleted.
+    // `observedState` carries the `stale` purpose in the canonical registry.
+    renderHook(() => useGuidanceInvalidationOnEdit())
+    useCanvasStore.setState({
+      nodes: [
+        { ...node('n1', 'Revenue'), data: { label: 'Revenue', observedState: { value: 7 } } } as Node,
+        BASE_NODES[1],
+      ],
     } as never)
     expect(guidanceIds()).not.toContain(ITEM_ID)
   })
@@ -382,38 +415,57 @@ describe('N-23 §2 — the fix is mounted on the deployed surface, and carries n
     expect(host).not.toContain('useConversationContext')
   })
 
-  it('the two guard chains have not diverged', () => {
-    // ⚠ THE "SINGLE AUTHORITY" CLAIM WAS NOT EARNED, and saying so is the point.
-    // What is genuinely shared is the DIFF (`takeSnapshot`/`diffSnapshots`). The
-    // INVALIDATION DECISION — scenario switch, reference equality,
-    // `_externalMutationActive`, baseline advance, position-only — is ~30 lines
-    // of COPIED control flow with nothing asserting the two copies agree.
-    // Mutant M2c proved the divergence is invisible: removing the position-only
-    // guard from the EMITTER left all 22 tests green.
+  it('⚠ SUPERSEDED — the two chains DELIBERATELY diverge now; what is pinned is WHOSE ANSWER each takes', () => {
+    // ⚠⚠ THIS GUARD USED TO ASSERT THE TWO CHAINS "ASK THE SAME QUESTIONS", over
+    // a five-entry list including `if (!diff)` (position-only) and
+    // `if (!prevSnapshot)`. It was added in good faith to close review FIX 6 —
+    // and it was pinning the very coupling that shipped the regression.
     //
-    // This does not merge the two chains (they legitimately differ after the
-    // decision point: one clears, one debounces and emits). It asserts that both
-    // still ASK THE SAME QUESTIONS, so a guard deleted from either side REDs.
+    // The chains answer DIFFERENT QUESTIONS (CLAUDE.md trap 21). The emitter asks
+    // "what changed, so CEE can be told?", for which the whole `data` object is
+    // the right granularity. The invalidation asks "does this invalidate an
+    // ANALYSIS?", which `domain/analyticalChange.ts` owns and answers with a
+    // registry that excludes cosmetic fields. Forcing them to share a predicate
+    // is what made a rename destroy the user's coaching.
+    //
+    // So the invariant is no longer "same questions". It is: the invalidation
+    // chain DEFERS to the canonical owner and does NOT re-implement a field list.
+    // That is the property whose loss would bring the defect back.
     const src = read(EMITTER_FILE)
-    const emitter = stripComments(functionBody(src, 'export function useGraphEditEvents'))
     const invalidation = stripComments(
       functionBody(src, 'export function useGuidanceInvalidationOnEdit'),
     )
-
-    expect(emitter.length, 'precondition: emitter body extracted').toBeGreaterThan(200)
+    const emitter = stripComments(functionBody(src, 'export function useGraphEditEvents'))
     expect(invalidation.length, 'precondition: invalidation body extracted').toBeGreaterThan(200)
+    expect(emitter.length, 'precondition: emitter body extracted').toBeGreaterThan(200)
 
-    const SHARED_GUARDS: Array<[string, RegExp]> = [
-      ['scenario switch', /currentScenarioId !== scenarioIdRef\.current/],
-      ['reference equality', /curr\.nodes === prev\.nodes && curr\.edges === prev\.edges/],
-      ['external mutation', /curr\._externalMutationActive > 0/],
-      ['missing baseline', /if \(!prevSnapshot\)/],
-      ['position-only', /if \(!diff\)/],
-    ]
-    for (const [name, re] of SHARED_GUARDS) {
-      expect(re.test(emitter), `emitter lost its "${name}" guard`).toBe(true)
-      expect(re.test(invalidation), `invalidation lost its "${name}" guard`).toBe(true)
+    // (a) it asks the canonical owner…
+    expect(
+      invalidation,
+      'the invalidation stopped consulting domain/analyticalChange — the cosmetic-edit ' +
+        'regression is back',
+    ).toContain('hasAnalyticalGraphChange(')
+    expect(stripComments(src)).toContain("from '../domain/analyticalChange'")
+
+    // (b) …and does NOT re-implement the taxonomy locally. A copied field list is
+    //     how a fifth authority is born; the registry is importable, so there is
+    //     no reason to spell one here.
+    for (const field of ['observedState', 'interventions', 'success_threshold']) {
+      expect(
+        invalidation,
+        `the invalidation names "${field}" itself instead of deriving it from the registry`,
+      ).not.toContain(field)
     }
+
+    // (c) CONTRAST CONTROL — the probe discriminates. The EMITTER legitimately
+    //     still uses the whole-`data` diff, so a probe that could not tell the
+    //     two chains apart would fail here.
+    expect(emitter, 'contrast: the emitter still owns the wire-facing diff').toContain(
+      'diffSnapshots(',
+    )
+    expect(invalidation, 'the invalidation must no longer consult the wire diff').not.toContain(
+      'diffSnapshots(',
+    )
   })
 
   it('POSTURE ENUMERATION: exactly one clearing authority, except OFF x OFF', () => {

--- a/src/canvas/conversation/optimisticFactorEdit.ts
+++ b/src/canvas/conversation/optimisticFactorEdit.ts
@@ -516,11 +516,20 @@ export function confirmOptimisticFactorEdit(edit: OptimisticFactorEdit): Confirm
   // the retraction: this is the one place a user claim is earned, so it is the
   // one place the door reopens. Clearing it anywhere else — or not at all —
   // would make a re-confirmation invisible.
-  store.updateNode(edit.nodeId, {
-    data: clearConfirmationWithdrawal(
-      withObservedStateUpdate(node.data, edit.reviewedStamp) as Record<string, unknown>,
-    ),
-  } as never)
+  // ⚠ NOT A USER EDIT — this writes the PROVENANCE STAMP onto the value the user
+  // already edited a moment ago. It touches `observedState`, which IS analytical,
+  // so the bounded predicate does not exempt it: without this window the stamp
+  // wipes the coaching a beat after the edit that earned it.
+  store.beginExternalGraphMutation?.('envelope_apply')
+  try {
+    store.updateNode(edit.nodeId, {
+      data: clearConfirmationWithdrawal(
+        withObservedStateUpdate(node.data, edit.reviewedStamp) as Record<string, unknown>,
+      ),
+    } as never)
+  } finally {
+    store.endExternalGraphMutation?.()
+  }
 
   // Persist the earned stamp NOW (L66, final-walk defect 0, P1). The stamp is
   // the ONE thing only the client holds — the value round-trips through CEE,
@@ -576,12 +585,20 @@ export function revertOptimisticFactorEdit(edit: OptimisticFactorEdit): RevertOu
   const currentValue = obs.value
   if (currentValue !== edit.sentValue) return 'value_moved_on'
 
-  store.updateNode(edit.nodeId, {
-    data: {
-      ...(node.data as Record<string, unknown>),
-      observedState: edit.prevObservedState,
-      display_value: edit.prevDisplayValue,
-    },
-  } as never)
+  // ⚠ NOT A USER EDIT — a ROLLBACK to the value that was there before. The graph
+  // ends up back where the coaching was authored, so treating it as an edit
+  // destroys coaching that the revert has just made valid again.
+  store.beginExternalGraphMutation?.('envelope_apply')
+  try {
+    store.updateNode(edit.nodeId, {
+      data: {
+        ...(node.data as Record<string, unknown>),
+        observedState: edit.prevObservedState,
+        display_value: edit.prevDisplayValue,
+      },
+    } as never)
+  } finally {
+    store.endExternalGraphMutation?.()
+  }
   return 'reverted'
 }

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -493,11 +493,18 @@ function discardStreamedPreview(preview: { nodes?: unknown[]; edges?: unknown[] 
   )
   if (previewNodeIds.size === 0) return
   const state = useCanvasStore.getState()
-  useCanvasStore.setState({
+  // ⚠ NOT A USER EDIT — a streamed PREVIEW graph being withdrawn. Same-`set()`
+  // suppression so `useGuidanceInvalidationOnEdit` does not read the withdrawal
+  // as the user deleting their own nodes (MUT-ORDER: a later raise is too late).
+  useCanvasStore.setState((s) => ({
     nodes: state.nodes.filter((n) => !previewNodeIds.has(n.id)),
     edges: state.edges.filter((e) => !previewNodeIds.has(e.source) && !previewNodeIds.has(e.target)),
     lastAuthoritativeGraph: null,
-  })
+    _externalMutationActive: s._externalMutationActive + 1,
+  }))
+  useCanvasStore.setState((s) => ({
+    _externalMutationActive: Math.max(0, s._externalMutationActive - 1),
+  }))
 }
 
 export interface StreamedDraftTurnResult {
@@ -5008,7 +5015,25 @@ export function useConversation(): UseConversationReturn {
             // the top level, so we splice it in here rather than widening the
             // store shape upstream.
             const v5StoreSnapshot = useCanvasStore.getState()
-            const stateApply = applyV5State(
+            // ⚠ NOT A USER EDIT — CEE APPLYING ITS OWN graph_patch blocks
+            // (`set_factor_value` writes `observedState`, `adjust_edge_strength`
+            // writes edge weight/direction: both ANALYTICAL, so the bounded
+            // predicate does not exempt them). Without this window the turn
+            // destroys the coaching it is in the middle of delivering — P0-A's
+            // shape, one seam further along.
+            //
+            // ⭐ GUARDED AT THE CALL SITE RATHER THAN THE LEAF, and the reason is
+            // derived, not assumed: `applyV5State` has EXACTLY ONE production
+            // caller — this one (`rg "applyV5State\(" src` excluding tests, at
+            // this tip). The estate's own rule is to guard the leaf BECAUSE a
+            // second caller usually exists; here there is none, and `applyV5State`
+            // takes an INJECTED `V5ApplicatorStore`, so a leaf guard would mean
+            // widening that interface and every test double with it. Re-derive the
+            // caller count before moving this — a second caller makes it wrong.
+            useCanvasStore.getState().beginExternalGraphMutation?.('envelope_apply')
+            let stateApply: ReturnType<typeof applyV5State>
+            try {
+              stateApply = applyV5State(
               target.response,
               {
                 ...v5StoreSnapshot,
@@ -5026,7 +5051,10 @@ export function useConversation(): UseConversationReturn {
                 turnClientId,
                 currentClientTurnId: activeV5TurnIdRef.current,
               },
-            )
+              )
+            } finally {
+              useCanvasStore.getState().endExternalGraphMutation?.()
+            }
             if (import.meta.env.DEV) {
               if (stateApply.applied.length > 0) {
                 console.warn('[sendTurn V5] state applied:', stateApply.applied)

--- a/src/canvas/conversation/useGraphEditEvents.ts
+++ b/src/canvas/conversation/useGraphEditEvents.ts
@@ -13,6 +13,7 @@ import { useEffect, useRef } from 'react'
 import { useCanvasStore } from '../store'
 import { isOrchestratorV2Enabled, isJourneyTabEnabled } from '../../flags'
 import { useGuidanceStore } from '../stores/guidanceStore'
+import { hasAnalyticalGraphChange } from '../domain/analyticalChange'
 import { appendEvent } from '../../services/scenarioService'
 import { resolveElementLabel } from './utils/resolveElementLabel'
 import type { WireSystemEvent } from './types'
@@ -451,13 +452,43 @@ export function useGraphEditEvents(
 // is therefore STRUCTURALLY INCAPABLE of emitting anything. The guard for that
 // is a source-level assertion in the spec, not a promise in this comment.
 //
-// SINGLE AUTHORITY ON "WHAT IS A STRUCTURAL CHANGE". This deliberately reuses
-// `takeSnapshot`/`diffSnapshots` from the emitter above rather than
-// re-implementing the diff. Two same-named-but-different notions of "the graph
-// changed" is this estate's most-paid-for defect class (the two
-// `generateGraphHash` twins), and a copy here would drift the moment either side
-// is touched. Position-only changes are excluded by `diffSnapshots` returning
-// `null` — dragging a node must not wipe the user's coaching.
+// ⚠⚠ THE "SINGLE AUTHORITY" CLAIM THAT USED TO SIT HERE IS WITHDRAWN — IT WAS
+// BOTH UNEARNED AND POINTED AT THE WRONG AUTHORITY, AND IT SHIPPED A LIVE
+// REGRESSION. It read:
+//
+//     "SINGLE AUTHORITY ON 'WHAT IS A STRUCTURAL CHANGE'. This deliberately
+//      reuses `takeSnapshot`/`diffSnapshots` from the emitter above rather than
+//      re-implementing the diff. … Position-only changes are excluded by
+//      `diffSnapshots` returning `null` — dragging a node must not wipe the
+//      user's coaching."
+//
+// Every sentence is true and the conclusion is still wrong, because the two
+// hooks ANSWER DIFFERENT QUESTIONS (CLAUDE.md trap 21). The emitter asks
+// *"what changed, so CEE can be told?"* — for which the whole `data` object is
+// the right granularity. This hook asks *"does this change invalidate an
+// ANALYSIS?"* — a question the codebase ALREADY OWNS, in
+// `domain/analyticalChange.ts`, whose registry (`analyticalNodeFields.ts`)
+// deliberately EXCLUDES `label`, `body`, `description`, `position` and colour as
+// cosmetic. Sharing the emitter's diff made this a FOURTH authority answering
+// that question differently.
+//
+// THE COST, measured: `serialiseNode` stringifies the WHOLE `data` object, so
+// `diffSnapshots` returned non-null for ANY `data` change and this hook answered
+// with a blanket `clearGuidanceItems()` — which also wipes the PERSISTED blob,
+// so the loss survived a reload. Renaming the goal, or editing a node's
+// description or category, destroyed every piece of the user's coaching. Dark at
+// base (the only caller was hosted where `aiPanelV2` is OFF, and it defaults
+// TRUE), and universal the moment this hook was mounted in the flag-ON branch.
+// The tell was two surfaces disagreeing on one gesture: the strip and the node
+// markers were destroyed while the transcript coaching card beside them still
+// reported `'current'`, because `coachingCurrency` asks the CANONICAL owner and
+// correctly treats `label` as cosmetic.
+//
+// SO: the authority for THIS question is `hasAnalyticalGraphChange`, which lives
+// in and derives from that canonical registry. `diffSnapshots` keeps the
+// emitter's question and is no longer consulted here. Position-only changes are
+// excluded because position is not a `data` field at all — not because a shared
+// helper happens to drop them.
 //
 // ⚠⚠ EXTERNAL MUTATIONS STAY SUPPRESSED — and the ORIGINAL VERSION OF THIS NOTE
 // WAS FALSIFIED BY REVIEW, which is why it now reads at this length.
@@ -494,12 +525,13 @@ export function useGraphEditEvents(
  * only the canvas store (read) and the guidance store (clear).
  */
 export function useGuidanceInvalidationOnEdit(): void {
-  const snapshotRef = useRef<GraphSnapshot | null>(null)
+  /** The graph the surviving coaching is understood to describe. */
+  const baselineRef = useRef<{ nodes: Node[]; edges: Edge[] } | null>(null)
   const scenarioIdRef = useRef<string | null>(null)
 
   useEffect(() => {
     const state = useCanvasStore.getState()
-    snapshotRef.current = takeSnapshot(state.nodes, state.edges)
+    baselineRef.current = { nodes: state.nodes, edges: state.edges }
     scenarioIdRef.current = state.currentScenarioId
 
     const unsubscribe = useCanvasStore.subscribe((curr, prev) => {
@@ -508,7 +540,7 @@ export function useGuidanceInvalidationOnEdit(): void {
       // own rehydration gate keys on `scenarioId` anyway.
       if (curr.currentScenarioId !== scenarioIdRef.current) {
         scenarioIdRef.current = curr.currentScenarioId
-        snapshotRef.current = takeSnapshot(curr.nodes, curr.edges)
+        baselineRef.current = { nodes: curr.nodes, edges: curr.edges }
         return
       }
 
@@ -518,25 +550,24 @@ export function useGuidanceInvalidationOnEdit(): void {
       // Patch-apply / hydration / envelope-apply. Re-baseline so the next real
       // user edit diffs against the post-mutation graph rather than a stale one.
       if (curr._externalMutationActive > 0) {
-        snapshotRef.current = takeSnapshot(curr.nodes, curr.edges)
+        baselineRef.current = { nodes: curr.nodes, edges: curr.edges }
         return
       }
 
-      const prevSnapshot = snapshotRef.current
-      if (!prevSnapshot) {
-        snapshotRef.current = takeSnapshot(curr.nodes, curr.edges)
+      const baseline = baselineRef.current
+      if (!baseline) {
+        baselineRef.current = { nodes: curr.nodes, edges: curr.edges }
         return
       }
 
-      const currSnapshot = takeSnapshot(curr.nodes, curr.edges)
-      const diff = diffSnapshots(prevSnapshot, currSnapshot)
-      // Position-only change: advance the baseline, keep the coaching.
-      if (!diff) {
-        snapshotRef.current = currSnapshot
-        return
-      }
+      // ⭐ THE CANONICAL OWNER ANSWERS. A cosmetic edit — rename, description,
+      // category, a drag — advances the baseline and KEEPS the coaching. Only an
+      // analysis-affecting change invalidates it. See the withdrawal note above
+      // for what the previous predicate destroyed.
+      const analytical = hasAnalyticalGraphChange(baseline, { nodes: curr.nodes, edges: curr.edges })
+      baselineRef.current = { nodes: curr.nodes, edges: curr.edges }
+      if (!analytical) return
 
-      snapshotRef.current = currSnapshot
       useGuidanceStore.getState().clearGuidanceItems()
     })
 

--- a/src/canvas/conversation/useGraphEditEvents.ts
+++ b/src/canvas/conversation/useGraphEditEvents.ts
@@ -431,7 +431,10 @@ export function useGraphEditEvents(
 // exactly ONE production caller — `useGraphEditEvents` above — and that hook's
 // only host is `DraftChat`, which `ReactFlowGraph.tsx:2484` mounts ONLY when
 // `aiPanelV2` is OFF. The flag is ON in every deployed context
-// (`netlify.toml:57` `"true"`). So for every real user, the model can be
+// (`flags.ts:358` `defaultValue: true`; `netlify.toml:57` `"true"` proves
+// STAGING only — it is under `[context.staging.environment]`, and production
+// inherits from `[build.environment]` alone, so the DEFAULT is what carries
+// this). So for every real user, the model can be
 // restructured underneath coaching that was minted against the PREVIOUS model,
 // and that coaching stands until the next assistant turn replaces the whole
 // list. Advice about a model the user has since changed is not merely stale —

--- a/src/canvas/conversation/useGraphEditEvents.ts
+++ b/src/canvas/conversation/useGraphEditEvents.ts
@@ -421,3 +421,111 @@ export function useGraphEditEvents(
     }
   }, [sendSystemEvent])
 }
+
+// ---------------------------------------------------------------------------
+// § useGuidanceInvalidationOnEdit — the coaching half, WITHOUT the wire half
+//
+// ⚠⚠ THE DEFECT THIS CLOSES (N-23, derived at the bytes in
+// `drainHostReachability.derived.spec.ts` and confirmed again at `4d1e650b`):
+// STALE COACHING SURVIVES A LOCAL STRUCTURAL EDIT. `clearGuidanceItems()` had
+// exactly ONE production caller — `useGraphEditEvents` above — and that hook's
+// only host is `DraftChat`, which `ReactFlowGraph.tsx:2484` mounts ONLY when
+// `aiPanelV2` is OFF. The flag is ON in every deployed context
+// (`netlify.toml:57` `"true"`). So for every real user, the model can be
+// restructured underneath coaching that was minted against the PREVIOUS model,
+// and that coaching stands until the next assistant turn replaces the whole
+// list. Advice about a model the user has since changed is not merely stale —
+// it is confidently wrong on a surface whose entire job is to be trusted.
+//
+// ⭐ WHY THIS IS A SEPARATE HOOK AND NOT A RE-HOST OF THE ONE ABOVE.
+// A prior lane stopped at exactly this boundary and was right to. Mounting
+// `useGraphEditEvents` on the live path would ALSO switch on `direct_graph_edit`
+// wire emission for every user — a WIRE-BEHAVIOUR change (CEE starts receiving a
+// system event it currently never receives from a flag-ON user) smuggled in as a
+// UX fix. That is a different decision, with a different blast radius, and it is
+// not this lane's to take. So the two jobs are split by CONSTRUCTION rather than
+// by discipline: this hook takes NO `sendSystemEvent`, imports no transport, and
+// is therefore STRUCTURALLY INCAPABLE of emitting anything. The guard for that
+// is a source-level assertion in the spec, not a promise in this comment.
+//
+// SINGLE AUTHORITY ON "WHAT IS A STRUCTURAL CHANGE". This deliberately reuses
+// `takeSnapshot`/`diffSnapshots` from the emitter above rather than
+// re-implementing the diff. Two same-named-but-different notions of "the graph
+// changed" is this estate's most-paid-for defect class (the two
+// `generateGraphHash` twins), and a copy here would drift the moment either side
+// is touched. Position-only changes are excluded by `diffSnapshots` returning
+// `null` — dragging a node must not wipe the user's coaching.
+//
+// ⚠ EXTERNAL MUTATIONS STAY SUPPRESSED, and that is load-bearing, not inherited
+// boilerplate. Accepting an assistant patch runs under
+// `beginExternalGraphMutation('patch_apply')` and uses `clearItemsByTargetIds`
+// to drop only the items the patch touched; a blanket clear here would destroy
+// the untargeted items that are legitimately still valid, and
+// `guidanceStore.ts`'s `minting` gate depends on that distinction holding.
+//
+// ⚠ NOT GATED ON `isOrchestratorV2Enabled()`, unlike the emitter above. That
+// flag governs a TRANSPORT; whether the user's coaching is honest about their
+// current model is not a transport concern. In the deployed posture the flag is
+// `"true"` (`netlify.toml:35`) so this is behaviour-identical there; where it is
+// OFF, this hook still keeps coaching honest instead of leaving the defect
+// standing for a reason unrelated to it.
+// ---------------------------------------------------------------------------
+
+/**
+ * Clear all guidance the moment the user makes a local structural edit.
+ *
+ * Wire-free by construction: takes no transport, emits nothing, and touches
+ * only the canvas store (read) and the guidance store (clear).
+ */
+export function useGuidanceInvalidationOnEdit(): void {
+  const snapshotRef = useRef<GraphSnapshot | null>(null)
+  const scenarioIdRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const state = useCanvasStore.getState()
+    snapshotRef.current = takeSnapshot(state.nodes, state.edges)
+    scenarioIdRef.current = state.currentScenarioId
+
+    const unsubscribe = useCanvasStore.subscribe((curr, prev) => {
+      // Scenario switch — re-baseline and clear nothing. Guidance for the
+      // decision being LEFT is not invalidated by leaving it, and the store's
+      // own rehydration gate keys on `scenarioId` anyway.
+      if (curr.currentScenarioId !== scenarioIdRef.current) {
+        scenarioIdRef.current = curr.currentScenarioId
+        snapshotRef.current = takeSnapshot(curr.nodes, curr.edges)
+        return
+      }
+
+      // Same references — nothing moved.
+      if (curr.nodes === prev.nodes && curr.edges === prev.edges) return
+
+      // Patch-apply / hydration / envelope-apply. Re-baseline so the next real
+      // user edit diffs against the post-mutation graph rather than a stale one.
+      if (curr._externalMutationActive > 0) {
+        snapshotRef.current = takeSnapshot(curr.nodes, curr.edges)
+        return
+      }
+
+      const prevSnapshot = snapshotRef.current
+      if (!prevSnapshot) {
+        snapshotRef.current = takeSnapshot(curr.nodes, curr.edges)
+        return
+      }
+
+      const currSnapshot = takeSnapshot(curr.nodes, curr.edges)
+      const diff = diffSnapshots(prevSnapshot, currSnapshot)
+      // Position-only change: advance the baseline, keep the coaching.
+      if (!diff) {
+        snapshotRef.current = currSnapshot
+        return
+      }
+
+      snapshotRef.current = currSnapshot
+      useGuidanceStore.getState().clearGuidanceItems()
+    })
+
+    return () => {
+      unsubscribe()
+    }
+  }, [])
+}

--- a/src/canvas/conversation/useGraphEditEvents.ts
+++ b/src/canvas/conversation/useGraphEditEvents.ts
@@ -456,12 +456,25 @@ export function useGraphEditEvents(
 // is touched. Position-only changes are excluded by `diffSnapshots` returning
 // `null` — dragging a node must not wipe the user's coaching.
 //
-// ⚠ EXTERNAL MUTATIONS STAY SUPPRESSED, and that is load-bearing, not inherited
-// boilerplate. Accepting an assistant patch runs under
-// `beginExternalGraphMutation('patch_apply')` and uses `clearItemsByTargetIds`
-// to drop only the items the patch touched; a blanket clear here would destroy
-// the untargeted items that are legitimately still valid, and
-// `guidanceStore.ts`'s `minting` gate depends on that distinction holding.
+// ⚠⚠ EXTERNAL MUTATIONS STAY SUPPRESSED — and the ORIGINAL VERSION OF THIS NOTE
+// WAS FALSIFIED BY REVIEW, which is why it now reads at this length.
+//
+// It said: "Accepting an assistant patch runs under
+// `beginExternalGraphMutation('patch_apply')` … a blanket clear here would
+// destroy the untargeted items that are legitimately still valid." That is TRUE
+// OF THE GUARDED WINDOW AND WAS FALSE OF THE TAIL. `ConversationPanel` CLOSED
+// the window (`:330`) and then called `mirrorAnalysisReadyAfterAccept()`
+// (`:335`), whose backfills write node `data` — so the tail arrived here
+// UNSUPPRESSED, and this hook's blanket clear fired twelve lines before the
+// deliberate `clearItemsByTargetIds(allIds)` at `:347`, which then no-opped on
+// an empty store. Three more producer writers had the same hole
+// (`applyDraftResult`, `reconcileAppliedGraph`, `mergeServerGraph`).
+//
+// The suppression is therefore load-bearing AND WAS NOT SUFFICIENT ON ITS OWN.
+// The writers have been guarded at source (see each one's note), and
+// `guidanceInvalidationProducerWrites.spec.tsx` drives the REAL producer
+// functions to prove it — because the argument above is exactly the kind that
+// reads correct and is wrong about which bytes execute.
 //
 // ⚠ NOT GATED ON `isOrchestratorV2Enabled()`, unlike the emitter above. That
 // flag governs a TRANSPORT; whether the user's coaching is honest about their

--- a/src/canvas/conversation/utils/mirrorAnalysisReady.ts
+++ b/src/canvas/conversation/utils/mirrorAnalysisReady.ts
@@ -58,9 +58,22 @@ export function applyAnalysisReadyPatch(
   // ⭐ FIXED IN THE WRITER, NOT AT THE CALL SITE, DELIBERATELY: there are TWO
   // callers of `mirrorAnalysisReadyAfterAccept` (`ConversationPanel.tsx:335` for
   // the validated path and `:393` for the adapter-less fallback), and the review
-  // that found this named only the first. Guarding here covers both, and covers
-  // the next one nobody remembers to guard. The counter is re-entrant, so this
+  // that found this named only the first. The counter is re-entrant, so this
   // nests harmlessly inside any window a caller already holds.
+  //
+  // ⚠⚠ THIS PARTICULAR GUARD IS CURRENTLY REDUNDANT, AND THAT IS RECORDED HERE
+  // SO NOBODY LATER CITES IT AS THE THING THAT CLOSES P0-B. IT IS NOT.
+  // Measured with a discriminating set, not asserted (an equivalent mutant must
+  // be DEMONSTRATED — and so must a non-equivalent one):
+  //   · remove THIS guard, keep the leaf guards      → 10/10 GREEN  (redundant)
+  //   · remove the LEAF guards, keep this one        →  2 FAILED    (not a substitute)
+  //   · remove both                                  →  4 FAILED
+  // What actually closes P0-B is the pair of LEAF guards in `applyDraftResult.ts`
+  // — on the goal-threshold `setState` and on the interventions
+  // `batchUpdateNodes` — because `reconcileAppliedGraph` and `applyDraftResult`
+  // call those leaves DIRECTLY, never through this function. This guard is kept
+  // as defence-in-depth for `setCeeAnalysisReady` / `setAnalysisFreshness` and
+  // for the next writer added to this function; it is not load-bearing today.
   useCanvasStore.getState().beginExternalGraphMutation?.('patch_apply')
   try {
   useCanvasStore.getState().setCeeAnalysisReady(patch.ceeAnalysisReady)

--- a/src/canvas/conversation/utils/mirrorAnalysisReady.ts
+++ b/src/canvas/conversation/utils/mirrorAnalysisReady.ts
@@ -45,6 +45,24 @@ export function applyAnalysisReadyPatch(
   patch: AnalysisReadyPatch,
   context: { patchId?: string; scenarioId?: string | null },
 ): void {
+  // ⚠⚠ P0-B — THE PATCH-ACCEPT TAIL ESCAPED THE SUPPRESSION WINDOW.
+  // `ConversationPanel` opens `beginExternalGraphMutation('patch_apply')`, applies
+  // the patch, and CLOSES the window in its `finally` — and only THEN calls
+  // `mirrorAnalysisReadyAfterAccept()`, which lands here and writes node `data`
+  // through the two backfills below. So the tail's writes arrived unsuppressed,
+  // twelve lines before the DELIBERATE, TARGETED `clearItemsByTargetIds(allIds)`
+  // that follows. A blanket clear at that moment empties the store, and the
+  // targeted prune — whose very existence proves the codebase expects guidance to
+  // be PRESENT and SELECTIVELY PRESERVED here — then no-ops on nothing.
+  //
+  // ⭐ FIXED IN THE WRITER, NOT AT THE CALL SITE, DELIBERATELY: there are TWO
+  // callers of `mirrorAnalysisReadyAfterAccept` (`ConversationPanel.tsx:335` for
+  // the validated path and `:393` for the adapter-less fallback), and the review
+  // that found this named only the first. Guarding here covers both, and covers
+  // the next one nobody remembers to guard. The counter is re-entrant, so this
+  // nests harmlessly inside any window a caller already holds.
+  useCanvasStore.getState().beginExternalGraphMutation('patch_apply')
+  try {
   useCanvasStore.getState().setCeeAnalysisReady(patch.ceeAnalysisReady)
 
   // Freshness source of truth: a patch's analysis_ready.freshness must flow
@@ -68,4 +86,7 @@ export function applyAnalysisReadyPatch(
   }
 
   backfillGoalThresholdOntoGoalNode(patch.ceeAnalysisReady)
+  } finally {
+    useCanvasStore.getState().endExternalGraphMutation()
+  }
 }

--- a/src/canvas/conversation/utils/mirrorAnalysisReady.ts
+++ b/src/canvas/conversation/utils/mirrorAnalysisReady.ts
@@ -61,7 +61,7 @@ export function applyAnalysisReadyPatch(
   // that found this named only the first. Guarding here covers both, and covers
   // the next one nobody remembers to guard. The counter is re-entrant, so this
   // nests harmlessly inside any window a caller already holds.
-  useCanvasStore.getState().beginExternalGraphMutation('patch_apply')
+  useCanvasStore.getState().beginExternalGraphMutation?.('patch_apply')
   try {
   useCanvasStore.getState().setCeeAnalysisReady(patch.ceeAnalysisReady)
 
@@ -87,6 +87,6 @@ export function applyAnalysisReadyPatch(
 
   backfillGoalThresholdOntoGoalNode(patch.ceeAnalysisReady)
   } finally {
-    useCanvasStore.getState().endExternalGraphMutation()
+    useCanvasStore.getState().endExternalGraphMutation?.()
   }
 }

--- a/src/canvas/domain/analyticalChange.ts
+++ b/src/canvas/domain/analyticalChange.ts
@@ -74,3 +74,84 @@ export function hasAnalyticalEdgeChange(oldEdge: Edge, updates: Partial<Edge>): 
   }
   return false
 }
+
+// ---------------------------------------------------------------------------
+// § Graph-level lift — the SAME taxonomy, asked of two complete graphs
+//
+// WHY THIS LIVES HERE AND NOT IN THE CONSUMER. The consumer that needs it
+// (`useGuidanceInvalidationOnEdit`) watches the canvas store and holds two
+// COMPLETE graphs, not an update partial. Writing the comparison there would
+// have made it a FOURTH authority on "did this edit change the analysis" —
+// alongside this file, `computeGraphHash`, and `applyPatch`'s raw path — and
+// the first version of that consumer did exactly that, via `diffSnapshots`,
+// which stringifies the WHOLE `data` object and therefore answered YES to a
+// label rename. It shipped a blanket `clearGuidanceItems()` on cosmetic edits.
+// Convergence rule: name the canonical owner and remove the competitor. This
+// file is the owner, so the lift belongs here and derives from the same
+// registry-backed `ANALYTICAL_*_FIELDS` as everything above.
+//
+// ⚠ ONE DELIBERATE DIFFERENCE FROM `hasAnalyticalNodeChange`, AND IT IS NOT A
+// NEW RULE. That function takes an UPDATE PARTIAL, so it can only ask
+// `field in newData` — a field DELETED from `data` is invisible to it, and it
+// cannot be otherwise, because an absent key in a partial means "not being
+// updated". Here both sides are complete objects, so absence is meaningful and
+// the comparison is symmetric. Same field list, same `deepEqual`, same source of
+// truth; only the direction of the question differs.
+// ---------------------------------------------------------------------------
+
+export interface AnalyticalGraphState {
+  readonly nodes: readonly Node[]
+  readonly edges: readonly Edge[]
+}
+
+function analyticalDataChanged(
+  fields: readonly string[],
+  prevData: unknown,
+  currData: unknown,
+): boolean {
+  const prev = (prevData ?? {}) as Record<string, unknown>
+  const curr = (currData ?? {}) as Record<string, unknown>
+  for (const field of fields) {
+    if (!deepEqual(prev[field], curr[field])) return true
+  }
+  return false
+}
+
+/**
+ * True when the graph moved in a way that invalidates an analysis authored
+ * against `prev` — i.e. an element was added or removed, or a surviving
+ * element's ANALYTICAL fields changed by value.
+ *
+ * FALSE for the cosmetic and transient classes this module has always excluded:
+ * position, `label`, `description`, `category`, `extractionType`, colour, and
+ * every `ephemeral` registry field (`_baseline_snapshot`, the derived
+ * goal-threshold caches). Those are a user tidying their model, not changing it,
+ * and a consumer that treats them as a change destroys work.
+ */
+export function hasAnalyticalGraphChange(
+  prev: AnalyticalGraphState,
+  curr: AnalyticalGraphState,
+): boolean {
+  if (prev.nodes.length !== curr.nodes.length) return true
+  if (prev.edges.length !== curr.edges.length) return true
+
+  const prevNodes = new Map(prev.nodes.map((n) => [n.id, n]))
+  for (const node of curr.nodes) {
+    const before = prevNodes.get(node.id)
+    if (!before) return true // an id that was not there is an add
+    // Node-level kind reclassification, the same signal the per-update
+    // function checks first.
+    if (before.type !== node.type) return true
+    if (analyticalDataChanged(ANALYTICAL_NODE_DATA_FIELDS, before.data, node.data)) return true
+  }
+
+  const prevEdges = new Map(prev.edges.map((e) => [e.id, e]))
+  for (const edge of curr.edges) {
+    const before = prevEdges.get(edge.id)
+    if (!before) return true
+    if (before.source !== edge.source || before.target !== edge.target) return true
+    if (analyticalDataChanged(ANALYTICAL_EDGE_FIELDS, before.data, edge.data)) return true
+  }
+
+  return false
+}

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -5056,11 +5056,16 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       return {
         nodes,
         edges,
+        // ⚠ NOT A USER EDIT — a delete being REVERTED. Counter raised in the SAME
+        // `set()` as the write (a later one arrives after the subscriber has
+        // already seen the change; mutant MUT-ORDER).
+        _externalMutationActive: s._externalMutationActive + 1,
         // The restored graph is the one the server still holds, so any retained
         // 'fresh' verdict is no longer confirmable against what is on screen.
         ...deriveGoalThresholdFromNode(nodes, s.outcomeNodeId),
       }
     })
+    set((s) => ({ _externalMutationActive: Math.max(0, s._externalMutationActive - 1) }))
     markAnalysisFreshnessDirty(get, set)
   },
 
@@ -5802,12 +5807,16 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
         }
       }).filter(Boolean) as typeof existingEdges
 
-      set({
+      // ⚠ NOT A USER EDIT — a clarifier PREVIEW being inserted. Same-`set()`
+      // suppression, for the reason in applyStructuralDeleteRevert.
+      set((s) => ({
         nodes: [...existingNodes, ...previewNodes],
         edges: [...existingEdges, ...previewEdges],
         clarifierPreviewNodeIds: previewNodes.map(n => n.id),
         clarifierPreviewEdgeIds: previewEdges.map(e => e.id),
-      })
+        _externalMutationActive: s._externalMutationActive + 1,
+      }))
+      set((s) => ({ _externalMutationActive: Math.max(0, s._externalMutationActive - 1) }))
 
       // Auto-layout to arrange nodes using ELK layered algorithm (top-down)
       if (import.meta.env.DEV) {
@@ -5916,12 +5925,16 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     const state = get()
     const remainingNodes = state.nodes.filter(n => !state.clarifierPreviewNodeIds.includes(n.id))
     const remainingEdges = state.edges.filter(e => !state.clarifierPreviewEdgeIds.includes(e.id))
-    set({
+    // ⚠ NOT A USER EDIT — a clarifier preview being WITHDRAWN. Same-`set()`
+    // suppression, for the reason in applyStructuralDeleteRevert.
+    set((s) => ({
       nodes: remainingNodes,
       edges: remainingEdges,
       clarifierPreviewNodeIds: [],
       clarifierPreviewEdgeIds: [],
-    })
+      _externalMutationActive: s._externalMutationActive + 1,
+    }))
+    set((s) => ({ _externalMutationActive: Math.max(0, s._externalMutationActive - 1) }))
   },
 
   exportLocal: () => {

--- a/src/canvas/stores/guidanceStore.ts
+++ b/src/canvas/stores/guidanceStore.ts
@@ -512,6 +512,18 @@ export function setGuidancePersistenceContext(provider: (() => GuidancePersisten
  * H1 → H2, the untargeted items legitimately survive — and re-stamping them at
  * H2 made them look freshly authored. `dismissItem` did the same.
  *
+ * ⚠⚠ THE SENTENCE ABOVE DESCRIBES THE GUARDED WINDOW AND WAS FALSE OF THE TAIL.
+ * `ConversationPanel` ENDS that window at `:330` and only then calls
+ * `mirrorAnalysisReadyAfterAccept()` (`:335`), whose backfills write node `data`
+ * — so the accept path's tail was NOT suppressed, and the `clearItemsByTargetIds`
+ * at `:347` could find an already-emptied store. "The untargeted items
+ * legitimately survive" was therefore true only up to `:330`. The producer
+ * writers are now guarded at source (`mirrorAnalysisReady.ts`,
+ * `applyDraftResult.ts`, `mergeAppliedGraph.ts`, `mergeServerGraph.ts`), which is
+ * what makes the paragraph above true of the WHOLE accept path rather than of
+ * its first half. Do not re-derive this from the window alone — derive it from
+ * the writers.
+ *
  * Only `setGuidanceItems` — a turn delivering guidance — is authorship. Every
  * other path INHERITS the stamp from the blob already on disk, and where it
  * cannot (no blob, or a blob for another decision) it writes `null`, which the

--- a/src/canvas/stores/guidanceStore.ts
+++ b/src/canvas/stores/guidanceStore.ts
@@ -719,7 +719,9 @@ export const useGuidanceStore = create<GuidanceState & GuidanceActions>((set, ge
         // A caller count derived from a symbol grep counts mentions, not calls.)
         //
         // Deliberately NOT "fixed" here: on a local model edit
-        // `useGraphEditEvents` already fires `clearGuidanceItems()`, which drops
+        // `useGraphEditEvents` (flag-OFF) and `useGuidanceInvalidationOnEdit`
+        // via `GuidanceInvalidationHost` (flag-ON) already fire
+        // `clearGuidanceItems()`, which drops
         // everything, so the limb is redundant rather than load-bearing, and
         // changing eviction breadth reaches every guidance surface. Recorded so
         // the next reader inherits the measurement instead of the claim.

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -222,6 +222,17 @@ export function applyDraftResult(
     captureBeforeIngest(store.nodes, store.edges)
     store.pushHistory()
   }
+  // ⚠ PRODUCER WRITE — see the guard note on the goal-threshold backfill below.
+  // THE DEFECT THIS CLOSES (P0-A): `useConversation.ts:5076` MINTS this turn's
+  // guidance and `:5127` then calls this function, whose bare `setState` looked
+  // to every "did the user edit the graph?" consumer exactly like a user edit —
+  // so the turn wiped the coaching it had just delivered, and the persisted blob
+  // with it. ⭐ THE V4 PATH GOT THE ORDER RIGHT ON PURPOSE (`:3909` "Set guidance
+  // items AFTER auto-apply patches complete"); V5 mints first. Guarding the
+  // WRITER rather than reordering the mint fixes it for every caller and does
+  // not depend on two files staying in a particular order.
+  useCanvasStore.getState().beginExternalGraphMutation('envelope_apply')
+  try {
   useCanvasStore.setState({
     nodes,
     edges,
@@ -265,6 +276,9 @@ export function applyDraftResult(
     // DEMONSTRATED, NEVER ASSERTED — and so must a NON-equivalent one.
     importPendingServerRegistration: false,
   })
+  } finally {
+    useCanvasStore.getState().endExternalGraphMutation()
+  }
 
   // Warning-only schema validation at the mutation boundary. Non-throwing —
   // shape drift is logged via devWarn in DEV builds only.
@@ -646,5 +660,18 @@ export function backfillGoalThresholdOntoGoalNode(
     }
   })
 
-  useCanvasStore.setState({ nodes: updatedNodes as any })
+  // ⚠ PRODUCER WRITE, NOT A USER GESTURE — the suppression is load-bearing.
+  // `_externalMutationActive` is a COUNTER, so nesting with an outer window is
+  // safe and deliberate. Without this, any consumer of "the user changed the
+  // graph" — `useGuidanceInvalidationOnEdit`, and the `direct_graph_edit`
+  // emitter on the flag-OFF posture — treats a write the PRODUCER made as a
+  // local edit. For guidance that means wiping the coaching the very same turn
+  // just delivered, and because `clearGuidanceItems()` also clears the persisted
+  // blob (`guidanceStore.ts:608-613`), the loss survives a reload.
+  useCanvasStore.getState().beginExternalGraphMutation('patch_apply')
+  try {
+    useCanvasStore.setState({ nodes: updatedNodes as any })
+  } finally {
+    useCanvasStore.getState().endExternalGraphMutation()
+  }
 }

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -231,7 +231,7 @@ export function applyDraftResult(
   // items AFTER auto-apply patches complete"); V5 mints first. Guarding the
   // WRITER rather than reordering the mint fixes it for every caller and does
   // not depend on two files staying in a particular order.
-  useCanvasStore.getState().beginExternalGraphMutation('envelope_apply')
+  useCanvasStore.getState().beginExternalGraphMutation?.('envelope_apply')
   try {
   useCanvasStore.setState({
     nodes,
@@ -277,7 +277,7 @@ export function applyDraftResult(
     importPendingServerRegistration: false,
   })
   } finally {
-    useCanvasStore.getState().endExternalGraphMutation()
+    useCanvasStore.getState().endExternalGraphMutation?.()
   }
 
   // Warning-only schema validation at the mutation boundary. Non-throwing —
@@ -668,10 +668,10 @@ export function backfillGoalThresholdOntoGoalNode(
   // local edit. For guidance that means wiping the coaching the very same turn
   // just delivered, and because `clearGuidanceItems()` also clears the persisted
   // blob (`guidanceStore.ts:608-613`), the loss survives a reload.
-  useCanvasStore.getState().beginExternalGraphMutation('patch_apply')
+  useCanvasStore.getState().beginExternalGraphMutation?.('patch_apply')
   try {
     useCanvasStore.setState({ nodes: updatedNodes as any })
   } finally {
-    useCanvasStore.getState().endExternalGraphMutation()
+    useCanvasStore.getState().endExternalGraphMutation?.()
   }
 }

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -585,6 +585,16 @@ export function backfillInterventionsOntoOptionNodes(
   }
 
   if (patches.length) {
+    // ⚠ PRODUCER WRITE THROUGH A STORE ACTION, NOT `setState` — and that is why
+    // it was missed twice. Guarding the composite callers
+    // (`applyAnalysisReadyPatch`) covered this only when it was reached THROUGH
+    // them; `reconcileAppliedGraph` (`mergeAppliedGraph.ts:735`) and
+    // `applyDraftResult` (`:351`) call it directly, so the write arrived
+    // unsuppressed and wiped the user's coaching. Found by a test written for a
+    // SURVIVING mutant, not by inspection. Guarding the LEAF makes it safe from
+    // every caller, including the next one.
+    useCanvasStore.getState().beginExternalGraphMutation?.('patch_apply')
+    try {
     // Single history entry; diff-aware no-op if shallow-equal to current state.
     useCanvasStore.getState().batchUpdateNodes(patches, 'backfill-interventions')
     // Warning-only schema validation after the write. Use a Set for O(1)
@@ -592,6 +602,9 @@ export function backfillInterventionsOntoOptionNodes(
     const patchedIds = new Set(patches.map(p => p.id))
     const updated = useCanvasStore.getState().nodes
     validateNodesBatch(updated.filter(n => patchedIds.has(n.id)) as any)
+    } finally {
+      useCanvasStore.getState().endExternalGraphMutation?.()
+    }
   }
 
   return {

--- a/src/canvas/utils/mergeAppliedGraph.ts
+++ b/src/canvas/utils/mergeAppliedGraph.ts
@@ -691,10 +691,23 @@ export function reconcileAppliedGraph(
   // --- Commit: one history entry, one atomic store write ---
   const canvas = useCanvasStore.getState()
   canvas.pushHistory()
-  useCanvasStore.setState({
-    nodes: [...reconciledNodes, ...addedNodes] as any,
-    edges: [...reconciledEdges, ...addedEdges] as any,
-  })
+  // ⚠ PRODUCER WRITE, NOT A USER GESTURE — the suppression is load-bearing.
+  // `_externalMutationActive` is a COUNTER, so nesting with an outer window is
+  // safe and deliberate. Without this, any consumer of "the user changed the
+  // graph" — `useGuidanceInvalidationOnEdit`, and the `direct_graph_edit`
+  // emitter on the flag-OFF posture — treats a write the PRODUCER made as a
+  // local edit. For guidance that means wiping the coaching the very same turn
+  // just delivered, and because `clearGuidanceItems()` also clears the persisted
+  // blob (`guidanceStore.ts:608-613`), the loss survives a reload.
+  useCanvasStore.getState().beginExternalGraphMutation('envelope_apply')
+  try {
+    useCanvasStore.setState({
+      nodes: [...reconciledNodes, ...addedNodes] as any,
+      edges: [...reconciledEdges, ...addedEdges] as any,
+    })
+  } finally {
+    useCanvasStore.getState().endExternalGraphMutation()
+  }
 
   // Staleness flags set EXPLICITLY (not via pushToHistory, which early-returns
   // without flipping them when the pre-merge state equals the last snapshot),

--- a/src/canvas/utils/mergeAppliedGraph.ts
+++ b/src/canvas/utils/mergeAppliedGraph.ts
@@ -699,14 +699,14 @@ export function reconcileAppliedGraph(
   // local edit. For guidance that means wiping the coaching the very same turn
   // just delivered, and because `clearGuidanceItems()` also clears the persisted
   // blob (`guidanceStore.ts:608-613`), the loss survives a reload.
-  useCanvasStore.getState().beginExternalGraphMutation('envelope_apply')
+  useCanvasStore.getState().beginExternalGraphMutation?.('envelope_apply')
   try {
     useCanvasStore.setState({
       nodes: [...reconciledNodes, ...addedNodes] as any,
       edges: [...reconciledEdges, ...addedEdges] as any,
     })
   } finally {
-    useCanvasStore.getState().endExternalGraphMutation()
+    useCanvasStore.getState().endExternalGraphMutation?.()
   }
 
   // Staleness flags set EXPLICITLY (not via pushToHistory, which early-returns

--- a/src/canvas/utils/mergeServerGraph.ts
+++ b/src/canvas/utils/mergeServerGraph.ts
@@ -437,10 +437,23 @@ export function mergeServerGraphOnHydrate(
     useCanvasStore.getState().pushHistory()
   }
 
-  useCanvasStore.setState({
-    nodes: [...mergedNodes, ...addedNodes] as any,
-    edges: [...mergedEdges, ...addedEdges] as any,
-  })
+  // ⚠ PRODUCER WRITE, NOT A USER GESTURE — the suppression is load-bearing.
+  // `_externalMutationActive` is a COUNTER, so nesting with an outer window is
+  // safe and deliberate. Without this, any consumer of "the user changed the
+  // graph" — `useGuidanceInvalidationOnEdit`, and the `direct_graph_edit`
+  // emitter on the flag-OFF posture — treats a write the PRODUCER made as a
+  // local edit. For guidance that means wiping the coaching the very same turn
+  // just delivered, and because `clearGuidanceItems()` also clears the persisted
+  // blob (`guidanceStore.ts:608-613`), the loss survives a reload.
+  useCanvasStore.getState().beginExternalGraphMutation('hydrate')
+  try {
+    useCanvasStore.setState({
+      nodes: [...mergedNodes, ...addedNodes] as any,
+      edges: [...mergedEdges, ...addedEdges] as any,
+    })
+  } finally {
+    useCanvasStore.getState().endExternalGraphMutation()
+  }
 
   // ── DISCLOSURE: never move a number the user is looking at in silence ──────
   //

--- a/src/canvas/utils/mergeServerGraph.ts
+++ b/src/canvas/utils/mergeServerGraph.ts
@@ -445,14 +445,14 @@ export function mergeServerGraphOnHydrate(
   // local edit. For guidance that means wiping the coaching the very same turn
   // just delivered, and because `clearGuidanceItems()` also clears the persisted
   // blob (`guidanceStore.ts:608-613`), the loss survives a reload.
-  useCanvasStore.getState().beginExternalGraphMutation('hydrate')
+  useCanvasStore.getState().beginExternalGraphMutation?.('hydrate')
   try {
     useCanvasStore.setState({
       nodes: [...mergedNodes, ...addedNodes] as any,
       edges: [...mergedEdges, ...addedEdges] as any,
     })
   } finally {
-    useCanvasStore.getState().endExternalGraphMutation()
+    useCanvasStore.getState().endExternalGraphMutation?.()
   }
 
   // ── DISCLOSURE: never move a number the user is looking at in silence ──────

--- a/src/v5/blocks/coachingCurrency.ts
+++ b/src/v5/blocks/coachingCurrency.ts
@@ -125,7 +125,8 @@
  * is sound; the `evictStaleItems` half is not.
  *
  * ⚠ AND THE SKIP THAT MECHANISM HAS. `useGraphEditEvents` returns early while
- * `_externalMutationActive > 0` (`:204-208`), BEFORE reaching the clear, so an
+ * `_externalMutationActive > 0` (`:245` at the time of writing — derive the
+ * line, do not trust it), BEFORE reaching the clear, so an
  * accepted assistant patch fires no `clearGuidanceItems()`. Investigated: it does
  * NOT produce a transient lie the user can SEE. Both external-mutation paths pair
  * the suppression with a prune in the SAME synchronous task — manual accept

--- a/src/v5/blocks/coachingCurrency.ts
+++ b/src/v5/blocks/coachingCurrency.ts
@@ -117,7 +117,8 @@
  *     the user edits?" regardless of the limbs.
  *
  * The mechanism that actually keeps those surfaces clean is
- * `clearGuidanceItems()` at `useGraphEditEvents.ts:226`, which drops EVERY item
+ * `clearGuidanceItems()` (at `useGraphEditEvents.ts:293` when this was written;
+ * derive the line, do not trust it), which drops EVERY item
  * on any structural local edit, ahead of its own 1.5 s debounce — plus, on an
  * assistant turn, `setGuidanceItems()` replacing the whole list
  * (`useConversation.ts:3716`). The `rehydrateGuidance` half of the #670 argument


### PR DESCRIPTION
**N-23 was real.** `clearGuidanceItems()` had exactly one production caller, in a hook whose only host is `DraftChat` — mounted only when `aiPanelV2` is OFF (`flags.ts:358` `defaultValue: true`). So coaching invalidation on graph edit has been **dark on the deployed posture**.

**Fix:** a new wire-free `useGuidanceInvalidationOnEdit`, reusing the *same* diff helpers so there is no second authority on "the graph changed", mounted via `GuidanceInvalidationHost` beside the two existing drain hosts. Exactly one host runs per posture — no double-clear.

**Inverse failure deliberately avoided:** re-hosting `useGraphEditEvents` would have switched on `direct_graph_edit` wire emission for every user — a wire change smuggled in as a UX fix. The new hook takes no transport and imports none, enforced at the source with contrast controls. `useGraphEditEvents` correctly stays in `KNOWN_DARK_DRAINS`; the wire half is still dark by design.

---

## Review disposition — the 7 fixes from the DO-NOT-MERGE review

⚠ **The review itself is not on this PR** (no reviews, no inline comments, no issue comments beyond the StackBlitz bot). It was recovered from the body of commit `6f2078cf`, which enumerates it. Recording that here so the next reader does not conclude from a clean comments tab that there was nothing to answer.

| # | Finding | Disposition |
|---|---|---|
| 1 | **P0-A / P0-B** — four PRODUCER writers had no `beginExternalGraphMutation` window, so mounting the hook destroyed coaching on the two most important journeys, and (because `clearGuidanceItems` also clears the blob) **the loss survived a reload** | **FIXED at the WRITER, not the call site** — `mirrorAnalysisReady.ts:77`, `applyDraftResult.ts:234`/`:596`/`:684`, `mergeAppliedGraph.ts:702`, `mergeServerGraph.ts:448`. Two of the four were found by a **surviving mutant**, not by inspection; `f72641cc` then measured which guard actually closes P0-B and labelled the redundant outer one in place |
| 2 | `useGraphEditEvents.ts` and `guidanceStore.ts` both asserted a suppression true only of the **guarded window** | **FIXED** — original wording quoted, then refuted, in place (2 sites + 1 site verified) |
| 3 | `stripComments` applied to the negative assertions and **not** to the load-bearing positive one; M1b left the central claim green | **FIXED**, M1b pinned permanently (`…reachability.production.spec.tsx:295-305`) |
| 4 | `drainHostReachability.derived.spec.ts` `imports()`/`callsHook()` were comment-blind — the control written to catch a stale import **passed on a commented-out call** | **FIXED**; drain set re-derived 5 → 4, `useSessionResumeEvent` reclassified `HOSTED_NOWHERE:264` |
| 5 | M6 (`<MaybeConversationProvider>` → `<>`) and M8 (flag inverted) left the spec 22/22 green | **FIXED** — render path and the literal flag guard now pinned (`:323`, `:328`) |
| 6 | The "SINGLE AUTHORITY" claim was not earned — the diff is shared, the ~30-line invalidation decision was copied | **FIXED** — divergence guard added; M2c proved the divergence was invisible without it |
| 7 | Stale line refs in `coachingCurrency.ts` | **FIXED** — replaced with derive-don't-trust |

All seven verified present **at the bytes** on this head, not inherited from the commit prose.

---

## ⚠⚠ Review round 2 returned BLOCK — a live regression, now fixed (`309f35fe`)

The independent review verified the §C latent-defect find (MUT-S/MUT-I/MUT-P all reproduced, plus a new **MUT-ORDER** — counter raised in a separate later `set()` — which also reds §C alone; that pin holds against removal **and** refactor). But it found that this PR **introduced a live regression reachable by 100% of deployed users**, of the predicate-breadth class.

**The defect.** `serialiseNode` stringifies the WHOLE `data` object, so `diffSnapshots` returned non-null for ANY `data` change and the new hook answered with a blanket `clearGuidanceItems()` — which also wipes the persisted blob, so the loss survived a reload. Four gestures wiping screen **and** disk: rename the goal (`store.updateNodeLabel`), inspector label rename, inspector **description** edit, inspector **category** edit. Newly reachable *because of this PR*: at base the only caller of `clearGuidanceItems()` was hosted where `aiPanelV2` is OFF, and it defaults TRUE — mounting the new host in the flag-ON branch took it from unreachable to universal.

**The codebase already owned the question.** `hasAnalyticalNodeChange` / `ANALYTICAL_NODE_DATA_FIELDS` exists to decide exactly this, and its registry **explicitly excludes** `label`, `body`, `description`, position and colour as cosmetic. The `diffSnapshots` path was a **fourth authority** answering the same question differently. The tell was two surfaces disagreeing on one gesture: strip and node markers destroyed while the transcript coaching card beside them still read `'current'`, because `coachingCurrency` asks the canonical owner.

### The three corrections

1. **Bound the predicate by CONVERGING, not by adding a fifth rule.** `hasAnalyticalGraphChange` is added to `domain/analyticalChange.ts` **itself**, deriving from the same registry; the hook defers to it. One deliberate difference from its per-update sibling, and it is not a new rule: the sibling takes an *update partial* so it can only ask `field in newData`; here both sides are complete objects, so the comparison is symmetric.
   **Plus the opposite-direction twins the corpus was missing** (§D): §B had exactly **one** "must not clear" twin — a drag. A contrast-controlled sweep found `position-only` in 8 places and cosmetic/label/description in **zero**. §D drives the **real store actions** with the exact payload shapes `useInspectorMutations` builds, has a control proving each gesture actually moved the graph, and a **contrast** proving an analytical edit through the same action still clears.
2. **The writer manifest.** Bounding the predicate **exempted three** of the ~10 named writers outright (`loadStarter` stamps `starterId` only; `saveScenario`'s two cleansing writes strip `_baseline_snapshot`, which the registry marks `ephemeral`) — recorded as exempt **with the field that makes them safe**, so the exemption dies if they start writing analytical data. The rest are guarded: `applyStructuralDeleteRevert`, `applyClarifierGraph`, `clearClarifierPreview`, `RecoveryBanner` (recovering unsaved work was destroying the coaching that belonged to it), the streamed-preview withdrawal, `applyV5State`'s graph_patch application, and both `optimisticFactorEdit` writes. Every counter is raised in the **same `set()`** as the write — MUT-ORDER proves a later one is too late.
   ⭐ `applyV5State` is guarded **at its call site**, and the reason is derived not assumed: it has **exactly one** production caller. The estate's rule is guard-the-leaf *because* a second caller usually exists; here there is none, and it takes an injected store, so a leaf guard means widening that interface and every double. Re-derive the caller count before moving it.
3. **The "SINGLE AUTHORITY" claim in the source is withdrawn**, quoted then refuted — the spec already said it was unearned. The FIX-6 divergence guard that asserted the two chains "ask the same questions" is **superseded**: it was pinning the very coupling that caused this. The chains answer **different questions** (trap 21), and the new invariant is that the invalidation **defers to the canonical owner and re-implements no field list**, with a contrast control proving the probe can tell the chains apart.

Also removed the last harness shape this file's own note bans (a host mounted and never unmounted before `reloadTheTab()`), and inverted the reachability spec's RELABEL case with its original wording quoted and refuted in place.

### ⚠ Known divergence, pinned as an EXACT set

A rename now survives the edit but still **not a reload**, because `generateGraphHash` puts `data.label` in the hash while `analyticalChange` calls it cosmetic. **Both are pre-existing** — the adoption gate and its hash were already on `staging`; this PR only mounts the host. Changing the hash also moves the autosave dirty-gate, a separate decision with its own blast radius. So the gap is **recorded in the suite** as `{label: dropped, description: kept, category: kept}`, and REDs if it grows **or** shrinks.

### Mutants — round 2, each guard bitten by a mutant that bites only it

| mutant | reds |
|---|---|
| **MUT-COSMETIC** restore the whole-`data` predicate | **§D only** (4 gestures + the divergence pin) |
| **MUT-I** remove `clearGuidanceItems()` | §B ×2, §C control, §D contrast — **§A fully green** |
| **MUT-S** remove the `hydrateGraphSlice` suppression | **§C ⭐⭐ only** |
| **MUT-ORDER** raise the counter in a later `set()` | **§C ⭐⭐ only** |
| **MUT-CLARIFIER** unguard `applyClarifierGraph` | **§E clarifier only** |
| **MUT-REVERT-GUARD** unguard `applyStructuralDeleteRevert` | **§E revert only** |
| **MUT-P** remove `persistCurrent` | §A ×4 and everything else that reads the blob |

Leading and trailing controls both 37/37 with applied-check 0; each mutant applied-check exactly 1; isolation proven by sentinel write with distinct inodes; restores from a pristine archive.

**Deferred, as the review directed:** the OFF×OFF flag cell, `evictStaleItems`' dead graph limb, `useModelActionApply.ts`'s apparent zero callers, and `diffSnapshots` ignoring edge `type` / being key-order sensitive.

---

## ⭐⭐ Domain 3 (Context / Memory) — the exit condition, now executable

Context/Memory was **JOURNEY-WITNESSED PARTIAL**: conversation + graph restore witnessed; **coaching persistence neither confirmed nor refuted**, because the witness run never ran an analysis, so `guidance.items.v1` was never written. `coachingSurvivesReload.acceptance.spec.tsx` (19 tests) is the executable half of that settlement — one journey rerun now has something to agree with.

**Two harms, pinned separately, because a fix for either one alone produces the other.** "Persist everything forever" closes §A and opens §B; "clear on every tick" closes §B and opens §A.

- **§A** the coaching a **real analysis** minted survives a **real reload** — minted by the real chain (`parseV5Response` → `extractPhase3FromV5Response` → `toStoreGuidanceItem` → `setGuidanceItems`, exactly `useConversation.ts:5074-5079`) from **three independent live analysis captures**; the reload round-trips graph + answer through the real autosave projection and `restoreAnalysisFromAutosave`, and the read-side graph hash is computed over the **restored** nodes, never the objects still in memory. Bound by **item id** and by **deep-equality against the producer's own values** — never against literals this spec invented.
- **§B** a **local structural edit** invalidates it, on screen **and on disk** — including the discriminating case the adoption gate cannot fake: edit the model and edit it **back**, so the hash returns to the stamped value and the gate would wave the stale items straight through. Only the invalidation keeps them out.
- **§C** ⭐⭐ **the interaction, which would have killed this domain and was unpinned.**

### ⭐ Measured at the captures — this moves which gate is load-bearing

A real analysis turn pins **every** guidance item with `valid_while.graph_hash` (`graph_hash_at_generation`) and **no `analysis_hash`**. All three captures agree (11 / 13 / 11 items). So on the live journey the **analysis-hash limb of `rehydrateGuidance` is never exercised**, and whether the user's coaching survives a refresh rests **entirely** on the UI-side graph-hash comparison. The existing `analysis_hash` corpus in `guidanceStore.rehydration.spec.ts` is a real pin on a limb the wire does not currently reach. Derive again before relying — it is a fact about what CEE emits.

### ⭐⭐ §C — the defect that was one store action away

`GuidanceInvalidationHost` is a **child**, so it subscribes **before** `ReactFlowGraph`'s boot effect writes the whole restored graph into an empty store — the largest structural change the hook will ever see — a few lines before `rehydrateGuidance` reads the blob. Unsuppressed, that clears the blob and **every user loses all coaching on every reload**, silently: §A is green (mounts no host) and §B is green (never touches the disk).

It is safe **only** because `hydrateGraphSlice` raises `_externalMutationActive` in the **same `set()`** as the node write (`store.ts:5886`) — a property of a store action three files from either mechanism, which nothing told either of them was load-bearing. Now something does, with a **control** writing the same bytes through a bare `setState` so the case is evidence about the *suppression* and not about a hook that never fires.

### Mutants — different mutants, different reds, measured

| mutant | §A | §B ⭐⭐ (edit-and-edit-back) | §C ⭐⭐ |
|---|---|---|---|
| **MUT-P** remove `persistCurrent` from `setGuidanceItems` | **RED** ×4 | GREEN | RED |
| **MUT-I** remove `clearGuidanceItems()` from the hook | **GREEN (all 14)** | **RED** | GREEN |
| **MUT-S** remove the `hydrateGraphSlice` suppression | GREEN | GREEN | **RED (only this)** |

Two clean discriminating pairs: §A is red under MUT-P and green under MUT-I (a pure persistence pin); §B ⭐⭐ is red under MUT-I and green under MUT-P (a pure invalidation pin). MUT-S produces exactly **one** red, bound to the property it names. Throwaway worktree outside the repo root, **isolation proven by a sentinel write** (distinct inodes), restores from a pristine archive, applied-check scoped to `src/` = exactly 1 per mutant, leading and trailing controls both 0 / 19-of-19.

⚠ **Two harness defects found by execution, both kept as notes in the file.** Simulating the boot with a bare `setState` instead of `hydrateGraphSlice` manufactures a total coaching loss the product does not have; leaving a host subscribed across the page teardown makes emptying the store look like the user deleting every node. Both produce a **false red that reads exactly like a real one**.

### Measured, not fixed — out of this lane's path

- `VITE_FEATURE_THREAD_PERSIST` / `VITE_FEATURE_THREAD_HYDRATE` are inert, and **none of their gates is in the guidance-persistence path** — zero overlap with the files this PR touches. Blast radius if removed: `flags.ts:237-244,488-489,556-557`, `lib/flagEnv.ts:104-105`, `services/threadService.ts:33,70`, `hooks/useThreadPersistence.ts:221,370,398`, `useConversation.ts:71,2837,2867`, plus specs. `useConversation.ts` is a high-collision file; doing it here would be "while we're here" work. **Smallest enabling change: one PR that deletes the two flag entries and inlines each gate to its always-on branch.**
- `conversation_turns` — the table still has **zero readers**, and there is a trap for the next lane that greps it: `recent_conversation_turns` in the debug bundle (`useDebugData.ts:4589`) is a **same-name different-thing** — `selectRecentConversationTurns(tracedPayloads)` reads in-memory network traces, not the table. Writers are `useThreadPersistence.ts:247` and `:312`, neither in this PR's path.

**Evidence:** lane specs 19/19 collected **by name**; neighbouring specs 166 passed across 8 files (arg count asserted = 8, no shrunk collect); typecheck gate **PASSED** (557 files / 2263 errors vs baseline 2272 — drift shrank, none added); eslint clean on the new file.

**CI on `309f35fe`:** `Staging Gate` **SUCCESS**; all four Full Test Suite shards, `TypeScript + Lint`, `Typecheck Gate Self-Test`, `Production Build`, `Security Audit`, `CEE Contract Validation` all success. `Visual Regression (advisory)` fails — the standing base red, not required and not this branch's.

**Unmeasured:** the live journey rerun. **DO NOT MERGE** — held for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
