### PR TITLE
fix(olumi): render the analysis narrative on ONE channel — UX gate 4b, plus a scope correction on 4a

### DIFF
--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -252,13 +252,34 @@ export const InlineBlocks = memo(function InlineBlocks({
    */
   /**
    * SECOND-CHANNEL ROUTING (UX gate 2026-08-18 point 4b). Computed ONCE per
-   * turn from the turn's own blocks, because the analysis-result card cannot
-   * see its siblings and must not guess. Structural — block presence, never a
-   * string comparison. See `turnDeliversNarrativeAsTypedCard`.
+   * turn, because the analysis-result card cannot see its siblings and must
+   * not guess. Structural — block presence, never a string comparison. See
+   * `turnDeliversNarrativeAsTypedCard`.
+   *
+   * ⚠⚠ COMPUTED OVER `topLevel`, NOT OVER `blocks`, AND THE DIFFERENCE IS A
+   * DELETED PARAGRAPH. The first version of this passed the whole `blocks`
+   * array, so a narrative card DEMOTED into the closed disclosure still
+   * suppressed the untyped copy: the analysis card withheld the paragraph and
+   * the disclosure hid the card, so the narrative was NOWHERE. Proven by
+   * execution on real producer bytes, changing only the card's ORDER —
+   * narrative 1st among candidates renders once; narrative 4th rendered ZERO
+   * times. Real turns carry 9–17 point candidates against `MAX_POINTS`, so
+   * 6–14 are demoted on every analysis turn; only CEE's `priority_rank: 10`
+   * (the minimum in all 8 captures) kept the narrative top-level. That is a
+   * PRODUCER-OWNED FACT mirrored nowhere in the UI — a re-rank upstream would
+   * have deleted the paragraph with no UI signal. Reading `topLevel` removes
+   * the dependency on it rather than mirroring it.
+   *
+   * This is exactly what the C13 comment twenty lines below warns against:
+   * gate on a card being CURRENTLY RENDERED, never on mere presence.
+   *
+   * ⚠ Deliberately NOT gated on `isBlockHidden`: `topLevel` membership is
+   * stable with respect to `detailExpanded`, so the paragraph cannot appear
+   * or vanish as the user opens the disclosure.
    */
   const narrativeDeliveredByTypedCard = useMemo(
-    () => turnDeliversNarrativeAsTypedCard(blocks),
-    [blocks],
+    () => turnDeliversNarrativeAsTypedCard(topLevel.map((e) => blocks[e.index])),
+    [topLevel, blocks],
   )
 
   const detailIndices = useMemo(() => new Set(detail.map((e) => e.index)), [detail])

--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -67,7 +67,11 @@ import { ArtefactBlock as ArtefactBlockComponent } from '../../components/chat/A
 import type { PatchBlockState, PatchRejectionInfo } from './useConversation'
 import { GraphPatchBlockRenderer, ProposalBlockRenderer } from './blocks/GraphPatchBlockRenderer'
 import { isPhase3CardBlock, isBiasSignalCoachingBlock } from './phase3Pacing'
-import { composeMessage, dedupeRenderedText } from './messageComposition'
+import {
+  composeMessage,
+  dedupeRenderedText,
+  turnDeliversNarrativeAsTypedCard,
+} from './messageComposition'
 import { GraphVocabularyLegend } from './GraphVocabularyLegend'
 import { V5AnalysisResultBlock } from '../../v5/blocks/V5AnalysisResultBlock'
 import { V5GraphPatchBlock } from '../../v5/blocks/V5GraphPatchBlock'
@@ -246,6 +250,17 @@ export const InlineBlocks = memo(function InlineBlocks({
    * it is in the detail class and the disclosure is closed. Previously this was
    * a disjunction over two budgets that could (and did) disagree.
    */
+  /**
+   * SECOND-CHANNEL ROUTING (UX gate 2026-08-18 point 4b). Computed ONCE per
+   * turn from the turn's own blocks, because the analysis-result card cannot
+   * see its siblings and must not guess. Structural — block presence, never a
+   * string comparison. See `turnDeliversNarrativeAsTypedCard`.
+   */
+  const narrativeDeliveredByTypedCard = useMemo(
+    () => turnDeliversNarrativeAsTypedCard(blocks),
+    [blocks],
+  )
+
   const detailIndices = useMemo(() => new Set(detail.map((e) => e.index)), [detail])
   const isBlockHidden = useCallback(
     (i: number) => !detailExpanded && detailIndices.has(i),
@@ -305,6 +320,7 @@ export const InlineBlocks = memo(function InlineBlocks({
           onProposalConfirm={onProposalConfirm}
           assistantTextWordCount={assistantTextWordCount}
           commentaryTextOverride={commentaryTextOverrides.get(index)}
+          narrativeDeliveredByTypedCard={narrativeDeliveredByTypedCard}
           isLatestAssistantTurn={isLatestAssistantTurn}
           onRevealHiddenBlocks={hasCollapsedContent ? revealHiddenBlocks : undefined}
           blockContainerRef={blockContainerRef}
@@ -385,6 +401,11 @@ interface BlockRendererProps {
    * when something was withheld, so the ordinary path is untouched.
    */
   commentaryTextOverride?: string
+  /**
+   * UX gate 2026-08-18 point 4b — does this turn deliver the analysis
+   * narrative as its own titled card? Only `v5_analysis_result` reads it.
+   */
+  narrativeDeliveredByTypedCard?: boolean
   /** L-42: only the newest assistant turn's applied-edit card may claim the staleness voice. */
   isLatestAssistantTurn?: boolean
   /** C11: reveal collapsed pacing/budget content (present only while something is collapsed). */
@@ -404,6 +425,7 @@ function BlockRenderer({
   onProposalConfirm,
   assistantTextWordCount = 0,
   commentaryTextOverride,
+  narrativeDeliveredByTypedCard = false,
   isLatestAssistantTurn = false,
   onRevealHiddenBlocks,
   blockContainerRef,
@@ -493,7 +515,12 @@ function BlockRenderer({
     // V5 block kinds — no flag gate; whole V5 path is behind
     // VITE_ENABLE_V5_ORCHESTRATOR at the dispatcher level.
     case 'v5_analysis_result':
-      return <V5AnalysisResultBlock block={block} />
+      return (
+        <V5AnalysisResultBlock
+          block={block}
+          narrativeDeliveredByTypedCard={narrativeDeliveredByTypedCard}
+        />
+      )
 
     case 'v5_graph_patch':
       return (

--- a/src/canvas/conversation/__tests__/InlineBlocks.narrativeChannel.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.narrativeChannel.spec.tsx
@@ -88,9 +88,10 @@
  */
 import { describe, it, expect, vi } from 'vitest'
 import { render } from '@testing-library/react'
-import { readFileSync } from 'node:fs'
+import { readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
 import { InlineBlocks } from '../InlineBlocks'
+import { MAX_POINTS, NARRATIVE_REVIEW_CARD_KIND } from '../messageComposition'
 import type {
   ConversationBlock,
   V5AnalysisResultBlock as V5AnalysisResultBlockType,
@@ -114,43 +115,142 @@ vi.mock('../../store', () => {
   }
 })
 
-const CAPTURE_DIR = join(
-  __dirname,
-  '..',
-  '..',
-  '..',
-  'lib',
-  'coherence',
-  '__tests__',
-  'fixtures',
-  'captures',
-)
+const SRC_ROOT = join(__dirname, '..', '..', '..')
+
+/**
+ * The corpus is DERIVED, not hand-listed — and it spans TWO directories.
+ *
+ * An earlier version of this spec hardcoded two filenames from ONE directory
+ * while the measurement behind the fix had a denominator of eight spanning
+ * two. Six real payloads carrying the field were therefore exercised by no
+ * test at all: a hand-maintained mirror of a corpus, which is the defect class
+ * this platform pays for most often (trap 12).
+ *
+ * Discovery selects exactly the turns the routing is about: an analysis-result
+ * block carrying `narrative_summary`, plus a narrative review card. Because a
+ * derived list can silently shrink to nothing and still look green, the count
+ * is asserted against a FLOOR below (trap 12d: derivation proves agreement,
+ * never completeness).
+ */
+const CAPTURE_DIRS = [
+  join(SRC_ROOT, 'lib', 'coherence', '__tests__', 'fixtures', 'captures'),
+  join(SRC_ROOT, 'v5', '__tests__', 'fixtures'),
+]
+
+/** The number of qualifying payloads measured at 2026-08-18. Never fewer. */
+const CORPUS_FLOOR = 8
 
 interface RawCapture {
   blocks: Array<Record<string, unknown>>
 }
 
-function loadCapture(file: string): RawCapture {
-  return JSON.parse(readFileSync(join(CAPTURE_DIR, file), 'utf8')) as RawCapture
+function readBlocks(raw: unknown): Array<Record<string, unknown>> | null {
+  if (typeof raw !== 'object' || raw === null) return null
+  const top = (raw as { blocks?: unknown }).blocks
+  if (Array.isArray(top)) return top as Array<Record<string, unknown>>
+  const payload = (raw as { payload?: unknown }).payload
+  if (typeof payload === 'object' && payload !== null) {
+    const nested = (payload as { blocks?: unknown }).blocks
+    if (Array.isArray(nested)) return nested as Array<Record<string, unknown>>
+  }
+  return null
+}
+
+function narrativeSummaryOf(blocks: Array<Record<string, unknown>>): string | null {
+  for (const b of blocks) {
+    if (b.type !== 'analysis_result' && b.type !== 'v5_analysis_result') continue
+    const enrichment = b.enrichment as Record<string, unknown> | undefined
+    const review = enrichment?.decision_review as Record<string, unknown> | undefined
+    const summary = review?.narrative_summary
+    if (typeof summary === 'string' && summary.trim().length > 0) return summary
+  }
+  return null
+}
+
+function discoverCaptures(): string[] {
+  const found: string[] = []
+  for (const dir of CAPTURE_DIRS) {
+    for (const name of readdirSync(dir)) {
+      if (!name.endsWith('.json')) continue
+      const path = join(dir, name)
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(readFileSync(path, 'utf8'))
+      } catch {
+        continue
+      }
+      const blocks = readBlocks(parsed)
+      if (!blocks) continue
+      if (narrativeSummaryOf(blocks) === null) continue
+      const hasNarrativeCard = blocks.some(
+        (b) => b.type === 'review_card' && b.card_kind === 'narrative',
+      )
+      if (hasNarrativeCard) found.push(path)
+    }
+  }
+  return found.sort()
+}
+
+const CAPTURES = discoverCaptures()
+
+/** Short, readable name for `it.each` output. */
+const nameOf = (path: string): string => path.split('/').slice(-1)[0]
+
+function captureByName(name: string): string {
+  const hit = CAPTURES.find((p) => nameOf(p) === name)
+  if (!hit) throw new Error(`capture ${name} not in the derived corpus`)
+  return hit
+}
+
+function loadCapture(path: string): RawCapture {
+  return JSON.parse(readFileSync(path, 'utf8')) as RawCapture
+}
+
+function liftReviewCard(rawCard: Record<string, unknown>): V5ReviewCardBlock {
+  return {
+    type: 'v5_review_card',
+    block_id: rawCard.block_id as string,
+    title: rawCard.title as string,
+    body: rawCard.body as string,
+    severity: rawCard.severity as V5ReviewCardBlock['severity'],
+    card_kind: rawCard.card_kind as V5ReviewCardBlock['card_kind'],
+    target_refs: (rawCard.target_refs ?? []) as V5ReviewCardBlock['target_refs'],
+    priority_rank: rawCard.priority_rank as number,
+    freshness: rawCard.freshness as V5ReviewCardBlock['freshness'],
+  }
 }
 
 /**
- * Lift the turn's `analysis_result` and its narrative `review_card` into the
- * UI's own block union, copying fields VERBATIM — the same copy `mapV5Blocks`
- * performs for these two wire types. Nothing is reshaped, so the bytes under
- * test are the producer's.
+ * Lift the turn's `analysis_result` and ALL of its review cards into the UI's
+ * own block union, copying fields VERBATIM — the same copy `mapV5Blocks`
+ * performs for these wire types. The bytes under test are the producer's.
+ *
+ * ⚠⚠ ALL THE CARDS, NOT JUST THE NARRATIVE ONE, AND THAT IS THE WHOLE POINT.
+ *
+ * The first version of this helper reduced a 15-block capture to TWO blocks.
+ * Every byte it kept was the producer's, so the docblock's "nothing is
+ * reshaped" was true of the BYTES — and false of the TURN SHAPE. With two
+ * blocks the composition cap (`MAX_POINTS`) is never reached, so the suite was
+ * structurally incapable of observing what happens when the narrative card is
+ * DEMOTED. That is the corpus-excludes-the-class trap: the reduction removed
+ * exactly the pressure that turns a suppression into a deletion, and it hid a
+ * real content-loss defect through a full green suite and a six-mutant kit.
+ *
+ * Real turns carry 4–7 review cards against a cap of 3, so keeping them all
+ * means the cap is genuinely exercised on every capture.
  */
 function liftCapture(file: string): {
   blocks: ConversationBlock[]
   narrativeSummary: string
   narrativeCardBody: string
+  narrativeCardKind: unknown
   winProbabilityLabels: string[]
+  reviewCardCount: number
 } {
   const raw = loadCapture(file)
   const rawResult = raw.blocks.find((b) => b.type === 'analysis_result')
-  const rawNarrative = raw.blocks.find(
-    (b) => b.type === 'review_card' && b.card_kind === 'narrative',
-  )
+  const rawCards = raw.blocks.filter((b) => b.type === 'review_card')
+  const rawNarrative = rawCards.find((b) => b.card_kind === 'narrative')
   if (!rawResult) throw new Error(`${file}: no analysis_result block`)
   if (!rawNarrative) throw new Error(`${file}: no narrative review_card`)
 
@@ -166,24 +266,38 @@ function liftCapture(file: string): {
     win_probabilities: winProbabilities,
     enrichment,
   }
-  const narrativeCard: V5ReviewCardBlock = {
-    type: 'v5_review_card',
-    block_id: rawNarrative.block_id as string,
-    title: rawNarrative.title as string,
-    body: rawNarrative.body as string,
-    severity: rawNarrative.severity as V5ReviewCardBlock['severity'],
-    card_kind: rawNarrative.card_kind as V5ReviewCardBlock['card_kind'],
-    target_refs: (rawNarrative.target_refs ?? []) as V5ReviewCardBlock['target_refs'],
-    priority_rank: rawNarrative.priority_rank as number,
-    freshness: rawNarrative.freshness as V5ReviewCardBlock['freshness'],
-  }
 
   return {
-    blocks: [resultBlock, narrativeCard],
+    // Producer order preserved: the analysis result, then the cards as sent.
+    blocks: [resultBlock, ...rawCards.map(liftReviewCard)],
     narrativeSummary,
     narrativeCardBody: rawNarrative.body as string,
+    narrativeCardKind: rawNarrative.card_kind,
     winProbabilityLabels: Object.keys(winProbabilities),
+    reviewCardCount: rawCards.length,
   }
+}
+
+/**
+ * The same turn with the narrative card moved PAST the point cap, changing
+ * nothing but ORDER. This is the shape a CEE re-rank would produce.
+ */
+function withNarrativeDemoted(blocks: ConversationBlock[]): ConversationBlock[] {
+  const narrative = blocks.find(
+    (b) => b.type === 'v5_review_card' && b.card_kind === 'narrative',
+  )
+  if (!narrative) throw new Error('no narrative card to demote — probe is vacuous')
+  const rest = blocks.filter((b) => b !== narrative)
+  const others = rest.filter((b) => b.type === 'v5_review_card')
+  if (others.length < MAX_POINTS) {
+    throw new Error(
+      `capture has only ${others.length} sibling cards; need >= ${MAX_POINTS} to demote`,
+    )
+  }
+  // Insert after enough candidates that the narrative falls outside the cap.
+  const head = rest.slice(0, rest.indexOf(others[MAX_POINTS - 1]) + 1)
+  const tail = rest.slice(head.length)
+  return [...head, narrative, ...tail]
 }
 
 /** Whitespace-normalised occurrence count of `needle` in `haystack`. */
@@ -201,11 +315,6 @@ function countOccurrences(haystack: string, needle: string): number {
   }
 }
 
-const CAPTURES = [
-  'w998-2026-08-16-a1-turn3.json',
-  'seeded-2026-08-17-w2d-analysis-turn.json',
-] as const
-
 describe('Olumi copy assembly — the narrative channel renders once', () => {
   /**
    * THE PRECONDITION THIS ROUTING RESTS ON, PINNED IN-TEST.
@@ -216,27 +325,47 @@ describe('Olumi copy assembly — the narrative channel renders once', () => {
    * card no longer restates. A guard whose precondition nothing pins is a
    * guard that can quietly stop discriminating (platform trap 13b).
    */
-  it.each(CAPTURES)(
+  it('the derived corpus reaches its floor and spans both capture directories', () => {
+    // A derived list that silently shrinks to nothing still runs green. The
+    // floor is what makes the derivation fail loud instead (trap 12d).
+    expect(CAPTURES.length).toBeGreaterThanOrEqual(CORPUS_FLOOR)
+    const dirs = new Set(CAPTURES.map((p) => p.split('/').slice(0, -1).join('/')))
+    expect(dirs.size).toBe(CAPTURE_DIRS.length)
+  })
+
+  /**
+   * F3 — `NARRATIVE_REVIEW_CARD_KIND` is a hand-maintained mirror of CEE's
+   * vocabulary that the type system cannot check. This is the derived guard
+   * that REDs if the producer renames the kind out from under it.
+   */
+  it.each(CAPTURES.map((p) => [nameOf(p), p] as const))(
+    '%s: the producer still calls the narrative card by the kind the code matches',
+    (_name, file) => {
+      expect(liftCapture(file).narrativeCardKind).toBe(NARRATIVE_REVIEW_CARD_KIND)
+    },
+  )
+
+  it.each(CAPTURES.map((p) => [nameOf(p), p] as const))(
     '%s: the producer emits the narrative on BOTH channels, byte-identical',
-    (file) => {
+    (_name, file) => {
       const { narrativeSummary, narrativeCardBody } = liftCapture(file)
       expect(narrativeSummary.length).toBeGreaterThan(0)
       expect(narrativeCardBody).toBe(narrativeSummary)
     },
   )
 
-  it.each(CAPTURES)(
+  it.each(CAPTURES.map((p) => [nameOf(p), p] as const))(
     '%s: the narrative paragraph renders EXACTLY ONCE in the turn',
-    (file) => {
+    (_name, file) => {
       const { blocks, narrativeSummary } = liftCapture(file)
       const { container } = render(<InlineBlocks blocks={blocks} turnId="t-narrative" />)
       expect(countOccurrences(container.textContent ?? '', narrativeSummary)).toBe(1)
     },
   )
 
-  it.each(CAPTURES)(
+  it.each(CAPTURES.map((p) => [nameOf(p), p] as const))(
     '%s: the surviving copy is the TITLED card, not the untyped one',
-    (file) => {
+    (_name, file) => {
       const { blocks, narrativeSummary } = liftCapture(file)
       const { container } = render(<InlineBlocks blocks={blocks} turnId="t-narrative" />)
 
@@ -258,9 +387,9 @@ describe('Olumi copy assembly — the narrative channel renders once', () => {
    * NO narrative card must still show the narrative. Absence of the card may
    * only ever cost a duplicate — never a paragraph.
    */
-  it.each(CAPTURES)(
+  it.each(CAPTURES.map((p) => [nameOf(p), p] as const))(
     '%s: with NO narrative card, the analysis-result copy still renders',
-    (file) => {
+    (_name, file) => {
       const { blocks, narrativeSummary } = liftCapture(file)
       const withoutCard = blocks.filter((b) => b.type !== 'v5_review_card')
       expect(withoutCard).toHaveLength(1)
@@ -281,7 +410,7 @@ describe('Olumi copy assembly — the narrative channel renders once', () => {
    * 0/8) and must keep rendering in the analysis-result card exactly as
    * before, card present or not.
    */
-  it.each(CAPTURES)('%s: readiness_rationale is untouched by the routing', (file) => {
+  it.each(CAPTURES.map((p) => [nameOf(p), p] as const))('%s: readiness_rationale is untouched by the routing', (_name, file) => {
     const raw = loadCapture(file)
     const rawResult = raw.blocks.find((b) => b.type === 'analysis_result')!
     const decisionReview = (rawResult.enrichment as Record<string, unknown>)
@@ -294,10 +423,50 @@ describe('Olumi copy assembly — the narrative channel renders once', () => {
     const { container } = render(<InlineBlocks blocks={blocks} turnId="t-narrow" />)
     expect(container.textContent).toContain(readiness as string)
   })
+
+  /**
+   * ⭐⭐ F1 — THE DEMOTION CASE. The defect this suite could not previously see.
+   *
+   * The routing predicate first read the WHOLE block list, so a narrative card
+   * demoted into the CLOSED disclosure still suppressed the untyped copy: the
+   * analysis card withheld the paragraph and the disclosure hid the card, so
+   * the narrative was NOWHERE. Nothing but the card's ORDER changes here —
+   * every byte is still the producer's.
+   *
+   * The turn stayed correct on real traffic only because CEE assigns the
+   * narrative card `priority_rank: 10`, the minimum in all 8 captures. That is
+   * a producer-owned fact mirrored nowhere in the UI; this test is what stands
+   * in for it, so a re-rank upstream REDs here instead of deleting a paragraph
+   * in front of a customer.
+   */
+  it.each(CAPTURES.map((p) => [nameOf(p), p] as const))(
+    '%s: the turn really does exceed the point cap (the pressure is real)',
+    (_name, file) => {
+      expect(liftCapture(file).reviewCardCount).toBeGreaterThan(MAX_POINTS)
+    },
+  )
+
+  it.each(CAPTURES.map((p) => [nameOf(p), p] as const))(
+    '%s: DEMOTED into the closed disclosure, the narrative still renders exactly once',
+    (_name, file) => {
+      const { blocks, narrativeSummary } = liftCapture(file)
+      const demoted = withNarrativeDemoted(blocks)
+      // Same blocks, same bytes — order only.
+      expect(demoted).toHaveLength(blocks.length)
+
+      const { container } = render(<InlineBlocks blocks={demoted} turnId="t-demoted" />)
+      expect(countOccurrences(container.textContent ?? '', narrativeSummary)).toBe(1)
+      // …and it is the analysis-result copy that carries it, because the card
+      // the user would have read is collapsed out of view.
+      expect(
+        container.querySelector('[data-testid="v5-analysis-result-narrative-summary"]'),
+      ).not.toBeNull()
+    },
+  )
 })
 
 describe('Olumi copy assembly — a label is rendered in full, never cut', () => {
-  const W998 = 'w998-2026-08-16-a1-turn3.json'
+  const W998 = captureByName('w998-2026-08-16-a1-turn3.json')
 
   /** TWIN A — long label, BALANCED brackets. Verbatim producer bytes. */
   const BALANCED_LABEL =

--- a/src/canvas/conversation/__tests__/InlineBlocks.narrativeChannel.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.narrativeChannel.spec.tsx
@@ -1,0 +1,391 @@
+/**
+ * Olumi copy assembly — THE NARRATIVE CHANNEL, and full-label rendering.
+ *
+ * ## UX gate 2026-08-18, point 4 (deployed `4d1e650b`, fresh guest)
+ *
+ * Two defects were recorded against "Olumi conversation copy assembly". This
+ * file pins the one that is genuinely the UI's, and pins the UI's half of the
+ * one that is not.
+ *
+ * ### (b) "One paragraph renders verbatim twice" — THIS IS OURS
+ *
+ * Root cause, derived at the producer's own bytes rather than at the render
+ * site: CEE's `decision_review_enricher` emits ONE piece of content on TWO
+ * channels of the same turn —
+ *
+ *   · `analysis_result.enrichment.decision_review.narrative_summary`
+ *   · a `review_card` with `card_kind: "narrative"`, title "How the analysis
+ *     reads", whose `body` is the SAME STRING, byte for byte
+ *
+ * — and the UI renders both. Measured across every analysis-turn capture in
+ * this repo that carries `narrative_summary` (8 payloads, 2026-07-31 →
+ * 2026-08-17): the narrative card is present in 8/8, exactly one per turn,
+ * body byte-identical in 8/8. `readiness_rationale` is duplicated in 0/8 —
+ * that contrast is what proves the measurement discriminates rather than
+ * agreeing with itself (platform trap 13e).
+ *
+ * ⚠ THE FIX IS NOT STRING-EQUALITY DE-DUPLICATION AT THE RENDER SITE, and
+ * that is deliberate. A string filter would suppress a LEGITIMATELY repeated
+ * sentence later, and it would hide the composer defect instead of resolving
+ * it. `messageComposition.ts` already refuses to de-duplicate a text against
+ * itself for exactly this reason. What is resolved here is the CHANNEL: when
+ * the turn delivers the narrative as a typed, titled card, the untyped copy
+ * inside the analysis-result card does not render. One content, one surface.
+ *
+ * This also REPAIRS A STALE PREMISE rather than overriding a live rule.
+ * `V5AnalysisResultBlock`'s docblock justified rendering these fields as "the
+ * fields no other wire block delivers" (ROADMAP 2.154). For
+ * `narrative_summary` that premise is measurably false: another wire block
+ * does deliver it, as a first-class ranked card. The analysis-result copy is
+ * the accidental second reader.
+ *
+ * ### (a) "The opening sentence quotes a goal truncated mid-phrase" — NOT OURS
+ *
+ * Derived, not assumed. The gate's truncated strings arrive ALREADY TRUNCATED
+ * on the wire: in `acceptance-2026-08-17-j1r1-t1.json` the producer's
+ * `assistant_text` carries `"• diversify fast by buying a small M&E"` while
+ * the SAME payload carries the full 75-character label intact at
+ * `draft_graph.nodes[12].label`, `analysis_ready.options[1].label` and three
+ * more sites. The UI product source composes no such sentence at all: a
+ * case-insensitive sweep for `built a first decision model` / `decision model
+ * for` over every `.ts` / `.tsx` file under `src` hits ONLY fixtures and
+ * specs — never product
+ * code, with the fixture hits standing as the probe's positive control.
+ *
+ * So the UI cannot fix (a) without inventing text the user never wrote. What
+ * the UI CAN be held to — and is, below — is the other half of that contract:
+ * **whatever label it is given, it renders in full and unaltered.** The two
+ * cases are opposite-direction twins drawn from ONE real capture:
+ *
+ *   TWIN A  a 183-char label with BALANCED brackets  → renders in full
+ *   TWIN B  a 102-char label the producer already cut inside an UNCLOSED
+ *           bracket → renders VERBATIM: not cut further, and not silently
+ *           repaired either
+ *
+ * Twin B is the one that matters for the lead question. Masking the
+ * producer's malformation would be the same defect class wearing a fix's
+ * clothes — "the product misquotes the user's own model back to them". The UI
+ * must show what it was given, so the upstream defect stays visible to the
+ * lane that owns it.
+ *
+ * ## Fixture provenance and state-class
+ *
+ * Every string asserted here is a PRODUCER string, read at run time out of the
+ * append-only capture corpus (`src/lib/coherence/__tests__/fixtures/captures/`,
+ * see its `PROVENANCE.md`) — never a sentence composed by this spec. A
+ * self-authored fixture encodes the author's model of the producer rather than
+ * the producer (platform trap 16-inverse). The captures are `fresh` and
+ * `seeded` wire recordings; no capture is edited by this file.
+ *
+ * The one string NOT from the corpus is the UX gate's own recorded goal label,
+ * quoted verbatim from `UX-GATE-2026-08-18.md`. It is a producer string
+ * recorded at the deployed build; only its PLACEMENT in a card body is this
+ * spec's, and that is stated rather than implied.
+ *
+ * Assertions bind to their object by identity — the exact producer string, and
+ * the block that carries it — never by a value predicate another block could
+ * satisfy (platform trap 19).
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { InlineBlocks } from '../InlineBlocks'
+import type {
+  ConversationBlock,
+  V5AnalysisResultBlock as V5AnalysisResultBlockType,
+  V5ReviewCardBlock,
+} from '../types'
+
+vi.mock('../../store', () => {
+  const mockState = {
+    nodes: [] as Array<{ id: string }>,
+    selectNodeWithoutHistory: vi.fn(),
+    selectNodes: vi.fn(),
+    setShowInspectorPanel: vi.fn(),
+    setHighlightedNodes: vi.fn(),
+    setHighlightedEdges: vi.fn(),
+  }
+  return {
+    useCanvasStore: Object.assign(
+      (selector: (s: unknown) => unknown) => selector(mockState),
+      { getState: () => mockState },
+    ),
+  }
+})
+
+const CAPTURE_DIR = join(
+  __dirname,
+  '..',
+  '..',
+  '..',
+  'lib',
+  'coherence',
+  '__tests__',
+  'fixtures',
+  'captures',
+)
+
+interface RawCapture {
+  blocks: Array<Record<string, unknown>>
+}
+
+function loadCapture(file: string): RawCapture {
+  return JSON.parse(readFileSync(join(CAPTURE_DIR, file), 'utf8')) as RawCapture
+}
+
+/**
+ * Lift the turn's `analysis_result` and its narrative `review_card` into the
+ * UI's own block union, copying fields VERBATIM — the same copy `mapV5Blocks`
+ * performs for these two wire types. Nothing is reshaped, so the bytes under
+ * test are the producer's.
+ */
+function liftCapture(file: string): {
+  blocks: ConversationBlock[]
+  narrativeSummary: string
+  narrativeCardBody: string
+  winProbabilityLabels: string[]
+} {
+  const raw = loadCapture(file)
+  const rawResult = raw.blocks.find((b) => b.type === 'analysis_result')
+  const rawNarrative = raw.blocks.find(
+    (b) => b.type === 'review_card' && b.card_kind === 'narrative',
+  )
+  if (!rawResult) throw new Error(`${file}: no analysis_result block`)
+  if (!rawNarrative) throw new Error(`${file}: no narrative review_card`)
+
+  const enrichment = rawResult.enrichment as Record<string, unknown>
+  const decisionReview = enrichment.decision_review as Record<string, unknown>
+  const narrativeSummary = decisionReview.narrative_summary as string
+  const winProbabilities = rawResult.win_probabilities as Record<string, number>
+
+  const resultBlock: V5AnalysisResultBlockType = {
+    type: 'v5_analysis_result',
+    summary: rawResult.summary as string,
+    leading_option_id: (rawResult.leading_option_id as string | null) ?? null,
+    win_probabilities: winProbabilities,
+    enrichment,
+  }
+  const narrativeCard: V5ReviewCardBlock = {
+    type: 'v5_review_card',
+    block_id: rawNarrative.block_id as string,
+    title: rawNarrative.title as string,
+    body: rawNarrative.body as string,
+    severity: rawNarrative.severity as V5ReviewCardBlock['severity'],
+    card_kind: rawNarrative.card_kind as V5ReviewCardBlock['card_kind'],
+    target_refs: (rawNarrative.target_refs ?? []) as V5ReviewCardBlock['target_refs'],
+    priority_rank: rawNarrative.priority_rank as number,
+    freshness: rawNarrative.freshness as V5ReviewCardBlock['freshness'],
+  }
+
+  return {
+    blocks: [resultBlock, narrativeCard],
+    narrativeSummary,
+    narrativeCardBody: rawNarrative.body as string,
+    winProbabilityLabels: Object.keys(winProbabilities),
+  }
+}
+
+/** Whitespace-normalised occurrence count of `needle` in `haystack`. */
+function countOccurrences(haystack: string, needle: string): number {
+  const h = haystack.replace(/\s+/g, ' ')
+  const n = needle.replace(/\s+/g, ' ').trim()
+  if (n.length === 0) throw new Error('needle is empty — the probe would be vacuous')
+  let count = 0
+  let from = 0
+  for (;;) {
+    const at = h.indexOf(n, from)
+    if (at === -1) return count
+    count++
+    from = at + n.length
+  }
+}
+
+const CAPTURES = [
+  'w998-2026-08-16-a1-turn3.json',
+  'seeded-2026-08-17-w2d-analysis-turn.json',
+] as const
+
+describe('Olumi copy assembly — the narrative channel renders once', () => {
+  /**
+   * THE PRECONDITION THIS ROUTING RESTS ON, PINNED IN-TEST.
+   *
+   * The channel fix is sound only because the typed card genuinely carries the
+   * narrative. If CEE ever makes the two channels diverge, this REDs and a
+   * human adjudicates — rather than the routing silently dropping prose the
+   * card no longer restates. A guard whose precondition nothing pins is a
+   * guard that can quietly stop discriminating (platform trap 13b).
+   */
+  it.each(CAPTURES)(
+    '%s: the producer emits the narrative on BOTH channels, byte-identical',
+    (file) => {
+      const { narrativeSummary, narrativeCardBody } = liftCapture(file)
+      expect(narrativeSummary.length).toBeGreaterThan(0)
+      expect(narrativeCardBody).toBe(narrativeSummary)
+    },
+  )
+
+  it.each(CAPTURES)(
+    '%s: the narrative paragraph renders EXACTLY ONCE in the turn',
+    (file) => {
+      const { blocks, narrativeSummary } = liftCapture(file)
+      const { container } = render(<InlineBlocks blocks={blocks} turnId="t-narrative" />)
+      expect(countOccurrences(container.textContent ?? '', narrativeSummary)).toBe(1)
+    },
+  )
+
+  it.each(CAPTURES)(
+    '%s: the surviving copy is the TITLED card, not the untyped one',
+    (file) => {
+      const { blocks, narrativeSummary } = liftCapture(file)
+      const { container } = render(<InlineBlocks blocks={blocks} turnId="t-narrative" />)
+
+      // The untyped copy inside the analysis-result card is the one withheld…
+      const untyped = container.querySelector(
+        '[data-testid="v5-analysis-result-narrative-summary"]',
+      )
+      expect(untyped).toBeNull()
+
+      // …and the narrative survives under its own heading, so nothing is lost.
+      expect(container.textContent).toContain('How the analysis reads')
+      expect(container.textContent).toContain(narrativeSummary)
+    },
+  )
+
+  /**
+   * THE OPPOSITE-DIRECTION TWIN, and the one that stops this fix becoming a
+   * content-loss defect. A turn whose producer sent `narrative_summary` with
+   * NO narrative card must still show the narrative. Absence of the card may
+   * only ever cost a duplicate — never a paragraph.
+   */
+  it.each(CAPTURES)(
+    '%s: with NO narrative card, the analysis-result copy still renders',
+    (file) => {
+      const { blocks, narrativeSummary } = liftCapture(file)
+      const withoutCard = blocks.filter((b) => b.type !== 'v5_review_card')
+      expect(withoutCard).toHaveLength(1)
+
+      const { container } = render(
+        <InlineBlocks blocks={withoutCard} turnId="t-no-card" />,
+      )
+      expect(countOccurrences(container.textContent ?? '', narrativeSummary)).toBe(1)
+      expect(
+        container.querySelector('[data-testid="v5-analysis-result-narrative-summary"]'),
+      ).not.toBeNull()
+    },
+  )
+
+  /**
+   * THE NARROWNESS TWIN. Only the narrative channel is routed. The other
+   * `decision_review` prose fields are NOT duplicated by any card (measured
+   * 0/8) and must keep rendering in the analysis-result card exactly as
+   * before, card present or not.
+   */
+  it.each(CAPTURES)('%s: readiness_rationale is untouched by the routing', (file) => {
+    const raw = loadCapture(file)
+    const rawResult = raw.blocks.find((b) => b.type === 'analysis_result')!
+    const decisionReview = (rawResult.enrichment as Record<string, unknown>)
+      .decision_review as Record<string, unknown>
+    const readiness = decisionReview.readiness_rationale
+    expect(typeof readiness).toBe('string')
+    expect((readiness as string).length).toBeGreaterThan(0)
+
+    const { blocks } = liftCapture(file)
+    const { container } = render(<InlineBlocks blocks={blocks} turnId="t-narrow" />)
+    expect(container.textContent).toContain(readiness as string)
+  })
+})
+
+describe('Olumi copy assembly — a label is rendered in full, never cut', () => {
+  const W998 = 'w998-2026-08-16-a1-turn3.json'
+
+  /** TWIN A — long label, BALANCED brackets. Verbatim producer bytes. */
+  const BALANCED_LABEL =
+    'building the analytics add-on customers keep asking for (two quarters of ' +
+    'engineering time, roughly £250k in payroll, might lift retention from 88% ' +
+    'to 92% and support a 10% price rise)'
+
+  /**
+   * TWIN B — long label the PRODUCER already cut mid-phrase inside an UNCLOSED
+   * bracket. This is the gate's own defect shape, on the wire.
+   */
+  const UNBALANCED_LABEL =
+    'expanding into the German market (probably £400k up front for localisation, ' +
+    'sales hires and compliance'
+
+  /**
+   * The UX gate's recorded goal label, quoted verbatim from
+   * `UX-GATE-2026-08-18.md` — in the 85–101 character band the gate recorded,
+   * the length class that was being cut on the deployed build. Its placement
+   * in a card body is this spec's; the string is the product's.
+   */
+  const UX_GATE_GOAL_LABEL =
+    'Several of our largest enterprise customers are asking for a self-hosted deployment option'
+
+  it('the capture really carries both twins, and they differ in bracket balance', () => {
+    const { winProbabilityLabels } = liftCapture(W998)
+    expect(winProbabilityLabels).toContain(BALANCED_LABEL)
+    expect(winProbabilityLabels).toContain(UNBALANCED_LABEL)
+
+    // The discrimination this pair exists to make.
+    const balance = (s: string) =>
+      s.split('(').length - 1 === s.split(')').length - 1
+    expect(balance(BALANCED_LABEL)).toBe(true)
+    expect(balance(UNBALANCED_LABEL)).toBe(false)
+  })
+
+  it('TWIN A: a 183-char balanced-bracket label renders in full', () => {
+    const { blocks } = liftCapture(W998)
+    const { container } = render(<InlineBlocks blocks={blocks} turnId="t-twin-a" />)
+    const text = container.textContent ?? ''
+
+    expect(text).toContain(BALANCED_LABEL)
+    // Bound by identity: the label's own closing bracket, not merely "some" text.
+    expect(text).toContain('support a 10% price rise)')
+    expect(text).not.toContain('building the analytics add-on customers keep asking for…')
+  })
+
+  it('TWIN B: a producer-truncated label renders verbatim — not cut further, not repaired', () => {
+    const { blocks } = liftCapture(W998)
+    const { container } = render(<InlineBlocks blocks={blocks} turnId="t-twin-b" />)
+    const text = container.textContent ?? ''
+
+    // Rendered in full, exactly as received…
+    expect(text).toContain(UNBALANCED_LABEL)
+    // …with the producer's own unclosed bracket still visible. The UI must not
+    // hide an upstream defect by "closing" it — that would be the product
+    // misquoting the user's model back to them, which is the class being fixed.
+    expect(text).not.toContain(`${UNBALANCED_LABEL})`)
+    // …and the UI adds no ellipsis of its own to this label.
+    expect(text).not.toContain('sales hires and compliance…')
+    expect(text).not.toContain('sales hires and compliance...')
+  })
+
+  it('a 91-char label in a card body renders in full, with no character cap', () => {
+    const card: V5ReviewCardBlock = {
+      type: 'v5_review_card',
+      block_id: 'rc_goal_label',
+      title: 'How the analysis reads',
+      body: `I've built a first decision model for "${UX_GATE_GOAL_LABEL}".`,
+      severity: 'info',
+      card_kind: 'narrative',
+      target_refs: [],
+      priority_rank: 10,
+      freshness: 'fresh',
+    }
+    const { container } = render(<InlineBlocks blocks={[card]} turnId="t-long-label" />)
+    const text = container.textContent ?? ''
+
+    // The gate recorded the drafted goal label at 85–101 characters; this one
+    // is in that band, which is the length class that was being cut.
+    expect(UX_GATE_GOAL_LABEL.length).toBeGreaterThanOrEqual(85)
+    expect(UX_GATE_GOAL_LABEL.length).toBeLessThanOrEqual(101)
+    expect(text).toContain(UX_GATE_GOAL_LABEL)
+    // Balanced quotes around the label — the gate's acceptance condition.
+    expect(text).toContain(`"${UX_GATE_GOAL_LABEL}"`)
+    // The gate's exact broken rendering must not reappear.
+    expect(text).not.toContain(
+      'Several of our largest enterprise customers are asking for a self-hosted".',
+    )
+  })
+})

--- a/src/canvas/conversation/__tests__/InlineBlocks.narrativeChannel.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.narrativeChannel.spec.tsx
@@ -334,31 +334,60 @@ describe('Olumi copy assembly — a label is rendered in full, never cut', () =>
     expect(balance(UNBALANCED_LABEL)).toBe(false)
   })
 
-  it('TWIN A: a 183-char balanced-bracket label renders in full', () => {
+  /**
+   * ⚠ BOUND TO THE PILL, NOT TO THE WHOLE CARD — and the first version of
+   * these two tests was NOT, which is why this comment exists.
+   *
+   * Written first as `expect(container.textContent).toContain(LABEL)`, both
+   * twins SURVIVED a mutant that truncated the pill to `optionKey.slice(0, 40)`
+   * — 14/14 green while the very defect they exist to catch was live. The
+   * labels also appear in `enrichment.option_comparison`, which other parts of
+   * this card read, so the assertions were passing on a DIFFERENT OBJECT than
+   * the one under test (platform trap 19: bind by identity, never by a value
+   * predicate another object could satisfy).
+   *
+   * They now bind to the option pill itself — the `role="listitem"` inside
+   * `v5-analysis-result-probabilities` whose text STARTS with the label — and
+   * the same truncating mutant now REDs both.
+   */
+  function optionPillTexts(container: HTMLElement): string[] {
+    const list = container.querySelector(
+      '[data-testid="v5-analysis-result-probabilities"]',
+    )
+    if (!list) throw new Error('no probability pill list rendered — probe is vacuous')
+    const pills = Array.from(list.querySelectorAll('[role="listitem"]'))
+    if (pills.length === 0) throw new Error('pill list is empty — probe is vacuous')
+    return pills.map((p) => p.textContent ?? '')
+  }
+
+  it('TWIN A: a 183-char balanced-bracket label renders in full, in its own pill', () => {
     const { blocks } = liftCapture(W998)
     const { container } = render(<InlineBlocks blocks={blocks} turnId="t-twin-a" />)
-    const text = container.textContent ?? ''
+    const pills = optionPillTexts(container)
 
-    expect(text).toContain(BALANCED_LABEL)
-    // Bound by identity: the label's own closing bracket, not merely "some" text.
-    expect(text).toContain('support a 10% price rise)')
-    expect(text).not.toContain('building the analytics add-on customers keep asking for…')
+    // Exactly one pill carries this option, and it carries the WHOLE label —
+    // closing bracket included.
+    const matching = pills.filter((t) => t.startsWith(BALANCED_LABEL))
+    expect(matching).toHaveLength(1)
+    expect(matching[0]).toContain('support a 10% price rise)')
+    expect(matching[0]).not.toContain('…')
   })
 
   it('TWIN B: a producer-truncated label renders verbatim — not cut further, not repaired', () => {
     const { blocks } = liftCapture(W998)
     const { container } = render(<InlineBlocks blocks={blocks} turnId="t-twin-b" />)
-    const text = container.textContent ?? ''
+    const pills = optionPillTexts(container)
 
     // Rendered in full, exactly as received…
-    expect(text).toContain(UNBALANCED_LABEL)
+    const matching = pills.filter((t) => t.startsWith(UNBALANCED_LABEL))
+    expect(matching).toHaveLength(1)
     // …with the producer's own unclosed bracket still visible. The UI must not
     // hide an upstream defect by "closing" it — that would be the product
     // misquoting the user's model back to them, which is the class being fixed.
-    expect(text).not.toContain(`${UNBALANCED_LABEL})`)
+    expect(matching[0]).not.toContain(`${UNBALANCED_LABEL})`)
     // …and the UI adds no ellipsis of its own to this label.
-    expect(text).not.toContain('sales hires and compliance…')
-    expect(text).not.toContain('sales hires and compliance...')
+    expect(matching[0]).not.toContain('…')
+    expect(matching[0]).not.toContain('...')
   })
 
   it('a 91-char label in a card body renders in full, with no character cap', () => {

--- a/src/canvas/conversation/messageComposition.ts
+++ b/src/canvas/conversation/messageComposition.ts
@@ -551,6 +551,21 @@ export function collectConsentSurfaceText(
  * the spec pins that precondition against the corpus so a divergence REDs
  * rather than quietly dropping text.
  */
+/**
+ * ⚠ A HAND-MAINTAINED MIRROR OF CEE'S VOCABULARY, and named as one.
+ *
+ * `card_kind` is deliberately typed loosely on the wire so a future producer
+ * kind passes through without a UI release, which means a CEE rename would
+ * NOT be a type error here — this constant would simply stop matching and the
+ * duplicate would come back. It fails OPEN (a duplicate, never a deletion),
+ * which is the safe direction, but nothing in the type system REDs on drift.
+ *
+ * So the spec carries a CORPUS-DERIVED guard: it reads the narrative card's
+ * `card_kind` out of every capture in the corpus and asserts it equals this
+ * constant. Derivation cannot prove the constant is RIGHT, only that the
+ * corpus and the code still agree — which is exactly the drift that would
+ * silently reopen the defect (platform trap 12/12d).
+ */
 export const NARRATIVE_REVIEW_CARD_KIND = 'narrative'
 
 /**
@@ -566,10 +581,15 @@ export function turnDeliversNarrativeAsTypedCard(
 ): boolean {
   if (!blocks || blocks.length === 0) return false
   return blocks.some((block) => {
-    if (block.type !== 'v5_review_card' && block.type !== 'review_card') return false
-    const kind = (block as { card_kind?: unknown }).card_kind
-    if (kind !== NARRATIVE_REVIEW_CARD_KIND) return false
-    const body = (block as { body?: unknown }).body
+    // `v5_review_card` ONLY. The legacy `review_card` was in this condition
+    // and was UNREACHABLE: `ReviewCardBlock` (types.ts) carries
+    // title/body/variant/tone/priority and has NO `card_kind` at all, so the
+    // kind test below could never pass for it. A dead branch in a predicate
+    // reads as coverage of a case that cannot occur — removed rather than
+    // left to imply the legacy shape was considered and handled.
+    if (block.type !== 'v5_review_card') return false
+    if (block.card_kind !== NARRATIVE_REVIEW_CARD_KIND) return false
+    const body: unknown = block.body
     return typeof body === 'string' && body.trim().length > 0
   })
 }

--- a/src/canvas/conversation/messageComposition.ts
+++ b/src/canvas/conversation/messageComposition.ts
@@ -504,6 +504,77 @@ export function collectConsentSurfaceText(
 }
 
 /**
+ * SECOND-CHANNEL ROUTING — a different question from suppression, kept apart
+ * from it on purpose (UX gate 2026-08-18 point 4b).
+ *
+ * ## The producer fact
+ *
+ * CEE's `decision_review_enricher` emits the analysis narrative on TWO
+ * channels of the SAME turn:
+ *
+ *   · `analysis_result.enrichment.decision_review.narrative_summary`
+ *     — untyped prose inside the pinned answer card;
+ *   · a `review_card` with `card_kind: "narrative"`, title "How the analysis
+ *     reads" — the same string, byte for byte.
+ *
+ * Measured over every analysis-turn capture in this repo carrying
+ * `narrative_summary` (8 payloads, 2026-07-31 → 2026-08-17): the narrative
+ * card is present in 8/8, exactly one per turn, byte-identical in 8/8, and
+ * always the turn's FIRST point candidate — so it is always top-level, never
+ * demoted into the disclosure. The contrast that proves the measurement
+ * discriminates: `readiness_rationale` is duplicated in 0/8.
+ *
+ * ## Why this is NOT `dedupeRenderedText`
+ *
+ * `dedupeRenderedText` answers "has a higher tier already rendered this exact
+ * segment?" — a string question, deliberately narrow, and deliberately unable
+ * to touch a typed card (withholding a line of a card changes what the card
+ * means, and a card emptied of its body is a worse artefact than the
+ * duplicate). Running it over these two surfaces would ALSO suppress a
+ * legitimately repeated sentence the day CEE has a reason to repeat one, and
+ * it would leave the two channels in place, hidden.
+ *
+ * The question here is not about strings at all. It is: WHICH CHANNEL
+ * DELIVERS THIS CONTENT? Answered structurally, by block presence, so the
+ * routing cannot depend on the prose staying byte-identical and cannot
+ * silently start or stop discriminating when the wording changes. Two harms
+ * under one predicate is the mistake this module already refuses to make
+ * (trap 22b); this is the second predicate, named apart.
+ *
+ * ## Direction of the residual risk
+ *
+ * The card wins because it TITLES the content ("How the analysis reads") and
+ * is always top-level. Absence of the card costs a duplicate, never a
+ * paragraph — the caller's flag defaults to "not delivered", exactly as
+ * `collectConsentSurfaceText` defaults to collecting nothing. The one thing
+ * this cannot survive is CEE making the two channels carry DIFFERENT prose;
+ * the spec pins that precondition against the corpus so a divergence REDs
+ * rather than quietly dropping text.
+ */
+export const NARRATIVE_REVIEW_CARD_KIND = 'narrative'
+
+/**
+ * Does this turn deliver the analysis narrative as a TYPED, TITLED card?
+ *
+ * True iff the turn carries a review card of the narrative kind with a
+ * non-empty body. Body content is never compared to anything — only its
+ * existence, because an empty card delivers nothing and must not cause the
+ * untyped copy to be withheld.
+ */
+export function turnDeliversNarrativeAsTypedCard(
+  blocks: readonly ConversationBlock[] | undefined,
+): boolean {
+  if (!blocks || blocks.length === 0) return false
+  return blocks.some((block) => {
+    if (block.type !== 'v5_review_card' && block.type !== 'review_card') return false
+    const kind = (block as { card_kind?: unknown }).card_kind
+    if (kind !== NARRATIVE_REVIEW_CARD_KIND) return false
+    const body = (block as { body?: unknown }).body
+    return typeof body === 'string' && body.trim().length > 0
+  })
+}
+
+/**
  * Invariant 1, as an executable check: the composition is a TOTAL PARTITION of
  * the input indices. Exported so the spec binds the real function rather than
  * re-implementing the rule (a guard that re-states the code agrees with itself

--- a/src/v5/blocks/V5AnalysisResultBlock.tsx
+++ b/src/v5/blocks/V5AnalysisResultBlock.tsx
@@ -9,6 +9,18 @@
  *     `story_headlines`, `robustness_explanation`, `readiness_rationale`,
  *     `scenario_contexts` (ROADMAP 2.154). This is where the analysis
  *     EXPLANATION lives, so it renders here beside the summary it explains.
+ *
+ *     ⚠ CORRECTED 2026-08-18 (UX gate point 4b) — THAT PREMISE IS FALSE FOR
+ *     ONE OF THE FIVE. `narrative_summary` IS delivered by another wire
+ *     block: the same turn carries a `review_card` of `card_kind:
+ *     "narrative"`, titled "How the analysis reads", whose body is the same
+ *     string byte for byte (8/8 analysis-turn captures, 2026-07-31 →
+ *     2026-08-17; `readiness_rationale` duplicated in 0/8, which is the
+ *     contrast proving the measurement discriminates). Rendering both put the
+ *     same paragraph on screen twice, a few hundred pixels apart, on the
+ *     deployed build. So `narrative_summary` now renders here ONLY when the
+ *     typed card is absent — see the `narrativeDeliveredByTypedCard` prop.
+ *     The premise still holds for the other four, and they are untouched.
  *   - When the payload on that key is genuinely malformed: a hidden operator
  *     marker, and nothing else changes.
  *
@@ -52,6 +64,23 @@ import { calibrateUncertaintyCopy } from '../../components/results/utils/uncerta
 
 export interface V5AnalysisResultBlockProps {
   block: V5AnalysisResultBlockType
+  /**
+   * SECOND-CHANNEL ROUTING (UX gate 2026-08-18 point 4b). True when the SAME
+   * turn also carries a typed narrative review card ("How the analysis
+   * reads"), which CEE emits with the identical string — see
+   * `turnDeliversNarrativeAsTypedCard` in `messageComposition.ts` for the
+   * producer measurement and the reasoning.
+   *
+   * When true, this card omits its `narrative_summary` paragraph AND NOTHING
+   * ELSE: the other four prose fields are not duplicated by any card (0/8 in
+   * the corpus) and are untouched.
+   *
+   * Defaults to FALSE so every existing caller renders byte-for-byte as
+   * before, and so a caller that cannot answer the question causes a
+   * duplicate rather than a dropped paragraph. Absence must never cost
+   * content — the same default `collectConsentSurfaceText` takes.
+   */
+  narrativeDeliveredByTypedCard?: boolean
 }
 
 /**
@@ -247,7 +276,10 @@ function useOptionLabelResolver(
   return (optionId: string) => resolveCanvasLabel(optionId, merged)
 }
 
-function V5AnalysisResultBlockImpl({ block }: V5AnalysisResultBlockProps): ReactElement {
+function V5AnalysisResultBlockImpl({
+  block,
+  narrativeDeliveredByTypedCard = false,
+}: V5AnalysisResultBlockProps): ReactElement {
   // ROADMAP 2.154 — the wire has FOUR states and only ONE of them is an alarm.
   // `absent` (the enricher's soft-fail skips) and `degraded`
   // (`decision_review: null`, CEE's "attempted, degraded at the call site")
@@ -391,7 +423,14 @@ function V5AnalysisResultBlockImpl({ block }: V5AnalysisResultBlockProps): React
           data-testid="v5-analysis-result-decision-review"
           data-produced-at={review030.produced_at}
         >
-          {review030.narrative_summary !== null && (
+          {/*
+            UX gate 2026-08-18 point 4b — the narrative is withheld HERE only
+            when the turn delivers it as its own titled card. Not a string
+            comparison and not a de-duplication: a channel choice, made on
+            block presence, so it cannot depend on the prose staying
+            byte-identical. See `turnDeliversNarrativeAsTypedCard`.
+          */}
+          {review030.narrative_summary !== null && !narrativeDeliveredByTypedCard && (
             <p
               className={`${typography.panelBody} ${PROSE_WRAP}`}
               data-testid="v5-analysis-result-narrative-summary"


### PR DESCRIPTION
UX gate 2026-08-18 point 4, measured on deployed `4d1e650b`, fresh guest.
Evidence: `olumi-docs/feedback-2026-08-16/UX-GATE-2026-08-18.md`.

Two defects were recorded. **One is ours and is fixed here. One is not ours, and
the derivation refuting it is the other half of this PR.**

> **⚠ Correction to an earlier revision of this description.** It said *"the flag
> defaults to `false`"*. **There is no flag.** `narrativeDeliveredByTypedCard` is a
> TypeScript **parameter default**, and the sole production call site
> (`InlineBlocks.tsx`) always passes the computed value. **The fix is
> unconditionally ON** — no dark launch, no new gate, nothing to enable. The wrong
> word sent a reviewer hunting a defect that does not exist; the parameter default
> matters only for direct unit callers of the component.

---

## 4b — "One paragraph renders verbatim twice" — FIXED

CEE's `decision_review_enricher` emits the analysis narrative on **two channels of
the same turn**:

| channel | carrier |
|---|---|
| untyped | `analysis_result.enrichment.decision_review.narrative_summary` |
| typed | a `review_card`, `card_kind: "narrative"`, title **"How the analysis reads"** |

`body` is the same string **byte for byte**, and the UI rendered both.

Measured over **all 8** analysis-turn payloads in the repo carrying the field
(2026-07-31 → 2026-08-17): narrative card present **8/8**, byte-identical **8/8**.
Contrast: `story_headlines`, `robustness_explanation`, `readiness_rationale`,
`scenario_contexts` are each present 8/8 and duplicated **0/8** — so the premise
correction is confined to exactly one limb.

### The fix is a CHANNEL CHOICE, not string-equality de-duplication

Not fixed by comparing strings at the render site: a string filter would suppress a
legitimately repeated sentence later and would hide the composer defect rather than
resolve it. `turnDeliversNarrativeAsTypedCard` answers *which channel delivers this
content?* **structurally**, so it cannot drift as wording changes.

It also repairs a **stale premise** rather than overriding a live rule:
`V5AnalysisResultBlock` justified these fields as *"the five fields no other wire
block delivers"* (ROADMAP 2.154), which is measurably false for `narrative_summary`.

---

## Review round 2 — F1–F4 resolved

### ⭐ F1 (REQUIRED) — gated on PRESENCE, not on RENDERED. Real content loss. FIXED.

The predicate read the **whole** block list, including blocks demoted into the
**closed** disclosure. `v5_review_card` is a point candidate, not pinned, and real
turns carry **4–7 review cards against `MAX_POINTS = 3`**. A demoted narrative card
therefore still suppressed the untyped copy — the analysis card withheld the
paragraph *and* the disclosure hid the card. **The paragraph was nowhere.**

Reproduced on real producer bytes, changing only **order**: narrative 1st → renders
1×; narrative 4th → renders **0×**.

**This is precisely what the C13 rule twenty lines below my own code warns against:**
*"gates on a phase-3 card being CURRENTLY RENDERED — never on mere presence in the
turn."*

**The mechanism I had not identified:** the card is top-level *only* because CEE
assigns `priority_rank: 10` — the minimum in all 8 captures — and Phase 3 blocks sort
ascending by producer rank. A producer-owned fact, mirrored nowhere in the UI. I had
**stated** "always the turn's first point candidate" in this description as a corpus
observation and then leaned on it as a guarantee. The fix now reads `topLevel`, which
**removes** the dependency instead of mirroring it.

Deliberately **not** gated on `isBlockHidden` — `topLevel` membership is stable
w.r.t. `detailExpanded`, so the paragraph cannot appear or vanish as the disclosure
opens.

**Why my suite could not see it, which is the more important half.** `liftCapture`
reduced a 15-block capture to **two** blocks, so the cap was never reached and the
demotion path could not occur. Every byte was the producer's — *"nothing is
reshaped"* was true of the **bytes** and false of the **turn shape**, and the
reshaping removed exactly the pressure that turns a suppression into a deletion.
Corpus-excludes-the-class, straight through a green suite and a six-mutant kit.
`liftCapture` now keeps **all** review cards, and each capture asserts it exceeds the
cap.

### F2 (recommended) — corpus now DERIVED. FIXED.

Was a hardcoded 2-file list from one directory while the measurement denominator was
8 across two — **six real payloads carrying the field were exercised by no test.**
Discovery now spans both directories, with `CORPUS_FLOOR = 8` and a two-directory
assertion so a silently-shrinking derivation cannot read green.

### F3 — mirror named, and now guarded. FIXED.

`NARRATIVE_REVIEW_CARD_KIND` is documented in-code as the hand-maintained mirror of
CEE vocabulary it is (fails **open** — a duplicate, never a deletion), and carries a
**corpus-derived guard**. Mutant **M10** (rename the constant) REDs 24.

### F4 — unreachable branch removed. FIXED.

The legacy `review_card` limb could never match: `ReviewCardBlock` has **no
`card_kind` field**. Removed rather than left implying coverage of an impossible case.

---

## 4a — "The opening sentence quotes a goal truncated mid-phrase" — NOT A UI DEFECT

The strings arrive **already truncated on the wire**: `acceptance-2026-08-17-j1r1-t1`
carries `assistant_text` with `"• diversify fast by buying a small M&E"` while **the
same payload** carries the full 75-char label intact at five other sites. No UI
product code composes that sentence (positive control: the sweep hits fixtures/specs
only). The UI cannot fix it without inventing text — which is the defect class itself.
**Owner: the CEE lane.**

What the UI **is** held to, pinned as opposite-direction twins from one real capture:

| twin | label | assertion |
|---|---|---|
| **A** | 183 chars, **balanced** brackets | renders **in full** |
| **B** | 102 chars, producer cut inside an **UNCLOSED** bracket | renders **verbatim** — not cut further, **not silently repaired** |

Reviewer-confirmed: **M8 (repair the bracket) REDs TWIN B and only TWIN B** — the
no-repair pin is genuine and discriminating, so the upstream defect stays visible to
its owning lane.

---

## Verification at this tip

RED-first at pristine: `expected 2 to be 1` on both captures.

Mutant kit — worktree outside the repo root, isolation **proven by writing a
sentinel** (distinct inodes, APFS), restores read from a **pristine archive** never
from the other copy, applied-check by diff-vs-archive:

| mutant | result |
|---|---|
| CONTROL | 0 applied · 69 passed |
| **M9 revert F1** | **RED ×8** — exactly the 8 demotion tests, nothing else |
| M3 revert the guard (the fix) | RED ×16 |
| M2 predicate always `true` | RED ×16 |
| M10 kind constant renamed | RED ×24 |
| CONTROL-TRAILING | 0 applied · 69 passed |

Round-1 mutants still hold (reviewer reproduced independently): M1 ×4, M1b ×4, M4 ×2,
M5 ×2, M6 GREEN, M7 ×5, M8 ×1. RED sets disjoint.

Earlier round-1 self-caught vacuity, kept on the record: both full-label twins were
first written as whole-container `toContain` and **survived** the pill-truncating
mutant; they are now bound by identity to the pill and proven with a discriminating
pair (M4 RED / M6 GREEN).

### Gates

- Derived regression manifest (every spec referencing the three changed modules):
  **53 files / 1008 tests passing**
- `npm run typecheck`: **PASSED**. Drift 2272 → 2263; `--update-baseline` deliberately
  **not** run — not attributable to this change.
- `eslint` changed files: **0 errors** (3 pre-existing warnings, confirmed against `staging`)
- Own spec collects **69 tests by name** on the derived corpus, with
  `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported

### UNMEASURED — stated, not implied

- **MOUNTED acceptance not met and not meetable by this PR.** Needs merge → deploy →
  fresh-guest witness. Rung: **TESTED**.
- Full `lint` / `test:required` not run end-to-end locally; CI not polled.
- The applied-check covers the two conversation files; **M3 mutates
  `V5AnalysisResultBlock.tsx`, which it does not measure** — that mutant's evidence is
  its RED count plus grep confirmation of the edit.
- "Opening sentence contains the goal label in full" **cannot be met by the UI alone** —
  gated on the CEE `assistant_text` fix.

### Collisions

None — zero open UI PRs touch `InlineBlocks.tsx`, `messageComposition.ts` or
`V5AnalysisResultBlock.tsx`. No overlap with the workspace-shell occlusion or
Analysis-panel ordering lanes.

No capture was edited; the corpus is append-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
