### PR TITLE
fix(canvas): the chat panel and the header pill stop covering the model — UX gate point 7

### DIFF
--- a/src/canvas/__tests__/computeFitPadding.contributorSet.spec.ts
+++ b/src/canvas/__tests__/computeFitPadding.contributorSet.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * THE CONTRIBUTOR SET CANNOT GROW WITHOUT SOMEONE APPLYING THE FOUR CRITERIA.
+ *
+ * WHY THIS FILE EXISTS. `computeFitPadding`'s header used to promise that *"a
+ * future lane adding a free-floating occluder to this function REDs the
+ * padding-invariance guard (G2a)"*. **It does not.** G2a is three hardcoded
+ * selector strings (`floating-olumi-panel`, its side tab, the restore pill), so
+ * a re-admission under any OTHER selector — or via the store rather than a rect
+ * — sails past it green. A hand-maintained mirror inside the guard written to
+ * prevent hand-maintained mirrors (adversarial review of #786, 19 Aug 2026).
+ *
+ * So this guard is DERIVED FROM THE BYTES rather than from a list a human must
+ * remember to sync: it reads `computeFitPadding.ts`, extracts every selector
+ * actually reached by `rectOf(...)` inside the function, and asserts that set
+ * equals the exported declaration.
+ *
+ * ⚠ WHAT IT PROVES AND WHAT IT CANNOT (trap 12d, stated up front). It proves the
+ * CODE AND THE DECLARATION AGREE. It can never prove the declaration is RIGHT —
+ * whether a given piece of chrome is edge-anchored, non-movable, non-dismissible
+ * and persistent is a judgement, and the header labels those four criteria
+ * REVIEW-ONLY for exactly that reason. Deriving a guard from a list moves the
+ * risk; it does not remove it. What this buys is that the list cannot change
+ * silently, which is the half that was missing.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  FIT_PADDING_CONTRIBUTORS,
+  DOCK_SELECTOR,
+  SIDEBAR_SELECTOR,
+  TOP_BAR_SELECTOR,
+} from '../utils/computeFitPadding'
+
+const SOURCE_PATH = resolve(__dirname, '../utils/computeFitPadding.ts')
+const SOURCE = readFileSync(SOURCE_PATH, 'utf8')
+
+/** The body of `export function computeFitPadding` — the only scope that matters. */
+function computeFitPaddingBody(): string {
+  const start = SOURCE.indexOf('export function computeFitPadding(')
+  expect(start, 'computeFitPadding must exist — a rename silently empties this guard').toBeGreaterThan(-1)
+  // Everything from the signature to the end of file is a superset of the body
+  // and contains no other function, so it is a safe (over-inclusive) scope.
+  return SOURCE.slice(start)
+}
+
+/** Every argument passed to `rectOf(...)` in that body, as written. */
+function extractedContributorTokens(): string[] {
+  const body = computeFitPaddingBody()
+  return [...body.matchAll(/\brectOf\(\s*([^)]*?)\s*\)/g)].map((m) => m[1])
+}
+
+/** Resolve an identifier token to the selector it names; string literals pass through. */
+const TOKEN_TO_SELECTOR: Record<string, string> = {
+  DOCK_SELECTOR,
+  SIDEBAR_SELECTOR,
+  TOP_BAR_SELECTOR,
+}
+
+describe('computeFitPadding — the declared contributor set is derived from the bytes', () => {
+  it('POSITIVE CONTROL: the extractor finds a non-zero number of rectOf call sites', () => {
+    // Trap 13: an extractor that silently matches nothing agrees with every
+    // other extractor that matched nothing, and `toEqual` on two empty arrays
+    // passes. Assert it can SEE before believing what it says.
+    const tokens = extractedContributorTokens()
+    expect(tokens.length, 'the extractor read nothing — every assertion below would be vacuous').toBeGreaterThan(0)
+    expect(tokens.length).toBe(FIT_PADDING_CONTRIBUTORS.length)
+  })
+
+  it('every selector the function actually reaches is one the module DECLARES', () => {
+    const reached = extractedContributorTokens().map((token) => {
+      const resolved = TOKEN_TO_SELECTOR[token]
+      // An inline string literal is a contributor that was never declared —
+      // name it in the failure rather than resolving to undefined.
+      expect(
+        resolved,
+        `rectOf(${token}) reaches a selector that is not in FIT_PADDING_CONTRIBUTORS. ` +
+          `Adding an occluder here means applying criteria 1-4 in the module header ` +
+          `(edge-anchored / not user-movable / not dismissible / persistent) and declaring it.`,
+      ).toBeTypeOf('string')
+      return resolved
+    })
+    expect(new Set(reached)).toEqual(new Set(FIT_PADDING_CONTRIBUTORS))
+  })
+
+  it('CONTRAST CONTROL: the extractor discriminates — a fourth call site is detected', () => {
+    // Proves the assertion above is sensitive to what it claims to measure,
+    // without mutating the real file. If this regex could not see a fourth
+    // contributor, the guard would agree with itself forever.
+    const withExtra = computeFitPaddingBody().replace(
+      'const topBar = rectOf(TOP_BAR_SELECTOR)',
+      "const smuggled = rectOf('[data-testid=\"floating-olumi-panel\"]')\n    const topBar = rectOf(TOP_BAR_SELECTOR)",
+    )
+    const tokens = [...withExtra.matchAll(/\brectOf\(\s*([^)]*?)\s*\)/g)].map((m) => m[1])
+    expect(tokens.length).toBe(FIT_PADDING_CONTRIBUTORS.length + 1)
+    expect(tokens.some((t) => !(t in TOKEN_TO_SELECTOR))).toBe(true)
+  })
+
+  it('the function reaches for no STORE — a contributor cannot be smuggled in as state', () => {
+    // The rect-based guard above is blind to `useFloatingPanelState.getState()`.
+    // computeFitPadding is a pure DOM measurement and must stay one.
+    const body = computeFitPaddingBody()
+    for (const forbidden of ['getState(', 'useFloatingPanelState', 'useUIStore', 'useCanvasStore']) {
+      expect(body.includes(forbidden), `computeFitPadding must not read ${forbidden}`).toBe(false)
+    }
+  })
+})

--- a/src/canvas/__tests__/topBarFitInset.spec.ts
+++ b/src/canvas/__tests__/topBarFitInset.spec.ts
@@ -1,0 +1,181 @@
+/**
+ * UX GATE 7b — THE FIT FRAME CLEARS THE FLOATING HEADER PILL.
+ *
+ * `computeFitPadding` used to carry, on the line that set `top`, the claim
+ * *"Top bar sits above `.react-flow` in the flex layout, so it never overlaps
+ * the flow rect"*. That was FALSE at the deployed tip, and it is the whole
+ * defect: `TopBar` is a fixed pill (`position: fixed; top: 12px; height: 45px;
+ * z-index: 3000`, `TopBar.module.css:1-19`) painted OVER a full-window
+ * `.react-flow`, so a fitted graph's top row lands underneath it and, at
+ * z-3000 over z-0, is not hit-testable.
+ *
+ * ⚠ SCOPE, BEFORE THE ASSERTIONS (platform trap 3). Everything here is
+ * ARITHMETIC over stubbed rects. jsdom runs no CSS layout, so nothing in this
+ * file proves a rendered overlap, a settled camera or a hit test. What it does
+ * prove is that the padding this function returns clears a bar of the measured
+ * geometry, and that the amount is DERIVED from that geometry rather than
+ * written down. The occlusion and hit-test claims are browser claims and are
+ * carried in the PR.
+ *
+ * LIVE PRECONDITION, derived on the deployed build
+ * `4d1e650b5d3314f1fb4e2279f1bee917206047d8` (fresh guest, `/#/canvas`,
+ * 1280x800, `getBoundingClientRect`):
+ *   `[role="banner"]`  -> { left 12, top 12, right 526.6, bottom 57 }  (h 45, z 3000, fixed)
+ *   `.react-flow`      -> { left 0,  top 0,  right 1280,  bottom 800 } (z 0, relative)
+ *   exactly ONE `[role="banner"]` in the document
+ * The DEPLOYED_* constants below are that measurement, and the expected 73px is
+ * derived from them here rather than asserted as a number pulled from the air.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { computeFitPadding, TOP_BAR_SELECTOR } from '../utils/computeFitPadding'
+
+function fakeEl(rect: Partial<DOMRect>): HTMLElement {
+  const full: DOMRect = {
+    x: 0, y: 0, width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0,
+    toJSON: () => ({}), ...rect,
+  } as DOMRect
+  return { getBoundingClientRect: () => full } as unknown as HTMLElement
+}
+
+function stubSelectors(map: Record<string, HTMLElement | null>) {
+  vi.spyOn(document, 'querySelector').mockImplementation(
+    (sel: string) => (sel in map ? map[sel] : null) as Element | null,
+  )
+}
+
+const DOCK = 'aside[aria-label="Outputs dock"]'
+const SIDEBAR = 'nav[aria-label="Canvas tools"]'
+
+/** The 19 Aug 2026 live measurement at 1280x800 on `4d1e650b`. */
+const DEPLOYED_FLOW = { left: 0, right: 1280, width: 1280, top: 0, bottom: 800, height: 800 }
+const DEPLOYED_BANNER = { left: 12, right: 526.6, width: 514.6, top: 12, bottom: 57, height: 45 }
+const DEPLOYED_DOCK = { left: 852, right: 1268, width: 416, top: 12, bottom: 784, height: 772 }
+const DEPLOYED_SIDEBAR = { left: 12, right: 60, width: 48, top: 73, bottom: 300, height: 227 }
+
+/** Mirrors the module's own constants so the expectations are derived, not copied. */
+const GAP = 16
+const baseMargin = (d: number) => Math.max(0, Math.floor((d - d / 1.08) * 0.5))
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('computeFitPadding — the floating header pill is an occluder (UX gate 7b)', () => {
+  it('reserves the bar it can SEE: top = (bar.bottom - flow.top) + GAP at the deployed geometry', () => {
+    stubSelectors({
+      [TOP_BAR_SELECTOR]: fakeEl(DEPLOYED_BANNER),
+      [DOCK]: fakeEl(DEPLOYED_DOCK),
+      [SIDEBAR]: fakeEl(DEPLOYED_SIDEBAR),
+    })
+    const p = computeFitPadding(fakeEl(DEPLOYED_FLOW))
+
+    // Derived from the live rects above, not written down:
+    const expectedTop = Math.max(
+      baseMargin(DEPLOYED_FLOW.height),
+      DEPLOYED_BANNER.bottom - DEPLOYED_FLOW.top + GAP,
+    )
+    expect(expectedTop).toBe(73) // 57 + 16; sanity on the derivation itself
+    expect(p.top).toBe(`${expectedTop}px`)
+
+    // PIN THE PRECONDITION (trap 13b): this assertion is only meaningful while
+    // the bar genuinely EXCEEDS the base margin. If the base ever grew past the
+    // bar, `top` would be right for the wrong reason and this suite would go
+    // quiet without a single red.
+    expect(DEPLOYED_BANNER.bottom - DEPLOYED_FLOW.top + GAP).toBeGreaterThan(
+      baseMargin(DEPLOYED_FLOW.height),
+    )
+
+    // The other three sides are untouched by this change.
+    expect(p.right).toBe('444px') // dock overlap 428 + GAP
+    expect(p.left).toBe('76px') // sidebar overlap 60 + GAP
+    expect(p.bottom).toBe(`${baseMargin(DEPLOYED_FLOW.height)}px`)
+  })
+
+  it('DERIVES the amount from the measured rect — a taller bar reserves proportionally more', () => {
+    // This is the anti-magic-number assertion. A hardcoded 57/73 (or a read of
+    // `--topbar-h`, which TopBar writes as the literal string '57px') passes the
+    // test above and FAILS this one.
+    const results = [45, 64, 96].map((height) => {
+      stubSelectors({ [TOP_BAR_SELECTOR]: fakeEl({ ...DEPLOYED_BANNER, height, bottom: 12 + height }) })
+      const p = computeFitPadding(fakeEl(DEPLOYED_FLOW))
+      vi.restoreAllMocks()
+      return p.top
+    })
+    expect(results).toEqual(['73px', '92px', '124px']) // (12 + h) + 16
+  })
+
+  it('reserves NOTHING when no bar is mounted — the no-occluder case is unchanged', () => {
+    stubSelectors({})
+    const p = computeFitPadding(fakeEl(DEPLOYED_FLOW))
+    expect(p.top).toBe(`${baseMargin(DEPLOYED_FLOW.height)}px`)
+    expect(p.top).toBe('29px')
+  })
+
+  it('reserves nothing when the bar does not overlap the flow rect (canvas offset below it)', () => {
+    // An embedded / offset canvas whose top edge already starts below the bar.
+    // Overlap is measured against the FLOW rect, never the window, so this is
+    // correctly zero rather than a blanket 73px.
+    stubSelectors({ [TOP_BAR_SELECTOR]: fakeEl(DEPLOYED_BANNER) })
+    const p = computeFitPadding(
+      fakeEl({ left: 0, right: 1280, width: 1280, top: 120, bottom: 800, height: 680 }),
+    )
+    expect(p.top).toBe(`${baseMargin(680)}px`)
+  })
+
+  it('is bounded: a pathological bar cannot consume the pane (MAX_PADDING_FRACTION still caps)', () => {
+    stubSelectors({
+      [TOP_BAR_SELECTOR]: fakeEl({ left: 0, right: 600, width: 600, top: 0, bottom: 900, height: 900 }),
+    })
+    const p = computeFitPadding(fakeEl({ left: 0, right: 600, width: 600, top: 0, bottom: 500, height: 500 }))
+    expect(parseFloat(p.top) + parseFloat(p.bottom)).toBeLessThanOrEqual(Math.floor(500 * 0.8))
+  })
+
+  it('the floating panel STILL reserves nothing, WITH the bar present (G2a holds across the change)', () => {
+    // The lead question for this lane was whether the 7b fix is another instance
+    // of the class it removes — "a panel's mere existence consumes canvas".
+    // The discriminator is edge-anchoring, and this is the executable half of
+    // it: adding an edge-anchored contributor must not re-admit the
+    // free-floating one. Same POSITIONS spirit as G2a, run with the header up.
+    const PANEL = '[data-testid="floating-olumi-panel"]'
+    const SIDE_TAB = '[data-testid="floating-olumi-panel-side-tab"]'
+    const PILL = '[aria-label="Restore Olumi"]'
+
+    stubSelectors({
+      [TOP_BAR_SELECTOR]: fakeEl(DEPLOYED_BANNER),
+      [DOCK]: fakeEl(DEPLOYED_DOCK),
+      [SIDEBAR]: fakeEl(DEPLOYED_SIDEBAR),
+    })
+    const before = computeFitPadding(fakeEl(DEPLOYED_FLOW))
+    vi.restoreAllMocks()
+
+    // PIN THE PRECONDITION: the baseline must be the real reservation on all
+    // four sides, including the new top. Otherwise the invariance below is
+    // measuring nothing.
+    expect(before, 'baseline must be the real 1280x800 reservation, header included').toEqual({
+      top: '73px', right: '444px', bottom: '29px', left: '76px',
+    })
+
+    const POSITIONS = [
+      { name: 'bottom-right anchor (post-draft)', left: 436, top: 240, w: 400, h: 544 },
+      { name: 'centred over the model', left: 440, top: 125, w: 400, h: 550 },
+      { name: 'hugging the header pill', left: 52, top: 16, w: 400, h: 550 },
+      { name: 'wide + bottom-hugging', left: 300, top: 700, w: 700, h: 90 },
+    ] as const
+
+    for (const pos of POSITIONS) {
+      const rect = { left: pos.left, right: pos.left + pos.w, top: pos.top, bottom: pos.top + pos.h, width: pos.w, height: pos.h }
+      for (const sel of [PANEL, SIDE_TAB, PILL]) {
+        stubSelectors({
+          [TOP_BAR_SELECTOR]: fakeEl(DEPLOYED_BANNER),
+          [DOCK]: fakeEl(DEPLOYED_DOCK),
+          [SIDEBAR]: fakeEl(DEPLOYED_SIDEBAR),
+          [sel]: fakeEl(rect),
+        })
+        const after = computeFitPadding(fakeEl(DEPLOYED_FLOW))
+        vi.restoreAllMocks()
+        expect(after, `${sel} at ${pos.name} must change the padding by exactly zero`).toEqual(before)
+      }
+    }
+  })
+})

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -588,7 +588,17 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
   // and the "never strand the user with zero composers" invariant cannot move.
   useEffect(() => {
     if (!isOpen || yieldToFirstUse || yieldToDockedOlumi) return
-    if (revealWouldImposeFloating({ isMinimised, source, userRepositioned, userChoseFloating })) return
+    // ⚠ FLAG-GATED, exactly as `yieldToDockedOlumi` above is. Routing this cell
+    // to the dock is only honest when the dock CAN host Olumi, and that is
+    // `isAiPanelV2Enabled()`: with the flag OFF, `OutputsDock` redirects tab
+    // `olumi` -> `results`, so an unconditional guard would deregister the
+    // channel while nothing else can take it — `focusFloating()` false, the
+    // dock branch skipped, and `revealOlumiSurface()` returning false having
+    // fronted NOTHING. `VITE_FEATURE_AI_PANEL_V2` is set only under
+    // `[context.staging.environment]`, so that is production and every
+    // rollback posture. Not staging-reachable; it would silently disable the
+    // documented rollback lever. The twin test pins the flag-OFF direction.
+    if (isAiPanelV2Enabled() && revealWouldImposeFloating({ isMinimised, source, userRepositioned, userChoseFloating })) return
     return registerFloatingFocus(() => {
       const state = useFloatingPanelState.getState()
       if (state.isMinimised) {

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -394,6 +394,9 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
   // user drags the panel, and the channel would stay deregistered after the
   // drag made it a user-owned surface again.
   const userRepositioned = useFloatingPanelState((s) => s.userRepositioned)
+  // The pill-restore ownership fact. Subscribed for the same reason as
+  // `userRepositioned`: the focus-channel registration branches on it.
+  const userChoseFloating = useFloatingPanelState((s) => s.userChoseFloating)
   const position = useFloatingPanelState((s) => s.position)
   const size = useFloatingPanelState((s) => s.size)
   const setPosition = useFloatingPanelState((s) => s.setPosition)
@@ -401,7 +404,7 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
   const setSize = useFloatingPanelState((s) => s.setSize)
   const close = useFloatingPanelState((s) => s.close)
   const minimise = useFloatingPanelState((s) => s.minimise)
-  const restore = useFloatingPanelState((s) => s.restore)
+  const restoreByUser = useFloatingPanelState((s) => s.restoreByUser)
   // First-use composer takes over rendering whenever the canvas is empty AND
   // the panel was opened by the system (initial first-use OR re-opened on a
   // canvas reset). This includes the post-submit / pre-graph window so the
@@ -574,15 +577,18 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
   // area 40% → 0% and obscured nodes 9 → 1 at 1280x800.
   //
   // The predicate is `revealWouldImposeFloating`, defined once beside
-  // `canAutoDock`; a minimised panel the user OPENED or MOVED is excluded and
-  // still restores here, and the restore branch below stays for exactly that.
+  // `canAutoDock`; a minimised panel the user OPENED, MOVED or RESTORED FROM
+  // THE PILL is excluded and still restores here, and the restore branch below
+  // stays for exactly that. (The pill case is the ninth cell the first version
+  // of this change missed — `restore()` confers no ownership, so the pill now
+  // calls `restoreByUser`.)
   // The empty-canvas hero is untouched BY CONSTRUCTION rather than by a second
   // rule: `registerFloatingFocus` is a single module slot and `yieldToFirstUse`
   // already hands it to `FirstUseComposer` there, so no node count is consulted
   // and the "never strand the user with zero composers" invariant cannot move.
   useEffect(() => {
     if (!isOpen || yieldToFirstUse || yieldToDockedOlumi) return
-    if (revealWouldImposeFloating({ isMinimised, source, userRepositioned })) return
+    if (revealWouldImposeFloating({ isMinimised, source, userRepositioned, userChoseFloating })) return
     return registerFloatingFocus(() => {
       const state = useFloatingPanelState.getState()
       if (state.isMinimised) {
@@ -592,7 +598,7 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
         inputBarRef.current?.focus()
       }
     })
-  }, [isOpen, isMinimised, source, userRepositioned, yieldToFirstUse, yieldToDockedOlumi])
+  }, [isOpen, isMinimised, source, userRepositioned, userChoseFloating, yieldToFirstUse, yieldToDockedOlumi])
 
   // Clamp on viewport resize AND on dock resize/open/close so the panel
   // never leaves the visible area and never lands under the dock. The
@@ -913,7 +919,7 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
     pillEl = (
       <button
         type="button"
-        onClick={restore}
+        onClick={restoreByUser}
         className="fixed inline-flex items-center gap-1.5 px-2 py-1 rounded-full bg-panel border border-panel-border shadow-2 hover:bg-panel-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-info"
         style={{
           zIndex: 300,

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -16,6 +16,7 @@ import { useConversationContext } from '../conversation/ConversationContext'
 import { ConversationPanel } from '../conversation/ConversationPanel'
 import {
   useFloatingPanelState,
+  revealWouldImposeFloating,
   type FloatingPanelPosition,
   type FloatingPanelSize,
 } from '../hooks/useFloatingPanelState'
@@ -388,6 +389,11 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
   const isOpen = useFloatingPanelState((s) => s.isOpen)
   const isMinimised = useFloatingPanelState((s) => s.isMinimised)
   const source = useFloatingPanelState((s) => s.source)
+  // Subscribed (not read via getState) because the focus-channel registration
+  // below branches on it: a getState read would not re-run the effect when the
+  // user drags the panel, and the channel would stay deregistered after the
+  // drag made it a user-owned surface again.
+  const userRepositioned = useFloatingPanelState((s) => s.userRepositioned)
   const position = useFloatingPanelState((s) => s.position)
   const size = useFloatingPanelState((s) => s.size)
   const setPosition = useFloatingPanelState((s) => s.setPosition)
@@ -549,8 +555,34 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
   // - When the panel is minimised the input is unmounted; restore first and
   //   schedule the focus on the next frame so React can remount before we
   //   call .focus() on the ref.
+  //
+  // ⭐⭐ AND SKIP WHEN REGISTERING WOULD MAKE THIS CHANNEL LIE (19 Aug 2026 —
+  // UX gate 7a). `revealOlumi`'s doctrine reads this registration as the
+  // surface's OWN STATEMENT THAT IT IS VISIBLE: *"Both floating surfaces
+  // register their focus channel under exactly the condition that makes them
+  // paint."* That sentence was FALSE for one state, and the false case was the
+  // one every fresh user reaches. A minimised panel is mounted at
+  // `display: none` with `isOpen` still true, so it registered — and its
+  // handler then CREATED the surface by calling `restore()`. The reveal
+  // primitive asked "is there a floating surface the user already has?", got
+  // "yes" from a pill, and put a 400x550 window over the model. Trap 21 exactly:
+  // a channel that answers "can I take focus?" read as "am I on screen?".
+  //
+  // So a MINIMISED panel the user never chose does not register, `focusFloating()`
+  // returns false, and `revealOlumiSurface` claims the DOCK — the same end state
+  // as the `Dock to panel` control, which the gate measured taking hidden graph
+  // area 40% → 0% and obscured nodes 9 → 1 at 1280x800.
+  //
+  // The predicate is `revealWouldImposeFloating`, defined once beside
+  // `canAutoDock`; a minimised panel the user OPENED or MOVED is excluded and
+  // still restores here, and the restore branch below stays for exactly that.
+  // The empty-canvas hero is untouched BY CONSTRUCTION rather than by a second
+  // rule: `registerFloatingFocus` is a single module slot and `yieldToFirstUse`
+  // already hands it to `FirstUseComposer` there, so no node count is consulted
+  // and the "never strand the user with zero composers" invariant cannot move.
   useEffect(() => {
     if (!isOpen || yieldToFirstUse || yieldToDockedOlumi) return
+    if (revealWouldImposeFloating({ isMinimised, source, userRepositioned })) return
     return registerFloatingFocus(() => {
       const state = useFloatingPanelState.getState()
       if (state.isMinimised) {
@@ -560,7 +592,7 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
         inputBarRef.current?.focus()
       }
     })
-  }, [isOpen, yieldToFirstUse, yieldToDockedOlumi])
+  }, [isOpen, isMinimised, source, userRepositioned, yieldToFirstUse, yieldToDockedOlumi])
 
   // Clamp on viewport resize AND on dock resize/open/close so the panel
   // never leaves the visible area and never lands under the dock. The

--- a/src/canvas/components/__tests__/revealDoesNotImposeFloating.spec.tsx
+++ b/src/canvas/components/__tests__/revealDoesNotImposeFloating.spec.tsx
@@ -1,0 +1,212 @@
+/**
+ * UX GATE 7a — AN AUTOMATIC REVEAL NO LONGER IMPOSES A FLOATING WINDOW.
+ *
+ * ⚠ WHAT THIS FILE DOES NOT CLAIM (platform trap 3, stated before the
+ * assertions). jsdom runs no CSS layout. Nothing here proves that a docked
+ * conversation stops covering the graph, or that hidden graph area goes
+ * 40% -> 0%. Those are BROWSER claims measured with bounding rects and
+ * hit-tests, and they are carried in the PR. What this file proves is the
+ * WIRING: which surface an automatic reveal fronts, in every ownership state.
+ *
+ * THE DEFECT. After the first draft, `FirstUseComposer` minimises the
+ * transcript-less hero so the model gets the canvas. `isOpen` stays TRUE while
+ * minimised (the panel is kept mounted at `display: none`), so
+ * `FloatingOlumiPanel` still registered the module-level focus channel — and
+ * its handler called `restore()`. `revealOlumiSurface` reads that registration
+ * as "a floating surface is on screen", so from the first draft onward every
+ * automatic reveal (and `withOlumiReveal` wraps EVERY guidance-store send, so
+ * analysis coaching is one) re-opened a 400x550 window over the model. Measured
+ * on the deployed build `4d1e650b` at fit-to-view: 40% / 33% / 28% of the graph
+ * hidden at 1280 / 1440 / 1512.
+ *
+ * ⭐⭐ THE FOUNDER RULING THIS MUST NOT VIOLATE, and the reason half of these
+ * tests exist:
+ *
+ *   > "DO NOT remove floating/concurrent Olumi... FLOATING AND LAYOUT-RESERVING
+ *   > ARE DIFFERENT CONCEPTS... FIX THE COMPOSITION, NOT THE CAPABILITY."
+ *
+ * A suite that only proved "the imposing case now docks" would be a guard
+ * watching one door (trap 22b): it would pass just as happily if the change had
+ * deleted floating altogether. So EVERY case below has its OPPOSITE-DIRECTION
+ * TWIN — for each state that must now dock, a neighbouring state that must
+ * still float, differing in exactly one field.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { act, render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+vi.mock('../../../flags', async (io) => ({
+  ...(await io<Record<string, unknown>>()),
+  isAiPanelV2Enabled: () => true,
+}))
+
+const canvasMockState = {
+  nodes: [{ id: 'n1' }],
+  edges: [] as Array<unknown>,
+  results: { status: 'idle' as const },
+  _internal: {} as Record<string, unknown>,
+  selection: null as null | { id: string; label: string; kind: string },
+  ceeAnalysisReady: null as unknown,
+  graphHealth: null as unknown,
+  runMeta: {} as Record<string, unknown>,
+}
+vi.mock('../../store', () => {
+  const useCanvasStore: any = (selector: (s: any) => any) => selector(canvasMockState)
+  useCanvasStore.getState = () => canvasMockState
+  useCanvasStore.setState = (patch: any) => Object.assign(canvasMockState, patch)
+  useCanvasStore.subscribe = () => () => {}
+  return {
+    useCanvasStore,
+    selectResultsStatus: (s: any) => s.results?.status,
+    selectReport: (s: any) => s.results?.report,
+    selectError: (s: any) => s.results?.error,
+    selectResultsSource: (s: any) => s.results?.source,
+  }
+})
+vi.mock('../../conversation/ConversationPanel', () => ({ ConversationPanel: () => null }))
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({ useStageAwarePlaceholder: () => 'Ask' }))
+vi.mock('../../conversation/useConversation', async () => {
+  const { useState } = await import('react')
+  return {
+    useConversation: () => {
+      const [sendMessage] = useState(() => vi.fn())
+      return {
+        messages: [], isThinking: false, longRunningHint: null, sendMessage,
+        sendSystemEvent: vi.fn(), sendChip: vi.fn(), retryLast: vi.fn(),
+        patchBlockStates: new Map(), setPatchBlockState: vi.fn(),
+        patchRejections: new Map(), setPatchRejection: vi.fn(),
+      }
+    },
+    isNonConversationalContent: () => false,
+  }
+})
+
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { FloatingOlumiPanel } from '../FloatingOlumiPanel'
+import {
+  useFloatingPanelState,
+  canAutoDock,
+  revealWouldImposeFloating,
+  type FloatingPanelSource,
+} from '../../hooks/useFloatingPanelState'
+import { focusFloating } from '../../hooks/useFloatingFocus'
+import { revealOlumiSurface } from '../../conversation/revealOlumi'
+import { useUIStore } from '../../../stores/uiStore'
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ConversationProvider>{children}</ConversationProvider>
+}
+
+/** The state a fresh user is in after their first draft: the system opened the
+ *  hero, the user never touched it, and the post-draft transition minimised it. */
+const IMPOSING = { source: 'system-first-use' as FloatingPanelSource, userRepositioned: false, isMinimised: true }
+
+function mountPanelIn(state: { source: FloatingPanelSource; userRepositioned: boolean; isMinimised: boolean }) {
+  useFloatingPanelState.setState({ isOpen: true, ...state })
+  return render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true })
+  Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true })
+  useFloatingPanelState.getState().reset()
+})
+afterEach(() => {
+  useFloatingPanelState.getState().reset()
+})
+
+describe('revealWouldImposeFloating — the predicate (UX gate 7a)', () => {
+  const SOURCES: FloatingPanelSource[] = ['system-first-use', 'user']
+  const BOOLS = [false, true]
+
+  it('is true for EXACTLY ONE of the eight ownership/visibility states', () => {
+    // Enumerated, not sampled: the whole state space, with the true-set pinned
+    // by identity. A widening of the predicate REDs here rather than silently
+    // taking floating away from a user who chose it.
+    const trueStates: string[] = []
+    for (const source of SOURCES) {
+      for (const userRepositioned of BOOLS) {
+        for (const isMinimised of BOOLS) {
+          if (revealWouldImposeFloating({ source, userRepositioned, isMinimised })) {
+            trueStates.push(`${source}/${userRepositioned ? 'moved' : 'unmoved'}/${isMinimised ? 'minimised' : 'visible'}`)
+          }
+        }
+      }
+    }
+    expect(trueStates).toEqual(['system-first-use/unmoved/minimised'])
+  })
+
+  it('is a DIFFERENT question from canAutoDock — they disagree on a reachable state', () => {
+    // Trap 21: two concepts under similar names is how one fix re-opens
+    // another's defect. This pins that they are not interchangeable, so a later
+    // tidy-up cannot collapse them without a red.
+    const visibleSystemPanel = { source: 'system-first-use' as FloatingPanelSource, userRepositioned: false, isMinimised: false }
+    expect(canAutoDock(visibleSystemPanel)).toBe(true)
+    expect(revealWouldImposeFloating(visibleSystemPanel)).toBe(false)
+  })
+})
+
+describe('the focus channel stops lying about being on screen (UX gate 7a)', () => {
+  it('a minimised, system-opened, never-moved panel does NOT register — so focusFloating() is false', () => {
+    mountPanelIn(IMPOSING)
+    expect(focusFloating()).toBe(false)
+    // ...and nothing restored it. The old handler called restore() here, which
+    // is exactly how the window arrived over the model.
+    expect(useFloatingPanelState.getState().isMinimised).toBe(true)
+  })
+
+  it('and revealOlumiSurface() therefore fronts the DOCK, not a floating window', () => {
+    mountPanelIn(IMPOSING)
+    const spy = vi.spyOn(useUIStore.getState(), 'forceActivateOutputTab')
+    expect(revealOlumiSurface()).toBe(true)
+    expect(spy).toHaveBeenCalledWith('olumi')
+    expect(useFloatingPanelState.getState().isMinimised).toBe(true)
+  })
+
+  // ── OPPOSITE-DIRECTION TWINS: floating is not removed ────────────────────
+  // Each differs from IMPOSING in exactly ONE field, and each must still float.
+
+  it('TWIN (isMinimised): a VISIBLE system panel still registers and is still fronted', () => {
+    mountPanelIn({ ...IMPOSING, isMinimised: false })
+    expect(focusFloating()).toBe(true)
+    const spy = vi.spyOn(useUIStore.getState(), 'forceActivateOutputTab')
+    expect(revealOlumiSurface()).toBe(true)
+    expect(spy, 'a surface the user is looking at must be fronted, never replaced by the dock').not.toHaveBeenCalled()
+  })
+
+  it('TWIN (source): a minimised panel the USER opened still registers and RESTORES to floating', () => {
+    mountPanelIn({ ...IMPOSING, source: 'user' })
+    expect(focusFloating()).toBe(true)
+    expect(useFloatingPanelState.getState().isMinimised, 'the user chose floating — reveal must give it back').toBe(false)
+  })
+
+  it('TWIN (userRepositioned): a minimised panel the user MOVED still registers and RESTORES to floating', () => {
+    mountPanelIn({ ...IMPOSING, userRepositioned: true })
+    expect(focusFloating()).toBe(true)
+    expect(useFloatingPanelState.getState().isMinimised).toBe(false)
+  })
+
+  it('the panel re-registers the moment the user drags it — the effect is subscribed, not snapshotted', () => {
+    // Bound to the real failure mode: reading userRepositioned via getState()
+    // instead of a store subscription leaves the channel deregistered for the
+    // rest of the session after the user makes it theirs. That defect is
+    // invisible to every test above.
+    const { rerender } = mountPanelIn(IMPOSING)
+    expect(focusFloating()).toBe(false)
+    act(() => {
+      useFloatingPanelState.getState().setPosition({ x: 100, y: 100 }) // flips userRepositioned
+    })
+    rerender(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />)
+    expect(focusFloating(), 'a dragged panel is a user-owned surface again').toBe(true)
+  })
+})

--- a/src/canvas/components/__tests__/revealDoesNotImposeFloating.spec.tsx
+++ b/src/canvas/components/__tests__/revealDoesNotImposeFloating.spec.tsx
@@ -45,9 +45,14 @@ vi.mock('../../utils/markdown', () => ({
   renderMarkdown: (s: string) => s,
   sanitiseMarkdown: (s: string) => s,
 }))
+// MUTABLE, not a `vi.fn`: this config sets `mockReset: true`, which in vitest 1.x
+// resets a spy's implementation to `undefined` — a flag mock built as a spy would
+// silently read FALSE in every test after the first. Plain state is immune, and
+// `beforeEach` re-pins the default so the flag-OFF twin cannot leak.
+const flagState = vi.hoisted(() => ({ aiPanelV2: true }))
 vi.mock('../../../flags', async (io) => ({
   ...(await io<Record<string, unknown>>()),
-  isAiPanelV2Enabled: () => true,
+  isAiPanelV2Enabled: () => flagState.aiPanelV2,
 }))
 
 const canvasMockState = {
@@ -137,6 +142,7 @@ function mountPanelIn(state: { source: FloatingPanelSource; userRepositioned: bo
 }
 
 beforeEach(() => {
+  flagState.aiPanelV2 = true
   Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true })
   Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true })
   useFloatingPanelState.getState().reset()
@@ -292,5 +298,33 @@ describe('the focus channel stops lying about being on screen (UX gate 7a)', () 
     })
     rerender(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />)
     expect(focusFloating(), 'a dragged panel is a user-owned surface again').toBe(true)
+  })
+
+  it('TWIN (flag): with aiPanelV2 OFF the imposing cell STILL registers — the dock cannot host Olumi', () => {
+    // ⭐ THE OPPOSITE-DIRECTION TWIN FOR THE *FLAG* AXIS. Every case above runs
+    // with the flag ON, where the dock genuinely hosts Olumi and routing the
+    // imposing cell there is honest. `VITE_FEATURE_AI_PANEL_V2` is set only
+    // under `[context.staging.environment]` (netlify.toml), so OFF is
+    // production and every rollback posture — and there `OutputsDock`
+    // redirects tab 'olumi' -> 'results'. An UNGATED guard would therefore
+    // deregister this channel while nothing else can take it:
+    // `revealOlumiSurface()` returns `focusFloating()` on that branch, so an
+    // automatic reveal would return false HAVING FRONTED NOTHING AT ALL.
+    //
+    // Without this case the guard's flag-dependence is unpinned: a tidy-up
+    // that drops the `isAiPanelV2Enabled()` conjunct at
+    // `FloatingOlumiPanel.tsx` goes fully green. Revert that conjunct and this
+    // test — and only this test — REDs.
+    flagState.aiPanelV2 = false
+    mountPanelIn(IMPOSING)
+    expect(
+      focusFloating(),
+      'flag OFF: the dock cannot host Olumi, so the floating channel must stay registered',
+    ).toBe(true)
+    // ...and the reveal primitive therefore fronts something rather than nothing.
+    expect(
+      revealOlumiSurface(),
+      'flag OFF: reveal must front the floating surface, not return false having fronted nothing',
+    ).toBe(true)
   })
 })

--- a/src/canvas/components/__tests__/revealDoesNotImposeFloating.spec.tsx
+++ b/src/canvas/components/__tests__/revealDoesNotImposeFloating.spec.tsx
@@ -33,7 +33,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import { act, render } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 
 vi.mock('../../../lib/supabase', () => ({
@@ -153,30 +153,67 @@ describe('revealWouldImposeFloating — the predicate (UX gate 7a)', () => {
   const SOURCES: FloatingPanelSource[] = ['system-first-use', 'user']
   const BOOLS = [false, true]
 
-  it('is true for EXACTLY ONE of the eight ownership/visibility states', () => {
-    // Enumerated, not sampled: the whole state space, with the true-set pinned
-    // by identity. A widening of the predicate REDs here rather than silently
-    // taking floating away from a user who chose it.
+  it('is true for EXACTLY ONE of the SIXTEEN ownership/visibility states', () => {
+    // Enumerated, not sampled. `FloatingPanelSource` is a closed two-value
+    // union, so 2x2x2x2 is the WHOLE space and this cannot be short.
+    //
+    // ⚠ IT WAS EIGHT STATES UNTIL THE #786 REVIEW, and the missing axis was the
+    // defect: `userChoseFloating` did not exist, so the cell "user restored it
+    // from the pill, then minimised it again" fell into the imposing bucket and
+    // the product moved their conversation to the dock. An enumeration is only
+    // exhaustive over the axes it knows about.
     const trueStates: string[] = []
     for (const source of SOURCES) {
       for (const userRepositioned of BOOLS) {
         for (const isMinimised of BOOLS) {
-          if (revealWouldImposeFloating({ source, userRepositioned, isMinimised })) {
-            trueStates.push(`${source}/${userRepositioned ? 'moved' : 'unmoved'}/${isMinimised ? 'minimised' : 'visible'}`)
+          for (const userChoseFloating of BOOLS) {
+            if (revealWouldImposeFloating({ source, userRepositioned, isMinimised, userChoseFloating })) {
+              trueStates.push(
+                `${source}/${userRepositioned ? 'moved' : 'unmoved'}/${isMinimised ? 'minimised' : 'visible'}/${userChoseFloating ? 'chosen' : 'not-chosen'}`,
+              )
+            }
           }
         }
       }
     }
-    expect(trueStates).toEqual(['system-first-use/unmoved/minimised'])
+    expect(trueStates).toEqual(['system-first-use/unmoved/minimised/not-chosen'])
   })
 
   it('is a DIFFERENT question from canAutoDock — they disagree on a reachable state', () => {
     // Trap 21: two concepts under similar names is how one fix re-opens
     // another's defect. This pins that they are not interchangeable, so a later
     // tidy-up cannot collapse them without a red.
-    const visibleSystemPanel = { source: 'system-first-use' as FloatingPanelSource, userRepositioned: false, isMinimised: false }
+    const visibleSystemPanel = { source: 'system-first-use' as FloatingPanelSource, userRepositioned: false, isMinimised: false, userChoseFloating: false }
     expect(canAutoDock(visibleSystemPanel)).toBe(true)
     expect(revealWouldImposeFloating(visibleSystemPanel)).toBe(false)
+  })
+
+  it('CELL-9: pill-restore ownership is recorded WITHOUT widening canAutoDock', () => {
+    // The forbidden fix was to make restore() set source:'user' — which would
+    // have flipped canAutoDock too, changing whether the post-draft transition
+    // may reposition the panel. A different question, answered by accident.
+    // This pins that the two moved independently.
+    useFloatingPanelState.getState().open('system-first-use')
+    useFloatingPanelState.getState().minimise()
+    const before = useFloatingPanelState.getState()
+    expect(canAutoDock(before)).toBe(true)
+    expect(revealWouldImposeFloating(before)).toBe(true)
+
+    useFloatingPanelState.getState().restoreByUser()
+    const after = useFloatingPanelState.getState()
+    expect(after.userChoseFloating).toBe(true)
+    expect(after.source, 'source must NOT be rewritten').toBe('system-first-use')
+    expect(after.userRepositioned, 'userRepositioned must NOT be rewritten').toBe(false)
+    expect(canAutoDock(after), 'canAutoDock must be untouched by a pill restore').toBe(true)
+  })
+
+  it("CONTROL: the AUTOMATIC restore() still confers no ownership — that is why the field exists", () => {
+    // The measured fact the review found: restore() sets only isMinimised.
+    // If a later tidy-up merges restoreByUser into restore, this REDs.
+    useFloatingPanelState.getState().open('system-first-use')
+    useFloatingPanelState.getState().minimise()
+    useFloatingPanelState.getState().restore()
+    expect(useFloatingPanelState.getState().userChoseFloating).toBe(false)
   })
 })
 
@@ -218,6 +255,29 @@ describe('the focus channel stops lying about being on screen (UX gate 7a)', () 
     mountPanelIn({ ...IMPOSING, userRepositioned: true })
     expect(focusFloating()).toBe(true)
     expect(useFloatingPanelState.getState().isMinimised).toBe(false)
+  })
+
+  it('CELL-9: a user who CHOSE floating from the pill keeps it after minimising again', () => {
+    // ⭐ THE CELL THE FIRST VERSION OF THIS CHANGE MISSED, driven through the
+    // real control rather than through the store: mount in the imposing state,
+    // CLICK THE PILL, minimise again, and the channel must be back.
+    const { rerender } = mountPanelIn(IMPOSING)
+    expect(focusFloating(), 'precondition: the imposing cell starts dark').toBe(false)
+
+    // The pill is rendered even while the channel is dark — that is what makes
+    // this reachable, and it is the user's only in-place route to floating.
+    const pill = screen.getByTestId('floating-olumi-panel-pill')
+    act(() => { fireEvent.click(pill) })
+    expect(useFloatingPanelState.getState().isMinimised).toBe(false)
+    expect(useFloatingPanelState.getState().userChoseFloating, 'the click IS the choice').toBe(true)
+
+    act(() => { useFloatingPanelState.getState().minimise() })
+    rerender(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />)
+    expect(
+      focusFloating(),
+      'a user who chose floating must not be silently relocated to the dock on the next reveal',
+    ).toBe(true)
+    expect(useFloatingPanelState.getState().isMinimised, 'and the reveal restores it').toBe(false)
   })
 
   it('the panel re-registers the moment the user drags it — the effect is subscribed, not snapshotted', () => {

--- a/src/canvas/components/__tests__/revealDoesNotImposeFloating.spec.tsx
+++ b/src/canvas/components/__tests__/revealDoesNotImposeFloating.spec.tsx
@@ -111,15 +111,39 @@ function Wrapper({ children }: { children: ReactNode }) {
  *  hero, the user never touched it, and the post-draft transition minimised it. */
 const IMPOSING = { source: 'system-first-use' as FloatingPanelSource, userRepositioned: false, isMinimised: true }
 
+/**
+ * Mount the panel in a given ownership/visibility state AND PIN THE
+ * PRECONDITION IN-TEST (trap 13b).
+ *
+ * ⚠ EVERY ASSERTION IN THIS FILE IS VACUOUS UNLESS THE PANEL IS ACTUALLY
+ * MOUNTED AND NOT YIELDING, and that is not hypothetical — it happened while
+ * this file was being written. `FloatingOlumiPanel` also suppresses itself when
+ * the dock hosts Olumi (`yieldToDockedOlumi`), and the
+ * `revealOlumiSurface()` test above leaves `activeOutputTab === 'olumi'` in the
+ * SHARED ui store. Every later test then measured a panel that had yielded, so
+ * `focusFloating()` was false for a reason that had nothing to do with the
+ * predicate under test — a suite that would have gone green the moment the
+ * three twins were deleted. The `beforeEach` reset closes the leak; this
+ * assertion is what makes a future leak RED instead of silent.
+ */
 function mountPanelIn(state: { source: FloatingPanelSource; userRepositioned: boolean; isMinimised: boolean }) {
   useFloatingPanelState.setState({ isOpen: true, ...state })
-  return render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+  const utils = render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+  expect(
+    document.querySelector('[data-testid="floating-olumi-panel"]'),
+    'PRECONDITION: the panel must be mounted and not yielding, or focusFloating() is answering a different question',
+  ).not.toBeNull()
+  return utils
 }
 
 beforeEach(() => {
   Object.defineProperty(window, 'innerWidth', { value: 1280, configurable: true })
   Object.defineProperty(window, 'innerHeight', { value: 800, configurable: true })
   useFloatingPanelState.getState().reset()
+  // The dock tab is REAL product state and is not reset by vitest's mock
+  // hygiene. Leaving it on 'olumi' makes the panel yield — see mountPanelIn.
+  useUIStore.setState({ activeOutputTab: 'results' })
+  sessionStorage.clear()
 })
 afterEach(() => {
   useFloatingPanelState.getState().reset()

--- a/src/canvas/components/olumiSurface.ts
+++ b/src/canvas/components/olumiSurface.ts
@@ -20,6 +20,24 @@
  *
  * Pure + dependency-free → exhaustively unit-tested in
  * `__tests__/olumiSurfaceInvariant.spec.ts`.
+ *
+ * ⚠⚠ THIS MODULE CALLS ITSELF A SINGLE SOURCE OF TRUTH AND IS CURRENTLY DORMANT
+ * — AND IT DISAGREES WITH THE LIVE RULE ON ONE CELL (recorded 19 Aug 2026, at
+ * the #786 review; verified by sweep, positive control `revealOlumiSurface`
+ * → 22 files, contrast control `dockHostsOlumi` → 5 production files, so this
+ * is real absence and not a blind probe). `resolveOlumiSurface` has ZERO
+ * production consumers: one definition, two comment mentions, everything else
+ * is tests. Its sibling `dockHostsOlumi` IS live in five production files.
+ *
+ * The disagreement: `floatingOpen` is fed from the store's `isOpen`, which stays
+ * TRUE while the panel is minimised. So on a populated canvas this function
+ * returns `'floating'` for a minimised, system-opened, never-chosen panel —
+ * exactly the cell `revealWouldImposeFloating` now routes to the DOCK. Nothing
+ * reads it, so nothing is wrong today. **It stops being safe the day someone
+ * wires it.** A lane doing so must first decide whether `floatingOpen` means
+ * "mounted" or "on screen", and reconcile with
+ * `useFloatingPanelState.revealWouldImposeFloating` — not silently adopt this
+ * answer because the header says single source of truth.
  */
 
 import type { OutputTab } from '../../stores/uiStore'

--- a/src/canvas/conversation/revealOlumi.ts
+++ b/src/canvas/conversation/revealOlumi.ts
@@ -41,10 +41,33 @@ import { focusDockedOlumi } from './dockedOlumiFocus'
  * ⭐ The test for "is a floating/hero composer on screen?" is
  * `focusFloating()`'s OWN RETURN VALUE, and that is deliberate. Both floating
  * surfaces register their focus channel under exactly the condition that makes
- * them paint — `FloatingOlumiPanel` under `isOpen && !yieldToFirstUse &&
- * !yieldToDockedOlumi`, `FirstUseComposer` under its `shouldRender` — and
- * both deregister on cleanup. So a registration IS the surface's own statement
- * that it is visible, taken from the surface itself.
+ * them paint — `FirstUseComposer` under its `shouldRender`,
+ * `FloatingOlumiPanel` under `isOpen && !yieldToFirstUse && !yieldToDockedOlumi
+ * && !revealWouldImposeFloating(...)` — and both deregister on cleanup. So a
+ * registration IS the surface's own statement that it is visible, taken from
+ * the surface itself.
+ *
+ * ⚠⚠ THAT SENTENCE WAS FALSE FOR ONE STATE UNTIL 19 AUG 2026, AND IT WAS THE
+ * STATE EVERY FRESH USER REACHED (UX gate point 7a). A MINIMISED floating panel
+ * is kept mounted at `display: none` with `isOpen` still true, so it registered
+ * while showing nothing but a pill — and its handler CREATED the surface by
+ * calling `restore()`. This function therefore asked "is there a floating
+ * surface the user already has?", was told "yes" by a pill, and returned
+ * without ever considering the dock. From the first draft onward — the
+ * post-draft transition minimises the transcript-less hero — EVERY automatic
+ * reveal in the session re-opened a 400x550 window over the model, including
+ * the coaching sends that `withOlumiReveal` wraps. Measured at fit-to-view on
+ * the deployed build `4d1e650b`: 40% / 33% / 28% of the graph hidden at
+ * 1280 / 1440 / 1512.
+ *
+ * The fix is at the surface, not here: `FloatingOlumiPanel` no longer registers
+ * when the panel is minimised AND system-opened AND never moved
+ * (`revealWouldImposeFloating`), so `focusFloating()` returns false and the
+ * branch below claims the dock — the same end state as the `Dock to panel`
+ * control. **The doctrine did not change; the oracle was made to answer the
+ * question the doctrine asks.** A panel the user opened, moved, or is currently
+ * looking at still registers and is still fronted here, unchanged: floating is
+ * not being removed, only stopped from being imposed.
  *
  * The alternative was to re-derive visibility here from the canvas node count,
  * the dock's persisted open-state and the active tab. That would be a SECOND

--- a/src/canvas/hooks/useFloatingPanelState.ts
+++ b/src/canvas/hooks/useFloatingPanelState.ts
@@ -23,6 +23,23 @@ export interface FloatingPanelState {
   /** Minimised: collapses to a small restore pill at the panel's current
    *  position. Distinct from `!isOpen` which fully unmounts. */
   isMinimised: boolean
+  /**
+   * THE USER HAS DELIBERATELY CHOSEN THIS FLOATING SURFACE — a THIRD ownership
+   * fact, deliberately not folded into either of the other two.
+   *
+   * `source` records who OPENED the panel. `userRepositioned` records whether
+   * they MOVED it. Neither is true of the one remaining way a user can choose
+   * floating: clicking the restore pill on a panel the system opened. That
+   * click is an explicit choice and nothing recorded it — see `restoreByUser`.
+   *
+   * ⚠ THE OBVIOUS FIX IS THE WRONG ONE. Making `restore()` set
+   * `source: 'user'` would ALSO widen `canAutoDock`, silently changing whether
+   * the post-draft transition may reposition the panel — a different question,
+   * answered by accident. That is exactly the trap-21 collision
+   * `revealWouldImposeFloating`'s own header warns about, so this is a separate
+   * field read by exactly one predicate.
+   */
+  userChoseFloating: boolean
   /** Top-left position. null = compute on first open (centred on canvas). */
   position: FloatingPanelPosition | null
   /** Current panel size. */
@@ -41,8 +58,14 @@ export interface FloatingPanelState {
   toggle: () => void
   /** Collapse to the restore pill — preserves position/size/source/draft. */
   minimise: () => void
-  /** Restore from the pill back to the full panel. */
+  /** Restore from the pill back to the full panel. AUTOMATIC path — confers no
+   *  ownership. Used by the focus channel when it restores a panel the user
+   *  already owns. */
   restore: () => void
+  /** Restore because the USER clicked the pill. Same visual effect as
+   *  `restore`, plus the ownership `restore` cannot confer. The pill is the
+   *  only caller. */
+  restoreByUser: () => void
   /** Commit a final position after a pointer drag. Sets userRepositioned. */
   setPosition: (pos: FloatingPanelPosition) => void
   /** Commit a final size after a pointer resize. Sets userRepositioned. */
@@ -67,11 +90,12 @@ export interface FloatingPanelState {
 
 const DEFAULT_SIZE: FloatingPanelSize = { width: 400, height: 550 }
 
-const INITIAL: Pick<FloatingPanelState, 'isOpen' | 'userRepositioned' | 'source' | 'isMinimised' | 'position' | 'size' | 'isAutoRepositioning'> = {
+const INITIAL: Pick<FloatingPanelState, 'isOpen' | 'userRepositioned' | 'source' | 'isMinimised' | 'userChoseFloating' | 'position' | 'size' | 'isAutoRepositioning'> = {
   isOpen: false,
   userRepositioned: false,
   source: 'user',
   isMinimised: false,
+  userChoseFloating: false,
   position: null,
   size: DEFAULT_SIZE,
   isAutoRepositioning: false,
@@ -87,15 +111,17 @@ let _autoRepositionClearId: number | null = null
 
 export const useFloatingPanelState = create<FloatingPanelState>((set, get) => ({
   ...INITIAL,
-  open: (source) => set({ isOpen: true, source, userRepositioned: false, isMinimised: false }),
-  close: () => set({ isOpen: false, isMinimised: false }),
+  open: (source) =>
+    set({ isOpen: true, source, userRepositioned: false, isMinimised: false, userChoseFloating: false }),
+  close: () => set({ isOpen: false, isMinimised: false, userChoseFloating: false }),
   toggle: () => {
     const cur = get()
-    if (cur.isOpen) set({ isOpen: false, isMinimised: false })
-    else set({ isOpen: true, source: 'user', userRepositioned: false, isMinimised: false })
+    if (cur.isOpen) set({ isOpen: false, isMinimised: false, userChoseFloating: false })
+    else set({ isOpen: true, source: 'user', userRepositioned: false, isMinimised: false, userChoseFloating: false })
   },
   minimise: () => set({ isMinimised: true }),
   restore: () => set({ isMinimised: false }),
+  restoreByUser: () => set({ isMinimised: false, userChoseFloating: true }),
   setPosition: (position) => set({ position, userRepositioned: true }),
   setSize: (size) => set({ size, userRepositioned: true }),
   setInitialPosition: (position) =>
@@ -205,17 +231,39 @@ export function canAutoDock(state: Pick<FloatingPanelState, 'source' | 'userRepo
  * > DIFFERENT CONCEPTS… FIX THE COMPOSITION, NOT THE CAPABILITY."
  *
  * Floating stays fully available and fully functional. Only the mode an
- * AUTOMATIC reveal opens in changes. Every user-owned state is excluded by the
- * predicate itself and still restores to floating:
- *   - `source === 'user'`  — opened from the chevron, the tab, or a float-out;
- *   - `userRepositioned`   — dragged or resized, i.e. positioned by choice;
- *   - `!isMinimised`       — already on screen, so it IS the surface the user
- *                            has, and a reveal must front it (`revealOlumi`).
- * The pill's own `onClick={restore}` is untouched, so floating is one click
- * away at all times, and the dock's float-out control is unchanged.
+ * AUTOMATIC reveal opens in changes. Four ownership facts exclude a panel, and
+ * each is a distinct way a user can say "I chose this":
+ *   - `source === 'user'`      — opened from the chevron, the tab, or a float-out;
+ *   - `userRepositioned`       — dragged or resized, i.e. positioned by choice;
+ *   - `userChoseFloating`      — restored from the pill (see below);
+ *   - `!isMinimised`           — already on screen, so it IS the surface the
+ *                                user has, and a reveal must front it.
+ *
+ * ⭐⭐ THE FOURTH FACT EXISTS BECAUSE THE FIRST VERSION OF THIS PREDICATE HAD A
+ * NINTH CELL AND I DID NOT ENUMERATE IT (adversarial review of #786). This
+ * header used to claim *"every user-owned state is excluded by the predicate
+ * itself"*. **THAT WAS FALSE**, and false in the direction that costs the
+ * capability the founder ruling protects. `restore()` sets only
+ * `isMinimised: false` — measured — so a user who clicked the pill (an explicit
+ * choice of floating) and later minimised it again was re-classified as
+ * system-imposed: the channel went dark and the next automatic reveal moved
+ * their conversation to the dock. `restoreByUser` records the choice the click
+ * always was.
+ *
+ * ⚠ AND THE SENTENCE THAT REPLACED IT MUST BE NARROWER, because the pill does
+ * NOT survive a dock claim. Once the reveal claims the dock,
+ * `yieldToDockedOlumi` unmounts the panel and `OutputsDock`'s close-effect
+ * calls `close()` — measured: `pillPresent=false, panelPresent=false`. So the
+ * honest statement is: **for a panel the user has chosen, floating is one click
+ * away on the pill at all times; for the un-chosen system panel this predicate
+ * docks, the pill is gone and the route back is the dock's float-out control**
+ * (`floatOutToWindow` → `open('user')`, which excludes the panel permanently
+ * thereafter). That is the same end state as the `Dock to panel` control the
+ * gate measured, and it is the intended one — but it is not "one click away",
+ * and saying so would be the confident wrongness this estate keeps paying for.
  */
 export function revealWouldImposeFloating(
-  state: Pick<FloatingPanelState, 'source' | 'userRepositioned' | 'isMinimised'>,
+  state: Pick<FloatingPanelState, 'source' | 'userRepositioned' | 'isMinimised' | 'userChoseFloating'>,
 ): boolean {
-  return state.isMinimised && canAutoDock(state)
+  return state.isMinimised && !state.userChoseFloating && canAutoDock(state)
 }

--- a/src/canvas/hooks/useFloatingPanelState.ts
+++ b/src/canvas/hooks/useFloatingPanelState.ts
@@ -165,3 +165,57 @@ export const useFloatingPanelState = create<FloatingPanelState>((set, get) => ({
 export function canAutoDock(state: Pick<FloatingPanelState, 'source' | 'userRepositioned'>): boolean {
   return state.source === 'system-first-use' && !state.userRepositioned
 }
+
+/**
+ * WOULD FRONTING THE FLOATING PANEL PUT A WINDOW ON SCREEN THAT THE USER NEVER
+ * CHOSE? (19 Aug 2026 — UX gate point 7a.)
+ *
+ * ⚠ THIS IS A DIFFERENT QUESTION FROM `canAutoDock`, AND THE TWO MUST NOT BE
+ * COLLAPSED (platform trap 21 — two concepts under similar names is how one
+ * fix re-opens another's defect). `canAutoDock` asks whether the post-draft
+ * transition MAY MOVE OR MINIMISE the panel without overriding a user choice.
+ * This asks whether an AUTOMATIC REVEAL may RESTORE it. They share the
+ * ownership half on purpose — one definition of "the system opened this and
+ * the user has never touched it", so the two cannot drift — and diverge on the
+ * half that decides this one: whether the panel is currently OUT OF SIGHT.
+ *
+ * ── THE DEFECT THIS CLOSES ────────────────────────────────────────────────
+ *
+ * After the first draft, `FirstUseComposer` minimises the transcript-less hero
+ * to the pill so the model gets the canvas. `isOpen` stays TRUE while minimised
+ * (the panel is kept mounted at `display: none`). `FloatingOlumiPanel`'s focus
+ * channel registers on `isOpen`, and its handler calls `restore()`. So from
+ * that moment every automatic reveal — and `withOlumiReveal` wraps EVERY
+ * guidance-store send, so analysis coaching is one — re-opened a full 400x550
+ * window over the graph. The user never chose floating; the product chose it
+ * for them, once, and then for the rest of the session.
+ *
+ * Measured on the deployed build `4d1e650b`, fresh guest, at fit-to-view:
+ * 40% / 33% / 28% of the graph hidden at 1280 / 1440 / 1512, 9 of 14 nodes
+ * obscured at 1280, and the node carrying the product's own "Leading option"
+ * badge 58% covered before the user had done anything. Its position confirms
+ * the mechanism arithmetically: the gate measured `x=436, y=240`, which is
+ * exactly `performReposition`'s bottom-right anchor computed while the dock was
+ * expanded (`1280 - 428 - 400 - 16` and `800 - 544 - 16`) — i.e. the panel the
+ * user saw was the MINIMISED hero, restored at the anchor it was minimised from.
+ *
+ * ── WHAT THIS DOES NOT DO (founder ruling, do not violate) ────────────────
+ *
+ * > "DO NOT remove floating/concurrent Olumi… FLOATING AND LAYOUT-RESERVING ARE
+ * > DIFFERENT CONCEPTS… FIX THE COMPOSITION, NOT THE CAPABILITY."
+ *
+ * Floating stays fully available and fully functional. Only the mode an
+ * AUTOMATIC reveal opens in changes. Every user-owned state is excluded by the
+ * predicate itself and still restores to floating:
+ *   - `source === 'user'`  — opened from the chevron, the tab, or a float-out;
+ *   - `userRepositioned`   — dragged or resized, i.e. positioned by choice;
+ *   - `!isMinimised`       — already on screen, so it IS the surface the user
+ *                            has, and a reveal must front it (`revealOlumi`).
+ * The pill's own `onClick={restore}` is untouched, so floating is one click
+ * away at all times, and the dock's float-out control is unchanged.
+ */
+export function revealWouldImposeFloating(
+  state: Pick<FloatingPanelState, 'source' | 'userRepositioned' | 'isMinimised'>,
+): boolean {
+  return state.isMinimised && canAutoDock(state)
+}

--- a/src/canvas/utils/computeFitPadding.ts
+++ b/src/canvas/utils/computeFitPadding.ts
@@ -54,16 +54,47 @@
  * the model — 33% / 18% / 12% behind it at 1280 / 1440 / 1512, with header
  * controls answering 3 of 4 hit probes inside it.
  *
- * ⚠ WHY THIS IS NOT THE RESERVATION THE HEADER BELOW ABOLISHES. The rule is
- * unchanged and is the discriminator: **ONLY EDGE-ANCHORED, LAYOUT-RESERVING
- * CHROME CONTRIBUTES.** The floating conversation panel is free-floating,
- * user-movable and dismissible, so "how much does it occlude" has no single
- * answer and clearing it cost a `cheapestClearance` band of 392px / 52% of the
- * fit box. The top bar is anchored to one edge, is not movable, is not
- * dismissible, and has exactly one answer — `bar.bottom - flow.top` — the same
- * predicate the dock and the sidebar already use. The cost is bounded and small:
- * top goes 29px → 73px at 800px of pane, 5.5% of the vertical, against 52%.
- * A future lane must apply the same test before adding a contributor here.
+ * ⚠ WHY THIS IS NOT THE RESERVATION THE HEADER BELOW ABOLISHES — AND THE FOUR
+ * CRITERIA A CONTRIBUTOR MUST MEET, stated as a test rather than a slogan.
+ *
+ * The short rule used to read "only EDGE-ANCHORED, LAYOUT-RESERVING chrome
+ * contributes". ⚠ **"LAYOUT-RESERVING" IS THE WRONG WORD AND ALWAYS WAS**
+ * (adversarial review, 19 Aug 2026): all three contributors are
+ * `position: fixed` and none of them reserves layout in the CSS sense — they
+ * are overlays, and what this function does is buy the graph back the canvas
+ * they permanently sit on. A contributor qualifies only if ALL FOUR hold:
+ *
+ *   1. **EDGE-ANCHORED** — pinned to the side it reserves from, so "how much
+ *      does it occlude" has exactly one answer.
+ *   2. **NOT USER-MOVABLE** — that answer cannot change under the user's hand.
+ *   3. **NOT DISMISSIBLE** — the user cannot clear it, so the cost is not a
+ *      charge for something they could remove.
+ *   4. **PERSISTENT — present whenever the canvas is.** ⭐ ADDED BY REVIEW, and
+ *      it is not hypothetical: the reviewer swept every `position: fixed` rule
+ *      in `src/` and found **`ValidationChip`** (`fixed; bottom: 1rem;
+ *      right: 1rem; z-1000`) passes 1-3 — edge-anchored, non-movable, and with
+ *      no dismiss control — while being a transient corner chip that must never
+ *      move the camera. Criteria 1-3 alone ADMIT IT.
+ *
+ * The floating conversation panel fails 1, 2 and 3, so "how much does it
+ * occlude" has no single answer and clearing it cost a `cheapestClearance` band
+ * of 392px / 52% of the fit box. The top bar passes all four, and its cost is
+ * bounded and small: top goes 29px → 73px at 800px of pane, 5.5% of the
+ * vertical, against 52%.
+ *
+ * ⚠ AND THE APPROXIMATION, STATED RATHER THAN DISCOVERED LATER: a rectangular
+ * inset is a FULL BAND, and two of the three contributors do not span the edge
+ * they reserve from — the LeftSidebar is 227px of an 800px edge, the top bar
+ * 514.6px of a 1280px one. So this over-reserves on the part of the edge they
+ * do not cover. That is a deliberate conservative approximation (the alternative
+ * vocabulary — per-region insets — does not exist in `fitView`), it is what the
+ * dock and sidebar have always done, and it is only defensible while the amount
+ * stays small. It is a reason to keep the contributor set SHORT, not a reason to
+ * reach for `cheapestClearance` again.
+ *
+ * Criteria 1-4 are **REVIEW-ONLY** — no mechanism can decide "persistent" or
+ * "dismissible" from the bytes. What IS mechanised is that the set cannot grow
+ * without someone applying them: see `FIT_PADDING_CONTRIBUTORS` below.
  *
  * ⭐⭐ THE STATED RULE, added 18 Aug 2026: **ONLY EDGE-ANCHORED, LAYOUT-RESERVING
  * CHROME CONTRIBUTES.** The OutputsDock and the LeftSidebar are edge-anchored, so
@@ -140,6 +171,30 @@ const GAP = 16
  * asserts the element this selector finds IS it, and that it is unique.
  */
 export const TOP_BAR_SELECTOR = '[role="banner"]'
+/** The OutputsDock (rail when collapsed, panel when expanded). */
+export const DOCK_SELECTOR = 'aside[aria-label="Outputs dock"]'
+/** The LeftSidebar ("Canvas tools"). */
+export const SIDEBAR_SELECTOR = 'nav[aria-label="Canvas tools"]'
+
+/**
+ * THE DECLARED CONTRIBUTOR SET — the whole of it, and the only thing standing
+ * between this function and the reservation it exists to have abolished.
+ *
+ * G2a (the padding-invariance guard) names three floating-panel selectors and
+ * therefore only catches a re-admission spelled those three ways. This set is
+ * the general case: `computeFitPadding.contributorSet.spec.ts` reads THIS FILE'S
+ * BYTES, extracts every selector actually reached by `rectOf(...)` inside
+ * `computeFitPadding`, and asserts the two sets are equal. A lane adding ANY
+ * fourth occluder — by any selector — REDs it and must either declare it here,
+ * having applied criteria 1-4 above, or not add it.
+ *
+ * ⚠ WHAT THIS CANNOT DO (trap 12d): it proves the code and this list AGREE. It
+ * cannot prove the list is RIGHT — that is criteria 1-4, and they are
+ * review-only. Deriving a guard from a list moves the risk; it does not remove
+ * it. The same spec also asserts this function reaches for no store, so a
+ * contributor smuggled in as state rather than as a rect REDs too.
+ */
+export const FIT_PADDING_CONTRIBUTORS = [DOCK_SELECTOR, SIDEBAR_SELECTOR, TOP_BAR_SELECTOR] as const
 /** Never let combined per-axis padding exceed this fraction of the pane (keeps a fitting area). */
 const MAX_PADDING_FRACTION = 0.8
 
@@ -208,13 +263,13 @@ export function computeFitPadding(flowEl?: Element | null): FitPadding {
     // Right edge — OutputsDock (rail when collapsed, full panel when expanded).
     // Overlap = flowRect.right − dock.left, so it naturally includes the dock's
     // own right gap (the dock is positioned `right: 12`).
-    const dock = rectOf('aside[aria-label="Outputs dock"]')
+    const dock = rectOf(DOCK_SELECTOR)
     if (dock) {
       const overlap = Math.max(0, flowRect.right - dock.left)
       if (overlap > 0) right = Math.max(right, overlap + GAP)
     }
     // Left edge — LeftSidebar ("Canvas tools").
-    const sidebar = rectOf('nav[aria-label="Canvas tools"]')
+    const sidebar = rectOf(SIDEBAR_SELECTOR)
     if (sidebar) {
       const overlap = Math.max(0, sidebar.right - flowRect.left)
       if (overlap > 0) left = Math.max(left, overlap + GAP)
@@ -235,9 +290,17 @@ export function computeFitPadding(flowEl?: Element | null): FitPadding {
     // ⭐ NOTHING ELSE CONTRIBUTES. The floating conversation panel, its side tab
     // and its minimised pill are read here NOWHERE — deliberately, and see the
     // header for the 392px this gives back and for why `cameraComfort` still
-    // observes the panel. A future lane adding a free-floating occluder to this
-    // function REDs the padding-invariance guard (G2a). The three that DO
-    // contribute are each anchored to the edge they reserve from.
+    // observes the panel.
+    //
+    // ⚠ THE OLD SENTENCE HERE OVERCLAIMED, AND IT OVERCLAIMED ABOUT A GUARD, so
+    // it taught readers to stop checking (adversarial review, 19 Aug 2026). It
+    // said *"a future lane adding a free-floating occluder to this function REDs
+    // the padding-invariance guard (G2a)"*. **G2a is three hardcoded selector
+    // strings** — a re-admission under any OTHER selector, or via the store,
+    // stays green. A hand-maintained mirror inside the guard written to prevent
+    // one. The true scope: G2a REDs a re-admission of the panel BY THOSE THREE
+    // SELECTORS. What catches the general case is the structural guard over
+    // `FIT_PADDING_CONTRIBUTORS`, which is derived from these bytes.
   }
 
   // Defensive clamp: never reserve so much padding that the pane is left with no

--- a/src/canvas/utils/computeFitPadding.ts
+++ b/src/canvas/utils/computeFitPadding.ts
@@ -36,6 +36,35 @@
  * like FloatingOlumiPanel.measureDockInset), so it stays correct if the canvas
  * is offset or embedded.
  *
+ * ⭐⭐ THE TOP BAR IS AN OCCLUDER, AND THIS FUNCTION USED TO SAY IT WAS NOT
+ * (19 Aug 2026 — UX gate point 7b). The comment on the `top`/`bottom` branch
+ * below read *"Top bar sits above `.react-flow` in the flex layout, so it never
+ * overlaps the flow rect"*. **That was false at the deployed tip.** `TopBar`
+ * has been a FLOATING PILL since the Miro-style header landed:
+ * `position: fixed; top: 12px; left: 12px; height: 45px; z-index: 3000`
+ * (`TopBar.module.css:1-19`), and `.react-flow` is the full window.
+ *
+ * Derived live on the deployed build `4d1e650b`, fresh guest, 1280x800:
+ * `[role="banner"]` = `{left 12, top 12, right 526.6, bottom 57}`, `.react-flow`
+ * = `{left 0, top 0, right 1280, bottom 800}`. So the bar overlaps the flow rect
+ * by **57px** while this function reserved the 29px base margin — a fitted graph's
+ * top row lands UNDER the bar BY CONSTRUCTION. At z-3000 over a z-0 canvas it is
+ * not merely obscured but unclickable: `elementFromPoint` inside the bar returns
+ * the bar's own controls. The UX gate measured the Decision node — the anchor of
+ * the model — 33% / 18% / 12% behind it at 1280 / 1440 / 1512, with header
+ * controls answering 3 of 4 hit probes inside it.
+ *
+ * ⚠ WHY THIS IS NOT THE RESERVATION THE HEADER BELOW ABOLISHES. The rule is
+ * unchanged and is the discriminator: **ONLY EDGE-ANCHORED, LAYOUT-RESERVING
+ * CHROME CONTRIBUTES.** The floating conversation panel is free-floating,
+ * user-movable and dismissible, so "how much does it occlude" has no single
+ * answer and clearing it cost a `cheapestClearance` band of 392px / 52% of the
+ * fit box. The top bar is anchored to one edge, is not movable, is not
+ * dismissible, and has exactly one answer — `bar.bottom - flow.top` — the same
+ * predicate the dock and the sidebar already use. The cost is bounded and small:
+ * top goes 29px → 73px at 800px of pane, 5.5% of the vertical, against 52%.
+ * A future lane must apply the same test before adding a contributor here.
+ *
  * ⭐⭐ THE STATED RULE, added 18 Aug 2026: **ONLY EDGE-ANCHORED, LAYOUT-RESERVING
  * CHROME CONTRIBUTES.** The OutputsDock and the LeftSidebar are edge-anchored, so
  * "how much do they occlude" has exactly one answer and the caller reserves it on
@@ -102,6 +131,15 @@
 const BASE_RATIO = 0.08
 /** Breathing gap between the graph and an occluding panel edge. */
 const GAP = 16
+/**
+ * The floating TopBar pill, spelled ONCE. `role="banner"` is the page's header
+ * LANDMARK and there is exactly one in the app (`TopBar.tsx:209` is the only
+ * `role="banner"` in `src/`) — so this binds to the bar by identity rather than
+ * by a class name or a position predicate another fixed element could satisfy.
+ * Pinned by `topBarFitInset.dom.spec.tsx`, which renders the real `TopBar` and
+ * asserts the element this selector finds IS it, and that it is unique.
+ */
+export const TOP_BAR_SELECTOR = '[role="banner"]'
 /** Never let combined per-axis padding exceed this fraction of the pane (keeps a fitting area). */
 const MAX_PADDING_FRACTION = 0.8
 
@@ -159,8 +197,10 @@ export function computeFitPadding(flowEl?: Element | null): FitPadding {
 
   let right = baseX
   let left = baseX
-  // Top bar sits above `.react-flow` in the flex layout, so it never overlaps
-  // the flow rect — top/bottom keep the base margin.
+  // Bottom keeps the base margin: nothing is anchored to the bottom edge of the
+  // canvas. `top` is resolved against the floating top bar below — see the
+  // header for why the old claim on this line ("the top bar never overlaps the
+  // flow rect") was false at the deployed tip.
   let top = baseY
   let bottom = baseY
 
@@ -179,12 +219,25 @@ export function computeFitPadding(flowEl?: Element | null): FitPadding {
       const overlap = Math.max(0, sidebar.right - flowRect.left)
       if (overlap > 0) left = Math.max(left, overlap + GAP)
     }
+    // Top edge — the floating TopBar pill (`role="banner"`, the header landmark).
+    // MEASURED, NEVER NAMED AS A NUMBER: the bar's height is a CSS value that has
+    // already moved once, and `--topbar-h` is a hand-maintained mirror of it
+    // (`TopBar.tsx` writes the literal '57px' next to the comment "12px top + 45px
+    // height"). Reading the live rect is the same derivation the dock and the
+    // sidebar use, and it is the one that stays true when the bar's height,
+    // padding or offset changes.
+    const topBar = rectOf(TOP_BAR_SELECTOR)
+    if (topBar) {
+      const overlap = Math.max(0, topBar.bottom - flowRect.top)
+      if (overlap > 0) top = Math.max(top, overlap + GAP)
+    }
 
     // ⭐ NOTHING ELSE CONTRIBUTES. The floating conversation panel, its side tab
     // and its minimised pill are read here NOWHERE — deliberately, and see the
     // header for the 392px this gives back and for why `cameraComfort` still
     // observes the panel. A future lane adding a free-floating occluder to this
-    // function REDs the padding-invariance guard (G2a).
+    // function REDs the padding-invariance guard (G2a). The three that DO
+    // contribute are each anchored to the edge they reserve from.
   }
 
   // Defensive clamp: never reserve so much padding that the pane is left with no

--- a/src/canvas/utils/reservedBoxWatcher.ts
+++ b/src/canvas/utils/reservedBoxWatcher.ts
@@ -13,10 +13,23 @@
  * THE SIGNAL IS DERIVED, NOT MIRRORED (CLAUDE.md trap 12). This watcher does not
  * keep a list of "things that change the reserved box" and hope it stays
  * current — it recomputes `computeFitPadding()` and compares the result. A
- * trigger that fires spuriously costs three `getBoundingClientRect` calls and
- * changes nothing; a trigger we failed to think of degrades to the previous
- * behaviour (no re-fit), never to a wrong fit. The triggers are therefore
- * allowed to be approximate, and the decision never is.
+ * trigger that fires spuriously costs four `getBoundingClientRect` calls and
+ * changes nothing (⚠ it was three until the floating top bar became a
+ * contributor on 19 Aug 2026 — a hand-maintained count, corrected at review);
+ * a trigger we failed to think of degrades to the previous behaviour (no
+ * re-fit), never to a wrong fit. The triggers are therefore allowed to be
+ * approximate, and the decision never is.
+ *
+ * ⚠ BUT "DEGRADES TO NO RE-FIT" IS STICKY, AND THERE IS A NAMED HOLE (recorded
+ * at the #786 review rather than left to be discovered). None of the triggers
+ * fires when a `position: fixed` OVERLAY MOUNTS: the `ResizeObserver` watches
+ * `.react-flow`, whose box does not change when something is painted on top of
+ * it. So if the top bar is not yet measurable at fit time, `max(0, ...)` yields
+ * the old base margin and nothing later notices. The top bar mounts with the
+ * route, ahead of the canvas, so this is not reachable today — but it is pinned
+ * as a VALUE test ("the padding is 73px given this rect"), never as a RECOVERY
+ * test ("the padding self-corrects after the rect appears"), and the difference
+ * is exactly what would be missed.
  *
  * The trigger set, each with its reason:
  *  - `resize` on window — the viewport itself changed.

--- a/src/components/layout/__tests__/topBarFitInsetIdentity.dom.spec.tsx
+++ b/src/components/layout/__tests__/topBarFitInsetIdentity.dom.spec.tsx
@@ -1,0 +1,63 @@
+/**
+ * UX GATE 7b — THE SELECTOR THE FIT FRAME USES POINTS AT THE REAL TOP BAR.
+ *
+ * `computeFitPadding` reserves the top edge by measuring
+ * `document.querySelector(TOP_BAR_SELECTOR)`. `topBarFitInset.spec.ts` proves
+ * the ARITHMETIC against a stubbed rect; it cannot prove the selector finds the
+ * bar a user actually sees. Without this file the whole 7b fix could be
+ * measuring nothing and every test would still be green — platform trap 13 (an
+ * absence/presence probe with no positive control) reached through a selector.
+ *
+ * IDENTITY BINDING (trap 19): the assertion is not "some element matched". It
+ * is that the matched element IS the rendered `TopBar` — the one carrying the
+ * single model-name control this bar owns — and that it is UNIQUE, so the
+ * `querySelector` (which silently takes the first match) cannot drift onto a
+ * different landmark.
+ *
+ * jsdom proves the binding, never the geometry (trap 3): `position: fixed` and
+ * the 45px height come from CSS that jsdom does not run, so nothing here
+ * asserts a pixel. The live rect is recorded in `topBarFitInset.spec.ts`.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { TopBar } from '../TopBar'
+import { ToastProvider } from '../../../canvas/ToastContext'
+import { TOP_BAR_SELECTOR } from '../../../canvas/utils/computeFitPadding'
+
+function renderTopBar() {
+  return render(
+    <MemoryRouter>
+      <ToastProvider>
+        <TopBar
+          scenarioTitle="Pricing model 2025"
+          onTitleChange={vi.fn()}
+          onSave={vi.fn()}
+          onShare={vi.fn()}
+        />
+      </ToastProvider>
+    </MemoryRouter>,
+  )
+}
+
+describe('TOP_BAR_SELECTOR binds to the rendered TopBar (UX gate 7b)', () => {
+  // Ordered FIRST on purpose: it must observe a document this file has not
+  // rendered into, so it cannot depend on RTL's afterEach cleanup running.
+  it('CONTRAST CONTROL: with no TopBar rendered, the selector finds nothing', () => {
+    expect(document.querySelector(TOP_BAR_SELECTOR)).toBeNull()
+  })
+
+  it('finds exactly one element, and it is the TopBar itself', () => {
+    renderTopBar()
+
+    const matches = document.querySelectorAll(TOP_BAR_SELECTOR)
+    expect(matches.length, 'querySelector takes the FIRST match — a second banner would silently redirect the fit inset').toBe(1)
+
+    const bar = matches[0] as HTMLElement
+    // Identity, not "an element exists": the bar is the ancestor of the single
+    // model-name control it owns. A different landmark picking up role="banner"
+    // would fail here rather than quietly becoming the fit occluder.
+    expect(bar.contains(screen.getByTestId('scenario-name-button'))).toBe(true)
+  })
+
+})


### PR DESCRIPTION
## UX GATE point 7 — the chat panel and the header pill stop covering the model

Closes both halves of the gate's worst failure. **No new UI. Floating Olumi is not removed, not
disabled, and not made unreachable** — only the mode an *automatic* reveal opens in changes.

### The four orientation questions, answered first

**(a) Canonical authority for the conversation panel's presentation mode.**
`src/canvas/conversation/revealOlumi.ts` — the convergence primitive every Ask-Olumi, chip, coaching
and rerun action funnels through, including `withOlumiReveal`, which wraps every guidance-store send.
Its rule is *"reveal the surface the user ALREADY HAS; claim the dock only when no Olumi composer is
on screen"*, and its oracle is `focusFloating()`'s return value. `olumiSurface.ts`
(`resolveOlumiSurface`) is the sibling authority for *which surface is visible*; it has **no production
consumers** (verified repo-wide) and is untouched here.

**(b) Canonical authority for the canvas fit viewport.**
`src/canvas/utils/computeFitPadding.ts`. Its stated rule — **only edge-anchored, layout-reserving
chrome contributes** — is unchanged and is the discriminator this PR turns on.

**(c) What this deletes or supersedes.** Nothing is deleted. Two false statements are superseded:
1. `computeFitPadding`'s comment *"Top bar sits above `.react-flow` in the flex layout, so it never
   overlaps the flow rect"*. **False at the deployed tip** — `TopBar` is a fixed pill.
2. `revealOlumi`'s doctrine sentence *"a registration IS the surface's own statement that it is
   visible"*. **False for the minimised case** — the doctrine was right, the oracle did not implement
   it. The fix makes the sentence true rather than changing it.
`cheapestReservation`'s successor `cheapestClearance` (in `cameraComfort.ts`) is **not** reintroduced
into layout. `canAutoDock` is **not** widened.

**(d) Known inverse/mirror failure this must avoid.** `cheapestReservation` — a fix in this family
that turned a free-floating overlay into a full-height reserved column because the only vocabulary
available was rectangular edge insets. See "the lead question" below.

---

### 7b — the fit frame now clears the header pill

`TopBar` is `position: fixed; top: 12px; left: 12px; height: 45px; z-index: 3000`
(`TopBar.module.css:1-19`) painted over a full-window `.react-flow`. Derived **live on the deployed
build `4d1e650b5d3314f1fb4e2279f1bee917206047d8`**, fresh guest, `/#/canvas`, 1280×800:

| element | rect | |
|---|---|---|
| `[role="banner"]` | `left 12, top 12, right 526.6, bottom 57` | fixed, **z-3000**, exactly one in the document |
| `.react-flow` | `left 0, top 0, right 1280, bottom 800` | relative, **z-0** |
| `aside[aria-label="Outputs dock"]` | `left 852` → overlap 428 | |

So the bar overlaps the flow rect by **57px** while the function reserved the **29px** base margin:
a fitted graph's top row lands under the bar **by construction**, and at z-3000 over z-0 it is not
merely obscured but unclickable (`elementFromPoint` at (300,30) and (100,40) returns `_topBarCenter_`
/ `_topBarLeft_`, and at (500,20) the `Account menu` button — the canvas is beneath).

**The change:** the bar contributes `max(0, bar.bottom − flow.top) + GAP` on the side it is anchored
to — the identical predicate the dock and the sidebar already use. Top goes **29px → 73px**.
**Derived from the live rect, never from `--topbar-h`**, which `TopBar.tsx:101` writes as the literal
string `'57px'` beside the comment "12px top + 45px height" — a hand-maintained mirror of a CSS value.

**Layout authority untouched.** No change to `layout.ts`, row packing, node positions or
`nodeLayoutConstants`. This is a camera/fit inset only, which is the mechanism R1 permits.

### 7a — an automatic reveal no longer imposes a floating window

After the first draft, `FirstUseComposer` minimises the transcript-less hero so the model gets the
canvas. **`isOpen` stays `true` while minimised** (the panel is kept mounted at `display: none`), so
`FloatingOlumiPanel` still registered the module-level focus channel — and its handler called
`restore()`. `revealOlumiSurface` read that registration as "a floating surface is on screen", so from
the first draft onward **every** automatic reveal re-opened a 400×550 window over the model.

The mechanism is confirmed arithmetically against the gate's own measurement: it recorded the panel at
`x=436, y=240`, which is exactly `performReposition`'s bottom-right anchor computed while the dock was
expanded — `1280 − 428 − 400 − 16 = 436` and `800 − 544 − 16 = 240`, with `REPOSITION_EDGE_MARGIN = 16`
and the dock overlap 428 measured live above. The window the user saw **was the minimised hero,
restored at the anchor it was minimised from.**

**The change:** `FloatingOlumiPanel` does not register the focus channel when
`revealWouldImposeFloating({ isMinimised, source, userRepositioned })` — minimised **and**
system-opened **and** never moved. `focusFloating()` then returns false and `revealOlumiSurface`
claims the dock: the same end state as the `Dock to panel` control, which the gate measured taking
hidden graph area **40% → 0%** and obscured nodes **9 → 1** at 1280×800.

**Floating is not removed.** Every user-owned state is excluded by the predicate and still floats:
`source === 'user'`, `userRepositioned`, and `!isMinimised` (a panel on screen IS the surface the user
has, and a reveal must front it). The pill's `onClick={restore}` and the dock's float-out are
untouched. `userRepositioned` is **subscribed**, not snapshotted, so the channel returns the moment
the user drags the panel.

The predicate is defined once beside `canAutoDock` and documented as a **different question** (trap
21): `canAutoDock` asks whether the post-draft transition may *move or minimise* the panel; this asks
whether an automatic reveal may *restore* it. They share the ownership half deliberately, so the two
cannot drift.

The empty-canvas "never strand the user with zero composers" invariant is preserved **by
construction, not by a second rule**: `registerFloatingFocus` is a single module slot and
`yieldToFirstUse` already hands it to `FirstUseComposer` there, so no node count is consulted.

---

### ⭐ The lead question: is this fix another instance of the class it removes?

The class is *"a panel's mere existence consumes canvas the user needs"*. **No — and the
discriminator is executable, not rhetorical.**

| | the removed reservation | the top bar |
|---|---|---|
| anchored | free-floating, user-draggable | fixed to one edge |
| dismissible | yes (close / minimise) | no |
| "how much does it occlude?" | no single answer → `cheapestClearance` band | exactly one: `bar.bottom − flow.top` |
| cost at 1280×800 | **392px, 52% of the fit box** | **44px, 5.5% of the vertical** |

The executable half: **G2a's floating-panel padding-invariance is re-run with the bar present**, over
four real panel positions × three of its selectors, asserting the padding changes by exactly zero.
Adding an edge-anchored contributor must not re-admit the free-floating one, and mutant **M3** (which
re-admits it) REDs that test.

---

### Evidence

**RED-first at pristine `4d1e650b`** — throwaway worktree at an absolute path **outside the repo
root**, isolation proven by a **sentinel WRITE** (distinct inodes `666725715` vs `667355501`; source
tail unchanged after writing `MUTATED` into the worktree copy; source `git status` empty). Restores
come from a **pristine archive outside the tree**, never `git checkout --` (trap 9h).
**9 of 16 RED**, named: `expected '29px' to be '73px'` · `expected [ '29px','29px','29px' ] to deeply
equal [ '73px','92px','124px' ]` · `baseline must be the real 1280x800 reservation, header included` ·
`revealWouldImposeFloating is not a function` (×2) · `expected true to be false` (×2) ·
`expected "forceActivateOutputTab" to be called with arguments: [ 'olumi' ]` · `expected +0 to be 1`.
The 7 green at pristine are the correct ones — the three opposite-direction twins and the
unchanged-behaviour cases. Applied-check scoped to `src/` = **3**, control = **0**.

**Mutants — 7/7 bite**, each with applied-check = 1, control 0 before and after, trailing control 16/16.

| # | mutation | red |
|---|---|---|
| M1 | delete the top-bar branch | 3 |
| M2 | **hardcode `57`** instead of measuring | 2 — and the deployed-geometry test stays **GREEN** |
| M3 | re-admit the floating panel as a reservation | 1 (the invariance test) |
| M4 | remove the reveal guard | 3 |
| M5 | **drop the `isMinimised` conjunct** | 3 — incl. the *visible-panel* twin |
| M6 | **drop the ownership half** | 4 — incl. the *user-opened* and *user-moved* twins |
| M7 | snapshot `userRepositioned` instead of subscribing | 1 |

Three discriminating pairs, not just biting mutants:
- **M2** proves the "DERIVES the amount" test binds to the *derivation* — a hardcoded 57 passes the
  deployed-geometry assertion and fails only that one.
- **M5 / M6** have **disjoint red sets**: widening the predicate REDs the visible-panel twin, narrowing
  it REDs the user-owned twins. Neither conjunct can move silently, in either direction — which is the
  guard against this being a fix that quietly takes floating away.

**Suites.** 16 new tests, all asserted **by name** with a non-zero expected count (6 + 2 + 8), run
with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported.
One defect found and fixed in my own harness: `revealOlumiSurface()` leaves `activeOutputTab='olumi'`
in the **shared** ui store, which makes the panel yield to the docked composer — so every later test
was reading `focusFloating() === false` for a reason unrelated to the predicate. It was caught by the
twins, not by the passing tests. `beforeEach` now resets it and `mountPanelIn` **pins the precondition
in-test** so a future leak REDs instead of going quiet.

**Named gate:** `bash scripts/ci/typecheck-gate.sh` → **PASSED** (3532/3572 files, ratchet 2263 vs
baseline 2272). It emits `::notice:: Drift shrank — tighten it with --update-baseline`; **declined** —
the 9 are not attributable to the four source files this PR touches. ESLint clean on all seven changed
files.

### ⚠ UNMEASURED — the MOUNTED acceptance is a post-deploy step

**jsdom cannot prove visibility or occlusion, and nothing in this PR claims it does.** The following is
**not yet witnessed** and can only be run after this deploys:

> Deployed build, fresh guest, at **1280 / 1440 / 1512**, after a completed analysis:
> hidden graph area **0%**, the Decision node **hit-testable at all four probe points**, and the
> floating mode still reachable and still floating when chosen.

Also unmeasured: the live post-fix fit transform. My browser probe on `4d1e650b` established the
**preconditions** (banner geometry, z-order, flow rect, hit-test blockade, dock overlap) on a
**hydrated guest** canvas at 100% zoom — a different state class from the gate's fresh post-analysis
fit, and it is reported as such rather than as a reproduction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

### Regression evidence — 282 spec files, 3,084 tests, green

Ran the whole `src/canvas/__tests__`, `src/canvas/components/__tests__`,
`src/canvas/hooks/__tests__` and `src/components/layout/__tests__` trees at branch tip
`e4d4a429`, from a clean working tree that was unmodified for the duration (the mutant and
pristine-comparison worktrees are separate checkouts elsewhere on disk).

```
Test Files  282 passed (282)
     Tests  3084 passed | 15 skipped (3099)
  Duration  1114.85s     [exited with code 0]
```

**The manifest is complete and derived, not inferred from the aggregate** (a total says nothing about
a file it never collected). `find` reports **283** spec files across those four directories; vitest's
config excludes exactly one of them (`ReactFlowGraph.layout.dom.spec.tsx`), and there are **zero**
iCloud `<n>` conflict copies to account for. 283 − 1 = **282**, which is the number the run reports —
so every collectable spec in those trees ran, with none silently dropped.

R1's `layoutViewportIndependence.guard`, `computeFitPadding.spec.ts` (including G2a),
`cameraComfort.floatingCompanion`, `olumiSurfaceInvariant`, all three `FloatingOlumiPanel` specs,
`FirstUseComposer`, `PersistentInputStrip` and `useFloatingPanelState` are all inside that set and
all green.

**One order-dependent spec, pre-existing, worth recording.**
`OutputsDock.conversationSingleton.spec.tsx` is **green in the batch above** — the configuration CI
actually runs — but fails when executed as a single file. Measured isolated with the identical
command, in a throwaway worktree for the pristine arm:

| run, isolated | failed | passed |
|---|---|---|
| pristine `4d1e650b` | **4** | 8 |
| this branch | **3** | 9 |

So it is not this PR's: it is red at pristine too, and *more* red there. The failing test names at
this tip are a **strict subset** of pristine's — no test fails here that passes at `4d1e650b`.
(`docked-tab float-out switches active tab AND opens floating` flips red → green in the isolated arm;
not investigated, and not claimed as a fix.) The isolation sensitivity is recorded, not repaired —
it is out of this lane's scope.
