### PR TITLE
test(conversation): pin what the user's own words already render as — the 'add formatting' premise is refuted

### DIFF
--- a/src/canvas/conversation/__tests__/MessageBubble.userTextFormatting.spec.tsx
+++ b/src/canvas/conversation/__tests__/MessageBubble.userTextFormatting.spec.tsx
@@ -1,0 +1,160 @@
+/**
+ * MessageBubble — the user's OWN words: what formatting survives, and what
+ * must never become markup.
+ *
+ * WHY THIS FILE EXISTS
+ * --------------------
+ * A lane was briefed to ADD light formatting (bold / italic / bullets /
+ * numbered lists / line breaks) to user messages, on the stated premise that
+ * the user bubble rendered raw text. That premise was refuted at this tip:
+ * the user bubble and the assistant bubble share ONE body path
+ * (`safeRichText` → `dangerouslySetInnerHTML`, MessageBubble.tsx), so four of
+ * those five already render. Nothing pinned that, which is how it came to be
+ * described as missing.
+ *
+ * These tests are therefore CHARACTERISATION PINS, not the guard of a new
+ * feature — no behaviour is changed by the commit that introduces them. They
+ * make the current contract fail loud in BOTH directions:
+ *
+ *   · supported subset  — bold, bullets, numbered lists, line breaks render as
+ *     the corresponding ELEMENT inside the user's own bubble;
+ *   · literal subset    — italic (`*x*` / `_x_`) is DELIBERATELY unsupported
+ *     (`safeRichText`'s documented allowlist contract, 2d88c8cf, which removed
+ *     DOMPurify + `marked` on purpose). Pinned so that re-adding it is a
+ *     deliberate contract change with a failing test to answer, not a silent
+ *     drift;
+ *   · injection         — `<script>`, `<b>`, `<img onerror>` render as VISIBLE
+ *     TEXT and create NO corresponding element node.
+ *
+ * The injection cases assert BOTH halves: textContent shows the literal
+ * characters AND `querySelector` finds no element. Asserting only the text
+ * would pass against an implementation that also injected a live node, and
+ * asserting only the absence would pass against one that silently dropped the
+ * user's words.
+ *
+ * Assertions bind by identity — `message-user` → `message-body-text` — never
+ * by a substring another node in the tree could satisfy.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MessageBubble } from '../MessageBubble'
+import type { ConversationMessage } from '../types'
+
+/** Render a user message and return its body element, bound by test id. */
+function renderUserBody(content: string): HTMLElement {
+  const message: ConversationMessage = {
+    id: 'msg-user-fmt',
+    role: 'user',
+    content,
+    timestamp: new Date(),
+  }
+  render(<MessageBubble message={message} onChipClick={vi.fn()} />)
+  // Bind to the USER bubble specifically, then to its body within.
+  const bubble = screen.getByTestId('message-user')
+  const body = bubble.querySelector('[data-testid="message-body-text"]')
+  expect(body, 'user bubble must render a body element').not.toBeNull()
+  return body as HTMLElement
+}
+
+describe("MessageBubble — the user's own words", () => {
+  describe('supported formatting renders as elements', () => {
+    it('renders **bold** as a <strong> element carrying the bold text', () => {
+      const body = renderUserBody('the **decisive** factor')
+      const strong = body.querySelector('strong')
+      expect(strong).not.toBeNull()
+      expect(strong?.textContent).toBe('decisive')
+    })
+
+    it('renders "- " bullets as a <ul> with one <li> per item', () => {
+      const body = renderUserBody('- hiring freeze\n- price rise')
+      const ul = body.querySelector('ul')
+      expect(ul).not.toBeNull()
+      const items = Array.from(ul!.querySelectorAll('li')).map((li) => li.textContent)
+      expect(items).toEqual(['hiring freeze', 'price rise'])
+    })
+
+    it('renders "* " bullets as a <ul> — the form pasted briefs most often use', () => {
+      const body = renderUserBody('* hiring freeze\n* price rise')
+      const ul = body.querySelector('ul')
+      expect(ul).not.toBeNull()
+      expect(ul!.querySelectorAll('li')).toHaveLength(2)
+    })
+
+    it('renders "1. " numbered items as an <ol> with one <li> per item', () => {
+      const body = renderUserBody('1. frame it\n2. decide it')
+      const ol = body.querySelector('ol')
+      expect(ol).not.toBeNull()
+      const items = Array.from(ol!.querySelectorAll('li')).map((li) => li.textContent)
+      expect(items).toEqual(['frame it', 'decide it'])
+      // Bound by element type: a <ul> here would mean bullets, not numbering.
+      expect(body.querySelector('ul')).toBeNull()
+    })
+
+    it('renders a single newline as a <br> element, not a collapsed space', () => {
+      const body = renderUserBody('first line\nsecond line')
+      expect(body.querySelectorAll('br').length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('separates blank-line paragraphs with a gap spacer', () => {
+      const body = renderUserBody('opening para\n\nsecond para')
+      expect(body.querySelector('br.md-gap')).not.toBeNull()
+    })
+  })
+
+  describe('deliberately unsupported syntax stays literal', () => {
+    // Pins safeRichText's documented allowlist. If italic is ever added this
+    // test MUST be updated deliberately — that is the point of pinning it.
+    it('leaves *italic* as literal text and creates no <em>', () => {
+      const body = renderUserBody('an *urgent* decision')
+      expect(body.textContent).toContain('*urgent*')
+      expect(body.querySelector('em')).toBeNull()
+      expect(body.querySelector('i')).toBeNull()
+    })
+
+    it('leaves _italic_ as literal text and creates no <em>', () => {
+      const body = renderUserBody('an _urgent_ decision')
+      expect(body.textContent).toContain('_urgent_')
+      expect(body.querySelector('em')).toBeNull()
+    })
+
+    it('leaves backtick code as literal text and creates no <code>', () => {
+      const body = renderUserBody('run `deploy` now')
+      expect(body.textContent).toContain('`deploy`')
+      expect(body.querySelector('code')).toBeNull()
+    })
+
+    it('leaves an unbalanced asterisk as literal text', () => {
+      const body = renderUserBody('margin * 2 and ** more')
+      expect(body.textContent).toContain('*')
+      expect(body.querySelector('strong')).toBeNull()
+      expect(body.querySelector('em')).toBeNull()
+    })
+  })
+
+  describe('user-supplied markup can never become markup', () => {
+    it('renders <script> as visible text and creates NO script element', () => {
+      const body = renderUserBody('<script>alert(1)</script>')
+      expect(body.textContent).toContain('<script>')
+      expect(body.textContent).toContain('</script>')
+      expect(body.querySelector('script')).toBeNull()
+    })
+
+    it('renders <b>x</b> as visible text and creates NO b element', () => {
+      const body = renderUserBody('<b>x</b>')
+      expect(body.textContent).toContain('<b>x</b>')
+      expect(body.querySelector('b')).toBeNull()
+    })
+
+    it('renders an <img onerror> payload as visible text and creates NO img element', () => {
+      const body = renderUserBody('<img src=x onerror=alert(1)>')
+      expect(body.textContent).toContain('<img')
+      expect(body.querySelector('img')).toBeNull()
+    })
+
+    it('renders a bare ampersand as a single literal & character', () => {
+      const body = renderUserBody('Tom & Jerry')
+      expect(body.textContent).toContain('Tom & Jerry')
+    })
+  })
+})


### PR DESCRIPTION
## ⚠ The brief's premise is refuted — four of the five requested capabilities already ship

This lane was briefed to **add** light formatting (bold, italic, bullets, numbered lists, line
breaks) to the user's own message bubble, on the stated premise that it renders raw text.

**Measured at `aa916511` (this PR's base), by executing the code and by rendering the component:
bold, `- ` bullets, `* ` bullets, `1. ` numbered lists, single-newline breaks and blank-line
paragraph gaps ALREADY render in the user's own bubble.** The stated user problem — *"someone
pasting a messy strategic brief can see their bullets as bullets when they scroll back"* — is
already solved on staging.

**So this PR ships no behaviour change. It contains one new spec file and nothing else.**

### Why the premise was wrong

`MessageBubble.tsx` has **one body path for both roles**. `isUser` picks the wrapper class and
several markers, but the body element (`data-testid="message-body-text"`, line 415) is shared:

```
dangerouslySetInnerHTML={{ __html: safeRichText(…) }}
```

`src/canvas/utils/safeRichText.ts` is a dependency-free restricted renderer supporting exactly
`**bold**`, `- `/`* ` bullets, `1. `/`1) ` numbered lists, `<br>` line breaks, plus heading and
table degradation. Bullets and ordered lists were added four days before this tip (PX-B, #717).

Three of the brief's four hard constraints were written against a picture that does not hold:

| Constraint | Status at this tip |
|---|---|
| Don't add a dependency | **Already satisfied and deliberate.** `2d88c8cf` removed DOMPurify + `marked` on purpose. ⚠ `marked@16.4.1` is still *declared* in `package.json` with **zero import sites repo-wide** — dead residue of that removal, worth deleting separately. |
| No HTML rendering path / no `dangerouslySetInnerHTML` | **Already false.** This is exactly how the path works, and has since `2d88c8cf`. It is escape-based and safe (see below), but "parse to React elements only" would mean a **second renderer**. |
| Don't replace the `<textarea>` | Satisfied — untouched. |
| Assistant messages untouched | **Not separable from the above.** User and assistant share `safeRichText`; nothing can be changed for one without the other. |

### The one genuine gap: italic — and it is a deliberate, tested contract

`*italic*` / `_italic_` do **not** render. That is not an oversight. It is `safeRichText`'s
documented allowlist contract, and **two existing tests pin its absence on purpose**:

- `markdown.spec.ts:97` — *"does NOT convert italic — single asterisks remain as literal text"*
- `markdown.spec.ts:220` — *"does NOT produce `<em>`, `<code>`, `<pre>`, `<blockquote>` or `<h*>`"*

Adding italic therefore means **overturning a deliberate decision and deleting its guard tests, on
a renderer shared with assistant messages**. Per the scope-expansion rule I stopped at that
boundary rather than doing it unasked. It is a one-line change to `convertInline` plus `em` in
`ALLOWED_TAGS` — I have proven it works (mutant M4 below) — **but it needs a ruling, not a lane's
unilateral edit.** `*` collides with bold and bullet markers and `_` with `snake_case`/`fac_*` ids,
so it is also a natural-language predicate that would need an outside corpus.

## What this PR does contain

A characterisation spec (14 tests) pinning what the user's own words render as. Nothing pinned this
before, which is precisely how a shipped capability came to be described as missing. It fails loud
in **both** directions: the supported subset must keep rendering as elements, the deliberately
unsupported subset must stay literal, and user markup must stay text.

Assertions bind by identity (`message-user` → `message-body-text`), never by a substring another
node could satisfy.

### Round-trip / injection safety (verified by rendering, both halves asserted)

`<script>alert(1)</script>`, `<b>x</b>` and `<img src=x onerror=…>` render as **visible literal
text** and create **no corresponding element node** — asserted on `textContent` *and* on
`querySelector` returning null. Asserting only the text would pass against an implementation that
also injected a live node; asserting only absence would pass against one that dropped the user's
words. Backticks, `&`, and unbalanced `*` stay literal too.

### Wire payload

**Unchanged, at the strongest available level: this PR touches zero production files.**
`git diff staging..HEAD --name-only` excluding tests returns **0**. The composer `.trim()`s only
leading/trailing whitespace; `message.content` is the raw string; display is a pure read of it.

## Call sites that render or echo user-authored text (the brief asked for this list)

| # | Surface | Treatment | Right? |
|---|---|---|---|
| 1 | `MessageBubble.tsx:415` body — **shared with assistant** | `safeRichText` → formatted | ✅ this is the surface in question |
| 2 | `MessageBubble.tsx:283` chip-initiated pill (`chipActionIndicator`) | React text node, literal | ✅ chip echoes are short labels; formatting them would be noise |
| 3 | `zones/MessageActions.tsx:84` copy-to-clipboard | writes raw `message.content` | ✅ **copy must stay byte-exact** — this is what makes the round trip safe |
| 4 | `zones/ChatMessage.tsx` | wrapper only, delegates to (1) | ✅ no independent render |
| 5 | `panels/AIClarifierChat.tsx:258` `{msg.content}` | React text node, literal | ⚠ **inconsistent with (1)** — a separate legacy surface; flagged, not changed |
| 6 | `utils/transcriptStore.ts` persist/restore | raw string round-trip | ✅ storage, not display |
| 7 | `hooks/useThreadPersistence.ts`, `utils/hydrateThread.ts` | raw string | ✅ storage |
| 8 | `components/debug/utils/exportBundle.ts`, `hooks/useDebugData.ts` | raw string in JSON | ✅ **must stay literal** — a debug bundle showing formatted text would misreport the wire |
| 9 | Composer `<textarea>` (`GrowingInput` / `ChatComposer`) | plain controlled value | ✅ untouched; chips still inject text |

Sites 2, 3, 5, 8 stay literal **by design**, each for a stated reason. Site 5 is the one genuine
cross-surface inconsistency and predates this lane.

## Verification

- Fresh blobless clone, unique `/private/tmp` path; `HEAD` asserted `aa916511` == remote `staging`.
- New spec **collected by name: 14 tests** (not inferred from a suite total). Related specs run by
  explicit path: `markdown` 36, `safeRichText.listRendering` 20, `MessageBubble.sentinel` 5,
  `MessageBubble.actions` 11 — **86 passed / 5 files**.
- `pnpm run typecheck` ✅ (3538/3578 files loaded; **no diagnostics added**). Declined the gate's
  `--update-baseline` suggestion — the 9-diagnostic shrink is not this PR's doing.
- `eslint` on the added file ✅; hooks ratchet exactly at baseline (229/13).
- Full suite deliberately **not** run locally (machine contention, six concurrent lanes).

### Mutants — in a worktree outside the repo root, isolation proven by WRITING

A sentinel was written into the worktree and the source asserted unchanged; inodes compared
(`672649701` vs `672888929`) because `cp -R` can preserve APFS hard links. Restores are
`git checkout HEAD --`, never index-relative. Every mutant carries an applied-check of exactly 1.

| Mutant | Result |
|---|---|
| **Control** (no mutation, applied **0**) | 14/14 green |
| **M1** — `escapeHtml` stops escaping `<`/`>` | **3 RED** — the injection tests (the brief's required mutant) |
| **M2** — bold transform removed | **1 RED** |
| **M3** — bullet branch disabled | **2 RED** |
| **M4** — italic support *added* (`<em>` + allowlist) | **2 RED** — the contract pins catch a silent re-add |
| **Trailing control** | tree clean, 14/14 green |

M4 is the opposite-direction twin: M1–M3 prove the pins bite when a capability is removed, M4
proves they bite when one is added past the documented contract.

## Findings for the register — user-text fidelity (reported, deliberately NOT fixed)

`safeRichText` was written for orchestrator output, so three of its transforms are wrong when
applied to **the user's own words**. All three are pre-existing, none is a security issue, and each
needs a shared-renderer change plus a policy call, so per the scope rule they are reported:

1. **Emoji are silently stripped.** A user types `Great idea 🚀` and their own message renders
   `Great idea` — the product deletes a character they typed.
2. **Em dashes are mangled.** `Revenue — the key driver` renders `Revenue  -  the key driver`
   (double-spaced hyphen).
3. **Entity round-trip corrupts literal text.** `decodeOrchestratorEntities` runs *before*
   escaping, so a user typing `&lt;b&gt;` literally is shown `<b>`, and `&amp;` is shown `&`.

MessageBubble's own comment says *"the user's own words are never withheld"*. These three quietly
contradict it. Fixing them means branching `safeRichText` by role — a real design change, and
arguably more valuable to a user pasting a strategic brief than italic is.

## ⛔ DO NOT MERGE

Held per the dispatch instruction pending the SENDABLE witness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
