### PR TITLE
fix(analysis): the evidence check stops claiming an all-clear it has no authority for, and the answer stops sitting below the fold

### DIFF
--- a/e2e/geometry/analysisAnswerFirst.measure.ts
+++ b/e2e/geometry/analysisAnswerFirst.measure.ts
@@ -17,20 +17,40 @@
  * path) + a REAL captured CEE analysis turn replayed through `applyV5State`,
  * the same entry point `useConversation` uses. No hand-written report.
  *
- * ⚠ AND WHAT THIS IS NOT. The deployed defect was measured with a THIN BRIEF
- * (the user's typed brief had no success measure), which force-expanded the
- * overview card to its full body — that is how the verdict reached 573px in a
- * 515px region. The five committed starters all carry a success measure, so
- * they render the card's `ready` state and this harness CANNOT reproduce the
- * thin-brief geometry (`e2e/visual/states.visual.spec.ts` records the same
- * class of gap for completed analysis generally). The captured turns whose
- * state DOES read thin carry option ids that match no starter graph, so the
- * hero does not mount for them — measured, both ways.
+ * ── ⚠ WHY THE REPLAY IS TRIMMED, AND WHY THE FIRST VERSION MEASURED NOTHING ─
+ * The deployed defect was measured with a THIN BRIEF (the user's typed brief
+ * had no success measure), which force-expanded the overview card to its full
+ * body — that is how the verdict reached 573px in a 515px region.
  *
- * So this file measures the OFFSET the collapse removes and the resulting hero
- * position in the state it CAN reach truthfully. The thin-brief above-the-fold
- * claim is settled on the deployed build, not here, and is reported as such
- * rather than being manufactured from a fixture written to produce it.
+ * The first version of this file replayed the capture UNTRIMMED and was a
+ * NON-DISCRIMINATING CONTROL with respect to the change it was written for.
+ * Derived, not guessed: the capture's `analysis_ready.status` is `'ready'` and
+ * it carries `goal_threshold_raw: 1000000`, so `computeSuccessState` branch 2
+ * fires, `successIsSet` is true and `liveState` is `'ready'`. At PRISTINE
+ * (`autoExpand = state !== 'ready' && state !== 'unassessed'`) that is already
+ * `false`, and after the fix it is `false` too — so all three assertions below
+ * passed at pristine and the measured furniture offset was not attributable to
+ * the diff.
+ *
+ * (The header used to explain the same shortfall by saying the five committed
+ * starters "all carry a success measure". That is not what happens here:
+ * `build-vs-buy`'s goal node carries NO threshold and its own `analysis_ready`
+ * carries none either — the measure arrives ONLY from the replayed capture. The
+ * reason mattered, because it is what makes the trim below possible.)
+ *
+ * So the replay now DROPS `goal_threshold_raw` and `goal_threshold_unit` from
+ * `analysis_ready`, and nothing else. `status` stays `'ready'` (so the state is
+ * not `needs_input`) and the normalised `goal_threshold: 0.8` stays, so this is
+ * the product's own real value-scale degradation case: a threshold present on
+ * the wire but not displayable ⇒ `displayText: null` ⇒ `liveState: 'thin'`.
+ * That is a state pristine WOULD auto-expand and the fix collapses, so the
+ * numbers below now measure the change. The precondition is PINNED on screen
+ * (the thin copy) rather than assumed — a run that silently landed back in
+ * `ready` would otherwise report a comfortable number about nothing.
+ *
+ * It remains a REPLAY, not the deployed thin-brief journey: the brief text is
+ * the starter's, and the above-the-fold claim for a genuinely typed thin brief
+ * is settled on the deployed build, not here.
  *
  * ── PRECONDITIONS ARE PINNED, NOT HOPED FOR (trap 13b) ─────────────────────
  * A run in which the hero never mounted would otherwise report a comfortable
@@ -85,7 +105,20 @@ for (const vp of VPS) {
     await clearNotifications(page)
     await minimiseFloatingOlumiPanel(page).catch(() => {})
 
-    const envelope = JSON.parse(readFileSync(CAPTURE, 'utf8'))
+    const raw = JSON.parse(readFileSync(CAPTURE, 'utf8'))
+    // ⚠ The ONLY modification to the captured turn, and it is a DELETION of two
+    // keys — never a substitution. See the header: with them present the state
+    // is `ready`, which pristine already collapses, and this file measures a
+    // difference the change did not make.
+    const { goal_threshold_raw: _raw, goal_threshold_unit: _unit, ...analysisReadyThin } = raw.analysis_ready
+    const envelope = { ...raw, analysis_ready: analysisReadyThin }
+    // Assert the trim landed on the object we think it did — a rename upstream
+    // would otherwise leave this file silently replaying the untrimmed capture.
+    expect(
+      'goal_threshold_raw' in raw.analysis_ready && !('goal_threshold_raw' in envelope.analysis_ready),
+      'the capture must carry goal_threshold_raw and the replay must not',
+    ).toBe(true)
+    expect(envelope.analysis_ready.status, 'status must stay ready — this is a thin measure, not a blocked run').toBe('ready')
     const applied = await page.evaluate(async (env) => {
       // Resolved by the BROWSER against Vite's dev module graph — the same
       // applicator `useConversation` calls on a real turn.
@@ -114,6 +147,14 @@ for (const vp of VPS) {
     // PRECONDITION: the verdict is actually on screen. Without this the
     // measurement below is a comfortable number about an absent component.
     await expect(page.getByTestId('hero-headline')).toBeVisible({ timeout: 20_000 })
+    // PRECONDITION: the card is in the `thin` state — the state pristine
+    // auto-expands. Without this pin a run that landed back in `ready` would
+    // report the same comfortable numbers while measuring nothing, which is
+    // exactly what the untrimmed version of this file did.
+    await expect(
+      page.getByText('Framing needs one clarification'),
+      'the replay must reach the thin state, or this file is measuring a state pristine already collapsed',
+    ).toBeVisible({ timeout: 20_000 })
 
     const m = await page.evaluate(() => {
       const dock = document.querySelector('[data-testid="outputs-dock"]') as HTMLElement
@@ -136,6 +177,10 @@ for (const vp of VPS) {
         // Identity of the collapsed state + proof the content is still offered.
         subCardsExpanded: document.querySelector('[data-testid="brief-dim-goal"]') !== null,
         disclosure: toggle?.getAttribute('aria-expanded') ?? null,
+        // Recorded in the output line so the state class is in the artefact,
+        // not only in an assertion that has already passed.
+        briefState: (document.querySelector('[data-testid="decision-overview"]')?.textContent ?? '')
+          .includes('Framing needs one clarification') ? 'thin' : 'other',
         evidenceCheck: (document.querySelector('[data-testid="checks-evidence"]')?.textContent ?? '').trim(),
       }
     })

--- a/e2e/geometry/analysisAnswerFirst.measure.ts
+++ b/e2e/geometry/analysisAnswerFirst.measure.ts
@@ -52,6 +52,22 @@
  * the starter's, and the above-the-fold claim for a genuinely typed thin brief
  * is settled on the deployed build, not here.
  *
+ * ── WHAT THE TRIM BOUGHT, MEASURED (19 Aug 2026, local Chromium) ───────────
+ * The same file, run twice, differing ONLY in `DecisionOverviewCard`'s
+ * `autoExpand` (the PR's one-line change, reverted in place as a mutant and
+ * restored HEAD-relative):
+ *
+ *   pristine  overview h=282  hero.top=536  subCardsExpanded=true   → 2 FAILED
+ *   fixed     overview h=135  hero.top=389  subCardsExpanded=false  → 2 passed
+ *
+ * ⚠ STATED PRECISELY, because two of the three gate assertions discriminate
+ * and one does NOT: `subCardsExpanded` and `disclosure` flip, and they are why
+ * the pristine arm REDs. `hero.top < fold` passes in BOTH arms here
+ * (536 < 586 at 1280x800 — 91% of the fold, i.e. barely). This replayed thin
+ * state is not the deployed typed-thin-brief that put the verdict at 573px in
+ * a 515px region, so the above-the-fold assertion remains a floor this
+ * harness cannot exercise adversarially. Do not read it as the evidence.
+ *
  * ── PRECONDITIONS ARE PINNED, NOT HOPED FOR (trap 13b) ─────────────────────
  * A run in which the hero never mounted would otherwise report a comfortable
  * number about a component that is not on screen (trap 3b). Both anchors are

--- a/e2e/geometry/analysisAnswerFirst.measure.ts
+++ b/e2e/geometry/analysisAnswerFirst.measure.ts
@@ -1,0 +1,155 @@
+/**
+ * ANSWER FIRST — a real-browser MEASUREMENT of where the Analysis panel puts
+ * the result relative to the framing furniture above it.
+ *
+ * WHY IT EXISTS: jsdom cannot prove "above the fold" — that is layout
+ * (CLAUDE.md trap 3). The unit specs pin the COLLAPSE
+ * (`DecisionOverviewCard.answerFirst.spec.tsx`); this pins its GEOMETRY, in
+ * real Chromium, at real viewports, against a real captured analysis turn.
+ *
+ * ⚠ RUN IT DELIBERATELY, it is not in any gate:
+ *     pnpm exec playwright test -c playwright.geometry.config.ts
+ * `*.measure.ts`, never `*.spec.ts`, so the main e2e config cannot collect it
+ * into a run with no dev server on its port.
+ *
+ * ── STATE CLASS, STATED HONESTLY (the fixture rule) ────────────────────────
+ * FRESH session, real starter draft (`applyDraftResult`, the product's own
+ * path) + a REAL captured CEE analysis turn replayed through `applyV5State`,
+ * the same entry point `useConversation` uses. No hand-written report.
+ *
+ * ⚠ AND WHAT THIS IS NOT. The deployed defect was measured with a THIN BRIEF
+ * (the user's typed brief had no success measure), which force-expanded the
+ * overview card to its full body — that is how the verdict reached 573px in a
+ * 515px region. The five committed starters all carry a success measure, so
+ * they render the card's `ready` state and this harness CANNOT reproduce the
+ * thin-brief geometry (`e2e/visual/states.visual.spec.ts` records the same
+ * class of gap for completed analysis generally). The captured turns whose
+ * state DOES read thin carry option ids that match no starter graph, so the
+ * hero does not mount for them — measured, both ways.
+ *
+ * So this file measures the OFFSET the collapse removes and the resulting hero
+ * position in the state it CAN reach truthfully. The thin-brief above-the-fold
+ * claim is settled on the deployed build, not here, and is reported as such
+ * rather than being manufactured from a fixture written to produce it.
+ *
+ * ── PRECONDITIONS ARE PINNED, NOT HOPED FOR (trap 13b) ─────────────────────
+ * A run in which the hero never mounted would otherwise report a comfortable
+ * number about a component that is not on screen (trap 3b). Both anchors are
+ * asserted before anything is measured.
+ *
+ * Output: one `ANSWERFIRST {...}` line per viewport on stdout.
+ */
+import { test, expect } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { repoRoot } from '../visual/repoRoot'
+import type { Page } from '@playwright/test'
+import {
+  openCanvas,
+  preparePage,
+  seedStarterDraft,
+  clearNotifications,
+  minimiseFloatingOlumiPanel,
+} from '../visual/harness'
+
+/** A real captured CEE analysis turn (2026-08-04), replayed unmodified. */
+const CAPTURE = join(repoRoot(), 'src/v5/__tests__/fixtures/live-analysis-turn-walkA-2026-08-04.json')
+const STARTER = 'build-vs-buy' as const
+const VPS = [
+  { width: 1280, height: 800 },
+  { width: 1440, height: 900 },
+]
+
+/**
+ * ⚠ COLD-START, MEASURED: the FIRST test in a run can outlast `openCanvas`'s
+ * 30s wait while Vite dev-compiles the canvas chunk — the page is still on its
+ * "Loading Canvas..." route loader. That produced a failure whose snapshot
+ * contained no app at all, which must never be read as a layout finding. One
+ * reload and retry, then fail for real.
+ */
+async function openCanvasWarm(page: Page): Promise<void> {
+  try {
+    await openCanvas(page)
+  } catch {
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await openCanvas(page)
+  }
+}
+
+for (const vp of VPS) {
+  test(`ANSWER FIRST @${vp.width}x${vp.height}`, async ({ page }) => {
+    await preparePage(page, vp)
+    await openCanvasWarm(page)
+    const seeded = await seedStarterDraft(page, STARTER)
+    expect(seeded.nodeCount, 'build-vs-buy is 19 nodes; a different count means the fixture drifted').toBe(19)
+    await clearNotifications(page)
+    await minimiseFloatingOlumiPanel(page).catch(() => {})
+
+    const envelope = JSON.parse(readFileSync(CAPTURE, 'utf8'))
+    const applied = await page.evaluate(async (env) => {
+      // Resolved by the BROWSER against Vite's dev module graph — the same
+      // applicator `useConversation` calls on a real turn.
+      // Held in a VARIABLE, not a literal: this path exists only as a Vite
+      // dev-server URL, and a string literal here is a TS2307 (the shared
+      // harness documents the same remedy for `seedStarterDraft`).
+      const modulePath = '/src/v5/applyV5State.ts'
+      const mod = (await import(/* @vite-ignore */ modulePath)) as {
+        applyV5State: (r: unknown, s: unknown, o: unknown) => { applied: string[] }
+      }
+      const w = window as unknown as { useCanvasStore: { getState: () => Record<string, unknown> } }
+      const snap = w.useCanvasStore.getState()
+      return mod.applyV5State(
+        env,
+        { ...snap, currentResultsHash: (snap.results as { hash?: string } | null)?.hash ?? null, backfillGoalThreshold: () => {} },
+        { turnClientId: 'measure', currentClientTurnId: 'measure' },
+      )
+    }, envelope)
+    expect(applied.applied.length, 'applyV5State applied nothing — the turn did not land').toBeGreaterThan(0)
+
+    // Tolerant NAVIGATION (results is the default tab); the strict checks are
+    // the two visibility preconditions below, which fail loud if it is not.
+    const resultsTab = page.getByTestId('outputs-dock-tab-results')
+    if (await resultsTab.count()) await resultsTab.click().catch(() => {})
+    await expect(page.getByTestId('decision-overview')).toBeVisible({ timeout: 20_000 })
+    // PRECONDITION: the verdict is actually on screen. Without this the
+    // measurement below is a comfortable number about an absent component.
+    await expect(page.getByTestId('hero-headline')).toBeVisible({ timeout: 20_000 })
+
+    const m = await page.evaluate(() => {
+      const dock = document.querySelector('[data-testid="outputs-dock"]') as HTMLElement
+      let sc: HTMLElement = dock
+      for (const el of [...dock.querySelectorAll('*')] as HTMLElement[]) {
+        if (el.scrollHeight > el.clientHeight + 40 && /auto|scroll/.test(getComputedStyle(el).overflowY)) { sc = el; break }
+      }
+      const r = sc.getBoundingClientRect()
+      const at = (k: string) => {
+        const e = document.querySelector(`[data-testid="${k}"]`) as HTMLElement | null
+        if (!e) return null
+        const b = e.getBoundingClientRect()
+        return { top: Math.round(b.top - r.top + sc.scrollTop), h: Math.round(b.height) }
+      }
+      const toggle = document.querySelector('[data-testid="brief-bar"]')
+      return {
+        fold: sc.clientHeight,
+        overview: at('decision-overview'),
+        heroHeadline: at('hero-headline'),
+        // Identity of the collapsed state + proof the content is still offered.
+        subCardsExpanded: document.querySelector('[data-testid="brief-dim-goal"]') !== null,
+        disclosure: toggle?.getAttribute('aria-expanded') ?? null,
+        evidenceCheck: (document.querySelector('[data-testid="checks-evidence"]')?.textContent ?? '').trim(),
+      }
+    })
+
+    const hero = m.heroHeadline!
+    const pct = Math.round((hero.top / m.fold) * 100)
+    // eslint-disable-next-line no-console
+    console.log(`ANSWERFIRST ${JSON.stringify({ vp: vp.width, ...m, heroPctOfFold: pct, aboveFold: hero.top < m.fold })}`)
+
+    // The one claim this file is willing to make as a GATE, in the state it
+    // can reach truthfully: with the furniture collapsed, the verdict is on
+    // the first screenful.
+    expect(hero.top, `verdict at ${hero.top}px in a ${m.fold}px region (${pct}%)`).toBeLessThan(m.fold)
+    expect(m.subCardsExpanded, 'the framing sub-cards must not be holding the first screenful').toBe(false)
+    expect(m.disclosure, 'the collapsed card must still offer its content').toBe('false')
+  })
+}

--- a/src/canvas/components/utils/__tests__/postAnalysisFooter.spec.ts
+++ b/src/canvas/components/utils/__tests__/postAnalysisFooter.spec.ts
@@ -11,6 +11,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
+import { everyEvidenceGapAddressed } from '@/components/results/utils/evidenceGapConfidenceDisplay'
 import { derivePostFooterStatus, derivePostFooterMeta } from '../postAnalysisFooter'
 import type { PostFooterMetaInput } from '../postAnalysisFooter'
 import type { RobustnessDisplayVerdict } from '@/components/results/types'
@@ -180,14 +181,93 @@ describe('derivePostFooterMeta — F7: the "{N}% stability" numeric segment is r
     ).toBeNull()
   })
 
-  it('treats non-numeric review-card confidence as ok (no false "Evidence gaps remain", no stability)', () => {
+  /**
+   * ⭐ CORRECTED — this test used to assert 'Evidence strong' for exactly this
+   * input, and it was pinning the defect rather than a behaviour.
+   *
+   * `useResultsSectionData` maps a gap with no stated `confidence` to `null`
+   * DELIBERATELY, and `evidenceGapConfidenceDisplay`'s contract is that
+   * "Callers must SUPPRESS the figure and anything derived from it". The old
+   * predicate (`some(g => typeof g.confidence === 'number' && g.confidence < 50)`)
+   * derived from it anyway: unstated was "not weak", so the footer printed an
+   * all-clear — "Evidence strong" — about gaps whose strength the producer had
+   * never stated. "No false 'Evidence gaps remain'" was the wrong thing to
+   * protect; the false claim was in the other direction.
+   *
+   * The gaps are real producer findings and none of them is known to be
+   * addressed, so "Evidence gaps remain" is the licensed reading.
+   */
+  it('never says "Evidence strong" about gaps whose confidence the producer never stated', () => {
     expect(
       derivePostFooterMetaWithForcedStability({
         stability: 0.95,
         robustnessVerdict: 'robust',
         reviewCards: [{ confidence: undefined }, { confidence: null }],
       }),
+    ).toBe('Evidence gaps remain')
+  })
+
+  /**
+   * CONTROL — the fix is "stop minting an all-clear", NOT "delete the
+   * all-clear". Every gap stated at or above the threshold still earns it.
+   */
+  it('still says "Evidence strong" when EVERY gap carries a stated confidence >= 50', () => {
+    expect(
+      derivePostFooterMetaWithForcedStability({
+        stability: 0.95,
+        robustnessVerdict: 'robust',
+        reviewCards: [{ confidence: 50 }, { confidence: 90 }],
+      }),
     ).toBe('Evidence strong')
+  })
+
+  /** A single unstated gap in an otherwise strong list is enough to withdraw it. */
+  it('one unstated confidence in a strong list withdraws the all-clear', () => {
+    expect(
+      derivePostFooterMetaWithForcedStability({
+        stability: 0.95,
+        robustnessVerdict: 'robust',
+        reviewCards: [{ confidence: 90 }, { confidence: null }],
+      }),
+    ).toBe('Evidence gaps remain')
+  })
+
+  /**
+   * A non-finite number is not a stated figure either — `NaN`/`Infinity` are
+   * the shapes a `?? 0`-style fabrication leaves behind, and
+   * `resolveEvidenceGapConfidenceDisplay` already refuses them.
+   */
+  it('a non-finite confidence is not a stated figure', () => {
+    expect(
+      derivePostFooterMetaWithForcedStability({
+        stability: 0.95,
+        robustnessVerdict: 'robust',
+        reviewCards: [{ confidence: Number.NaN }],
+      }),
+    ).toBe('Evidence gaps remain')
+  })
+
+  /**
+   * ⭐ CROSS-SURFACE SINGLE PREDICATE (correction 3). This footer and the
+   * results panel's "What we checked" tick are fed the SAME list by
+   * `OutputsDock`, and they used to carry byte-identical copies of the same
+   * defective predicate. They now share ONE, so a change to it cannot fix one
+   * surface and leave the other lying.
+   */
+  it('agrees with the results-panel predicate on every confidence state', () => {
+    const cases: Array<{ confidence: number | null | undefined }> = [
+      { confidence: undefined }, { confidence: null }, { confidence: Number.NaN },
+      { confidence: 0 }, { confidence: 49 }, { confidence: 50 }, { confidence: 90 },
+    ]
+    for (const c of cases) {
+      const meta = derivePostFooterMetaWithForcedStability({
+        stability: 0.95, robustnessVerdict: 'robust', reviewCards: [c],
+      })
+      expect(
+        meta === 'Evidence strong',
+        `confidence=${String(c.confidence)} → footer said "${meta}"`,
+      ).toBe(everyEvidenceGapAddressed([c]))
+    }
   })
 
   it('no determinate verdict + any stability + no cards → null (stability alone can never render)', () => {

--- a/src/canvas/components/utils/postAnalysisFooter.ts
+++ b/src/canvas/components/utils/postAnalysisFooter.ts
@@ -48,8 +48,9 @@
  *   - the producer's `robustnessVerdictReason` — leading segment, VERBATIM
  *     (producer-owned display phrase; never authored in the UI, never shown
  *     without its verdict)
- *   - "Evidence gaps remain" — appended when any review-card confidence < 50%
- *   - "Evidence strong"      — appended when there are gaps AND none weak
+ *   - "Evidence strong"      — appended ONLY when there are gaps AND every one
+ *     of them carries a STATED confidence at or above the addressed threshold
+ *   - "Evidence gaps remain" — appended otherwise, when there are gaps
  *   - omitted entirely when there are no review cards at all
  *
  * The Lucide icon is supplied by name (`'check' | 'warning' | 'unknown'`)
@@ -58,6 +59,7 @@
  */
 
 import type { RobustnessDisplayVerdict } from '@/components/results/types'
+import { everyEvidenceGapAddressed } from '@/components/results/utils/evidenceGapConfidenceDisplay'
 
 export type PostFooterIcon = 'check' | 'warning' | 'unknown'
 
@@ -171,10 +173,27 @@ export function derivePostFooterMeta({
     robustnessVerdict === 'moderate' ||
     robustnessVerdict === 'fragile' ||
     robustnessVerdict === 'not_assessed'
-  const evidenceWeak = reviewCards.some(g => typeof g.confidence === 'number' && g.confidence < 50)
+  // ⭐ NO ALL-CLEAR WITHOUT AUTHORITY — THE CROSS-SURFACE TWIN.
+  //
+  // This used to read
+  //   `reviewCards.some(g => typeof g.confidence === 'number' && g.confidence < 50)`
+  // — byte-for-byte the predicate `TriageActionCardsBody` used for its
+  // "Evidence covered" tick, on a DIFFERENT surface (`results-analysis-footer`)
+  // fed from the SAME list (`OutputsDock` passes
+  // `confidence.topEvidenceGaps ?? confidence.evidenceGaps ?? []` to both).
+  //
+  // Two-valued over a three-valued input: a gap whose confidence the producer
+  // NEVER STATED is `null` by design, so it was not "weak", so it was
+  // "Evidence strong" — an all-clear minted from a silence. A defect fixed on
+  // one surface and left on its twin is the same defect, and this estate's
+  // chronic failure is precisely the same predicate living under two names.
+  //
+  // So there is now ONE predicate, imported, not a second copy that happens to
+  // agree today: `everyEvidenceGapAddressed` — which is also what the results
+  // panel's tick and its "N of M addressed" counter are derived from.
   const evidenceText = reviewCards.length === 0
     ? null
-    : (evidenceWeak ? 'Evidence gaps remain' : 'Evidence strong')
+    : (everyEvidenceGapAddressed(reviewCards) ? 'Evidence strong' : 'Evidence gaps remain')
   const parts: string[] = []
   // The blocked reason leads: it is the only part the user can act on, and a
   // disabled control whose reason is hover-only is a control with no reason.

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -24,6 +24,7 @@ import {
   resolveEvidenceGapConfidenceDisplay,
   evidenceGapGenericText,
   evidenceGapSourcePill,
+  isEvidenceGapAddressed,
 } from './utils/evidenceGapConfidenceDisplay'
 import { dedupTriageItems } from './utils/dedupTriageItems'
 import { TriageCard } from '@/components/shared/TriageCard'
@@ -467,7 +468,6 @@ function T1ChecksFooter({
     robustnessVerdict === 'moderate' ||
     robustnessVerdict === 'fragile'
   const gaps = data.confidence.topEvidenceGaps ?? data.confidence.evidenceGaps ?? []
-  const evidenceWeak = gaps.some(g => typeof g.confidence === 'number' && g.confidence < 50)
   // ⭐ NO DENIAL WITHOUT AUTHORITY — THE EVIDENCE TWIN (UX gate point 8,
   // 18 Aug 2026). This is the SAME ruling applied 24 lines above to the leader
   // verdict, applied to the check it missed on the same day.
@@ -503,8 +503,30 @@ function T1ChecksFooter({
   // emptiness that two different states produce.
   const evidenceAssessed = data.confidence.evidenceGapsAssessed === true
   const evidenceKnown = gaps.length > 0
-  const addressed = gaps.filter(g => typeof g.confidence === 'number' && g.confidence >= 50).length
+  const addressed = gaps.filter(g => isEvidenceGapAddressed(g.confidence)).length
   const total = gaps.length
+  // ⭐ NO ALL-CLEAR WITHOUT AUTHORITY — THE UNKNOWN-CONFIDENCE FACE OF IT.
+  //
+  // This used to be `!evidenceWeak && evidenceKnown`, with
+  // `evidenceWeak = gaps.some(g => typeof g.confidence === 'number' && g.confidence < 50)`
+  // — a TWO-valued predicate over a THREE-valued input. `useResultsSectionData`
+  // maps a gap with no stated `confidence` to `null` DELIBERATELY, and
+  // `evidenceGapConfidenceDisplay`'s contract is explicit that "Callers must
+  // SUPPRESS the figure and anything derived from it". `evidenceWeak` derived
+  // from it anyway, so "the producer never said" came out as "not weak", which
+  // came out as a green tick and "Evidence covered".
+  //
+  // Concrete input, and it is one payload producing two contradicting
+  // sentences ONE ROW APART:
+  //   `[{ factor_id: 'f1', factor_label: 'Supplier lead time', voi_score: 0.9 }]`
+  // (no `confidence`) rendered ✓ "Evidence covered" while `checks-addressed`
+  // beside it rendered "0 of 1 evidence gaps addressed".
+  //
+  // The tick is now DERIVED FROM THE SAME `addressed` COUNT that span renders,
+  // so the two cannot disagree by construction — a stronger guarantee than two
+  // predicates that merely happen to agree today (CLAUDE.md trap 21: the fix
+  // for two authorities is to make them one, not to align their defaults).
+  const evidenceAllAddressed = evidenceKnown && addressed === total
 
   // §6.2g: the legacy arm ("Winner" / "No winner") is DELETED, not
   // re-anchored. `useV17Copy` already selected the glossary-compliant labels
@@ -565,7 +587,7 @@ function T1ChecksFooter({
           dataTestid="checks-robust"
         />
         <ChecksGlyph
-          ok={!evidenceWeak && evidenceKnown}
+          ok={evidenceAllAddressed}
           // Two states render the muted help glyph rather than the red X, for
           // two different reasons: the producer assessed and found nothing (a
           // real, licensed all-clear) and the producer never assessed (no

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -468,16 +468,40 @@ function T1ChecksFooter({
     robustnessVerdict === 'fragile'
   const gaps = data.confidence.topEvidenceGaps ?? data.confidence.evidenceGaps ?? []
   const evidenceWeak = gaps.some(g => typeof g.confidence === 'number' && g.confidence < 50)
-  // ⚠ L-58 / L-38. `evidenceKnown` is `gaps.length > 0` and NOTHING MORE, and
-  // the label it drove said "Evidence unknown" — which is not what the value
-  // means. An empty list is the producer returning no evidence gaps; whether
-  // that is "assessed, none found" or "not assessed" is genuinely
-  // indistinguishable here, because `useResultsSectionData` collapses absent
-  // and empty through `?? []` (`:3221-3226`). So the honest label states the
-  // ONE thing we hold — that nothing was flagged — and claims neither
-  // coverage nor an absence of assessment. (Trap 13c: the expectation is
-  // derived from the producer's semantics, not from what the field's name
-  // suggests it ought to mean.)
+  // ⭐ NO DENIAL WITHOUT AUTHORITY — THE EVIDENCE TWIN (UX gate point 8,
+  // 18 Aug 2026). This is the SAME ruling applied 24 lines above to the leader
+  // verdict, applied to the check it missed on the same day.
+  //
+  // The previous note (kept below in spirit) was right that "assessed, none
+  // found" and "not assessed" were indistinguishable here — and then drew the
+  // wrong conclusion from it. It chose to state "the ONE thing we hold"
+  // ("No evidence gaps flagged") on a value that, when the producer is silent,
+  // holds NOTHING. That is a denial minted by the UI out of a producer's
+  // silence, and it is exactly what the leader-verdict ruling forbids:
+  //
+  //   "`unknown` licenses silence, never a denial"
+  //   "Reconciling the DEFAULTS would have been the wrong fix; withdrawing
+  //    the unlicensed claim is the right one."
+  //
+  // MEASURED, and this is why it matters rather than being a nicety: on the
+  // deployed build the producer is ALWAYS silent (see the derivation comment
+  // in `useResultsSectionData`), so this glyph rendered "No evidence gaps
+  // flagged" on EVERY completed analysis — 12 of 12 real-browser runs across
+  // 6 captured turns and 2 graphs — while the same screen carried four live
+  // evidence-weakness flags from the fields the producer DOES populate.
+  // A constant string is not a check; it is furniture that reads as one.
+  //
+  // ⚠ THE FIX IS NOT "MAKE TWO READERS AGREE". The assumed-strength card, the
+  // Strengthen queue and the canvas science icons answer DIFFERENT questions
+  // (edge-strength provenance, recommendation lifecycle, factor extraction
+  // provenance) — they are not second opinions about this one, and aligning
+  // them would be reconciling defaults across concepts (CLAUDE.md trap 21).
+  // What is deleted is this surface's licence to speak when its own authority
+  // said nothing. The remaining wider divergence is reported, not patched here.
+  //
+  // The distinction now arrives explicitly rather than being inferred from an
+  // emptiness that two different states produce.
+  const evidenceAssessed = data.confidence.evidenceGapsAssessed === true
   const evidenceKnown = gaps.length > 0
   const addressed = gaps.filter(g => typeof g.confidence === 'number' && g.confidence >= 50).length
   const total = gaps.length
@@ -542,15 +566,31 @@ function T1ChecksFooter({
         />
         <ChecksGlyph
           ok={!evidenceWeak && evidenceKnown}
-          // An empty gap list is the NEUTRAL third state, not a failure — the
-          // red X was itself part of the wrongness ("Evidence unknown" scored
-          // as a fault). `unknown` renders the muted help glyph.
+          // Two states render the muted help glyph rather than the red X, for
+          // two different reasons: the producer assessed and found nothing (a
+          // real, licensed all-clear) and the producer never assessed (no
+          // claim available). Neither is a failure; only one is a finding.
           unknown={!evidenceKnown}
           okLabel="Evidence covered"
-          notOkLabel={evidenceKnown ? 'Evidence gaps' : 'No evidence gaps flagged'}
-          // Only the empty-list arm needs the caveat: with gaps present the
-          // label is a plain count-backed fact.
-          title={evidenceKnown ? undefined : 'The analysis returned no evidence gaps for this run.'}
+          notOkLabel={
+            evidenceKnown
+              ? 'Evidence gaps'
+              : evidenceAssessed
+                ? 'No evidence gaps flagged'
+                : // States that the check could not be made. It is NOT a
+                  // verdict about the model's evidence — it is the absence of
+                  // one, which is why it must not read like "No evidence gaps
+                  // flagged" (a finding). Same idiom as the two checks beside
+                  // it: 'Leading option not assessed', 'Robustness not assessed'.
+                  'Evidence not assessed'
+          }
+          title={
+            evidenceKnown
+              ? undefined
+              : evidenceAssessed
+                ? 'The analysis returned no evidence gaps for this run.'
+                : 'This run did not return an evidence assessment, so the analysis makes no claim either way.'
+          }
           dataTestid="checks-evidence"
         />
         {total > 0 && (

--- a/src/components/results/__tests__/checksFooter.evidenceNoDenialWithoutAuthority.spec.tsx
+++ b/src/components/results/__tests__/checksFooter.evidenceNoDenialWithoutAuthority.spec.tsx
@@ -62,6 +62,7 @@ import { useResultsSectionData } from '../useResultsSectionData'
 import { ResultsBody } from '../ResultsBody'
 import { useCanvasStore } from '../../../canvas/store'
 import { mapV2ResponseToReportV1 } from '../../../adapters/plot/v2/responseMapper'
+import { hydrateAnalysisFromV2Response } from '../../../hooks/hydrateAnalysis'
 import type { V2RunResponse } from '../../../adapters/plot/v2/types'
 
 vi.mock('@xyflow/react', async () => {
@@ -79,7 +80,8 @@ const GAP_FACTOR_LABEL = 'Supplier lead time'
 type EvidenceGapWire = {
   factor_id: string
   factor_label: string
-  confidence: number
+  /** ABSENT when the producer never stated one — the third state. */
+  confidence?: number
   voi_score: number
   suggestion: string
 }
@@ -146,7 +148,13 @@ function setStore(producer: ProducerEvidence): void {
  * object `T1ChecksFooter` receives, so a green result cannot come from a
  * fixture that quietly stopped reproducing the state under test.
  */
-function readEvidenceSurfaces(): { label: string; assessed: boolean | undefined; gapCardPresent: boolean } {
+function readEvidenceSurfaces(): {
+  label: string
+  assessed: boolean | undefined
+  gapCardPresent: boolean
+  /** The sibling `checks-addressed` span, ONE ROW away from the label. */
+  addressedText: string | null
+} {
   const { result } = renderHook(() => useResultsSectionData())
   const assessed = result.current.confidence.evidenceGapsAssessed
   const { container } = render(
@@ -155,10 +163,12 @@ function readEvidenceSurfaces(): { label: string; assessed: boolean | undefined;
   const el = container.querySelector('[data-testid="checks-evidence"]')
   if (!el) throw new Error('checks-evidence did not render — the probe is blind, not the product silent')
   const queue = container.querySelector('[data-testid="unified-triage-queue"]')
+  const addressed = container.querySelector('[data-testid="checks-addressed"]')
   return {
     label: (el.textContent ?? '').replace(/\s+/g, ' ').trim(),
     assessed,
     gapCardPresent: (queue?.textContent ?? '').includes(GAP_FACTOR_LABEL),
+    addressedText: addressed ? (addressed.textContent ?? '').replace(/\s+/g, ' ').trim() : null,
   }
 }
 
@@ -220,6 +230,125 @@ describe('checks-evidence: no all-clear without authority', () => {
   })
 
   /**
+   * ⭐ THE SAME RULING, ONE HOP UPSTREAM — THE ONLY LIVE WRITER OF THE STORE.
+   *
+   * Every case above authors `runMeta.m1Coaching` as an object literal, which
+   * is exactly why this hole was invisible to the corpus (CLAUDE.md trap 22: a
+   * corpus drawn from the author's head cannot see the class the author did
+   * not imagine). The store field is not written by hand in the product. Its
+   * SOLE live writer is `extractM1CoachingFromV2` inside
+   * `hydrateAnalysisFromV2Response` (`src/hooks/hydrateAnalysis.ts`), called
+   * only from `useScenario.ts` when a persisted scenario is restored
+   * (`row.analysis_status === 'ready'`).
+   *
+   * That writer used to map `evidence_gaps: coaching.evidence_gaps ?? []` — so
+   * a persisted response with `m1_coaching` PRESENT and no `evidence_gaps` key
+   * had an array MINTED for it, `Array.isArray` read true, and the footer
+   * rendered "No evidence gaps flagged" again. The same collapse the fix above
+   * withdraws, restored one hop upstream by the same idiom, on the one path
+   * that actually writes the field.
+   *
+   * These cases seed the store THROUGH that writer — the producer's own bytes,
+   * not the author's model of them (trap 16: a fixture you wrote yourself is
+   * not evidence about the wire).
+   */
+  describe('through the SOLE live writer (hydrateAnalysisFromV2Response)', () => {
+    /**
+     * Seeds the store the way the product does on a persisted-scenario load:
+     * the persisted V2 payload → `hydrateAnalysisFromV2Response` →
+     * `resultsHydrateFromSupabase`. Nothing about `m1Coaching` is authored here.
+     */
+    function setStoreViaHydration(m1Coaching: Record<string, unknown> | undefined): void {
+      const persisted = { ...makeV2Response(), ...(m1Coaching !== undefined ? { m1_coaching: m1Coaching } : {}) }
+      const hydrated = hydrateAnalysisFromV2Response(persisted, null)
+      if (!hydrated) {
+        throw new Error(
+          'hydrateAnalysisFromV2Response returned null — the fixture no longer validates, so this probe is blind, not the product silent',
+        )
+      }
+      useCanvasStore.setState({
+        nodes: OPTION_NODES,
+        edges: [],
+        goalThreshold: null,
+        viewMode: 'expert',
+      } as never)
+      useCanvasStore.getState().resultsHydrateFromSupabase(hydrated as never)
+      // PRECONDITION PIN (trap 13b): the real store action really did install a
+      // report, so a later label reading is about a mounted result and not
+      // about an empty panel.
+      if (useCanvasStore.getState().results?.report == null) {
+        throw new Error('resultsHydrateFromSupabase installed no report — the probe is blind')
+      }
+    }
+
+    it('persisted m1_coaching PRESENT with NO evidence_gaps key → no all-clear is minted', () => {
+      // The producer spoke about coaching and said NOTHING about evidence.
+      setStoreViaHydration({ executive_summary: 'Wholesale leads on the numbers we have.' })
+      const { label, assessed } = readEvidenceSurfaces()
+      // Precondition: this is the no-authority state. At pristine this reads
+      // `true`, because the writer minted the array.
+      expect(
+        assessed,
+        'the writer must not mint an assessment the persisted payload never carried',
+      ).toBe(false)
+      expect(
+        label,
+        `"No evidence gaps flagged" is an all-clear. The persisted response carried no evidence assessment, so there is nothing to clear. Read: ${label}`,
+      ).not.toMatch(/No evidence gaps flagged/i)
+      expect(label).not.toMatch(/Evidence covered/i)
+      expect(label).toBe('Evidence not assessed')
+    })
+
+    it('persisted m1_coaching ABSENT entirely → no all-clear either', () => {
+      setStoreViaHydration(undefined)
+      const { label, assessed } = readEvidenceSurfaces()
+      expect(assessed).toBe(false)
+      expect(label).toBe('Evidence not assessed')
+    })
+
+    /**
+     * CONTROL — the fix is "stop fabricating", NOT "delete the authority".
+     * A persisted response that really did assess and find nothing keeps its
+     * licensed all-clear through the same writer.
+     */
+    it('persisted evidence_gaps: [] → the all-clear survives the writer, because it was really sent', () => {
+      setStoreViaHydration({ evidence_gaps: [] })
+      const { label, assessed } = readEvidenceSurfaces()
+      expect(assessed).toBe(true)
+      expect(label).toBe('No evidence gaps flagged')
+    })
+
+    /** CONTRAST CONTROL — the writer still carries real gaps through. */
+    it('persisted evidence_gaps with a gap → the check reports gaps', () => {
+      setStoreViaHydration({ evidence_gaps: [WEAK_GAP] })
+      const { label, assessed, gapCardPresent } = readEvidenceSurfaces()
+      expect(assessed).toBe(true)
+      expect(label).toBe('Evidence gaps')
+      expect(gapCardPresent, `the gap card for "${GAP_FACTOR_LABEL}" must survive hydration`).toBe(true)
+    })
+
+    /**
+     * The discriminating triple again, but every state arriving through the
+     * live writer. A blanket change in either direction REDs here.
+     */
+    it('the three persisted states produce three DIFFERENT labels through the writer', () => {
+      setStoreViaHydration({ evidence_gaps: [WEAK_GAP] })
+      const withGaps = readEvidenceSurfaces().label
+      document.body.innerHTML = ''
+      setStoreViaHydration({ evidence_gaps: [] })
+      const assessedEmpty = readEvidenceSurfaces().label
+      document.body.innerHTML = ''
+      setStoreViaHydration({ executive_summary: 'no evidence key here' })
+      const silent = readEvidenceSurfaces().label
+
+      expect(
+        new Set([withGaps, assessedEmpty, silent]).size,
+        `withGaps="${withGaps}" assessedEmpty="${assessedEmpty}" silent="${silent}"`,
+      ).toBe(3)
+    })
+  })
+
+  /**
    * THE MOUNTED ACCEPTANCE, in test form: the summary line and the gap cards
    * are ONE READER. Mutating the single source must move BOTH.
    *
@@ -247,4 +376,102 @@ describe('checks-evidence: no all-clear without authority', () => {
     expect(back.gapCardPresent).toBe(false)
     expect(back.label).toBe('Evidence not assessed')
   })
+
+  /**
+   * ⭐ THE UNKNOWN-CONFIDENCE FACE OF THE SAME RULING (correction 2).
+   *
+   * The cases above vary whether the producer SPOKE. These vary whether the
+   * producer stated a CONFIDENCE for a gap it did flag — a third value the
+   * summary row used to be blind to.
+   *
+   * `useResultsSectionData` maps a gap with no stated confidence to `null`
+   * DELIBERATELY, and `evidenceGapConfidenceDisplay` states the contract:
+   * "Callers must SUPPRESS the figure and anything derived from it". The tick
+   * derived from it via `evidenceWeak = ...confidence < 50`, so unstated read
+   * as "not weak" ⇒ green ✓ "Evidence covered" — beside a sibling span, ONE
+   * ROW away, reading "0 of 1 evidence gaps addressed". One payload, two
+   * contradicting sentences.
+   */
+  describe('a gap whose confidence the producer never stated', () => {
+    /** The reviewer's concrete failing input, verbatim in shape. */
+    const UNSTATED_GAP: EvidenceGapWire = {
+      factor_id: 'f1',
+      factor_label: GAP_FACTOR_LABEL,
+      voi_score: 0.9,
+      suggestion: 'Ask procurement for the last six months of lead times.',
+    }
+
+    it('does NOT license the all-clear, and agrees with the counter beside it', () => {
+      setStore({ gaps: [UNSTATED_GAP] })
+      const { label, assessed, addressedText } = readEvidenceSurfaces()
+      // Preconditions: the producer really did flag a gap, and really did not
+      // state its confidence — so this is the third state and not an assessed
+      // zero (which would be a stated measurement).
+      expect(assessed).toBe(true)
+      expect(
+        addressedText,
+        'precondition: the sibling counter must be rendering the unaddressed state',
+      ).toBe('0 of 1 evidence gaps addressed')
+      expect(
+        label,
+        `"Evidence covered" is an all-clear about a gap whose strength the producer never stated. Read: ${label} — beside "${addressedText}"`,
+      ).not.toMatch(/Evidence covered/i)
+      expect(label).toBe('Evidence gaps')
+    })
+
+    /**
+     * CONTROL — the fix must not swallow the licensed all-clear. A gap the
+     * producer DID state at or above the threshold still earns the tick.
+     */
+    it('a STATED strong confidence still earns "Evidence covered"', () => {
+      setStore({ gaps: [{ ...UNSTATED_GAP, confidence: 80 }] })
+      const { label, addressedText } = readEvidenceSurfaces()
+      expect(addressedText).toBe('1 of 1 evidence gaps addressed')
+      expect(label).toBe('Evidence covered')
+    })
+
+    /** CONTROL — a stated weak confidence keeps reading as gaps. */
+    it('a STATED weak confidence still reads "Evidence gaps"', () => {
+      setStore({ gaps: [{ ...UNSTATED_GAP, confidence: 20 }] })
+      const { label, addressedText } = readEvidenceSurfaces()
+      expect(addressedText).toBe('0 of 1 evidence gaps addressed')
+      expect(label).toBe('Evidence gaps')
+    })
+
+    /**
+     * THE SUMMARY ROW AND ITS COUNTER ARE ONE READER — asserted as an
+     * INVARIANT over all three confidence states rather than as three
+     * independent facts, so a future change cannot re-open the contradiction
+     * in one row only.
+     */
+    it('INVARIANT: the tick appears iff every flagged gap is counted as addressed', () => {
+      for (const confidence of [undefined, 20, 49, 50, 80]) {
+        document.body.innerHTML = ''
+        setStore({ gaps: [{ ...UNSTATED_GAP, ...(confidence === undefined ? {} : { confidence }) }] })
+        const { label, addressedText } = readEvidenceSurfaces()
+        const counterSaysAllAddressed = addressedText === '1 of 1 evidence gaps addressed'
+        expect(
+          label === 'Evidence covered',
+          `confidence=${String(confidence)} → label="${label}" counter="${addressedText}" — the two rows disagree`,
+        ).toBe(counterSaysAllAddressed)
+      }
+    })
+
+    /**
+     * A MIXED list: one addressed, one never stated. The tick must not appear
+     * on the strength of the one that was stated.
+     */
+    it('a mixed list does not average away the unstated one', () => {
+      setStore({
+        gaps: [
+          { ...UNSTATED_GAP, factor_id: 'f_strong', factor_label: 'Warehouse capacity', confidence: 90 },
+          UNSTATED_GAP,
+        ],
+      })
+      const { label, addressedText } = readEvidenceSurfaces()
+      expect(addressedText).toBe('1 of 2 evidence gaps addressed')
+      expect(label).toBe('Evidence gaps')
+    })
+  })
 })
+

--- a/src/components/results/__tests__/checksFooter.evidenceNoDenialWithoutAuthority.spec.tsx
+++ b/src/components/results/__tests__/checksFooter.evidenceNoDenialWithoutAuthority.spec.tsx
@@ -1,0 +1,250 @@
+/**
+ * "What we checked" may not state an EVIDENCE all-clear it has no authority
+ * to state — the evidence twin of `checksFooter.noDenialWithoutAuthority`.
+ *
+ * ── The defect, measured on the DEPLOYED surface ───────────────────────────
+ * Driven on staging `4d1e650b` (fresh guest, one real typed brief, one real
+ * first-pass analysis), the Analysis panel said all of these at one moment:
+ *
+ *   · `checks-evidence`   → "No evidence gaps flagged"
+ *   · canvas node badge   → "High-leverage assumption with no supporting evidence."
+ *   · Analysis panel      → "0 addressed · 7 worth checking"
+ *   · Analysis panel      → "10 other relationships driving this result also
+ *                            have placeholder strengths"
+ *
+ * ── Why "make the readers agree" is the WRONG fix ──────────────────────────
+ * Those four are NOT four readings of one fact. Derived at the bytes, they are
+ * four different questions: producer factor-level evidence gaps
+ * (`m1_coaching.evidence_gaps`), local factor extraction provenance
+ * (`observedState.extractionType`), the Strengthen recommendation lifecycle,
+ * and local EDGE-strength provenance joined to producer fragile edges.
+ * Aligning their defaults would be reconciling four concepts under one word
+ * (CLAUDE.md trap 21) and would delete true signal.
+ *
+ * ── What was actually wrong: one surface speaking without authority ────────
+ * `evidenceKnown` was `gaps.length > 0`, and `useResultsSectionData` collapses
+ * "producer sent an empty list" and "producer never spoke" into the SAME empty
+ * array via `?? []`. The footer rendered that collapsed emptiness as an
+ * affirmative all-clear.
+ *
+ * On the deployed path the producer NEVER speaks, so the sentence was a
+ * CONSTANT. Measured three independent ways at `4d1e650b`:
+ *   · `applyV5State` — the canonical analysis path — contains ZERO references
+ *     to `m1Coaching`, and `useConversation`'s `resultsComplete` passes none;
+ *   · of 13 real captured analysis turns in this repo, 12 carry no
+ *     `evidence_gaps` key and the 13th carries an empty array. POSITIVE
+ *     CONTROL: three older captures carry 3 gaps each, so the probe sees
+ *     presence — this is real absence, not a blind instrument;
+ *   · driven in real Chromium across 6 captures x 2 starter graphs, the footer
+ *     rendered "No evidence gaps flagged" in 12 of 12 runs.
+ * Meanwhile `robustness.fragile_edges` and `factor_sensitivity` — the fields
+ * the live evidence-weakness surfaces read — are present in 8 of 8 of those
+ * same analysis turns.
+ *
+ * The sibling ruling already settled the principle for the leader verdict:
+ * *"'unknown' licenses silence, never a denial"* and *"Reconciling the
+ * DEFAULTS would have been the wrong fix; withdrawing the unlicensed claim is
+ * the right one."* This spec applies it to the check it missed.
+ *
+ * ── What this spec pins ────────────────────────────────────────────────────
+ * 1. A DISCRIMINATING TRIPLE (trap 19) — three producer states must produce
+ *    three DIFFERENT labels, so a blanket change in either direction REDs.
+ *    The "assessed, none found" row is the control that stops the fix
+ *    degenerating into "delete the all-clear", which would lose a true claim.
+ * 2. ONE READER (the mounted acceptance) — mutating the single source moves
+ *    the summary line and the gap cards TOGETHER. Neither assertion alone
+ *    shows this: the pair does.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render, renderHook } from '@testing-library/react'
+import { useResultsSectionData } from '../useResultsSectionData'
+import { ResultsBody } from '../ResultsBody'
+import { useCanvasStore } from '../../../canvas/store'
+import { mapV2ResponseToReportV1 } from '../../../adapters/plot/v2/responseMapper'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return { ...actual, Handle: () => null }
+})
+
+const WINNER_ID = 'opt_wholesale'
+const RUNNER_UP_ID = 'opt_retail'
+
+/** Distinctive enough that no other row could satisfy the assertion (trap 19). */
+const GAP_FACTOR_ID = 'fac_supplier_lead_time'
+const GAP_FACTOR_LABEL = 'Supplier lead time'
+
+type EvidenceGapWire = {
+  factor_id: string
+  factor_label: string
+  confidence: number
+  voi_score: number
+  suggestion: string
+}
+
+/**
+ * The three producer states, named. `undefined` is the DEPLOYED state — the
+ * producer never sent the array at all.
+ */
+type ProducerEvidence = { gaps: EvidenceGapWire[] } | { silent: true }
+
+function makeV2Response(): V2RunResponse {
+  const outcome = (mean: number) => ({
+    mean, std: 12, p10: mean - 20, p50: mean, p90: mean + 20,
+    n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1,
+  })
+  return {
+    analysis_status: 'computed',
+    option_comparison_status: 'computed',
+    robustness_status: 'computed',
+    drivers_status: 'computed',
+    option_comparison: [
+      { option_id: WINNER_ID, option_label: 'Double Down on Wholesale', confidence_interval: [40, 80], win_probability: 0.72, outcome: outcome(60) },
+      { option_id: RUNNER_UP_ID, option_label: 'Open Retail Shop', confidence_interval: [20, 60], win_probability: 0.2, outcome: outcome(40) },
+    ],
+    critiques: [], drivers: [], edge_sensitivity: [], factor_sensitivity: [],
+    robustness: {
+      fragile_edges: [], robust_edges: ['e1'],
+      recommended_option_id: WINNER_ID, recommendation_stability: 0.92,
+      near_tie: { is_tie: false, top_option_id: WINNER_ID, second_option_id: RUNNER_UP_ID, gap: 0.52, threshold: 0.1 },
+    } as never,
+    response_hash: 'h',
+    meta: { seed_used: '42', n_samples: 1000, detail_level: 'standard', latency_ms: 100 },
+  } as V2RunResponse
+}
+
+const OPTION_NODES = [
+  { id: WINNER_ID, type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', type: 'option', label: 'Double Down on Wholesale' } },
+  { id: RUNNER_UP_ID, type: 'option', position: { x: 400, y: 0 }, data: { kind: 'option', type: 'option', label: 'Open Retail Shop' } },
+]
+
+function setStore(producer: ProducerEvidence): void {
+  const v2 = makeV2Response()
+  // `runMeta.m1Coaching` is the ONLY writer of the evidence-gap authority
+  // (`useResultsSectionData:1233`). 'silent' omits the array entirely, which is
+  // what the deployed V5 path produces — not an empty array.
+  const m1Coaching = 'silent' in producer ? {} : { evidence_gaps: producer.gaps }
+  useCanvasStore.setState({
+    results: { status: 'complete', progress: 100, report: mapV2ResponseToReportV1(v2, { seed: 42 }) },
+    runMeta: { m1Coaching },
+    nodes: OPTION_NODES,
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: v2,
+    goalThreshold: null,
+    viewMode: 'expert',
+  } as never)
+}
+
+/**
+ * Reads BOTH surfaces from ONE render, plus the assessed flag the footer
+ * itself consumes.
+ *
+ * PRECONDITION PIN (trap 13b): `evidenceGapsAssessed` is read from the very
+ * object `T1ChecksFooter` receives, so a green result cannot come from a
+ * fixture that quietly stopped reproducing the state under test.
+ */
+function readEvidenceSurfaces(): { label: string; assessed: boolean | undefined; gapCardPresent: boolean } {
+  const { result } = renderHook(() => useResultsSectionData())
+  const assessed = result.current.confidence.evidenceGapsAssessed
+  const { container } = render(
+    <ResultsBody resultsSectionData={result.current} tornadoData={{ rows: [], expectedOutcome: null }} />,
+  )
+  const el = container.querySelector('[data-testid="checks-evidence"]')
+  if (!el) throw new Error('checks-evidence did not render — the probe is blind, not the product silent')
+  const queue = container.querySelector('[data-testid="unified-triage-queue"]')
+  return {
+    label: (el.textContent ?? '').replace(/\s+/g, ' ').trim(),
+    assessed,
+    gapCardPresent: (queue?.textContent ?? '').includes(GAP_FACTOR_LABEL),
+  }
+}
+
+const WEAK_GAP: EvidenceGapWire = {
+  factor_id: GAP_FACTOR_ID, factor_label: GAP_FACTOR_LABEL,
+  confidence: 20, voi_score: 0.8, suggestion: 'Ask procurement for the last six months of lead times.',
+}
+
+describe('checks-evidence: no all-clear without authority', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      results: null, rawV2Response: null, runMeta: {}, nodes: [], edges: [], hasCompletedFirstRun: false,
+    } as never)
+    document.body.innerHTML = ''
+  })
+
+  it('producer sent gaps → the check reports gaps', () => {
+    setStore({ gaps: [WEAK_GAP] })
+    const { label, assessed } = readEvidenceSurfaces()
+    expect(assessed).toBe(true)
+    expect(label).toBe('Evidence gaps')
+  })
+
+  it('producer ASSESSED and found none → the all-clear is licensed and still rendered', () => {
+    setStore({ gaps: [] })
+    const { label, assessed } = readEvidenceSurfaces()
+    // Precondition: the producer really did speak, with an empty list.
+    expect(assessed).toBe(true)
+    expect(label).toBe('No evidence gaps flagged')
+  })
+
+  it('producer NEVER SPOKE → the check makes no claim about evidence', () => {
+    setStore({ silent: true })
+    const { label, assessed } = readEvidenceSurfaces()
+    // Precondition: this really is the no-authority state, not an assessed zero.
+    expect(assessed).toBe(false)
+    expect(
+      label,
+      `"No evidence gaps flagged" is an all-clear. The producer sent no assessment, so there is nothing to clear. Read: ${label}`,
+    ).not.toMatch(/No evidence gaps flagged/i)
+    expect(label).not.toMatch(/Evidence covered/i)
+    expect(label).toBe('Evidence not assessed')
+  })
+
+  it('the three producer states produce three DIFFERENT labels — the probe discriminates', () => {
+    setStore({ gaps: [WEAK_GAP] })
+    const withGaps = readEvidenceSurfaces().label
+    document.body.innerHTML = ''
+    setStore({ gaps: [] })
+    const assessedEmpty = readEvidenceSurfaces().label
+    document.body.innerHTML = ''
+    setStore({ silent: true })
+    const silent = readEvidenceSurfaces().label
+
+    expect(
+      new Set([withGaps, assessedEmpty, silent]).size,
+      `withGaps="${withGaps}" assessedEmpty="${assessedEmpty}" silent="${silent}"`,
+    ).toBe(3)
+  })
+
+  /**
+   * THE MOUNTED ACCEPTANCE, in test form: the summary line and the gap cards
+   * are ONE READER. Mutating the single source must move BOTH.
+   *
+   * Asserted as a PAIRED TRANSITION rather than two independent facts — either
+   * assertion alone is satisfiable by a surface that is not reading the source
+   * at all (it might simply never render, or always render).
+   */
+  it('ONE READER: mutating the single source moves the summary line and the gap cards together', () => {
+    setStore({ silent: true })
+    const before = readEvidenceSurfaces()
+    document.body.innerHTML = ''
+    setStore({ gaps: [WEAK_GAP] })
+    const after = readEvidenceSurfaces()
+
+    // Both surfaces moved, on the same mutation, in the same direction.
+    expect(before.gapCardPresent, 'no gap card before the mutation').toBe(false)
+    expect(after.gapCardPresent, `the gap card for "${GAP_FACTOR_LABEL}" must appear when the source gains a gap`).toBe(true)
+    expect(before.label).toBe('Evidence not assessed')
+    expect(after.label).toBe('Evidence gaps')
+
+    // And the reverse direction, so neither surface is merely monotonic.
+    document.body.innerHTML = ''
+    setStore({ silent: true })
+    const back = readEvidenceSurfaces()
+    expect(back.gapCardPresent).toBe(false)
+    expect(back.label).toBe('Evidence not assessed')
+  })
+})

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -327,8 +327,37 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
           ? 'thin'
           : 'ready'
   const state: BriefState = stateOverride ?? liveState
-  // Unassessed is a QUIET no-claim state — collapsed like ready (review S2).
-  const autoExpand = state !== 'ready' && state !== 'unassessed'
+  // ⭐ ANSWER FIRST (UX gate point 3, 18 Aug 2026 — measured on deployed
+  // `4d1e650b`, fresh guest, 1280x800).
+  //
+  // This card auto-expanded on every non-ready framing quality, INCLUDING
+  // after a completed analysis. Measured on staging: the verdict sentence sat
+  // 573px down a 515px-tall visible region — 111% of a panel height — and the
+  // four Goal/Context/Constraints/Options sub-cards plus the brief actions and
+  // the framing question were the bulk of what pushed it there. A fresh user
+  // who had just clicked "Analyse first pass" saw no answer at all without
+  // scrolling.
+  //
+  // ORDERING, NOT DELETION. Nothing is removed: the same four dimensions, the
+  // same "Review your decision brief" action and the same framing question all
+  // still render, one click away behind the disclosure control this card
+  // already owns (`aria-expanded`, below). Paul's constraint on every
+  // simplification is "less interface, not less intelligence" — so the
+  // framing prompt keeps its full content and loses only its claim on the
+  // first screenful once there is a result to read.
+  //
+  // `blocked` is deliberately EXEMPT. It is the danger-severity state ("resolve
+  // before relying on the read"): a framing problem serious enough to undermine
+  // the result must not be folded away behind the result it undermines.
+  //
+  // Derived from the report, not from the caller's mount gate. `OutputsDock`
+  // only mounts this card post-analysis today, which would make `hasResult`
+  // structurally true and this condition invisible — but a card that reads its
+  // own precondition cannot be silently re-pointed by a future mount site
+  // (CLAUDE.md trap 3b), and pre-analysis mounts keep the historic behaviour.
+  const hasResult = useCanvasStore((s) => s.results?.report != null)
+  const autoExpand =
+    state === 'blocked' || (!hasResult && state !== 'ready' && state !== 'unassessed')
 
   const [expanded, setExpanded] = useState(autoExpand)
   useEffect(() => setExpanded(autoExpand), [autoExpand])

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.answerFirst.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.answerFirst.spec.tsx
@@ -1,0 +1,156 @@
+/**
+ * ANSWER FIRST — the framing prompt yields the first screenful to the result.
+ *
+ * ── The defect, measured on the DEPLOYED surface ───────────────────────────
+ * Driven on staging `4d1e650b` (fresh guest, one real typed brief, one real
+ * first-pass analysis, 1280x800, live DOM): with the Analysis panel scrolled to
+ * the top, the verdict sentence sat 573px down a 515px-tall visible region —
+ * 111% of a panel height before the answer appeared. A user who had just
+ * clicked "Analyse first pass" saw no answer at all without scrolling.
+ *
+ * Everything above it was set-up: `Decision overview` -> `Draft decision` ->
+ * `Framing needs one clarification` with four Goal/Context/Constraints/Options
+ * sub-cards -> `Review your decision brief` -> `Olumi's framing question`.
+ *
+ * The cause is this card: `autoExpand` was `state !== 'ready' && state !==
+ * 'unassessed'`, which force-expands the whole brief body on the derived
+ * `thin` quality (no success measure) — and it kept doing so after a completed
+ * analysis, when there is finally an answer that outranks the prompt.
+ *
+ * ── Why this and not a reorder ─────────────────────────────────────────────
+ * The gate's remedy is "move the verdict above the framing furniture, OR
+ * collapse that furniture to one line". Moving is the more invasive of the
+ * two: `OutputsDock.analysis-run.spec.tsx` pins "the overview mounts FIRST,
+ * above the freshness strip (canonical hierarchy)" as a RULING, with a long
+ * defence in `OutputsDock.tsx` ("the card is the ORIENTATION surface"). This
+ * takes the second remedy, which needs no doctrine change.
+ *
+ * ── ORDERING, NOT DELETION ─────────────────────────────────────────────────
+ * Paul's constraint on every simplification is "less interface, not less
+ * intelligence". Nothing is removed: the same four dimensions, the same brief
+ * actions and the same framing question all still render, one click away
+ * behind the disclosure control this card already owns. The last case pins
+ * that, so a future "simplification" cannot quietly turn a collapse into a
+ * deletion and stay green.
+ *
+ * ── What this spec pins ────────────────────────────────────────────────────
+ * A DISCRIMINATING TRIPLE (CLAUDE.md trap 19), because a single case is
+ * satisfiable by a card that never expands at all:
+ *
+ *   thin, NO result yet      -> EXPANDED   (historic behaviour, unchanged)
+ *   thin, result present     -> COLLAPSED  (the fix)
+ *   BLOCKED, result present  -> EXPANDED   (the deliberate exemption)
+ *
+ * The first row is the control that stops the fix becoming "never expand".
+ * The third is the control that stops it becoming "always collapse once a
+ * report exists" — a danger-severity framing problem must not be folded away
+ * behind the very result it undermines.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { DecisionOverviewCard } from '../DecisionOverviewCard'
+import { useCanvasStore } from '../../../../canvas/store'
+import { useGuidanceStore } from '../../../../canvas/stores/guidanceStore'
+
+/** `thin` = analysis_ready is 'ready' but no success measure is set. */
+const READY_NO_MEASURE = { status: 'ready', options: [{ id: 'o1' }], goal_node_id: 'g1' }
+const GOAL_NODE_NO_MEASURE = { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'G' } }
+const BLOCKER_HEALTH = { issues: [{ severity: 'blocker', message: 'Goal is not reachable from any option' }] }
+
+/** A minimal completed report — presence is the whole signal the card reads. */
+const COMPLETED = { status: 'complete', progress: 100, report: { insights: { summary: 'x' } } }
+
+function mount(opts: { hasResult: boolean; blocked?: boolean }) {
+  localStorage.setItem('feature.decisionOverview', '1')
+  useCanvasStore.setState({
+    ceeAnalysisReady: READY_NO_MEASURE,
+    nodes: [GOAL_NODE_NO_MEASURE],
+    goalThreshold: null,
+    goalConstraints: null,
+    currentBriefText: null,
+    graphHealth: opts.blocked ? BLOCKER_HEALTH : null,
+    results: opts.hasResult ? COMPLETED : null,
+  } as never)
+  return render(<DecisionOverviewCard title="Draft decision" />)
+}
+
+/**
+ * Expansion read by IDENTITY — the presence of a brief-dimension sub-card,
+ * never a height, a class or page text another element could satisfy
+ * (CLAUDE.md trap 19).
+ */
+function isExpanded(): boolean {
+  return screen.queryByTestId('brief-dim-goal') !== null
+}
+
+describe('Decision overview: the answer outranks the framing prompt', () => {
+  beforeEach(() => {
+    useGuidanceStore.setState({ guidanceItems: [] } as never)
+    localStorage.clear()
+    document.body.innerHTML = ''
+  })
+
+  it('thin brief, NO result yet → still auto-expands (the prompt is the main event)', () => {
+    mount({ hasResult: false })
+    // Precondition: this really is the thin state the defect needs.
+    expect(screen.getByTestId('brief-bar').textContent).toMatch(/needs one clarification/i)
+    expect(isExpanded()).toBe(true)
+  })
+
+  it('thin brief, result present → collapses to its one-line summary', () => {
+    mount({ hasResult: true })
+    expect(screen.getByTestId('brief-bar').textContent).toMatch(/needs one clarification/i)
+    expect(
+      isExpanded(),
+      'the framing sub-cards must not hold the first screenful once there is an answer to read',
+    ).toBe(false)
+  })
+
+  it('BLOCKED brief, result present → still expands (danger is exempt)', () => {
+    mount({ hasResult: true, blocked: true })
+    expect(
+      isExpanded(),
+      'a blocker-severity framing problem must not be folded away behind the result it undermines',
+    ).toBe(true)
+  })
+
+  it('the three states discriminate — not "never expand", not "always expand"', () => {
+    mount({ hasResult: false })
+    const thinNoResult = isExpanded()
+    document.body.innerHTML = ''
+    mount({ hasResult: true })
+    const thinWithResult = isExpanded()
+    document.body.innerHTML = ''
+    mount({ hasResult: true, blocked: true })
+    const blockedWithResult = isExpanded()
+
+    expect(
+      [thinNoResult, thinWithResult, blockedWithResult],
+      `thinNoResult=${thinNoResult} thinWithResult=${thinWithResult} blockedWithResult=${blockedWithResult}`,
+    ).toEqual([true, false, true])
+  })
+
+  it('LESS INTERFACE, NOT LESS INTELLIGENCE: collapsed still offers the full brief one click away', () => {
+    mount({ hasResult: true })
+    expect(isExpanded()).toBe(false)
+
+    // ⚠ BOUND BY IDENTITY, and this assertion was WRONG on its first draft in
+    // exactly the way this file warns about. It selected
+    // `[aria-expanded]` inside the card — a predicate the ActionsMenu trigger
+    // ALSO satisfies, and which precedes the disclosure control in the DOM. It
+    // clicked the wrong element and reported the content as unrecoverable
+    // (CLAUDE.md trap 19, caught by the test failing rather than by review).
+    const toggle = screen.getByTestId('brief-bar')
+    expect(
+      toggle.getAttribute('aria-expanded'),
+      'brief-bar IS the disclosure control; if it stops carrying aria-expanded the binding has moved',
+    ).toBe('false')
+
+    fireEvent.click(toggle)
+    expect(
+      isExpanded(),
+      'expanding must restore the framing sub-cards — the content is deferred, never deleted',
+    ).toBe(true)
+  })
+})

--- a/src/components/results/types.ts
+++ b/src/components/results/types.ts
@@ -973,6 +973,16 @@ export interface ConfidenceSectionData {
    * cause. It can no longer arise: this list is empty iff `evidenceGaps` is.
    */
   topEvidenceGaps?: EvidenceGapItem[]
+  /**
+   * Did the producer ASSESS evidence on this run at all?
+   *
+   * `evidenceGaps` being empty answers two different questions with one value
+   * — "assessed, none found" and "never assessed" — and a surface that turns
+   * the empty list into an affirmative "No evidence gaps flagged" is making a
+   * claim only the first of those licenses. True iff `m1_coaching.evidence_gaps`
+   * arrived as an array. See the derivation comment in `useResultsSectionData`.
+   */
+  evidenceGapsAssessed?: boolean
   /** M1 Coaching next actions - prioritised recommendations */
   nextActions?: NextActionItem[]
   /** M1 Coaching top next actions (max 3, sorted by priority) */

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -3138,6 +3138,41 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       humanisedCritiques,
       // P1 Integration: Top fragile edge for HeroSection bullet 3
       topFragileEdge: topFragileEdgeData,
+      // ⭐ THE PRODUCER'S SILENCE IS A THIRD STATE, AND IT USED TO BE
+      // INDISTINGUISHABLE FROM AN ASSESSED ZERO (UX gate point 8, 18 Aug 2026).
+      //
+      // The IIFE below returns `{}` on an empty list, so `evidenceGaps` and
+      // `topEvidenceGaps` are `undefined` BOTH when the producer said "I found
+      // no evidence gaps" AND when the producer never spoke about evidence at
+      // all. Every consumer then collapses that through `?? []`, and the
+      // T1 checks footer rendered the result as an affirmative all-clear:
+      // "No evidence gaps flagged".
+      //
+      // On the deployed V5 path the producer NEVER speaks. Measured three
+      // independent ways at `4d1e650b`:
+      //   - `applyV5State` (the canonical analysis path) contains ZERO
+      //     references to `m1Coaching`, and `useConversation`'s
+      //     `resultsComplete` call passes no coaching, so `runMeta.m1Coaching`
+      //     is never written on a turn-driven analysis;
+      //   - of 13 real captured analysis turns in this repo, 12 carry no
+      //     `evidence_gaps` key at all and the 13th carries an empty array
+      //     (positive control: three older captures DO carry 3 gaps each, so
+      //     the probe can see presence — this is real absence, not blindness);
+      //   - driven in a real browser across 6 captures x 2 starter graphs,
+      //     the footer rendered "No evidence gaps flagged" in 12 of 12.
+      // `useResultsSectionData` itself already calls the m1Coaching read a
+      // "DEPRECATION FALLBACK ... effectively dead per B1 investigation".
+      //
+      // So the sentence was not a finding. It was a CONSTANT, and it rendered
+      // beside four live evidence-weakness signals that come from the fields
+      // the producer DOES populate (`robustness.fragile_edges` and
+      // `factor_sensitivity` — present in 8 of 8 of those same captures).
+      //
+      // This flag restores the distinction the `?? []` collapse destroys. It
+      // is deliberately the NARROW test (`Array.isArray`), not `m1Coaching !=
+      // null`: it is true only when the producer actually sent the array, so
+      // silence can never be read as an assessment.
+      evidenceGapsAssessed: Array.isArray(m1Coaching?.evidence_gaps),
       // Task 4 (M1 Coaching): Evidence gaps - sorted by VOI descending, deduped by factor_id
       ...(() => {
         const rawGaps = safeArray(m1Coaching?.evidence_gaps)

--- a/src/components/results/utils/evidenceGapConfidenceDisplay.ts
+++ b/src/components/results/utils/evidenceGapConfidenceDisplay.ts
@@ -67,3 +67,66 @@ export function evidenceGapSourcePill(
   if (display.pct < 40) return { label: 'AI estimate', borderClass: 'border-info/30' }
   return { label: 'Estimated', borderClass: 'border-warning/30' }
 }
+
+// ---------------------------------------------------------------------------
+// "Is this gap ADDRESSED?" — the third state, for the surfaces that summarise
+// a whole LIST of gaps rather than rendering one.
+// ---------------------------------------------------------------------------
+
+/**
+ * The threshold at or above which a STATED confidence counts as addressed.
+ * Named once, here, because two surfaces summarise the same list and a second
+ * copy of `50` is the hand-maintained mirror this estate keeps paying for.
+ */
+export const EVIDENCE_GAP_ADDRESSED_MIN_PCT = 50
+
+/**
+ * ⭐ NO ALL-CLEAR WITHOUT AUTHORITY, APPLIED TO THE SUMMARY ROWS.
+ *
+ * Two surfaces summarised the gap list with the SAME defective predicate:
+ *
+ *   `gaps.some(g => typeof g.confidence === 'number' && g.confidence < 50)`
+ *
+ * — `TriageActionCardsBody`'s "What we checked" row (`ok` ⇒ a green tick and
+ * "Evidence covered") and `derivePostFooterMeta`'s `results-analysis-footer`
+ * (⇒ "Evidence strong"). Both are two-valued over a THREE-valued input, and
+ * the third value is the one this module exists to protect: a gap whose
+ * confidence the producer NEVER STATED resolves to `null` deliberately
+ * (`useResultsSectionData`, "No absence-fabrication"), and this module's own
+ * contract says *"Callers must SUPPRESS the figure and anything derived from
+ * it"*. `evidenceWeak` was derived from it — so unstated read as "not weak",
+ * which read as "fine".
+ *
+ * Measured consequence, one payload, two rows apart: a single gap
+ * `{ factor_id: 'f1', factor_label: 'Supplier lead time', voi_score: 0.9 }`
+ * with no `confidence` rendered a green ✓ "Evidence covered" beside
+ * "0 of 1 evidence gaps addressed".
+ *
+ * So `addressed` is a POSITIVE claim requiring a stated figure, and the two
+ * summary rows are derived from THE SAME count the "N of M addressed" span
+ * renders — they can no longer disagree by construction, which is a stronger
+ * guarantee than two predicates that happen to be written identically today.
+ *
+ * NOT weakness. An unstated confidence is not evidence of a weak gap either;
+ * it simply cannot license the all-clear.
+ */
+export function isEvidenceGapAddressed(confidence: number | null | undefined): boolean {
+  const display = resolveEvidenceGapConfidenceDisplay(confidence)
+  return display.show && display.pct >= EVIDENCE_GAP_ADDRESSED_MIN_PCT
+}
+
+/**
+ * True iff the producer flagged at least one gap AND every one of them is
+ * addressed by a STATED confidence. This is the only state that licenses
+ * "Evidence covered" / "Evidence strong".
+ *
+ * An empty list returns `false` on purpose: "no gaps" is a different question
+ * (was anything assessed at all?) and its callers answer it separately —
+ * folding it in here would be reconciling two questions under one name
+ * (CLAUDE.md trap 21).
+ */
+export function everyEvidenceGapAddressed(
+  gaps: ReadonlyArray<{ confidence?: number | null }>,
+): boolean {
+  return gaps.length > 0 && gaps.every(g => isEvidenceGapAddressed(g.confidence))
+}

--- a/src/hooks/__tests__/hydrateAnalysis.spec.ts
+++ b/src/hooks/__tests__/hydrateAnalysis.spec.ts
@@ -236,7 +236,7 @@ describe('extractM1CoachingFromV2', () => {
     expect(extractM1CoachingFromV2(v2)).toBeNull()
   })
 
-  it('extracts coaching fields with defaults', () => {
+  it('extracts coaching fields with defaults — but MINTS NO EVIDENCE ASSESSMENT', () => {
     const v2 = makeMinimalV2Response({
       m1_coaching: {
         executive_summary: { headline: 'H', body: 'B' },
@@ -246,8 +246,40 @@ describe('extractM1CoachingFromV2', () => {
 
     expect(result).not.toBeNull()
     expect(result!.executive_summary).toEqual({ headline: 'H', body: 'B' })
-    expect(result!.evidence_gaps).toEqual([])
+    // ⭐ This line used to read `.toEqual([])`, and it was pinning the defect.
+    // `useResultsSectionData` derives `evidenceGapsAssessed` from
+    // `Array.isArray(m1Coaching?.evidence_gaps)` precisely so that producer
+    // SILENCE cannot be read as an assessment — and a minted `[]` here defeated
+    // that one hop upstream, putting the all-clear "No evidence gaps flagged"
+    // on screen for a run nobody assessed. The key must be genuinely ABSENT,
+    // not an empty array: `Array.isArray(undefined)` is false, `[]` is true,
+    // and that single boolean is the whole authority.
+    expect(result!.evidence_gaps).toBeUndefined()
+    expect(
+      Object.prototype.hasOwnProperty.call(result!, 'evidence_gaps'),
+      'a present key holding undefined would still be a claim shaped like an answer',
+    ).toBe(false)
     expect(result!.next_actions).toEqual([])
     expect(result!.story_headlines).toEqual({})
+  })
+
+  it('carries a genuinely-sent empty assessment through — absence and emptiness stay distinct', () => {
+    const v2 = makeMinimalV2Response({
+      m1_coaching: { evidence_gaps: [] } as any,
+    })
+    const result = extractM1CoachingFromV2(v2)
+
+    // The producer DID assess and found nothing. That is a real finding and
+    // must survive, or the fix above degenerates into deleting the authority.
+    expect(Array.isArray(result!.evidence_gaps)).toBe(true)
+    expect(result!.evidence_gaps).toEqual([])
+  })
+
+  it('carries real gaps through unchanged', () => {
+    const gap = { factor_id: 'f1', factor_label: 'Supplier lead time', voi_score: 0.9, suggestion: 'Ask procurement.' }
+    const v2 = makeMinimalV2Response({ m1_coaching: { evidence_gaps: [gap] } as any })
+    const result = extractM1CoachingFromV2(v2)
+
+    expect(result!.evidence_gaps).toEqual([gap])
   })
 })

--- a/src/hooks/hydrateAnalysis.ts
+++ b/src/hooks/hydrateAnalysis.ts
@@ -66,7 +66,30 @@ export function extractM1CoachingFromV2(response: V2RunResponse): M1Coaching | n
     readiness: coaching.readiness ?? undefined,
     readiness_signals: coaching.readiness_signals ?? undefined,
     key_drivers: coaching.key_drivers ?? undefined,
-    evidence_gaps: coaching.evidence_gaps ?? [],
+    // ⭐ NO DENIAL WITHOUT AUTHORITY, AT THE ONLY LIVE WRITER OF THE FIELD.
+    //
+    // This used to read `coaching.evidence_gaps ?? []`. That is the exact
+    // collapse the footer fix withdraws, one hop UPSTREAM of it and on the one
+    // path that actually writes `runMeta.m1Coaching`: a persisted response with
+    // `m1_coaching` present and no `evidence_gaps` key had an array MINTED for
+    // it here, so `useResultsSectionData`'s deliberately narrow
+    // `Array.isArray(m1Coaching?.evidence_gaps)` read TRUE, and "What we
+    // checked" rendered the unlicensed all-clear "No evidence gaps flagged" on
+    // a run the producer never assessed. The comment there — "silence can never
+    // be read as an assessment" — and the doc on `evidenceGapsAssessed` were
+    // both FALSE on this path, because the silence had already been overwritten
+    // before that flag ever looked.
+    //
+    // The key is therefore ABSENT when the producer sent nothing, and present
+    // (including as a genuine `[]`) only when the producer actually spoke.
+    // `M1Coaching.evidence_gaps` is optional, so absence is expressible.
+    //
+    // ⚠ Its two neighbours below (`next_actions`, `assumptions_ledger`) carry
+    // the same idiom and are deliberately NOT changed here: nothing reads an
+    // "assessed?" distinction off either of them today, so changing them would
+    // be scope this lane has not derived consumers for. Recorded, not silently
+    // fixed.
+    ...(Array.isArray(coaching.evidence_gaps) ? { evidence_gaps: coaching.evidence_gaps } : {}),
     next_actions: coaching.next_actions ?? [],
     assumptions_ledger: Array.isArray(coaching.assumptions_ledger) ? coaching.assumptions_ledger : [],
     top_fragile_edge: coaching.top_fragile_edge ?? undefined,


### PR DESCRIPTION
UX gate FAIL points **3** and **8**, measured on deployed `4d1e650b` (fresh guest, 1280×800, live DOM).
Evidence: `olumi-docs/feedback-2026-08-16/UX-GATE-2026-08-18.md`.

## The four questions, answered first

**Canonical authority for the evidence-gap count** — `m1_coaching.evidence_gaps`, derived once in `useResultsSectionData` and read by every gap surface in the panel (summary glyph, addressed counter, triage gap cards, `results-analysis-footer`). They were already **one reader**; this PR does not add a second.

**Canonical authority for result-vs-framing ordering** — there isn't one. The order is **static JSX**: `OutputsDock` renders `DecisionOverviewCard`, then `AnalysisStateRegion` → `ResultsBody` → `AnalysisHeroContainer`. No ordering array, config or registry exists on this path.

**What this deletes / supersedes** — the **UI-minted denial**. `m1_coaching.evidence_gaps` keeps its role as the evidence authority; what is deleted is its ability to *license a verdict when it said nothing*. `useResultsSectionData` collapsed "producer sent an empty list" and "producer never spoke" into one empty array via `?? []`, and the footer rendered that collapsed emptiness as an affirmative all-clear. Nothing else is superseded — **no doctrine is changed**, and `OutputsDock`'s "the overview mounts FIRST" ruling is left intact.

**Known inverse/mirror failure this avoids** — CLAUDE.md **trap 21**, two questions under similar names. The four contradicting surfaces are *not* four readings of one fact: producer factor-level gaps, local factor extraction provenance, the Strengthen recommendation lifecycle, and local edge-strength provenance joined to producer fragile edges. **Aligning their defaults would reconcile four concepts under one word and delete true signal.** Also **trap 11** — every claim here is mutation-proven, and one mutant initially produced a **false survivor** (see below).

**Mounted acceptance** — after a completed analysis at 1280: the verdict is visible without scrolling, and the gap summary and gap cards move together under mutation of the single source. Both measured below; the thin-brief half is explicitly deferred to the deployed witness.

---

## Point 8 — the sentence was a constant, not a finding

`"No evidence gaps flagged"` rendered beside four live gap flags. It could not have said anything else: on the deployed path the producer never speaks. Measured three independent ways at `4d1e650b`:

- `applyV5State` — the canonical analysis path — has **zero** references to `m1Coaching`, and `useConversation`'s `resultsComplete` passes none, so `runMeta.m1Coaching` is never written on a turn-driven analysis;
- of **13** real captured analysis turns, **12** carry no `evidence_gaps` key and the 13th carries an empty array. **Positive control:** three older captures carry 3 gaps each, so the probe sees presence — real absence, not a blind instrument;
- driven in real Chromium across **6 captures × 2 starter graphs**, the footer rendered the sentence in **12 of 12** runs.

Meanwhile `robustness.fragile_edges` and `factor_sensitivity` — what the live evidence-weakness surfaces read — are present in **8 of 8** of those same turns. The repo already calls the m1Coaching read a *"DEPRECATION FALLBACK … effectively dead per B1 investigation"*.

The fix applies the **`NO DENIAL WITHOUT AUTHORITY`** ruling that sits **24 lines above in the same file, dated the same day** and was applied to the leader verdict but not to this one: *"`unknown` licenses silence, never a denial"*. Three honest states now: `Evidence gaps` · `No evidence gaps flagged` (only when the producer actually assessed) · `Evidence not assessed`.

## Point 3 — collapse, not reorder

`DecisionOverviewCard` auto-expanded on every non-ready framing quality, **including after a completed analysis**. The gate's remedy is "move the verdict above the framing furniture, **or** collapse that furniture to one line" — this takes the second, because moving the card would invert the canonical hierarchy that `OutputsDock.analysis-run.spec.tsx` pins as a **ruling**.

**Ordering, not deletion.** The four dimension sub-cards, the brief actions and the framing question all still render behind the disclosure control the card already owns. `blocked` is exempt — a danger-severity framing problem must not be folded away behind the result it undermines.

## ⭐ Corrections applied after an independent adversarial review (head `ba69dbc8`)

The review found the ruling this PR exists to apply — **NO DENIAL WITHOUT AUTHORITY** — defeated one hop upstream and unapplied on two sibling surfaces. Three code corrections plus one evidence restatement.

**1. `hydrateAnalysis.ts:69` — the `?? []` that defeated the whole fix.** `extractM1CoachingFromV2` is the **sole live writer** of `runMeta.m1Coaching` (called only from `useScenario.ts:775`, on a persisted-scenario restore). It mapped `evidence_gaps: coaching.evidence_gaps ?? []`, so a persisted response with `m1_coaching` present and **no** `evidence_gaps` key had an array minted for it ⇒ `Array.isArray(...)` true ⇒ `evidenceGapsAssessed: true` ⇒ **"No evidence gaps flagged"** — the same unlicensed all-clear, restored above the fix by the same idiom. The doc at `types.ts:982` and the code comment *"silence can never be read as an assessment"* were **false on that path**. The key is now absent when the producer sent nothing. `next_actions` / `assumptions_ledger` carry the same idiom and are deliberately **not** changed: nothing reads an assessed/not-assessed distinction off either.

**RED-first, shown failing first.** New cases seed the store **through `hydrateAnalysisFromV2Response` + `resultsHydrateFromSupabase`** rather than authoring a `runMeta.m1Coaching` literal — all three pre-existing producer states were authored that way, which is exactly why this hole was invisible to the corpus (**trap 22**). At pristine: **2 failed / 8 passed / 10 collected**; after the fix, 15/15. The absent-`m1_coaching` case **passed at pristine** and is kept as the contrast: only the *present-but-silent* path was defective.

**2. `TriageActionCardsBody.tsx:470,568` — unknown confidence read as "not weak".** `useResultsSectionData:3225` maps a gap with no stated `confidence` to `null` **deliberately**, and `evidenceGapConfidenceDisplay` states *"Callers must SUPPRESS the figure and anything derived from it"*. `evidenceWeak` derived from it, so `confidence: null` ⇒ not weak ⇒ `ok` ⇒ green ✓ **"Evidence covered"** while `checks-addressed` one row below rendered **"0 of 1 evidence gaps addressed"**. One payload, two contradicting sentences. The tick is now derived from **the same `addressed` count that span renders**, so the two rows cannot disagree by construction.

**3. `postAnalysisFooter.ts:174-177` — the cross-surface twin.** Byte-identical predicate, different surface (`results-analysis-footer`), fed the **same list** by `OutputsDock:1542` — so a gap whose confidence the producer never stated read as **"Evidence strong"**. Both surfaces now share **one** predicate (`everyEvidenceGapAddressed`), not two copies that happen to agree today.

**Two pre-existing tests were pinning defects 1 and 3** (`hydrateAnalysis.spec.ts:249` asserting `evidence_gaps` `.toEqual([])`; `postAnalysisFooter.spec.ts:183` *"treats non-numeric review-card confidence as ok"*). Both corrected **at source** with the reasoning recorded, never absorbed into a baseline.

**4. The evidence table below was a non-discriminating control — corrected by fixing the harness, not the prose.** See the ⚠ note under it.

## Evidence

⚠ **The first version of this table was not attributable to this diff, and the harness has been fixed rather than the wording.** The replayed capture carries `analysis_ready.status: 'ready'` **and** `goal_threshold_raw: 1000000`, so `computeSuccessState` branch 2 fires ⇒ `state = 'ready'` ⇒ `autoExpand` is `false` at pristine **and** `false` after the fix. All three gate assertions therefore passed at pristine, and *"furniture 135px (was 282px)"* was not measuring the change.

**Fixed the better way:** the replay now **drops `goal_threshold_raw` / `goal_threshold_unit`** from `analysis_ready` and nothing else. `status` stays `ready` and the normalised `goal_threshold: 0.8` stays, so this is the product's own value-scale degradation case — present on the wire, not displayable ⇒ `displayText: null` ⇒ **`liveState: 'thin'`**, a state pristine auto-expands. The state is **pinned on screen** before anything is measured (a run that landed back in `ready` would otherwise report a comfortable number about nothing), and it is emitted in the output line as `briefState`.

*(The header's earlier explanation — that all five starters carry a success measure — was also wrong for this one: `build-vs-buy`'s goal node carries no threshold and its own `analysis_ready` carries none either. The measure arrived **only** from the replayed capture, which is what made the trim possible. Corrected in the file.)*

**Real Chromium, re-measured 19 Aug** (`e2e/geometry/analysisAnswerFirst.measure.ts`, trimmed replay via `applyV5State`, `briefState: "thin"`) — the **same file run twice**, differing only in `DecisionOverviewCard`'s `autoExpand` (reverted in place as a mutant, applied-check scoped to `src/` = exactly 1, restored `git checkout HEAD --`, clean tree asserted before and after):

| viewport | arm | verdict | fold | % of fold | furniture | sub-cards | result |
|---|---|---|---|---|---|---|---|
| 1280×800 | **pristine** | 536px | 586px | 91% | 282px | **expanded** | **FAILED** |
| 1280×800 | **fixed** | 389px | 586px | **66%** | **135px** | collapsed, toggle intact | passed |
| 1440×900 | **pristine** | 536px | 686px | 78% | 282px | **expanded** | **FAILED** |
| 1440×900 | **fixed** | 389px | 686px | **57%** | **135px** | collapsed, toggle intact | passed |

The 135px/282px figures are now reproduced by a harness that **REDs without the fix**, so the column is attributable. **Stated precisely: two of the three gate assertions discriminate, one does not.** `subCardsExpanded` and `disclosure` flip and are why the pristine arm REDs; **`hero.top < fold` passes in BOTH arms** (536 < 586 — 91% of the fold, barely). This replayed thin state is not the deployed typed-thin-brief that put the verdict at 573px in a 515px region, so the above-the-fold assertion remains a floor this harness cannot exercise adversarially. Recorded in the file's header, not only here.

**Mutants** — throwaway worktree outside the repo root, isolation proven by *writing* a sentinel and asserting the source is unchanged (inodes differ), applied-check scoped to `src/` with control exactly 0 before and after:

| mutant | result |
|---|---|
| M1 glyph reverts to the unlicensed denial | **3 failed** |
| M2 assessed flag always `true` | **3 failed** |
| M3 `autoExpand` reverts to pre-fix | **3 failed** |
| M4 gap cards stop rendering (card half only) | **1 failed** |

M1 and M4 are a **discriminating pair**: M1 REDs the summary half, M4 the card half, so the one-reader test provably observes both rather than passing on one.

⚠ **M3 first reported SURVIVED, and it was a false survivor** — the worktree was cut at the commit *before* that spec existed, so the mutation ran against a test that was not there. My harness lacked the collected-count assertion the standing brief requires. Re-cut at the correct HEAD, with the spec asserted to collect **5 tests by name at pristine**, M3 bites. Recorded because an unapplied or unobserved mutation is indistinguishable from an equivalent one.

**Suites (original)** — scoped `src/components/results` + `OutputsDock.analysis-run`: **236 files / 4143 tests, all pass**. New specs collect **5** and **5** by name.

**Suites (corrections, `ba69dbc8`)** — collected counts asserted **by name**, never inferred from the total, with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set: `checksFooter.evidenceNoDenialWithoutAuthority` **15/15** · `hydrateAnalysis` **23/23** · `postAnalysisFooter` **35/35** · `evidenceGapConfidenceDisplay` **9/9** · `postAnalysisFooter.blockedReasonVisible` **5/5** · `AnalysisFooter.metaWrap` **4/4** · `DecisionOverviewCard.answerFirst` **5/5** · `DecisionOverviewCard` **45/45** · `useScenario` **48/48** — **189 passed, 0 failed, no zero-collect**. Repo gates: `pnpm run lint` **exit 0** (0 errors; hooks ratchet exactly matching baseline) and `pnpm run typecheck` **PASSED** (3532/3572 files loaded; drift 2272 → 2263, none added; baseline deliberately **not** regenerated). CI's own `Full Test Suite` shards then passed the whole suite.

## Unmeasured / not done

- ~~**The thin-brief geometry is not reproducible in this harness.**~~ **Withdrawn — it was, and the stated reason was wrong.** The harness now reaches `thin` by trimming two keys from the replay (above). What remains genuinely out of reach is the **deployed typed-thin-brief**: the brief text here is still the starter's, and the 573px-in-a-515px-region above-the-fold acceptance must be witnessed on the deployed build.
- **`hero.top < fold` is not discriminating** even in the trimmed harness — it passes in both arms. Do not read it as the evidence for this change; `subCardsExpanded` / `disclosure` are.
- **Deliberately not fixed, recorded:** `DecisionOverviewCard.tsx:273`/`:455-457` *"Nothing set as a hard limit"* on producer silence · `useResultsSectionData.ts:3183-3188` raw-vs-filtered predicate split · `hydrateAnalysis.ts` identical `?? []` on `next_actions` and `assumptions_ledger` (no consumer reads an assessed distinction off either) · `strengthenCopy.ts:19` · the Visual Regression alarm itself.
- **CI polled to conclusion at `ba69dbc8`:** `total_count=14`, `running=0`. **Staging Gate — SUCCESS.** All four Full Test Suite shards + summary, TypeScript + Lint, Typecheck Gate Self-Test, Production Build, Security Audit (pnpm), CEE Contract Validation, Install & Cache, Flag Deployment Drift — all success. The only failure is **`Visual Regression (advisory)`**, the standing red: identically red on pristine staging `64ffb4de`, where its own self-test fails (*"noise floor 0.038 is not comfortably below the tolerance 0.0005"*). Not required, and not a failure of this work.

## Reported, deliberately NOT fixed here (scope boundary)

A sweep of the whole evidence axis found the divergence is far wider than these two points — **three partially-canonical authorities and nine-plus local heuristics**, with a producer-owned `factor_sensitivity[].value_defaulted` that **exactly one** surface consumes. Highlights for a follow-up lane, none touched:

- `useScienceIcons` icon #8 ("High-leverage assumption with no supporting evidence") gates on `extractionType === 'inferred'`, which confirm/override write paths deliberately do not clear — so it keeps asserting this about values a user just vouched for. `isReviewedSource` is **already imported in that file** and used by icon #2, which was fixed this way. `EstimateMarker` carries the identical defect.
- `useLensFilter`'s five-value source list is disjoint from the canonical ones — a user-confirmed factor falls through to `assumed`.
- `coachingConfig.factorControllableEvidence` renders an evidence-quality claim with **no predicate at all**.
- `evidenceCoverage.NON_EVIDENCE_PROVENANCE` and `usePreAnalysisData.hasEvidence` directly contradict each other on `provenance: 'assumption'`.

**No collision with the sibling occlusion lane** — this PR touches only the Analysis panel; nothing in the workspace shell or canvas fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


