### PR TITLE
feat(coaching+stage): typed coaching intents actually leave the UI, and the stage vocabulary converges

### DIFF
--- a/src/canvas/components/ModelTabBody.tsx
+++ b/src/canvas/components/ModelTabBody.tsx
@@ -151,7 +151,7 @@ export const ModelTabBody = memo(function ModelTabBody({
       item_type: 'trust',
       surface: 'model_tab',
       scenario_id: state.currentScenarioId ?? undefined,
-      profile_stage: (state.currentStage ?? undefined) as 'frame' | 'ideate' | 'evaluate' | 'decide' | undefined,
+      profile_stage: state.currentStage ?? undefined,
     })
   }, [])
 

--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -469,37 +469,52 @@ export const ACTIONS_MENU = [
     label: 'Pressure-test the frame',
     prompt: 'Is this the right question to be asking, and does it fit my wider goals?',
     // Frame-challenge coaching. explain_from_structure EXPLAINS the model;
-    // this spark challenges it — no honest vocabulary entry.
+    // this spark challenges it — no honest ACTION vocabulary entry.
     action_type: null,
+    // ⭐ ROUTED. CEE's typed coaching arm serves this intent, so the click
+    // arrives TYPED instead of as anonymous prose CEE has to re-infer.
+    intent: 'challenge_frame',
   },
   {
     id: 'widen_options',
     label: 'Widen the options',
     prompt: 'Suggest materially different options that work through a different mechanism from the ones I already have.',
-    // Option-elicitation coaching; the boundary enum has no add_option.
+    // Option-elicitation coaching; the ACTION enum has no add_option.
     action_type: null,
+    // ⭐ ROUTED, and the only one of the four with a published protocol behind
+    // it: CEE cites DSK-P-004 (Opportunity cost prompting) on frame-stage
+    // turns, where the bundle's own stage_applicability admits it.
+    intent: 'elicit_options',
   },
   {
     id: 'outside_view',
     label: 'Take the outside view',
     prompt: 'Take the outside view on this decision: what do similar decisions and base rates suggest?',
-    // Base-rate coaching — no vocabulary entry.
+    // Base-rate coaching — no ACTION vocabulary entry.
     action_type: null,
+    // Declared but NOT yet routed by CEE, so the send gate withholds it. The
+    // declaration is the point: when CEE's arm grows this intent, the send
+    // lights up with no change here.
+    intent: 'outside_view',
   },
   {
     id: 'pre_mortem',
     label: 'Run a pre-mortem',
     prompt: 'Run a pre-mortem with me: imagine this choice failed a year from now. What went wrong?',
-    // Failure-imagination coaching — no vocabulary entry.
+    // Failure-imagination coaching — no ACTION vocabulary entry.
     action_type: null,
+    // Declared, not yet routed — withheld by the send gate.
+    intent: 'pre_mortem',
   },
   {
     id: 'risks_upside',
     label: 'Find risks and upside',
     prompt: 'What risks and best-case upsides are missing from my model?',
     // Gap-elicitation coaching (what is MISSING) — explain_* describes what
-    // is present; no honest entry.
+    // is present; no honest ACTION entry.
     action_type: null,
+    // Declared, not yet routed — withheld by the send gate.
+    intent: 'elicit_risks',
   },
   {
     id: 'calibrate_estimates',
@@ -512,6 +527,9 @@ export const ACTIONS_MENU = [
     // analysis facts). Live since the 0.20.0 re-vendor + CEE acceptance
     // (2026-07-20) — now sends.
     action_type: 'analysis_readiness',
+    // Declared, not yet routed — withheld. Independent of action_type, which
+    // is live: an intent names WHAT the user wants, a handler names HOW.
+    intent: 'estimate_help',
   },
   {
     id: 'compare_view',
@@ -520,6 +538,10 @@ export const ACTIONS_MENU = [
     // compare_options compares DECISION OPTIONS, not the user's view vs the
     // model's — stamping it would misdeclare the intent.
     action_type: null,
+    // No honest INTENT either: the Intent set has no "compare my view with
+    // yours" member, and `discuss` would flatten a specific ask into the
+    // catch-all. Null is the honest answer, not a gap.
+    intent: null,
   },
   {
     id: 'prepare_first_analysis',
@@ -531,6 +553,10 @@ export const ACTIONS_MENU = [
     // wrongness class this metadata exists to kill. Live since the 0.20.0
     // re-vendor + CEE acceptance (2026-07-20) — now sends.
     action_type: 'analysis_readiness',
+    // The readiness ACTION already carries this spark's meaning precisely;
+    // adding an intent would be a second, weaker declaration of the same
+    // thing.
+    intent: null,
   },
 ] as const satisfies ReadonlyArray<ActionsMenuItem>
 
@@ -578,13 +604,23 @@ export const SPARK_PROMPTS = {
     label: 'Define success with Olumi',
     prompt: 'Help me define a measurable success target for this goal.',
     // Goal-target coaching; set_factor_value is a validated mutation, not
-    // a conversation — no honest entry.
+    // a conversation — no honest ACTION entry.
     action_type: null,
+    // ⭐ ROUTED. CEE's arm asks for a metric, a threshold and a date, and
+    // carries NO science badge — no published protocol names a
+    // success-definition exercise at this stage, and DSK-P-006 is explicitly
+    // contraindicated before the user has decided.
+    intent: 'define_success',
   },
   reflectBias: {
     id: 'reflect_bias',
     label: 'Talk it through with Olumi',
     prompt: 'You flagged a possible blind spot in how my model leans. Help me think it through.',
     action_type: null,
+    // ⭐ ROUTED. `challenge_assumption` — the consider-the-opposite family.
+    // CEE cites DSK-P-003 only on `decide` turns, where the bundle admits it;
+    // on the pre-analysis panel it coaches without a badge, because
+    // DSK-P-003 requires analysis results this surface does not have.
+    intent: 'challenge_assumption',
   },
 } satisfies Record<string, SparkPrompt>

--- a/src/canvas/components/pre-analysis-v3/hooks/useConversationActions.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/useConversationActions.ts
@@ -43,7 +43,7 @@ export function useConversationActions(): ConversationActions {
 
   const sendPrompt = useCallback(
     (spark: SparkPrompt): boolean => {
-      const { id, label, prompt, action_type } = spark
+      const { id, label, prompt, action_type, intent } = spark
       // 1. Live conversation context — no registration race possible.
       if (conversation) {
         conversation
@@ -53,6 +53,12 @@ export function useConversationActions(): ConversationActions {
             message: prompt,
             intent: 'primary',
             ...(action_type ? { action_type } : {}),
+            // ⭐ The spark's TYPED intent. `wire_intent`, not `intent` — the
+            // line above is the STYLING variant, a different concept sharing
+            // the name. This is the hop that stops the four coaching sparks
+            // arriving as anonymous prose; the send gate in buildV5Payload
+            // still decides whether it reaches CEE.
+            ...(intent ? { wire_intent: intent } : {}),
             parameters: { spark_id: id },
           })
           .catch(() => showToast(FIELD_FEEDBACK_COPY.olumiUnavailable, 'error'))
@@ -66,6 +72,10 @@ export function useConversationActions(): ConversationActions {
       if (callbacks._dispatchAction) {
         callbacks._dispatchAction({
           ...(action_type ? { action_type } : {}),
+          // Same typed intent on the guidance-store bridge. This path reaches
+          // `dispatchAction` directly, so the field is plain `intent` here —
+          // there is no styling variant on DispatchActionOpts to collide with.
+          ...(intent ? { intent } : {}),
           parameters: { spark_id: id },
           label,
           message: prompt,

--- a/src/canvas/components/pre-analysis-v3/types.ts
+++ b/src/canvas/components/pre-analysis-v3/types.ts
@@ -7,7 +7,7 @@
  * See docs/pre-analysis-panel-solution-design-v1.md.
  */
 
-import type { ActionTypeLiteral } from '@talchain/schemas/boundary'
+import type { ActionTypeLiteral, IntentLiteral } from '@talchain/schemas/boundary'
 import type { PendingWireActionType } from '../../conversation/chipMeta'
 import type { ValueProvenanceKind } from '../../domain/valueProvenance'
 
@@ -30,6 +30,26 @@ export interface SparkPrompt {
    * exists (coaching/readiness sparks).
    */
   action_type: ActionTypeLiteral | PendingWireActionType | null
+  /**
+   * ⭐ The typed authored INTENT this spark declares (`chip.intent` on the
+   * wire — the 11-member `Intent` set, distinct from the 11-member
+   * `ActionType` set above and decoupled from it: an `action_type` names a
+   * deterministic HANDLER, an `intent` names WHAT THE USER WANTS).
+   *
+   * This is what stops a coaching spark degrading to anonymous prose. Four
+   * MOUNTED sparks carry `action_type: null` because no honest handler exists
+   * for a conversation — and until CEE grew a routing arm they therefore
+   * carried NOTHING, so the click arrived as untyped text and CEE re-inferred
+   * the intent from the message. `intent` is the honest typed value for
+   * exactly those sparks.
+   *
+   * `null` when the spark declares no typed intent. The send gate in
+   * `buildV5Payload` (`sanitiseIntent` → `KNOWN_INTENTS ∧
+   * CEE_ACCEPTED_INTENTS`) still decides whether it reaches the wire, and it
+   * fails CLOSED: a spark may declare an intent CEE does not yet route, and
+   * the value is simply withheld until CEE accepts it.
+   */
+  intent: IntentLiteral | null
 }
 
 /**

--- a/src/canvas/components/pre-analysis/WorthInvestigating.tsx
+++ b/src/canvas/components/pre-analysis/WorthInvestigating.tsx
@@ -180,7 +180,7 @@ function GapRow({ gap, onSetValue, factorInfluence }: { gap: EvidenceGap; onSetV
       item_id: gap.factorId,
       surface: 'pre_analysis' as const,
       scenario_id: state.currentScenarioId ?? undefined,
-      profile_stage: (state.currentStage ?? undefined) as 'frame' | 'ideate' | 'evaluate' | 'decide' | undefined,
+      profile_stage: state.currentStage ?? undefined,
     }
     trackGuidance('EVIDENCE_GAP_SHOWN', { ...basePayload, item_type: 'evidence_gap' })
     if (onSetValue) {
@@ -203,7 +203,7 @@ function GapRow({ gap, onSetValue, factorInfluence }: { gap: EvidenceGap; onSetV
       item_type: 'evidence_gap',
       surface: 'pre_analysis',
       scenario_id: state.currentScenarioId ?? undefined,
-      profile_stage: (state.currentStage ?? undefined) as 'frame' | 'ideate' | 'evaluate' | 'decide' | undefined,
+      profile_stage: state.currentStage ?? undefined,
     })
   }
 
@@ -214,7 +214,7 @@ function GapRow({ gap, onSetValue, factorInfluence }: { gap: EvidenceGap; onSetV
       item_type: 'fix',
       surface: 'pre_analysis',
       scenario_id: state.currentScenarioId ?? undefined,
-      profile_stage: (state.currentStage ?? undefined) as 'frame' | 'ideate' | 'evaluate' | 'decide' | undefined,
+      profile_stage: state.currentStage ?? undefined,
     })
     onSetValue?.(gap.factorId)
   }

--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -642,6 +642,12 @@ export const ConversationPanel = memo(function ConversationPanel({
         message,
         intent: 'primary',
         ...(meta?.action_type ? { action_type: meta.action_type } : {}),
+        // ROADMAP 2.1288 — forward the producer's TYPED intent. Its absence
+        // here was the whole defect: the card declared `action_intent`, CEE's
+        // rail required `chip.intent`, and this line was the missing hop.
+        // `wire_intent`, not `intent` — the latter is the styling variant
+        // being set on the line above.
+        ...(meta?.intent ? { wire_intent: meta.intent } : {}),
         ...(meta?.parameters ? { parameters: meta.parameters } : {}),
       })
     // Prefill the visible composer (see prefillInto): the legacy ChatComposer

--- a/src/canvas/conversation/GuidanceStrip.tsx
+++ b/src/canvas/conversation/GuidanceStrip.tsx
@@ -179,7 +179,7 @@ export const GuidanceStrip = memo(function GuidanceStrip({
       item_type: coachingItemType(topItem.category),
       surface: 'guidance_panel',
       scenario_id: state.currentScenarioId ?? undefined,
-      profile_stage: (state.currentStage ?? undefined) as GuidanceEventPayload['profile_stage'] | undefined,
+      profile_stage: state.currentStage ?? undefined,
     })
   }, [topItem, dismissedId])
 
@@ -215,7 +215,7 @@ export const GuidanceStrip = memo(function GuidanceStrip({
       item_type: coachingItemType(topItem.category),
       surface: 'guidance_panel',
       scenario_id: state.currentScenarioId ?? undefined,
-      profile_stage: (state.currentStage ?? undefined) as GuidanceEventPayload['profile_stage'] | undefined,
+      profile_stage: state.currentStage ?? undefined,
       // Only when the dwell belongs to THIS item — never carried across a swap.
       ...(shownAtRef.current?.itemId === topItem.item_id
         ? { dwell_ms: bucketDwellMs(Date.now() - shownAtRef.current.at) }
@@ -234,7 +234,7 @@ export const GuidanceStrip = memo(function GuidanceStrip({
       item_type: coachingItemType(topItem.category),
       surface: 'guidance_panel',
       scenario_id: state.currentScenarioId ?? undefined,
-      profile_stage: (state.currentStage ?? undefined) as GuidanceEventPayload['profile_stage'] | undefined,
+      profile_stage: state.currentStage ?? undefined,
       // Only when the dwell belongs to THIS item — never carried across a swap.
       ...(shownAtRef.current?.itemId === topItem.item_id
         ? { dwell_ms: bucketDwellMs(Date.now() - shownAtRef.current.at) }

--- a/src/canvas/conversation/__tests__/useConversation.sendChipWireIntent.spec.ts
+++ b/src/canvas/conversation/__tests__/useConversation.sendChipWireIntent.spec.ts
@@ -1,0 +1,307 @@
+/**
+ * ROADMAP 2.1288 fast-follow — CALL-SITE pin for `sendChip`'s typed wire intent.
+ *
+ * #791 made typed coaching intents actually leave the UI. Its own spec
+ * (`V5CoachingActionChip.spec.tsx`) pins the PRODUCER end — a rendered click
+ * calls `_sendChip` with `intent: 'add_option'` in its meta — and
+ * `intentGate.spec.ts` pins the GATE end. Between them sit the two hops the PR
+ * ADDED, and at this head `wire_intent` had ZERO test references anywhere
+ * (contrast controls in the same sweep: `action_type` 62 files, `chipMeta` 10 —
+ * real absence, not instrument blindness).
+ *
+ * MEASURED BEFORE THIS SUITE EXISTED — deleting the hop
+ *   `...(chip.wire_intent ? { intent: chip.wire_intent } : {}),`
+ * in `sendChip` leaves the whole neighbourhood GREEN: 8 spec
+ * files, 250 passed / 22 skipped, counts byte-identical to pristine, INCLUDING
+ * `V5CoachingActionChip.spec.tsx` itself — because that spec mocks `_sendChip`
+ * and never exercises the real `ConversationPanel`/`useConversation` path. With
+ * the hop gone the widening card's `add_option` still reaches the store and
+ * still becomes `wire_intent`, then dies at that line; the turn ships without
+ * `chip.intent`, CEE's add-option rail never fires, and the defect #791 was
+ * written to close is fully restored under a green suite.
+ *
+ * That is the defect class named in the PR's own spec header — "a field that
+ * exists and is never populated is indistinguishable, from the type's point of
+ * view, from one that works" — occurring one layer BELOW where the author
+ * pinned it.
+ *
+ * This suite renders the REAL `useConversation` hook and drives the REAL
+ * `sendChip` → `dispatchAction` → `buildChipMeta` → `buildV5Payload` chain,
+ * mocking only the network runner (`callV5Turn`) and the auth/scenario bridges.
+ * Nothing between the chip and the wire is stubbed, so the observation point is
+ * the payload actually handed to the transport.
+ *
+ * BINDING BY IDENTITY (trap 19): every assertion binds via the chip's own `id`,
+ * asserted on the payload. "Some chip carried add_option" is a value predicate
+ * another object could satisfy; "the chip whose id is `chip-widen-1` carried
+ * add_option" is not.
+ *
+ * A DISCRIMINATING SET, not one case repeated:
+ *   1. `add_option`      → `chip.intent === 'add_option'`
+ *   2. `challenge_frame` → `chip.intent === 'challenge_frame'`
+ *      A hop hardcoded to 'add_option' passes (1) and FAILS (2); a hop that
+ *      forwards nothing fails both. Neither case alone proves forwarding.
+ *   3. no `wire_intent`  → NO `intent` KEY on the wire (absent, not `undefined`)
+ *      The gate is fail-closed by design, and the chip's UI STYLING
+ *      `intent: 'primary'` must never leak into the typed wire field it shares
+ *      a name with (CLAUDE.md trap 21 — two concepts under one name, which is
+ *      exactly why `wire_intent` carries a separate name at all).
+ *
+ * ⚠ THE HOP IS NAMED BY ITS CODE, NEVER BY A LINE NUMBER. It sat at
+ * `useConversation.ts:6565` when this suite was written and at :6600 one
+ * rebase later — #810's durable-deletion receipt and #804's model-building
+ * notices landed above it and moved it 35 lines without touching it. A line
+ * number in a test name is a hand-maintained mirror (CLAUDE.md trap 12): it
+ * drifts silently and reads as green the whole time. Locate the hop with
+ *   rg -n 'chip\.wire_intent \? \{ intent: chip\.wire_intent \}'
+ *
+ * MUTATION MAP — each applied to COMMITTED state in a throwaway worktree
+ * outside the repo root, applied-check scoped to `src/` reading exactly 1
+ * (control 0), restored from a pristine ARCHIVE between runs, leading and
+ * trailing controls GREEN. Every mutant bites a DIFFERENT subset, which is what
+ * makes this a discriminating kit rather than four tests agreeing with each
+ * other:
+ *
+ *   M1  delete the hop entirely
+ *         → 1 RED ('expected undefined to be add_option')
+ *           2 RED ('expected undefined to be challenge_frame'), 3 green
+ *   M2  hardcode `{ intent: 'add_option' }`
+ *         → 1 GREEN, 2 RED ('expected add_option to be challenge_frame'), 3 green
+ *         This pair (M1/M2) is the binding proof: case 1 alone is satisfied by a
+ *         constant, so it proves sensitivity to SOMETHING, not to the chip's own
+ *         intent. Only case 2 failing while case 1 passes proves the value is
+ *         forwarded rather than fabricated.
+ *   M3  forward the STYLING `chip.intent` instead of `chip.wire_intent`
+ *         → 1 RED, 2 RED, 3 green — green because the send gate WITHHOLDS
+ *           'primary' (not in CEE_ACCEPTED_INTENTS), so the leak is stopped one
+ *           layer down. Recorded rather than smoothed over: case 3's `not.toBe
+ *           ('primary')` limb is enforced by the GATE, not by this hop.
+ *   M4  fabricate a default: `intent: chip.wire_intent ?? 'add_option'`
+ *         → 1 green, 2 green, 3 RED ('expected true to be false')
+ *         This is what proves case 3 is not vacuous — it is the only mutant the
+ *         absence assertion catches, and without it case 3 would be a guard no
+ *         measurement had ever shown discriminating.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useConversation } from '../useConversation'
+import { useCanvasStore } from '../../store'
+import { useResultsStore } from '../../stores/resultsStore'
+import { CEE_ACCEPTED_INTENTS } from '../../../v5/buildPayload'
+import type { ActionChip } from '../types'
+
+// ---------------------------------------------------------------------------
+// Mocks — the network runner and the auth/scenario bridges ONLY.
+// `sendChip`, `dispatchAction`, `buildChipMeta`, `buildV5Payload` and the send
+// gate are all REAL: mocking any of them would rebuild the very vacuity this
+// suite exists to close.
+// ---------------------------------------------------------------------------
+
+const mockCallTurn = vi.fn()
+const mockStreamTurn = vi.fn()
+
+vi.mock('../turnService', () => ({
+  callOrchestratorTurn: (...args: unknown[]) => mockCallTurn(...args),
+  streamOrchestratorTurn: (...args: unknown[]) => mockStreamTurn(...args),
+  OrchestratorError: class OrchestratorError extends Error {
+    status: number
+    body: unknown
+    constructor(message: string, status: number, body: unknown) {
+      super(message)
+      this.name = 'OrchestratorError'
+      this.status = status
+      this.body = body
+    }
+  },
+}))
+
+const mockCallV5Turn = vi.fn()
+// `importOriginal`-spread rather than a hand-listed mock (CLAUDE.md trap 12):
+// a bare factory REPLACES the module, so every export added since — `__internals`
+// among them — silently vanishes and the caller fails at runtime instead of here.
+vi.mock('../../../v5/v5Adapter', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/v5Adapter')>()
+  return {
+    ...actual,
+    callV5Turn: (...args: unknown[]) => mockCallV5Turn(...args),
+    getV5Endpoint: () => 'https://cee.test/orchestrate/v2/turn',
+  }
+})
+
+// The streamed turn sibling is stubbed UNREACHABLE, deliberately and explicitly
+// — the same construction `useConversation.hook.spec.ts` uses for its payload
+// pins. It is not an artificial state: it is exactly a deployment where the
+// streamed route is absent or refusing, and the buffered fallback it triggers is
+// the chain under test here. Making the refusal explicit matters — left implicit,
+// the fallback happened only because an incomplete mock threw, which is an
+// accident that could silently stop happening.
+vi.mock('../../../v5/streamedTurnTransport', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/streamedTurnTransport')>()
+  return {
+    ...actual,
+    openV5TurnStream: async () => {
+      throw new TypeError('Failed to fetch')
+    },
+  }
+})
+
+vi.mock('../../../v5/eligibility', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../v5/eligibility')>()
+  const flags = await import('../../../flags')
+  return {
+    ...actual,
+    isV5Eligible: () => ({ eligible: true as const }),
+    isV5CanonicalRunPath: () => flags.isV5CanonicalAnalysisEnabled(),
+  }
+})
+
+const mockGetUserId = vi.fn<[], Promise<string | null>>()
+vi.mock('../../../lib/supabase', () => ({
+  getUserId: (...args: unknown[]) => mockGetUserId(...(args as [])),
+  getSessionIdentity: async () => ({
+    userId: (await mockGetUserId()) ?? null,
+    accessToken: null,
+  }),
+}))
+
+const mockLoadScenario = vi.fn<[string], Promise<unknown>>()
+vi.mock('../../../services/scenarioService', () => ({
+  loadScenario: (...args: unknown[]) => mockLoadScenario(...(args as [string])),
+}))
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const makeV5SuccessResult = (text = 'OK') => ({
+  kind: 'response' as const,
+  response: {
+    response_version: 2,
+    assistant_text: text,
+    blocks: [] as unknown[],
+    suggested_actions: [] as unknown[],
+    insights: [] as unknown[],
+    stage_indicator: 'frame',
+  },
+})
+
+/** The widening card's chip, as `ActionChip` — the shape #791 made travel. */
+function makeChip(overrides: Partial<ActionChip> & Pick<ActionChip, 'id'>): ActionChip {
+  return {
+    label: 'Add an option',
+    // The UI STYLING variant. Deliberately set on every fixture: if the hop
+    // ever forwards THIS field instead of `wire_intent`, case 3 goes RED.
+    intent: 'primary',
+    message: 'Add a fourth option: partner with a regional distributor.',
+    ...overrides,
+  }
+}
+
+type WirePayload = {
+  source?: string
+  chip?: { id?: string; action_type?: string; intent?: string; parameters?: unknown }
+}
+
+/** The payload actually handed to the transport for a given chip id. */
+function payloadForChipId(id: string): WirePayload {
+  const matches = mockCallV5Turn.mock.calls
+    .map((c) => c[0] as WirePayload)
+    .filter((p) => p.chip?.id === id)
+  // Pin the precondition in-test (trap 13b): exactly one turn, bound to THIS
+  // chip's identity. If the chain silently stopped sending, or sent something
+  // else, this fails here rather than letting a downstream assertion pass or
+  // fail for the wrong reason.
+  expect(matches).toHaveLength(1)
+  return matches[0]
+}
+
+// ---------------------------------------------------------------------------
+
+describe('sendChip — the typed wire intent reaches the wire', () => {
+  beforeEach(() => {
+    mockCallTurn.mockReset()
+    mockStreamTurn.mockReset()
+    mockCallV5Turn.mockReset()
+    mockCallV5Turn.mockResolvedValue(makeV5SuccessResult())
+    mockGetUserId.mockReset()
+    mockGetUserId.mockResolvedValue(null)
+    mockLoadScenario.mockReset()
+    mockLoadScenario.mockResolvedValue(null)
+
+    useResultsStore.setState({
+      results: {
+        status: 'idle',
+        progress: 0,
+        analysisSummary: undefined,
+        lastSnapshotId: undefined,
+      },
+    } as never)
+
+    useCanvasStore.getState().resetCanvas()
+    useCanvasStore.setState({
+      currentScenarioId: 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4',
+      nodes: [],
+      edges: [],
+    })
+  })
+
+  it('the gate accepts both intents this suite discriminates on (precondition, not a claim about the hop)', () => {
+    // Without this, cases 1 and 2 could both agree by being WITHHELD by the
+    // send gate rather than by being forwarded — a guard agreeing with itself
+    // (trap 13b). The gate is a hand-maintained allowlist; if it changes under
+    // this suite, the discrimination dies silently unless pinned here.
+    expect(CEE_ACCEPTED_INTENTS.has('add_option' as never)).toBe(true)
+    expect(CEE_ACCEPTED_INTENTS.has('challenge_frame' as never)).toBe(true)
+  })
+
+  it('a chip carrying wire_intent add_option ships chip.intent add_option on that chip', async () => {
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendChip(
+        makeChip({ id: 'chip-widen-1', wire_intent: 'add_option' }),
+      )
+    })
+
+    const payload = payloadForChipId('chip-widen-1')
+    expect(payload.chip?.intent).toBe('add_option')
+    // The identity the assertion is bound to, asserted explicitly.
+    expect(payload.chip?.id).toBe('chip-widen-1')
+    expect(payload.source).toBe('chip')
+  })
+
+  it('a chip carrying a DIFFERENT wire_intent ships THAT intent — a hardcoded add_option cannot pass', async () => {
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      await result.current.sendChip(
+        makeChip({
+          id: 'chip-challenge-1',
+          label: 'Challenge the frame',
+          message: 'Is this the right question to be asking at all?',
+          wire_intent: 'challenge_frame',
+        }),
+      )
+    })
+
+    const payload = payloadForChipId('chip-challenge-1')
+    expect(payload.chip?.intent).toBe('challenge_frame')
+    expect(payload.chip?.intent).not.toBe('add_option')
+    expect(payload.chip?.id).toBe('chip-challenge-1')
+  })
+
+  it('a chip with NO wire_intent ships NO intent KEY — the styling intent never leaks (fail-closed)', async () => {
+    const { result } = renderHook(() => useConversation())
+    await act(async () => {
+      // `intent: 'primary'` is present (makeChip sets it) and is the STYLING
+      // variant. It must not appear as the typed wire intent.
+      await result.current.sendChip(makeChip({ id: 'chip-plain-1' }))
+    })
+
+    const payload = payloadForChipId('chip-plain-1')
+    // The chip still travels — identity is not conditional on the intent.
+    expect(payload.chip?.id).toBe('chip-plain-1')
+    // ABSENT, not `undefined`: an explicit `intent: undefined` would serialise
+    // differently and is a different claim about the wire.
+    expect(payload.chip && 'intent' in payload.chip).toBe(false)
+    expect(payload.chip?.intent).not.toBe('primary')
+  })
+})

--- a/src/canvas/conversation/types.ts
+++ b/src/canvas/conversation/types.ts
@@ -902,6 +902,26 @@ export interface ActionChip {
   prompt?: string
   /** Action classification for deterministic routing */
   action_type?: string
+  /**
+   * ⭐ The producer-declared TYPED WIRE INTENT (`chip.intent` on the 0.22+
+   * schema: `add_option`, `elicit_options`, `challenge_frame`, …).
+   *
+   * ⚠ DELIBERATELY NOT CALLED `intent`. This interface already has an `intent`
+   * field three lines up and it means something completely different — the UI
+   * STYLING variant ('primary' | 'secondary' | 'undo'). Two concepts under one
+   * name is the estate's chronic defect (CLAUDE.md trap 21), and here it had
+   * teeth: `sendChip` explicitly refuses to forward `chip.intent` to the wire
+   * precisely BECAUSE it is the styling value, which left typed producers with
+   * no channel at all. The distinct name is what makes the two
+   * non-confusable at every call site.
+   *
+   * Forwarded by `sendChip` into `dispatchAction`'s `intent`, where
+   * `buildChipMeta` → `buildV5Payload`'s send gate
+   * (`KNOWN_INTENTS ∧ CEE_ACCEPTED_INTENTS`) decides whether it reaches CEE.
+   * The gate fails CLOSED, so an intent CEE does not route is withheld rather
+   * than 422'd.
+   */
+  wire_intent?: string
   /** Structured parameters for action execution */
   parameters?: Record<string, unknown>
 }

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -6586,9 +6586,18 @@ export function useConversation(): UseConversationReturn {
         // Thread the chip's first-class identity (`chip.id` on the 0.22 wire) —
         // NOT `chip.intent`, which is the UI *styling* intent ('primary' |
         // 'secondary' | 'undo'), a different concept from the wire `Intent` set.
+        //
+        // ⭐ The typed wire intent travels as `chip.wire_intent`, whose separate
+        // name exists exactly so the line above stays true. Before it, a typed
+        // producer had NO channel through this seam: the widening card authored
+        // `action_intent: 'add_option'`, CEE's add-option rail fires on
+        // `chip.intent === 'add_option'`, and the click fell to the free-text
+        // edit lane and returned a refusal (ROADMAP 2.1288). The send gate in
+        // `buildV5Payload` still decides whether the value reaches the wire.
         await dispatchAction({
           id: chip.id,
           action_type: chip.action_type,
+          ...(chip.wire_intent ? { intent: chip.wire_intent } : {}),
           parameters: chip.parameters,
           label: chip.label,
           message: messageToSend,

--- a/src/canvas/hooks/useGuidancePulseHighlight.ts
+++ b/src/canvas/hooks/useGuidancePulseHighlight.ts
@@ -70,7 +70,7 @@ export function useGuidancePulseHighlight(): void {
             item_type: 'highlight',
             surface: 'canvas',
             scenario_id: storeState.currentScenarioId ?? undefined,
-            profile_stage: (storeState.currentStage ?? undefined) as 'frame' | 'ideate' | 'evaluate' | 'decide' | undefined,
+            profile_stage: storeState.currentStage ?? undefined,
           })
         }
       }

--- a/src/canvas/stores/guidanceStore.ts
+++ b/src/canvas/stores/guidanceStore.ts
@@ -234,6 +234,33 @@ export interface SendChipMeta {
   id?: string
   /** `suggested_actions[].action_type` exactly as the producer emitted it. */
   action_type?: string
+  /**
+   * ⭐ The producer-declared TYPED INTENT (`suggested_actions[].action_intent`
+   * / a registry spark's authored intent), forwarded unchanged.
+   *
+   * ⚠⚠ THIS FIELD'S ABSENCE WAS A LIVE USER-FACING DEFECT (ROADMAP 2.1288),
+   * and the shape of it is worth keeping: the widening card authors
+   * `action_intent: 'add_option'` (CEE `draft-option-widening-blocks.ts:720`),
+   * CEE's add-option rail fires on `ingress.chip?.intent === 'add_option'`
+   * (`route-v2.ts:2819`), and there was NO TRANSPORT BETWEEN THEM. The turn
+   * fell to the free-text edit lane and came back a refusal — so the user
+   * clicked a chip the product itself offered and was told no, at the cost of
+   * their Run affordance. The missing piece was never a handler; it was this
+   * field.
+   *
+   * `buildV5Payload` already reads `chipMeta.intent` and already emits
+   * `chip.intent` on the wire, and its send gate
+   * (`KNOWN_INTENTS ∧ CEE_ACCEPTED_INTENTS`) still decides whether the value
+   * travels. So this can only ever forward an intent the PRODUCER declared and
+   * CEE has accepted — never one the UI invented, and never one CEE cannot
+   * route. Optional, so every existing caller is byte-identical.
+   *
+   * NOT to be confused with `ActionChip.intent`, which is the UI STYLING
+   * variant ('primary' | 'secondary' | 'undo') — a different concept that
+   * happens to share the name (see `useConversation.sendChip`, which
+   * deliberately does not forward it).
+   */
+  intent?: string
   /** `suggested_actions[].parameters`, forwarded unchanged. */
   parameters?: Record<string, unknown>
 }
@@ -271,7 +298,7 @@ export interface GuidanceState {
   /** Registered by ConversationPanel so inspector "Ask about this" can pre-fill chat input */
   _prefillChat: ((text: string) => void) | null
   /** Registered by ConversationPanel — unified action dispatch with chip_metadata */
-  _dispatchAction: ((opts: { action_type?: string; parameters?: Record<string, unknown>; label: string; message: string; hidden?: boolean; source: string }) => void) | null
+  _dispatchAction: ((opts: { action_type?: string; intent?: string; parameters?: Record<string, unknown>; label: string; message: string; hidden?: boolean; source: string }) => void) | null
   /**
    * Identity token for the ACTIVE registration. Ownership checks must use
    * this, never a callback identity: with the singleton conversation

--- a/src/telemetry/guidanceEvents.ts
+++ b/src/telemetry/guidanceEvents.ts
@@ -13,6 +13,7 @@
  */
 
 import { trackEvent } from '../lib/posthog'
+import type { ScenarioStage } from '../types/scenario'
 
 // ---------------------------------------------------------------------------
 // § 1 — Event name constants
@@ -55,8 +56,20 @@ export interface GuidanceEventPayload {
   surface: 'guidance_panel' | 'pre_analysis' | 'results' | 'model_tab' | 'inspector' | 'canvas'
   /** Current scenario ID (no content — only ID) */
   scenario_id?: string
-  /** Decision lifecycle stage */
-  profile_stage?: 'frame' | 'ideate' | 'evaluate' | 'decide'
+  /**
+   * Decision lifecycle stage.
+   *
+   * ⚠ THIS WAS A FIFTH SPELLING, AND IT WAS WRONG. It hand-typed
+   * `'frame' | 'ideate' | 'evaluate' | 'decide'` — the UI vocabulary MINUS
+   * `optimise`. Every writer reads `store.currentStage`, which is a full
+   * `ScenarioStage`, so five call sites had to CAST to satisfy this type and an
+   * `optimise` value shipped as an off-type string that the declaration says
+   * cannot occur. A type that is narrower than its only source is not a
+   * constraint, it is a lie with casts holding it up.
+   *
+   * Derived from `ScenarioStage` so it cannot disagree with what is stored.
+   */
+  profile_stage?: ScenarioStage
   /**
    * ROADMAP 1.68 — how long the item had been SHOWN when it was clicked or
    * dismissed, BUCKETED via `measurementConfig.bucketDwellMs`. This is 1.68's

--- a/src/v5/__tests__/intentGate.spec.ts
+++ b/src/v5/__tests__/intentGate.spec.ts
@@ -3,12 +3,14 @@
  * mirroring the action_type gate. Publication alone (or acceptance alone) must
  * never open the gate; the accept registry is the SECOND, independent signal.
  */
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { Intent } from '@talchain/schemas/boundary'
 import {
   KNOWN_INTENTS,
   CEE_ACCEPTED_INTENTS,
   isSendableToken,
+  buildV5Payload,
+  type BuildV5PayloadInput,
 } from '../buildPayload'
 
 describe('intent wire allowlist — schema parity (derive-don\'t-mirror)', () => {
@@ -73,5 +75,126 @@ describe('isSendableToken — the AND actually bites', () => {
 
   it('an unknown value is never sendable', () => {
     expect(isSendableToken('nonsense', published, accepted)).toBe(false)
+  })
+})
+
+/**
+ * ⭐ THE WITHHOLD IS OBSERVABLE IN DEV — the silence is what made the original
+ * defect invisible.
+ *
+ * A declared intent that fails the gate is dropped and the `intent` key is
+ * simply absent from the payload. That is the CORRECT behaviour and these tests
+ * re-assert it. What they add is that the drop is no longer SECRET: in a dev
+ * build nothing distinguished "no intent declared" from "intent declared and
+ * withheld", so four mounted affordances degraded to anonymous prose for weeks
+ * with every signal reading healthy.
+ *
+ * Assertions bind to the EXACT intent string, not to a loose "warn was called"
+ * predicate — a warning about some other token would satisfy the loose form.
+ */
+describe('withheld intents are visible in DEV — the drop is not silent', () => {
+  const TURN_ID = '33333333-3333-4333-8333-333333333333'
+  const SCENARIO_ID = '44444444-4444-4444-8444-444444444444'
+
+  /** A published Intent that CEE does NOT route. */
+  const WITHHELD_INTENT = 'pre_mortem'
+  /** A published Intent that CEE DOES route. */
+  const ACCEPTED_INTENT = 'challenge_frame'
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  function payloadForIntent(intent: string) {
+    const input: BuildV5PayloadInput = {
+      turnId: TURN_ID,
+      scenarioId: SCENARIO_ID,
+      stage: 'analyse',
+      turnClass: 'frame',
+      mode: 'user',
+      message: 'typed chip click',
+      source: 'chip',
+      chipMeta: { id: 'spark-under-test', intent },
+    }
+    const build = buildV5Payload(input)
+    if (!build.ok) throw new Error('payload build failed: ' + JSON.stringify(build))
+    return build.payload as { chip?: { id?: string; intent?: string } }
+  }
+
+  /**
+   * PRECONDITION PIN (trap 13b): the warning is DEV-gated, so a suite running
+   * with DEV false would pass every assertion below by never exercising the
+   * branch at all. Assert the gate condition itself so a non-DEV run REDs here
+   * instead of silently certifying nothing.
+   */
+  it('the suite runs in DEV, so the DEV-gated branch is actually reachable', () => {
+    expect(import.meta.env.DEV).toBe(true)
+  })
+
+  /**
+   * PRECONDITION PIN: prove this fixture is withheld BY THE GATE — published in
+   * the vendored enum but absent from the acceptance registry. Without this the
+   * test would still pass if `pre_mortem` were simply an unknown token, and it
+   * would stop discriminating the moment CEE started routing it.
+   */
+  it('warns, naming the exact withheld intent, when a published-but-unrouted intent is declared', () => {
+    expect(KNOWN_INTENTS.has(WITHHELD_INTENT as never)).toBe(true)
+    expect(CEE_ACCEPTED_INTENTS.has(WITHHELD_INTENT as never)).toBe(false)
+
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const payload = payloadForIntent(WITHHELD_INTENT)
+
+    // Behaviour is UNCHANGED: the key is still omitted, identity still travels.
+    expect(payload.chip && 'intent' in payload.chip).toBe(false)
+    expect(payload.chip?.id).toBe('spark-under-test')
+
+    // ...but the drop is now visible, and named.
+    expect(spy).toHaveBeenCalledTimes(1)
+    const message = String(spy.mock.calls[0]?.[0] ?? '')
+    expect(message).toContain(WITHHELD_INTENT)
+    expect(message).toContain('CEE_ACCEPTED_INTENTS')
+    spy.mockRestore()
+  })
+
+  /**
+   * ⭐ THE CONTRAST. Without this, the assertion above is satisfied by a build
+   * that warns on EVERY turn — which would spam the console and teach every
+   * developer to ignore it, i.e. the broken-alarm failure one level up.
+   */
+  it('does NOT warn for an ACCEPTED intent — the warning is specific to a withhold', () => {
+    expect(CEE_ACCEPTED_INTENTS.has(ACCEPTED_INTENT as never)).toBe(true)
+
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const payload = payloadForIntent(ACCEPTED_INTENT)
+
+    expect(payload.chip?.intent).toBe(ACCEPTED_INTENT)
+    expect(spy).not.toHaveBeenCalled()
+    spy.mockRestore()
+  })
+
+  /**
+   * ⭐ THE OTHER CONTRAST, and the one that stops this becoming console spam:
+   * the ordinary chip carries NO intent at all. That path must stay silent, or
+   * the warning fires on essentially every turn in the product.
+   */
+  it('does NOT warn when no intent is declared — the ordinary no-intent turn stays silent', () => {
+    const spy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const input: BuildV5PayloadInput = {
+      turnId: TURN_ID,
+      scenarioId: SCENARIO_ID,
+      stage: 'analyse',
+      turnClass: 'frame',
+      mode: 'user',
+      message: 'plain chip click',
+      source: 'chip',
+      chipMeta: { id: 'spark-without-intent' },
+    }
+    const build = buildV5Payload(input)
+    if (!build.ok) throw new Error('payload build failed: ' + JSON.stringify(build))
+    const payload = build.payload as { chip?: { id?: string; intent?: string } }
+
+    expect(payload.chip && 'intent' in payload.chip).toBe(false)
+    expect(spy).not.toHaveBeenCalled()
+    spy.mockRestore()
   })
 })

--- a/src/v5/__tests__/intentGate.spec.ts
+++ b/src/v5/__tests__/intentGate.spec.ts
@@ -22,12 +22,34 @@ describe('intent wire allowlist — schema parity (derive-don\'t-mirror)', () =>
     }
   })
 
-  it('add_option is the currently-accepted intent; coaching intents are withheld', () => {
-    expect(CEE_ACCEPTED_INTENTS.has('add_option')).toBe(true)
-    // The coaching/elicitation arm is not confirmed deployed — withheld until
-    // the registry-stamping lane adds them with deploy provenance.
-    expect(CEE_ACCEPTED_INTENTS.has('challenge_frame')).toBe(false)
-    expect(CEE_ACCEPTED_INTENTS.has('elicit_options')).toBe(false)
+  /**
+   * ⭐ THE ACCEPTED SET IS THE UI HALF OF A TWO-REPO GATE, so it is pinned by
+   * EXACT IDENTITY rather than by spot checks. CEE's arm routes exactly
+   * `ROUTED_COACHING_INTENTS` (`orchestrator-v5/coaching/typed-intent-directive.ts`)
+   * plus the pre-existing `add_option` rail; widening either half alone
+   * re-creates the silent-drop bug the gate exists to prevent — in one
+   * direction the chip degrades to prose, in the other CEE is told it routes
+   * something it does not.
+   *
+   * `toEqual` on the whole set, not `.has()` per member: a `.has()` list cannot
+   * see an entry that should NOT be there, which is the failure mode with a
+   * cross-repo cost.
+   */
+  it('the accepted set is EXACTLY add_option plus the four CEE routes', () => {
+    expect(new Set(CEE_ACCEPTED_INTENTS)).toEqual(
+      new Set(['add_option', 'challenge_frame', 'define_success', 'elicit_options', 'challenge_assumption']),
+    )
+  })
+
+  it('the intents CEE does NOT route are still withheld — the gate has not been opened wholesale', () => {
+    // Paired with the assertion above: that one alone is satisfied by a build
+    // that accepts everything AND happens to list these five. These four are
+    // published `Intent` members with mounted sparks and no CEE arm; a build
+    // that accepted them would send an intent the service cannot serve.
+    for (const withheld of ['outside_view', 'pre_mortem', 'elicit_risks', 'discuss'] as const) {
+      expect(KNOWN_INTENTS.has(withheld), `${withheld} must be published`).toBe(true)
+      expect(CEE_ACCEPTED_INTENTS.has(withheld), `${withheld} must be withheld`).toBe(false)
+    }
   })
 })
 

--- a/src/v5/__tests__/stageVocabularyConvergence.spec.ts
+++ b/src/v5/__tests__/stageVocabularyConvergence.spec.ts
@@ -1,0 +1,295 @@
+/**
+ * ⭐ ONE CANONICAL STAGE VOCABULARY, MAPPED AT ONE NAMED EDGE — and a guard that
+ * REDs when a fourth spelling appears or the edge stops being total.
+ *
+ * ── THE STATE THIS ENDS ──────────────────────────────────────────────────────
+ * Three vocabularies coexisted across the estate, and the UI carried TWO MORE
+ * spellings on top of them:
+ *
+ *   wire (CANONICAL)     frame | analyse | decide | review       @talchain/schemas `Stage`
+ *   UI `ScenarioStage`   frame | ideate | evaluate | decide | optimise
+ *   CEE V4 / DSK         frame | ideate | evaluate | decide | optimise
+ *   ⚠ `applyV5State.isStage`   the wire union, HAND-SPELLED — a fourth declaration
+ *   ⚠ `guidanceEvents.profile_stage`  the UI union MINUS `optimise` — a fifth,
+ *                              and a WRONG one: every writer reads
+ *                              `store.currentStage` (a full `ScenarioStage`), so
+ *                              five call sites CAST to satisfy it and an
+ *                              `optimise` value shipped as an off-type string
+ *                              the declaration says cannot occur.
+ *
+ * Both are now DERIVED (`Stage.safeParse`, `ScenarioStage`) rather than
+ * re-declared, and the five casts are gone with them.
+ *
+ * ── THE RULING ───────────────────────────────────────────────────────────────
+ * Name ONE canonical owner and map at the edges; remove the competitor rather
+ * than translating between three forever; DO NOT MINT A FOURTH.
+ *
+ *   CANONICAL   `Stage` / `StageType` — the wire enum, which declares itself
+ *               canonical and instructs consumers to derive from it.
+ *   EDGE        `src/v5/stageMapper.ts` — the ONE place the UI's product
+ *               vocabulary is translated to and from it.
+ *
+ * ── ⚠ WHAT THIS CANNOT DO ────────────────────────────────────────────────────
+ * It is a DERIVED guard, so it proves AGREEMENT, never CORRECTNESS. The
+ * allowlists are deliberately small and reviewed; a new occurrence anywhere else
+ * REDs, and that is the only property claimed. Each is paired with a control
+ * proving the sweep can see a violation AND discriminates a consumer from a
+ * declaration.
+ */
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, relative, sep } from 'node:path'
+
+import { describe, it, expect } from 'vitest'
+import { Stage } from '@talchain/schemas/boundary'
+
+import { scenarioStageToV5Stage, v5StageToScenarioStage } from '../stageMapper'
+import type { ScenarioStage } from '../../types/scenario'
+
+const SRC_ROOT = join(process.cwd(), 'src')
+
+/** Files permitted to DECLARE the five-member UI vocabulary. Exactly one: the owner. */
+const UI_VOCABULARY_OWNER = ['types', 'scenario.ts'].join(sep)
+
+/** Files permitted to TRANSLATE between the two vocabularies. Exactly one: the edge. */
+const TRANSLATION_EDGE = ['v5', 'stageMapper.ts'].join(sep)
+
+const UI_ONLY = ['ideate', 'optimise'] as const
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '')
+}
+
+/**
+ * A DECLARATION is a SHAPE, not a count: two or more members ADJACENT IN ONE
+ * LIST, separated only by `|` (a union) or `,` (an array). Separate `===`
+ * comparisons are CONSUMPTION and are correct — a guard that could not tell
+ * them apart would force every branching rule into an allowlist.
+ *
+ * ⚠ `ideate` and `optimise` are the discriminators, NOT `evaluate`.
+ * `strengthenTypes.ts` declares `HelpType = 'clarify' | 'broaden' | 'challenge'
+ * | 'evaluate' | 'commit'`, where `'evaluate'` is a HELP TYPE and nothing to do
+ * with a stage. A homograph is not a vocabulary; sweeping on it would have
+ * produced a false positive on a file this ruling has no business touching.
+ */
+function declaresUiVocabulary(source: string): boolean {
+  const code = stripComments(source)
+  const anyMember = `["'\`](?:frame|ideate|evaluate|decide|optimise)["'\`]`
+  const discriminator = `["'\`](?:${UI_ONLY.join('|')})["'\`]`
+  const asList = new RegExp(
+    `${discriminator}\\s*[|,]\\s*(?:${anyMember}\\s*[|,]\\s*)*${anyMember}|` +
+      `${anyMember}\\s*[|,]\\s*(?:${anyMember}\\s*[|,]\\s*)*${discriminator}`,
+  ).test(code)
+  // Same second shape as the wire predicate — see `declaresByComparisonChain`.
+  // Requires a discriminator (`ideate`/`optimise`) so a chain over the shared
+  // members alone is not attributed to this vocabulary.
+  const asChain =
+    declaresByComparisonChain(source, ['frame', 'ideate', 'evaluate', 'decide', 'optimise']) &&
+    UI_ONLY.some(u => new RegExp(`===\\s*["'\`]${u}["'\`]`).test(code))
+  return asList || asChain
+}
+
+/**
+ * ⭐ THE SECOND SHAPE A RE-DECLARATION TAKES — added because the first version of
+ * this guard MISSED IT, and the miss was found by mutation rather than by
+ * reading.
+ *
+ * Restoring `isStage`'s hand-spelled union
+ * (`v === 'frame' || v === 'analyse' || v === 'decide' || v === 'review'`) left
+ * this file entirely GREEN. The list-shape predicate above only sees members
+ * separated by a bare `|` or `,`; a `||` COMPARISON CHAIN is a re-declaration of
+ * the same set wearing predicate clothing, and it is the exact form the real
+ * defect took.
+ *
+ * The threshold is THREE members, and that is a judgement with a reason: a
+ * two-way check (`stage === 'analyse' || stage === 'decide'`) is ordinary,
+ * legitimate consumption of two stages and appears in healthy code, whereas a
+ * chain naming three or more of a four-member set is enumerating the set. Both
+ * readings are pinned by controls below, so the line sits where a reader can
+ * see and argue with it.
+ */
+function declaresByComparisonChain(source: string, members: readonly string[]): boolean {
+  const code = stripComments(source)
+  const m = `["'\`](?:${members.join('|')})["'\`]`
+  return new RegExp(`(?:===\\s*${m}\\s*\\|\\|\\s*[A-Za-z_$.[\\]]+\\s*){2,}===\\s*${m}`).test(code)
+}
+
+/** The wire union, hand-spelled — a re-declaration of something the contract owns. */
+function declaresWireVocabulary(source: string): boolean {
+  const code = stripComments(source)
+  const m = `["'\`](?:frame|analyse|decide|review)["'\`]`
+  const asList = new RegExp(
+    `["'\`]analyse["'\`]\\s*[|,]\\s*(?:${m}\\s*[|,]\\s*)*${m}|${m}\\s*[|,]\\s*(?:${m}\\s*[|,]\\s*)*["'\`]analyse["'\`]`,
+  ).test(code)
+  return asList || declaresByComparisonChain(source, ['frame', 'analyse', 'decide', 'review'])
+}
+
+function productionSources(): string[] {
+  const out: string[] = []
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry)
+      if (statSync(full).isDirectory()) {
+        if (entry === '__tests__' || entry === '__fixtures__' || entry === 'test' || entry === 'fixtures') continue
+        walk(full)
+        continue
+      }
+      if (!/\.tsx?$/.test(entry)) continue
+      if (/\.(spec|test)\.tsx?$/.test(entry) || entry.endsWith('.d.ts')) continue
+      out.push(full)
+    }
+  }
+  walk(SRC_ROOT)
+  return out
+}
+
+describe('stage vocabulary — one canonical owner, one named edge, no fourth', () => {
+  it('the canonical vocabulary is the wire enum, bound by identity to the contract', () => {
+    expect(Stage.options).toEqual(['frame', 'analyse', 'decide', 'review'])
+  })
+
+  it('the sweep is NOT vacuous — it reads real files, and it FINDS the owner', () => {
+    // ⭐ THE CONTROL WITHOUT WHICH THE TWO ABSENCE ASSERTIONS BELOW PROVE
+    // NOTHING. A sweep rooted at the wrong cwd, or one whose directory filter
+    // excluded everything, returns an EMPTY offender list — identical output to
+    // a codebase that is genuinely clean (CLAUDE.md trap 13). So: the sweep must
+    // read a plausible number of files, and it must positively identify the ONE
+    // file that legitimately declares the vocabulary. If the allowlist were
+    // removed, that file would be the offender — which is the discrimination
+    // being demonstrated.
+    const files = productionSources()
+    expect(files.length, 'the sweep read almost nothing — it is pointed at the wrong tree').toBeGreaterThan(500)
+    const owner = files.map(f => relative(SRC_ROOT, f)).filter(rel => rel === UI_VOCABULARY_OWNER)
+    expect(owner, 'the sweep cannot see the declaring file at all').toEqual([UI_VOCABULARY_OWNER])
+    expect(
+      declaresUiVocabulary(readFileSync(join(SRC_ROOT, UI_VOCABULARY_OWNER), 'utf8')),
+      'the owner file is not detected as declaring the vocabulary — the predicate is blind',
+    ).toBe(true)
+  })
+
+  it('the UI vocabulary has exactly ONE declaration', () => {
+    const offenders = productionSources()
+      .map(f => relative(SRC_ROOT, f))
+      .filter(rel => rel !== UI_VOCABULARY_OWNER && rel !== TRANSLATION_EDGE)
+      .filter(rel => declaresUiVocabulary(readFileSync(join(SRC_ROOT, rel), 'utf8')))
+    expect(
+      offenders,
+      'a file outside the owner and the edge re-declares the UI stage vocabulary — ' +
+        'that is a fourth vocabulary, and it will drift',
+    ).toEqual([])
+  })
+
+  it('the CANONICAL vocabulary is never hand-spelled outside the edge', () => {
+    // ⚠ `applyV5State.isStage` was exactly this until this lane: a hand-spelled
+    // `'frame' || 'analyse' || 'decide' || 'review'`, which reads GREEN while
+    // being wrong — a member added in a re-vendor would be silently rejected as
+    // "no stage signal". It now calls `Stage.safeParse`.
+    const offenders = productionSources()
+      .map(f => relative(SRC_ROOT, f))
+      .filter(rel => rel !== TRANSLATION_EDGE)
+      .filter(rel => declaresWireVocabulary(readFileSync(join(SRC_ROOT, rel), 'utf8')))
+    expect(
+      offenders,
+      'a file re-declares the canonical wire vocabulary instead of deriving from `Stage`',
+    ).toEqual([])
+  })
+
+  it('POSITIVE + CONTRAST CONTROLS — the sweep sees violations and discriminates consumers', () => {
+    // Trap 13 (an absence claim needs a demonstrated presence) and trap 20's
+    // corollary (keep a probe whose expected answer DIFFERS — a blind
+    // instrument can fake agreement but not a discrimination).
+    expect(declaresUiVocabulary(`type S = 'frame' | 'ideate' | 'evaluate' | 'decide' | 'optimise'`)).toBe(true)
+    expect(declaresUiVocabulary(`const S = ['ideate', 'evaluate']`)).toBe(true)
+    expect(declaresWireVocabulary(`type W = 'frame' | 'analyse' | 'decide' | 'review'`)).toBe(true)
+
+    // A CONSUMER must not be flagged.
+    expect(
+      declaresUiVocabulary(`if (s === 'ideate') return 1\nif (s === 'evaluate') return 2`),
+      'separate comparisons are consumption, not declaration',
+    ).toBe(false)
+    // A docblock must not be flagged.
+    expect(declaresUiVocabulary(`/** 'frame' | 'ideate' | 'optimise' */\nconst x = 1`)).toBe(false)
+    // ⭐ THE HOMOGRAPH. `HelpType` is a real declaration in this repo containing
+    // `'evaluate'`; it is NOT a stage vocabulary and must never be flagged.
+    expect(
+      declaresUiVocabulary(`type HelpType = 'clarify' | 'broaden' | 'challenge' | 'evaluate' | 'commit'`),
+      'a homograph is not a vocabulary',
+    ).toBe(false)
+  })
+
+  it('CONTROLS FOR THE COMPARISON-CHAIN SHAPE — the one the first version of this guard missed', () => {
+    // ⚠ This block exists because a mutant SURVIVED. Restoring `isStage`'s
+    // hand-spelled union left every assertion in this file green: the guard
+    // could see a re-declaration written as a LIST and was blind to the same
+    // re-declaration written as a `||` CHAIN. A survivor is a claim, and this
+    // one was not equivalent — it was the real defect's actual shape.
+    expect(
+      declaresWireVocabulary(
+        `return v === 'frame' || v === 'analyse' || v === 'decide' || v === 'review'`,
+      ),
+      'the exact pre-fix `isStage` body must be caught',
+    ).toBe(true)
+    expect(
+      declaresUiVocabulary(
+        `return s === 'frame' || s === 'ideate' || s === 'evaluate' || s === 'optimise'`,
+      ),
+    ).toBe(true)
+
+    // CONTRAST — a two-way check is legitimate consumption and must NOT be
+    // flagged. This is where the threshold sits, stated so a reader can argue
+    // with it rather than discover it.
+    expect(
+      declaresWireVocabulary(`if (stage === 'analyse' || stage === 'decide') return true`),
+      'a two-way stage check is consumption, not a re-declaration',
+    ).toBe(false)
+    expect(declaresWireVocabulary(`if (stage === 'analyse') return true`)).toBe(false)
+  })
+})
+
+describe('the ONE edge is TOTAL in both directions', () => {
+  const UI_STAGES: readonly ScenarioStage[] = ['frame', 'ideate', 'evaluate', 'decide', 'optimise']
+
+  it('every canonical stage maps to a UI stage', () => {
+    // Derived by iterating the CONTRACT, so a member added in a re-vendor REDs
+    // here instead of silently returning null into the canvas store — which is
+    // a value `scenarios.stage`'s CHECK constraint would reject.
+    for (const stage of Stage.options) {
+      expect(v5StageToScenarioStage(stage), `no UI stage for canonical \`${stage}\``).not.toBeNull()
+    }
+  })
+
+  it('every UI stage maps to a canonical stage', () => {
+    for (const stage of UI_STAGES) {
+      expect(Stage.options).toContain(scenarioStageToV5Stage(stage))
+    }
+  })
+
+  it('the UI list this file iterates IS the declared type (no third list smuggled in)', () => {
+    // ⚠ The two arrays above are the one hand-maintained thing left here, and a
+    // hand-maintained list is what this whole file exists to abolish. It cannot
+    // be derived — `ScenarioStage` is a TYPE, with no runtime members — so it is
+    // pinned instead: each member must round-trip through the edge, which is
+    // impossible for a value the edge's `Record<ScenarioStage, …>` does not key.
+    // A member added to the type without being added here therefore REDs at the
+    // exhaustiveness of that Record, at COMPILE time, not silently at runtime.
+    for (const stage of UI_STAGES) {
+      const canonical = scenarioStageToV5Stage(stage)
+      expect(v5StageToScenarioStage(canonical)).not.toBeNull()
+    }
+    expect(new Set(UI_STAGES).size, 'duplicate member in the UI list').toBe(UI_STAGES.length)
+  })
+
+  it('the mapping is LOSSY in exactly one place, and it is named', () => {
+    // `frame` and `ideate` both map to canonical `frame`, so the inverse cannot
+    // recover `ideate`. That is a real property of the edge, and pinning it
+    // stops a later reader "fixing" the asymmetry into a round-trip the wire
+    // cannot support — `ideate` has no canonical counterpart to carry it.
+    expect(scenarioStageToV5Stage('frame')).toBe('frame')
+    expect(scenarioStageToV5Stage('ideate')).toBe('frame')
+    expect(v5StageToScenarioStage('frame')).toBe('frame')
+    // Every other UI stage DOES round-trip — the contrast that makes the line
+    // above a statement about `ideate` and not about the mapper generally.
+    for (const stage of ['evaluate', 'decide', 'optimise'] as const) {
+      expect(v5StageToScenarioStage(scenarioStageToV5Stage(stage))).toBe(stage)
+    }
+  })
+})

--- a/src/v5/__tests__/typedChipProducers.seam.spec.ts
+++ b/src/v5/__tests__/typedChipProducers.seam.spec.ts
@@ -234,10 +234,13 @@ describe('typed coaching intents — mounted spark → chip.intent on the wire',
    * Every mounted spark that declares a typed wire intent, read from the
    * registry and DEDUPED BY ID.
    *
-   * The dedupe is not tidiness — `SPARK_PROMPTS` ALIASES two `ACTIONS_MENU`
-   * entries (`pressure_test_frame`, `widen_options`) so one affordance has two
-   * mount points. Without the dedupe the contrast assertion below reported the
-   * same spark twice and read as a registry defect. One affordance, one row.
+   * The dedupe is not tidiness — `SPARK_PROMPTS` ALIASES five `ACTIONS_MENU`
+   * entries via `fromActionsMenu` (`widen_options`, `pre_mortem`,
+   * `calibrate_estimates`, `pressure_test_frame`, `risks_upside`), so five
+   * affordances each have two mount points; only `define_success` and
+   * `reflect_bias` are declared inline with no menu counterpart. Without the
+   * dedupe the contrast assertion below reported the same spark twice and read
+   * as a registry defect. One affordance, one row.
    */
   const declaringSparks = [...new Map(
     [...ACTIONS_MENU, ...Object.values(SPARK_PROMPTS)]
@@ -249,7 +252,13 @@ describe('typed coaching intents — mounted spark → chip.intent on the wire',
     // Trap 13: `it.each` over an empty array reports ZERO tests and a GREEN
     // suite. The count is asserted by name so an emptied registry REDs here
     // rather than silently deleting the coverage below.
-    expect(declaringSparks.length).toBeGreaterThanOrEqual(7)
+    //
+    // EXACT, not a floor: six ACTIONS_MENU entries declare an intent
+    // (`compare_view` and `prepare_first_analysis` declare `null`) and two
+    // panel-only sparks add `define_success` and `reflect_bias` — eight after
+    // the dedupe. A `>=` floor cannot see a spark that LOSES its intent while
+    // another gains one, which is the drift this assertion exists to catch.
+    expect(declaringSparks.length).toBe(8)
   })
 
   it.each(declaringSparks.map(s => [s.id, s.intent] as const))(
@@ -260,13 +269,13 @@ describe('typed coaching intents — mounted spark → chip.intent on the wire',
       if (accepted) {
         expect(
           body.chip?.intent,
-          `\${sparkId} declares an ACCEPTED intent but it did not reach the wire — ` +
+          `${sparkId} declares an ACCEPTED intent but it did not reach the wire — ` +
             'the chip has degraded to anonymous prose, which is the defect this closes',
         ).toBe(intent)
       } else {
         expect(
           body.chip && 'intent' in body.chip,
-          `\${sparkId} declares \${intent}, which CEE does not route — sending it would ` +
+          `${sparkId} declares ${intent}, which CEE does not route — sending it would ` +
             'claim a capability the deployed service does not have',
         ).toBe(false)
       }

--- a/src/v5/__tests__/typedChipProducers.seam.spec.ts
+++ b/src/v5/__tests__/typedChipProducers.seam.spec.ts
@@ -18,7 +18,8 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { OrchestratorTurnPayloadSchema } from '@talchain/schemas/boundary'
 
 import { buildChipMeta, type ChipMetaInput } from '../../canvas/conversation/chipMeta'
-import { buildV5Payload, type BuildV5PayloadInput } from '../buildPayload'
+import { CEE_ACCEPTED_INTENTS, buildV5Payload, type BuildV5PayloadInput } from '../buildPayload'
+import { ACTIONS_MENU, SPARK_PROMPTS } from '../../canvas/components/pre-analysis-v3/constants'
 import { callV5Turn } from '../v5Adapter'
 import {
   buildSetFactorValueParameters,
@@ -188,14 +189,111 @@ describe('first-class chip.id lift + intent send gate', () => {
     expect(body.chip?.id).toBe('explicit')
   })
 
-  it('WITHHOLDS a not-yet-accepted intent (challenge_frame) — no intent key on the wire', async () => {
+  it('WITHHOLDS a not-yet-accepted intent (pre_mortem) — no intent key on the wire', async () => {
+    // `pre_mortem` is PUBLISHED in the vendored enum and DECLARED by a mounted
+    // spark, and CEE has no arm for it — so the gate must still fail closed and
+    // the chip behave like an identity-only chip. (This case used to be
+    // `challenge_frame`; that intent is now routed, so the withhold arm moved
+    // to an intent that is genuinely unrouted rather than being deleted.)
     const body = await wireBody(
-      { intent: 'challenge_frame', parameters: { spark_id: 'frame_1' } },
+      { intent: 'pre_mortem', parameters: { spark_id: 'pre_mortem' } },
       'chip',
     )
-    // The gate fails closed: the chip behaves like an identity-only chip.
     expect(body.chip && 'intent' in body.chip).toBe(false)
-    expect(body.chip?.id).toBe('frame_1')
-    expect(body.chip?.parameters).toEqual({ spark_id: 'frame_1' })
+    expect(body.chip?.id).toBe('pre_mortem')
+    expect(body.chip?.parameters).toEqual({ spark_id: 'pre_mortem' })
+  })
+})
+
+/**
+ * ⭐⭐ THE PRODUCER→WIRE CHAIN FOR A TYPED COACHING INTENT — the capability this
+ * lane exists to deliver, asserted on the ACTUAL HTTP BODY.
+ *
+ * ── THE DEFECT ───────────────────────────────────────────────────────────────
+ * `CEE_ACCEPTED_INTENTS` had exactly ONE member. Four MOUNTED sparks carry
+ * `action_type: null` (no honest handler exists for a conversation) and, until
+ * now, carried nothing else either — so the click reached CEE as anonymous
+ * prose and CEE re-inferred the intent from the message text. On the widening
+ * card the fall-through was worse than silent: the turn took the free-text edit
+ * lane, came back a REFUSAL, and the recovery chips replaced the row that held
+ * `Run analysis` (ROADMAP 2.1288, DOM-witnessed 2/2 on 17 Aug). The user
+ * accepted the product's own suggestion and paid for it with their ability to
+ * run.
+ *
+ * ── DERIVED FROM THE REGISTRY, NEVER FROM A HAND-TYPED LIST ──────────────────
+ * The cases below are built by READING the mounted spark registry
+ * (`ACTIONS_MENU` / `SPARK_PROMPTS`) and filtering to the sparks that declare an
+ * intent. A test that hand-typed `'challenge_frame'` would pass while the spark
+ * a user actually clicks declared something else, or nothing at all — the exact
+ * gap that let four mounted affordances sit untyped for weeks. Here, unmount a
+ * spark or drop its intent and this suite stops covering it AND the count
+ * assertion REDs.
+ */
+describe('typed coaching intents — mounted spark → chip.intent on the wire', () => {
+  /**
+   * Every mounted spark that declares a typed wire intent, read from the
+   * registry and DEDUPED BY ID.
+   *
+   * The dedupe is not tidiness — `SPARK_PROMPTS` ALIASES two `ACTIONS_MENU`
+   * entries (`pressure_test_frame`, `widen_options`) so one affordance has two
+   * mount points. Without the dedupe the contrast assertion below reported the
+   * same spark twice and read as a registry defect. One affordance, one row.
+   */
+  const declaringSparks = [...new Map(
+    [...ACTIONS_MENU, ...Object.values(SPARK_PROMPTS)]
+      .filter((s): s is typeof s & { intent: string } => typeof s.intent === 'string' && s.intent.length > 0)
+      .map(s => [s.id, s] as const),
+  ).values()]
+
+  it('the registry declares intents at all — the sweep is not empty', () => {
+    // Trap 13: `it.each` over an empty array reports ZERO tests and a GREEN
+    // suite. The count is asserted by name so an emptied registry REDs here
+    // rather than silently deleting the coverage below.
+    expect(declaringSparks.length).toBeGreaterThanOrEqual(7)
+  })
+
+  it.each(declaringSparks.map(s => [s.id, s.intent] as const))(
+    'spark %s declares intent %s — and the gate decides, not the declaration',
+    async (sparkId, intent) => {
+      const body = await wireBody({ intent, parameters: { spark_id: sparkId } }, 'chip')
+      const accepted = CEE_ACCEPTED_INTENTS.has(intent as never)
+      if (accepted) {
+        expect(
+          body.chip?.intent,
+          `\${sparkId} declares an ACCEPTED intent but it did not reach the wire — ` +
+            'the chip has degraded to anonymous prose, which is the defect this closes',
+        ).toBe(intent)
+      } else {
+        expect(
+          body.chip && 'intent' in body.chip,
+          `\${sparkId} declares \${intent}, which CEE does not route — sending it would ` +
+            'claim a capability the deployed service does not have',
+        ).toBe(false)
+      }
+      // Identity travels either way, so an unrouted spark is no worse off than
+      // before this lane.
+      expect(body.chip?.id).toBe(sparkId)
+    },
+  )
+
+  it('CONTRAST — at least one spark is SENT and at least one is WITHHELD', () => {
+    // ⭐ Without this the it.each above is satisfied by a build where the gate
+    // accepts EVERYTHING (every branch takes the `accepted` arm) or accepts
+    // NOTHING (every branch takes the withhold arm). Neither would be caught by
+    // a per-case assertion, because each case would still agree with itself.
+    const sent = declaringSparks.filter(s => CEE_ACCEPTED_INTENTS.has(s.intent as never))
+    const withheld = declaringSparks.filter(s => !CEE_ACCEPTED_INTENTS.has(s.intent as never))
+    expect(sent.map(s => s.id).sort()).toEqual(
+      ['define_success', 'pressure_test_frame', 'reflect_bias', 'widen_options'],
+    )
+    expect(withheld.length, 'no spark is withheld — the gate has been opened wholesale').toBeGreaterThan(0)
+  })
+
+  it('a composer turn carrying the same intent value still sends it — the gate is not source-scoped', async () => {
+    // The gate is about the VALUE, not the surface. Pinned so a future
+    // source-scoped narrowing is a deliberate, visible change rather than a
+    // silent one.
+    const body = await wireBody({ intent: 'challenge_frame', parameters: { spark_id: 'x' } }, 'chip_click')
+    expect(body.chip?.intent).toBe('challenge_frame')
   })
 })

--- a/src/v5/applyV5State.ts
+++ b/src/v5/applyV5State.ts
@@ -45,7 +45,7 @@
  * mutations are property assignments keyed by target_id.
  */
 import type { OlumiResponse, StageType, AnalysisStateV1 } from '@talchain/schemas/boundary'
-import { AnalysisStateV1Schema } from '@talchain/schemas/boundary'
+import { AnalysisStateV1Schema, Stage } from '@talchain/schemas/boundary'
 import type { Edge, Node } from '@xyflow/react'
 
 import type { ReportV1 } from '../adapters/plot/types'
@@ -498,10 +498,24 @@ export interface ApplyV5StateOptions {
   currentClientTurnId?: string | null
 }
 
+/**
+ * ⭐ DERIVED FROM THE CONTRACT, NOT RE-DECLARED.
+ *
+ * This predicate used to spell the canonical vocabulary out by hand:
+ * `v === 'frame' || v === 'analyse' || v === 'decide' || v === 'review'`. That
+ * is a FOURTH declaration of a set the shared schema already owns and
+ * explicitly instructs consumers to derive from — and it is the drift shape
+ * this estate keeps paying for, because it is a hand-maintained mirror that
+ * reads GREEN while it is wrong: a member added to `Stage` in a re-vendor would
+ * simply be rejected here, silently, as "no stage signal".
+ *
+ * `Stage` is a Zod enum, so `safeParse` IS the membership test. There is
+ * nothing left to keep in sync.
+ */
 function isStage(s: string | { stage?: string } | undefined): s is StageType {
   if (!s) return false
   const v = typeof s === 'string' ? s : s.stage
-  return v === 'frame' || v === 'analyse' || v === 'decide' || v === 'review'
+  return Stage.safeParse(v).success
 }
 
 function normaliseStage(

--- a/src/v5/blocks/ActionChip.tsx
+++ b/src/v5/blocks/ActionChip.tsx
@@ -50,8 +50,20 @@ export interface ActionChipProps {
   /** DOM test id for the chip. */
   testId: string
   /**
-   * Producer's `action_intent`. A machine token: it rides as a data-*
-   * attribute for downstream readers and is NEVER rendered as copy.
+   * Producer's `action_intent` — a machine token, NEVER rendered as copy.
+   *
+   * ⚠⚠ IT USED TO RIDE ONLY AS A `data-*` ATTRIBUTE, AND THAT WAS THE WHOLE
+   * DEFECT. CEE's widening card authors `action_intent: 'add_option'`; CEE's
+   * add-option rail fires on `ingress.chip?.intent === 'add_option'`
+   * (`route-v2.ts:2819`); and this component — the one that RENDERS that card's
+   * chip — called `sendChip(label, message)` with no third argument. The
+   * producer's typed intent reached the DOM and stopped there. So the user
+   * clicked a chip the product itself had offered, the turn fell through to the
+   * free-text edit lane, and it came back a refusal (ROADMAP 2.1288,
+   * DOM-witnessed 2/2 on 17 Aug) — at the cost of the Run affordance, because
+   * the recovery chips replaced the row.
+   *
+   * The transport was never a missing handler. It was this argument.
    */
   intent?: string
 }
@@ -67,9 +79,14 @@ export function ActionChip({ label, message, testId, intent }: ActionChipProps):
     if (settled) return
     // Fail closed WITHOUT acknowledging (see header).
     if (!sendChip) return
-    sendChip(label, message)
+    // The producer's typed intent travels as chip META, not just as a DOM
+    // attribute. `buildV5Payload`'s send gate
+    // (`KNOWN_INTENTS ∧ CEE_ACCEPTED_INTENTS`) still decides whether it reaches
+    // the wire and still fails CLOSED, so this can only ever forward an intent
+    // the PRODUCER declared and the deployed CEE routes.
+    sendChip(label, message, intent ? { intent } : undefined)
     setSettled(true)
-  }, [settled, sendChip, label, message])
+  }, [settled, sendChip, label, message, intent])
 
   return (
     <button

--- a/src/v5/blocks/__tests__/V5CoachingActionChip.spec.tsx
+++ b/src/v5/blocks/__tests__/V5CoachingActionChip.spec.tsx
@@ -98,7 +98,9 @@ describe('V5CoachingBlock — action chip dispatch (2.225)', () => {
     expect(sendChip).toHaveBeenCalledTimes(1)
     // label = what the chip DISPLAYS; message = what is SENT. Both producer
     // copy, neither templated, interpolated or appended to.
-    expect(sendChip).toHaveBeenCalledWith('Confirm this assumption', PRODUCER_PROMPT)
+    expect(sendChip).toHaveBeenCalledWith('Confirm this assumption', PRODUCER_PROMPT, {
+      intent: 'confirm_factor',
+    })
     const [, message] = sendChip.mock.calls[0] as [string, string]
     expect(message).toBe(PRODUCER_PROMPT)
     // Guard against a composed message that merely CONTAINS the producer text.
@@ -115,7 +117,10 @@ describe('V5CoachingBlock — action chip dispatch (2.225)', () => {
     await user.tab()
     expect(screen.getByTestId('v5-coaching-action')).toHaveFocus()
     await user.keyboard('{Enter}')
-    expect(sendChip).toHaveBeenCalledWith('Re-run analysis', PRODUCER_PROMPT)
+    // No `action_intent` on this block, so no meta — the third argument is
+    // `undefined`, not an empty object. A producer that declared nothing must
+    // not have something invented on its behalf.
+    expect(sendChip).toHaveBeenCalledWith('Re-run analysis', PRODUCER_PROMPT, undefined)
   })
 
   it('fires at most once — a settled chip does not re-send', async () => {
@@ -193,5 +198,82 @@ describe('V5CoachingBlock — fail-closed semantics (2.225)', () => {
     await user.click(action)
     expect(action).not.toBeDisabled()
     expect(action).not.toHaveAttribute('data-settled')
+  })
+})
+
+/**
+ * ⭐⭐ THE TRANSPORT THE BANKED BRANCH LEFT OPEN — and the one that carries the
+ * motivating defect.
+ *
+ * ROADMAP 2.1288: CEE's widening card authors `action_intent: 'add_option'`
+ * (`draft-option-widening-blocks.ts:720`); CEE's add-option rail fires on
+ * `ingress.chip?.intent === 'add_option'` (`route-v2.ts:2819`); and this
+ * component — the one that RENDERS that card's chip — called
+ * `sendChip(label, message)` with NO third argument. The producer's typed
+ * intent reached the DOM as `data-action-intent` and stopped there.
+ *
+ * ⚠ WHY THIS FILE AND NOT THE STORE'S. The typed-intent branch added
+ * `SendChipMeta.intent` and the `ConversationPanel` forward, so the TYPE layer
+ * was complete and a type-level test would have passed. The value still never
+ * left the component, because the caller passed no meta at all. A field that
+ * exists and is never populated is indistinguishable, from the type's point of
+ * view, from one that works — which is why this is asserted at the CALL, on a
+ * rendered click, and not on the interface.
+ */
+describe('V5CoachingBlock — the producer\'s typed intent leaves the component (2.1288)', () => {
+  let sendChip: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    sendChip = vi.fn()
+    useGuidanceStore.setState({ _sendChip: sendChip })
+  })
+
+  it('forwards `action_intent` as chip META, not only as a DOM attribute', async () => {
+    const user = userEvent.setup()
+    render(
+      <V5CoachingBlock
+        block={{
+          ...BASE,
+          coaching_kind: 'widening',
+          action_intent: 'add_option',
+          action_label: 'Add this option',
+          action_prompt: PRODUCER_PROMPT,
+        }}
+      />,
+    )
+    const chip = screen.getByTestId('v5-coaching-action')
+
+    // The DOM attribute is the PRE-FIX behaviour, still correct and still
+    // present. Asserted here so the test cannot be satisfied by moving the
+    // value rather than by also transporting it.
+    expect(chip).toHaveAttribute('data-action-intent', 'add_option')
+
+    await user.click(chip)
+
+    expect(sendChip).toHaveBeenCalledTimes(1)
+    const [, , meta] = sendChip.mock.calls[0] as [string, string, { intent?: string } | undefined]
+    expect(
+      meta?.intent,
+      'the widening card\'s intent did not leave the component — the click will take ' +
+        'the free-text edit lane and come back a refusal, at the cost of the Run affordance',
+    ).toBe('add_option')
+  })
+
+  it('CONTRAST — a card with NO action_intent sends no meta at all', async () => {
+    // The discriminating half. Without it, the assertion above is satisfied by
+    // a build that stamps some intent on every chip; with it, the value is
+    // provably the PRODUCER'S and not the UI's invention.
+    const user = userEvent.setup()
+    render(
+      <V5CoachingBlock
+        block={{ ...BASE, action_label: 'Add this option', action_prompt: PRODUCER_PROMPT }}
+      />,
+    )
+    const chip = screen.getByTestId('v5-coaching-action')
+    expect(chip).not.toHaveAttribute('data-action-intent')
+
+    await user.click(chip)
+    const [, , meta] = sendChip.mock.calls[0] as [string, string, unknown]
+    expect(meta, 'the UI must never author an intent the producer did not declare').toBeUndefined()
   })
 })

--- a/src/v5/buildPayload.ts
+++ b/src/v5/buildPayload.ts
@@ -1003,15 +1003,36 @@ export const KNOWN_INTENTS: ReadonlySet<IntentLiteral> = new Set<IntentLiteral>(
  *   atomic held proposal via add-option-transaction.ts; an incomplete/absent
  *   `chip.parameters` falls through benignly to the coach (never a 422).
  *
- * NOT yet listed (deliberately withheld): the coaching / elicitation intents
- * (`elicit_options`, `challenge_frame`, `challenge_assumption`, `outside_view`,
- * `pre_mortem`, `elicit_risks`, `estimate_help`, `mitigation_help`,
- * `define_success`, `discuss`). Their typed CEE routing arm (design §3.1) is not
- * confirmed on the deployed service; the registry-stamping lane adds them here
- * WITH deploy provenance, in lockstep with the CEE coaching-arm deploy.
+ * - challenge_frame, define_success, elicit_options, challenge_assumption:
+ *   CEE's TYPED COACHING ARM (`orchestrator-v5/coaching/typed-intent-directive.ts`),
+ *   which appends a method directive to the routing turn so the coach authors
+ *   the answer with the named method in front of it. These four are listed
+ *   together because they are exactly the four MOUNTED affordances that were
+ *   degrading to generic free prose — `pressure_test_frame`, `define_success`,
+ *   `widen_options` and `reflect_bias`, all of which carry `action_type: null`
+ *   because no honest handler exists for a conversation.
+ *
+ *   ⚠⚠ DEPLOY ORDER IS LOAD-BEARING AND THIS ENTRY IS THE SECOND HALF. CEE's
+ *   arm must be MERGED AND DEPLOYED BEFORE this list grows, because listing an
+ *   intent here is precisely the claim "the deployed service routes this". On
+ *   an OLD CEE, a new UI sending these four is not a 422 — CEE's ingress
+ *   accepts any published `Intent` and simply finds no arm, so the turn behaves
+ *   exactly as it does today (free prose). The cost of getting the order wrong
+ *   is therefore a silent no-op, not a break; but the LIST WOULD BE LYING in
+ *   the interval, and this registry's whole value is that it does not.
+ *
+ * NOT yet listed (deliberately withheld): the remaining coaching / elicitation
+ * intents (`outside_view`, `pre_mortem`, `elicit_risks`, `estimate_help`,
+ * `mitigation_help`, `discuss`). Several sparks now DECLARE these — the
+ * declaration is deliberate and the gate is what withholds them, so each lights
+ * up with zero further UI change the moment CEE routes it.
  */
 export const CEE_ACCEPTED_INTENTS: ReadonlySet<IntentLiteral> = new Set<IntentLiteral>([
   'add_option',
+  'challenge_frame',
+  'define_success',
+  'elicit_options',
+  'challenge_assumption',
 ])
 
 function sanitiseIntent(raw: string | undefined): IntentLiteral | undefined {

--- a/src/v5/buildPayload.ts
+++ b/src/v5/buildPayload.ts
@@ -1037,7 +1037,29 @@ export const CEE_ACCEPTED_INTENTS: ReadonlySet<IntentLiteral> = new Set<IntentLi
 
 function sanitiseIntent(raw: string | undefined): IntentLiteral | undefined {
   if (!raw) return undefined
-  return isSendableToken(raw, KNOWN_INTENTS, CEE_ACCEPTED_INTENTS)
-    ? (raw as IntentLiteral)
-    : undefined
+  if (isSendableToken(raw, KNOWN_INTENTS, CEE_ACCEPTED_INTENTS)) return raw as IntentLiteral
+
+  /**
+   * ⭐ OBSERVABILITY ONLY — the gate's BEHAVIOUR is unchanged and the `intent`
+   * key stays omitted from the payload exactly as before.
+   *
+   * WHY THIS EXISTS: a declared intent that failed the gate used to disappear
+   * with no trace anywhere, and that SILENCE is the mechanism that made the
+   * original defect invisible — nothing in a dev session distinguished "this
+   * chip declared no intent" from "this chip declared one and the gate dropped
+   * it", so four mounted affordances degraded to anonymous prose for weeks with
+   * every signal reading healthy. A withheld intent is a legitimate, expected
+   * state; it simply must not be a SECRET one.
+   *
+   * The `!raw` early return above means this can only fire for a NON-EMPTY
+   * declared string. The ordinary no-intent turn — the overwhelming majority —
+   * returns before reaching here and never logs.
+   */
+  if (import.meta.env.DEV) {
+    console.warn(
+      `[v5] chip.intent "${raw}" withheld from the wire — not in CEE_ACCEPTED_INTENTS. ` +
+        'The send gate dropped it; the chip still travels with its identity.',
+    )
+  }
+  return undefined
 }


### PR DESCRIPTION
**Domain 10 — Strategic Reasoning. Branch + review only; do not merge.**
UI half of **CEE #1042**. Builds on the banked `feat/typed-coaching-intent-arm` and **closes the transport gap that branch left open**.

## ⚠⚠ The banked branch did not actually close the motivating defect

It added `SendChipMeta.intent` and the `ConversationPanel` forward, so the **type layer** was complete — and **`ActionChip.tsx:70` still called `sendChip(label, message)` with no third argument**. That component renders CEE's widening card chip. So `action_intent` reached the DOM as `data-action-intent` and **stopped there**: exactly the hop ROADMAP 2.1288 names (`draft-option-widening-blocks.ts:720` authors it, `route-v2.ts:2819` requires it, nothing carried it between them).

A field that exists and is never populated is, from the type's point of view, **indistinguishable from one that works**. That is why the test for it is on a **rendered click**, not on the interface.

## What a user gets

Four **mounted** sparks — `pressure_test_frame`, `define_success`, `widen_options`, `reflect_bias` — carry `action_type: null` because no honest handler exists for a conversation. Their typed intent now reaches `chip.intent` on the wire, so CEE's arm can route them instead of re-inferring intent from prose. The card-hosted path (the widening card) works too.

The gate still **fails closed** and is still two-signal: `outside_view`, `pre_mortem`, `elicit_risks`, `estimate_help` are **declared and withheld**, because CEE does not route them. Listing an intent is the claim *"the deployed service routes this"* — so `CEE_ACCEPTED_INTENTS` grows only in lockstep with CEE's arm.

## Stage convergence: two more spellings removed

Beyond the three known vocabularies, the UI carried **two further declarations**, both hand-maintained mirrors:

- **`applyV5State.isStage`** hand-spelled the **canonical** union (`v === 'frame' || 'analyse' || 'decide' || 'review'`) — a fourth declaration of a set the shared schema owns and explicitly says to derive from. It reads **green while being wrong**: a member added in a re-vendor would be silently rejected as *"no stage signal"*. Now `Stage.safeParse`.
- **`guidanceEvents.profile_stage`** declared the UI union **minus `optimise`** — a fifth spelling, and a wrong one. Every writer reads `store.currentStage` (a full `ScenarioStage`), so **five call sites cast** to satisfy it and an `optimise` value shipped as an off-type string the declaration says cannot occur. *A type narrower than its only source is not a constraint; it is a lie with casts holding it up.* Derived from `ScenarioStage`; all five casts deleted.

Canonical is `Stage`/`StageType`. `ScenarioStage` survives behind **one** named edge, `src/v5/stageMapper.ts`. The guard pins one declaration per vocabulary, one edge, no fourth — and, the part a sweep cannot give you, that **the edge is total in both directions**, derived by iterating the contract so a re-vendor REDs here rather than silently writing `null` into a store column whose CHECK constraint would reject it.

## Verification

**Mutants — 5/5 bite** (applied-check ≥1 file each, restore clean each time, trailing control green). Isolation proven by **writing a sentinel** into the throwaway worktree and asserting the source was unchanged, not by locating the path.

| Mutant | Expected RED | Result |
|---|---|---|
| **U1 revert the `CEE_ACCEPTED_INTENTS` widening** (the brief's named mutant) | intent gate + seam | 3 tests RED across 2 files |
| U2 `ActionChip` stops forwarding the intent (the gap, restored) | chip transport | 3 tests RED |
| U3 `isStage` hand-spelled again | convergence | RED — **see below** |
| U4 a spark's declared intent dropped | seam contrast | RED |
| U5 the edge stops being total | mapper + convergence | 5 tests RED |

### ⚠ U3 SURVIVED the first round, and the fix is the most useful thing here

Restoring `isStage`'s hand-spelled union left the suite **entirely green**. The guard bound "a declaration" to a **list shape** (members separated by `|` or `,`) and was blind to the same re-declaration written as a **`||` comparison chain** — which is the form the real defect actually took. A survivor is a claim either way, and this one was **not equivalent**.

The predicate now catches both shapes, with the threshold at **three** members and the reasoning stated in the test: a two-way check (`stage === 'analyse' || stage === 'decide'`) is legitimate consumption and must not be flagged, so a reader can argue with the line rather than discover it. Both readings are pinned by controls. **The gap was found by mutation, not by reading.**

### Controls, each one differing from the others

- at least one spark **sent** and at least one **withheld** — so the per-case assertions cannot all be satisfied by a gate that accepts (or rejects) everything;
- a card with **no** `action_intent` sends **no** meta — so the transport assertion is provably about the producer's value, not a UI invention;
- the sweep must read **>500 files** and positively identify the one legitimate declaring file — an empty offender list is otherwise indistinguishable from a mis-rooted sweep;
- `HelpType = … | 'evaluate' | …` must **not** be flagged. A **homograph is not a vocabulary**, and sweeping on `evaluate` would have produced a false positive on a file this ruling has no business touching.

Cases are derived by **reading the mounted spark registry**, never a hand-typed intent list — a test spelling `'challenge_frame'` itself would pass while the spark a user clicks declared nothing, which is exactly how four mounted affordances sat untyped.

Two things measured rather than assumed: the registry **aliases** `pressure_test_frame` and `widen_options` across `ACTIONS_MENU` and `SPARK_PROMPTS` (first contrast assertion reported one spark twice — deduped by id); and the existing `intentGate` spec used `.has()` spot checks, which **cannot see an entry that should not be there** — replaced with `toEqual` on the whole set.

Local: typecheck gate **PASSED**, drift **shrank** 2272 → 2263 (9 fixed, none added — attributable to the removed casts and the derived predicate); eslint **0 errors** on every touched path; 7 touched specs **183/183**, collected counts verified **by name**.

## Findings, not fixed here (reported rather than crossed into)

- **`ChatThread.tsx:207` renders only the LAST assistant message's `actionChips`**, so any new assistant message wholesale replaces the previous turn's chip row. That is the UI-side mechanism by which a refusal turn takes away `Run analysis`. Out of scope here; the Run-affordance assertion lives at CEE (#1042), where the executor is the only party that can put the affordance in the payload.
- **`setStage` is dead.** `scenarioService.setStage` → `useScenario.setStage` → the `set_stage_and_log` RPC has **zero product call sites** (contrast control: seven sibling mutators return 1–3 each). So `scenarios.stage` is written exactly once, as the literal `'frame'` at insert — **the hub badge reads "Frame" for every scenario, forever**, and the Journey timeline collapses to a single "Frame" group. The RPC also holds a **second** copy of the five-member guard list. Deleting it is a capability question, not a convergence one.
- **`scenarioStageToV5Stage` is exported with no product callers** outside its own module (only `deriveV5Stage` uses it). Making it private would move `stageMapper.test.ts`; left alone.
