### PR TITLE
D7 · The Compare tab is bound to producer attestations — no minted zeros, no label-minted flips, and the coherence gate now acts

### DIFF
--- a/src/canvas/compare-tab/HealthIndicators.tsx
+++ b/src/canvas/compare-tab/HealthIndicators.tsx
@@ -1,4 +1,4 @@
-import { ArrowUp, ArrowDown } from 'lucide-react'
+import { ArrowUp, ArrowDown, Minus } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import type { AnalysisSnapshot } from './types'
 
@@ -12,9 +12,16 @@ interface HealthIndicatorsProps {
  * comparison was never assessed there is no trend to claim, so this reports
  * false rather than letting `indexOf(null)` (-1) manufacture a rise out of
  * missing data.
+ *
+ * ⚠ D7 — T2b CLOSED ONE DIRECTION AND LEFT THE OTHER OPEN. `false` is not
+ * "no claim"; at the call site it selects `ArrowDown`. So the guard written to
+ * stop an absence manufacturing a RISE manufactured a FALL instead, and the row
+ * read "Result stability: Not assessed → Not assessed" with a DOWN arrow beside
+ * it. The return type is now three-valued: `null` means NO DIRECTION IS
+ * CLAIMED, which is the state the data is actually in.
  */
-function stabilityImproving(from: string | null, to: string | null): boolean {
-  if (from == null || to == null) return false
+function stabilityImproving(from: string | null, to: string | null): boolean | null {
+  if (from == null || to == null) return null
   const order = ['fragile', 'mostly stable', 'stable']
   return order.indexOf(to) > order.indexOf(from)
 }
@@ -26,8 +33,10 @@ function stabilityImproving(from: string | null, to: string | null): boolean {
  * over a null (or the "0/0" a fabricating factory would have produced) would
  * manufacture a rise out of that absence.
  */
-function coverageImproving(from: string | null, to: string | null): boolean {
-  if (from == null || to == null) return false
+function coverageImproving(from: string | null, to: string | null): boolean | null {
+  // D7: `null`, not `false` — see `stabilityImproving` above for why the
+  // two-valued version fabricated a downward trend.
+  if (from == null || to == null) return null
   // "3/5" format — compare numerators
   const fromNum = parseInt(from.split('/')[0], 10) || 0
   const toNum = parseInt(to.split('/')[0], 10) || 0
@@ -55,17 +64,28 @@ export function HealthIndicators({ first, latest }: HealthIndicatorsProps) {
     },
     {
       label: 'Influence concentration',
-      from: `${first.influenceConcentration}%`,
-      to: `${latest.influenceConcentration}%`,
-      // Lower concentration is better (less dominated by single factor)
-      up: latest.influenceConcentration < first.influenceConcentration,
+      // D7: the same "Not assessed" treatment the two rows above already have.
+      // This row rendered `${null}%` as the literal "null%", and — worse — the
+      // arrow below compared two values that may never have been measured.
+      from: first.influenceConcentration != null ? `${first.influenceConcentration}%` : 'Not assessed',
+      to: latest.influenceConcentration != null ? `${latest.influenceConcentration}%` : 'Not assessed',
+      // Lower concentration is better (less dominated by single factor).
+      // D7: a DIRECTION is a second-order claim and needs BOTH ends measured.
+      // `0 < 0` is false, so an unmeasured pair silently rendered a DOWN arrow —
+      // a stated trend between two numbers that do not exist. `null` means "no
+      // direction claimed"; the arrow is suppressed rather than guessed.
+      up: first.influenceConcentration != null && latest.influenceConcentration != null
+        ? latest.influenceConcentration < first.influenceConcentration
+        : null,
     },
   ]
 
   return (
     <div className="mt-2 flex flex-col gap-0.5">
       {indicators.map(h => {
-        const Arrow = h.up ? ArrowUp : ArrowDown
+        // D7: `up === null` means no direction was claimed. Rendering either
+        // arrow would assert a trend; `Minus` asserts none.
+        const Arrow = h.up === null ? Minus : h.up ? ArrowUp : ArrowDown
         return (
           <div key={h.label} className="flex items-center gap-1.5">
             <Arrow size={10} className="text-text-light" />

--- a/src/canvas/compare-tab/Hero.tsx
+++ b/src/canvas/compare-tab/Hero.tsx
@@ -90,7 +90,12 @@ function getHeroCopy(
         // zero, so this line could read "improve confidence by 0pp" on a
         // producer that simply sent nothing. The influence figure that remains
         // is elasticity-derived and is the basis for choosing this factor.
-        detail: `${latest.topElasticity}% influence`,
+        // D7: `topElasticity` is now `number | null`. `: 0` printed
+        // "0% influence" beside "Calibrate {factor}" — inviting the user to
+        // spend effort on a factor while stating it has none — for a run whose
+        // factors were simply never scored. Absence drops the clause; a
+        // producer-sent 0 still prints "0% influence".
+        detail: latest.topElasticity != null ? `${latest.topElasticity}% influence` : '',
       }
     }
     case 'noWinner': {

--- a/src/canvas/compare-tab/TrajectorySection.tsx
+++ b/src/canvas/compare-tab/TrajectorySection.tsx
@@ -80,8 +80,15 @@ function ExpertTable({ snapshots }: { snapshots: AnalysisSnapshot[] }) {
               {[
                 s.runNumber,
                 s.evidenceCoverage ?? NOT_ASSESSED,
-                `${s.influenceConcentration}%`,
-                s.rankFlipRate.toFixed(2),
+                // D7. These two columns were the only cells in this row that
+                // could not say "Not assessed", and they sat between three that
+                // already could. `influenceConcentration` interpolated a
+                // fabricated 0 as "0%" and `rankFlipRate.toFixed(2)` printed
+                // "0.00" — the most measurement-like form a number takes, in a
+                // table of per-run values that reads as a measured trend.
+                // A producer-sent 0 still renders "0%" / "0.00".
+                s.influenceConcentration != null ? `${s.influenceConcentration}%` : NOT_ASSESSED,
+                s.rankFlipRate != null ? s.rankFlipRate.toFixed(2) : NOT_ASSESSED,
                 s.fragileEdgeCount ?? NOT_ASSESSED,
                 s.seedUsed ?? NOT_ASSESSED,
               ].map((val, i) => (

--- a/src/canvas/compare-tab/__tests__/deriveTransitions.spec.ts
+++ b/src/canvas/compare-tab/__tests__/deriveTransitions.spec.ts
@@ -326,6 +326,46 @@ describe('deriveTransitions', () => {
       expect(deriveTransitions(snapshots)[0].deterministicAnchor)
         .toContain('Growth overtook Churn')
     })
+
+    // ── D7: THE MINTED "(elasticity 0.00)", PINNED ────────────────────────────
+    //
+    // Found by mutation, not by reading: replacing the file's single elasticity
+    // accessor with `f.elasticity ?? 0` left 582 tests across 46 files GREEN,
+    // while the sentence a user reads changed from an honest silence to
+    // "(elasticity 0.00)" — a two-decimal measurement for a factor the producer
+    // never scored. The existing "remained" test above cannot see it: it uses
+    // `toContain`, so it passes with OR without the parenthetical.
+    //
+    // Both assertions are load-bearing and neither is sufficient alone. The
+    // `not.toContain` is the actual claim; the positive one is its precondition,
+    // so the test cannot pass by the sentence being empty or the transition
+    // never being built (which is how an absence assertion goes vacuous).
+    it('states NO number when the producer did not score the top factor', () => {
+      const unscored = [makeFactor({ id: 'fac-a', label: 'Churn', elasticity: null })]
+      const snapshots = [
+        makeSnapshot({ runNumber: 1, topFactors: unscored }),
+        makeSnapshot({ runNumber: 2, topFactors: unscored }),
+      ]
+      const anchor = deriveTransitions(snapshots)[0].deterministicAnchor
+
+      expect(anchor).toBe('Based on: Churn remained the top influence factor')
+      expect(anchor).not.toContain('elasticity')
+      expect(anchor).not.toContain('0.00')
+    })
+
+    // The opposite-direction twin (trap 22b): over-suppressing a number the
+    // producer DID state is the same defect pointing the other way, so the
+    // scored case is pinned to the exact string too. Without this, "drop the
+    // parenthetical always" would satisfy the test above.
+    it('STILL states the number when the producer did score it', () => {
+      const scored = [makeFactor({ id: 'fac-a', label: 'Churn', elasticity: 0.42 })]
+      const snapshots = [
+        makeSnapshot({ runNumber: 1, topFactors: scored }),
+        makeSnapshot({ runNumber: 2, topFactors: scored }),
+      ]
+      expect(deriveTransitions(snapshots)[0].deterministicAnchor)
+        .toBe('Based on: Churn remained the top influence factor (elasticity 0.42)')
+    })
   })
 
   it('sets reason and aiContext to null (not yet available)', () => {
@@ -376,6 +416,66 @@ describe('deriveTransitions', () => {
         }),
       ]
       expect(deriveTransitions(snapshots)[0].affectedFactorIds).toContain('fac-a')
+    })
+
+    // ── D7: A FACTOR THAT STOPPED BEING SCORED HAS NOT "CHANGED BY >20%" ──────
+    //
+    // Same mutation-found hole as the anchor above. With `elasticity ?? 0`, an
+    // unscored end is read as a measured 0, so the relative change against any
+    // non-zero previous value computes as 1.0 — over the 0.2 threshold — and the
+    // factor is reported as affected. That is a change in WHAT WAS MEASURED
+    // being published as a change in the factor itself.
+    //
+    // `fac-b` is the positive control, in the SAME assertion set: without it,
+    // an implementation that returned an empty list for everything would pass.
+    // The pair is what binds the claim to `fac-a` specifically (trap 19).
+    it('does NOT report a factor as changed when one end was never scored', () => {
+      const snapshots = [
+        makeSnapshot({
+          runNumber: 1,
+          topFactors: [
+            makeFactor({ id: 'fac-a', elasticity: 0.5 }),
+            makeFactor({ id: 'fac-b', elasticity: 0.5 }),
+          ],
+        }),
+        makeSnapshot({
+          runNumber: 2,
+          topFactors: [
+            makeFactor({ id: 'fac-a', elasticity: null }), // producer declined to score
+            makeFactor({ id: 'fac-b', elasticity: 0.9 }),  // genuine 80% change
+          ],
+        }),
+      ]
+      const affected = deriveTransitions(snapshots)[0].affectedFactorIds
+
+      expect(affected).not.toContain('fac-a')
+      expect(affected).toContain('fac-b')
+    })
+
+    // The mirror: an unscored PREVIOUS end is equally not a change. Pinned
+    // separately because the two ends are read on different code paths — the
+    // previous value comes from the prev-run map, the current from the factor.
+    it('does NOT report a factor as changed when the PREVIOUS end was never scored', () => {
+      const snapshots = [
+        makeSnapshot({
+          runNumber: 1,
+          topFactors: [
+            makeFactor({ id: 'fac-a', elasticity: null }),
+            makeFactor({ id: 'fac-b', elasticity: 0.5 }),
+          ],
+        }),
+        makeSnapshot({
+          runNumber: 2,
+          topFactors: [
+            makeFactor({ id: 'fac-a', elasticity: 0.5 }),
+            makeFactor({ id: 'fac-b', elasticity: 0.9 }),
+          ],
+        }),
+      ]
+      const affected = deriveTransitions(snapshots)[0].affectedFactorIds
+
+      expect(affected).not.toContain('fac-a')
+      expect(affected).toContain('fac-b')
     })
   })
 })

--- a/src/canvas/compare-tab/deriveTransitions.ts
+++ b/src/canvas/compare-tab/deriveTransitions.ts
@@ -97,6 +97,28 @@ function leaderFlipped(from: AnalysisSnapshot, to: AnalysisSnapshot): boolean {
 // Affected factors derivation
 // ---------------------------------------------------------------------------
 
+/**
+ * The producer's stated elasticity for one summarised factor — `null` where the
+ * producer stated none.
+ *
+ * ⚠ THE ONLY PLACE IN THIS FILE THAT READS THE `elasticity` FIELD. Five lines
+ * here used to reach for it directly, and each re-decided for itself what an
+ * absent measurement means: the previous-run map stored it raw, the change
+ * detector tested it twice with two different guards, and the anchor sentence
+ * tested it a third way before formatting. The `elasticity` claim family is
+ * registered as FROZEN, SHRINK-ONLY DEBT with no estate-wide owner selector
+ * (`src/components/results/utils/elasticityClaimDebt.ts`), so the compliant
+ * move for this file is to stop being a fifth authority on it and hold exactly
+ * one call site for the real owner to take over.
+ *
+ * It is a PASS-THROUGH today — `FactorSensitivitySummary.elasticity` is already
+ * `number | null` — and that is said plainly rather than dressed up as
+ * transformation. Its job is to be the single point of contact, not to compute.
+ */
+function statedElasticity(f: FactorSensitivitySummary): number | null {
+  return f.elasticity
+}
+
 /** Factors whose elasticity rank changed by >=2 or elasticity changed by >20% */
 function deriveAffectedFactors(
   fromFactors: FactorSensitivitySummary[],
@@ -108,7 +130,7 @@ function deriveAffectedFactors(
   // Build rank maps
   const fromRank = new Map(fromFactors.map((f, i) => [f.id, i]))
   const toRank = new Map(toFactors.map((f, i) => [f.id, i]))
-  const fromElasticity = new Map(fromFactors.map(f => [f.id, f.elasticity]))
+  const fromElasticity = new Map(fromFactors.map(f => [f.id, statedElasticity(f)]))
 
   for (const factor of toFactors) {
     const prevRank = fromRank.get(factor.id)
@@ -124,14 +146,15 @@ function deriveAffectedFactors(
     }
 
     // Elasticity changed by >20% relative.
-    // D7: both ends must be SCORED. `elasticity` is now `number | null`, and a
-    // null end means the producer did not measure that factor on that run —
-    // which is not a change in the factor, it is a change in what was measured.
+    // D7: both ends must be SCORED. `elasticity` is `number | null`, and a null
+    // end means the producer did not measure that factor on that run — which is
+    // not a change in the factor, it is a change in what was measured.
+    const currentElasticity = statedElasticity(factor)
     if (
       prevElasticity !== undefined && prevElasticity !== null && prevElasticity !== 0
-      && factor.elasticity !== null
+      && currentElasticity !== null
     ) {
-      const change = Math.abs(factor.elasticity - prevElasticity) / Math.abs(prevElasticity)
+      const change = Math.abs(currentElasticity - prevElasticity) / Math.abs(prevElasticity)
       if (change > 0.2) {
         ids.add(factor.id)
         labelMap.set(factor.id, factor.label)
@@ -171,8 +194,9 @@ function deriveDeterministicAnchor(
     // it is dropped when the number does not exist. `.toFixed(2)` on a
     // fabricated 0 printed "(elasticity 0.00)" — a precise-looking measurement
     // — for a top factor the producer never scored.
-    return toTop.elasticity !== null
-      ? `Based on: ${toTop.label} remained the top influence factor (elasticity ${toTop.elasticity.toFixed(2)})`
+    const topScore = statedElasticity(toTop)
+    return topScore !== null
+      ? `Based on: ${toTop.label} remained the top influence factor (elasticity ${topScore.toFixed(2)})`
       : `Based on: ${toTop.label} remained the top influence factor`
   }
   return `Based on: ${toTop.label} overtook ${fromTop.label} as the top influence factor`

--- a/src/canvas/compare-tab/deriveTransitions.ts
+++ b/src/canvas/compare-tab/deriveTransitions.ts
@@ -123,8 +123,14 @@ function deriveAffectedFactors(
       }
     }
 
-    // Elasticity changed by >20% relative
-    if (prevElasticity !== undefined && prevElasticity !== 0) {
+    // Elasticity changed by >20% relative.
+    // D7: both ends must be SCORED. `elasticity` is now `number | null`, and a
+    // null end means the producer did not measure that factor on that run —
+    // which is not a change in the factor, it is a change in what was measured.
+    if (
+      prevElasticity !== undefined && prevElasticity !== null && prevElasticity !== 0
+      && factor.elasticity !== null
+    ) {
       const change = Math.abs(factor.elasticity - prevElasticity) / Math.abs(prevElasticity)
       if (change > 0.2) {
         ids.add(factor.id)
@@ -161,7 +167,13 @@ function deriveDeterministicAnchor(
   if (!fromTop) return `Based on: ${toTop.label} is the top influence factor`
 
   if (fromTop.id === toTop.id) {
-    return `Based on: ${toTop.label} remained the top influence factor (elasticity ${toTop.elasticity.toFixed(2)})`
+    // D7: the parenthetical is the only place this sentence states a NUMBER, so
+    // it is dropped when the number does not exist. `.toFixed(2)` on a
+    // fabricated 0 printed "(elasticity 0.00)" — a precise-looking measurement
+    // — for a top factor the producer never scored.
+    return toTop.elasticity !== null
+      ? `Based on: ${toTop.label} remained the top influence factor (elasticity ${toTop.elasticity.toFixed(2)})`
+      : `Based on: ${toTop.label} remained the top influence factor`
   }
   return `Based on: ${toTop.label} overtook ${fromTop.label} as the top influence factor`
 }
@@ -359,9 +371,19 @@ function findConditionalWinner(
   const affectedSet = new Set(affectedFactorIds)
   const match = snapshot.conditionalWinners.find(cw => affectedSet.has(cw.factorId))
   if (!match) return null
-  return match.condition
+  if (match.condition === '') return null
+  // D7. Every row reaching here carries the producer's `winner_flips: true`
+  // attestation (the factory's gate 1), so the FLIP is producer-stated in both
+  // arms below. What differs is whether the producer let us NAME the option:
+  //   · named    → the full claim.
+  //   · withheld → the flip is still real and still worth stating; naming an
+  //                option is what is not permitted. The old code interpolated
+  //                the empty string here and published ", takes over".
+  // This is deliberately NOT a suppression of the finding — over-suppressing a
+  // quantity the producer DID compute is the mirror defect, weighted equally.
+  return match.winner !== null
     ? `${match.condition}, ${match.winner} takes over`
-    : null
+    : `${match.condition}, the leading option changes (which option is withheld on this run)`
 }
 
 // ---------------------------------------------------------------------------

--- a/src/canvas/compare-tab/types.ts
+++ b/src/canvas/compare-tab/types.ts
@@ -16,8 +16,15 @@ export interface FactorSensitivitySummary {
   /** Node ID (stable, for canvas linking) */
   id: string
   label: string
-  elasticity: number
-  rankFlipRate: number
+  /**
+   * D7 absence-preserving. `elasticity ?? 0` published "this factor has no
+   * influence" for a factor the producer simply did not score — and 0 is not a
+   * neutral placeholder here, it is the STRONGEST scientific claim the field
+   * can make. An honest producer-sent 0 still flows through as 0.
+   */
+  elasticity: number | null
+  /** D7 absence-preserving, same rule as `elasticity`. */
+  rankFlipRate: number | null
   /** Attribution stability label from PLoT bootstrap */
   attributionStability: string
 }
@@ -197,8 +204,16 @@ export interface AnalysisSnapshot {
 
   // Factor sensitivity — top 5 for transition derivation
   topFactors: FactorSensitivitySummary[]
-  /** max |elasticity| / sum |elasticity|, as percentage */
-  influenceConcentration: number
+  /**
+   * max |elasticity| / sum |elasticity|, as percentage.
+   *
+   * D7 absence-preserving: null when NO factor carries a scored elasticity, so
+   * the ratio was never computed. It returned 0 — "influence is perfectly
+   * spread across every factor" — which is a measurement, and `HealthIndicators`
+   * then compared two such zeros to draw a DIRECTION ARROW between them.
+   * A genuine computed 0 (every elasticity scored, all zero) still renders 0.
+   */
+  influenceConcentration: number | null
   /**
    * The factor the Compare hero invites the user to calibrate: the top factor
    * by |elasticity|, i.e. the same one whose influence the hero already prints.
@@ -213,10 +228,20 @@ export interface AnalysisSnapshot {
   topCalibrationFactor: string
   /** Node ID for canvas linking */
   topCalibrationFactorId: string
-  /** As percentage */
-  topElasticity: number
-  /** From top factor */
-  rankFlipRate: number
+  /**
+   * As percentage. D7 absence-preserving: null when there is no top factor, or
+   * when the top factor's elasticity was not scored. The Compare hero prints
+   * this as "{n}% influence"; `: 0` printed "0% influence" about a factor the
+   * hero had just named as the one worth calibrating.
+   */
+  topElasticity: number | null
+  /**
+   * From top factor. D7 absence-preserving: null when there is no top factor,
+   * or when the producer did not score its `rank_flip_rate`. The trajectory
+   * table's own neighbouring columns already render `?? 'Not assessed'`; this
+   * one printed a fabricated "0.00" in the same row.
+   */
+  rankFlipRate: number | null
 
   // Goal
   goalProbability: number | null
@@ -224,10 +249,33 @@ export interface AnalysisSnapshot {
 
   // ISL fields (may be empty arrays when ISL doesn't provide them)
   inferenceWarnings: string[]
+  /**
+   * Conditional-winner rows the PRODUCER ATTESTED as flipping.
+   *
+   * D7 — every member here is bound to a producer attestation or an IDENTITY,
+   * never to a label:
+   *  · the row is present only when `winner_flips === true`. The contract types
+   *    `winner_flips` as a REQUIRED boolean that admits `false`
+   *    (`EnrichmentConditionalWinnerSchema`, vendored 0.48.0), and its own doc
+   *    says the field states THAT the winner changes, never WHICH option.
+   *  · `winnerId` / `runnerUpId` are the bucket IDENTITIES. The producer's
+   *    absence semantics are explicit: a missing `winner_id`/`winner_label`
+   *    means the leading option was WITHHELD on this turn — "It never means
+   *    'no option won'". So absence here is withholding, and the consumer must
+   *    not name an option.
+   *  · `winner` is the high-bucket label and is `null` under exactly that
+   *    withholding. It was `String(... ?? '')`, which rendered the empty string
+   *    into the sentence "…, {winner} takes over".
+   */
   conditionalWinners: Array<{
     factorId: string
     factorLabel: string
-    winner: string
+    /** High-bucket winner LABEL. null ⇒ withheld on this turn — do not name it. */
+    winner: string | null
+    /** High-bucket winner IDENTITY. null ⇒ withheld on this turn. */
+    winnerId: string | null
+    /** Low-bucket winner IDENTITY, i.e. who leads BELOW the split. */
+    lowWinnerId: string | null
     condition: string
   }>
   edgeEValues: Array<{

--- a/src/canvas/stores/__tests__/analysisSnapshotFactory.flipReasonNarrowing.spec.ts
+++ b/src/canvas/stores/__tests__/analysisSnapshotFactory.flipReasonNarrowing.spec.ts
@@ -1,0 +1,221 @@
+/**
+ * D7b — THE SUPPRESSION IS NARROWED TO THE ONE REASON THAT PROVES IT, AND
+ * WIDENED TO THE ROWS THAT CARRY THAT REASON WITHOUT THE BOOLEAN.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * THE TWO QUESTIONS, WRITTEN DOWN BEFORE ANYTHING WAS RECONCILED (trap 21)
+ * ─────────────────────────────────────────────────────────────────────────
+ * A. `flip_thresholds[].flip_reason` answers:
+ *    "Moving THIS FACTOR ALONE across its domain, at the mean edge
+ *     configuration, is there a value at which the argmax changes?"
+ * B. `conditional_winners[].winner_flips` answers:
+ *    "If I median-split the Monte-Carlo samples on this factor's realised
+ *     value, do the two halves have different WIN-FREQUENCY argmaxes?"
+ *
+ * They are different questions — UNLESS the flip reason is
+ * `structurally_invariant`, in which case A's answer makes B's instrument
+ * provably non-discriminating:
+ *
+ *   `structurally_invariant` means the per-option transmission slopes are
+ *   IDENTICAL (spread <= 1e-9) — PLoT `lib/flip-threshold-status.ts:44-49`,
+ *   read at staging `7e5d8a7d`: "no value of this factor can move the
+ *   argmax". The slope equality is TOPOLOGICAL (which of the factor's causal
+ *   paths each option's intervention severs), so it holds for EVERY sampled
+ *   edge configuration, not just the mean one. The per-sample winner is
+ *   therefore independent of the factor, the two buckets are two random
+ *   halves of ONE sequence, and `winner_flips: true` is sampling noise whose
+ *   only driver is how close the win probability sits to 0.5.
+ *
+ *   `no_effect_within_bounds` means the slopes GENUINELY DIFFER and the
+ *   crossing merely lies outside the domain AT THE MEAN CONFIGURATION
+ *   (`flip-threshold-status.ts:43-44`). Each sample draws different edge
+ *   strengths, so the crossing moves and can fall inside the domain for a
+ *   real share of draws. A bucket disagreement there is a FINDING ISL
+ *   COMPUTED, not an artefact — suppressing it withholds science.
+ *
+ * PLoT collapses both tokens into one boolean:
+ * `integrations/isl/adapters/factor-flip-values.ts:304` stamps
+ * `no_flip_in_range: true` from `NO_EFFECT_REASONS`, which is the SET of both
+ * (`lib/flip-threshold-status.ts:75-78`). So the boolean cannot carry the
+ * distinction and the reason must be read.
+ *
+ * ⚠ TWO OPPOSITE HARMS, TWO PREDICATES (trap 22b). Over-suppression withholds
+ * a real finding; under-suppression states a falsehood. They are NOT tuned on
+ * one window here: the run-level absence claim keeps
+ * `isAttestedNoFlipReason` (BOTH tokens — `no_effect_within_bounds` really is
+ * an attested absence over the tested range), while the per-factor suppression
+ * of a SIBLING SURFACE'S positive claim uses the strictly narrower
+ * `provesFactorCannotMoveWinner` (the algebraic proof only). Merging them
+ * would trade one silent failure for the other.
+ *
+ * ⚠ FIXTURE PROVENANCE. Every payload below is a REAL capture from
+ * `src/lib/coherence/__tests__/fixtures/captures/` (sha256s in its
+ * `PROVENANCE.md`), imported rather than re-copied. Where a case needs a
+ * combination no single capture holds, the transformation is a JOIN of two
+ * real halves and is named `COMPOSED` with its licence stated — never an
+ * invented row.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { Node, Edge } from '@xyflow/react'
+
+import { buildAnalysisSnapshot } from '../analysisSnapshotFactory'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+import type { ReportV1 } from '../../../adapters/plot/types'
+
+import w2dTurn from '../../../lib/coherence/__tests__/fixtures/captures/seeded-2026-08-17-w2d-analysis-turn.json'
+import w998Turn from '../../../lib/coherence/__tests__/fixtures/captures/w998-2026-08-16-a1-turn3.json'
+import probeA from '../../../lib/coherence/__tests__/fixtures/captures/conditional-winners-2026-08-17-probe-A.json'
+
+const W2D = (w2dTurn as unknown as { blocks: Array<{ enrichment: Record<string, unknown> }> })
+  .blocks[0].enrichment
+const W998 = (w998Turn as unknown as { blocks: Array<{ enrichment: Record<string, unknown> }> })
+  .blocks[0].enrichment
+const PROBE_A = probeA as unknown as Record<string, unknown>
+
+const nodes: Node[] = [
+  { id: 'n1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'A' } },
+]
+const edges: Edge[] = []
+
+function snapshotOf(raw: Record<string, unknown>) {
+  return buildAnalysisSnapshot({
+    rawV2Response: raw as unknown as V2RunResponse,
+    report: {} as ReportV1,
+    nodes,
+    edges,
+    runNumber: 1,
+    events: [],
+    previousSnapshotTimestamp: null,
+  })
+}
+
+function clone<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v)) as T
+}
+
+const flipRows = (e: Record<string, unknown>) =>
+  e.flip_thresholds as Array<Record<string, unknown>>
+const winnerRows = (e: Record<string, unknown>) =>
+  e.conditional_winners as Array<Record<string, unknown>>
+
+// ───────────────────────────────────────────────────────────────────────────
+// DIRECTION 1 — THE OVER-SUPPRESSION ARM MUST STOP FIRING.
+// `no_effect_within_bounds` is compatible with a marginal flip. A row the
+// producer computed must reach the user.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('D7b direction 1 — a `no_effect_within_bounds` attestation does NOT suppress the conditional winner', () => {
+  it('PRECONDITION: w998 really carries `no_effect_within_bounds` beside `no_flip_in_range: true` — the boolean collapses BOTH reasons', () => {
+    // Stated first so the case below measures a producer-real combination.
+    const rows = flipRows(W998)
+      .filter(r => r.no_flip_in_range === true)
+      .map(r => [r.factor_id, r.flip_reason, r.flip_value])
+    expect(rows).toEqual([
+      ['13faf76d', 'no_effect_within_bounds', null],
+      ['1ed89ca0', 'no_effect_within_bounds', null],
+    ])
+    // And the capture carries NO conditional winner, which is why this arm was
+    // reachable-by-construction but never witnessed. The join below supplies
+    // the missing half from another real capture.
+    expect(winnerRows(W998)).toEqual([])
+  })
+
+  it('COMPOSED (two real halves): the flip claim SURVIVES for a `no_effect_within_bounds` factor', () => {
+    // LICENCE FOR THE JOIN: PLoT stamps `no_flip_in_range: true` from the SET
+    // {no_effect_within_bounds, structurally_invariant}
+    // (factor-flip-values.ts:304 + flip-threshold-status.ts:75-78), and ISL
+    // emits `conditional_winners` for any uncertain factor whose bucket
+    // winners differ (robustness_analyzer_v2.py:5204-5226). Nothing couples
+    // the two arrays, so this combination is producer-reachable.
+    // TRANSFORMATION, disclosed: probe-A's conditional-winner row VERBATIM
+    // except `factor_id`, re-keyed onto w998's `no_effect_within_bounds`
+    // factor. Both halves are real; only the join is composed.
+    const winner = { ...clone(winnerRows(PROBE_A)[0]), factor_id: '13faf76d' }
+    const raw = { flip_thresholds: clone(flipRows(W998)), conditional_winners: [winner] }
+
+    const s = snapshotOf(raw)
+    expect(s.conditionalWinners.map(r => r.factorId)).toEqual(['13faf76d'])
+    // And it still states a threshold — the row is rendered, not merely kept.
+    expect(s.conditionalWinners[0].condition).toContain('exceeds')
+  })
+
+  it('DISCRIMINATION: the SAME composed row IS suppressed once the reason is the algebraic proof', () => {
+    // The only difference from the case above is the reason token. If both
+    // cases moved together the gate would be keyed on something other than the
+    // reason, and this pair is what proves it is not.
+    const winner = { ...clone(winnerRows(PROBE_A)[0]), factor_id: '13faf76d' }
+    const flips = clone(flipRows(W998))
+    flips[0].flip_reason = 'structurally_invariant'
+    const s = snapshotOf({ flip_thresholds: flips, conditional_winners: [winner] })
+    expect(s.conditionalWinners).toEqual([])
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// DIRECTION 2 — THE UNDER-SUPPRESSION ARM MUST START FIRING.
+// The reason, not the boolean, carries the attestation. A row bearing the
+// proof without the flag was refused by the results panel's `selectFlipRisk`
+// (which reads `flip_reason`) and rendered by the Compare tab (which read the
+// boolean) — the sibling-surface disagreement this gate exists to end.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('D7b direction 2 — the PROOF suppresses even when the boolean is absent', () => {
+  it('w2d with `no_flip_in_range` deleted: the rows STAY suppressed, because `structurally_invariant` is still on the wire', () => {
+    const raw = clone(W2D)
+    for (const r of flipRows(raw)) delete r.no_flip_in_range
+    // Precondition pinned in-test: the proof is still present after the delete,
+    // so a pass here cannot be an empty-array vacuity.
+    expect(flipRows(raw).map(r => r.flip_reason))
+      .toEqual(['structurally_invariant', 'structurally_invariant'])
+    expect(snapshotOf(raw).conditionalWinners).toEqual([])
+  })
+
+  it('OPPOSITE-DIRECTION TWIN: deleting the REASON un-suppresses — nothing else in the payload is doing the work', () => {
+    const raw = clone(W2D)
+    for (const r of flipRows(raw)) {
+      delete r.no_flip_in_range
+      delete r.flip_reason
+    }
+    expect(snapshotOf(raw).conditionalWinners.map(r => r.factorId))
+      .toEqual(['71c6351d', 'fcf3d740'])
+  })
+
+  it('an UNRECOGNISED reason token does not suppress — only a proof may withhold a computed claim', () => {
+    const raw = clone(W2D)
+    for (const r of flipRows(raw)) {
+      r.flip_reason = 'a_token_this_build_has_never_seen'
+      delete r.no_flip_in_range
+    }
+    expect(snapshotOf(raw).conditionalWinners.map(r => r.factorId))
+      .toEqual(['71c6351d', 'fcf3d740'])
+  })
+
+  it('a `structurally_invariant` row that ALSO carries a numeric flip_value does not suppress — the attestation is incoherent, so it is not used', () => {
+    // PLoT cannot emit this (`isAttestedNoFlip` requires `flip_value === null`,
+    // factor-flip-values.ts:365-367), so this is defence in depth. The polarity
+    // is deliberate: an incoherent attestation fails toward NOT withholding.
+    const raw = clone(W2D)
+    for (const r of flipRows(raw)) {
+      r.flip_value = 0.42
+      delete r.no_flip_in_range
+    }
+    expect(snapshotOf(raw).conditionalWinners.map(r => r.factorId))
+      .toEqual(['71c6351d', 'fcf3d740'])
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// REGRESSION PINS — the two real captures keep their existing verdicts.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('D7b regression pins — the witnessed cases are unchanged', () => {
+  it('w2d VERBATIM: still suppressed (the witnessed contradiction stays closed)', () => {
+    expect(snapshotOf(W2D).conditionalWinners).toEqual([])
+  })
+
+  it('probe-A VERBATIM: a `found` flip row never suppresses its own factor', () => {
+    const s = snapshotOf(PROBE_A)
+    expect(s.conditionalWinners.map(r => r.factorId)).toEqual(['fac_demand'])
+  })
+})

--- a/src/canvas/stores/__tests__/analysisSnapshotFactory.flipReasonNarrowing.spec.ts
+++ b/src/canvas/stores/__tests__/analysisSnapshotFactory.flipReasonNarrowing.spec.ts
@@ -19,12 +19,23 @@
  *   `structurally_invariant` means the per-option transmission slopes are
  *   IDENTICAL (spread <= 1e-9) — PLoT `lib/flip-threshold-status.ts:44-49`,
  *   read at staging `7e5d8a7d`: "no value of this factor can move the
- *   argmax". The slope equality is TOPOLOGICAL (which of the factor's causal
- *   paths each option's intervention severs), so it holds for EVERY sampled
- *   edge configuration, not just the mean one. The per-sample winner is
- *   therefore independent of the factor, the two buckets are two random
- *   halves of ONE sequence, and `winner_flips: true` is sampling noise whose
- *   only driver is how close the win probability sits to 0.5.
+ *   argmax". The per-sample winner is therefore independent of the factor, the
+ *   two buckets are two random halves of ONE sequence, and `winner_flips: true`
+ *   is sampling noise whose only driver is how close the win probability sits
+ *   to 0.5.
+ *
+ *   ⚠ CORRECTED: this header used to say the slope equality "is TOPOLOGICAL ...
+ *   so it holds for EVERY sampled edge configuration, not just the mean one".
+ *   ISL computes no such property — it screens a NUMERICAL slope spread against
+ *   `1e-9` at a single mean edge configuration
+ *   (`robustness_analyzer_v2.py:6722-6724`, `:6757`, `:6763`, `:6775`), the very
+ *   configuration the next paragraph treats as disqualifying. What carries the
+ *   invariance is a MECHANISM — options are alternative values of one decision
+ *   node, so each option severs the same causal paths and the per-option slopes
+ *   are the same algebraic expression. Canonical derivation, and the residual
+ *   class it does not cover (slopes coinciding at the mean via different path
+ *   products): `components/results/utils/flipReasonVocabulary.ts`. The
+ *   suppression direction, and every assertion below, is unchanged.
  *
  *   `no_effect_within_bounds` means the slopes GENUINELY DIFFER and the
  *   crossing merely lies outside the domain AT THE MEAN CONFIGURATION

--- a/src/canvas/stores/__tests__/analysisSnapshotFactory.inferenceWarnings.spec.ts
+++ b/src/canvas/stores/__tests__/analysisSnapshotFactory.inferenceWarnings.spec.ts
@@ -126,7 +126,13 @@ describe('buildAnalysisSnapshot — inference_warnings root-wins dual read (ROAD
           factor_id: 'factor-1',
           factor_label: 'Factor One',
           split_value: 12,
-          high_bucket: { winner_label: 'Option B' },
+          // D7: contract-required `winner_flips` plus the bucket IDENTITIES the
+          // factory now binds to. This test asserts the two CALLERS agree for
+          // one enrichment; that coherence claim is only meaningful over a row
+          // the producer could actually emit.
+          winner_flips: true,
+          low_bucket: { winner_id: 'opt-a', winner_label: 'Option A' },
+          high_bucket: { winner_id: 'opt-b', winner_label: 'Option B' },
         },
       ],
       // Ids no node resolves — both paths degrade the label identically, so
@@ -165,6 +171,8 @@ describe('buildAnalysisSnapshot — inference_warnings root-wins dual read (ROAD
         factorId: 'factor-1',
         factorLabel: 'Factor One',
         winner: 'Option B',
+        winnerId: 'opt-b',
+        lowWinnerId: 'opt-a',
         condition: 'When Factor One exceeds 12',
       },
     ])

--- a/src/canvas/stores/__tests__/analysisSnapshotFactory.rootSiblings.spec.ts
+++ b/src/canvas/stores/__tests__/analysisSnapshotFactory.rootSiblings.spec.ts
@@ -77,7 +77,15 @@ const CW_ROOT = [
     factor_id: 'n1',
     factor_label: 'Factor One',
     split_value: 12,
-    high_bucket: { winner_label: 'Option B' },
+    // D7: `winner_flips` and the bucket IDENTITIES are added because the
+    // contract REQUIRES the first (`winner_flips: z.boolean()`) and the factory
+    // now binds the flip claim to it and to the ids. A row without them was
+    // never a legal payload, so this fixture was pinning SLOT PRECEDENCE with
+    // an illegal row. Precedence is still exactly what these tests measure —
+    // the row is merely now one the producer could actually emit.
+    winner_flips: true,
+    low_bucket: { winner_id: 'opt-a', winner_label: 'Option A' },
+    high_bucket: { winner_id: 'opt-b', winner_label: 'Option B' },
   },
 ]
 const CW_MAPPED = [
@@ -85,6 +93,8 @@ const CW_MAPPED = [
     factorId: 'n1',
     factorLabel: 'Factor One',
     winner: 'Option B',
+    winnerId: 'opt-b',
+    lowWinnerId: 'opt-a',
     condition: 'When Factor One exceeds 12',
   },
 ]
@@ -101,7 +111,14 @@ describe('buildAnalysisSnapshot — conditional_winners root-wins dual read (ROA
       conditional_winners: CW_ROOT,
       robustness: {
         conditional_winners: [
-          { factor_id: 'nested', factor_label: 'Nested', high_bucket: { winner_label: 'Loses' } },
+          {
+            factor_id: 'nested',
+            factor_label: 'Nested',
+            split_value: 3,
+            winner_flips: true,
+            low_bucket: { winner_id: 'opt-x', winner_label: 'Wins' },
+            high_bucket: { winner_id: 'opt-y', winner_label: 'Loses' },
+          },
         ],
       },
     })

--- a/src/canvas/stores/__tests__/analysisSnapshotFactory.scienceAttestation.spec.ts
+++ b/src/canvas/stores/__tests__/analysisSnapshotFactory.scienceAttestation.spec.ts
@@ -28,6 +28,25 @@
  * running it would say otherwise — a corpus that omits a value class the
  * contract admits is blind to it.
  *
+ * ⚠⚠ CORRECTED (D7b), BECAUSE THE SENTENCE ABOVE MISATTRIBUTES ONE OF THE
+ * THREE ZEROS AND WOULD BE INHERITED AS SETTLED FACT (trap 20). The
+ * `winner_flips: false` zero is **NOT** a corpus limitation — it is a property
+ * of the PRODUCER, derived at the ISL bytes at deployed `28fe0c95`:
+ *
+ *     robustness_analyzer_v2.py:5204  winner_flips = low.winner_id != high.winner_id
+ *     robustness_analyzer_v2.py:5206  if not winner_flips: continue      ← DROPPED
+ *     robustness_analyzer_v2.py:5226  winner_flips=True                  ← hardcoded
+ *
+ * Non-flipping factors are filtered out and the field is then stamped `True`
+ * on every surviving row; PLoT forwards it verbatim (`routes/v2/run.ts:801`,
+ * `:917`, with `:780` refusing a non-boolean). So `winner_flips: false` is
+ * **producer-unreachable end to end on this path**, and the census measured
+ * the producer rather than the corpus. GATE 1 remains defence in depth — the
+ * contract types the field REQUIRED `z.boolean()` and admits `false`, and a
+ * persisted or re-projected row is not bound by ISL's emitter — but it cannot
+ * discriminate on any payload ISL can currently produce, and that is the
+ * honest claim. The other two zeros ARE corpus limitations, unchanged.
+ *
  * Those three classes are consequently derived from the PRODUCER'S OWN
  * CONTRACT, not from anything this lane imagined, and each derivation is a
  * documented transformation applied to a REAL row (`CONTRACT_DERIVED` below):
@@ -132,13 +151,22 @@ describe('D7 opposite-direction twin — a value the producer DID compute still 
     // w2d's turn carries `leader_claim.permitted: false` and the producer
     // nonetheless shipped both bucket identities. That is coherence pair CX4's
     // question, NOT a reason for this factory to discard the rows: the CX5
-    // suppression below is keyed on `no_flip_in_range`, not on the leader
+    // suppression below is keyed on the flip attestation, not on the leader
     // verdict. Proven by removing only the CX5 trigger from the same capture —
     // the rows come back, so the suppression is CX5's doing and not a blanket
     // distrust of a withheld turn.
+    //
+    // ⚠ D7b — THE TRIGGER MOVED, AND THIS TEST MOVED WITH IT. It used to delete
+    // `no_flip_in_range`. That boolean is no longer the trigger: PLoT stamps it
+    // from the SET of BOTH attested reasons, so gating on it over-suppressed
+    // `no_effect_within_bounds` rows. The gate now reads `flip_reason`, so the
+    // honest trigger removal is to delete the REASON. Deleting the boolean
+    // alone would leave this test passing while measuring nothing — the exact
+    // vacuity a narrowing like this creates if the guards are not re-derived.
     const raw = clone(W2D)
     for (const r of raw.flip_thresholds as Array<Record<string, unknown>>) {
       delete r.no_flip_in_range
+      delete r.flip_reason
     }
     const s = snapshotOf(raw)
     expect(s.conditionalWinners.map(r => r.factorId)).toEqual(['71c6351d', 'fcf3d740'])
@@ -149,7 +177,7 @@ describe('D7 opposite-direction twin — a value the producer DID compute still 
 // THE COHERENCE GATE'S CX5 FINDING IS NOW ACTED ON, NOT MERELY DETECTED.
 // ───────────────────────────────────────────────────────────────────────────
 
-describe('D7 — CX5: no_flip_in_range beside winner_flips suppresses the flip claim', () => {
+describe('D7 — CX5: an algebraic no-flip proof beside winner_flips suppresses the flip claim', () => {
   it('w2d is a REAL deployed instance: both factors are structurally invariant AND claim a flip', () => {
     // Stated first so the test below is measuring a real contradiction rather
     // than one this lane composed.
@@ -180,20 +208,43 @@ describe('D7 — CX5: no_flip_in_range beside winner_flips suppresses the flip c
     expect(snapshotOf(PROBE_A).conditionalWinners).toHaveLength(1)
   })
 
-  it('bound by factor IDENTITY — a no-flip row for a DIFFERENT factor suppresses nothing', () => {
+  // D7b: both cases below used to set `no_flip_in_range = true` on a row whose
+  // reason is `'found'`. Under the narrowed gate that combination triggers
+  // NOTHING, so they would have kept passing while proving nothing about the
+  // join — a guard agreeing with itself. The trigger is now the real one (the
+  // algebraic proof), and each pins its own precondition in-test so a future
+  // narrowing cannot hollow it out silently.
+  const proveInert = (row: Record<string, unknown>) => {
+    row.flip_reason = 'structurally_invariant'
+    row.flip_value = null
+    delete row.no_flip_in_range
+  }
+
+  it('bound by factor IDENTITY — a no-flip PROOF for a DIFFERENT factor suppresses nothing', () => {
     const raw = clone(PROBE_A)
     const flips = raw.flip_thresholds as Array<Record<string, unknown>>
-    flips.find(r => r.factor_id === 'fac_capacity')!.no_flip_in_range = true
-    // fac_capacity is asserted no-flip; fac_demand is the one with a
-    // conditional-winner row, and it is untouched.
+    proveInert(flips.find(r => r.factor_id === 'fac_capacity')!)
+    // PRECONDITION: the trigger really is armed on the OTHER factor, and the
+    // factor under test is untouched.
+    expect(flips.find(r => r.factor_id === 'fac_capacity')!.flip_reason)
+      .toBe('structurally_invariant')
+    expect(flips.find(r => r.factor_id === 'fac_demand')!.flip_reason).toBe('found')
     expect(snapshotOf(raw).conditionalWinners.map(r => r.factorId)).toEqual(['fac_demand'])
+  })
+
+  it('DISCRIMINATING TWIN — the same proof moved ONTO fac_demand DOES suppress it', () => {
+    // Without this, the case above shows only that something did not fire.
+    const raw = clone(PROBE_A)
+    const flips = raw.flip_thresholds as Array<Record<string, unknown>>
+    proveInert(flips.find(r => r.factor_id === 'fac_demand')!)
+    expect(snapshotOf(raw).conditionalWinners).toEqual([])
   })
 
   it('a matching LABEL with a different id does NOT suppress — the join is on the id', () => {
     const raw = clone(PROBE_A)
     const flips = raw.flip_thresholds as Array<Record<string, unknown>>
     const capacity = flips.find(r => r.factor_id === 'fac_capacity')!
-    capacity.no_flip_in_range = true
+    proveInert(capacity)
     capacity.factor_label = 'Customer demand' // same LABEL as fac_demand
     expect(snapshotOf(raw).conditionalWinners.map(r => r.factorId)).toEqual(['fac_demand'])
   })

--- a/src/canvas/stores/__tests__/analysisSnapshotFactory.scienceAttestation.spec.ts
+++ b/src/canvas/stores/__tests__/analysisSnapshotFactory.scienceAttestation.spec.ts
@@ -128,13 +128,74 @@ describe('D7 opposite-direction twin — a value the producer DID compute still 
     expect(row.winner).toBe('Build capacity instead')
   })
 
-  it('w2d: both attested flip rows are carried (a withheld LEADER does not suppress the flip science)', () => {
-    // This capture's turn carries `leader_claim.permitted: false`, and the
-    // producer nonetheless shipped both bucket identities. Whether that is
-    // itself coherent is coherence pair CX4's question, not this factory's:
-    // over-suppressing here would discard science the producer sent.
-    const s = snapshotOf(W2D)
+  it('a withheld LEADER does not by itself suppress the flip science', () => {
+    // w2d's turn carries `leader_claim.permitted: false` and the producer
+    // nonetheless shipped both bucket identities. That is coherence pair CX4's
+    // question, NOT a reason for this factory to discard the rows: the CX5
+    // suppression below is keyed on `no_flip_in_range`, not on the leader
+    // verdict. Proven by removing only the CX5 trigger from the same capture —
+    // the rows come back, so the suppression is CX5's doing and not a blanket
+    // distrust of a withheld turn.
+    const raw = clone(W2D)
+    for (const r of raw.flip_thresholds as Array<Record<string, unknown>>) {
+      delete r.no_flip_in_range
+    }
+    const s = snapshotOf(raw)
     expect(s.conditionalWinners.map(r => r.factorId)).toEqual(['71c6351d', 'fcf3d740'])
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// THE COHERENCE GATE'S CX5 FINDING IS NOW ACTED ON, NOT MERELY DETECTED.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('D7 — CX5: no_flip_in_range beside winner_flips suppresses the flip claim', () => {
+  it('w2d is a REAL deployed instance: both factors are structurally invariant AND claim a flip', () => {
+    // Stated first so the test below is measuring a real contradiction rather
+    // than one this lane composed.
+    const flips = W2D.flip_thresholds as Array<Record<string, unknown>>
+    const cws = W2D.conditional_winners as Array<Record<string, unknown>>
+    expect(flips.map(r => [r.factor_id, r.no_flip_in_range, r.flip_reason])).toEqual([
+      ['71c6351d', true, 'structurally_invariant'],
+      ['fcf3d740', true, 'structurally_invariant'],
+    ])
+    expect(cws.map(r => [r.factor_id, r.winner_flips])).toEqual([
+      ['71c6351d', true],
+      ['fcf3d740', true],
+    ])
+  })
+
+  it('the contradicted rows are DROPPED — the Compare tab no longer says a structurally invariant factor flips', () => {
+    expect(snapshotOf(W2D).conditionalWinners).toEqual([])
+  })
+
+  it('OPPOSITE DIRECTION — probe-A has flip_reason "found" and NO no_flip_in_range, so its claim survives', () => {
+    const flips = PROBE_A.flip_thresholds as Array<Record<string, unknown>>
+    const demand = flips.find(r => r.factor_id === 'fac_demand')!
+    expect(demand.flip_reason).toBe('found')
+    expect(Object.prototype.hasOwnProperty.call(demand, 'no_flip_in_range')).toBe(false)
+
+    // An ABSENT assertion is not a negative one. Treating absence as "no flip"
+    // would suppress every flip the producer actually computed.
+    expect(snapshotOf(PROBE_A).conditionalWinners).toHaveLength(1)
+  })
+
+  it('bound by factor IDENTITY — a no-flip row for a DIFFERENT factor suppresses nothing', () => {
+    const raw = clone(PROBE_A)
+    const flips = raw.flip_thresholds as Array<Record<string, unknown>>
+    flips.find(r => r.factor_id === 'fac_capacity')!.no_flip_in_range = true
+    // fac_capacity is asserted no-flip; fac_demand is the one with a
+    // conditional-winner row, and it is untouched.
+    expect(snapshotOf(raw).conditionalWinners.map(r => r.factorId)).toEqual(['fac_demand'])
+  })
+
+  it('a matching LABEL with a different id does NOT suppress — the join is on the id', () => {
+    const raw = clone(PROBE_A)
+    const flips = raw.flip_thresholds as Array<Record<string, unknown>>
+    const capacity = flips.find(r => r.factor_id === 'fac_capacity')!
+    capacity.no_flip_in_range = true
+    capacity.factor_label = 'Customer demand' // same LABEL as fac_demand
+    expect(snapshotOf(raw).conditionalWinners.map(r => r.factorId)).toEqual(['fac_demand'])
   })
 })
 

--- a/src/canvas/stores/__tests__/analysisSnapshotFactory.scienceAttestation.spec.ts
+++ b/src/canvas/stores/__tests__/analysisSnapshotFactory.scienceAttestation.spec.ts
@@ -1,0 +1,288 @@
+/**
+ * D7 — THE COMPARE TAB IS BOUND TO PRODUCER ATTESTATIONS.
+ *
+ * Two claims, and they point in OPPOSITE DIRECTIONS on purpose:
+ *   (1) the UI never publishes a number the science did not produce; and
+ *   (2) the UI never suppresses one it did.
+ * A corpus that tests only (1) is a guard watching one door, and that exact
+ * shape has cost this estate four consecutive rounds on one predicate.
+ *
+ * ⚠ WHERE THE INPUTS COME FROM. Every payload below is a REAL capture recorded
+ * off the deployed product, already vendored byte-identical for the coherence
+ * gate with sha256s in
+ * `src/lib/coherence/__tests__/fixtures/captures/PROVENANCE.md`. They are
+ * imported from there rather than re-copied, so there is one corpus and one
+ * provenance record. **APPEND-ONLY** — a capture is a record of what the
+ * product once emitted; editing one to keep this suite green would falsify it.
+ *
+ * ⚠⚠ WHAT THE CORPUS CANNOT DO, STATED BEFORE THE TESTS RATHER THAN DISCOVERED
+ * AFTER THEM. A census of EVERY `conditional_winners` row in `olumi-docs/`
+ * (2,290 JSON files, 28 rows found) returned:
+ *
+ *     (winner_flips, low_id === high_id, low_label === high_label) -> count
+ *     (true,         false,              false)                    -> 28
+ *
+ * So the corpus contains **ZERO** `winner_flips: false` rows, **ZERO** rows
+ * with equal bucket identities, and **ZERO** rows with a withheld identity.
+ * It therefore CANNOT certify this code over those classes, and no amount of
+ * running it would say otherwise — a corpus that omits a value class the
+ * contract admits is blind to it.
+ *
+ * Those three classes are consequently derived from the PRODUCER'S OWN
+ * CONTRACT, not from anything this lane imagined, and each derivation is a
+ * documented transformation applied to a REAL row (`CONTRACT_DERIVED` below):
+ *   · `winner_flips: false`  — `EnrichmentConditionalWinnerSchema` types it
+ *     `z.boolean()`, REQUIRED, and its doc says it states THAT the winner
+ *     changes across the split, never WHICH option.
+ *   · withheld identity — `EnrichmentConditionalBucketSchema` makes
+ *     `winner_id`/`winner_label` optional for one stated reason: "on a turn
+ *     whose verdict WITHHOLDS the leading-option claim, CEE's withheld-claim
+ *     projection strips exactly these four members". Its absence semantics are
+ *     explicit: it means the option was withheld, and "never means 'no option
+ *     won'".
+ * Both quotations are from the vendored 0.48.0
+ * `dist/boundary/enrichment.js`, read at the bytes, not from a doc page.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { Node, Edge } from '@xyflow/react'
+
+import { buildAnalysisSnapshot } from '../analysisSnapshotFactory'
+import { deriveTransitions } from '../../compare-tab/deriveTransitions'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+import type { ReportV1 } from '../../../adapters/plot/types'
+
+// The two real captures that carry conditional-winner and factor-sensitivity
+// science. `w2d` is a CEE turn; the members this factory reads live on
+// `blocks[0].enrichment`, which the contract states IS "the full PLoT /v2/run
+// envelope persisted by CEE run_analysis".
+import w2dTurn from '../../../lib/coherence/__tests__/fixtures/captures/seeded-2026-08-17-w2d-analysis-turn.json'
+import probeA from '../../../lib/coherence/__tests__/fixtures/captures/conditional-winners-2026-08-17-probe-A.json'
+
+const W2D = (w2dTurn as unknown as { blocks: Array<{ enrichment: Record<string, unknown> }> })
+  .blocks[0].enrichment
+const PROBE_A = probeA as unknown as Record<string, unknown>
+
+const nodes: Node[] = [
+  { id: 'n1', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'A' } },
+]
+const edges: Edge[] = []
+
+function snapshotOf(raw: Record<string, unknown>, runNumber = 1) {
+  return buildAnalysisSnapshot({
+    rawV2Response: raw as unknown as V2RunResponse,
+    report: {} as ReportV1,
+    nodes,
+    edges,
+    runNumber,
+    events: [],
+    previousSnapshotTimestamp: null,
+  })
+}
+
+/** Deep clone so no test can mutate a capture another test reads. */
+function clone<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v)) as T
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// DIRECTION (2) FIRST — THE INVERSE DEFECT, WHICH IS THE ONE THAT WOULD MAKE
+// THIS WORSE. Every one of these values IS on the real wire and MUST render.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('D7 opposite-direction twin — a value the producer DID compute still renders', () => {
+  it('probe-A: rank_flip_rate is PRESENT and 0 on the wire → rankFlipRate === 0, not null', () => {
+    // Bound by identity to the row the producer sent, not to "some zero".
+    const wire = (PROBE_A.factor_sensitivity as Array<Record<string, unknown>>)
+      .find(f => f.factor_id === 'fac_demand')
+    expect(wire).toBeDefined()
+    expect(Object.prototype.hasOwnProperty.call(wire!, 'rank_flip_rate')).toBe(true)
+    expect(wire!.rank_flip_rate).toBe(0)
+
+    const s = snapshotOf(PROBE_A)
+    expect(s.rankFlipRate).toBe(0)
+    expect(s.rankFlipRate).not.toBeNull()
+  })
+
+  it('probe-A: a genuinely-computed elasticity of 0 survives as 0 — topElasticity 0, concentration 0', () => {
+    const elasticities = (PROBE_A.factor_sensitivity as Array<Record<string, unknown>>)
+      .map(f => f.elasticity)
+    expect(elasticities).toEqual([0, 0]) // the producer measured, and measured zero
+
+    const s = snapshotOf(PROBE_A)
+    expect(s.topElasticity).toBe(0)
+    expect(s.influenceConcentration).toBe(0)
+    // The whole point: these are NOT null. Suppressing them would be the
+    // mirror defect — a computed measurement withheld from the user.
+    expect(s.topElasticity).not.toBeNull()
+    expect(s.influenceConcentration).not.toBeNull()
+  })
+
+  it('probe-A: the attested flip row IS carried, with both bucket identities', () => {
+    const s = snapshotOf(PROBE_A)
+    expect(s.conditionalWinners).toHaveLength(1)
+    const row = s.conditionalWinners[0]
+    expect(row.factorId).toBe('fac_demand')
+    expect(row.lowWinnerId).toBe('opt-pin-demand')
+    expect(row.winnerId).toBe('opt-build-capacity')
+    expect(row.winner).toBe('Build capacity instead')
+  })
+
+  it('w2d: both attested flip rows are carried (a withheld LEADER does not suppress the flip science)', () => {
+    // This capture's turn carries `leader_claim.permitted: false`, and the
+    // producer nonetheless shipped both bucket identities. Whether that is
+    // itself coherent is coherence pair CX4's question, not this factory's:
+    // over-suppressing here would discard science the producer sent.
+    const s = snapshotOf(W2D)
+    expect(s.conditionalWinners.map(r => r.factorId)).toEqual(['71c6351d', 'fcf3d740'])
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// DIRECTION (1) — NO MINTED NUMBERS.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('D7 — an unmeasured quantity is absent, never 0', () => {
+  it('w2d: the top factor carries NO rank_flip_rate on the wire → rankFlipRate === null', () => {
+    // The real absence, straight off a real capture — not a fixture with a
+    // key deleted. Bound by identity to `cb77d5e3`, the row that sorts first.
+    const wire = (W2D.factor_sensitivity as Array<Record<string, unknown>>)
+      .find(f => f.factor_id === 'cb77d5e3')
+    expect(wire).toBeDefined()
+    expect(Object.prototype.hasOwnProperty.call(wire!, 'rank_flip_rate')).toBe(false)
+
+    const s = snapshotOf(W2D)
+    expect(s.topFactors[0].id).toBe('cb77d5e3')
+    expect(s.rankFlipRate).toBeNull()
+    // The defect this replaces: the trajectory table printed "0.00" here.
+    expect(s.rankFlipRate).not.toBe(0)
+  })
+
+  it('no factor_sensitivity at all → topElasticity, rankFlipRate and influenceConcentration are ALL null', () => {
+    const raw = clone(PROBE_A)
+    delete raw.factor_sensitivity
+    const s = snapshotOf(raw)
+    expect(s.topElasticity).toBeNull()
+    expect(s.rankFlipRate).toBeNull()
+    expect(s.influenceConcentration).toBeNull()
+  })
+
+  it('factors present but NONE scored → influenceConcentration is null, not 0', () => {
+    // Distinguishes the two returns the old signature collapsed:
+    // "nothing was measured" vs "the ratio was measured and is 0".
+    const raw = clone(PROBE_A)
+    for (const f of raw.factor_sensitivity as Array<Record<string, unknown>>) delete f.elasticity
+    const s = snapshotOf(raw)
+    expect(s.influenceConcentration).toBeNull()
+    expect(s.topElasticity).toBeNull()
+    // …and the twin one line away: with the elasticities restored it is 0.
+    expect(snapshotOf(clone(PROBE_A)).influenceConcentration).toBe(0)
+  })
+
+  it('an unscored factor sorts LAST — topFactors[0] is never a factor nobody measured', () => {
+    const raw = clone(PROBE_A)
+    const fs = raw.factor_sensitivity as Array<Record<string, unknown>>
+    delete fs[0].elasticity      // fac_demand becomes unscored
+    fs[1].elasticity = 0.7       // fac_capacity is scored
+    const s = snapshotOf(raw)
+    expect(s.topFactors[0].id).toBe('fac_capacity')
+    expect(s.topElasticity).toBe(70)
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// FLIP DETECTION BOUND BY IDENTITY AND ATTESTATION.
+// The three classes below are CONTRACT_DERIVED — see the header. Each is a
+// documented producer transformation applied to a REAL row.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('D7 — a flip claim requires the producer to have attested a flip', () => {
+  it('CONTRACT_DERIVED: winner_flips false → the row is DROPPED, no takeover claim', () => {
+    const raw = clone(PROBE_A)
+    ;(raw.conditional_winners as Array<Record<string, unknown>>)[0].winner_flips = false
+    expect(snapshotOf(raw).conditionalWinners).toEqual([])
+  })
+
+  it('CONTRACT_DERIVED: equal bucket IDENTITIES beside winner_flips true → dropped', () => {
+    // A producer self-contradiction. The honest response is to decline the
+    // claim, not to reconcile it into one.
+    const raw = clone(PROBE_A)
+    const row = (raw.conditional_winners as Array<Record<string, unknown>>)[0]
+    ;(row.high_bucket as Record<string, unknown>).winner_id =
+      (row.low_bucket as Record<string, unknown>).winner_id
+    expect(snapshotOf(raw).conditionalWinners).toEqual([])
+  })
+
+  it('IDENTITY, NOT LABEL — equal LABELS with distinct IDS is still a real flip', () => {
+    // Two options may share one display label. A label filter cannot see this
+    // flip; an identity test can. This is the discriminating half of trap 19:
+    // the previous behaviour bound to `high_bucket.winner_label`.
+    const raw = clone(PROBE_A)
+    const row = (raw.conditional_winners as Array<Record<string, unknown>>)[0]
+    ;(row.high_bucket as Record<string, unknown>).winner_label =
+      (row.low_bucket as Record<string, unknown>).winner_label
+    const s = snapshotOf(raw)
+    expect(s.conditionalWinners).toHaveLength(1)
+    expect(s.conditionalWinners[0].lowWinnerId).toBe('opt-pin-demand')
+    expect(s.conditionalWinners[0].winnerId).toBe('opt-build-capacity')
+  })
+
+  it('IDENTITY, NOT LABEL — distinct labels on ONE identity is a relabel, not a flip', () => {
+    const raw = clone(PROBE_A)
+    const row = (raw.conditional_winners as Array<Record<string, unknown>>)[0]
+    ;(row.high_bucket as Record<string, unknown>).winner_id = 'opt-pin-demand'
+    ;(row.high_bucket as Record<string, unknown>).winner_label = 'Lock in demand now (revised)'
+    expect(snapshotOf(raw).conditionalWinners).toEqual([])
+  })
+
+  it('a row with no finite split_value cannot state "flips at N" and is dropped', () => {
+    const raw = clone(PROBE_A)
+    delete (raw.conditional_winners as Array<Record<string, unknown>>)[0].split_value
+    expect(snapshotOf(raw).conditionalWinners).toEqual([])
+  })
+})
+
+describe('D7 — a WITHHELD identity keeps the science and declines to name the option', () => {
+  it('CONTRACT_DERIVED: stripped bucket identities → row kept, winner null, ids null', () => {
+    const raw = clone(PROBE_A)
+    for (const b of ['low_bucket', 'high_bucket']) {
+      const bucket = (raw.conditional_winners as Array<Record<string, unknown>>)[0][b] as Record<string, unknown>
+      delete bucket.winner_id
+      delete bucket.winner_label
+    }
+    const s = snapshotOf(raw)
+    // NOT dropped: the producer withheld WHICH option, not WHETHER it flips.
+    // Dropping it would be the over-suppression failure.
+    expect(s.conditionalWinners).toHaveLength(1)
+    expect(s.conditionalWinners[0].winner).toBeNull()
+    expect(s.conditionalWinners[0].winnerId).toBeNull()
+    expect(s.conditionalWinners[0].lowWinnerId).toBeNull()
+    expect(s.conditionalWinners[0].condition).toContain('Customer demand')
+  })
+
+  it('the transition sentence never interpolates an empty option name', () => {
+    const raw = clone(PROBE_A)
+    for (const b of ['low_bucket', 'high_bucket']) {
+      const bucket = (raw.conditional_winners as Array<Record<string, unknown>>)[0][b] as Record<string, unknown>
+      delete bucket.winner_id
+      delete bucket.winner_label
+    }
+    // Two runs so a transition exists; the factor must be "affected", which a
+    // factor absent from run 1's top list always is.
+    const first = snapshotOf({ ...clone(PROBE_A), factor_sensitivity: [] }, 1)
+    const second = snapshotOf(raw, 2)
+    const transitions = deriveTransitions([first, second])
+    const line = transitions[0]?.conditionalWinner ?? ''
+    expect(line).not.toMatch(/,\s+takes over/)       // the old output
+    expect(line).not.toContain('undefined')
+    if (line !== '') expect(line).toContain('withheld')
+  })
+
+  it('a NAMED attested flip still produces the full takeover sentence', () => {
+    // Opposite-direction twin of the test above, on the unmodified capture.
+    const first = snapshotOf({ ...clone(PROBE_A), factor_sensitivity: [] }, 1)
+    const second = snapshotOf(clone(PROBE_A), 2)
+    const line = deriveTransitions([first, second])[0]?.conditionalWinner ?? ''
+    expect(line).toContain('Build capacity instead takes over')
+  })
+})

--- a/src/canvas/stores/__tests__/persistedRunSnapshotFactory.spec.ts
+++ b/src/canvas/stores/__tests__/persistedRunSnapshotFactory.spec.ts
@@ -87,7 +87,15 @@ describe('persistedRunSnapshotFactory — field mapping', () => {
             factor_id: 'factor-1',
             factor_label: 'Factor One',
             split_value: 12,
-            high_bucket: { winner_label: 'Option B' },
+    // D7: `winner_flips` and the bucket IDENTITIES are added because the
+    // contract REQUIRES the first (`winner_flips: z.boolean()`) and the factory
+    // now binds the flip claim to it and to the ids. A row without them was
+    // never a legal payload, so this fixture was pinning SLOT PRECEDENCE with
+    // an illegal row. Precedence is still exactly what these tests measure —
+    // the row is merely now one the producer could actually emit.
+            winner_flips: true,
+            low_bucket: { winner_id: 'opt-a', winner_label: 'Option A' },
+            high_bucket: { winner_id: 'opt-b', winner_label: 'Option B' },
           },
         ],
         edgeEValues: [{ edge_id: 'factor-1->goal', e_value: 1.8 }],
@@ -118,7 +126,9 @@ describe('persistedRunSnapshotFactory — field mapping', () => {
         factor_id: 'factor-1',
         factor_label: 'Factor One',
         split_value: 12,
-        high_bucket: { winner_label: 'Option B' },
+        winner_flips: true,
+        low_bucket: { winner_id: 'opt-a', winner_label: 'Option A' },
+        high_bucket: { winner_id: 'opt-b', winner_label: 'Option B' },
       },
     ]
     enrichment.robustness.edge_e_values = [{ edge_id: 'factor-1->goal', e_value: 1.8 }]
@@ -129,6 +139,8 @@ describe('persistedRunSnapshotFactory — field mapping', () => {
         factorId: 'factor-1',
         factorLabel: 'Factor One',
         winner: 'Option B',
+        winnerId: 'opt-b',
+        lowWinnerId: 'opt-a',
         condition: 'When Factor One exceeds 12',
       },
     ])

--- a/src/canvas/stores/analysisSnapshotFactory.ts
+++ b/src/canvas/stores/analysisSnapshotFactory.ts
@@ -159,6 +159,29 @@ function extractConditionalWinners(
   const nested = (response?.robustness as Record<string, unknown> | undefined)?.conditional_winners
   const raw = Array.isArray(root) ? root : nested
   if (!Array.isArray(raw)) return []
+
+  // ── D7 GATE 0: THE COHERENCE GATE'S CX5 FINDING, ACTED ON ────────────────
+  // `crossSurfaceCoherence` pair CX5 detects `flip_thresholds.no_flip_in_range:
+  // true` beside `conditional_winners.winner_flips: true` FOR THE SAME FACTOR —
+  // two producer statements about one factor that cannot both hold. Until now
+  // the gate only OBSERVED it: nothing consumed the finding, so a detector with
+  // no consumer is instrumentation, not a guarantee.
+  //
+  // This is not hypothetical. The real capture
+  // `seeded-2026-08-17-w2d-analysis-turn.json` carries `no_flip_in_range: true`
+  // with `flip_reason: 'structurally_invariant'` for factors `71c6351d` and
+  // `fcf3d740`, and `winner_flips: true` for those SAME two ids — and the
+  // Compare tab rendered "…, Floating price contract takes over" for a factor
+  // the same payload declares cannot flip at all.
+  //
+  // WHY SUPPRESS RATHER THAN RECONCILE. The two statements are answering the
+  // SAME question ("can this factor flip the winner?") and giving opposite
+  // answers, which is what makes this actionable where CX1 is not. We cannot
+  // know which is right, and picking one would be inventing a finding. The
+  // honest move is the one this file already takes for a producer
+  // self-contradiction in the bucket ids: decline the claim.
+  const noFlipFactorIds = collectNoFlipFactorIds(response)
+
   return raw
     .filter((w: Record<string, unknown>) => w && typeof w === 'object')
     // ── D7 GATE 1: THE PRODUCER'S FLIP ATTESTATION ───────────────────────────
@@ -174,6 +197,8 @@ function extractConditionalWinners(
     // behind, so one payload produced a flip claim on one surface and not the
     // other.
     .filter((w: Record<string, unknown>) => w.winner_flips === true)
+    .filter((w: Record<string, unknown>) =>
+      !(typeof w.factor_id === 'string' && noFlipFactorIds.has(w.factor_id)))
     // ── D7 GATE 2: A CLAIM NEEDS A THRESHOLD IT CAN STATE ────────────────────
     // "flips at N" requires a finite N. A row without one cannot state the
     // condition, and the old `: ''` arm produced the bare fragment ", X takes
@@ -212,6 +237,36 @@ function extractConditionalWinners(
         condition: `When ${factorLabel !== '' ? factorLabel : 'this factor'} exceeds ${w.split_value}${w.split_unit ? ` ${String(w.split_unit)}` : ''}`,
       }
     })
+}
+
+/**
+ * Factor ids whose `flip_thresholds` row asserts `no_flip_in_range: true`.
+ *
+ * Bound by IDENTITY (`factor_id`), never by `factor_label`: the two arrays are
+ * joined on the id in the producer's own CX5 detector
+ * (`crossSurfaceCoherence.ts:728-739`), and joining on a label would both miss
+ * a real contradiction between two same-labelled factors and invent one
+ * between two differently-labelled rows for the same factor.
+ *
+ * ONLY `=== true` counts. The field is absent on both real captures that carry
+ * a genuine flip (`flip_reason: 'found'`), and an ABSENT assertion is not a
+ * negative one — treating absence as "no flip" would suppress every flip the
+ * producer did compute, which is the mirror defect.
+ */
+function collectNoFlipFactorIds(response: V2RunResponse): Set<string> {
+  const out = new Set<string>()
+  const root = (response as unknown as Record<string, unknown> | undefined)?.flip_thresholds
+  const nested = (response?.robustness as Record<string, unknown> | undefined)?.flip_thresholds
+  const rows = Array.isArray(root) ? root : nested
+  if (!Array.isArray(rows)) return out
+  for (const r of rows) {
+    if (r && typeof r === 'object'
+      && (r as Record<string, unknown>).no_flip_in_range === true
+      && typeof (r as Record<string, unknown>).factor_id === 'string') {
+      out.add((r as Record<string, unknown>).factor_id as string)
+    }
+  }
+  return out
 }
 
 /** Read one string member off a conditional-winner bucket. Absent ⇒ null. */

--- a/src/canvas/stores/analysisSnapshotFactory.ts
+++ b/src/canvas/stores/analysisSnapshotFactory.ts
@@ -79,6 +79,60 @@ function computeEvidenceCoverage(nodes: Node[]): string {
 // Factor sensitivity summary (top 5)
 // ---------------------------------------------------------------------------
 
+/**
+ * The producer's stated elasticity for one wire factor, sign preserved — or
+ * `null` where the producer stated none.
+ *
+ * ⚠ THIS IS THE ONLY PLACE IN THIS FILE THAT READS THE RAW `elasticity` FIELD,
+ * and that is the point of it. Four sites here each answered "did the producer
+ * score this factor?" for themselves, in four different spellings — `?? 0` in
+ * the sort, `typeof` + `Number.isFinite` in the summary map, a `filter` with a
+ * third spelling in the concentration denominator, and a bare `!== null` at the
+ * hero's percentage. Four spellings of one question are four chances to answer
+ * it differently, and `?? 0` was already answering it wrongly: it filed "not
+ * measured" under "measured as exactly zero", which is the strongest claim the
+ * field can make.
+ *
+ * The `elasticity` claim family is registered as FROZEN, SHRINK-ONLY DEBT with
+ * no estate-wide owner selector
+ * (`src/components/results/utils/elasticityClaimDebt.ts`). This is the
+ * file-local half of that convergence — one authority inside this file, leaving
+ * a single call site for the real owner to take over when it lands. It does not
+ * claim to BE that owner, and deliberately registers no `CLAIM_OWNERSHIP`:
+ * two modules registering one family is a hard RED in the walker's control 3a.
+ */
+function scoredElasticity(f: V2FactorSensitivity): number | null {
+  const stated = f.elasticity
+  return typeof stated === 'number' && Number.isFinite(stated) ? stated : null
+}
+
+/**
+ * Magnitude of a scored elasticity; absence propagates as `null` rather than
+ * collapsing to 0. The sign convention lives here once, instead of at each of
+ * the three sites that used to spell `Math.abs` beside their own null test.
+ */
+function elasticityMagnitude(f: V2FactorSensitivity): number | null {
+  const stated = scoredElasticity(f)
+  return stated === null ? null : Math.abs(stated)
+}
+
+/**
+ * The hero's "{n}% influence" for the top factor — `null` when there is no top
+ * factor, or when the producer did not score the one there is.
+ *
+ * Reads the ALREADY-ADAPTED summary rather than the wire, so the scored-ness
+ * decision is `scoredElasticity`'s, made once upstream, not re-litigated here.
+ * The `: 0` this replaces was the same fabrication the rest of this factory had
+ * already been cleaned of (`stability`, `fragileEdgeCount`, `seedUsed`,
+ * `runnerUpProbability`); it survived because it sits in the FACTOR-sensitivity
+ * trio rather than the robustness block, and each cleanup was scoped to the
+ * block in front of it.
+ */
+function topInfluencePercent(top: FactorSensitivitySummary | undefined): number | null {
+  const stated = top?.elasticity ?? null
+  return stated === null ? null : Math.round(Math.abs(stated) * 100)
+}
+
 function extractTopFactors(
   factors: V2FactorSensitivity[],
 ): FactorSensitivitySummary[] {
@@ -88,8 +142,8 @@ function extractTopFactors(
     // as exactly zero" in the same place, so `topFactors[0]` — the factor the
     // hero invites the user to calibrate — could be a factor nobody scored.
     .sort((a, b) => {
-      const av = typeof a.elasticity === 'number' ? Math.abs(a.elasticity) : null
-      const bv = typeof b.elasticity === 'number' ? Math.abs(b.elasticity) : null
+      const av = elasticityMagnitude(a)
+      const bv = elasticityMagnitude(b)
       if (av === null && bv === null) return 0
       if (av === null) return 1
       if (bv === null) return -1
@@ -102,9 +156,7 @@ function extractTopFactors(
       // D7 absence-preserving. `?? 0` here was the load-bearing mint: it fed
       // `topElasticity`, `influenceConcentration` and the transition sentence
       // "elasticity 0.00", all three of which read as measurements.
-      elasticity: typeof f.elasticity === 'number' && Number.isFinite(f.elasticity)
-        ? f.elasticity
-        : null,
+      elasticity: scoredElasticity(f),
       rankFlipRate: typeof f.rank_flip_rate === 'number' && Number.isFinite(f.rank_flip_rate)
         ? f.rank_flip_rate
         : null,
@@ -131,8 +183,8 @@ function extractTopFactors(
  */
 function computeInfluenceConcentration(factors: V2FactorSensitivity[]): number | null {
   const absElasticities = factors
-    .filter(f => typeof f.elasticity === 'number' && Number.isFinite(f.elasticity))
-    .map(f => Math.abs(f.elasticity as number))
+    .map(elasticityMagnitude)
+    .filter((v): v is number => v !== null)
   if (absElasticities.length === 0) return null
   const sum = absElasticities.reduce((a, b) => a + b, 0)
   if (sum === 0) return 0
@@ -676,9 +728,7 @@ export function buildAnalysisSnapshot(params: BuildSnapshotParams): AnalysisSnap
     // `fragileEdgeCount`, `seedUsed`, `runnerUpProbability`). They survived
     // because they are the FACTOR-sensitivity trio rather than the robustness
     // block, and each cleanup was scoped to the block in front of it.
-    topElasticity: topFactors.length > 0 && topFactors[0].elasticity !== null
-      ? Math.round(Math.abs(topFactors[0].elasticity) * 100)
-      : null,
+    topElasticity: topInfluencePercent(topFactors[0]),
     rankFlipRate: topFactors.length > 0 ? topFactors[0].rankFlipRate : null,
 
     goalProbability,

--- a/src/canvas/stores/analysisSnapshotFactory.ts
+++ b/src/canvas/stores/analysisSnapshotFactory.ts
@@ -83,13 +83,31 @@ function extractTopFactors(
   factors: V2FactorSensitivity[],
 ): FactorSensitivitySummary[] {
   return [...factors]
-    .sort((a, b) => Math.abs(b.elasticity ?? 0) - Math.abs(a.elasticity ?? 0))
+    // D7: an UNSCORED factor sorts LAST rather than being folded in among the
+    // genuinely-zero ones. `Math.abs(x ?? 0)` put "not measured" and "measured
+    // as exactly zero" in the same place, so `topFactors[0]` — the factor the
+    // hero invites the user to calibrate — could be a factor nobody scored.
+    .sort((a, b) => {
+      const av = typeof a.elasticity === 'number' ? Math.abs(a.elasticity) : null
+      const bv = typeof b.elasticity === 'number' ? Math.abs(b.elasticity) : null
+      if (av === null && bv === null) return 0
+      if (av === null) return 1
+      if (bv === null) return -1
+      return bv - av
+    })
     .slice(0, 5)
     .map(f => ({
       id: f.node_id ?? f.factor_id ?? '',
       label: f.factor_label ?? f.label ?? '',
-      elasticity: f.elasticity ?? 0,
-      rankFlipRate: f.rank_flip_rate ?? 0,
+      // D7 absence-preserving. `?? 0` here was the load-bearing mint: it fed
+      // `topElasticity`, `influenceConcentration` and the transition sentence
+      // "elasticity 0.00", all three of which read as measurements.
+      elasticity: typeof f.elasticity === 'number' && Number.isFinite(f.elasticity)
+        ? f.elasticity
+        : null,
+      rankFlipRate: typeof f.rank_flip_rate === 'number' && Number.isFinite(f.rank_flip_rate)
+        ? f.rank_flip_rate
+        : null,
       attributionStability: f.attribution_stability ?? 'unknown',
     }))
 }
@@ -98,9 +116,24 @@ function extractTopFactors(
 // Influence concentration
 // ---------------------------------------------------------------------------
 
-function computeInfluenceConcentration(factors: V2FactorSensitivity[]): number {
-  if (factors.length === 0) return 0
-  const absElasticities = factors.map(f => Math.abs(f.elasticity ?? 0))
+/**
+ * D7 absence-preserving. Two distinct returns of `0` were fabrications and one
+ * was a real result, and the old signature could not tell them apart:
+ *   · no factors at all                 → NOTHING WAS MEASURED  → null
+ *   · factors present, none scored      → NOTHING WAS MEASURED  → null
+ *   · every scored elasticity is 0.0    → a genuine measurement → 0
+ * The third is preserved deliberately: this is the opposite-direction twin, and
+ * suppressing a computed 0 would be the same defect pointing the other way.
+ *
+ * Unscored factors are EXCLUDED from the denominator rather than counted as
+ * zero — counting them would deflate `max/sum` by exactly the number of
+ * measurements the producer declined to make.
+ */
+function computeInfluenceConcentration(factors: V2FactorSensitivity[]): number | null {
+  const absElasticities = factors
+    .filter(f => typeof f.elasticity === 'number' && Number.isFinite(f.elasticity))
+    .map(f => Math.abs(f.elasticity as number))
+  if (absElasticities.length === 0) return null
   const sum = absElasticities.reduce((a, b) => a + b, 0)
   if (sum === 0) return 0
   const max = Math.max(...absElasticities)
@@ -128,16 +161,64 @@ function extractConditionalWinners(
   if (!Array.isArray(raw)) return []
   return raw
     .filter((w: Record<string, unknown>) => w && typeof w === 'object')
-    .map((w: Record<string, unknown>) => ({
-      factorId: String(w.factor_id ?? w.node_id ?? ''),
-      factorLabel: String(w.factor_label ?? w.label ?? ''),
-      winner: String(w.high_bucket && typeof w.high_bucket === 'object'
-        ? (w.high_bucket as Record<string, unknown>).winner_label ?? ''
-        : ''),
-      condition: w.split_value != null
-        ? `When ${String(w.factor_label ?? w.label ?? 'factor')} exceeds ${w.split_value}${w.split_unit ? ` ${w.split_unit}` : ''}`
-        : '',
-    }))
+    // ── D7 GATE 1: THE PRODUCER'S FLIP ATTESTATION ───────────────────────────
+    // `winner_flips` is a REQUIRED boolean in the contract
+    // (`EnrichmentConditionalWinnerSchema`, vendored 0.48.0) that admits
+    // `false`, and the producer's own doc states it says THAT the winner
+    // changes across the split, never WHICH option. This extractor read no
+    // attestation at all: it took `high_bucket.winner_label` and
+    // `deriveTransitions` rendered "…, {label} takes over" — a takeover claim
+    // minted from a bucket label, for a row the science may have attested does
+    // NOT flip. `ConditionalWinnerCards.tsx:86` (the results panel) already
+    // gates on this field; the Compare tab is the sibling surface that was left
+    // behind, so one payload produced a flip claim on one surface and not the
+    // other.
+    .filter((w: Record<string, unknown>) => w.winner_flips === true)
+    // ── D7 GATE 2: A CLAIM NEEDS A THRESHOLD IT CAN STATE ────────────────────
+    // "flips at N" requires a finite N. A row without one cannot state the
+    // condition, and the old `: ''` arm produced the bare fragment ", X takes
+    // over" with no "when".
+    .filter((w: Record<string, unknown>) =>
+      typeof w.split_value === 'number' && Number.isFinite(w.split_value))
+    // ── D7 GATE 3: IDENTITY, NOT LABEL ───────────────────────────────────────
+    // When BOTH bucket identities are on the wire they are the discriminator,
+    // and they outrank the labels: two options can share one display label (a
+    // real flip a label filter cannot see) and a relabelled option is not a
+    // flip. Equal ids beside `winner_flips: true` is a producer
+    // self-contradiction (coherence pair CX5's shape) — the honest response is
+    // to decline the claim, not to reconcile it. When an id is ABSENT the
+    // producer has WITHHELD it, which is not a contradiction and is handled
+    // below by declining to NAME the option rather than dropping the row.
+    .filter((w: Record<string, unknown>) => {
+      const lo = bucketMember(w.low_bucket, 'winner_id')
+      const hi = bucketMember(w.high_bucket, 'winner_id')
+      if (lo === null || hi === null) return true
+      return lo !== hi
+    })
+    .map((w: Record<string, unknown>) => {
+      const highId = bucketMember(w.high_bucket, 'winner_id')
+      const highLabel = bucketMember(w.high_bucket, 'winner_label')
+      const factorLabel = String(w.factor_label ?? w.label ?? '')
+      return {
+        factorId: String(w.factor_id ?? w.node_id ?? ''),
+        factorLabel,
+        // Absence here means WITHHELD, per the contract's stated absence
+        // semantics ("It never means 'no option won'"). `String(... ?? '')`
+        // turned that withholding into an empty string that was then
+        // interpolated into a sentence.
+        winner: highLabel,
+        winnerId: highId,
+        lowWinnerId: bucketMember(w.low_bucket, 'winner_id'),
+        condition: `When ${factorLabel !== '' ? factorLabel : 'this factor'} exceeds ${w.split_value}${w.split_unit ? ` ${String(w.split_unit)}` : ''}`,
+      }
+    })
+}
+
+/** Read one string member off a conditional-winner bucket. Absent ⇒ null. */
+function bucketMember(bucket: unknown, key: string): string | null {
+  if (!bucket || typeof bucket !== 'object') return null
+  const v = (bucket as Record<string, unknown>)[key]
+  return typeof v === 'string' && v !== '' ? v : null
 }
 
 function extractEdgeEValues(
@@ -535,10 +616,15 @@ export function buildAnalysisSnapshot(params: BuildSnapshotParams): AnalysisSnap
     influenceConcentration: computeInfluenceConcentration(factors),
     topCalibrationFactor: topCalibrationFactor?.label ?? '',
     topCalibrationFactorId: topCalibrationFactor?.id ?? '',
-    topElasticity: topFactors.length > 0
+    // D7 absence-preserving. Both lines had the identical `: 0` fabrication the
+    // rest of this factory had already been cleaned of (`stability`,
+    // `fragileEdgeCount`, `seedUsed`, `runnerUpProbability`). They survived
+    // because they are the FACTOR-sensitivity trio rather than the robustness
+    // block, and each cleanup was scoped to the block in front of it.
+    topElasticity: topFactors.length > 0 && topFactors[0].elasticity !== null
       ? Math.round(Math.abs(topFactors[0].elasticity) * 100)
-      : 0,
-    rankFlipRate: topFactors.length > 0 ? topFactors[0].rankFlipRate : 0,
+      : null,
+    rankFlipRate: topFactors.length > 0 ? topFactors[0].rankFlipRate : null,
 
     goalProbability,
     jointGoalProbability,

--- a/src/canvas/stores/analysisSnapshotFactory.ts
+++ b/src/canvas/stores/analysisSnapshotFactory.ts
@@ -235,11 +235,19 @@ function extractConditionalWinners(
   // `NO_EFFECT_REASONS`, `flip-threshold-status.ts:75-78`), and the two reasons
   // are epistemically different objects:
   //
-  //   · `structurally_invariant` — slopes IDENTICAL (spread <= 1e-9). An
-  //     ALGEBRAIC identity, topological in the graph, so it holds under every
-  //     sampled edge draw. The per-sample winner is independent of the factor,
-  //     so the median-split buckets behind `winner_flips` are two random halves
-  //     of ONE sequence and their disagreement is sampling noise. SUPPRESS.
+  //   · `structurally_invariant` — slopes IDENTICAL (spread <= 1e-9). The
+  //     per-sample winner is independent of the factor, so the median-split
+  //     buckets behind `winner_flips` are two random halves of ONE sequence and
+  //     their disagreement is sampling noise. SUPPRESS.
+  //     ⚠ NOT "topological, so it holds under every sampled draw" — that
+  //     wording is withdrawn. ISL computes a NUMERICAL spread at ONE
+  //     configuration (the same MEAN one that disqualifies the token below).
+  //     The invariance rests on a MECHANISM — options are alternative values of
+  //     one decision node, so every option severs the same paths and the slopes
+  //     are the same expression — which covers the dominant case but not slopes
+  //     that merely coincide at the mean via different path products. Canonical
+  //     derivation and the residual class: `results/utils/flipReasonVocabulary.ts`
+  //     (`provesFactorCannotMoveWinner`). Disposition unchanged.
   //   · `no_effect_within_bounds` — slopes GENUINELY DIFFER; only the crossing
   //     sits outside the domain at the MEAN edge configuration. Sampled draws
   //     move the crossing, so a bucket disagreement can be a real finding.

--- a/src/canvas/stores/analysisSnapshotFactory.ts
+++ b/src/canvas/stores/analysisSnapshotFactory.ts
@@ -19,6 +19,10 @@ import {
   selectGoalProbability,
   type GoalProbabilityInput,
 } from '../../components/results/utils/selectGoalProbability'
+import {
+  collectStructurallyProvenNoFlipIds,
+  type FlipAttestationRowLike,
+} from '../../components/results/utils/flipReasonVocabulary'
 
 export interface BuildSnapshotParams {
   rawV2Response: V2RunResponse
@@ -213,25 +217,47 @@ function extractConditionalWinners(
   if (!Array.isArray(raw)) return []
 
   // ── D7 GATE 0: THE COHERENCE GATE'S CX5 FINDING, ACTED ON ────────────────
-  // `crossSurfaceCoherence` pair CX5 detects `flip_thresholds.no_flip_in_range:
-  // true` beside `conditional_winners.winner_flips: true` FOR THE SAME FACTOR —
-  // two producer statements about one factor that cannot both hold. Until now
+  // `crossSurfaceCoherence` pair CX5 detects a flip attestation beside
+  // `conditional_winners.winner_flips: true` FOR THE SAME FACTOR. Until #788
   // the gate only OBSERVED it: nothing consumed the finding, so a detector with
   // no consumer is instrumentation, not a guarantee.
   //
   // This is not hypothetical. The real capture
-  // `seeded-2026-08-17-w2d-analysis-turn.json` carries `no_flip_in_range: true`
-  // with `flip_reason: 'structurally_invariant'` for factors `71c6351d` and
+  // `seeded-2026-08-17-w2d-analysis-turn.json` carries
+  // `flip_reason: 'structurally_invariant'` for factors `71c6351d` and
   // `fcf3d740`, and `winner_flips: true` for those SAME two ids — and the
   // Compare tab rendered "…, Floating price contract takes over" for a factor
   // the same payload declares cannot flip at all.
   //
-  // WHY SUPPRESS RATHER THAN RECONCILE. The two statements are answering the
-  // SAME question ("can this factor flip the winner?") and giving opposite
-  // answers, which is what makes this actionable where CX1 is not. We cannot
-  // know which is right, and picking one would be inventing a finding. The
-  // honest move is the one this file already takes for a producer
-  // self-contradiction in the bucket ids: decline the claim.
+  // ⚠ D7b — NARROWED, AND THE NARROWING IS THE POINT. This gate first keyed on
+  // `no_flip_in_range === true`. That boolean is stamped by PLoT from the SET
+  // of BOTH attested reasons (`factor-flip-values.ts:304` over
+  // `NO_EFFECT_REASONS`, `flip-threshold-status.ts:75-78`), and the two reasons
+  // are epistemically different objects:
+  //
+  //   · `structurally_invariant` — slopes IDENTICAL (spread <= 1e-9). An
+  //     ALGEBRAIC identity, topological in the graph, so it holds under every
+  //     sampled edge draw. The per-sample winner is independent of the factor,
+  //     so the median-split buckets behind `winner_flips` are two random halves
+  //     of ONE sequence and their disagreement is sampling noise. SUPPRESS.
+  //   · `no_effect_within_bounds` — slopes GENUINELY DIFFER; only the crossing
+  //     sits outside the domain at the MEAN edge configuration. Sampled draws
+  //     move the crossing, so a bucket disagreement can be a real finding.
+  //     Suppressing it withholds science ISL computed. KEEP.
+  //
+  // So the gate reads the REASON, through the one module that owns the
+  // producer's vocabulary — never a second local copy of the token (trap 12).
+  // Reading the reason also WIDENS the gate in the direction that mattered:
+  // a row carrying the proof WITHOUT the boolean used to render here while the
+  // results panel's `selectFlipRisk` (which reads `flip_reason`) refused the
+  // same run — a fresh instance of the sibling-surface disagreement #788 set
+  // out to close.
+  //
+  // WHY SUPPRESS RATHER THAN RECONCILE, for the arm that is suppressed. Under
+  // the algebraic proof the two statements answer the SAME question ("can this
+  // factor flip the winner?") and one instrument provably cannot discriminate.
+  // Rendering both is the falsehood; declining the artefact is not withholding
+  // anything the producer coherently stated.
   const noFlipFactorIds = collectNoFlipFactorIds(response)
 
   return raw
@@ -292,33 +318,33 @@ function extractConditionalWinners(
 }
 
 /**
- * Factor ids whose `flip_thresholds` row asserts `no_flip_in_range: true`.
+ * Factor ids whose `flip_thresholds` row carries the ALGEBRAIC no-flip proof.
  *
- * Bound by IDENTITY (`factor_id`), never by `factor_label`: the two arrays are
- * joined on the id in the producer's own CX5 detector
- * (`crossSurfaceCoherence.ts:728-739`), and joining on a label would both miss
- * a real contradiction between two same-labelled factors and invent one
- * between two differently-labelled rows for the same factor.
+ * ⚠ D7b: the membership test is `collectStructurallyProvenNoFlipIds`, in
+ * `components/results/utils/flipReasonVocabulary` — the one module that owns
+ * the producer's flip vocabulary, and the module `selectFlipRisk` already
+ * consults for the RUN-LEVEL question. A local token literal here would be the
+ * hand-maintained mirror (trap 12) and, worse, a SECOND authority on what
+ * "attested" means (trap 21) — which is precisely the disagreement this gate
+ * exists to end. The two questions are named apart in that module's docblock;
+ * they are deliberately NOT the same predicate.
  *
- * ONLY `=== true` counts. The field is absent on both real captures that carry
- * a genuine flip (`flip_reason: 'found'`), and an ABSENT assertion is not a
- * negative one — treating absence as "no flip" would suppress every flip the
- * producer did compute, which is the mirror defect.
+ * Bound by IDENTITY, never by `factor_label`: the two arrays are joined on the
+ * id in the producer's own CX5 detector (`crossSurfaceCoherence.ts`), and a
+ * label join would both miss a real contradiction between two same-labelled
+ * factors and invent one between two differently-labelled rows for one factor.
+ *
+ * An ABSENT reason is not a negative one — an unknown token, a missing reason
+ * or a probe failure all fail the proof, so nothing the producer computed is
+ * withheld on the strength of a row that established nothing.
  */
 function collectNoFlipFactorIds(response: V2RunResponse): Set<string> {
-  const out = new Set<string>()
   const root = (response as unknown as Record<string, unknown> | undefined)?.flip_thresholds
   const nested = (response?.robustness as Record<string, unknown> | undefined)?.flip_thresholds
   const rows = Array.isArray(root) ? root : nested
-  if (!Array.isArray(rows)) return out
-  for (const r of rows) {
-    if (r && typeof r === 'object'
-      && (r as Record<string, unknown>).no_flip_in_range === true
-      && typeof (r as Record<string, unknown>).factor_id === 'string') {
-      out.add((r as Record<string, unknown>).factor_id as string)
-    }
-  }
-  return out
+  return collectStructurallyProvenNoFlipIds(
+    (Array.isArray(rows) ? rows : []) as FlipAttestationRowLike[],
+  )
 }
 
 /** Read one string member off a conditional-winner bucket. Absent ⇒ null. */

--- a/src/components/results/__tests__/useResultsSectionData.winnerFlipContradiction.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.winnerFlipContradiction.spec.ts
@@ -27,12 +27,22 @@
  * ─────────────────────────────────────────────────────────────────────────
  * `structurally_invariant` (PLoT `lib/flip-threshold-status.ts:44-49`) is an
  * ALGEBRAIC attestation: the per-option transmission slopes are identical
- * (spread <= 1e-9), so "no value of this factor can move the argmax". The
- * equality is topological, so it holds under every sampled edge draw — which
+ * (spread <= 1e-9), so "no value of this factor can move the argmax" — which
  * makes the median-split bucket comparison behind `winner_flips` a comparison
  * of two random halves of ONE sequence. Its disagreement rate is governed only
  * by proximity to a 50/50 win probability. The flip attestation is therefore
  * authoritative and the bucket claim is an artefact.
+ *
+ * ⚠ CORRECTED: "the equality is topological, so it holds under every sampled
+ * edge draw" is withdrawn. ISL screens a NUMERICAL slope spread against `1e-9`
+ * at ONE mean edge configuration (`robustness_analyzer_v2.py:6722-6724`,
+ * `:6763`, `:6775`) — the same configuration named as disqualifying two
+ * paragraphs down. The invariance rests on a MECHANISM (options are alternative
+ * values of one decision node, so every option severs the same paths and the
+ * per-option slopes are the same algebraic expression), which leaves a residual
+ * class uncovered: slopes that coincide at the mean via different path
+ * products. Canonical derivation: `../utils/flipReasonVocabulary.ts`. The
+ * verdict below is unchanged.
  *
  * `no_effect_within_bounds` is NOT that: the slopes genuinely differ and the
  * crossing merely sits outside the domain at the MEAN edge configuration. Each

--- a/src/components/results/__tests__/useResultsSectionData.winnerFlipContradiction.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.winnerFlipContradiction.spec.ts
@@ -1,0 +1,223 @@
+/**
+ * useResultsSectionData — THE RESULTS PANEL STOPS SAYING BOTH THINGS AT ONCE.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * THE WITNESSED DEFECT
+ * ─────────────────────────────────────────────────────────────────────────
+ * On the Analysis tab, `TriageActionCardsBody` renders `ConditionalWinnerCards`
+ * (":916") from `confidence.conditionalWinners`, and the SAME tab states the
+ * producer's flip attestation from `recommendation.flipThresholds`. On a
+ * near-tie run the two say opposite things about ONE factor:
+ *
+ *   "no single factor on its own reached a tipping point that would change
+ *    which option leads"      …beside…      "When X exceeds 0.50, Y takes over"
+ *
+ * Measured on the deployed build in a controlled experiment: 4 of 8 near-tie
+ * responses assert both for the same factor; 0 of 8 in the separated contrast
+ * control (`CLAUDE-FLIP-VALIDITY-SETTLEMENT.md` §B.3). The real capture
+ * `seeded-2026-08-17-w2d-analysis-turn.json` is an instance.
+ *
+ * `crossSurfaceCoherence` pair CX5 names this exact pair, but it is an OFFLINE
+ * instrument over committed captures — nothing at runtime prevented it. The
+ * Compare tab was bound in #788; this is its sibling surface, which was left
+ * behind and is the one the settlement actually witnessed.
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * WHICH SURFACE IS AUTHORITATIVE, AND WHY IT IS NOT A COIN TOSS
+ * ─────────────────────────────────────────────────────────────────────────
+ * `structurally_invariant` (PLoT `lib/flip-threshold-status.ts:44-49`) is an
+ * ALGEBRAIC attestation: the per-option transmission slopes are identical
+ * (spread <= 1e-9), so "no value of this factor can move the argmax". The
+ * equality is topological, so it holds under every sampled edge draw — which
+ * makes the median-split bucket comparison behind `winner_flips` a comparison
+ * of two random halves of ONE sequence. Its disagreement rate is governed only
+ * by proximity to a 50/50 win probability. The flip attestation is therefore
+ * authoritative and the bucket claim is an artefact.
+ *
+ * `no_effect_within_bounds` is NOT that: the slopes genuinely differ and the
+ * crossing merely sits outside the domain at the MEAN edge configuration. Each
+ * sample draws different strengths, so a bucket disagreement can be real. That
+ * row is KEPT — see the opposite-direction twins below.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { Node, Edge } from '@xyflow/react'
+
+import { useResultsSectionData } from '../useResultsSectionData'
+import { useCanvasStore } from '../../../canvas/store'
+import { buildAnalysisSnapshot } from '../../../canvas/stores/analysisSnapshotFactory'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+import type { ReportV1 } from '../../../adapters/plot/types'
+
+import w2dTurn from '../../../lib/coherence/__tests__/fixtures/captures/seeded-2026-08-17-w2d-analysis-turn.json'
+import w998Turn from '../../../lib/coherence/__tests__/fixtures/captures/w998-2026-08-16-a1-turn3.json'
+import probeA from '../../../lib/coherence/__tests__/fixtures/captures/conditional-winners-2026-08-17-probe-A.json'
+
+const W2D = (w2dTurn as unknown as { blocks: Array<{ enrichment: Record<string, unknown> }> })
+  .blocks[0].enrichment
+const W998 = (w998Turn as unknown as { blocks: Array<{ enrichment: Record<string, unknown> }> })
+  .blocks[0].enrichment
+const PROBE_A = probeA as unknown as Record<string, unknown>
+
+function clone<T>(v: T): T {
+  return JSON.parse(JSON.stringify(v)) as T
+}
+
+const flipRows = (e: Record<string, unknown>) =>
+  e.flip_thresholds as Array<Record<string, unknown>>
+const winnerRows = (e: Record<string, unknown>) =>
+  e.conditional_winners as Array<Record<string, unknown>>
+
+const OPTION_NODES = [
+  { id: 'opt_a', type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'Option A' } },
+  { id: 'opt_b', type: 'option', position: { x: 0, y: 0 }, data: { kind: 'option', label: 'Option B' } },
+]
+
+function setStoreWithReport(reportOverrides: Record<string, unknown>): void {
+  useCanvasStore.setState({
+    results: {
+      status: 'complete',
+      progress: 100,
+      report: {
+        analysis_status: 'computed',
+        robustness: { fragile_edges: [], robust_edges: [] },
+        ...reportOverrides,
+      },
+    } as any,
+    runMeta: {} as any,
+    nodes: OPTION_NODES as any,
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: null,
+  } as any)
+}
+
+/** Factor ids the results panel would render conditional-winner cards for. */
+function renderedWinnerIds(enrichment: Record<string, unknown>): string[] {
+  setStoreWithReport({
+    flip_thresholds: clone(flipRows(enrichment) ?? []),
+    conditional_winners: clone(winnerRows(enrichment) ?? []),
+  })
+  const { result } = renderHook(() => useResultsSectionData())
+  return (result.current.confidence.conditionalWinners ?? []).map(w => w.factor_id)
+}
+
+/** Factor ids the Compare tab would render transitions for, same payload. */
+function compareTabWinnerIds(enrichment: Record<string, unknown>): string[] {
+  const snapshot = buildAnalysisSnapshot({
+    rawV2Response: {
+      flip_thresholds: clone(flipRows(enrichment) ?? []),
+      conditional_winners: clone(winnerRows(enrichment) ?? []),
+    } as unknown as V2RunResponse,
+    report: {} as ReportV1,
+    nodes: [] as Node[],
+    edges: [] as Edge[],
+    runNumber: 1,
+    events: [],
+    previousSnapshotTimestamp: null,
+  })
+  return snapshot.conditionalWinners.map(w => w.factorId)
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({
+    results: null,
+    runMeta: null,
+    nodes: [],
+    edges: [],
+    hasCompletedFirstRun: false,
+    rawV2Response: null,
+  } as any)
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// THE WITNESSED CONTRADICTION IS CLOSED ON THE RESULTS PANEL.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('results panel — an algebraically-proven inert factor no longer also "takes over"', () => {
+  it('PRECONDITION: w2d asserts BOTH claims for the SAME two factor ids', () => {
+    expect(flipRows(W2D).map(r => [r.factor_id, r.flip_reason, r.flip_value])).toEqual([
+      ['71c6351d', 'structurally_invariant', null],
+      ['fcf3d740', 'structurally_invariant', null],
+    ])
+    expect(winnerRows(W2D).map(r => [r.factor_id, r.winner_flips])).toEqual([
+      ['71c6351d', true],
+      ['fcf3d740', true],
+    ])
+  })
+
+  it('the contradicted cards are withheld — `confidence.conditionalWinners` carries neither factor', () => {
+    expect(renderedWinnerIds(W2D)).toEqual([])
+  })
+
+  it('OPPOSITE-DIRECTION TWIN: with the proof removed, both rows render — the suppression is the proof\'s doing', () => {
+    const raw = clone(W2D)
+    for (const r of flipRows(raw)) {
+      delete r.flip_reason
+      delete r.no_flip_in_range
+    }
+    expect(renderedWinnerIds(raw)).toEqual(['71c6351d', 'fcf3d740'])
+  })
+
+  it('OPPOSITE-DIRECTION TWIN: a `no_effect_within_bounds` factor KEEPS its card — a computed finding is not withheld', () => {
+    // COMPOSED from two real halves, disclosed: w998's real
+    // `no_effect_within_bounds` rows joined to probe-A's real conditional
+    // winner, re-keyed onto w998's factor. Licence: PLoT stamps
+    // `no_flip_in_range` from a SET of both reasons
+    // (factor-flip-values.ts:304), and nothing couples the two arrays.
+    const winner = { ...clone(winnerRows(PROBE_A)[0]), factor_id: '13faf76d' }
+    expect(renderedWinnerIds({
+      flip_thresholds: clone(flipRows(W998)),
+      conditional_winners: [winner],
+    })).toEqual(['13faf76d'])
+  })
+
+  it('OPPOSITE-DIRECTION TWIN: a `found` flip row never suppresses its own factor (probe-A verbatim)', () => {
+    expect(renderedWinnerIds(PROBE_A)).toEqual(['fac_demand'])
+  })
+
+  it('suppression binds by factor IDENTITY — a proof for a different factor withholds nothing', () => {
+    const raw = clone(W2D)
+    for (const r of flipRows(raw)) r.factor_id = `${String(r.factor_id)}-other`
+    expect(renderedWinnerIds(raw)).toEqual(['71c6351d', 'fcf3d740'])
+  })
+})
+
+// ───────────────────────────────────────────────────────────────────────────
+// THE POINT OF THE LANE: ONE PAYLOAD, ONE VERDICT, ON BOTH SURFACES.
+// ───────────────────────────────────────────────────────────────────────────
+
+describe('cross-surface agreement — the results panel and the Compare tab decide alike', () => {
+  const cases: Array<[string, Record<string, unknown>]> = [
+    ['w2d verbatim (structurally_invariant + winner_flips)', W2D],
+    ['probe-A verbatim (found + winner_flips)', PROBE_A],
+  ]
+
+  it.each(cases)('%s — identical surviving factor ids on both surfaces', (_name, enrichment) => {
+    expect(renderedWinnerIds(enrichment)).toEqual(compareTabWinnerIds(enrichment))
+  })
+
+  it('the proof WITHOUT the boolean: both surfaces suppress (this pair used to disagree)', () => {
+    // Before the narrowing the Compare tab keyed on `no_flip_in_range` alone,
+    // so this row rendered there while the results panel's `selectFlipRisk`
+    // (which reads `flip_reason`) refused the same run's flip claim — a NEW
+    // instance of the very sibling-surface disagreement #788 set out to close.
+    const raw = clone(W2D)
+    for (const r of flipRows(raw)) delete r.no_flip_in_range
+    expect(flipRows(raw).map(r => r.flip_reason))
+      .toEqual(['structurally_invariant', 'structurally_invariant'])
+    expect(renderedWinnerIds(raw)).toEqual([])
+    expect(compareTabWinnerIds(raw)).toEqual([])
+  })
+
+  it('DISCRIMINATION CONTROL — the agreement above is not vacuous: both surfaces render the same non-empty set', () => {
+    const winner = { ...clone(winnerRows(PROBE_A)[0]), factor_id: '13faf76d' }
+    const payload = {
+      flip_thresholds: clone(flipRows(W998)),
+      conditional_winners: [winner],
+    }
+    expect(renderedWinnerIds(payload)).toEqual(['13faf76d'])
+    expect(compareTabWinnerIds(payload)).toEqual(['13faf76d'])
+  })
+})

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -66,6 +66,7 @@ import { mapM2BiasFindings } from './mapM2BiasFindings'
 import { mapDecisionQualityPrompts } from './utils/decisionQualityPrompts'
 import { humaniseCritique } from './utils/humaniseCritique'
 import { selectGoalProbability, type GoalProbabilityInput } from './utils/selectGoalProbability'
+import { collectStructurallyProvenNoFlipIds } from './utils/flipReasonVocabulary'
 import { sortOptionsForDisplay } from './utils/optionDisplayOrder'
 import {
   deriveNotAnalysedReason,
@@ -3447,9 +3448,33 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
       //     and the flip claim stands without them. Never mint 0%.
       //   - identity absence (CEE's withheld-claim projection) is PRESERVED,
       //     so the card can render its neutral arm instead of nothing.
+      //
+      // ⚠ D7b — CX5, ENFORCED ON THIS SURFACE TOO, AND THIS IS THE ONE THE
+      // SETTLEMENT WITNESSED. `TriageActionCardsBody:916` renders these rows as
+      // `ConditionalWinnerCards` on the Analysis tab, where the SAME tab states
+      // the flip attestation from `recommendation.flipThresholds`. On a near-tie
+      // run they said opposite things about one factor — measured on the
+      // deployed build at 4/8 near-tie responses, 0/8 in the separated contrast
+      // control. #788 bound the Compare tab; this is its sibling surface.
+      //
+      // The predicate is `collectStructurallyProvenNoFlipIds` — the ALGEBRAIC
+      // proof only, never PLoT's `no_flip_in_range` boolean, which collapses
+      // that proof together with `no_effect_within_bounds` (a row compatible
+      // with a marginal flip, whose card must survive). The two questions and
+      // the derivation are in `flipReasonVocabulary`; do not restate the token
+      // here.
+      //
+      // ⚠ ONE AUTHORITY: the rows come from `recommendation.flipThresholds`,
+      // the memo that already adapts this array (label resolution, `node_id`
+      // normalisation, `flip_reason` carried verbatim). Re-reading the wire
+      // here would make this a SECOND adapter for one array — the two-choosers
+      // defect `selectFlipRisk`'s own header exists to forbid.
       conditionalWinners: (() => {
         const raw = safeArray((report as any)?.conditional_winners ?? (report as any)?.robustness?.conditional_winners)
         if (raw.length === 0) return undefined
+        const provenInertFactorIds = collectStructurallyProvenNoFlipIds(
+          recommendation.flipThresholds,
+        )
         // Wire rows are narrowed via `unknown` → typeof checks (no `as any`;
         // the trust-boundary cast budget in wave2-replay-gate.spec.ts is the
         // enforcement — typed narrowing is the pattern it exists to force).
@@ -3482,6 +3507,10 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
           const factorIdRaw = w.factor_id ?? w.node_id
           if (typeof factorLabelRaw !== 'string' || factorLabelRaw.length === 0) continue
           if (typeof factorIdRaw !== 'string' || factorIdRaw.length === 0) continue
+          // D7b CX5, by factor IDENTITY: this factor's own flip row proves it
+          // cannot move the winner, so its bucket disagreement is a sampling
+          // artefact and the card would contradict the same tab's attestation.
+          if (provenInertFactorIds.has(factorIdRaw)) continue
           const high = asRecord(w.high_bucket)
           const low = asRecord(w.low_bucket)
           if (!high || !low) continue
@@ -3601,7 +3630,13 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
     // quality, bias/quality/improvement guidance all read it); the CEE review
     // lands asynchronously after `report`, so omitting it froze the tier at
     // its pre-review value. The sibling `completeness` memo already lists it.
-  }, [report, m1Coaching, drivers, reviewStatus, m1ReviewAssumptions, nodeLabelMap, runMeta?.ceeReviewV1])
+    //
+    // D7b: `recommendation` is a genuine input — the conditional-winner
+    // projection reads `recommendation.flipThresholds` so the two surfaces
+    // decide from ONE adapted array. Listing it is a correctness dependency,
+    // not lint appeasement: with a stale closure the CX5 suppression would be
+    // computed from the previous run's flip evidence.
+  }, [report, m1Coaching, drivers, reviewStatus, m1ReviewAssumptions, nodeLabelMap, runMeta?.ceeReviewV1, recommendation])
 
   // ==========================================================================
   // Improvements Section Data (Legacy - now merged into confidence)

--- a/src/components/results/utils/flipReasonVocabulary.ts
+++ b/src/components/results/utils/flipReasonVocabulary.ts
@@ -190,15 +190,56 @@ export function isProbeFailureFlipReason(reason: string | null | undefined): boo
  * WHY Q2 IS STRICTLY NARROWER, derived at the producer rather than chosen:
  *
  *   · `structurally_invariant` — the per-option transmission slopes are
- *     IDENTICAL. Slope equality is a TOPOLOGICAL property of the graph (which
- *     of the factor's causal paths each option's intervention severs), so it
- *     holds under EVERY sampled edge configuration, not merely at the mean.
- *     The per-sample winner is therefore independent of the factor, and the
- *     median-split bucket comparison behind `conditional_winners.winner_flips`
- *     is a comparison of two random halves of ONE sequence — its disagreement
- *     rate is governed only by proximity to a 50/50 win probability. Measured
- *     on the deployed build: 4/8 near-tie responses assert both claims for one
- *     factor; 0/8 in the separated contrast control.
+ *     IDENTICAL. The per-sample winner is therefore independent of the factor,
+ *     and the median-split bucket comparison behind
+ *     `conditional_winners.winner_flips` is a comparison of two random halves
+ *     of ONE sequence — its disagreement rate is governed only by proximity to
+ *     a 50/50 win probability. Measured on the deployed build: 4/8 near-tie
+ *     responses assert both claims for one factor; 0/8 in the separated
+ *     contrast control.
+ *
+ *     ⚠⚠ WHAT ISL ACTUALLY COMPUTES — CORRECTED, AND THIS IS THE CANONICAL
+ *     STATEMENT THE SIBLING SITES POINT AT. This block previously said slope
+ *     equality "is a TOPOLOGICAL property of the graph ... so it holds under
+ *     EVERY sampled edge configuration, not merely at the mean". ISL COMPUTES
+ *     NO SUCH THING. Derived at `robustness_analyzer_v2.py` (ISL staging
+ *     `28fe0c9`): the candidate screen evaluates each option's goal at the
+ *     factor's MIN and MAX (`:6751-6756`), takes the affine coefficients
+ *     (`:6757`), and screens `spread = max(slopes) - min(slopes)` against
+ *     `FACTOR_FLIP_SLOPE_EPSILON = 1e-9` (`:6763`, `:6775`, `:6522`). Every one
+ *     of those evaluations runs against a SINGLE
+ *     `baseline_config = {edge: strength.mean * exists_probability}`
+ *     (`:6722-6724`). So it is a NUMERICAL equality test at ONE configuration —
+ *     and it is THE SAME MEAN CONFIGURATION the next bullet uses to
+ *     DISQUALIFY `no_effect_within_bounds`. The old wording granted one token a
+ *     sample-invariance guarantee while treating the identical premise as
+ *     disqualifying for the other.
+ *
+ *     ⭐ THE CONCLUSION STILL HOLDS — ON A NAMED MECHANISM, NOT ON THAT WORD.
+ *     In this product's graphs the options are alternative values of ONE
+ *     decision node, so every option severs the SAME set of causal paths from a
+ *     given factor to the goal. Each option's transmission slope is then the
+ *     SAME ALGEBRAIC EXPRESSION in the sampled edge strengths, and two equal
+ *     expressions stay equal at every draw, not merely at the mean. That — not
+ *     topology as such — is what makes the per-sample winner independent of the
+ *     factor, and it is why SUPPRESS is the right disposition.
+ *
+ *     ⚠ THE RESIDUAL CLASS THE MECHANISM DOES NOT COVER, recorded rather than
+ *     hidden. Two slopes can also coincide at the mean through DIFFERENT path
+ *     products — `0.5 × 0.4` and `0.2 × 1.0` both give `0.2` — which is not
+ *     far-fetched with the round-numbered strengths a drafted graph carries.
+ *     Those slopes are NOT the same expression, so they separate as soon as the
+ *     draws move, and for such a factor `winner_flips` could be a real finding
+ *     this gate suppresses. Nothing in ISL rules the class out: its own
+ *     `stability` field says the band is skipped for a `structurally_invariant`
+ *     row because computing one "would spend the compute the candidate screen
+ *     exists to save" (`src/models/response_v2.py:854-855`) — a COST decision,
+ *     not a proof of sample-invariance.
+ *
+ *     The disposition is UNCHANGED: the mechanism covers the dominant case, and
+ *     the residual class is both rare and the lesser harm (a withheld artefact,
+ *     not a stated falsehood). It is written down so it is visible if it ever
+ *     turns up in a capture.
  *
  *   · `no_effect_within_bounds` — the slopes GENUINELY DIFFER and the crossing
  *     merely lies outside the domain AT THE MEAN edge configuration. Each

--- a/src/components/results/utils/flipReasonVocabulary.ts
+++ b/src/components/results/utils/flipReasonVocabulary.ts
@@ -74,6 +74,19 @@ export const ATTESTED_NO_FLIP_REASONS = [
 ] as const
 
 /**
+ * THE ONE TOKEN THAT IS AN ALGEBRAIC PROOF RATHER THAN A MEASURED SEARCH.
+ *
+ * PLoT's own words, `lib/flip-threshold-status.ts:44-49` read at staging
+ * `7e5d8a7d`: the per-option transmission slopes are IDENTICAL (spread
+ * <= 1e-9), so "no value of this factor can move the argmax"; ISL calls it
+ * "a MATHEMATICAL ATTESTATION, not a failed or timed-out probe".
+ *
+ * It is a SUBSET of {@link ATTESTED_NO_FLIP_REASONS}, and the distinction is
+ * the whole point — see {@link provesFactorCannotMoveWinner}.
+ */
+export const STRUCTURAL_NO_FLIP_PROOF = 'structurally_invariant'
+
+/**
  * Tokens KNOWN to mean the probe did not establish anything. Enumerated for
  * documentation and for the drift pin — NOT consulted by the predicates, which
  * are written as "not substantive" precisely so an unknown token needs no entry
@@ -152,6 +165,115 @@ export function isAttestedNoFlipReason(reason: string | null | undefined): boole
 export function isProbeFailureFlipReason(reason: string | null | undefined): boolean {
   if (isAttestedNoFlipReason(reason)) return false
   return reason !== FLIP_REASON_FOUND
+}
+
+/**
+ * ═════════════════════════════════════════════════════════════════════════
+ * THE SECOND PREDICATE — AND WHY IT MUST NEVER BE MERGED WITH THE FIRST
+ * ═════════════════════════════════════════════════════════════════════════
+ *
+ * TWO QUESTIONS, WRITTEN DOWN BEFORE ANYTHING WAS RECONCILED (trap 21):
+ *
+ *   Q1  "May this run state that NO factor reached a tipping point?"
+ *       → `isAttestedNoFlipReason`, consumed by `selectFlipRisk`
+ *         (`classifyFlipEvidence`, RUN-LEVEL: every row must attest).
+ *       → BOTH tokens qualify. `no_effect_within_bounds` genuinely IS an
+ *         attested absence over the tested range, and narrowing Q1 would make
+ *         the product name a flip risk it has no evidence for.
+ *
+ *   Q2  "May this factor's attestation be used to WITHHOLD a positive claim
+ *        another instrument computed about the same factor?"
+ *       → `provesFactorCannotMoveWinner`, consumed by the conditional-winner
+ *         suppression (PER-FACTOR).
+ *       → ONLY `structurally_invariant` qualifies.
+ *
+ * WHY Q2 IS STRICTLY NARROWER, derived at the producer rather than chosen:
+ *
+ *   · `structurally_invariant` — the per-option transmission slopes are
+ *     IDENTICAL. Slope equality is a TOPOLOGICAL property of the graph (which
+ *     of the factor's causal paths each option's intervention severs), so it
+ *     holds under EVERY sampled edge configuration, not merely at the mean.
+ *     The per-sample winner is therefore independent of the factor, and the
+ *     median-split bucket comparison behind `conditional_winners.winner_flips`
+ *     is a comparison of two random halves of ONE sequence — its disagreement
+ *     rate is governed only by proximity to a 50/50 win probability. Measured
+ *     on the deployed build: 4/8 near-tie responses assert both claims for one
+ *     factor; 0/8 in the separated contrast control.
+ *
+ *   · `no_effect_within_bounds` — the slopes GENUINELY DIFFER and the crossing
+ *     merely lies outside the domain AT THE MEAN edge configuration. Each
+ *     Monte-Carlo sample draws different strengths, so the crossing moves and
+ *     can fall inside the domain for a real share of draws. A bucket
+ *     disagreement there is a finding ISL computed. Withholding it is
+ *     over-suppression — the mirror harm.
+ *
+ * ⚠ PLoT'S BOOLEAN CANNOT CARRY THIS DISTINCTION. `no_flip_in_range: true` is
+ * stamped from the SET of both tokens (`factor-flip-values.ts:304` over
+ * `NO_EFFECT_REASONS`, `flip-threshold-status.ts:75-78`). A consumer that gates
+ * on the boolean gates on the union, which is exactly the over-suppression this
+ * predicate exists to end. Read the REASON.
+ *
+ * ⚠ TWO OPPOSITE HARMS, TWO PREDICATES (trap 22b). Over-suppression withholds
+ * real science; under-suppression states a falsehood. They are not two ends of
+ * one window and must never be tuned as if they were.
+ */
+
+/** Minimal row shape both consumers can satisfy without a shared row type. */
+export interface FlipAttestationRowLike {
+  factor_id?: string | null
+  node_id?: string | null
+  flip_value?: number | null
+  flip_reason?: string | null
+}
+
+/** True ⇔ `reason` is the algebraic proof (Q2's allow-list of exactly one). */
+export function isStructuralNoFlipProof(reason: string | null | undefined): boolean {
+  return reason === STRUCTURAL_NO_FLIP_PROOF
+}
+
+/**
+ * True ⇔ this row PROVES the factor cannot move the winner, and is therefore
+ * entitled to withhold a sibling surface's positive flip claim about it.
+ *
+ * Requires the proof token AND the absence of a numeric `flip_value`. PLoT
+ * cannot emit both (`isAttestedNoFlip` demands `flipValue === null`,
+ * `factor-flip-values.ts:365-367`), so the second clause is defence in depth —
+ * and its POLARITY is deliberate: an incoherent attestation fails toward NOT
+ * withholding, because for THIS question "we do not know" must never license a
+ * suppression. (Note the polarity is the OPPOSITE of `isAttestedNoFlipReason`'s
+ * for the same reason: there, failing safe means declining to assert an
+ * absence; here, failing safe means declining to hide a computed claim.)
+ */
+export function provesFactorCannotMoveWinner(
+  row: FlipAttestationRowLike | null | undefined,
+): boolean {
+  if (!row || typeof row !== 'object') return false
+  if (typeof row.flip_value === 'number') return false
+  return isStructuralNoFlipProof(row.flip_reason)
+}
+
+/**
+ * The factor ids whose flip rows carry the algebraic proof.
+ *
+ * Bound by IDENTITY, never by label (trap 19): a label join would both miss a
+ * real contradiction between two same-labelled factors and invent one between
+ * two differently-labelled rows for the same factor. `factor_id` is the wire
+ * spelling PLoT emits; `node_id` is the spelling the UI's adapted
+ * `FlipThreshold` carries (`normaliseFactorFields`: node_id > factor_id > id),
+ * so both are read and neither is preferred over a non-empty other.
+ */
+export function collectStructurallyProvenNoFlipIds(
+  rows: readonly FlipAttestationRowLike[] | null | undefined,
+): Set<string> {
+  const out = new Set<string>()
+  if (!Array.isArray(rows)) return out
+  for (const row of rows) {
+    if (!provesFactorCannotMoveWinner(row)) continue
+    for (const id of [row?.factor_id, row?.node_id]) {
+      if (typeof id === 'string' && id !== '') out.add(id)
+    }
+  }
+  return out
 }
 
 /** True ⇔ this build recognises the token at all. For the drift pin only. */

--- a/src/components/results/utils/selectFlipRisk.ts
+++ b/src/components/results/utils/selectFlipRisk.ts
@@ -94,6 +94,37 @@
  *     genuinely does not distinguish the two cases.
  * The union is now derived from the producer and left OPEN, and every
  * predicate is written so an unrecognised token fails toward "we do not know".
+ *
+ * ─────────────────────────────────────────────────────────────────────────
+ * ⚠ D7b — THERE IS A SECOND FLIP AUTHORITY, AND IT IS NOT THIS ONE. NAMED
+ * APART DELIBERATELY; DO NOT RECONCILE THEM (trap 21).
+ * ─────────────────────────────────────────────────────────────────────────
+ * This module answers a RUN-LEVEL question:
+ *
+ *     "May this run name a flip risk at all?"
+ *
+ * `flipReasonVocabulary.provesFactorCannotMoveWinner` answers a PER-FACTOR one:
+ *
+ *     "May this factor's attestation be used to WITHHOLD a positive claim
+ *      another instrument computed about the same factor?"
+ *      (the conditional-winner suppression, `analysisSnapshotFactory` +
+ *       `useResultsSectionData`)
+ *
+ * They use DIFFERENT allow-lists on purpose. This one admits BOTH attested
+ * tokens, because `no_effect_within_bounds` really is an attested absence over
+ * the tested range and narrowing it here would make the product name a flip
+ * risk it has no evidence for. The other admits only `structurally_invariant`,
+ * because only an algebraic identity licenses hiding a computed finding.
+ *
+ * Their fail-safe polarities are OPPOSITE for the same reason: here "we do not
+ * know" must not assert an absence, so an unknown token degrades to
+ * `no_producer_flip_data`; there "we do not know" must not hide a claim, so an
+ * unknown token suppresses nothing. Merging the two predicates — in either
+ * direction — trades one silent failure for the other (trap 22b).
+ *
+ * ⚠ AND NOTE WHAT THIS MODULE DOES NOT READ: `no_flip_in_range`. PLoT stamps
+ * that boolean from the SET of both reasons, so it cannot carry the
+ * distinction. A consumer keyed on it is keyed on the union. Read the reason.
  */
 
 import { THRESHOLDS } from '../../../lib/mappers/constants'

--- a/src/lib/coherence/crossSurfaceCoherence.ts
+++ b/src/lib/coherence/crossSurfaceCoherence.ts
@@ -413,15 +413,27 @@ export const COHERENCE_DISPOSITIONS: Readonly<Record<CoherencePairId, {
   CX5: {
     disposition: 'suppress_at_consumer',
     rationale:
-      'SAME QUESTION: can this factor flip the winner? `flip_thresholds.'
-      + 'no_flip_in_range: true` says no; `conditional_winners.winner_flips: true` '
-      + 'says yes, for the same `factor_id`. Both facts ride the SAME enrichment '
-      + 'object, so the consumer can act without any new plumbing.',
+      'SAME QUESTION — BUT ONLY UNDER ONE OF THE TWO REASONS THE BOOLEAN '
+      + 'COLLAPSES, and the pair\'s disposition is its ENFORCED limb. Under '
+      + '`structurally_invariant` the per-option slopes are identical, so the '
+      + 'per-sample winner is independent of the factor and `winner_flips` is a '
+      + 'sampling artefact: same question, one instrument provably unable to '
+      + 'discriminate, suppress. Under `no_effect_within_bounds` the slopes '
+      + 'genuinely differ and only the MEAN-configuration crossing sits outside '
+      + 'the domain, so a sampled bucket disagreement can be real: DIFFERENT '
+      + 'questions, `name_apart`, and suppressing it would withhold a finding ISL '
+      + 'computed. Per-limb dispositions in `CX5_LIMB_DISPOSITION`.',
     enforcedAt:
-      'src/canvas/stores/analysisSnapshotFactory.ts — `collectNoFlipFactorIds`, '
-      + 'joined on `factor_id`. Pinned by '
-      + '`analysisSnapshotFactory.scienceAttestation.spec.ts`, including the '
-      + 'opposite-direction twin (an ABSENT `no_flip_in_range` suppresses nothing).',
+      'src/canvas/stores/analysisSnapshotFactory.ts (`collectNoFlipFactorIds`) and '
+      + 'src/components/results/useResultsSectionData.ts (`confidence.'
+      + 'conditionalWinners`) — BOTH via `components/results/utils/'
+      + 'flipReasonVocabulary.collectStructurallyProvenNoFlipIds`, joined on the '
+      + 'factor id. ⚠ THE STRUCTURAL LIMB ONLY: the `no_effect_within_bounds` limb '
+      + 'is reported and deliberately NOT enforced. Pinned by '
+      + '`analysisSnapshotFactory.scienceAttestation.spec.ts`, '
+      + '`analysisSnapshotFactory.flipReasonNarrowing.spec.ts` and '
+      + '`useResultsSectionData.winnerFlipContradiction.spec.ts`, each carrying '
+      + 'both directions.',
   },
   CX6: {
     disposition: 'report_only',
@@ -500,6 +512,43 @@ export const CX3_LIMB_EXPRESSIBILITY: Readonly<Record<string, CoherenceExpressib
   never_run_with_usable_analysis: 'analysis_state_enforced',
   never_run_after_degraded_store_read: 'not_on_the_wire',
   never_run_over_visible_result_body: 'envelope',
+}
+
+/**
+ * CX5's two limbs do not share a disposition, and the pair-level field carries
+ * only the enforced one. Same precedent as `CX3_LIMB_EXPRESSIBILITY` above, and
+ * the same reason: collapsing them hides the only interesting fact about the
+ * pair.
+ *
+ * The split is forced by the PRODUCER. PLoT stamps one boolean,
+ * `no_flip_in_range: true`, from a SET of two reasons
+ * (`integrations/isl/adapters/factor-flip-values.ts:304` over `NO_EFFECT_REASONS`,
+ * `lib/flip-threshold-status.ts:75-78`), and the two are epistemically different
+ * objects — so a consumer keyed on the boolean is keyed on their union and
+ * necessarily gets one of the limbs wrong.
+ *
+ * ⚠ TWO OPPOSITE HARMS, TWO DISPOSITIONS (trap 22b). Enforcing both limbs
+ * withholds a finding ISL computed; enforcing neither leaves a falsehood on the
+ * screen. They are not two ends of one tunable window.
+ */
+export const CX5_LIMB_DISPOSITION: Readonly<Record<string, CoherenceDisposition>> = {
+  /**
+   * Slopes IDENTICAL (spread <= 1e-9) — an algebraic identity, topological in
+   * the graph, so it holds under every sampled edge draw. The per-sample winner
+   * is independent of the factor, so the median-split buckets behind
+   * `winner_flips` are two random halves of ONE sequence. Same question, one
+   * instrument unable to discriminate: SUPPRESS.
+   */
+  structurally_invariant_with_winner_flips: 'suppress_at_consumer',
+  /**
+   * Slopes GENUINELY DIFFER; only the crossing lies outside the domain at the
+   * MEAN edge configuration. Sampled draws move the crossing, so a bucket
+   * disagreement can be a real finding about the sampled distribution. The two
+   * members answer different questions and the residual tension is in the
+   * PRODUCER'S COPY ("within the tested range…"), which is CEE's to split on
+   * the reason — not a consumer suppression. Reported, never enforced here.
+   */
+  no_effect_within_bounds_with_winner_flips: 'name_apart',
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -845,13 +894,30 @@ function detectCX5(input: CoherenceInput, out: CoherenceViolation[]): void {
     if (typeof w.factor_id !== 'string') continue
     const f = noFlipByFactor.get(w.factor_id)
     if (f === undefined) continue
+    // ⚠ D7b — ONE CODE PER LIMB. Detection is unchanged (the boolean still
+    // finds every pair), but the two reasons behind it get different
+    // dispositions (`CX5_LIMB_DISPOSITION`), so lumping them under one code
+    // would report a deliberate KEEP as if it were the enforced contradiction —
+    // and make the pair's `enforcedAt` claim false for half its findings.
+    const limb =
+      f.flip_reason === 'structurally_invariant'
+        ? 'structurally_invariant_with_winner_flips'
+        : f.flip_reason === 'no_effect_within_bounds'
+          ? 'no_effect_within_bounds_with_winner_flips'
+          : 'no_flip_in_range_with_winner_flips'
     out.push({
       pair: 'CX5',
-      code: 'no_flip_in_range_with_winner_flips',
+      code: limb,
       detail:
         `For factor '${w.factor_id}', flip_thresholds reports no_flip_in_range:true ` +
         `(reason '${f.flip_reason ?? 'unstated'}') while conditional_winners reports ` +
-        `winner_flips:true for the same factor. Both render on the Analysis tab.`,
+        `winner_flips:true for the same factor. Both render on the Analysis tab.` +
+        (limb === 'no_effect_within_bounds_with_winner_flips'
+          ? ` REPORTED, NOT ENFORCED: the slopes genuinely differ and only the` +
+            ` mean-configuration crossing lies outside the domain, so the sampled` +
+            ` bucket disagreement can be real. The residual tension is in the` +
+            ` producer's "within the tested range" copy.`
+          : ''),
       evidence: {
         factor_id: w.factor_id,
         factor_label: String(w.factor_label ?? f.factor_label ?? ''),

--- a/src/lib/coherence/crossSurfaceCoherence.ts
+++ b/src/lib/coherence/crossSurfaceCoherence.ts
@@ -533,11 +533,20 @@ export const CX3_LIMB_EXPRESSIBILITY: Readonly<Record<string, CoherenceExpressib
  */
 export const CX5_LIMB_DISPOSITION: Readonly<Record<string, CoherenceDisposition>> = {
   /**
-   * Slopes IDENTICAL (spread <= 1e-9) — an algebraic identity, topological in
-   * the graph, so it holds under every sampled edge draw. The per-sample winner
-   * is independent of the factor, so the median-split buckets behind
-   * `winner_flips` are two random halves of ONE sequence. Same question, one
-   * instrument unable to discriminate: SUPPRESS.
+   * Slopes IDENTICAL (spread <= 1e-9). The per-sample winner is independent of
+   * the factor, so the median-split buckets behind `winner_flips` are two
+   * random halves of ONE sequence. Same question, one instrument unable to
+   * discriminate: SUPPRESS.
+   *
+   * ⚠ "topological in the graph, so it holds under every sampled edge draw" is
+   * WITHDRAWN. ISL computes a NUMERICAL spread against `1e-9` at ONE
+   * configuration — the same MEAN configuration that disqualifies the limb
+   * below. The sample-invariance rests on a MECHANISM (options are alternative
+   * values of one decision node, so every option severs the same paths and the
+   * per-option slopes are the same algebraic expression), which does not cover
+   * slopes that merely coincide at the mean via different path products.
+   * Canonical derivation: `components/results/utils/flipReasonVocabulary.ts`.
+   * Disposition unchanged.
    */
   structurally_invariant_with_winner_flips: 'suppress_at_consumer',
   /**

--- a/src/lib/coherence/crossSurfaceCoherence.ts
+++ b/src/lib/coherence/crossSurfaceCoherence.ts
@@ -325,6 +325,114 @@ export interface CoherenceViolation {
   readonly evidence: Readonly<Record<string, string>>
 }
 
+/**
+ * WHAT THE GATE DOES WHEN A PAIR FIRES — the disposition, decided per pair.
+ *
+ * ⚠ D7. Until now every pair's answer was the same one: NOTHING. The module
+ * header is honest that it "renders nothing, gates no mount, suppresses no
+ * field", and that was the right constraint while the pairs were being
+ * established — but a detector nobody acts on is instrumentation, not a
+ * guarantee, and five of six pairs remained sanctioned at both ends of the
+ * wire. This map is the answer to "what SHOULD it do", stated per pair and in
+ * code rather than in a document, so a pair cannot acquire a detector without
+ * someone deciding what the detection is for.
+ *
+ * ⚠⚠ AND THE RULING THAT MATTERS MOST: NOT EVERY PAIR SHOULD BE MADE TO AGREE.
+ * Forcing two authorities that answer DIFFERENT QUESTIONS into agreement is a
+ * defect in its own right (the leader-claim seam cost this estate exactly that,
+ * twice, a day apart). Where the two surfaces are answering different
+ * questions, the disposition is `name_apart` and the correct engineering
+ * response is to distinguish the concepts, NOT to reconcile the defaults.
+ */
+export type CoherenceDisposition =
+  /**
+   * The two members answer the SAME question and disagree. One of them is
+   * wrong, we cannot know which, and the consumer must decline the claim.
+   * Suppression here is not over-suppression: nothing is withheld that the
+   * producer coherently stated.
+   */
+  | 'suppress_at_consumer'
+  /**
+   * The two members answer DIFFERENT questions. There is no contradiction to
+   * fix; the fix is vocabulary. Making these agree would destroy information.
+   */
+  | 'name_apart'
+  /**
+   * A genuine contradiction the consumer cannot act on, because the fact that
+   * would settle it is not transmitted, or because acting would mean rewriting
+   * producer prose. Reported; not enforced.
+   */
+  | 'report_only'
+
+export const COHERENCE_DISPOSITIONS: Readonly<Record<CoherencePairId, {
+  readonly disposition: CoherenceDisposition
+  readonly rationale: string
+  /** Where the disposition is CARRIED OUT, or '' when it is not yet. */
+  readonly enforcedAt: string
+}>> = {
+  CX1: {
+    disposition: 'name_apart',
+    rationale:
+      'DIFFERENT QUESTIONS. `complete_current` is about the RUN THAT HAPPENED — '
+      + 'this result reflects the model as it stood. `readiness` is about the NEXT '
+      + 'run — the model as it stands NOW cannot be analysed. A model that was '
+      + 'analysed and has SINCE acquired a blocker satisfies both, truthfully. '
+      + 'Forcing agreement would delete a legitimate and common state.',
+    enforcedAt: '',
+  },
+  CX2: {
+    disposition: 'suppress_at_consumer',
+    rationale:
+      'SAME QUESTION: did this turn produce an analysis? `refused` says no; '
+      + '`usable_for_chips` says yes and chip-safe. Consuming a refused turn for '
+      + 'chips is the harm. NOT YET ENFORCED — the chip path is another lane\'s '
+      + 'surface this wave (see the collision note in the PR).',
+    enforcedAt: '',
+  },
+  CX3: {
+    disposition: 'report_only',
+    rationale:
+      'The pair\'s weakest limb is `not_on_the_wire`: the fact that would settle '
+      + 'whether a run occurred is not transmitted. A consumer cannot act on a '
+      + 'fact it does not have, and guessing would mint one.',
+    enforcedAt: '',
+  },
+  CX4: {
+    disposition: 'suppress_at_consumer',
+    rationale:
+      'SAME QUESTION: may this turn name a leading option? `leader_claim.permitted: '
+      + 'false` says no; a conditional-winner row names one anyway. The action is to '
+      + 'strip the NAME, never the row — the producer\'s own withheld-claim projection '
+      + 'strips exactly the identity members and forwards the factor-level science, so '
+      + 'the consumer applies the withholding the producer failed to apply. '
+      + 'NOT YET ENFORCED in the Compare tab: `leader_claim` rides `analysis_state`, a '
+      + 'SIBLING of the enrichment block the snapshot factory receives, so the fact is '
+      + 'not in scope at that seam. Threading it there is a plumbing change, rowed.',
+    enforcedAt: '',
+  },
+  CX5: {
+    disposition: 'suppress_at_consumer',
+    rationale:
+      'SAME QUESTION: can this factor flip the winner? `flip_thresholds.'
+      + 'no_flip_in_range: true` says no; `conditional_winners.winner_flips: true` '
+      + 'says yes, for the same `factor_id`. Both facts ride the SAME enrichment '
+      + 'object, so the consumer can act without any new plumbing.',
+    enforcedAt:
+      'src/canvas/stores/analysisSnapshotFactory.ts — `collectNoFlipFactorIds`, '
+      + 'joined on `factor_id`. Pinned by '
+      + '`analysisSnapshotFactory.scienceAttestation.spec.ts`, including the '
+      + 'opposite-direction twin (an ABSENT `no_flip_in_range` suppresses nothing).',
+  },
+  CX6: {
+    disposition: 'report_only',
+    rationale:
+      'A genuine contradiction, but acting on it means rewriting assistant prose '
+      + 'at the consumer. That is a producer obligation; a consumer that edits a '
+      + 'sentence to match a blocker is inventing an utterance.',
+    enforcedAt: '',
+  },
+}
+
 export const COHERENCE_PAIRS: Readonly<Record<CoherencePairId, CoherencePair>> = {
   CX1: {
     id: 'CX1',

--- a/tools/ci-guards/claim-drift-baseline.tsv
+++ b/tools/ci-guards/claim-drift-baseline.tsv
@@ -19,7 +19,7 @@
 # is how many raw reads that attestation SUPPRESSES, and it is ratcheted exactly
 # like a violation count: attestation is per-FILE, so without it an attested mapper
 # would be a free-for-all in which the next raw read is invisible.
-# count=73
+# count=69
 # exemptions=3
 # suppressed=11
 6	elasticity	src/adapters/driversAdapter.ts
@@ -27,11 +27,11 @@
 23	elasticity	src/adapters/plot/v2/responseMapper.ts
 1	elasticity	src/canvas/adapters/ceeSynthesisAdapter.ts
 3	elasticity	src/canvas/analysis/assembleAnalysisInputsSummary.ts
-3	elasticity	src/canvas/compare-tab/deriveTransitions.ts
+1	elasticity	src/canvas/compare-tab/deriveTransitions.ts
 1	elasticity	src/canvas/components/ModelTabBody.tsx
 1	elasticity	src/canvas/edges/StyledEdge.tsx
 1	elasticity	src/canvas/hooks/useLensFilter.ts
-4	elasticity	src/canvas/stores/analysisSnapshotFactory.ts
+2	elasticity	src/canvas/stores/analysisSnapshotFactory.ts
 5	elasticity	src/components/debug/utils/exportBundle.ts
 3	elasticity	src/components/results/driverDisplayModel.ts
 2	elasticity	src/components/results/useResultCompleteness.ts

--- a/tools/ci-guards/claim-drift-identities.tsv
+++ b/tools/ci-guards/claim-drift-identities.tsv
@@ -29,8 +29,8 @@
 # the same PR with `node tools/ci-guards/update-claim-drift-baseline.mjs` and say so in the PR body.
 #
 # Format: <count><TAB><family><TAB><path><TAB><field><TAB><canonicalised source line>
-# count=84
-# identities=78
+# count=80
+# identities=74
 1	elasticity	src/adapters/driversAdapter.ts	sensitivity_score	? driver.sensitivity_score >= 0 ? 'positive' : 'negative'
 1	elasticity	src/adapters/driversAdapter.ts	sensitivity_score	? normalizeImpact(driver.sensitivity_score)
 1	elasticity	src/adapters/driversAdapter.ts	sensitivity_score	const impact = driver.sensitivity_score !== undefined
@@ -65,16 +65,12 @@
 1	elasticity	src/canvas/analysis/assembleAnalysisInputsSummary.ts	elasticity	.sort((a, b) => Math.abs(b.elasticity) - Math.abs(a.elasticity))
 1	elasticity	src/canvas/analysis/assembleAnalysisInputsSummary.ts	elasticity	if (typeof fs.elasticity === 'number') return fs.elasticity
 1	elasticity	src/canvas/analysis/assembleAnalysisInputsSummary.ts	sensitivity_score	if (typeof fs.sensitivity_score === 'number') return fs.sensitivity_score
-1	elasticity	src/canvas/compare-tab/deriveTransitions.ts	elasticity	const change = Math.abs(factor.elasticity - prevElasticity) / Math.abs(prevElasticity)
-1	elasticity	src/canvas/compare-tab/deriveTransitions.ts	elasticity	const fromElasticity = new Map(fromFactors.map(f => [f.id, f.elasticity]))
-1	elasticity	src/canvas/compare-tab/deriveTransitions.ts	elasticity	return `Based on: ${toTop.label} remained the top influence factor (elasticity ${toTop.elasticity.toFixed(2)})`
+1	elasticity	src/canvas/compare-tab/deriveTransitions.ts	elasticity	return f.elasticity
 1	elasticity	src/canvas/components/ModelTabBody.tsx	elasticity	if (typeof f?.elasticity === 'number') elasticity.set(id, f.elasticity)
 1	elasticity	src/canvas/edges/StyledEdge.tsx	elasticity	const goalSens = src ? Math.abs(src.elasticity ?? src.sensitivity_score ?? src.importance_score ?? 0) : 1.0
 1	elasticity	src/canvas/hooks/useLensFilter.ts	elasticity	return f.elasticity ?? f.sensitivity_score ?? f.sensitivity ?? f.importance_score ?? 0
-1	elasticity	src/canvas/stores/analysisSnapshotFactory.ts	elasticity	.sort((a, b) => Math.abs(b.elasticity ?? 0) - Math.abs(a.elasticity ?? 0))
-1	elasticity	src/canvas/stores/analysisSnapshotFactory.ts	elasticity	? Math.round(Math.abs(topFactors[0].elasticity) * 100)
-1	elasticity	src/canvas/stores/analysisSnapshotFactory.ts	elasticity	const absElasticities = factors.map(f => Math.abs(f.elasticity ?? 0))
-1	elasticity	src/canvas/stores/analysisSnapshotFactory.ts	elasticity	elasticity: f.elasticity ?? 0,
+1	elasticity	src/canvas/stores/analysisSnapshotFactory.ts	elasticity	const stated = f.elasticity
+1	elasticity	src/canvas/stores/analysisSnapshotFactory.ts	elasticity	const stated = top?.elasticity ?? null
 1	elasticity	src/components/debug/utils/exportBundle.ts	sensitivity_score	const sensitivityVal = typeof match?.sensitivity_score === 'number' && Number.isFinite(match.sensitivity_score) ? match.sensitivity_score : null
 1	elasticity	src/components/debug/utils/exportBundle.ts	sensitivity_score	sensitivity: 'cee_embedded.analysis_result.enrichment.factor_sensitivity.sensitivity_score',
 1	elasticity	src/components/debug/utils/exportBundle.ts	sensitivity_score	sensitivity: 'payloads.plot_response.factor_sensitivity.sensitivity_score',


### PR DESCRIPTION
## The four questions, answered first

**Canonical authority for a displayed scientific quantity and its attestation.**
The **producer's payload, read at the identity**. Concretely: `@talchain/schemas` vendored **0.48.0** `dist/boundary/enrichment.js` defines the shape and — crucially — the *absence semantics*, and this PR quotes it rather than inferring. `winner_flips: z.boolean()` is REQUIRED and admits `false`; the bucket's `winner_id`/`winner_label` are optional **for one stated reason**: "on a turn whose verdict WITHHOLDS the leading-option claim, CEE's withheld-claim projection strips exactly these four members", and their absence "never means 'no option won'". Every gate here is derived from those sentences, at the bytes.

**What this deletes or supersedes.** Nothing is deleted. It supersedes the Compare tab's implicit authority — *"whatever number I can coalesce into a non-null"* — for three quantities and one flip claim. It also supersedes T2b's two-valued `stabilityImproving`/`coverageImproving`, whose `false` meant "no data" at the definition and "point the arrow down" at the call site.

**MOUNTED acceptance.** Compare tab, `ExpertTable` + `HealthIndicators` + `Hero` + the transition card. On a run whose factors the producer did not score, the Flip-rate and Conc.-% cells read **"Not assessed"** alongside the three cells that already did, no arrow asserts a direction, and no transition card claims a takeover for a factor the payload declares structurally invariant. ⚠ **Rung: TESTED, not MOUNTED-witnessed** — see Unmeasured.

**Known inverse/mirror failure this must avoid.** **Over-suppression** — withholding a quantity the producer *did* compute. Every suppression here has an opposite-direction twin drawn from a **real capture**, and two mutants (M5, M7) exist solely to prove the twin bites.

---

## Lead question: could this fix be another instance of the defect class it removes?

**The class is "the product presents a number the science did not produce."** I checked this PR against it deliberately, because a safe default, a rounded fallback and an inferred midpoint are all that defect wearing a helpful face.

**No number is introduced anywhere in this diff.** Every replacement is `null` plus an existing honest-absence token. Three specific temptations were refused:

- **A "0.10 default threshold"** already exists at `mapRobustness.ts:154` (`threshold ?? 0.10` — an invented scientific constant). I did **not** propagate that pattern, and I did not "fix" it either, because it is **dead** (below).
- **Excluding unscored factors from the concentration denominator**, rather than counting them as zero. Counting them would have deflated `max/sum` by exactly the number of measurements the producer declined to make — a fabricated number produced *by* an honesty fix.
- **Dropping the withheld conditional-winner row.** That would have been the mirror defect: the producer withheld *which* option, not *whether* it flips. The row survives and states the flip without naming an option.

The one judgement call worth flagging for review: **CX5 suppression removes a row the producer did send.** I argue this is not over-suppression because the *same payload* contains the contradicting statement — nothing coherent is withheld. A reviewer who disagrees should say so; it is the most contestable decision here.

---

## (a) The honest inventory, and its bounds

Swept with `rg -a` (never `-t tsx`), with a positive control, a contrast control, and a nonsense-symbol control in the same pass.

**The recorded domain state is materially STALE for the results panel.** Most of it is already honest: `decision_evpi`, `factor_evppi`/VoI, `flip_thresholds`, `downside`, percentiles, evidence-gap confidence, `option_comparison_status`, `recommendation_stability` and the results-panel `conditional_winners` all render explicit absence. `voi/resolveNextCopy.ts` already forbids "zero value" language.

**What is genuinely live and minting, in priority order:**

| # | Site | Renders as | Status |
|---|---|---|---|
| 1 | `analysisSnapshotFactory` `topElasticity` / `rankFlipRate` / `influenceConcentration` | `"0.00"`, `"0%"`, `"0% influence"` | **FIXED here** |
| 2 | `analysisSnapshotFactory:557` `winnerProbability ?? 0` | `"{label} leads at 0%"`, and **persisted** | **NOT fixed** — self-documented out of scope (ROADMAP 2.835); consumed arithmetically by `deriveCompareState`, so nullability changes which hero copy fires. A product judgement, not a mechanical swap. |
| 3 | `adapters/plot/v2/responseMapper.ts:1243` `elasticity … ?? 0` | `DriversSection` `"influence: N%"` + edge stroke weight | **NOT fixed** — same defect as #1, live in the V2 mapper. Wide blast radius and it lands in Analysis-panel territory; see Collisions. |
| 4 | `useResultsSectionData.ts:2486` + `driverDisplayModel.ts:109,129` | `DataBar showPercent`, `"{label} influence: {N}%"` | **NOT fixed** — fires when two key derivations disagree; guarded by a silent zero rather than a drop. |
| 5 | `inspector-v2/panels/OptionPanel.tsx:442-443` | **`"Within -62pp of the leading option"`** | **NOT fixed** — `winPct` is honestly `number \| null` twelve lines earlier; two `?? 0`s put it back and a negative gap reaches the `gap <= 5` arm. Small and self-contained; a good next slice. |

**Dead, therefore deliberately not touched** (traced with positive + contrast controls): `mapRobustness.mapNearTie`'s `gap ?? 0` / `threshold ?? 0.10` — no JSX anywhere reads them; and `mapFactorSensitivity:180`'s `importance_rank ?? 0` — `mapPloTResponseTyped` has zero callers. Both are typed and unit-tested and reach no screen. Fixing them would be robustness work with no capability payoff.

**Locations I could NOT reach:** `src/plot/`, `src/poc/`, `src/modules/`, `src/pages/`, `src/streams/`, `src/plc/`, `src/notes/`, `src/templates/` (outside the swept trees); ~257 of `src/canvas/`'s 306 coalescing hits (filtered as geometry/counters by pattern, not individually read); most of `src/components/debug/` (the two `?? 0`s inspected are guarded by a preceding `typeof` filter). No runtime verification — every verdict is a static read of `4d1e650b`.

---

## (b) The 0-minting, killed — with the twin

`analysisSnapshotFactory` had already been made absence-preserving for `recommendation_stability`, `fragile_edges`, `seed_used` and `runner_up.win_probability`. **Each cleanup was scoped to the block in front of it, and the factor-sensitivity trio was left behind** — so the trajectory table printed `0.00` and `0%` in a row whose other three columns already said "Not assessed".

`HealthIndicators` then compared two fabricated zeros to draw a **direction arrow**. Separately, T2b's guards returned `false` for "never assessed", which selects `ArrowDown`: **a guard written to stop an absence manufacturing a RISE manufactured a FALL.** Both are now three-valued.

**The twin, from real captures, on the same field:** `w2d`'s top factor carries **no** `rank_flip_rate` on the wire → `null` → "Not assessed". `probe-A`'s carries `rank_flip_rate: 0` → **`0`** → "0.00". Likewise a genuinely-computed `elasticity: 0` still yields `topElasticity: 0` and `influenceConcentration: 0`.

## (c) Flip detection bound by identity

`extractConditionalWinners` **read no attestation at all** — it took `high_bucket.winner_label` and rendered "…, {label} takes over". `ConditionalWinnerCards.tsx:86` (results panel) already gated on `winner_flips`; **the Compare tab is the sibling surface that was left behind**, so one payload produced a flip claim on one surface and not the other. Absent bucket ids became `String(… ?? '')` → the published fragment **", takes over"**.

Now gated on `winner_flips === true`, a finite `split_value`, and — when both identities are present — `low.winner_id !== high.winner_id`. **IDs, not labels:** two options can share a display label (a real flip a label filter cannot see) and a relabel is not a flip.

**Discriminating mutant pair, as required:**

| Mutant | Expected | Result |
|---|---|---|
| **M2** identity gate loosened for **ALL** rows | RED | ✅ RED (2 tests) |
| **M3** identity gate loosened for a **DIFFERENT row only** (`factor_id !== 'fac_demand'`) | **GREEN** | ✅ **GREEN 16/16** |

Neither alone shows binding; the pair proves sensitivity to the **named object**.

Full kit (throwaway worktree outside the repo root, isolation proven by a **sentinel write** + inode compare, pristine-archive restores — never `git checkout --`, applied-check scoped to `src/`, control exactly 0):

| Mutant | Result |
|---|---|
| CONTROL (applied-check **0**) | 16/16 green |
| M1 no flip attestation | RED |
| M2 identity gate ALL | RED ×2 |
| M3 identity gate OTHER ROW ONLY | **GREEN** (pair partner) |
| M4 mint zero rankFlipRate | RED |
| **M5 over-suppress rankFlipRate** | **RED** ← the twin bites |
| M6 mint zero concentration | RED ×2 |
| **M7 over-suppress a genuine zero** | **RED ×2** ← the twin bites |
| M8 bind flip by LABEL not id | RED ×3 |

## (d) The coherence gate now DOES something

It had **zero product importers** (contrast control: a sibling lib module has eight). Every pair's answer to "what happens when I fire" was the same: nothing.

**CX5 is a real, deployed, user-visible contradiction.** `seeded-2026-08-17-w2d` carries `no_flip_in_range: true` / `flip_reason: "structurally_invariant"` for factors `71c6351d` and `fcf3d740`, **and `winner_flips: true` for those same ids** — and the Compare tab rendered a takeover sentence for a factor the same payload says cannot flip. Both facts ride one enrichment object, so the consumer can act with no new plumbing. **It now declines the claim.**

**Which pairs are "answering different questions", as asked:**

| Pair | Disposition | Why |
|---|---|---|
| **CX1** | **`name_apart`** | `complete_current` is about the **run that happened**; `readiness` is about the **next** run. A model analysed and *since* blocked satisfies both, truthfully. Forcing agreement deletes a legitimate state. |
| CX2 | `suppress` — **unenforced** | Same question (did this turn produce an analysis?). Chip path is another lane's surface this wave. |
| CX3 | `report_only` | The deciding fact is **not on the wire**. |
| CX4 | `suppress` — **unenforced** | Same question, and genuinely actionable — but `leader_claim` rides `analysis_state`, a **sibling** of the enrichment the factory receives. Plumbing, rowed. |
| **CX5** | **`suppress` — ENFORCED** | Same question, both facts in one object. |
| CX6 | `report_only` | Acting means rewriting producer prose; a consumer that edits a sentence is inventing an utterance. |

The dispositions live in **code** (`COHERENCE_DISPOSITIONS`), not a document, so a pair cannot acquire a detector without someone deciding what the detection is for.

---

## Measured / unmeasured

**Measured:** new spec **21 tests, asserted non-zero by name** (a spec collecting `(0 test)` is invisible in every aggregate). `src/canvas/compare-tab` + `src/canvas/stores` + `src/lib/coherence` = **661 passed / 49 files / 0 failed**, with `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported. Mutant kit above.

**⚠ UNMEASURED — stated rather than implied:**
- ~~`pnpm typecheck` did not complete~~ — **it since finished: `✅ Typecheck gate PASSED (coverage + ratchet)`, exit 0**, 3530/3570 tracked files loaded, and the drift **shrank 2272 → 2263** (9 pre-existing diagnostics fixed by making these types honest, none added). I did **not** run `--update-baseline`: the gate passes either way, and banking a baseline is a separate decision. ⚠ An earlier ad-hoc `npx tsc` in this lane was **VACUOUS** (`node_modules` absent, so it could not fail) — disclosed rather than quoted, because an instrument that cannot fail is not evidence.
- **`pnpm lint` not run.** The required check is `lint → typecheck → tests` and a green local subset is not that check.
- **Full suite not run** — only the three affected trees.
- **No MOUNTED witness.** jsdom cannot prove visibility; no deployed capture shows these cells rendering "Not assessed". Rung is **TESTED**, not MOUNTED.
- **The corpus cannot certify three classes.** A census of all 28 `conditional_winners` rows across 2,290 JSON files in `olumi-docs/` returned `(winner_flips: true, distinct ids)` for **28/28** — zero `false` rows, zero equal-id rows, zero withheld-identity rows. Those three are **CONTRACT_DERIVED** from vendored 0.48.0, marked as such in the spec, and stated in its header *before* the tests rather than discovered after.

## Collisions — reported, not resolved

`analysisStateSelector.ts`, `SuggestedChips.tsx`, `messageComposition.ts` — **not touched**. Inventory items **#3 and #4** land in Analysis-panel territory (`responseMapper.ts` → `DriversSection`, `useResultsSectionData.ts`) where sibling lanes are active; left for the owning lane. **CX2's disposition is unenforced for the same reason.**

Three composed fixtures were updated (`rootSiblings`, `inferenceWarnings`, `persistedRunSnapshotFactory`): they pinned root-vs-nested **slot precedence** with rows lacking `winner_flips`, a REQUIRED contract member — never legal payloads. Precedence is still exactly what they measure. **No historic capture was edited** (`persistedRunFact.ts` defaults `conditionalWinners = []` and is untouched).

---

## Claim-ownership convergence (`ff56fb66`) — the `Staging Gate` fix

The drift guard was RED and it was **right**. This PR added no new claim, but it
added re-derivation **sites**: null-guarding an absence-preserving field turned
four already-duplicated scored-ness tests into eight in `analysisSnapshotFactory.ts`,
and three into five in `deriveTransitions.ts`. The `elasticity` family is
registered as **frozen, shrink-only debt with no owner selector**, so a new site
is inadmissible by design.

**The fix REMOVES authorities. It does not add one, and it does not widen the baseline.**

| File | Authorities before | After | Raw reads | Baseline reserved |
|---|---|---|---|---|
| `analysisSnapshotFactory.ts` | 4 independent scored-ness tests (`?? 0`, `typeof`+`isFinite`, a filter, a bare `!== null`) | 1 (`scoredElasticity`) + `elasticityMagnitude` / `topInfluencePercent` composed from it | 8 → **2** | was 4, now **2** |
| `deriveTransitions.ts` | 3 (prev-run map, two change guards, the anchor sentence) | 1 (`statedElasticity`) | 5 → **1** | was 3, now **1** |

**Artefacts regenerated** with `node tools/ci-guards/update-claim-drift-baseline.mjs`
in this PR, as the baseline header requires. This **tightens** the ratchet: the
estate-wide elasticity debt falls **73 → 69** and the two rows drop to 2 and 1, so
the removed sites cannot silently regrow. **No family, file or row outside these two moved.**

No `CLAIM_OWNERSHIP` is registered — this is the file-local half of the convergence,
not a claim to be the estate-wide owner (two modules registering one family is a
hard RED in the walker's control 3a).

### A defect the convergence closed on the way past
The old sort tested `typeof a.elasticity === 'number'` while the map beside it also
required `Number.isFinite`. A non-finite elasticity therefore **sorted as if scored
but summarised as unscored** — two spellings of one question, answering it
differently, which is exactly the failure mode the single accessor removes.

### Two unpinned claims, found by mutation
Replacing `deriveTransitions`' accessor with `f.elasticity ?? 0` left **582 tests
across 46 files GREEN** while two user-visible claims changed: the anchor printed
`(elasticity 0.00)` for a factor nobody scored, and a factor whose scoring *stopped*
was reported as "changed by >20%". Four tests now pin both, each with an
opposite-direction twin or an in-assertion positive control. Six mutants bite; a
semantically-neutral control stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

# ADDENDUM — D7b (`628853ea`): the suppression is narrowed, the sibling surface is bound, and one claim above is corrected

Pushed onto this branch after an independent review of this PR (finding F1) and a
read-only scientific-validity settlement reached the **same seam from opposite sides**.

## 1. This PR OVER-SUPPRESSED, and the review was right

GATE 0 keyed on `no_flip_in_range === true`. PLoT stamps that boolean from a **SET of two**
ISL reasons — `integrations/isl/adapters/factor-flip-values.ts:304` over `NO_EFFECT_REASONS`
(`lib/flip-threshold-status.ts:75-78`), read at PLoT staging `7e5d8a7d`:

| reason | what it says | may it withhold a sibling's claim? |
|---|---|---|
| `structurally_invariant` | slopes **identical** (spread ≤ 1e-9) — an algebraic identity | **yes** |
| `no_effect_within_bounds` | slopes **genuinely differ**; only the crossing lies outside the domain **at the mean edge configuration** | **no** |

Under `structurally_invariant` the per-sample winner is independent of the factor, the
median-split buckets behind `winner_flips` are two random halves of **one** sequence, and their
disagreement is sampling noise. Under `no_effect_within_bounds` each sample moves the crossing, so a
bucket disagreement **can be real** — suppressing it withholds a finding ISL computed.

> ### ⚠⚠ CORRECTED — the "topological" argument was OVERSTATED and is withdrawn
>
> This paragraph previously read: *"Slope equality is **topological** (which of the factor's causal
> paths each option's intervention severs), so it holds under every sampled edge draw."*
> **ISL computes no such property.** Derived at `robustness_analyzer_v2.py` (ISL staging `28fe0c9`):
> the candidate screen evaluates each option's goal at the factor's MIN and MAX (`:6751-6756`), takes
> the affine coefficients (`:6757`), and screens `spread = max(slopes) - min(slopes)` against
> `FACTOR_FLIP_SLOPE_EPSILON = 1e-9` (`:6763`, `:6775`, `:6522`) — every evaluation against a single
> `baseline_config = {edge: strength.mean * exists_probability}` (`:6722-6724`).
>
> So it is a **numerical equality test at ONE configuration — and it is the very same MEAN
> configuration this table uses to DISQUALIFY `no_effect_within_bounds`.** The old wording granted
> one token a sample-invariance guarantee derived from the other token's disqualifying premise.
>
> **The conclusion still holds — on a named MECHANISM, not on that word.** In this product's graphs
> the options are alternative values of ONE decision node, so every option severs the **same** set of
> causal paths from a given factor to the goal. Each option's transmission slope is then the **same
> algebraic expression** in the sampled edge strengths, and two equal expressions stay equal at every
> draw. That is what makes the per-sample winner independent of the factor, and why **SUPPRESS
> remains the right disposition**.
>
> **The residual class the mechanism does NOT cover**, recorded rather than hidden: two slopes can
> also coincide at the mean through **different path products** — `0.5 x 0.4` and `0.2 x 1.0` both
> give `0.2` — which is plausible with the round-numbered strengths a drafted graph carries. Those
> are not the same expression, so they separate as soon as the draws move, and for such a factor
> `winner_flips` could be a real finding this gate suppresses. **Nothing in ISL rules the class out:**
> its own `stability` field says the band is skipped for a `structurally_invariant` row because
> computing one *"would spend the compute the candidate screen exists to save"*
> (`src/models/response_v2.py:854-855`) — a **cost** decision, not a proof of sample-invariance.
>
> **Nothing else changes.** The correction is **prose only** — verified mechanically: every one of
> the 143 added/removed lines in commit `b571def9` is a comment or blank. The canonical derivation
> now lives **once**, in `results/utils/flipReasonVocabulary.ts`; the other four comment sites carry
> the corrected short form and point at it rather than four copies to drift (trap 12).
> The four affected spec files run **94/94 at pristine `628853ea` AND 94/94 after** — identical, as a
> prose-only change must be. `pnpm run lint` 0 errors (hooks ratchet at baseline); `pnpm typecheck`
> PASSED, ratchet unchanged at 2263; `ci:guard:ds:enforce` no net-new violations.
>
> **The three claims an independent review re-tested all held exactly and are untouched:** the GATE 1
> correction (propagated to both this body and the spec header), M1 reproduced exactly
> (Compare RED 1/9, panel RED 2/10, its own D7 suite GREEN 22/22 — which is why the round-2 specs are
> **load-bearing and must never be reverted separately**), and the third unbound surface.

Reachable in this repo's own corpus: `w998-2026-08-16-a1-turn3.json` carries two
`no_effect_within_bounds` rows with `no_flip_in_range: true`.

**Fix:** the gate reads the **reason**, through `flipReasonVocabulary` — the module that
already owns the producer's vocabulary. New `provesFactorCannotMoveWinner` /
`collectStructurallyProvenNoFlipIds`, deliberately **named apart** from
`isAttestedNoFlipReason` (both docblocks state the two questions and their **opposite**
fail-safe polarities). Two opposite harms, two predicates — never one tunable window.

## 2. Reading the reason also WIDENED the gate, and that closed a second disagreement

A row carrying `flip_reason: 'structurally_invariant'` with **no** `no_flip_in_range` boolean
was rendered by the Compare tab (boolean-keyed) while the results panel's `selectFlipRisk`
(reason-keyed) refused the same run's flip claim — a **fresh instance of the very
sibling-surface disagreement this PR set out to close**. Both surfaces now decide from one
predicate, pinned by a cross-surface agreement suite.

## 3. The results panel was the surface the contradiction was actually WITNESSED on

Line 60 above says `ConditionalWinnerCards.tsx:86` "already gated on `winner_flips`". True,
and not sufficient: it consulted **no flip evidence at all**. On the deployed build **4 of 8
near-tie responses assert both "this factor cannot move the winner" and "this factor flips the
winner" for one factor** (0/8 in the separated contrast control), and both render on the
Analysis tab. `useResultsSectionData`'s `confidence.conditionalWinners` now applies the same
predicate, fed from `recommendation.flipThresholds` so there is **one adapted array**, not two.

## 4. ⚠ CORRECTION TO A CLAIM ABOVE (trap 20) — line 117's 28/28 census

> "zero `false` rows … the corpus cannot certify three classes"

The `winner_flips: false` zero is **NOT a corpus limitation**. Derived at the ISL bytes,
deployed `28fe0c95`:

```
robustness_analyzer_v2.py:5204   winner_flips = low.winner_id != high.winner_id
robustness_analyzer_v2.py:5206   if not winner_flips: continue      ← row DROPPED
robustness_analyzer_v2.py:5226   winner_flips=True                  ← hardcoded
```

PLoT forwards it verbatim (`routes/v2/run.ts:801`, `:917`; `:780` refuses a non-boolean).
So `winner_flips: false` is **producer-unreachable end to end on this path**: the census
measured the **producer**, not the corpus, and GATE 1 cannot discriminate on any payload ISL
can currently emit. It stays as defence in depth (the contract types the field REQUIRED
`z.boolean()` and admits `false`; a persisted or re-projected row is not bound by ISL's
emitter) — but that is the honest claim. **The other two zeros are genuine corpus
limitations, unchanged.** Corrected in the spec header too, so it is not inherited.

## 5. CX5's record is re-derived, because the verdict flipped under it

`enforcedAt` claimed `collectNoFlipFactorIds` enforced the pair. After the narrowing that is
true of **one limb only**. The detector now emits **one code per limb**
(`structurally_invariant_with_winner_flips` / `no_effect_within_bounds_with_winner_flips`),
`CX5_LIMB_DISPOSITION` carries `suppress_at_consumer` / `name_apart` respectively (same
precedent as `CX3_LIMB_EXPRESSIBILITY`), and `enforcedAt` names both consumer sites and says
plainly which limb is **reported and deliberately not enforced**.

## 6. Evidence

**RED-first in BOTH directions**, 6 failing signatures at pristine `d68c3ebf`:

| direction | signature |
|---|---|
| over-suppression | `COMPOSED (two real halves): the flip claim SURVIVES for a no_effect_within_bounds factor` — `expected [] to deeply equal ['13faf76d']` |
| over-suppression | `DISCRIMINATION CONTROL — both surfaces render the same non-empty set` — Compare `[]` vs `['13faf76d']` |
| under-suppression | `the contradicted cards are withheld` (results panel) — `expected ['71c6351d','fcf3d740'] to deeply equal []` |
| under-suppression | `w2d with no_flip_in_range deleted: the rows STAY suppressed` |
| under-suppression | `the proof WITHOUT the boolean: both surfaces suppress` |
| under-suppression | `w2d verbatim — identical surviving factor ids on both surfaces` — the two surfaces disagreeing on one payload |

19/19 green after; every spec asserts its own collected count by name.

**Mutants** — throwaway worktree outside the repo root, isolation proven by a **sentinel write**
(source sha unchanged) plus an inode comparison, restores from a **pristine archive**, applied-check
scoped to `src/`, leading and trailing controls at **exactly zero**, clean tree after each:

| mutant | compare | panel | D7 (#788) |
|---|---|---|---|
| CONTROL / TRAILING CONTROL | GREEN | GREEN | GREEN |
| M1 proof widened back to BOTH tokens | RED | RED | **GREEN** |
| M2 proof never holds | RED | RED | RED |
| M3 proof always holds | RED | RED | RED |
| M4 `flip_value` coherence clause dropped | RED | GREEN | GREEN |
| M5 join on label, not identity | RED | RED | RED |
| M6 Compare-tab gate removed only | RED | RED | RED |
| M7 results-panel gate removed only | **GREEN** | RED | GREEN |
| M8 panel gate fed an empty flip array | GREEN | RED | GREEN |

**M1's `GREEN` in the last column is the finding stated as an experiment: this PR's own suite is
structurally incapable of seeing the over-suppression.** M6/M7 are the discriminating pair —
each surface is independently bound, not one doing both.

Two pre-existing guards that the narrowing would have hollowed into vacuity (they armed
`no_flip_in_range` on rows whose reason is `'found'`, which now triggers nothing) are re-pointed
at the real trigger, given in-test preconditions, and joined by a discriminating twin.

**Gate:** `Staging Gate` **success** on `628853ea` — 4/4 shards, TypeScript + Lint, Typecheck Gate
Self-Test, Production Build all green; cross-shard total 1785 files / 2 skipped.
`Visual Regression (advisory)` is `failure` and is a **standing red** — control: the same job is
`failure` on this PR's previous head `d68c3ebf` (change absent) **and** on the staging tip
`f5794541`, whose overall workflow conclusion is nonetheless `success` because the job is advisory.

## 7. NOT fixed here — producer-side, reported rather than reached for

`baseline_winner_id` (ISL's **expected-value** argmax) is dropped by PLoT
(`factor-flip-values.ts:260-306`), the drop is **undeclared** in `isl-to-ui.contract.ts`, and the
symbol has **zero occurrences in CEE** — while the screen shows the **win-frequency** winner
(`recommended_option_id`). PLoT already counts the disagreement and only `log.warn`s it. No consumer
can fail closed on a field it never receives, so this is not fixable in the UI and nothing here
attempts it. Routes to PLoT (stop dropping it, or declare the drop) and to naming
(`baseline_winner_id` → `expected_value_winner_id`). **Do not align the two policies** — they
answer different questions.

