### PR TITLE
fix(D5): gate the chat run chip on analysisHeldOn

### DIFF
--- a/src/adapters/cee/types.ts
+++ b/src/adapters/cee/types.ts
@@ -393,10 +393,21 @@ export const ANALYSIS_READY_STATUSES = [
 export type AnalysisReadyStatus = (typeof ANALYSIS_READY_STATUSES)[number]
 
 /**
- * NOT a producer value — a sentinel the UI mints itself. `applyV5State.ts:262`
- * coerces a missing/non-string `analysis_ready.status` to `'unknown'` so the
- * lenient V5 normaliser never drops the payload. It means "CEE said nothing
- * about readiness on this turn", which is not a verdict of any kind.
+ * "CEE said nothing about readiness on this turn" — an ABSENCE, not a verdict
+ * of any kind, and specifically NOT a synonym for `blocked`.
+ *
+ * ⚠ CORRECTED. This said "NOT a producer value — a sentinel the UI mints
+ * itself". That was true when written and is now FALSE at both ends: CEE
+ * declares the identical string as `READINESS_STATUS_UNSUPPLIED`
+ * (`compose/analysis-state-v1.ts`) and emits it on the 12 of 22 turn exits that
+ * supply no readiness payload, `clarify_v2` included. The UI still mints it too
+ * (`applyV5State.ts:262` coerces a missing/non-string `analysis_ready.status`),
+ * so it now arrives by BOTH routes and means the same thing on each.
+ *
+ * ⚠ THE OBLIGATION THAT FOLLOWS, because a consumer already got this wrong:
+ * treat it as "fall back to the last known verdict", NEVER as "not ready".
+ * `analysisStateSelector` does exactly that; reading it as a negative removed
+ * the Run CTA from every pre-analysis clarification turn.
  */
 export const ANALYSIS_READY_STATUS_UNSUPPLIED = 'unknown'
 

--- a/src/canvas/conversation/__tests__/SuggestedChips.heldModelGate.spec.tsx
+++ b/src/canvas/conversation/__tests__/SuggestedChips.heldModelGate.spec.tsx
@@ -58,6 +58,14 @@ import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
 
 import { SuggestedChips } from '../zones/SuggestedChips'
+
+// Mocked so the dev-log counter assertion (case 9) can observe emissions.
+// `importOriginal` is spread so every OTHER export stays real — a bare factory
+// REPLACES the module and silently removes anything it forgets (trap 12).
+vi.mock('../../../v5/debugLog', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../v5/debugLog')>()),
+  logV5StateEvent: vi.fn(),
+}))
 import { useCanvasStore } from '../../store'
 import type { ActionChip } from '../types'
 
@@ -289,9 +297,11 @@ describe('SuggestedChips — the held-model gate (PoC domain 5)', () => {
   //    all, this goes red for the right reason.
   // ───────────────────────────────────────────────────────────────────────────
 
-  it('agrees with canRunAnalysis: whenever the run gate refuses for the hold, the chip is absent', async () => {
+  it('agrees with canRunAnalysis: the gate refuses FOR THE HOLD, and the chip is absent', async () => {
     const { canRunAnalysis } = await import('../../utils/canRunAnalysis')
-    const { analysisHeldOn } = await import('../../utils/analysisHeldOnInjectedModel')
+    const { analysisHeldOn, ANALYSIS_HELD_NOTICE } = await import(
+      '../../utils/analysisHeldOnInjectedModel'
+    )
 
     setReady('ready')
     setNodes(STARTER_NODES)
@@ -299,16 +309,128 @@ describe('SuggestedChips — the held-model gate (PoC domain 5)', () => {
     const heldOn = analysisHeldOn(STARTER_NODES)
     expect(heldOn).toBe('starter') // precondition PINNED in-test (trap 13b)
 
-    const gate = canRunAnalysis({
-      graphHealth: { errors: [], warnings: [] },
-      readiness: { status: 'ready' },
+    // ⚠ THE FIRST DRAFT OF THIS CASE WAS VACUOUS, and the way it was vacuous is
+    // worth keeping in view. Its fixture was `readiness: { status: 'ready' }`,
+    // but `canRunAnalysis` reads `can_run_analysis` — so `readinessObjectsToRun`
+    // fired on the MISSING field and `allowed` was false whether or not the
+    // model was held. The test agreed with the fix for a reason that had nothing
+    // to do with the fix. A gate that refuses for the wrong reason is not
+    // evidence about the hold (trap 13b).
+    //
+    // Fixed two ways, and BOTH are needed: the fixture now uses the real field
+    // names, and the assertion binds to the REASON rather than to the boolean,
+    // so only a refusal that is actually the hold can satisfy it.
+    const params = {
+      graphHealth: { issues: [] },
+      readiness: { can_run_analysis: true },
       hasBlockers: false,
       nodeCount: STARTER_NODES.length,
-      analysisHeldOn: heldOn,
-    } as any)
-    expect(gate.allowed).toBe(false) // the Analyse control refuses …
+    }
+
+    const held = canRunAnalysis({ ...params, analysisHeldOn: heldOn } as never)
+    expect(held.allowed).toBe(false)
+    expect(held.reason).toBe(ANALYSIS_HELD_NOTICE.starter) // …refused FOR THE HOLD
+
+    // ⭐ CONTRAST CONTROL, in the same run: the identical fixture with no hold
+    // must be ALLOWED. Without this the case could pass on any refusal at all.
+    const notHeld = canRunAnalysis({ ...params, analysisHeldOn: null } as never)
+    expect(notHeld.allowed).toBe(true)
 
     renderChips([makeChip({ id: 'coherent', action_type: 'run_analysis' })])
-    expect(screen.queryByTestId('suggested-chip-coherent')).toBeNull() // … and so does the chip
+    expect(screen.queryByTestId('suggested-chip-coherent')).toBeNull() // chip agrees
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 7. THE ESCAPE ROUTES MUST SURVIVE THE HOLD. A reviewer's mutant that also
+  //    silenced these SURVIVED 12/12 — the routes were present but UNPINNED, so
+  //    a future tightening could strand the user on a held model with a green
+  //    suite. `start_new_draft` is id-routed and carries no message, which is
+  //    exactly the shape a label/message-based filter would swallow.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it('still shows draft_graph on a held graph — re-drafting is the way OUT of the hold', () => {
+    setReady('ready')
+    setNodes(STARTER_NODES)
+    renderChips([makeChip({ id: 'draft_ok', action_type: 'draft_graph', label: 'Re-draft this live' })])
+    expect(screen.getByTestId('suggested-chip-draft_ok')).toBeInTheDocument()
+  })
+
+  it('still shows the id-routed start_new_draft chip (no message) on a held graph', () => {
+    setReady('ready')
+    setNodes(STARTER_NODES)
+    render(
+      <SuggestedChips
+        chips={[{ id: 'start_new_draft', label: 'Start a new draft', intent: 'primary' } as ActionChip]}
+        onChipClick={vi.fn()}
+      />,
+    )
+    expect(screen.getByTestId('suggested-chip-start_new_draft')).toBeInTheDocument()
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 8. ⭐ KNOWN-DROPPED, PINNED AS AN EXACT SET rather than left invisible.
+  //
+  //    `RUN_ANALYSIS_RE` is ANCHORED (`^(?:run|rerun)\s+(?:the\s+)?analysis\.?$`),
+  //    deliberately, so conversational chips like "Explain the analysis" survive.
+  //    The cost is that a chip with NO `action_type` whose message merely
+  //    CONTAINS a run request is not suppressed by the hold.
+  //
+  //    Widening the regex is the wrong trade: it is the same predicate that
+  //    protects the conversational chips, and loosening it to catch this case
+  //    re-opens the opposite harm (trap 22b — one predicate, two opposite
+  //    harms). So the gap is recorded HERE, as an exact set, and this test REDs
+  //    if the set grows OR shrinks. A gap in the suite is honest; a gap the
+  //    suite cannot see is how four rounds of oscillation happen.
+  //
+  //    ⚠ Residual harm is bounded, not zero: such a chip sends an ordinary
+  //    conversational turn, and an LLM-elected `run_analysis` is now itself
+  //    gated server-side by CEE's analysis-election gate.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it('KNOWN-DROPPED: an unanchored run request with no action_type is NOT suppressed', () => {
+    setReady('ready')
+    setNodes(STARTER_NODES)
+    renderChips([
+      makeChip({ id: 'known_dropped', label: 'Run analysis now', message: 'Please run the analysis now' }),
+    ])
+    // Documented gap, asserted as CURRENT behaviour so a change is visible.
+    expect(screen.getByTestId('suggested-chip-known_dropped')).toBeInTheDocument()
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 9. ⭐ THE M7-ANALOGUE NON-EQUIVALENCE, DEMONSTRATED RATHER THAN CLAIMED.
+  //
+  //    Mutant M7 showed that applying this filter DOWNSTREAM is behaviourally
+  //    equivalent for VISIBILITY. The source comment justifies the upstream
+  //    position by saying the dev-log counters operate on the admissible set —
+  //    and per the estate's own rule a NON-equivalence must be demonstrated too,
+  //    or the claim dropped. This is the demonstration: a held run chip must not
+  //    be reported as "removed for unreadiness", because it was not.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it('does not mis-report a HELD chip as removed-for-unreadiness in the dev log', async () => {
+    const { logV5StateEvent } = await import('../../../v5/debugLog')
+    const spy = vi.mocked(logV5StateEvent)
+    spy.mockClear()
+
+    setReady('needs_encoding') // not ready → the unready counter is live
+    setNodes(STARTER_NODES)
+    renderChips([makeChip({ id: 'held_devlog', action_type: 'run_analysis' })])
+
+    const unready = spy.mock.calls.filter((c) => c[0] === 'chip_filter_unready')
+    expect(unready).toHaveLength(0)
+
+    // ⭐ POSITIVE CONTROL, without which the assertion above is vacuous: the
+    // counter must actually FIRE for a chip that really was dropped for
+    // unreadiness. An absence proves nothing until the probe has shown it can
+    // see a presence (trap 13) — and if `import.meta.env.DEV` were false here,
+    // or the mock were not wired, this control would fail rather than let the
+    // absence pass silently.
+    cleanup()
+    spy.mockClear()
+    setNodes(DRAFTED_NODES) // not held → the hold cannot be the reason
+    renderChips([makeChip({ id: 'unready_devlog', action_type: 'run_analysis' })])
+    const fired = spy.mock.calls.filter((c) => c[0] === 'chip_filter_unready')
+    expect(fired).toHaveLength(1)
   })
 })

--- a/src/canvas/conversation/__tests__/SuggestedChips.heldModelGate.spec.tsx
+++ b/src/canvas/conversation/__tests__/SuggestedChips.heldModelGate.spec.tsx
@@ -1,0 +1,314 @@
+/**
+ * PoC DOMAIN 5 — the chat chip must read the SAME held-model authority every
+ * other run affordance reads.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE DEFECT (the domain's defining one: two surfaces, one run, two answers)
+ * ═══════════════════════════════════════════════════════════════════════════
+ * The `Run analysis` CHAT CHIP gated on `ceeAnalysisReady.status === 'ready'`
+ * — CEE's verdict about its OWN persisted graph — while the Analyse control
+ * gated on `analysisHeldOn(nodes)`, the client's verdict about whether the
+ * graph ON THIS CANVAS is one CEE ever received.
+ *
+ * ⭐ THEY ANSWER DIFFERENT QUESTIONS, and that is why aligning their defaults
+ * would have been the wrong fix (trap 21). Named apart:
+ *
+ *   `ceeAnalysisReady.status`  "is CEE's persisted model READY to analyse?"
+ *   `analysisHeldOn(nodes)`    "is the model on this canvas one CEE has
+ *                               NEVER RECEIVED?"
+ *
+ * Both are preconditions of the chip's PROMISE, which is neither of those
+ * questions but a third: *"if I click this, do I get an analysis of the model
+ * I am looking at?"* On a client-injected graph the first can be `ready` while
+ * the second is non-null — CEE is ready to analyse a DIFFERENT graph. The chip
+ * ran, the button refused, and the results named nodes absent from the canvas.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHY THIS IS A WIRING FIX AND NOT A NEW AUTHORITY (the lead question)
+ * ═══════════════════════════════════════════════════════════════════════════
+ * It introduces NO derived value. `analysisHeldOn` is already THE one authority
+ * for this fact and already has readers: `canRunAnalysis` (the Analyse control,
+ * via `OutputsDock` and `ConversationPanel`) and `StarterProvenanceBanner`.
+ * Every OTHER run affordance in the product routes through `executeCanonicalRun`,
+ * which applies that gate — node chips, the command palette, the actions menu,
+ * the inspector inline rerun, the define-success modal. The chat chip was the
+ * LAST run affordance that did not. Adding a reader of one authority is the
+ * fix; minting a second derivation would have been the defect.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE NAMED TRAP, MEASURED RATHER THAN ASSUMED
+ * ═══════════════════════════════════════════════════════════════════════════
+ * "Gating chip visibility on the client hold risks suppressing legitimate live
+ * runs." Derived at the bytes, and it does not:
+ *   · `analysisHeldOn` is non-null only when a node carries `data.starterId`
+ *     or `data.templateId` AND the run routes through the V5 canonical path;
+ *   · those stamps are written in exactly three places — `loadStarter.ts:155`,
+ *     `useBlueprintInsert.ts:78`, `ReactFlowGraph.tsx:1280` — and NO CEE draft
+ *     path writes either;
+ *   · the re-draft affordance calls `resetCanvas()` and replaces the graph, so
+ *     the stamp disappears exactly when CEE gains the model.
+ * So on a CEE-drafted model the hold is null and this gate is inert. That claim
+ * is not left to prose: every suppression case below has an OPPOSITE-DIRECTION
+ * TWIN asserting the chip still renders (trap 22b — a corpus that tests one
+ * direction is a guard watching one door).
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+import { SuggestedChips } from '../zones/SuggestedChips'
+import { useCanvasStore } from '../../store'
+import type { ActionChip } from '../types'
+
+/** A node the way the canvas store holds one. */
+function node(id: string, data: Record<string, unknown> = {}) {
+  return { id, type: 'factor', position: { x: 0, y: 0 }, data: { label: id, ...data } }
+}
+
+/** CEE-drafted graph: no client-injection stamp anywhere. THE CONTRAST CONTROL. */
+const DRAFTED_NODES = [node('n1'), node('n2')]
+/** Starter graph: `applyStarter` stamps EVERY node. */
+const STARTER_NODES = [node('n1', { starterId: 'pricing' }), node('n2', { starterId: 'pricing' })]
+/** Template insert: `insertBlueprint` stamps every node it adds. */
+const TEMPLATE_NODES = [node('n1', { templateId: 'tmpl_1' }), node('n2', { templateId: 'tmpl_1' })]
+
+function makeChip(overrides: Partial<ActionChip> = {}): ActionChip {
+  return {
+    id: overrides.id ?? 'chip_1',
+    label: 'Run analysis',
+    intent: 'primary',
+    message: 'Please run the analysis now',
+    ...overrides,
+  }
+}
+
+function setNodes(nodes: ReturnType<typeof node>[]) {
+  useCanvasStore.setState({ nodes: nodes as any })
+}
+
+function setReady(status: string | null) {
+  const payload = status
+    ? {
+        goal_node_id: 'goal_1',
+        status,
+        options: [{ id: 'opt_1', label: 'A', status: 'ready', interventions: {} }],
+      }
+    : null
+  useCanvasStore.setState({ ceeAnalysisReady: payload as any })
+}
+
+/** Drive the polish input exactly as `SuggestedChips.aiPanelV2Polish.spec` does. */
+function setStalePriorAnalysis() {
+  useCanvasStore.setState({
+    results: { status: 'complete', graphHash: 'abc123' } as any,
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+  })
+  useCanvasStore
+    .getState()
+    .setAnalysisFreshness({ freshness: 'stale', freshness_reason: 'graph_changed' })
+}
+
+function clearAnalysis() {
+  useCanvasStore.setState({
+    results: { status: 'idle' } as any,
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+  })
+}
+
+function renderChips(chips: ActionChip[]) {
+  render(<SuggestedChips chips={chips} onChipClick={vi.fn()} />)
+}
+
+describe('SuggestedChips — the held-model gate (PoC domain 5)', () => {
+  beforeEach(() => {
+    // The canonical run path is the hold's second conjunct. `v5CanonicalAnalysis`
+    // is a makeFlag that snapshots import.meta.env at module load, so
+    // localStorage is the only runtime-mutable override (the idiom the polish
+    // spec established for `feature.aiPanelV2`).
+    try {
+      localStorage.setItem('feature.v5CanonicalAnalysis', 'true')
+    } catch {
+      /* jsdom without storage — the assertions below would fail loudly */
+    }
+    vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'true')
+    setNodes(DRAFTED_NODES)
+    setReady(null)
+    clearAnalysis()
+  })
+
+  afterEach(() => {
+    cleanup()
+    try {
+      localStorage.removeItem('feature.v5CanonicalAnalysis')
+      localStorage.removeItem('feature.aiPanelV2')
+    } catch {
+      /* no-op */
+    }
+    vi.unstubAllEnvs()
+    setNodes([])
+    setReady(null)
+    clearAnalysis()
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 1. THE DEFECT ITSELF — CEE says ready about its own graph; the canvas holds
+  //    a graph CEE never received.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it('hides the run_analysis chip on a STARTER graph even when CEE reports ready', () => {
+    setReady('ready')
+    setNodes(STARTER_NODES)
+    renderChips([makeChip({ id: 'held_starter', action_type: 'run_analysis' })])
+    expect(screen.queryByTestId('suggested-chip-held_starter')).toBeNull()
+  })
+
+  it('hides the run_analysis chip on a TEMPLATE-inserted graph even when CEE reports ready', () => {
+    setReady('ready')
+    setNodes(TEMPLATE_NODES)
+    renderChips([makeChip({ id: 'held_template', action_type: 'run_analysis' })])
+    expect(screen.queryByTestId('suggested-chip-held_template')).toBeNull()
+  })
+
+  it('⭐ OPPOSITE-DIRECTION TWIN: still SHOWS the chip on a CEE-drafted graph when ready', () => {
+    setReady('ready')
+    setNodes(DRAFTED_NODES)
+    renderChips([makeChip({ id: 'drafted_ok', action_type: 'run_analysis' })])
+    expect(screen.getByTestId('suggested-chip-drafted_ok')).toBeInTheDocument()
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 2. THE BYPASS. `relabel-rerun` lets a run_analysis chip survive the
+  //    readiness gate. A rerun against a graph CEE never received is exactly as
+  //    wrong as a first run, so the hold must defeat the bypass too — this is
+  //    the case a gate placed downstream of the polish would MISS.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it('hides the chip on a held graph even via the relabel-rerun readiness-gate BYPASS', () => {
+    try {
+      localStorage.setItem('feature.aiPanelV2', 'true')
+    } catch {
+      /* no-op */
+    }
+    setReady('needs_encoding') // NOT ready — only the bypass could show this chip
+    setStalePriorAnalysis() // → 'changed' semantic → relabel-rerun → bypass
+    setNodes(STARTER_NODES)
+    renderChips([makeChip({ id: 'held_bypass', action_type: 'run_analysis' })])
+    expect(screen.queryByTestId('suggested-chip-held_bypass')).toBeNull()
+  })
+
+  it('⭐ OPPOSITE-DIRECTION TWIN: the relabel-rerun bypass still works on a drafted graph', () => {
+    try {
+      localStorage.setItem('feature.aiPanelV2', 'true')
+    } catch {
+      /* no-op */
+    }
+    setReady('needs_encoding')
+    setStalePriorAnalysis()
+    setNodes(DRAFTED_NODES)
+    renderChips([makeChip({ id: 'drafted_bypass', action_type: 'run_analysis' })])
+    expect(screen.getByTestId('suggested-chip-drafted_bypass')).toBeInTheDocument()
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 3. SCOPE. The hold refuses THE RUN, not the conversation. A gate that
+  //    silenced every chip on a starter would suppress the very affordances the
+  //    user needs to get OUT of the held state.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it('still shows a non-run chip (edit_graph) on a held graph', () => {
+    setReady('ready')
+    setNodes(STARTER_NODES)
+    renderChips([makeChip({ id: 'edit_ok', action_type: 'edit_graph', label: 'Add an option' })])
+    expect(screen.getByTestId('suggested-chip-edit_ok')).toBeInTheDocument()
+  })
+
+  it('still shows a conversational chip (no action_type) on a held graph', () => {
+    setReady('ready')
+    setNodes(STARTER_NODES)
+    renderChips([makeChip({ id: 'chat_ok', label: 'What does this model assume?' })])
+    expect(screen.getByTestId('suggested-chip-chat_ok')).toBeInTheDocument()
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 4. THE LEGACY / PROMPT-ONLY AFFORDANCE. A chip with no `action_type` whose
+  //    LABEL is "Run analysis" reaches CEE as a message CEE can route to a run,
+  //    so the hold must cover it. Detected with the SAME detector the polish
+  //    step already uses — no second predicate.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it('hides a prompt-only "Rerun analysis" affordance on a held graph', () => {
+    setReady('ready')
+    setNodes(STARTER_NODES)
+    renderChips([makeChip({ id: 'held_prompt', label: 'Rerun analysis', message: 'Rerun analysis' })])
+    expect(screen.queryByTestId('suggested-chip-held_prompt')).toBeNull()
+  })
+
+  it('⭐ OPPOSITE-DIRECTION TWIN: a prompt-only run affordance renders on a drafted graph', () => {
+    setReady('ready')
+    setNodes(DRAFTED_NODES)
+    renderChips([makeChip({ id: 'drafted_prompt', label: 'Rerun analysis', message: 'Rerun analysis' })])
+    expect(screen.getByTestId('suggested-chip-drafted_prompt')).toBeInTheDocument()
+  })
+
+  it('does NOT hide a conversational chip that merely mentions the analysis', () => {
+    setReady('ready')
+    setNodes(STARTER_NODES)
+    renderChips([makeChip({ id: 'explain_ok', label: 'Explain the analysis', message: 'Explain the analysis' })])
+    expect(screen.getByTestId('suggested-chip-explain_ok')).toBeInTheDocument()
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 5. THE RUN-PATH CONJUNCT. Off the V5 canonical path a run sends the canvas
+  //    graph directly, so the engine DOES see this model and the hold must not
+  //    fire. Pinned so the gate cannot quietly become unconditional.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it('does NOT hold a starter graph when the canonical run path is OFF', () => {
+    try {
+      localStorage.setItem('feature.v5CanonicalAnalysis', 'false')
+    } catch {
+      /* no-op */
+    }
+    vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', '')
+    setReady('ready')
+    setNodes(STARTER_NODES)
+    renderChips([makeChip({ id: 'v4_starter', action_type: 'run_analysis' })])
+    expect(screen.getByTestId('suggested-chip-v4_starter')).toBeInTheDocument()
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 6. THE DOMAIN CONTRACT, ASSERTED DIRECTLY: the chip and the Analyse control
+  //    must not disagree about the same run. This binds the chip's visibility to
+  //    the AUTHORITY ITSELF rather than to a value predicate that a second fact
+  //    could satisfy (trap 19) — if `SuggestedChips` ever re-derives the hold
+  //    from its own read of `nodes`, this stays green while the pair above still
+  //    catches a wrong answer; if the chip stops consulting the authority at
+  //    all, this goes red for the right reason.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it('agrees with canRunAnalysis: whenever the run gate refuses for the hold, the chip is absent', async () => {
+    const { canRunAnalysis } = await import('../../utils/canRunAnalysis')
+    const { analysisHeldOn } = await import('../../utils/analysisHeldOnInjectedModel')
+
+    setReady('ready')
+    setNodes(STARTER_NODES)
+
+    const heldOn = analysisHeldOn(STARTER_NODES)
+    expect(heldOn).toBe('starter') // precondition PINNED in-test (trap 13b)
+
+    const gate = canRunAnalysis({
+      graphHealth: { errors: [], warnings: [] },
+      readiness: { status: 'ready' },
+      hasBlockers: false,
+      nodeCount: STARTER_NODES.length,
+      analysisHeldOn: heldOn,
+    } as any)
+    expect(gate.allowed).toBe(false) // the Analyse control refuses …
+
+    renderChips([makeChip({ id: 'coherent', action_type: 'run_analysis' })])
+    expect(screen.queryByTestId('suggested-chip-coherent')).toBeNull() // … and so does the chip
+  })
+})

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -161,10 +161,29 @@ export function SuggestedChips({
   const freshnessSemantic = useAnalysisTrust().semantic
   const resultsComplete = useCanvasStore((s) => s.results?.status === 'complete')
   // ⭐ PoC DOMAIN 5 — the chip reads the SAME held-model authority the Analyse
-  // control reads (`canRunAnalysis` rung 2.5), so the two cannot disagree about
-  // whether THIS run is possible. Non-null ⇒ the canvas holds a client-injected
-  // graph that CEE never received, so a run would answer about a different
-  // model. See the hold filter below for why it is applied to `chips` directly.
+  // control reads (`canRunAnalysis` rung 2.5), so the two cannot disagree ABOUT
+  // THE HOLD. Non-null ⇒ the canvas holds a client-injected graph that CEE never
+  // received, so a run would answer about a different model.
+  //
+  // ⚠ AND THAT IS THE WHOLE OF THE CLAIM. An earlier draft said the two "cannot
+  // disagree about whether THIS run is possible", which is FALSE on at least
+  // three reachable states — graph-health errors, a streamed draft still
+  // settling, and `readiness.can_run_analysis: false` — in each of which this
+  // chip still renders beside a refusing gate. The gate has six rungs; the chip
+  // now shares one of them. The class is NARROWED, not removed.
+  //
+  // ⭐ THE FULLER FIX IS ONE PROP AWAY AND IS DELIBERATELY NOT TAKEN HERE.
+  // `ConversationPanel` already computes `runGateResult = canRunAnalysis({...})`
+  // — all six rungs — and guards its own `handleRunAnalysis` on it, while
+  // `handleChipClick` consults none of it. Passing that result down is the real
+  // repair; it is a change to the parent's contract with this component and to
+  // the click path, not to chip filtering, so it belongs in its own reviewed
+  // change rather than riding this one. Recorded here so the next reader sees a
+  // known remainder instead of inferring the job is finished.
+  //
+  // (Related, same neighbourhood: the wire already carries `usable_for_chips` —
+  // CEE's own chip-safety statement — surfaced at `analysisStateSelector` and
+  // read today only by the coherence DIAGNOSTIC, never by this surface.)
   const heldOn = useCanvasStore((s) => analysisHeldOn(s.nodes))
   const aiPanelV2On = isAiPanelV2Enabled()
   useEffect(() => {

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -29,6 +29,7 @@ import { useCanvasStore } from '../../store'
 import { type FreshnessDisplaySemantic } from '../../store/analysisFreshness'
 import { useAnalysisTrust } from '../../hooks/useAnalysisTrust'
 import { isChipRenderable } from '../chipDispatch'
+import { analysisHeldOn } from '../../utils/analysisHeldOnInjectedModel'
 import { V5_ENABLED_ACTIONS } from '../chipActionVocabulary'
 import { CHIP_CLASS } from '../../../v5/blocks/chipClass'
 import type { ActionChip } from '../types'
@@ -159,6 +160,12 @@ export function SuggestedChips({
   // here too, so the chip relabels to "Rerun" in step with the strip.
   const freshnessSemantic = useAnalysisTrust().semantic
   const resultsComplete = useCanvasStore((s) => s.results?.status === 'complete')
+  // ⭐ PoC DOMAIN 5 — the chip reads the SAME held-model authority the Analyse
+  // control reads (`canRunAnalysis` rung 2.5), so the two cannot disagree about
+  // whether THIS run is possible. Non-null ⇒ the canvas holds a client-injected
+  // graph that CEE never received, so a run would answer about a different
+  // model. See the hold filter below for why it is applied to `chips` directly.
+  const heldOn = useCanvasStore((s) => analysisHeldOn(s.nodes))
   const aiPanelV2On = isAiPanelV2Enabled()
   useEffect(() => {
     if (!chipError) return
@@ -196,8 +203,38 @@ export function SuggestedChips({
   //   action_type present but unknown → hide (treat as potentially executable
   //                                     with an unsatisfied gate)
   // On V4 (not V5-active), all chips pass through unchanged.
+  // ⭐ THE HELD-MODEL GATE (PoC domain 5) — a SEPARATE filter over `chips`,
+  // never a conjunct of the readiness predicate.
+  //
+  //  · ⚠ IT MUST NOT LIVE INSIDE THE READINESS GATE BELOW. That predicate has a
+  //    deliberate early `return true` for `runAnalysisPolish === 'relabel-rerun'`,
+  //    and an early `return true` for chips with no `action_type` — so a hold
+  //    written as one more clause in it is SKIPPED in exactly the states it
+  //    exists to catch. Measured, not asserted: that shape (mutant M3) turns
+  //    the bypass case and the prompt-only case RED. A rerun against a graph
+  //    CEE never received is exactly as wrong as a first run.
+  //  · ⚠ AND THE HONEST LIMIT OF THAT CLAIM, because a demonstrated-equivalent
+  //    mutant is worth more than a confident comment (trap 13c): applying this
+  //    SAME filter downstream, over the polished list, is behaviourally
+  //    IDENTICAL for visibility — mutant M7 survived 12/12. Upstream is chosen
+  //    so the dev-log counts below and the polish step both operate on the
+  //    admissible set, NOT because visibility depends on the position.
+  //  · UNCONDITIONALLY (not inside the `v5Active` branch), because the hold
+  //    already carries the run-path conjunct itself — `analysisHeldOn` returns
+  //    null off the V5 canonical path, where a run sends the canvas graph and
+  //    the engine genuinely does see this model. Re-testing the run path here
+  //    would be a second copy of that condition (trap 12).
+  //
+  // It removes ONLY run-analysis affordances: the hold refuses THE RUN, not the
+  // conversation, and the chips that get the user out of the held state
+  // (edit_graph, draft_graph, plain chat) must survive it. Detection is
+  // `isRunAnalysisAffordance` — the SAME detector the polish step below already
+  // uses, so a prompt-only "Rerun analysis" chip cannot slip through a narrower
+  // `action_type`-only test, and there is no second predicate to drift.
+  const admissible = heldOn === null ? chips : chips.filter((c) => !isRunAnalysisAffordance(c))
+
   const supported = v5Active
-    ? chips.filter((c) => {
+    ? admissible.filter((c) => {
         if (!c.action_type) return true
         const isV5Known = V5_ENABLED_ACTIONS.has(c.action_type)
         if (!isV5Known) return false
@@ -218,12 +255,12 @@ export function SuggestedChips({
         }
         return true
       })
-    : chips
+    : admissible
   if (import.meta.env.DEV && v5Active) {
-    const removedUnsupported = chips.filter(
+    const removedUnsupported = admissible.filter(
       (c) => c.action_type && !V5_ENABLED_ACTIONS.has(c.action_type),
     )
-    const removedUnready = chips.filter(
+    const removedUnready = admissible.filter(
       (c) =>
         c.action_type &&
         V5_ENABLED_ACTIONS.has(c.action_type) &&

--- a/src/canvas/state/__tests__/analysisStateSelector.unsuppliedReadiness.spec.ts
+++ b/src/canvas/state/__tests__/analysisStateSelector.unsuppliedReadiness.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * THE UNSUPPLIED-READINESS SENTINEL — a producer value the consumer must NOT
+ * read as a verdict.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE REGRESSION THIS CLOSES (found by adversarial review of CEE #1004)
+ * ═══════════════════════════════════════════════════════════════════════════
+ * CEE #1004 emits `analysis_state` on ALL 22 turn exits. Twelve of those exits
+ * supply no readiness payload — including `clarify_v2`, THE MAINLINE
+ * CONVERSATIONAL TURN — and on those `composeAnalysisStateV1` sets
+ * `readiness.status = READINESS_STATUS_UNSUPPLIED = 'unknown'`.
+ *
+ * CEE's own docstring for that constant says, in terms:
+ *     "It is NOT a synonym for `blocked`, and a consumer must not treat it as
+ *      one."
+ * This selector was treating it as one. Because the wire branch OVERRODE the
+ * retained `ceeAnalysisReady` slice, and `deriveAnalysisDisplayState` returns
+ * `not_ready` / "Set up your model" / **cta: null** for anything that is not
+ * exactly `'ready'`, a user with a fully-drafted, CEE-ready model who asked one
+ * clarifying question was told their model was not set up AND LOST THE RUN CTA.
+ *
+ * ⭐⭐ THE SHAPE, NOT THE INSTANCE. #1004's own review round 2 found this exact
+ * shape one field up — a per-turn composed value silently DEGRADING a retained
+ * known-good verdict — and fixed it for `run_state` by threading
+ * `exitFreshness`. Nobody looked at `readiness`, one line down, which has the
+ * IDENTICAL shape. Fixing one instance of a shape is not fixing the shape.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE RULE, AND ITS LIMIT
+ * ═══════════════════════════════════════════════════════════════════════════
+ * The sentinel means "no readiness verdict was supplied ON THIS TURN" — an
+ * ABSENCE, not a negative. An absence must fall back to the last known verdict;
+ * it must never override one. Every other producer status is a real verdict and
+ * still WINS over the legacy slice — pinned below by an opposite-direction twin,
+ * so this fallback cannot quietly widen into "the wire never wins" (trap 22b).
+ */
+import { describe, expect, it } from 'vitest'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+import { AnalysisStateV1Schema } from '@talchain/schemas/boundary'
+
+import { composeAnalysisState, type ComposeAnalysisStateInput } from '../analysisStateSelector'
+import { ANALYSIS_READY_STATUS_UNSUPPLIED } from '../../../adapters/cee/types'
+
+/**
+ * PRE-ANALYSIS, the state the regression destroys: a drafted model CEE has
+ * declared ready, no report on screen yet, no run fact, no freshness verdict.
+ */
+const PRE_ANALYSIS_LEGACY_READY: ComposeAnalysisStateInput = {
+  analysisState: null,
+  freshness: null,
+  dirty: false,
+  source: null,
+  resultsStatus: 'idle',
+  importHold: false,
+  hasReport: false,
+  ceeAnalysisReadyStatus: 'ready',
+  aiPanelV2On: true,
+}
+
+const ALL_UNUSABLE = {
+  usable_for_prose: false,
+  usable_for_chips: false,
+  usable_for_followup: false,
+  requires_rerun: false,
+  blocked_unusable: false,
+  contradictions: [],
+  leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+  robustness: {},
+} as const
+
+/**
+ * Build a wire verdict and PROVE it is one CEE may legally ship. The parse is
+ * the positive control: a fixture the contract would reject proves nothing
+ * about a payload a user can receive (trap 13).
+ */
+function wire(
+  run_state: AnalysisStateV1['run_state'],
+  readinessStatus: string,
+  overrides: Partial<AnalysisStateV1> = {},
+): AnalysisStateV1 {
+  const built = {
+    run_state,
+    readiness: { status: readinessStatus, blockers: [] },
+    ...ALL_UNUSABLE,
+    ...overrides,
+  }
+  const parsed = AnalysisStateV1Schema.safeParse(built)
+  if (!parsed.success) {
+    throw new Error(`fixture is not contract-valid: ${JSON.stringify(parsed.error.issues)}`)
+  }
+  return built as AnalysisStateV1
+}
+
+describe('analysisStateSelector — the unsupplied-readiness sentinel', () => {
+  // ───────────────────────────────────────────────────────────────────────────
+  // 1. THE REGRESSION. Both run-state kinds a clarify turn can carry.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it('never_run + unsupplied readiness KEEPS the legacy ready verdict and the Run CTA', () => {
+    const out = composeAnalysisState({
+      ...PRE_ANALYSIS_LEGACY_READY,
+      analysisState: wire({ kind: 'never_run' }, ANALYSIS_READY_STATUS_UNSUPPLIED),
+    })
+    expect(out.displayState.state).toBe('ready_to_analyse')
+    expect(out.displayState.cta).toEqual({ kind: 'primary', label: 'Run analysis' })
+  })
+
+  it('unknown_degraded + unsupplied readiness KEEPS the legacy ready verdict and the Run CTA', () => {
+    const out = composeAnalysisState({
+      ...PRE_ANALYSIS_LEGACY_READY,
+      analysisState: wire(
+        { kind: 'unknown_degraded', cause: 'no_graph_this_turn' },
+        ANALYSIS_READY_STATUS_UNSUPPLIED,
+      ),
+    })
+    expect(out.displayState.state).toBe('ready_to_analyse')
+    expect(out.displayState.cta).toEqual({ kind: 'primary', label: 'Run analysis' })
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 2. ⭐ OPPOSITE-DIRECTION TWINS — the wire still WINS whenever it states a
+  //    real verdict. Without these, "fall back on the sentinel" could widen
+  //    into "never trust the wire" and the suite would applaud.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it('a REAL producer readiness status still OVERRIDES a contradicting legacy ready', () => {
+    const out = composeAnalysisState({
+      ...PRE_ANALYSIS_LEGACY_READY,
+      analysisState: wire({ kind: 'never_run' }, 'needs_encoding'),
+    })
+    expect(out.displayState.state).toBe('not_ready')
+    expect(out.displayState.cta).toBeNull()
+  })
+
+  it('a blocked run_state still forces blocked, sentinel or not', () => {
+    const out = composeAnalysisState({
+      ...PRE_ANALYSIS_LEGACY_READY,
+      // CC-A (`blocked` ⇒ `blocked_unusable`) is enforced by the 0.48.0 parser,
+      // so the honest blocked fixture must carry it. The `safeParse` control
+      // caught the first draft of this case, which is what it is there for.
+      analysisState: wire(
+        { kind: 'blocked', reason_code: 'x', blockers: [] },
+        ANALYSIS_READY_STATUS_UNSUPPLIED,
+        { blocked_unusable: true },
+      ),
+    })
+    expect(out.displayState.state).not.toBe('ready_to_analyse')
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 3. THE FALLBACK FABRICATES NOTHING. When the legacy slice is ALSO
+  //    unsupplied there is no verdict anywhere, and the honest answer stays
+  //    not-ready — an absence must not become a positive claim.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it('does NOT invent readiness when the legacy slice is unsupplied too', () => {
+    const out = composeAnalysisState({
+      ...PRE_ANALYSIS_LEGACY_READY,
+      ceeAnalysisReadyStatus: ANALYSIS_READY_STATUS_UNSUPPLIED,
+      analysisState: wire({ kind: 'never_run' }, ANALYSIS_READY_STATUS_UNSUPPLIED),
+    })
+    expect(out.displayState.state).toBe('not_ready')
+    expect(out.displayState.cta).toBeNull()
+  })
+
+  it('does NOT invent readiness when the legacy slice is absent entirely', () => {
+    const out = composeAnalysisState({
+      ...PRE_ANALYSIS_LEGACY_READY,
+      ceeAnalysisReadyStatus: undefined,
+      analysisState: wire({ kind: 'never_run' }, ANALYSIS_READY_STATUS_UNSUPPLIED),
+    })
+    expect(out.displayState.state).toBe('not_ready')
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 4. POST-ANALYSIS is untouched — the review measured no regression there and
+  //    this pins it, so the fallback cannot start rewriting completed runs.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it('post-analysis complete_current + sentinel still reads as a completed run', () => {
+    const out = composeAnalysisState({
+      ...PRE_ANALYSIS_LEGACY_READY,
+      resultsStatus: 'complete',
+      hasReport: true,
+      source: 'cee_v5_run_analysis',
+      analysisState: wire(
+        { kind: 'complete_current', computed_at: '2026-08-18T09:00:00.000Z' },
+        ANALYSIS_READY_STATUS_UNSUPPLIED,
+      ),
+    })
+    expect(out.displayState.state).not.toBe('not_ready')
+  })
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 5. THE SENTINEL IS NOW A PRODUCER VALUE. CEE's `READINESS_STATUS_UNSUPPLIED`
+  //    and the UI's `ANALYSIS_READY_STATUS_UNSUPPLIED` must remain the SAME
+  //    string, or this fallback silently stops firing while every test that
+  //    hardcodes the literal keeps passing (trap 12).
+  // ───────────────────────────────────────────────────────────────────────────
+
+  it('the UI sentinel constant is still the exact string CEE emits', () => {
+    expect(ANALYSIS_READY_STATUS_UNSUPPLIED).toBe('unknown')
+  })
+})

--- a/src/canvas/state/__tests__/analysisStateSelector.unsuppliedReadiness.spec.ts
+++ b/src/canvas/state/__tests__/analysisStateSelector.unsuppliedReadiness.spec.ts
@@ -40,6 +40,9 @@ import { AnalysisStateV1Schema } from '@talchain/schemas/boundary'
 
 import { composeAnalysisState, type ComposeAnalysisStateInput } from '../analysisStateSelector'
 import { ANALYSIS_READY_STATUS_UNSUPPLIED } from '../../../adapters/cee/types'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { SRC, blankComments } from '../../utils/__tests__/helpers/derivedCallSites'
 
 /**
  * PRE-ANALYSIS, the state the regression destroys: a drafted model CEE has
@@ -200,5 +203,79 @@ describe('analysisStateSelector — the unsupplied-readiness sentinel', () => {
 
   it('the UI sentinel constant is still the exact string CEE emits', () => {
     expect(ANALYSIS_READY_STATUS_UNSUPPLIED).toBe('unknown')
+  })
+})
+
+// ═════════════════════════════════════════════════════════════════════════════
+// CONVERGENCE GUARD — one declaration of the sentinel IN THIS MODULE
+// ═════════════════════════════════════════════════════════════════════════════
+/**
+ * `analysisStateSelector.ts` used to declare its OWN `= 'unknown'` sentinel
+ * beside a docstring claiming it was therefore "named ONCE, at the single seam
+ * that reads it". The claim was false when written: this repo's cee-adapter
+ * already exported `ANALYSIS_READY_STATUS_UNSUPPLIED` and already had a
+ * consumer. Two names for one string, under a comment arguing there was one.
+ *
+ * ⚠ WHAT THIS GUARD DOES *NOT* CLAIM, stated so it never has to be weakened:
+ * it does NOT assert repo-wide uniqueness. A third declaration of the same
+ * string lives at `lib/coherence/crossSurfaceCoherence.ts` (exported, read by
+ * the coherence gate) and is deliberately out of scope here. A guard that
+ * asserted something false about the estate would be relaxed the first time it
+ * fired honestly, and a relaxed alarm teaches people to stop looking. So the
+ * scope is exactly one named module, and the name is in the assertion.
+ *
+ * ⚠ IT MUST BE ABLE TO FAIL, AND THE COMMENT-BLANKING IS WHY IT CAN. The real
+ * module QUOTES CEE's declaration inside a `//` comment as producer evidence.
+ * Over raw text this guard would red against correct code, and the obvious
+ * "fix" would be to loosen the pattern until it matched nothing — a guard
+ * agreeing with itself. It therefore scans comment-blanked source (reusing the
+ * canonical scanner, not a second copy of one), and carries the discriminating
+ * pair below: a fixture with a REAL declaration must be SEEN, a fixture with
+ * only a COMMENTED one must be IGNORED. Neither alone shows anything.
+ */
+describe('convergence — the unsupplied sentinel is declared once, at the boundary', () => {
+  /** Any `const|let|var <name> = 'unknown'` binding, however named. */
+  const SENTINEL_DECL = /\b(?:const|let|var)\s+[A-Za-z_$][\w$]*\s*(?::[^=\n]*)?=\s*(['"])unknown\1/g
+
+  const declarationsIn = (text: string): string[] =>
+    (blankComments(text).match(SENTINEL_DECL) ?? []).map((m) => m.trim())
+
+  const MODULE_PATH = join(SRC, 'canvas', 'state', 'analysisStateSelector.ts')
+  const moduleSource = readFileSync(MODULE_PATH, 'utf8')
+
+  it('CONTROL: the module under test was actually read (non-empty, and is the right file)', () => {
+    expect(moduleSource.length).toBeGreaterThan(1000)
+    expect(moduleSource).toContain('export function selectAnalysisReadinessAuthority')
+  })
+
+  it('POSITIVE CONTROL: the detector SEES a real local declaration', () => {
+    const fixture = "const READINESS_STATUS_UNSUPPLIED = 'unknown'\nexport function f() { return 1 }"
+    expect(declarationsIn(fixture)).toHaveLength(1)
+  })
+
+  it('POSITIVE CONTROL: it sees one under any other name, so a rename cannot evade it', () => {
+    const fixture = 'let somethingElse: string = "unknown"'
+    expect(declarationsIn(fixture)).toHaveLength(1)
+  })
+
+  it('BLINDNESS CONTROL: a declaration QUOTED IN A COMMENT is not counted', () => {
+    const fixture = "//     export const READINESS_STATUS_UNSUPPLIED = 'unknown'\nexport function f() { return 1 }"
+    expect(declarationsIn(fixture)).toHaveLength(0)
+  })
+
+  it('analysisStateSelector.ts declares no sentinel of its own', () => {
+    expect(declarationsIn(moduleSource)).toEqual([])
+  })
+
+  it('it consumes the canonical owner from the cee adapter instead', () => {
+    expect(blankComments(moduleSource)).toContain(
+      "import { ANALYSIS_READY_STATUS_UNSUPPLIED } from '../../adapters/cee/types'",
+    )
+  })
+
+  it('and the canonical owner is the string the comparison actually needs', () => {
+    expect(blankComments(moduleSource)).toContain(
+      'analysisState.readiness.status === ANALYSIS_READY_STATUS_UNSUPPLIED',
+    )
   })
 })

--- a/src/canvas/state/analysisStateSelector.ts
+++ b/src/canvas/state/analysisStateSelector.ts
@@ -776,19 +776,35 @@ export function useAnalysisState(): ComposedAnalysisState {
  * nor as "something is". `canRunAnalysis` is the only place entitled to decide
  * what to do about it, and it falls back to the side-car verdict — the
  * pre-0.46 behaviour, byte-for-byte.
- */
-/**
- * CEE's `READINESS_STATUS_UNSUPPLIED` (`orchestrator-v5/compose/analysis-state-v1.ts:106`).
  *
- * Restated here rather than imported because CEE is a separate service with no
- * shared export for it — the contract package types `status` as a plain string.
- * That makes this a hand-maintained mirror (trap 12), so it is named ONCE, at
- * the single seam that reads it, with the producer path in the comment above;
- * the guard below fails loud in the only way that matters — a rename at CEE
- * makes the sentinel arrive as a stated status, and the `unknown`-behaves-like-
- * absence test REDs.
+ * ⭐ THE SENTINEL HAS ONE OWNER, AND IT IS NOT THIS FILE.
+ * `ANALYSIS_READY_STATUS_UNSUPPLIED` (`adapters/cee/types.ts`) is the canonical
+ * declaration: the sentinel arrives across the CEE boundary, so it is named at
+ * the boundary and consumed here. This seam declares nothing.
+ *
+ * ⚠ IT USED TO DECLARE ITS OWN, AND THE STATED REASON WAS FALSE WHEN WRITTEN —
+ * which is worth recording, because the comment read as a justification rather
+ * than as the mirror it was. It said the value was "restated here rather than
+ * imported because CEE is a separate service with no shared export for it", and
+ * concluded it was therefore "named ONCE, at the single seam that reads it".
+ * The premise reasons about the wrong artefact: there is indeed no export in
+ * the CEE service or the contract package, but this repo's own cee-adapter has
+ * exported `ANALYSIS_READY_STATUS_UNSUPPLIED = 'unknown'` all along
+ * (`adapters/cee/types.ts:401` at the base of this change, with a consumer
+ * already reading it). So the local copy was never the only name; it was a
+ * second one, and the comment beside it argued for a locality the code did not
+ * have. Converged rather than left parallel: a duplicate authority under a
+ * confident "named ONCE" is how a third copy gets added.
+ *
+ * ⚠ AND THE HONEST LIMIT OF THAT CLAIM, because "one owner" is exactly the kind
+ * of sentence that goes stale: a THIRD declaration of the same `'unknown'`
+ * string exists at `lib/coherence/crossSurfaceCoherence.ts` (exported, read by
+ * the coherence gate). It is out of this change's scope and is NOT converged
+ * here. The guard in `analysisStateSelector.unsuppliedReadiness.spec.ts` is
+ * therefore scoped to THIS module by name and does not claim repo-wide
+ * uniqueness — a guard asserting something false about the estate would have to
+ * be weakened later, which is how alarms stop meaning anything.
  */
-const READINESS_STATUS_UNSUPPLIED = 'unknown'
 
 export function selectAnalysisReadinessAuthority(
   analysisState: AnalysisStateV1 | null,
@@ -826,7 +842,7 @@ export function selectAnalysisReadinessAuthority(
   //
   // So it collapses to the state this module already has a name for: NOT
   // STATED. Same value, same downstream behaviour, one concept.
-  if (analysisState.readiness.status === READINESS_STATUS_UNSUPPLIED) return null
+  if (analysisState.readiness.status === ANALYSIS_READY_STATUS_UNSUPPLIED) return null
 
   return {
     status: analysisState.readiness.status,

--- a/src/canvas/state/analysisStateSelector.ts
+++ b/src/canvas/state/analysisStateSelector.ts
@@ -77,6 +77,7 @@ import {
   deriveResultsTabFreshness,
   type ResultsTabFreshnessIndicator,
 } from '../components/resultsTabFreshness'
+import { ANALYSIS_READY_STATUS_UNSUPPLIED } from '../../adapters/cee/types'
 
 /** The results-slice statuses that mean "an analysis is in flight right now". */
 const RUNNING_STATUSES: ReadonlySet<string> = new Set(['preparing', 'connecting', 'streaming'])
@@ -605,12 +606,34 @@ export function composeAnalysisState(
     // legacy `ceeAnalysisReady` slice — same producer, one less derivation.
     // `blocked` is stated by `run_state`, not by the readiness code, so it is
     // forced across rather than hoped for.
+    //
+    // ⚠ EXCEPT THE UNSUPPLIED SENTINEL, WHICH IS AN ABSENCE AND NOT A VERDICT.
+    // CEE emits `analysis_state` on all 22 exits, and 12 of them supply no
+    // readiness payload — `clarify_v2`, the mainline conversational turn, among
+    // them. On those `composeAnalysisStateV1` sets `readiness.status` to its
+    // `READINESS_STATUS_UNSUPPLIED` sentinel, whose own producer docstring says:
+    // "It is NOT a synonym for `blocked`, and a consumer must not treat it as
+    // one." Overriding a retained `ready` with it told a user with a fully
+    // drafted, CEE-ready model that their model was not set up and REMOVED THE
+    // RUN CTA, on every clarifying question asked before the first analysis.
+    //
+    // So the sentinel FALLS BACK to the last known verdict; it never replaces
+    // one. Every real producer status still wins — pinned by an
+    // opposite-direction twin in `analysisStateSelector.unsuppliedReadiness.spec.ts`
+    // so this cannot widen into "the wire never wins".
+    //
+    // ⭐ THIS IS THE SAME SHAPE #1004's review round 2 fixed one field up (a
+    // per-turn composed value silently degrading a retained known-good verdict,
+    // fixed there by threading `exitFreshness`). Fixing one instance of a shape
+    // is not fixing the shape — this is the second instance.
     ceeAnalysisReadyStatus:
       wire === null
         ? ceeAnalysisReadyStatus
         : wireKind === 'blocked'
           ? 'blocked'
-          : wire.readiness.status,
+          : wire.readiness.status === ANALYSIS_READY_STATUS_UNSUPPLIED
+            ? ceeAnalysisReadyStatus
+            : wire.readiness.status,
     hasReport,
     // The orphan OR is preserved from useAnalysisDisplayState's own rule (RCA-D1).
     analysisChanged: wireForcesStale || semantic === 'changed' || trust.orphaned,

--- a/src/canvas/utils/__tests__/blockedReasonStaleWiring.derived.spec.ts
+++ b/src/canvas/utils/__tests__/blockedReasonStaleWiring.derived.spec.ts
@@ -27,80 +27,19 @@
  * `OutputsDock.staleVerdictCopy.spec.tsx` (the real wiring, through the
  * deployed-flag surface). The two kinds of guard are not redundant.
  */
-import { readFileSync, readdirSync, statSync } from 'node:fs'
-import { join, relative } from 'node:path'
-
 import { describe, it, expect } from 'vitest'
 
-const SRC = join(process.cwd(), 'src')
+import { composerCallSites, runGateCallSites } from './helpers/derivedCallSites'
 
-/** Every `.ts`/`.tsx` file under `src/`, tests and stories excluded. */
-function productionSources(dir: string, out: string[] = []): string[] {
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry)
-    if (statSync(full).isDirectory()) {
-      if (entry === '__tests__' || entry === 'node_modules') continue
-      productionSources(full, out)
-    } else if (/\.tsx?$/.test(entry) && !/\.(spec|test|stories)\.tsx?$/.test(entry)) {
-      out.push(full)
-    }
-  }
-  return out
-}
-
-/** Read the whole argument list of a call, balancing parens from the `(`. */
-function callArguments(text: string, openParenIndex: number): string {
-  let depth = 1
-  let i = openParenIndex + 1
-  while (i < text.length && depth > 0) {
-    if (text[i] === '(') depth++
-    else if (text[i] === ')') depth--
-    i++
-  }
-  return text.slice(openParenIndex + 1, i - 1)
-}
-
-function composerCallSites(): Array<{ file: string; args: string }> {
-  const found: Array<{ file: string; args: string }> = []
-  const pattern = /\bcomposeReadinessBlockedReason\s*\(/g
-  for (const file of productionSources(SRC)) {
-    // The composer's own module defines it; a definition is not a call site.
-    if (file.endsWith(join('canvas', 'utils', 'composeBlockedReason.ts'))) continue
-    const text = readFileSync(file, 'utf8')
-    let m: RegExpExecArray | null
-    while ((m = pattern.exec(text)) !== null) {
-      // Skip the import statement, which matches the bare identifier.
-      const lineStart = text.lastIndexOf('\n', m.index) + 1
-      const line = text.slice(lineStart, m.index)
-      if (/\bimport\b/.test(line)) continue
-      found.push({ file: relative(SRC, file), args: callArguments(text, m.index + m[0].length - 1) })
-    }
-  }
-  return found
-}
-
-/** Run-gate call sites, matched under the local alias both live callers use. */
-function runGateCallSites(): Array<{ file: string; args: string }> {
-  const found: Array<{ file: string; args: string }> = []
-  const pattern = /\bcanRunAnalysis(?:Util)?\s*\(\s*\{/g
-  for (const file of productionSources(SRC)) {
-    if (file.endsWith(join('canvas', 'utils', 'canRunAnalysis.ts'))) continue
-    const text = readFileSync(file, 'utf8')
-    let m: RegExpExecArray | null
-    while ((m = pattern.exec(text)) !== null) {
-      let depth = 1
-      let i = m.index + m[0].length
-      while (i < text.length && depth > 0) {
-        if (text[i] === '{') depth++
-        else if (text[i] === '}') depth--
-        i++
-      }
-      found.push({ file: relative(SRC, file), args: text.slice(m.index, i) })
-    }
-  }
-  return found
-}
-
+/**
+ * ⚠ SCANNER OWNERSHIP: this spec used to carry a verbatim copy of the source
+ * scan that `runGateCallSites.derived.spec.ts` also carried. Both copies
+ * matched their target symbol inside COMMENTS, so a prose mention of the gate
+ * in `SuggestedChips.tsx` was counted as a run-gate call site and this file's
+ * staleness assertion failed against a file that never calls the gate. One
+ * owner now: `helpers/derivedCallSites.ts`. Do not reintroduce a local copy —
+ * the duplication is what let a single defect survive two independent fixes.
+ */
 const COMPOSER_SITES = composerCallSites()
 const GATE_SITES = runGateCallSites()
 

--- a/src/canvas/utils/__tests__/helpers/derivedCallSites.ts
+++ b/src/canvas/utils/__tests__/helpers/derivedCallSites.ts
@@ -1,0 +1,222 @@
+/**
+ * CANONICAL OWNER of the derived run-gate call-site manifest.
+ *
+ * ── WHY THIS MODULE EXISTS ───────────────────────────────────────────────
+ * Two derived guards — `runGateCallSites.derived.spec.ts` and
+ * `blockedReasonStaleWiring.derived.spec.ts` — each carried their own
+ * verbatim copy of `productionSources()` + `runGateCallSites()`. Two copies
+ * of one semantic decision is competing logic: a correction to one silently
+ * leaves the other wrong, which is exactly how the defect below survived in
+ * BOTH of them at once. The scan now has ONE owner; the specs consume it and
+ * define no scanner of their own.
+ *
+ * ── THE DEFECT THIS FIXES (measured, not inferred) ───────────────────────
+ * The original matcher ran over RAW SOURCE TEXT, so it matched the gate's
+ * name inside COMMENTS. `SuggestedChips.tsx` documents a known remainder in
+ * prose:
+ *
+ *     // `ConversationPanel` already computes `runGateResult = canRunAnalysis({...})`
+ *
+ * That comment was counted as a third run-gate call site, and the guards then
+ * demanded it feed `draftStreamPhase` / `readinessStale`. Four tests failed
+ * against a file that contains no call to the gate at all. The guard's own
+ * header states its subject: "every run-gate CALL SITE". A comment is not a
+ * call site — it does not execute and cannot hand a user a live Run button —
+ * so matching one is a FALSE POSITIVE, and removing it restores the guard to
+ * its declared scope rather than narrowing it.
+ *
+ * ── HOW THE FIX PRESERVES THE ALARM ──────────────────────────────────────
+ * Comments are blanked to SPACES, preserving byte offsets, so:
+ *   - matching and brace-walking run over comment-free text, and
+ *   - the argument slice is taken from the ORIGINAL source, so the text a
+ *     spec asserts on is the real code it would have seen before.
+ * The dangerous direction here is stripping too MUCH (a scanner that ate a
+ * real call site would make every downstream assertion vacuous). Three things
+ * guard that: string and regex literals are tracked so a `//` inside one is
+ * never treated as a comment; the consuming spec pins the manifest BY NAME,
+ * so a swallowed call site goes red; and `assertSeesPresence` below is a
+ * self-test of the scanner over a fixture containing both a real call and a
+ * commented one.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative } from 'node:path'
+
+export const SRC = join(process.cwd(), 'src')
+
+/** Every `.ts`/`.tsx` file under `src/`, tests and stories excluded. */
+export function productionSources(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue
+      productionSources(full, out)
+    } else if (/\.tsx?$/.test(entry) && !/\.(spec|test|stories)\.tsx?$/.test(entry)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+/**
+ * Blank every comment to spaces, leaving all other bytes at their original
+ * offsets. String and regex literals are tracked so that a `//` or `/*`
+ * appearing INSIDE one is left alone — without that, a URL in a string or a
+ * regex such as `/https:\/\//` would blank the remainder of a real line of
+ * code and blind the scanner.
+ */
+export function blankComments(text: string): string {
+  const out = text.split('')
+  const blank = (from: number, to: number) => {
+    for (let k = from; k < to && k < out.length; k++) {
+      if (out[k] !== '\n') out[k] = ' '
+    }
+  }
+  let i = 0
+  // Tracks whether a `/` in this position starts a regex literal or is division.
+  let prevMeaningful = ''
+  while (i < text.length) {
+    const c = text[i]
+    const next = text[i + 1]
+    if (c === '/' && next === '/') {
+      let j = i
+      while (j < text.length && text[j] !== '\n') j++
+      blank(i, j)
+      i = j
+      continue
+    }
+    if (c === '/' && next === '*') {
+      let j = i + 2
+      while (j < text.length && !(text[j] === '*' && text[j + 1] === '/')) j++
+      blank(i, Math.min(j + 2, text.length))
+      i = j + 2
+      continue
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      let j = i + 1
+      while (j < text.length) {
+        if (text[j] === '\\') { j += 2; continue }
+        if (text[j] === c) break
+        j++
+      }
+      i = j + 1
+      prevMeaningful = c
+      continue
+    }
+    // A `/` here is a regex literal only where an operand cannot precede it.
+    if (c === '/' && /[(,=:[!&|?{};+\-*%<>~^]|^$/.test(prevMeaningful)) {
+      let j = i + 1
+      let inClass = false
+      while (j < text.length) {
+        if (text[j] === '\\') { j += 2; continue }
+        if (text[j] === '[') inClass = true
+        else if (text[j] === ']') inClass = false
+        else if (text[j] === '/' && !inClass) break
+        else if (text[j] === '\n') break
+        j++
+      }
+      i = j + 1
+      prevMeaningful = '/'
+      continue
+    }
+    if (!/\s/.test(c)) prevMeaningful = c
+    i++
+  }
+  return out.join('')
+}
+
+/** Walk from the `{` at `openIndex` to its matching close, over `scan` text. */
+function endOfArgumentObject(scan: string, openIndex: number): number {
+  let depth = 1
+  let i = openIndex
+  while (i < scan.length && depth > 0) {
+    if (scan[i] === '{') depth++
+    else if (scan[i] === '}') depth--
+    i++
+  }
+  return i
+}
+
+export interface CallSite {
+  file: string
+  args: string
+}
+
+/**
+ * Find every invocation of `pattern` in production source and return its
+ * argument text, taken from the ORIGINAL source at comment-free offsets.
+ *
+ * `skipFile` excludes a module that merely defines/documents the symbol.
+ */
+export function deriveCallSites(
+  pattern: RegExp,
+  opts: { skipFile?: string } = {},
+): CallSite[] {
+  const found: CallSite[] = []
+  for (const file of productionSources(SRC)) {
+    if (opts.skipFile && file.endsWith(opts.skipFile)) continue
+    const text = readFileSync(file, 'utf8')
+    const scan = blankComments(text)
+    const re = new RegExp(pattern.source, pattern.flags.includes('g') ? pattern.flags : pattern.flags + 'g')
+    let m: RegExpExecArray | null
+    while ((m = re.exec(scan)) !== null) {
+      const end = endOfArgumentObject(scan, m.index + m[0].length)
+      found.push({ file: relative(SRC, file), args: text.slice(m.index, end) })
+    }
+  }
+  return found
+}
+
+/** The run gate, under its exported name and the alias both live callers use. */
+export const RUN_GATE_PATTERN = /\bcanRunAnalysis(?:Util)?\s*\(\s*\{/g
+
+export function runGateCallSites(): CallSite[] {
+  return deriveCallSites(RUN_GATE_PATTERN, {
+    skipFile: join('canvas', 'utils', 'canRunAnalysis.ts'),
+  })
+}
+
+/** Read the whole argument list of a call, balancing parens from the `(`. */
+function callArguments(scan: string, openParenIndex: number): [number, number] {
+  let depth = 1
+  let i = openParenIndex + 1
+  while (i < scan.length && depth > 0) {
+    if (scan[i] === '(') depth++
+    else if (scan[i] === ')') depth--
+    i++
+  }
+  return [openParenIndex + 1, i - 1]
+}
+
+/**
+ * Paren-form variant of {@link deriveCallSites}, for a call whose arguments are
+ * not a single object literal. Import statements match the bare identifier and
+ * are skipped; comments are blanked by the same owner, so a symbol named in
+ * prose is not counted as a call (the defect documented at the top of this
+ * file applied to this scanner too).
+ */
+export function deriveParenCallSites(
+  pattern: RegExp,
+  opts: { skipFile?: string } = {},
+): CallSite[] {
+  const found: CallSite[] = []
+  for (const file of productionSources(SRC)) {
+    if (opts.skipFile && file.endsWith(opts.skipFile)) continue
+    const text = readFileSync(file, 'utf8')
+    const scan = blankComments(text)
+    const re = new RegExp(pattern.source, pattern.flags.includes('g') ? pattern.flags : pattern.flags + 'g')
+    let m: RegExpExecArray | null
+    while ((m = re.exec(scan)) !== null) {
+      const lineStart = scan.lastIndexOf('\n', m.index) + 1
+      if (/\bimport\b/.test(scan.slice(lineStart, m.index))) continue
+      const [from, to] = callArguments(scan, m.index + m[0].length - 1)
+      found.push({ file: relative(SRC, file), args: text.slice(from, to) })
+    }
+  }
+  return found
+}
+
+export function composerCallSites(): CallSite[] {
+  return deriveParenCallSites(/\bcomposeReadinessBlockedReason\s*\(/g, {
+    skipFile: join('canvas', 'utils', 'composeBlockedReason.ts'),
+  })
+}

--- a/src/canvas/utils/__tests__/runGateCallSites.derived.spec.ts
+++ b/src/canvas/utils/__tests__/runGateCallSites.derived.spec.ts
@@ -29,57 +29,27 @@
  * end-to-end behaviour is pinned separately by `streamedDraftTurn.spec.ts`,
  * which drives the real store through a real streamed turn.
  */
-import { readFileSync, readdirSync, statSync } from 'node:fs'
-import { join, relative } from 'node:path'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 
 import { describe, it, expect } from 'vitest'
 
-const SRC = join(process.cwd(), 'src')
-
-/** Every `.ts`/`.tsx` file under `src/`, tests and stories excluded. */
-function productionSources(dir: string, out: string[] = []): string[] {
-  for (const entry of readdirSync(dir)) {
-    const full = join(dir, entry)
-    if (statSync(full).isDirectory()) {
-      if (entry === '__tests__' || entry === 'node_modules') continue
-      productionSources(full, out)
-    } else if (/\.tsx?$/.test(entry) && !/\.(spec|test|stories)\.tsx?$/.test(entry)) {
-      out.push(full)
-    }
-  }
-  return out
-}
+import {
+  SRC,
+  blankComments,
+  runGateCallSites,
+} from './helpers/derivedCallSites'
 
 /**
- * Find every invocation of the run gate and return its argument-object text.
- *
- * Matches the local alias too (`canRunAnalysisUtil`), because both live callers
- * import it under that name — a matcher that only knew the exported name would
- * find zero call sites and this whole spec would pass by testing nothing.
+ * ⚠ THE SCANNER LIVES IN ONE PLACE NOW (`helpers/derivedCallSites.ts`).
+ * This spec previously defined its own copy, verbatim-duplicated into
+ * `blockedReasonStaleWiring.derived.spec.ts`. Both copies shared one defect —
+ * they matched the gate's name inside COMMENTS — so a prose reference in
+ * `SuggestedChips.tsx` was counted as a third call site and four tests failed
+ * against a file that never calls the gate. Fixing it in one copy would have
+ * left the other wrong. The helper is the canonical owner; this file consumes
+ * it and defines no scanner.
  */
-function runGateCallSites(): Array<{ file: string; args: string }> {
-  const found: Array<{ file: string; args: string }> = []
-  const pattern = /\bcanRunAnalysis(?:Util)?\s*\(\s*\{/g
-  for (const file of productionSources(SRC)) {
-    const text = readFileSync(file, 'utf8')
-    // The gate's own module defines and documents it; it is not a call site.
-    if (file.endsWith(join('canvas', 'utils', 'canRunAnalysis.ts'))) continue
-    let m: RegExpExecArray | null
-    while ((m = pattern.exec(text)) !== null) {
-      // Walk braces from the opening `{` to capture the whole argument object.
-      let depth = 1
-      let i = m.index + m[0].length
-      while (i < text.length && depth > 0) {
-        if (text[i] === '{') depth++
-        else if (text[i] === '}') depth--
-        i++
-      }
-      found.push({ file: relative(SRC, file), args: text.slice(m.index, i) })
-    }
-  }
-  return found
-}
-
 const CALL_SITES = runGateCallSites()
 
 describe('run-gate call sites — derived manifest', () => {
@@ -239,5 +209,64 @@ describe('the graph-write choke point consumes the persistence predicate (review
     const fn = source.slice(source.indexOf('async function persistGraphNow'))
     const body = fn.slice(0, fn.indexOf('\n}\n'))
     expect(body).toMatch(/saveGraphViaGatedPath\(/)
+  })
+})
+
+describe('the scanner ignores comments WITHOUT going blind to code', () => {
+  /**
+   * These pin the fix for the defect described at the top of
+   * `helpers/derivedCallSites.ts`. Each control is a DISCRIMINATING PAIR: the
+   * commented form must be invisible AND the executable form must still be
+   * seen, in the same fixture. A control that only proved "comments are
+   * ignored" would be satisfied by a scanner that had gone blind to
+   * everything, which is the failure mode that matters here — a scanner
+   * finding nothing makes every derived assertion in this file vacuous.
+   */
+  const find = (src: string) =>
+    (blankComments(src).match(/\bcanRunAnalysis(?:Util)?\s*\(\s*\{/g) ?? []).length
+
+  it('does not see the gate named in a LINE comment, but still sees a real call beside it', () => {
+    const src = [
+      '// `ConversationPanel` already computes `runGateResult = canRunAnalysis({...})`',
+      'const r = canRunAnalysisUtil({ readiness, draftStreamPhase })',
+    ].join('\n')
+    expect(find(src)).toBe(1)
+    // …and it is the executable one: the comment contributes nothing.
+    expect(find('// canRunAnalysis({ a })')).toBe(0)
+  })
+
+  it('does not see the gate named in a BLOCK comment or JSDoc', () => {
+    expect(find('/* canRunAnalysis({ a }) */')).toBe(0)
+    expect(find('/**\n * canRunAnalysisUtil({ a })\n */')).toBe(0)
+    // Discrimination, same shape: real code AFTER a block comment survives.
+    expect(find('/** canRunAnalysis({ a }) */\nconst r = canRunAnalysis({ b })')).toBe(1)
+  })
+
+  it('a `//` inside a STRING does not blank the rest of the line (blindness control)', () => {
+    // Without string tracking this URL would blank the call that follows it,
+    // silently removing a real call site from the manifest.
+    const src = `const u = 'https://example.test/x'; const r = canRunAnalysis({ readiness })`
+    expect(find(src)).toBe(1)
+  })
+
+  it('a regex literal containing a slash does not blank the rest of the line', () => {
+    const src = `const re = /https:\\/\\//; const r = canRunAnalysis({ readiness })`
+    expect(find(src)).toBe(1)
+  })
+
+  it('blanking preserves byte offsets, so argument slices stay aligned', () => {
+    const src = 'const a = 1 // canRunAnalysis({ x })\nconst b = 2'
+    const blanked = blankComments(src)
+    expect(blanked).toHaveLength(src.length)
+    expect(blanked.split('\n')).toHaveLength(src.split('\n').length)
+    expect(blanked.startsWith('const a = 1 ')).toBe(true)
+    expect(blanked).not.toMatch(/canRunAnalysis/)
+  })
+
+  it('CONTROL: the real manifest is non-empty, so the fix did not blind the scan', () => {
+    // The scanner-level twin of the file-level assertion above. If the comment
+    // fix had over-stripped, this is where it shows up as a zero rather than as
+    // a quietly-passing suite.
+    expect(CALL_SITES.length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
**Domain 5 · AnalysisState — the defining defect.**

`SuggestedChips` gated only on `ceeAnalysisReady.status === 'ready'` — CEE's verdict about *its own* graph. **Every other run affordance** (node chips, command palette, actions menu, inspector inline rerun, define-success modal) already routes through `executeCanonicalRun`, which applies `analysisHeldOn`. **The chat chip was the last bypass**, and `relabel-rerun` let it bypass even the readiness gate.

The RED run reproduced the disagreement as a test: `analysisHeldOn === 'starter'` and `canRunAnalysis().allowed === false` both passed **while the chip rendered**. That is P8 — offering an action the product cannot accept.

**Two authorities, deliberately kept distinct** — they answer genuinely different questions:
- *Cross-turn analysis state* → CEE `composeAnalysisStateV1`; UI single reader `analysisStateSelector`.
- *Whether this canvas's model is analysable at all* → `analysisHeldOn(nodes)`, **client-owned**. CEE cannot answer it — it cannot know the canvas holds a client-injected graph it never received. `analysis_state` cannot subsume it.

**Inverse failure guarded:** over-suppression — silencing legitimate runs, or silencing the chips that get the user *out* of the held state. Covered by opposite-direction twins and a run-path-OFF case. The deeper mirror (minting a third derived value) is avoided by adding a **reader** of the existing authority, not a new derivation.

---

## ⚠ CORRECTED AFTER REBASE — the "demonstrated-equivalent" mutant is no longer equivalent

Rebased onto staging `30db8ac3` and the documented mutants re-run at the rebased head. **One recorded result is now false and is withdrawn.** The original text is kept below rather than deleted, because a silently-overwritten label is the defect this section exists to correct.

> ~~**Author's own correction, kept in the record:** the first commit message claimed the hold *must* sit before the readiness gate. **Mutant M7 refuted it** — the same filter applied downstream survived 12/12. The narrower load-bearing claim: the hold must not be a *clause of* the readiness predicate (M3 red on 2 cases, due to its early `return true`s). M7 is recorded as a demonstrated-equivalent mutant.~~

**M7 now BITES.** Measured at the rebased head, applying the same filter downstream over `polished` reds **1 test**:

- `does not mis-report a HELD chip as removed-for-unreadiness in the dev log`

The reason is not that the code changed — it is that **the spec grew from 12 to 16 tests during review**, and one of the later tests pins the DEV-log mirror, which reads `admissible`. So the upstream placement genuinely is load-bearing for that assertion, exactly as the code comment beside it claims. **The PR is better pinned than this body said it was**; `M7 = demonstrated-equivalent` is withdrawn.

**M3 likewise reds 3, not 2** — same cause, the third being the dev-log test:

- `hides the chip on a held graph even via the relabel-rerun readiness-gate BYPASS`
- `hides a prompt-only "Rerun analysis" affordance on a held graph`
- `does not mis-report a HELD chip as removed-for-unreadiness in the dev log`

*Why this correction is worth making:* an honest "equivalent" label that has quietly become false teaches every later reader to stop looking at precisely the mutant that turned out to discriminate. A stale label is worse than no label.

**Mutant results at the rebased head** (throwaway worktree outside the repo root, isolation proven by *writing* a sentinel **and asserting it landed**, distinct inodes, source hash unchanged; restores from a pristine tar archive, never `git checkout --`; semantic applied-checks, not file counts; leading and trailing controls both GREEN 56/56 with `dirty=0`):

| mutant | reds |
|---|---|
| M-CORE remove the held-model filter | RED ×6 |
| M3 hold as a *clause of* the readiness predicate | RED ×3 |
| M7 same filter applied downstream | **RED ×1** (was recorded equivalent) |
| M-UNSUP revert the unsupplied-sentinel fallback | RED ×2 |
| M-CONVERGE re-declare the local sentinel | RED ×2 |
| M-GUARD-VACUITY break the convergence detector | RED ×2 (both positive controls) |

---

## Convergence — the unsupplied sentinel now has one owner

`analysisStateSelector.ts` declared its **own** `= 'unknown'` sentinel beside a docstring arguing it was therefore *"named ONCE, at the single seam that reads it"*.

**That claim was false when it was written**, not merely made false by this branch. `adapters/cee/types.ts:401` already exported `ANALYSIS_READY_STATUS_UNSUPPLIED` with the identical value, and already had a consumer. The premise reasoned about the wrong artefact: there is indeed no export in the CEE service or the contract package, but this repo's own cee-adapter has owned the constant all along. So the local copy was never the only name — it was a second authority under a comment asserting there was one.

**Canonical owner: `ANALYSIS_READY_STATUS_UNSUPPLIED` (`adapters/cee/types.ts`)** — the sentinel crosses the CEE boundary, so it is named at the boundary and consumed here. The local declaration is removed and its justification comment rewritten to state what is now true. **No behavioural change: both were `'unknown'`.**

**Why this was safe to converge rather than adjudicate — and it is the load-bearing point.** The two lanes reached the **same semantic rule independently**: the sentinel falls back to the last known verdict and is never read as "not ready". `selectAnalysisReadinessAuthority` returns a null authority (so `canRunAnalysis` falls back to the side-car verdict); `composeAnalysisState` falls back to `ceeAnalysisReadyStatus`. Same rule, two seams, arrived at separately. There was no disagreement to settle — only a duplicate name to remove.

**Pinned, and the pin is proven able to fail.** A convergence guard asserts this module declares no sentinel of its own and consumes the canonical one. It scans **comment-blanked** source, reusing the canonical scanner (`helpers/derivedCallSites.ts`) rather than a second copy of one — necessary because the module legitimately *quotes* CEE's declaration inside a comment as producer evidence, and over raw text the guard would red against correct code. It carries a discriminating pair: a fixture with a **real** declaration must be SEEN, one with only a **commented** declaration must be IGNORED.

- **M-CONVERGE** (re-introduce the local const) → **RED ×2**: `declares no sentinel of its own`, `the canonical owner is the string the comparison actually needs`.
- **M-GUARD-VACUITY** (break the detector regex) → **RED ×2**, both positive controls. The guard is not agreeing with itself.

**⚠ What the guard deliberately does NOT claim.** A **third** declaration of the same `'unknown'` string exists at `lib/coherence/crossSurfaceCoherence.ts:156` (exported, read by the coherence gate). It is **out of scope here** — it is not in this PR's diff, and pulling it in would create a file overlap with #788 and break the pairwise disjointness that currently lets these land in any order. The guard is therefore scoped to **this module, by name**, and asserts nothing repo-wide. A guard that claimed something false about the estate would be weakened the first time it fired honestly, and a weakened alarm teaches people to stop looking.

---

**Evidence at the rebased head.** Spec files re-run with counts asserted **by name** (a spec collecting `(0 test)` is invisible in every aggregate), `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported:

- `SuggestedChips.heldModelGate.spec.tsx` — **16**
- `analysisStateSelector.unsuppliedReadiness.spec.ts` — **15** (was 8; +7 convergence guard)
- `blockedReasonStaleWiring.derived.spec.ts` — **5**
- `runGateCallSites.derived.spec.ts` — **20**

**56 passed / 0 failed / 4 files.** Both *derived* specs (which scan source) still pass against staging's 206-file delta. `Staging Gate` **SUCCESS**; the only red is `Visual Regression (advisory)`, which fails identically on staging's own untouched head `30db8ac3` and is absent from the gate's `needs`.

> Superseded pre-rebase evidence line, kept for the record: ~~RED-first 5 failed / 7 passed / **12 collected** → 12/12 … Mutants **6/7 bitten, 1 demonstrated-equivalent** … Regression `src/canvas/conversation/__tests__` 167 files / 2271 passed / 0 failed; coherence gate + selector 142/142.~~ The collected count is now 16, and the equivalence claim is withdrawn above.

**MOUNTED acceptance (not yet witnessed — rung is TESTED):** on staging, V5 canonical path, load a starter — the Analyse control says *"Analysis is held on a saved example. Re-draft it live to run one."* **and** chat offers no Run/Rerun chip. Click *Re-draft this live* → the chip returns.

Pairs with CEE #1004 (rebased `877affe2`, head `259e6c75`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
