### PR TITLE
fix(analysis): the Analyse control stops refusing a model the producer just called ready — and the chat stops swallowing the click

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -156,6 +156,10 @@ import { verboseDebug } from '../../utils/verboseLog'
 import { AnalysisFooter } from '../shared/AnalysisFooter'
 import { derivePostFooterStatus, derivePostFooterMeta } from './utils/postAnalysisFooter'
 import { useGraphReadiness } from '../hooks/useGraphReadiness'
+import {
+  selectAnalysisReadinessAuthority,
+  useAnalysisReadinessAuthority,
+} from '../state/analysisStateSelector'
 // ROADMAP 2.635 (I-4) — read at DISPATCH time, not via a render-scope selector:
 // the whole point of the licence barrier is to see the store as it is when the
 // run actually goes out, not as it was when the gate was computed.
@@ -1081,6 +1085,12 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   // ROADMAP 2.635 — `stale` feeds the gate's COPY (I-3) and `verdictAtMs`
   // identifies WHICH verdict licensed a run (I-4).
   const { readiness, stale: readinessStale, verdictAtMs: readinessVerdictAtMs } = useGraphReadiness()
+  // ⭐ The CANONICAL readiness authority — `analysis_state.readiness`, stated by
+  // the producer on the turn. Read beside the side-car verdict deliberately: the
+  // two used to be one name with two meanings, and seeing them on adjacent lines
+  // is the cheapest possible reminder of which one decides. `canRunAnalysis`
+  // applies the precedence; this surface never does.
+  const analysisReadiness = useAnalysisReadinessAuthority()
 
   // C1 review: the orphan-banner footer suppression is GONE. It rested on a
   // premise that is false at this ref — it claimed the footer would carry
@@ -1144,6 +1154,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   const runGateResult = canRunAnalysisUtil({
     graphHealth: graphHealth ?? null,
     readiness,
+    analysisReadiness,
     hasBlockers: hasValidationBlockers,
     nodeCount: nodes.length,
     isRunning,
@@ -1220,12 +1231,22 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     // `readinessObjectsToRun`, the gate's own rung predicate, so there is still
     // exactly one definition of what a readiness objection is (I-5).
     const licenceAtDispatch = useReadinessStore.getState()
+    // Re-read at DISPATCH time, not closed over from render: the flush above is
+    // a real window and a fresh turn can land inside it. Reading the render-time
+    // value here would answer with a verdict the store may have already replaced.
+    const analysisReadinessAtDispatch = selectAnalysisReadinessAuthority(
+      useCanvasStore.getState().analysisStateV1,
+    )
     if (
       verdictLicenceSuperseded(licensedByVerdict, {
         verdictAtMs: licenceAtDispatch.verdictAtMs,
         stale: licenceAtDispatch.stale,
       }) &&
-      readinessObjectsToRun(licenceAtDispatch.readiness)
+      // ⭐ Same precedence at the barrier as at the gate. Without the second
+      // argument this asks the SIDE-CAR about a run the PRODUCER licensed, so a
+      // gate that correctly opened would be re-refused between the click and
+      // the wire — the silent-death class, re-created by omission.
+      readinessObjectsToRun(licenceAtDispatch.readiness, analysisReadinessAtDispatch)
     ) {
       console.warn('[OutputsDock] run licence superseded before dispatch', {
         licensedByVerdictAtMs: licensedByVerdict.verdictAtMs,

--- a/src/canvas/components/__tests__/OutputsDock.canonicalReadinessWiring.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.canonicalReadinessWiring.spec.tsx
@@ -1,0 +1,314 @@
+/**
+ * THE SENDABLE BLOCKER, REPRODUCED ON THE MOUNTED SURFACE AND KILLED THERE.
+ *
+ * ── THE CAPTURE THIS FILE IS BUILT FROM ────────────────────────────────────
+ * Frozen quartet, 19 Aug 2026, fresh guest, governed brief
+ * `04-conflicting-constraints`, 16-node model drafted successfully.
+ * `useCanvasStore.getState()` read:
+ *
+ *   analysisStateV1.readiness = { status: 'ready', blockers: [] }
+ *   analysisStateV1.run_state = { kind: 'never_run' }
+ *   ceeAnalysisReady.status   = 'ready'    (every option 'ready')
+ *
+ * …and `[data-testid="pre-analysis-v3-analyse"]` was DISABLED, titled
+ * *"Olumi needs something more from this model before the next analysis. Ask in
+ * the chat and it will explain what is missing."* The producer had just said
+ * nothing was missing. The product asserted an untruth about the user's own
+ * model, and the chat route it pointed at was itself silent.
+ *
+ * ── WHY A MOUNTED SPEC, WHEN THE GATE IS ALREADY PINNED PURE ───────────────
+ * `canonicalReadinessAuthority.spec.ts` proves `canRunAnalysis` answers
+ * correctly. It proves NOTHING about whether the dock asks it correctly — and
+ * this repo has the receipt: the sibling `OutputsDock.blockedReasonWiring.spec`
+ * exists because reverting the dock's wiring hunk alone left 268/268 tests green
+ * while the headline behaviour vanished. A pure-function fix nothing mounts is
+ * the estate's most familiar dark capability, and this IS the blocker, so the
+ * evidence has to reach the pixel the user cannot click.
+ *
+ * Every link here is live: canvas state → `useAnalysisReadinessAuthority`
+ * → `canRunAnalysis` → `getRunButtonTooltip` → the panel's `canRun` /
+ * `blockedReason` props → `PanelFooter`'s button. Nothing is injected as a prop.
+ *
+ * Scope (trap 3): the button's DISABLED state and its TITLE on the mounted
+ * footer. Not layout, not visibility, not above-the-fold.
+ *
+ * Trap 3b: `pre-analysis-v3-analyse` and `pre-analysis-v3-footer` are the ids
+ * the affordance sweep read off deployed builds, and `isPreAnalysisV3Enabled`
+ * is forced on below to mount the surface the deployment mounts.
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { beforeAll, beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+
+import { OutputsDock } from '../OutputsDock'
+import { ToastProvider } from '../../ToastContext'
+import { useCanvasStore } from '../../store'
+import { useReadinessStore } from '../../stores/readinessStore'
+import { clearInflightCache } from '../../hooks/useGraphReadiness'
+import { BLOCKED_REASON_COPY } from '../../utils/composeBlockedReason'
+import { FOOTER_COPY } from '../pre-analysis-v3/constants'
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) }
+})
+
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isTelemetryEnabled: () => false,
+    isJourneyTabEnabled: () => false,
+    isAiPanelV2Enabled: () => false,
+    isPreAnalysisV3Enabled: () => true,
+  }
+})
+
+vi.mock('../../conversation/useConversation', () => ({
+  useConversation: () => ({
+    messages: [],
+    isThinking: false,
+    longRunningHint: null,
+    sendMessage: vi.fn(),
+    sendSystemEvent: vi.fn(),
+    sendChip: vi.fn(),
+    retryLast: vi.fn(),
+    patchBlockStates: new Map(),
+    setPatchBlockState: vi.fn(),
+    patchRejections: new Map(),
+    setPatchRejection: vi.fn(),
+  }),
+}))
+
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Describe your decision…',
+}))
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * ⚠ NOT INVENTED. This is field-for-field the verdict `readinessStore`'s
+ * empty-canvas arm composes and then RETAINS across a failed refetch — five
+ * fields, no `goal_node_valid`, no `options_total`, no `scaffold_plan`. Those
+ * absences are exactly why `composeReadinessBlockedReason` falls through to
+ * `unspecified`, and therefore why the deployed tooltip read the way it did.
+ * A fixture outside the producer's output domain proves nothing (trap 16); this
+ * one is inside it.
+ */
+const SIDE_CAR_OBJECTS_WITHOUT_A_CAUSE = {
+  readiness_score: 0,
+  readiness_level: 'needs_work' as const,
+  can_run_analysis: false,
+  confidence_explanation: 'Add some nodes to get started',
+  improvements: [],
+}
+
+const OPTION_LABELS: Record<string, string> = {
+  opt_extend: 'Extend the free trial',
+  opt_hold: 'Hold the current price',
+  opt_bundle: 'Bundle onboarding in',
+}
+
+function analysisState(readiness: AnalysisStateV1['readiness']): AnalysisStateV1 {
+  return {
+    run_state: { kind: 'never_run' },
+    readiness,
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: false,
+    blocked_unusable: false,
+    contradictions: [],
+  } as AnalysisStateV1
+}
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+
+/** The captured canvas: a decision, a goal, three options, one factor. */
+function seedCapturedCanvas() {
+  const nodes = [
+    { id: 'd1', type: 'decision', position: { x: 0, y: 0 }, data: { kind: 'decision', label: 'How do we protect retention?' } },
+    { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { kind: 'goal', label: 'Grow retained revenue' } },
+    ...Object.entries(OPTION_LABELS).map(([id, label], i) => ({
+      id,
+      type: 'option',
+      position: { x: 10 * i, y: 0 },
+      data: { kind: 'option', label },
+    })),
+    { id: 'f1', type: 'factor', position: { x: 0, y: 0 }, data: { kind: 'factor', label: 'Support headcount' } },
+  ]
+  useCanvasStore.setState({
+    nodes: nodes as never,
+    edges: [{ id: 'e1', source: 'f1', target: 'g1', data: { weight: 0.5, direction: 'positive' } }] as never,
+    graphHealth: { status: 'healthy', score: 100, issues: [] },
+    hasCompletedFirstRun: false,
+    results: { status: 'idle', progress: 0 },
+    showDraftChat: false,
+    v5AnalysisFact: null,
+    analysisFreshness: null,
+    // The capture's value: the legacy slice agreed the model was ready. It is
+    // seeded so this test cannot pass merely because that slice was empty.
+    ceeAnalysisReady: {
+      goal_node_id: 'g1',
+      status: 'ready',
+      options: Object.keys(OPTION_LABELS).map((id) => ({ id, status: 'ready' })),
+    },
+  } as never)
+}
+
+/**
+ * Hold the side-car verdict in the store AND serve the identical body from the
+ * stubbed transport, so its own debounced refetch cannot swap the fixture out
+ * mid-assertion (the sibling spec's rule, and it is load-bearing here: the whole
+ * point is that this verdict OBJECTS throughout).
+ */
+function seedObjectingSideCar() {
+  clearInflightCache()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ ...SIDE_CAR_OBJECTS_WITHOUT_A_CAUSE }),
+      text: async () => '',
+      headers: new Headers(),
+    })),
+  )
+  useReadinessStore.setState({
+    readiness: SIDE_CAR_OBJECTS_WITHOUT_A_CAUSE,
+    loading: false,
+    error: null,
+    stale: false,
+    verdictAtMs: null,
+  })
+}
+
+beforeAll(async () => {
+  await import('../pre-analysis-v3')
+}, 30_000)
+
+beforeEach(() => {
+  ensureMatchMedia()
+  try { sessionStorage.clear() } catch { /* jsdom quirk */ }
+  seedObjectingSideCar()
+})
+
+afterEach(() => {
+  useReadinessStore.getState().reset()
+  useCanvasStore.setState({ analysisStateV1: null } as never)
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('the frozen capture, on the mounted control', () => {
+  it('AC1 — producer-ready with ZERO blockers: the Analyse control is ENABLED', async () => {
+    seedCapturedCanvas()
+    useCanvasStore.setState({
+      analysisStateV1: analysisState({ status: 'ready', blockers: [] }),
+    } as never)
+
+    render(
+      <ToastProvider>
+        <OutputsDock />
+      </ToastProvider>,
+    )
+
+    const analyse = await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
+    expect(analyse).toBeEnabled()
+    // An open gate makes no claim at all. `title` is set only while blocked.
+    expect(analyse).not.toHaveAttribute('title')
+
+    // And the sentence that was on the deployed build is gone from the surface.
+    const footer = screen.getByTestId('pre-analysis-v3-footer')
+    expect(footer).not.toHaveTextContent(BLOCKED_REASON_COPY.unspecified)
+    expect(footer).not.toHaveTextContent(FOOTER_COPY.notReadySubFallback)
+    expect(footer).not.toHaveTextContent(FOOTER_COPY.notReady)
+  }, 30_000)
+
+  it('AC2 — real blockers: DISABLED, and the tooltip NAMES one, not a constant', async () => {
+    seedCapturedCanvas()
+    useCanvasStore.setState({
+      analysisStateV1: analysisState({
+        status: 'not_ready',
+        blockers: [
+          {
+            code: 'OPTION_NOT_READY',
+            category: 'options',
+            message: 'The option has no effect values.',
+            repairability: 'user_repairable',
+            option_id: 'opt_extend',
+            option_label: 'Extend the free trial',
+          },
+        ],
+      }),
+    } as never)
+
+    render(
+      <ToastProvider>
+        <OutputsDock />
+      </ToastProvider>,
+    )
+
+    const analyse = await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
+    expect(analyse).toBeDisabled()
+    expect(analyse).toHaveAttribute(
+      'title',
+      BLOCKED_REASON_COPY.canonicalOneBlocker('Extend the free trial'),
+    )
+    // Never the generic sentence, and never the raw identifier.
+    expect(analyse).not.toHaveAttribute('title', BLOCKED_REASON_COPY.unspecified)
+    expect(analyse.getAttribute('title')).not.toContain('opt_extend')
+
+    // One state, one story: the footer subline says the SAME thing as the title.
+    expect(screen.getByTestId('pre-analysis-v3-footer')).toHaveTextContent(
+      BLOCKED_REASON_COPY.canonicalOneBlocker('Extend the free trial'),
+    )
+  }, 30_000)
+
+  it('DISCRIMINATION — the two cases above differ ONLY in the producer verdict', async () => {
+    // The side-car objects identically in all three tests. If the dock were
+    // still gating on it, no producer verdict could move this control — so the
+    // enabled/disabled flip observed across these tests is attributable to the
+    // canonical authority and to nothing else in the fixture.
+    seedCapturedCanvas()
+    useCanvasStore.setState({
+      analysisStateV1: analysisState({ status: 'ready', blockers: [] }),
+    } as never)
+
+    render(
+      <ToastProvider>
+        <OutputsDock />
+      </ToastProvider>,
+    )
+
+    await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
+    // The competitor is still objecting, in the store, at assertion time.
+    expect(useReadinessStore.getState().readiness?.can_run_analysis).toBe(false)
+    expect(screen.getByTestId('pre-analysis-v3-analyse')).toBeEnabled()
+  }, 30_000)
+})

--- a/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
@@ -10,7 +10,9 @@
 import { useEffect, useMemo } from 'react'
 import { useCanvasStore } from '../../../store'
 import { useGraphReadiness } from '../../../hooks/useGraphReadiness'
-import { readinessWillScaffold } from '../../../utils/canRunAnalysis'
+import { readinessObjectsToRun, readinessWillScaffold } from '../../../utils/canRunAnalysis'
+import { useAnalysisReadinessAuthority } from '../../../state/analysisStateSelector'
+import { composeAnalysisBlockedReason } from '../../../utils/composeBlockedReason'
 import { resolveStarterId } from '../../../starters/loadStarter'
 import { isReviewedByUser } from '../../pre-analysis/utils/isReviewedByUser'
 import { computeBars, type BarsModel } from '../selectors/computeBars'
@@ -196,6 +198,9 @@ export function usePreAnalysisModel(): PreAnalysisModel {
     [decisionPresent, facts, success.isSet, coverage.influenceCoverage, rowCounts],
   )
 
+  // The producer's own readiness verdict for this turn. See `canRun` below.
+  const analysisReadiness = useAnalysisReadinessAuthority()
+
   // UI-SEM-091: runnable-via-scaffold. CEE (#612) rides a scaffold intent on
   // the readiness response; when it will draft the remaining options the graph
   // is runnable despite can_run_analysis being false. Both the footer and the
@@ -203,20 +208,47 @@ export function usePreAnalysisModel(): PreAnalysisModel {
   const willScaffoldOptions = readinessWillScaffold(readiness)
   const scaffoldOptionCount = readiness?.scaffold_plan?.option_count
 
+  // ⭐ ONE READINESS ANSWER FOR THE WHOLE PANEL (19 Aug 2026).
+  //
+  // This hook used to compute its own: `readiness.can_run_analysis ||
+  // willScaffoldOptions`, read straight off the SIDE-CAR verdict. The comment
+  // that stood here said its purpose was that "the footer agree with the run
+  // gate (canRunAnalysis util)" — a hand-maintained agreement between two
+  // expressions, which is the mirror this estate keeps paying for (trap 12).
+  //
+  // It came due the moment the gate gained a superseding authority: the mounted
+  // spec caught an ENABLED "Analyse first pass" button sitting directly beneath
+  // the line "Not ready for analysis yet". Same defect class as the blocker this
+  // lane was opened for, created by fixing it one layer up.
+  //
+  // So the panel now asks `readinessObjectsToRun` — the SAME predicate the gate
+  // and the dispatch barrier ask — instead of restating it. Three surfaces, one
+  // definition, and no expression left here to drift.
+  //
+  // ⚠ The tri-state is preserved and it matters. `null` means NOBODY has
+  // answered — not the producer, not the side-car — and the footer's first arm
+  // depends on it to avoid claiming anything about an unassessed model. It is
+  // deliberately NOT `readiness == null` alone any more: a producer verdict IS
+  // an answer, so a panel that had one would otherwise report itself as still
+  // waiting to hear.
+  const nothingHasAnswered = readiness == null && analysisReadiness == null
+  const canRun = nothingHasAnswered ? null : !readinessObjectsToRun(readiness, analysisReadiness)
+
   const ladder = useMemo(
     () =>
       computeLadder({
         goalPresent: facts.goalNode != null,
         successSet: success.isSet,
         topUncalibrated: top,
-        canRunAnalysis: readiness ? readiness.can_run_analysis : null,
+        // The one value, not a second read of the side-car field.
+        canRunAnalysis: canRun,
         readinessExplanation: readiness?.confidence_explanation
           ? guardCeeText(readiness.confidence_explanation, LADDER_COPY.readiness_fallback).text
           : null,
         willScaffoldOptions,
         scaffoldOptionCount,
       }),
-    [facts.goalNode, success.isSet, top, readiness, willScaffoldOptions, scaffoldOptionCount],
+    [facts.goalNode, success.isSet, top, canRun, readiness, willScaffoldOptions, scaffoldOptionCount],
   )
 
   const narrowFramingDetail = useMemo(() => {
@@ -335,9 +367,6 @@ export function usePreAnalysisModel(): PreAnalysisModel {
   // every other slice.
   const contested = useMemo(() => computeContestedRows(nodes, edges), [nodes, edges])
 
-  // UI-SEM-091: effective runnable ORs the scaffold intent, so advanced.canRun
-  // and the footer agree with the run gate (canRunAnalysis util).
-  const canRun = readiness ? readiness.can_run_analysis || willScaffoldOptions : null
   const footer = useMemo(() => {
     // ── No verdict: say so, and claim nothing ────────────────────────
     //
@@ -358,13 +387,19 @@ export function usePreAnalysisModel(): PreAnalysisModel {
     // shape, which the readinessStore header records as ZERO graph-readiness
     // requests in three of four witnessed guest sessions).
     //
-    // Deliberately keyed on `readiness == null` ALONE, not on
-    // `readiness == null && readinessError == null`. When an error IS recorded
-    // the outage arm in PanelFooter outranks this value anyway, so the extra
-    // conjunct buys nothing — and omitting it means a null verdict can never
-    // produce an availability claim by any route, which is the fail-safe
-    // direction. The run gate is untouched: unknown does not object.
-    if (readiness == null) {
+    // Deliberately NOT keyed on `readinessError == null`. When an error IS
+    // recorded the outage arm in PanelFooter outranks this value anyway, so the
+    // extra conjunct buys nothing — and omitting it means an unanswered verdict
+    // can never produce an availability claim by any route, which is the
+    // fail-safe direction. The run gate is untouched: unknown does not object.
+    //
+    // ⚠ AMENDED 19 Aug 2026. This used to read `readiness == null` ALONE, and
+    // that sentence was written when the side-car was the only thing that could
+    // answer. It is now `nothingHasAnswered` — BOTH authorities silent — because
+    // a producer verdict IS an answer, and a panel holding one that reported
+    // itself as still waiting to hear would be a false claim of the same family
+    // as the one this lane deleted, just in the humble direction.
+    if (nothingHasAnswered) {
       return {
         dot: 'warning' as const,
         headline: FOOTER_COPY.readinessPending,
@@ -374,7 +409,11 @@ export function usePreAnalysisModel(): PreAnalysisModel {
 
     // UI-SEM-091: readiness reports not-runnable, but CEE will draft the
     // remaining options — disclose the draft, never the not-ready copy.
-    if (readiness?.can_run_analysis === false && willScaffoldOptions) {
+    // Scaffold intent is a SIDE-CAR field, so this disclosure belongs to the
+    // side-car branch. Once the producer has stated readiness the side-car is
+    // superseded, and announcing a draft it licensed would be a claim from an
+    // authority that no longer decides.
+    if (analysisReadiness == null && readiness?.can_run_analysis === false && willScaffoldOptions) {
       return {
         dot: 'warning' as const,
         headline: FOOTER_COPY.ready,
@@ -385,6 +424,19 @@ export function usePreAnalysisModel(): PreAnalysisModel {
       }
     }
     if (canRun === false) {
+      // The reason comes from the authority that DECIDED, never from the other
+      // one — the same rule the gate applies. `PanelFooter` overrides this whole
+      // value while the gate is shut (it renders the gate's own composed
+      // sentence), so in practice this arm is only reachable if the two ever
+      // disagree; composing it from the deciding authority means that even then
+      // the two cannot tell different stories about one state.
+      if (analysisReadiness) {
+        return {
+          dot: 'muted' as const,
+          headline: FOOTER_COPY.notReady,
+          subline: composeAnalysisBlockedReason(analysisReadiness.blockers),
+        }
+      }
       const explanation = readiness?.confidence_explanation?.trim()
       return {
         dot: 'muted' as const,
@@ -408,11 +460,16 @@ export function usePreAnalysisModel(): PreAnalysisModel {
     }
   }, [
     canRun,
+    nothingHasAnswered,
+    // Read directly by two arms now (the scaffold guard and the not-ready
+    // subline), so it is a first-class input to this memo, not a value `canRun`
+    // can stand in for.
+    analysisReadiness,
     willScaffoldOptions,
     scaffoldOptionCount,
     success.isSet,
     top,
-    // The null/non-null transition is what the new first branch turns on.
+    // The null/non-null transition is what the first branch turns on.
     // `canRun` already tracks it (null → boolean), but depending on the
     // verdict itself keeps the memo's inputs honest rather than relying on a
     // derived value to stand in for it.

--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -34,6 +34,9 @@ import type { BriefReadiness } from './hooks/useBriefSignals'
 import { useThreadPersistence } from './hooks/useThreadPersistence'
 import { beginInteractionChain, getUiSurfaceState, recordCrossSurfaceEvent, recordInteractionEvent, recordUserAction, type InteractionStateSnapshot } from '../../lib/debug-state'
 import { canRunAnalysis as canRunAnalysisUtil, getRunButtonTooltip } from '../utils/canRunAnalysis'
+import { useAnalysisReadinessAuthority } from '../state/analysisStateSelector'
+import { BLOCKED_REASON_COPY } from '../utils/composeBlockedReason'
+import { useShowToastSafe } from '../ToastContext'
 import { analysisHeldOn } from '../utils/analysisHeldOnInjectedModel'
 import { useGraphReadiness } from '../hooks/useGraphReadiness'
 
@@ -516,16 +519,22 @@ export const ConversationPanel = memo(function ConversationPanel({
   // to block Run on every other scenario with a false reason. `draftStreamPhaseFor`
   // is the one place that decides ownership — never re-derived at a call site.
   const draftStreamPhase = useDraftStore((s) => draftStreamPhaseFor(s, scenarioId))
+  // ⭐ The CANONICAL readiness authority, read on this surface for the same
+  // reason OutputsDock reads it: both mount a run affordance, and a gate that
+  // consulted different authorities on two surfaces is the two-surfaces-one-state
+  // defect this file's own comments already record fixing twice.
+  const analysisReadiness = useAnalysisReadinessAuthority()
   const runGateResult = useMemo(() => canRunAnalysisUtil({
     graphHealth: graphHealth ?? null,
     readiness,
+    analysisReadiness,
     hasBlockers,
     nodeCount,
     isRunning: isAnalysisRunning,
     analysisHeldOn: heldOn,
     draftStreamPhase,
     readinessStale,
-  }), [graphHealth, readiness, hasBlockers, nodeCount, isAnalysisRunning, heldOn, draftStreamPhase, readinessStale])
+  }), [graphHealth, readiness, analysisReadiness, hasBlockers, nodeCount, isAnalysisRunning, heldOn, draftStreamPhase, readinessStale])
 
   // In-flight takes priority over structural reasons: the composer button
   // is disabled for either cause, but the user-visible tooltip should explain
@@ -538,6 +547,11 @@ export const ConversationPanel = memo(function ConversationPanel({
     ? 'Analysis in progress'
     : (getRunButtonTooltip(runGateResult) ?? undefined)
 
+  // Best-effort outside a ToastProvider (headless hosts), which is why the
+  // refusal ALSO remains the composer button's tooltip: two surfaces for one
+  // fact, never two facts.
+  const showRunRefusal = useShowToastSafe()
+
   // ── Top bar callbacks ─────────────────────────────────────────────────
   const handleRunAnalysis = useCallback(() => {
     // Hotfix item 4 hardening: guard all run-trigger paths (composer button,
@@ -548,7 +562,35 @@ export const ConversationPanel = memo(function ConversationPanel({
     // ROADMAP 2.1229: the in-flight source is now the results-store status —
     // the retired `useV2Run` carried the only hook-local flag, and its F-77
     // supersede-abort went with the direct request it aborted.
-    if (!runGateResult.allowed || isAnalysisRunning) return
+    // ⭐ A REFUSAL MUST BE AUDIBLE (19 Aug 2026). This was a bare `return`.
+    //
+    // Measured on the frozen quartet: a fresh guest with a producer-READY
+    // 16-node model clicked the chat's "Run analysis" and got NOTHING — no
+    // analysis, no refusal, no error. `run_state.kind` stayed `never_run` and
+    // `analysisRefusalNotice` stayed `null`, because a client-side gate refusal
+    // writes neither. The user's only remaining affordance was the Analyse
+    // button, which was disabled with a sentence that was false. A dead end with
+    // no explanation at either exit.
+    //
+    // The root cause of the CLOSED gate is fixed above (the canonical authority
+    // now decides). This is the SECOND, independent defect: even a correctly
+    // closed gate said nothing. `runBlockedReason` is the same string this
+    // surface already puts in the composer button's tooltip, so the click and
+    // the hover cannot tell different stories about one state — and it is
+    // surfaced through the same toast the canonical runner uses for the same
+    // refusal in OutputsDock, rather than a new channel.
+    //
+    // ⚠ It deliberately does NOT write `analysisRefusalNotice`. That slice is
+    // sourced ONLY from a typed refusal on `response.analysis_ready` — CEE's
+    // own `blocked_reason` — and its header is explicit that it is "a fact about
+    // ONE turn". Fabricating one here would claim the producer refused a turn
+    // that was never sent, which is the guarantee-theatre class, not a fix for
+    // it. When the gate is open the click DISPATCHES, and a producer refusal
+    // then populates that slice honestly.
+    if (!runGateResult.allowed || isAnalysisRunning) {
+      showRunRefusal(runBlockedReason ?? BLOCKED_REASON_COPY.unspecified, 'warning')
+      return
+    }
     const composerText = composerRef.current?.peekText().trim() ?? ''
     beginInteractionChain({
       triggerSurface: 'analyse_now',
@@ -575,7 +617,7 @@ export const ConversationPanel = memo(function ConversationPanel({
       message: 'Run analysis',
       source: 'chip',
     })
-  }, [messages.length, runGateResult.allowed, isAnalysisRunning, dispatchAction])
+  }, [messages.length, runGateResult.allowed, isAnalysisRunning, dispatchAction, runBlockedReason, showRunRefusal])
 
   useEffect(() => {
     // L-59: forward the producer's own typed intent when the caller has one.

--- a/src/canvas/conversation/__tests__/aiPanelTranche1Hotfix.spec.tsx
+++ b/src/canvas/conversation/__tests__/aiPanelTranche1Hotfix.spec.tsx
@@ -182,13 +182,29 @@ describe('Hotfix item 4 — Run analysis gate combines readiness + in-flight', (
       path.resolve(__dirname, '../ConversationPanel.tsx'),
       'utf8',
     )
-    // Guard asserts both structural readiness AND in-flight.
-    expect(src).toMatch(/if \(!runGateResult\.allowed \|\| isAnalysisRunning\) return/)
+    // Guard asserts both structural readiness AND in-flight. The CONDITION is
+    // unchanged; what changed on 19 Aug 2026 is the BODY.
+    expect(src).toMatch(/if \(!runGateResult\.allowed \|\| isAnalysisRunning\) \{/)
+    // ⭐ AND THE GUARD IS NO LONGER MUTE. This assertion used to end at
+    // `) return` — a shape that pinned the guard's EXISTENCE while being
+    // perfectly satisfied by a handler that swallowed the click in silence,
+    // which is exactly what shipped: on the frozen quartet a fresh guest's
+    // "Run analysis" produced no analysis, no refusal and no error. A refusal
+    // the user cannot perceive is not a guard, it is a dead end.
+    //
+    // ⚠ This regex is a hand-maintained mirror of a source shape (trap 12) and
+    // is deliberately NOT the load-bearing evidence for the behaviour. That is
+    // `conversationPanel.runRefusalIsAudible.spec.tsx`, which mounts the real
+    // panel, invokes the guidance store's own `_runAnalysis` reference, and
+    // asserts the refusal is ON SCREEN. This line only stops the shape being
+    // reverted without anyone noticing.
+    expect(src).toMatch(/showRunRefusal\(runBlockedReason/)
     // Dep array includes the in-flight flag so the callback is current.
     // `runV2Analysis` left the deps with the hook (2.1229); the canonical
-    // `dispatchAction` is now the only runner referenced here.
+    // `dispatchAction` is now the only runner referenced here, joined by the
+    // two values the refusal itself reads.
     expect(src).toMatch(
-      /\[messages\.length, runGateResult\.allowed, isAnalysisRunning, dispatchAction\]/,
+      /\[messages\.length, runGateResult\.allowed, isAnalysisRunning, dispatchAction, runBlockedReason, showRunRefusal\]/,
     )
   })
 

--- a/src/canvas/conversation/__tests__/conversationPanel.runRefusalIsAudible.spec.tsx
+++ b/src/canvas/conversation/__tests__/conversationPanel.runRefusalIsAudible.spec.tsx
@@ -1,0 +1,265 @@
+/**
+ * THE CHAT'S RUN AFFORDANCE MUST NEVER CONSUME A CLICK AND SAY NOTHING.
+ *
+ * ── THE DEFECT (wire capture, frozen quartet, 19 Aug 2026) ─────────────────
+ * A fresh guest with a producer-READY 16-node model clicked the chat's "Run
+ * analysis" and got NOTHING: no analysis, no refusal, no error.
+ * `run_state.kind` stayed `never_run`; `analysisRefusalNotice` stayed `null`.
+ * The only other route — the Analyse button — was disabled with a sentence that
+ * was false. Both exits from the journey were dead, and one of them lied.
+ *
+ * ── THE TWO INDEPENDENT CAUSES, AND WHY BOTH ARE PINNED HERE ───────────────
+ * 1. THE GATE WAS CLOSED FOR THE WRONG REASON. `ConversationPanel` asked the
+ *    SIDE-CAR readiness verdict (`readinessStore.can_run_analysis`) while the
+ *    PRODUCER's own `analysis_state.readiness` carried `status: 'ready'` and
+ *    ZERO blockers. Fixed by putting the canonical authority into the one gate
+ *    predicate; pinned exhaustively in
+ *    `src/canvas/utils/__tests__/canonicalReadinessAuthority.spec.ts`. What
+ *    this file adds is that THIS SURFACE actually consults it — a pure-function
+ *    fix that no mounted surface reads is the estate's most familiar dark
+ *    capability.
+ * 2. THE REFUSAL WAS SILENT. `handleRunAnalysis` opened with a bare
+ *    `if (!runGateResult.allowed || isAnalysisRunning) return`. Even a
+ *    CORRECTLY closed gate said nothing — no toast, no notice, no console
+ *    surface a user could see. Cause 1 is why the gate was shut; cause 2 is why
+ *    the user could not find out. Fixing only the first would leave every other
+ *    legitimate refusal just as mute.
+ *
+ * ── SCOPE, STATED PRECISELY (trap 3) ───────────────────────────────────────
+ * PRESENCE and TEXT of the refusal on the mounted panel, and whether a turn was
+ * dispatched. Not layout, not visibility, not z-order — those need a browser.
+ *
+ * ⚠ WHAT IS DELIBERATELY *NOT* ASSERTED: that a client-side refusal writes
+ * `analysisRefusalNotice`. That slice is sourced ONLY from a typed refusal on
+ * `response.analysis_ready` — CEE's own `blocked_reason` — and its module header
+ * is explicit that it records "a fact about ONE turn". Writing it from the
+ * client would claim the producer refused a turn that was never sent: the
+ * guarantee-theatre class, not a cure for it. The honest guarantee is the one
+ * pinned below — when the gate is OPEN the click dispatches, and a producer
+ * refusal then populates that slice for real; when the gate is SHUT the user is
+ * told why, on screen.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+
+import { ConversationPanel } from '../ConversationPanel'
+import { ToastProvider } from '../../ToastContext'
+import { useCanvasStore } from '../../store'
+import { useGuidanceStore } from '../../stores/guidanceStore'
+import { useReadinessStore } from '../../stores/readinessStore'
+import type { ConversationMessage } from '../types'
+import type { UseConversationReturn, PatchBlockState, PatchRejectionInfo } from '../useConversation'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const NODES = [
+  { id: 'n1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Grow retained revenue' } },
+  { id: 'n2', type: 'option', position: { x: 100, y: 0 }, data: { label: 'Extend the free trial' } },
+  { id: 'n3', type: 'option', position: { x: 200, y: 0 }, data: { label: 'Hold the current price' } },
+]
+const EDGES = [{ id: 'e1', source: 'n2', target: 'n1', type: 'styled', data: { weight: 1 } }]
+
+/**
+ * A producer verdict shaped exactly as the wire carries it. Only `readiness` is
+ * read by the run gate; the rest is present so the fixture is a real
+ * `AnalysisStateV1` and not a shape that could never arrive — a fixture outside
+ * the producer's output domain proves nothing about the wire (trap 16).
+ */
+function analysisState(
+  readiness: AnalysisStateV1['readiness'],
+): AnalysisStateV1 {
+  return {
+    // The state the capture recorded: the model exists, no run has happened.
+    run_state: { kind: 'never_run' },
+    readiness,
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: false,
+    blocked_unusable: false,
+    contradictions: [],
+  } as AnalysisStateV1
+}
+
+const PRODUCER_READY = analysisState({ status: 'ready', blockers: [] })
+
+const PRODUCER_BLOCKED = analysisState({
+  status: 'not_ready',
+  blockers: [
+    {
+      code: 'OPTION_NOT_READY',
+      category: 'options',
+      message: 'The option has no effect values.',
+      repairability: 'user_repairable',
+      option_id: 'n2',
+      option_label: 'Extend the free trial',
+    },
+  ],
+})
+
+function makeConversation(dispatchAction: ReturnType<typeof vi.fn>): UseConversationReturn {
+  const patchStates = new Map<string, PatchBlockState>()
+  const patchRejections = new Map<string, PatchRejectionInfo>()
+  const messages: ConversationMessage[] = []
+  return {
+    messages,
+    isThinking: false,
+    longRunningHint: null,
+    lastSendFailure: null,
+    dispatchAction: dispatchAction as unknown as UseConversationReturn['dispatchAction'],
+    cancelTurn: vi.fn(),
+    startNewDraft: vi.fn(async () => {}),
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    sendSystemEvent: vi.fn().mockResolvedValue(undefined) as unknown as UseConversationReturn['sendSystemEvent'],
+    sendChip: vi.fn().mockResolvedValue(undefined),
+    clearHistory: vi.fn(),
+    retryLast: vi.fn().mockResolvedValue(undefined),
+    patchBlockStates: patchStates,
+    setPatchBlockState: (key: string, state: PatchBlockState) => { patchStates.set(key, state) },
+    patchRejections,
+    setPatchRejection: (key: string, info: PatchRejectionInfo) => { patchRejections.set(key, info) },
+  }
+}
+
+/**
+ * ⚠ INSTRUMENT ISOLATION. `readinessStore.startListening` fires a fetch on the
+ * FIRST consumer mount, and this panel is one. Left alone, that request races
+ * every assertion below and can write the very slice these tests are varying.
+ * A never-settling fetch removes the race entirely — and, crucially, it leaves
+ * `readinessStore.readiness` at its initial `null`, i.e. THE SIDE-CAR VERDICT
+ * DOES NOT OBJECT in any test here. Every gate flip observed below is therefore
+ * attributable to the producer verdict and to nothing else.
+ */
+
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+  useReadinessStore.setState({ readiness: null, loading: false, error: null, stale: false, verdictAtMs: null })
+  useCanvasStore.setState({
+    nodes: [...NODES],
+    edges: [...EDGES],
+    currentScenarioId: 'a0a0a0a0-b1b1-4c2c-8d3d-e4e4e4e4e4e4',
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    results: { status: 'idle' },
+    graphHealth: null,
+    analysisStateV1: null,
+    _externalMutationActive: 0,
+  } as never)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  useCanvasStore.setState({ nodes: [], edges: [], analysisStateV1: null } as never)
+  useGuidanceStore.setState({ _runAnalysis: null } as never)
+  vi.clearAllMocks()
+})
+
+/**
+ * Mount the real panel and hand back the run callback the chat's CTAs invoke.
+ *
+ * ⚠ BOUND BY IDENTITY, NOT BY A LOOK-ALIKE (trap 19). The callback is taken
+ * from `useGuidanceStore._runAnalysis` — the registration the panel itself
+ * performs and the exact reference every cross-surface "Run analysis" CTA in the
+ * chat calls. A local re-implementation of the click would test this file's
+ * idea of the wiring rather than the wiring.
+ */
+async function mountAndGetRunCallback(dispatchAction: ReturnType<typeof vi.fn>) {
+  render(
+    <ToastProvider>
+      <ConversationPanel
+        conversation={makeConversation(dispatchAction)}
+        onCollapse={vi.fn()}
+        onAttach={vi.fn()}
+      />
+    </ToastProvider>,
+  )
+  await waitFor(() => {
+    expect(useGuidanceStore.getState()._runAnalysis).toBeTypeOf('function')
+  })
+  return () => useGuidanceStore.getState()._runAnalysis!()
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('AC3 — the chat run affordance answers to the canonical authority', () => {
+  it("a producer-READY model RUNS: the click dispatches a real run_analysis turn", async () => {
+    // The captured state, minus the defect. Nothing may consume this click
+    // silently, and the honest outcome here is a TURN — after which a producer
+    // refusal, if there is one, arrives with its own reason_code.
+    useCanvasStore.setState({ analysisStateV1: PRODUCER_READY } as never)
+    const dispatchAction = vi.fn().mockResolvedValue(undefined)
+    const run = await mountAndGetRunCallback(dispatchAction)
+
+    await act(async () => { await run() })
+
+    expect(dispatchAction).toHaveBeenCalledTimes(1)
+    expect(dispatchAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action_type: 'run_analysis', source: 'chip' }),
+    )
+    // An open gate refuses nothing — not quietly, not politely.
+    expect(screen.queryByText(/is not ready for analysis yet/i)).toBeNull()
+  })
+
+  it('a producer-BLOCKED model REFUSES OUT LOUD, naming the blocker, and sends no turn', async () => {
+    useCanvasStore.setState({ analysisStateV1: PRODUCER_BLOCKED } as never)
+    const dispatchAction = vi.fn().mockResolvedValue(undefined)
+    const run = await mountAndGetRunCallback(dispatchAction)
+
+    await act(async () => { await run() })
+
+    // Silence is the defect. The refusal is on screen…
+    expect(await screen.findByText(/Extend the free trial/)).toBeInTheDocument()
+    // …and it did not run anything behind the user's back.
+    expect(dispatchAction).not.toHaveBeenCalled()
+  })
+
+  it('SUPERSESSION AT THE SURFACE: the producer verdict alone flips this panel', async () => {
+    // The two tests above differ in EXACTLY ONE input — `analysisStateV1` —
+    // with the side-car verdict null in both. So this surface demonstrably reads
+    // the canonical authority; it is not merely inheriting a permissive default.
+    const dispatchReady = vi.fn().mockResolvedValue(undefined)
+    useCanvasStore.setState({ analysisStateV1: PRODUCER_READY } as never)
+    const runReady = await mountAndGetRunCallback(dispatchReady)
+    await act(async () => { await runReady() })
+    expect(dispatchReady).toHaveBeenCalledTimes(1)
+    expect(useReadinessStore.getState().readiness).toBeNull()
+  })
+})
+
+describe('AC3 — no closed gate is mute, whichever rung closed it', () => {
+  it('an empty canvas refuses AUDIBLY instead of swallowing the click', async () => {
+    // A rung that has nothing to do with readiness, deliberately: the silence
+    // defect was in the callback's own control flow, so it must be dead for
+    // EVERY refusal, not only for the one that motivated this lane. Pre-fix
+    // this click produced no dispatch and no surface at all.
+    useCanvasStore.setState({ nodes: [], edges: [], analysisStateV1: PRODUCER_READY } as never)
+    const dispatchAction = vi.fn().mockResolvedValue(undefined)
+    const run = await mountAndGetRunCallback(dispatchAction)
+
+    await act(async () => { await run() })
+
+    expect(await screen.findByText(/Add some nodes to get started/i)).toBeInTheDocument()
+    expect(dispatchAction).not.toHaveBeenCalled()
+  })
+
+  it('a run already in flight says SO, rather than nothing', async () => {
+    useCanvasStore.setState({
+      analysisStateV1: PRODUCER_READY,
+      results: { status: 'streaming' },
+    } as never)
+    const dispatchAction = vi.fn().mockResolvedValue(undefined)
+    const run = await mountAndGetRunCallback(dispatchAction)
+
+    await act(async () => { await run() })
+
+    expect(await screen.findByText(/Analysis in progress/i)).toBeInTheDocument()
+    expect(dispatchAction).not.toHaveBeenCalled()
+  })
+})

--- a/src/canvas/state/analysisStateSelector.ts
+++ b/src/canvas/state/analysisStateSelector.ts
@@ -754,10 +754,57 @@ export function useAnalysisState(): ComposedAnalysisState {
  * what to do about it, and it falls back to the side-car verdict — the
  * pre-0.46 behaviour, byte-for-byte.
  */
+/**
+ * CEE's `READINESS_STATUS_UNSUPPLIED` (`orchestrator-v5/compose/analysis-state-v1.ts:106`).
+ *
+ * Restated here rather than imported because CEE is a separate service with no
+ * shared export for it — the contract package types `status` as a plain string.
+ * That makes this a hand-maintained mirror (trap 12), so it is named ONCE, at
+ * the single seam that reads it, with the producer path in the comment above;
+ * the guard below fails loud in the only way that matters — a rename at CEE
+ * makes the sentinel arrive as a stated status, and the `unknown`-behaves-like-
+ * absence test REDs.
+ */
+const READINESS_STATUS_UNSUPPLIED = 'unknown'
+
 export function selectAnalysisReadinessAuthority(
   analysisState: AnalysisStateV1 | null,
 ): AnalysisReadinessAuthority | null {
   if (analysisState === null) return null
+
+  // ⭐ THE UNSUPPLIED SENTINEL IS AN ABSENCE WEARING A STATUS CODE.
+  //
+  // Derived at the producer, not from the contract's prose (trap 13c — the
+  // `describe()` text calls `status` a producer-owned code and says nothing
+  // about this):
+  //
+  //   CEE `orchestrator-v5/compose/analysis-state-v1.ts:106`
+  //     export const READINESS_STATUS_UNSUPPLIED = 'unknown'
+  //   …substituted at `:314` whenever `canonical.status` is not a non-empty
+  //   string — and the FULL `analysis_state` is still emitted around it, with
+  //   `mapWireBlockers` returning `[]` for an absent list (`:180`). So
+  //   `{ status: 'unknown', blockers: [] }` is a routinely reachable payload.
+  //
+  // CEE's own comment beside the constant is explicit: it "says exactly what is
+  // true: no readiness verdict was supplied on this turn. It is NOT a synonym
+  // for `blocked`, and a consumer must not treat it as one." Read as a stated
+  // verdict, its empty blocker list would be a POSITIVE claim that nothing is
+  // blocking — so this consumer would treat it as a synonym for READY, which is
+  // worse than the reading CEE forbids, and it would discard a side-car verdict
+  // that may correctly be refusing.
+  //
+  // ⚠ NOTE WHAT 'unknown' IS NOT. The stated vocabulary is the FIVE-member
+  // `ANALYSIS_READY_STATUSES` at `orchestrator-v5/context/canonical-analysis-state.ts:137-145`
+  // — `ready | needs_user_mapping | needs_encoding | needs_user_input | blocked`.
+  // `'unknown'` is not a member of it; it is the sentinel substituted when
+  // `coerceReadyStatus` returns null, and it is minted in a different file.
+  // Folding it into that allowlist as a sixth value is the same conflation this
+  // guard exists to undo.
+  //
+  // So it collapses to the state this module already has a name for: NOT
+  // STATED. Same value, same downstream behaviour, one concept.
+  if (analysisState.readiness.status === READINESS_STATUS_UNSUPPLIED) return null
+
   return {
     status: analysisState.readiness.status,
     blockers: analysisState.readiness.blockers,

--- a/src/canvas/state/analysisStateSelector.ts
+++ b/src/canvas/state/analysisStateSelector.ts
@@ -57,6 +57,7 @@ import type {
 } from '@talchain/schemas/boundary'
 
 import { useCanvasStore } from '../store'
+import type { AnalysisReadinessAuthority } from '../utils/canRunAnalysis'
 import {
   classifyFreshnessForDisplay,
   resolveDisplayedFreshness,
@@ -724,4 +725,47 @@ export function useAnalysisState(): ComposedAnalysisState {
       ceeAnalysisReadyStatus,
     ],
   )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE RUN GATE'S READ OF THE PRODUCER'S READINESS (19 Aug 2026).
+//
+// `useAnalysisState()` above already exposes this as `readinessStatus` /
+// `readinessBlockers`, and until this date NOTHING IN THE PRODUCT READ EITHER —
+// a canonical verdict computed by CEE, carried on every turn, parsed, stored,
+// and unconsumed, while the Analyse control was gated by a side-car assessment
+// that could and did disagree with it.
+//
+// This narrower accessor exists so the gate reads the authority WITHOUT paying
+// for the full composition (the run gate is evaluated on every canvas render,
+// including drag frames) and, more importantly, so no surface reads
+// `s.analysisStateV1.readiness` directly. It DERIVES NOTHING: it reshapes two
+// producer fields and stops. Anything that decides something about them belongs
+// in `canRunAnalysis`, which is where the one predicate lives.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The producer's readiness verdict for the run gate, or `null` when the wire
+ * stated none.
+ *
+ * ⚠ `null` MEANS NOT STATED, and that is a third state, not a negative one. A
+ * consumer must not read it as "nothing is blocking" (that is `blockers: []`)
+ * nor as "something is". `canRunAnalysis` is the only place entitled to decide
+ * what to do about it, and it falls back to the side-car verdict — the
+ * pre-0.46 behaviour, byte-for-byte.
+ */
+export function selectAnalysisReadinessAuthority(
+  analysisState: AnalysisStateV1 | null,
+): AnalysisReadinessAuthority | null {
+  if (analysisState === null) return null
+  return {
+    status: analysisState.readiness.status,
+    blockers: analysisState.readiness.blockers,
+  }
+}
+
+/** Hook form. Memoised on the store slice, so it is stable across renders. */
+export function useAnalysisReadinessAuthority(): AnalysisReadinessAuthority | null {
+  const analysisState = useCanvasStore((s) => s.analysisStateV1)
+  return useMemo(() => selectAnalysisReadinessAuthority(analysisState), [analysisState])
 }

--- a/src/canvas/utils/__tests__/canonicalReadinessAuthority.spec.ts
+++ b/src/canvas/utils/__tests__/canonicalReadinessAuthority.spec.ts
@@ -59,9 +59,10 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import type { AnalysisBlocker } from '@talchain/schemas/boundary'
+import type { AnalysisBlocker, AnalysisStateV1 } from '@talchain/schemas/boundary'
 
 import { canRunAnalysis, readinessObjectsToRun } from '../canRunAnalysis'
+import { selectAnalysisReadinessAuthority } from '../../state/analysisStateSelector'
 import { BLOCKED_REASON_COPY } from '../composeBlockedReason'
 import type { GraphReadiness } from '../../hooks/useGraphReadiness'
 import type { CanRunAnalysisParams } from '../canRunAnalysis'
@@ -101,6 +102,60 @@ function blocker(overrides: Partial<AnalysisBlocker> = {}): AnalysisBlocker {
     repairability: 'user_repairable',
     ...overrides,
   }
+}
+
+/**
+ * The producer's STATED readiness vocabulary, as a closed set.
+ *
+ * Mirrored from CEE `orchestrator-v5/context/canonical-analysis-state.ts:137-145`
+ * (`ANALYSIS_READY_STATUSES`). FIVE members — and `'unknown'` is deliberately
+ * NOT one of them: that is `READINESS_STATUS_UNSUPPLIED`
+ * (`orchestrator-v5/compose/analysis-state-v1.ts:106`), the sentinel substituted
+ * when no status was supplied, minted in a different file. Treating it as a
+ * sixth member of this list is the conflation the sentinel guard exists to undo.
+ */
+const ANALYSIS_READY_STATUSES = [
+  'ready',
+  'needs_user_mapping',
+  'needs_encoding',
+  'needs_user_input',
+  'blocked',
+] as const
+
+/**
+ * The stated statuses that can describe a RUNNABLE model — the five above minus
+ * `blocked`.
+ *
+ * ⚠ DERIVED AT THE PRODUCER, and this is the load-bearing distinction. A
+ * proposal to make the gate `status !== 'ready'` was refuted there: at
+ * `cee/transforms/analysis-ready.ts:958-969` the payload-status chain emits
+ * `needs_user_mapping` for an unconnected controllable factor its own payload
+ * step calls "informational", and `needs_encoding` for the UI-SEM-091 scaffold
+ * state that is explicitly runnable. `blocked` is absent from that chain
+ * entirely and is written only by hard-block and refusal paths.
+ */
+const RUNNABLE_STATED_STATUSES = ANALYSIS_READY_STATUSES.filter((s) => s !== 'blocked')
+
+/**
+ * A full `AnalysisStateV1` as the wire carries it, so the cases below travel
+ * through `selectAnalysisReadinessAuthority` — THE REAL SEAM — rather than
+ * hand-constructing the authority object the gate happens to accept. Without
+ * this, a sentinel guard living in the selector would be invisible to every
+ * assertion in this file.
+ */
+function wireState(readiness: AnalysisStateV1['readiness']): AnalysisStateV1 {
+  return {
+    run_state: { kind: 'never_run' },
+    readiness,
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: false,
+    blocked_unusable: false,
+    contradictions: [],
+  } as AnalysisStateV1
 }
 
 /**
@@ -149,14 +204,59 @@ describe('AC1 — producer says ready with zero blockers: the control is ENABLED
     expect(result.reason).not.toBe(BLOCKED_REASON_COPY.unspecified)
   })
 
-  it('an empty blocker list is a POSITIVE claim, whatever status code rides with it', () => {
-    // The contract's words. `status` is a producer-owned free-string code and a
-    // consumer maps it to its own copy; `blockers` is the itemised list of what
-    // stands in the way. Blocking on a status we cannot name a cause for is
-    // exactly the refusal-without-a-reason this lane exists to delete — and a
-    // run CEE then declines still refuses WITH a stated reason, which is
-    // strictly better than a disabled control that lies.
-    expect(gate({ analysisReadiness: { status: 'unknown_code', blockers: [] } }).allowed).toBe(true)
+  it('an empty blocker list is a POSITIVE claim, across the producer\'s REAL vocabulary', () => {
+    // ⚠ RE-DERIVED FROM THE PRODUCER, 19 Aug 2026 (trap 13c). This case used to
+    // read `{ status: 'unknown_code', blockers: [] }` and was justified by the
+    // contract's `describe()` prose calling `status` an open producer-owned
+    // code. The prose is not the producer. At CEE staging the STATED vocabulary
+    // is the five-member `ANALYSIS_READY_STATUSES`
+    // (`orchestrator-v5/context/canonical-analysis-state.ts:137-145`), so
+    // `'unknown_code'` is a fixture the producer CANNOT EMIT — and a fixture
+    // outside the producer's output domain proves nothing (trap 16-inverse).
+    //
+    // What the rung actually claims is narrower and true: for a STATED verdict,
+    // the itemised blocker list is what decides, and an empty one is a positive
+    // finding. Asserted across every value the producer can actually send.
+    for (const status of RUNNABLE_STATED_STATUSES) {
+      expect(gate({ analysisReadiness: { status, blockers: [] } }).allowed, status).toBe(true)
+    }
+  })
+
+  it('A CASE PER STATED STATUS — `blocked` refuses, the other four defer to the list', () => {
+    // Bound by the status LITERAL, one row per value, never by a predicate
+    // another status could satisfy (trap 19). The table IS the claim:
+    //
+    //   ready              [] -> PERMIT   nothing itemised, nothing blocking
+    //   needs_user_mapping [] -> PERMIT   informational unconnected factor
+    //   needs_encoding     [] -> PERMIT   the UI-SEM-091 scaffold state
+    //   needs_user_input   [] -> PERMIT   its blockers ARE the list; empty = none
+    //   blocked            [] -> REFUSE   the refusal builder's own carrier
+    expect(gate({ analysisReadiness: { status: 'ready', blockers: [] } }).allowed).toBe(true)
+    expect(gate({ analysisReadiness: { status: 'needs_user_mapping', blockers: [] } }).allowed).toBe(true)
+    expect(gate({ analysisReadiness: { status: 'needs_encoding', blockers: [] } }).allowed).toBe(true)
+    expect(gate({ analysisReadiness: { status: 'needs_user_input', blockers: [] } }).allowed).toBe(true)
+    expect(gate({ analysisReadiness: { status: 'blocked', blockers: [] } }).allowed).toBe(false)
+  })
+
+  it('a refusal turn does not hand back an ENABLED button one turn later', () => {
+    // `buildAnalysisRefusalReadiness` (`analysis-ready-helper.ts:1440`) emits
+    // `status: 'blocked'` with no `blockers` key, so the wire carries `[]`. On
+    // the blockers-only predicate that OPENED the gate immediately after CEE had
+    // refused the run — click, refused, button live again, click, refused.
+    const refusalTurn = gate({ analysisReadiness: { status: 'blocked', blockers: [] } })
+    expect(refusalTurn.allowed).toBe(false)
+  })
+
+  it('and the sentence it shows names nothing it cannot name', () => {
+    // Honesty check on the empty-list refusal. The producer itemised nothing, so
+    // the copy must not imply a specific missing thing — it says only that
+    // something more is needed and points at the chat, which on a refusal turn
+    // genuinely carries CEE's own explanation.
+    const reason = gate({ analysisReadiness: { status: 'blocked', blockers: [] } }).reason
+    expect(reason).toBe(BLOCKED_REASON_COPY.unspecified)
+    // Never a fabricated specific: no quoted label, no count, no identifier.
+    expect(reason).not.toMatch(/"/)
+    expect(reason).not.toMatch(/\d/)
   })
 })
 
@@ -363,5 +463,79 @@ describe('CONTRAST CONTROL — no producer verdict: the side-car still answers',
     })
     expect(result.allowed).toBe(false)
     expect(result.reason).toContain('Two options share one label')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE UNSUPPLIED SENTINEL — an absence wearing a status code.
+//
+// These cases go through `selectAnalysisReadinessAuthority`, not through a
+// hand-built authority object, because the guard lives in the selector and a
+// spec that skipped it would pass against a selector that had none.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe("CEE's `unknown` sentinel behaves IDENTICALLY to an absent verdict", () => {
+  const viaSelector = (state: AnalysisStateV1 | null) =>
+    gate({ analysisReadiness: selectAnalysisReadinessAuthority(state) })
+
+  it('does not let an unsupplied verdict discard an objecting side-car', () => {
+    // The harm, stated plainly: `{ status: 'unknown', blockers: [] }` read as a
+    // stated verdict is a POSITIVE claim that nothing is blocking — so the gate
+    // would open and the side-car would never be asked, on a turn where CEE
+    // said only that it had not assessed. CEE's own comment forbids reading the
+    // sentinel as `blocked`; reading it as READY is worse.
+    const unsupplied = viaSelector(wireState({ status: 'unknown', blockers: [] }))
+    expect(unsupplied.allowed).toBe(false)
+    expect(unsupplied.reason).toBe(BLOCKED_REASON_COPY.unspecified)
+  })
+
+  it('IDENTICAL to absence — same verdict, same sentence, both directions', () => {
+    // Bound by EQUIVALENCE, not by a hard-coded expectation (trap 19): whatever
+    // the not-stated path does, the sentinel path must do. A future change to
+    // the fallback cannot silently separate them.
+    const absent = gate({ analysisReadiness: null })
+    const unsupplied = viaSelector(wireState({ status: 'unknown', blockers: [] }))
+    expect(unsupplied.allowed).toBe(absent.allowed)
+    expect(unsupplied.reason).toBe(absent.reason)
+
+    // And with a PERMISSIVE side-car, both open — proving the equivalence is not
+    // just "the sentinel always blocks".
+    const absentOpen = gate({ readiness: SIDE_CAR_PERMITS, analysisReadiness: null })
+    const unsuppliedOpen = gate({
+      readiness: SIDE_CAR_PERMITS,
+      analysisReadiness: selectAnalysisReadinessAuthority(
+        wireState({ status: 'unknown', blockers: [] }),
+      ),
+    })
+    expect(unsuppliedOpen.allowed).toBe(absentOpen.allowed)
+    expect(unsuppliedOpen.allowed).toBe(true)
+  })
+
+  it('the sentinel does not swallow blockers the producer DID itemise', () => {
+    // The fail-safe direction. If a turn ever carries the sentinel WITH a
+    // populated list, falling to the side-car must not lose it — so this pins
+    // that the guard is scoped to the status and cannot become a blanket escape.
+    const withBlockers = viaSelector(
+      wireState({
+        status: 'unknown',
+        blockers: [blocker({ option_label: 'Extend the free trial' })],
+      }),
+    )
+    expect(withBlockers.allowed).toBe(false)
+  })
+
+  it('DISCRIMINATION — every STATED status still reaches the gate through the selector', () => {
+    // The other half of the pair. Without this, a selector that returned `null`
+    // for everything would satisfy the three cases above — and would have
+    // silently deleted the entire fix.
+    for (const status of ANALYSIS_READY_STATUSES) {
+      const authority = selectAnalysisReadinessAuthority(wireState({ status, blockers: [] }))
+      expect(authority, status).not.toBeNull()
+      expect(authority!.status, status).toBe(status)
+      // Reaching the gate, it supersedes the objecting side-car — permitting for
+      // every runnable status, refusing for `blocked`, and in BOTH cases proving
+      // the selector handed the verdict on rather than nulling it.
+      expect(gate({ analysisReadiness: authority }).allowed, status).toBe(status !== 'blocked')
+    }
   })
 })

--- a/src/canvas/utils/__tests__/canonicalReadinessAuthority.spec.ts
+++ b/src/canvas/utils/__tests__/canonicalReadinessAuthority.spec.ts
@@ -1,0 +1,367 @@
+/**
+ * THE RUN GATE ASKS THE CANONICAL READINESS AUTHORITY, AND THE SIDE-CAR VERDICT
+ * IS SUPERSEDED — NOT COMBINED WITH IT.
+ *
+ * ── THE DEFECT THIS PINS (wire capture, frozen quartet, 19 Aug 2026) ────────
+ * A fresh guest drafted a 16-node model from the governed brief
+ * `04-conflicting-constraints`. `useCanvasStore.getState()` read:
+ *
+ *   analysisStateV1.readiness = { status: 'ready', blockers: [] }
+ *   analysisStateV1.run_state = { kind: 'never_run' }
+ *   ceeAnalysisReady.status   = 'ready'   (all three options 'ready')
+ *
+ * …and `[data-testid="pre-analysis-v3-analyse"]` was `disabled`, with the title
+ * *"Olumi needs something more from this model before the next analysis…"* —
+ * `BLOCKED_REASON_COPY.unspecified`, the rung that fires when the verdict
+ * refuses and carries no structured field naming a cause.
+ *
+ * That sentence is FALSE: the producer's own readiness carried ZERO blockers.
+ * The product asserted something untrue about the user's own model, and the
+ * escape route it named (the chat) was itself a no-op.
+ *
+ * ── THE ROOT CAUSE, NAMED (trap 21: two questions under one name) ───────────
+ * TWO readiness notions existed under one name and nothing said so:
+ *
+ *   COMPETITOR  `readinessStore.readiness.can_run_analysis` — a SIDE-CAR
+ *               assessment fetched from `/bff/cee/graph-readiness`. It is the
+ *               only thing `canRunAnalysis` ever asked, and it can object
+ *               while naming nothing (its empty-canvas verdict carries exactly
+ *               five fields and no structured cause, so a retained one lands
+ *               on the `unspecified` rung by construction).
+ *   CANONICAL   `analysis_state.readiness` — carried by the PRODUCER on every
+ *               turn. The contract is explicit that an empty `blockers` list
+ *               "is a POSITIVE claim: the producer assessed readiness and
+ *               found nothing blocking", and that `run_state` "is the
+ *               authority: a consumer must not derive, override or supplement
+ *               it". It reached the store, was exposed by
+ *               `analysisStateSelector` as `readinessStatus`/`readinessBlockers`
+ *               — and had ZERO product consumers. Computed, delivered, unread.
+ *
+ * ── THE CONVERGENCE (Paul's binding rule: name the owner, SUPERSEDE the rival)
+ * `readinessObjectsToRun` stays the ONE definition of a readiness objection and
+ * gains the canonical authority as its first argument. When the producer has
+ * stated readiness, the side-car verdict is NOT CONSULTED AT ALL. This is the
+ * same feature-detected precedence `analysisStateSelector` already applies to
+ * every other analysis truth — one authority, asked once — not a second rule
+ * bolted beside the first.
+ *
+ * ── WHAT EACH TEST BELOW IS FOR ─────────────────────────────────────────────
+ * The suite is written to FAIL in both directions, which is the whole point:
+ *   · AC1 REDs if the gate keeps consulting the side-car when the producer
+ *     said ready;
+ *   · AC2 REDs if a blocked state explains itself with a constant instead of
+ *     with the producer's own blocker list;
+ *   · SUPERSESSION REDs if the change is implemented as an OR (a permissive
+ *     side-car must not be able to open a gate the producer has closed);
+ *   · the LEGACY CONTRAST CONTROL is GREEN at pristine and must stay green —
+ *     it proves this file is bound to the real gate and is not vacuous
+ *     (trap 13e: an absence claim needs a contrast that reads non-zero).
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { AnalysisBlocker } from '@talchain/schemas/boundary'
+
+import { canRunAnalysis, readinessObjectsToRun } from '../canRunAnalysis'
+import { BLOCKED_REASON_COPY } from '../composeBlockedReason'
+import type { GraphReadiness } from '../../hooks/useGraphReadiness'
+import type { CanRunAnalysisParams } from '../canRunAnalysis'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Fixtures.
+//
+// ⚠ `SIDE_CAR_OBJECTS` is NOT invented: it is field-for-field the verdict
+// `readinessStore`'s empty-canvas arm composes and then RETAINS across a failed
+// refetch (`readinessStore.ts`, the `currentNodes.length === 0` branch). It
+// carries no `goal_node_valid`, no `options_total`, no `scaffold_plan` — which
+// is precisely why `composeReadinessBlockedReason` falls to `unspecified` and
+// why the deployed tooltip read the way it did.
+// ───────────────────────────────────────────────────────────────────────────
+
+const SIDE_CAR_OBJECTS: GraphReadiness = {
+  readiness_score: 0,
+  readiness_level: 'needs_work',
+  can_run_analysis: false,
+  confidence_explanation: 'Add some nodes to get started',
+  improvements: [],
+}
+
+const SIDE_CAR_PERMITS: GraphReadiness = {
+  readiness_score: 82,
+  readiness_level: 'ready',
+  can_run_analysis: true,
+  confidence_explanation: 'Analysis available',
+  improvements: [],
+}
+
+function blocker(overrides: Partial<AnalysisBlocker> = {}): AnalysisBlocker {
+  return {
+    code: 'OPTION_NOT_READY',
+    category: 'options',
+    message: 'The option has no effect values.',
+    repairability: 'user_repairable',
+    ...overrides,
+  }
+}
+
+/**
+ * The gate as the deployed canvas calls it: a real model on screen, nothing
+ * held, nothing streaming, no validation issues. Only the two readiness
+ * authorities vary between tests, so any difference in the verdict is
+ * attributable to them and to nothing else.
+ */
+function gate(overrides: Partial<CanRunAnalysisParams> = {}) {
+  return canRunAnalysis({
+    graphHealth: null,
+    readiness: SIDE_CAR_OBJECTS,
+    hasBlockers: false,
+    nodeCount: 16,
+    isRunning: false,
+    analysisHeldOn: null,
+    draftStreamPhase: 'idle',
+    optionsNeedingValues: [],
+    readinessStale: false,
+    ...overrides,
+  })
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ACCEPTANCE 1 — a producer-ready model with zero blockers is RUNNABLE.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('AC1 — producer says ready with zero blockers: the control is ENABLED', () => {
+  it('opens the gate even though the side-car verdict objects', () => {
+    const result = gate({
+      analysisReadiness: { status: 'ready', blockers: [] },
+    })
+
+    expect(result.allowed).toBe(true)
+    // An open gate makes no refusal at all — not a softer one.
+    expect(result.reason).toBeUndefined()
+    expect(result.blockingReasons ?? []).toEqual([])
+  })
+
+  it('never emits the false sentence the deployed build showed', () => {
+    const result = gate({
+      analysisReadiness: { status: 'ready', blockers: [] },
+    })
+
+    // The exact string read off the frozen build's button title.
+    expect(result.reason).not.toBe(BLOCKED_REASON_COPY.unspecified)
+  })
+
+  it('an empty blocker list is a POSITIVE claim, whatever status code rides with it', () => {
+    // The contract's words. `status` is a producer-owned free-string code and a
+    // consumer maps it to its own copy; `blockers` is the itemised list of what
+    // stands in the way. Blocking on a status we cannot name a cause for is
+    // exactly the refusal-without-a-reason this lane exists to delete — and a
+    // run CEE then declines still refuses WITH a stated reason, which is
+    // strictly better than a disabled control that lies.
+    expect(gate({ analysisReadiness: { status: 'unknown_code', blockers: [] } }).allowed).toBe(true)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ACCEPTANCE 2 — a genuinely blocked model is disabled AND says WHY, from the
+// producer's own list.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('AC2 — real blockers close the gate and NAME themselves', () => {
+  it('blocks, and quotes the blocker the producer scoped', () => {
+    const result = gate({
+      analysisReadiness: {
+        status: 'not_ready',
+        blockers: [blocker({ option_label: 'Extend the free trial' })],
+      },
+    })
+
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toContain('Extend the free trial')
+    expect(result.reason).not.toBe(BLOCKED_REASON_COPY.unspecified)
+  })
+
+  it('the sentence DERIVES from the list — two different lists cannot share one constant', () => {
+    // Trap 19, in its cheapest form: a constant satisfies any single assertion.
+    // Two lists that differ only in their labels must produce two sentences that
+    // differ in exactly the same way, or the copy is not derived at all.
+    const a = gate({
+      analysisReadiness: {
+        status: 'not_ready',
+        blockers: [blocker({ option_label: 'Extend the free trial' })],
+      },
+    }).reason
+    const b = gate({
+      analysisReadiness: {
+        status: 'not_ready',
+        blockers: [blocker({ option_label: 'Hold the current price' })],
+      },
+    }).reason
+
+    expect(a).not.toBe(b)
+    expect(a).toContain('Extend the free trial')
+    expect(b).toContain('Hold the current price')
+    expect(a).not.toContain('Hold the current price')
+  })
+
+  it('names a factor-scoped blocker too — the scope field, not one hard-coded key', () => {
+    const result = gate({
+      analysisReadiness: {
+        status: 'not_ready',
+        blockers: [blocker({ category: 'factors', factor_label: 'Support headcount' })],
+      },
+    })
+
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toContain('Support headcount')
+  })
+
+  it('two blockers name both; more than two publish the producer COUNT', () => {
+    const two = gate({
+      analysisReadiness: {
+        status: 'not_ready',
+        blockers: [
+          blocker({ option_label: 'Extend the free trial' }),
+          blocker({ option_label: 'Hold the current price' }),
+        ],
+      },
+    }).reason
+    expect(two).toContain('Extend the free trial')
+    expect(two).toContain('Hold the current price')
+
+    // Four unnameable blockers: the count is still drawn from the LIST, so it
+    // moves with the list. A constant cannot do that either.
+    const four = gate({
+      analysisReadiness: {
+        status: 'not_ready',
+        blockers: [blocker(), blocker(), blocker(), blocker()],
+      },
+    }).reason
+    const three = gate({
+      analysisReadiness: {
+        status: 'not_ready',
+        blockers: [blocker(), blocker(), blocker()],
+      },
+    }).reason
+    expect(four).toContain('4')
+    expect(three).toContain('3')
+    expect(four).not.toBe(three)
+    expect(four).not.toBe(BLOCKED_REASON_COPY.unspecified)
+  })
+
+  it('an unquotable label degrades to the count, never to a leaked identifier', () => {
+    // `safeDisplayLabel`'s rule, inherited unchanged: a label carrying a
+    // glossary-banned term is not quoted back, and the id is NEVER shown.
+    const result = gate({
+      analysisReadiness: {
+        status: 'not_ready',
+        blockers: [blocker({ option_id: 'opt_extend', option_label: 'Rebuild the graph layer' })],
+      },
+    })
+
+    expect(result.allowed).toBe(false)
+    expect(result.reason).not.toContain('opt_extend')
+    expect(result.reason).not.toContain('Rebuild the graph layer')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// SUPERSESSION — the canonical authority ANSWERS; it is not OR-ed with the
+// side-car. This is the test that fails if the fix is written as a parallel
+// rule, which is precisely what Paul's convergence ruling forbids.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('supersession, in BOTH directions', () => {
+  it('a permissive side-car cannot open a gate the producer has closed', () => {
+    const result = gate({
+      readiness: SIDE_CAR_PERMITS,
+      analysisReadiness: {
+        status: 'not_ready',
+        blockers: [blocker({ option_label: 'Hold the current price' })],
+      },
+    })
+
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toContain('Hold the current price')
+  })
+
+  it('an objecting side-car cannot close a gate the producer has opened', () => {
+    expect(gate({ readiness: SIDE_CAR_OBJECTS, analysisReadiness: { status: 'ready', blockers: [] } }).allowed).toBe(true)
+  })
+
+  it('the side-car staleness mark does not reach the producer verdict', () => {
+    // `readinessStale` is a fact about the SIDE-CAR's evidence. Letting it
+    // rewrite a producer-stated refusal would re-mix the two authorities the
+    // moment they were separated — the defect one level up.
+    const result = gate({
+      readinessStale: true,
+      analysisReadiness: {
+        status: 'not_ready',
+        blockers: [blocker({ option_label: 'Extend the free trial' })],
+      },
+    })
+
+    expect(result.reason).toContain('Extend the free trial')
+    expect(result.reason).not.toBe(BLOCKED_REASON_COPY.staleRecheck)
+  })
+
+  it('the dispatch barrier asks the SAME predicate, with the same precedence', () => {
+    // `readinessObjectsToRun` is re-asked at dispatch time (ROADMAP 2.635 I-4).
+    // If the precedence lived only in `canRunAnalysis`, the render gate would
+    // open and the barrier would refuse — a run that dies between the click and
+    // the wire, which is the silent class this lane is also fixing.
+    expect(readinessObjectsToRun(SIDE_CAR_OBJECTS, { status: 'ready', blockers: [] })).toBe(false)
+    expect(
+      readinessObjectsToRun(SIDE_CAR_PERMITS, { status: 'not_ready', blockers: [blocker()] }),
+    ).toBe(true)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// CONTRAST CONTROL — green at pristine, and it must stay green.
+//
+// Everything above is an assertion about a NEW branch. Without these, a fix
+// that simply forced `allowed: true` would satisfy AC1 and this file would
+// applaud. These pin the legacy behaviour that must survive untouched: when
+// the producer has stated NOTHING, the side-car still answers, both ways.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('CONTRAST CONTROL — no producer verdict: the side-car still answers', () => {
+  it('an objecting side-car still closes the gate when readiness is not stated', () => {
+    const result = gate({ analysisReadiness: null })
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toBe(BLOCKED_REASON_COPY.unspecified)
+  })
+
+  it('a permissive side-car still opens it when readiness is not stated', () => {
+    expect(gate({ readiness: SIDE_CAR_PERMITS, analysisReadiness: null }).allowed).toBe(true)
+  })
+
+  it('an omitted argument is identical to an explicit null — absence is one state', () => {
+    const omitted = gate()
+    const explicit = gate({ analysisReadiness: null })
+    expect(omitted.allowed).toBe(explicit.allowed)
+    expect(omitted.reason).toBe(explicit.reason)
+  })
+
+  it('the earlier rungs still outrank readiness, whichever authority answers', () => {
+    // A producer "ready" must not resurrect a run for an empty canvas, a held
+    // model, or a draft whose values have not settled. Those rungs answer
+    // different questions and return BEFORE readiness is consulted.
+    const ready = { status: 'ready', blockers: [] as AnalysisBlocker[] }
+    expect(gate({ nodeCount: 0, analysisReadiness: ready }).allowed).toBe(false)
+    expect(gate({ analysisHeldOn: 'starter', analysisReadiness: ready }).allowed).toBe(false)
+    expect(gate({ draftStreamPhase: 'settling', analysisReadiness: ready }).allowed).toBe(false)
+    expect(gate({ isRunning: true, analysisReadiness: ready }).allowed).toBe(false)
+  })
+
+  it('a validation blocker still closes the gate under a producer-ready verdict', () => {
+    // Two DIFFERENT questions again: `graphHealth` is the client's own
+    // validation, and the producer's readiness says nothing about it.
+    const result = gate({
+      graphHealth: { issues: [{ severity: 'error', message: 'Two options share one label' }] },
+      hasBlockers: true,
+      analysisReadiness: { status: 'ready', blockers: [] },
+    })
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toContain('Two options share one label')
+  })
+})

--- a/src/canvas/utils/__tests__/composeBlockedReason.spec.ts
+++ b/src/canvas/utils/__tests__/composeBlockedReason.spec.ts
@@ -345,6 +345,21 @@ describe('AMENDMENT A1 — the composed sentence is VETTED, never rewritten', ()
       // other and must classify as composed-safe, or the footer would degrade it
       // to the non-committal fallback and the staleness disclosure would vanish.
       staleRecheck: [BLOCKED_REASON_COPY.staleRecheck],
+      // The canonical rungs (19 Aug 2026) — the producer's own readiness
+      // blockers. Same obligation as every rung above: composed copy that the
+      // footer must render VERBATIM, never degrade to the fallback.
+      canonicalOneBlocker: [
+        BLOCKED_REASON_COPY.canonicalOneBlocker('Move billing to edge computing'),
+        BLOCKED_REASON_COPY.canonicalOneBlocker('Extend the free trial'),
+      ],
+      canonicalTwoBlockers: [
+        BLOCKED_REASON_COPY.canonicalTwoBlockers('Buy a vendor platform', 'Build in house'),
+      ],
+      canonicalManyBlockers: [
+        BLOCKED_REASON_COPY.canonicalManyBlockers(1),
+        BLOCKED_REASON_COPY.canonicalManyBlockers(3),
+        BLOCKED_REASON_COPY.canonicalManyBlockers(12),
+      ],
     }
     expect(Object.keys(samples).sort()).toEqual(Object.keys(BLOCKED_REASON_COPY).sort())
 

--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -37,8 +37,11 @@
  */
 
 import { draftValuesAreUnsettled, type DraftStreamPhase } from '../stores/draftStore'
+import type { AnalysisBlocker } from '@talchain/schemas/boundary'
+
 import type { GraphReadiness } from '../hooks/useGraphReadiness'
 import {
+  composeAnalysisBlockedReason,
   composeReadinessBlockedReason,
   type OptionNeedingValues,
 } from './composeBlockedReason'
@@ -121,11 +124,62 @@ export interface GraphHealthState {
   }>
 }
 
+/**
+ * ⭐ THE CANONICAL READINESS AUTHORITY — `analysis_state.readiness`, as the
+ * PRODUCER stated it on this turn (contract `@talchain/schemas/boundary`).
+ *
+ * ── WHY IT IS HERE, AND WHY THE OTHER ONE IS NOW SUBORDINATE ──────────────
+ * Until 19 Aug 2026 this gate had exactly one readiness input: the SIDE-CAR
+ * verdict fetched from `/bff/cee/graph-readiness` and held in `readinessStore`.
+ * Two notions of "ready" therefore existed under one name, and on the frozen
+ * quartet they DISAGREED on a fresh user's very first model:
+ *
+ *   analysis_state.readiness = { status: 'ready', blockers: [] }   ← producer
+ *   readinessStore.readiness.can_run_analysis = false              ← side-car
+ *
+ * The gate asked the side-car, closed, and — because that verdict carried no
+ * structured cause — explained itself with `BLOCKED_REASON_COPY.unspecified`:
+ * *"Olumi needs something more from this model before the next analysis."* The
+ * producer had just said nothing was missing. The product asserted an untruth
+ * about the user's own model and offered a chat route that was itself a no-op.
+ *
+ * ── THE RULE (Paul, binding): name the owner, SUPERSEDE the competitor ─────
+ * `analysis_state.readiness` is the owner. When it is STATED, the side-car
+ * verdict is NOT CONSULTED — not weighted, not OR-ed, not used as a tiebreak.
+ * When it is ABSENT (`null`), the side-car answers exactly as before. That is
+ * the same feature-detected precedence `analysisStateSelector` already applies
+ * to every other analysis truth, and it is why this change is a no-op for every
+ * pre-0.46 fixture in the suite: they carry no `analysis_state`.
+ *
+ * ⚠ `blockers` IS THE PREDICATE, NOT `status`. The contract: an empty list "is
+ * a POSITIVE claim: the producer assessed readiness and found nothing
+ * blocking", while `status` is a producer-owned free-string code a consumer
+ * maps to its own copy. Gating on a status whose cause we cannot name would
+ * re-create the very refusal-without-a-reason this exists to delete — and a run
+ * the producer then declines still refuses WITH a stated reason, which is
+ * strictly better than a control that lies about why it is dead.
+ */
+export interface AnalysisReadinessAuthority {
+  /** The producer's readiness status code. Carried for callers; never gates. */
+  readonly status: string
+  /**
+   * Everything standing between the model and an analysable state, itemised
+   * with per-option and per-factor scope. `[]` is a POSITIVE finding.
+   */
+  readonly blockers: readonly AnalysisBlocker[]
+}
+
 export interface CanRunAnalysisParams {
   /** Graph health from validation */
   graphHealth: GraphHealthState | null
   /** Graph readiness from CEE */
   readiness: GraphReadiness | null
+  /**
+   * ⭐ The canonical authority (above). `null`/omitted = NOT STATED, which is a
+   * different fact from "stated, and nothing is blocking" — collapsing the two
+   * is how an absence becomes a fabricated finding.
+   */
+  analysisReadiness?: AnalysisReadinessAuthority | null
   /** Whether there are critical/blocking actions */
   hasBlockers: boolean
   /** Number of nodes in graph */
@@ -240,7 +294,26 @@ export function readinessWillScaffold(readiness: GraphReadiness | null | undefin
  * exactly what POC-DONE's PC1 forbids. A truthful "we could not check, you can
  * still run" is not a dead end; a false "you cannot run" is.
  */
-export function readinessObjectsToRun(readiness: GraphReadiness | null | undefined): boolean {
+export function readinessObjectsToRun(
+  readiness: GraphReadiness | null | undefined,
+  analysisReadiness?: AnalysisReadinessAuthority | null,
+): boolean {
+  // ⭐ SUPERSESSION, APPLIED ONCE, HERE (19 Aug 2026).
+  //
+  // The precedence lives inside the ONE predicate rather than at the two call
+  // sites, for the same reason the predicate itself exists (I-5): the render
+  // gate and the dispatch barrier both ask this question, and a precedence rule
+  // written twice is the hand-maintained mirror that drifts in the permissive
+  // direction. Putting it here also makes the supersession un-bypassable — a
+  // future caller cannot accidentally get the old answer by forgetting a
+  // clause, because there is no clause to forget.
+  //
+  // Note what this deliberately does NOT do: it does not consult `readiness`
+  // at all once the producer has spoken. A conjunction or a disjunction here
+  // would be a PARALLEL RULE — two authorities kept in a relationship — which
+  // is exactly the shape that produced the defect.
+  if (analysisReadiness) return analysisReadiness.blockers.length > 0
+
   return Boolean(readiness) && !readiness!.can_run_analysis && !readinessWillScaffold(readiness)
 }
 
@@ -295,7 +368,7 @@ export const RUN_LICENCE_SUPERSEDED_REFUSAL =
  * @returns CanRunAnalysisResult with allowed status and reason
  */
 export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResult {
-  const { graphHealth, readiness, hasBlockers, nodeCount, isRunning = false, analysisHeldOn = null, draftStreamPhase = 'idle', optionsNeedingValues, readinessStale = false } = params
+  const { graphHealth, readiness, analysisReadiness = null, hasBlockers, nodeCount, isRunning = false, analysisHeldOn = null, draftStreamPhase = 'idle', optionsNeedingValues, readinessStale = false } = params
 
   const blockingReasons: string[] = []
 
@@ -400,13 +473,29 @@ export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResu
   // asserts a fact the panel's own counts could contradict.
   // ROADMAP 2.635 (I-5) — the rung's predicate is `readinessObjectsToRun`, so
   // the dispatch barrier can ask the SAME question without re-implementing it.
-  if (readinessObjectsToRun(readiness)) {
-    // ROADMAP 2.635 (I-3) — the staleness mark travels WITH the verdict into
-    // the composer. It is passed through rather than pre-derived here, for the
-    // same reason `draftStreamPhase` is (2.122): a predicate re-derived at each
-    // call site is a hand-maintained mirror, and the mutant that drops one
-    // clause from it survives.
-    const composed = composeReadinessBlockedReason(readiness, optionsNeedingValues, readinessStale)
+  if (readinessObjectsToRun(readiness, analysisReadiness)) {
+    // ⭐ The reason comes from WHICHEVER AUTHORITY DECIDED, never from the other
+    // one. A refusal explained by a verdict that did not make it is the
+    // two-questions-one-name defect wearing the fix's clothes: the gate would
+    // be right and the sentence beneath it would be about a different
+    // assessment. `readinessObjectsToRun` chose above; this chooses the same
+    // way, from the same value, one line later.
+    //
+    // ⚠ `readinessStale` is deliberately NOT forwarded on the canonical branch.
+    // It is `readinessStore.stale` — a fact about the SIDE-CAR's evidence, not
+    // about the producer's. Letting it rewrite a producer-stated refusal into
+    // "Olumi is checking again" would re-mix the two authorities in the very
+    // act of separating them, and would claim a refetch is in flight for a
+    // verdict no refetch will touch.
+    //
+    // ROADMAP 2.635 (I-3) — on the legacy branch the staleness mark still
+    // travels WITH the verdict into the composer, passed through rather than
+    // pre-derived here, for the same reason `draftStreamPhase` is (2.122): a
+    // predicate re-derived at each call site is a hand-maintained mirror, and
+    // the mutant that drops one clause from it survives.
+    const composed = analysisReadiness
+      ? composeAnalysisBlockedReason(analysisReadiness.blockers)
+      : composeReadinessBlockedReason(readiness, optionsNeedingValues, readinessStale)
     if (!blockingReasons.includes(composed)) {
       blockingReasons.push(composed)
     }

--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -294,6 +294,14 @@ export function readinessWillScaffold(readiness: GraphReadiness | null | undefin
  * exactly what POC-DONE's PC1 forbids. A truthful "we could not check, you can
  * still run" is not a dead end; a false "you cannot run" is.
  */
+/**
+ * The one member of the producer's readiness vocabulary that cannot describe a
+ * runnable model (CEE `cee/transforms/analysis-ready.ts`,
+ * `orchestrator/tools/analysis-ready-helper.ts`). Named once; the derivation
+ * lives at the single use site below.
+ */
+const ANALYSIS_READINESS_BLOCKED = 'blocked'
+
 export function readinessObjectsToRun(
   readiness: GraphReadiness | null | undefined,
   analysisReadiness?: AnalysisReadinessAuthority | null,
@@ -312,8 +320,73 @@ export function readinessObjectsToRun(
   // at all once the producer has spoken. A conjunction or a disjunction here
   // would be a PARALLEL RULE — two authorities kept in a relationship — which
   // is exactly the shape that produced the defect.
-  if (analysisReadiness) return analysisReadiness.blockers.length > 0
+  if (analysisReadiness) {
+    // ⭐ TWO CLAUSES, BOTH DRAWN FROM THE SAME AUTHORITY — still one owner.
+    //
+    // (a) `status === 'blocked'` — DERIVED, not assumed. It is the one member of
+    //     the vocabulary that cannot describe a runnable model, and it is
+    //     provably different from the other three non-ready values:
+    //       · it is ABSENT from the payload-status priority chain that grades an
+    //         ordinary model (`cee/transforms/analysis-ready.ts:958-969` emits
+    //         only needs_user_input | needs_user_mapping | needs_encoding |
+    //         ready — 0 occurrences of 'blocked'; contrast control in the same
+    //         range: 'needs_encoding' appears twice);
+    //       · its only writers are genuine refusal / hard-block paths —
+    //         `analysis-ready-helper.ts:1117` (hardBlocked), `:1123` (no
+    //         semantic payload at all) and `buildAnalysisRefusalReadiness:1440`.
+    //     `buildAnalysisRefusalReadiness` emits `status: 'blocked'` with NO
+    //     `blockers` key, so on a refusal turn the list is `[]` — and without
+    //     this clause the Analyse control would turn ENABLED one turn after CEE
+    //     refused the run. The user clicks, and is refused again.
+    //
+    // (b) `blockers.length > 0` — the itemised impediments, for every other
+    //     stated status.
+    //
+    // ⚠ WHY NOT THE SIMPLER `status !== 'ready'`. It was proposed, and it is
+    // REFUTED at the producer: two non-ready statuses describe models that ARE
+    // analysable.
+    //   · `needs_user_mapping` fires on `unreachableControllableBlockers`
+    //     (`analysis-ready.ts:961`) — a controllable factor with no inbound
+    //     option edge, which that file's own payload step calls "informational,
+    //     alongside existing blockers". A model with fully-encoded options and
+    //     one unconnected factor is analysable and would be refused.
+    //   · `needs_encoding` (`:966`) is EXACTLY the UI-SEM-091 scaffold state,
+    //     whose whole shipped point (CEE #612, and the comment at the scaffold
+    //     rung below) is that "the graph is runnable even though
+    //     can_run_analysis is false" — the run triggers the draft. Refusing it
+    //     would delete a shipped capability.
+    // Corroborated by CEE's own integrity guard, which flags only
+    // `status_ready_with_actionable_blockers`
+    // (`canonical-analysis-state.ts:494`) and deliberately excludes advisory
+    // blockers that "ride along on otherwise ready payloads by design". There is
+    // no reverse guard, because non-ready-yet-runnable is not an anomaly there —
+    // it is normal.
+    //
+    // So the honest predicate refuses what is provably unrunnable and lets the
+    // producer's itemised list decide the rest. Refusing on a status whose cause
+    // we cannot name would re-create the original defect in a new spelling.
+    return analysisReadiness.status === ANALYSIS_READINESS_BLOCKED || analysisReadiness.blockers.length > 0
+  }
 
+  // ⏳ REMOVAL TRIGGER for the side-car fallback below.
+  //
+  // This is NOT a pre-0.46-only shim and must not be read as one. The producer
+  // verdict is TURN-SCOPED: `analysisStateV1` is cleared on turn silence and on
+  // a schema-parse failure (`applyV5State.ts`), on import / reset /
+  // scenario-switch (`store.ts`), and is `null` at initial load — and CEE omits
+  // `analysis_state` on most `sendFinalised200` exits. So this branch fires
+  // routinely mid-journey, and ONE SILENT TURN re-opens the defect this lane
+  // closed. Keeping it is still correct: it is byte-identical to the behaviour
+  // shipping today, and deleting it now would hand a fresh user a dead Analyse
+  // control on any turn CEE stays quiet.
+  //
+  // DELETE THIS BRANCH, AND THE `readiness` PARAMETER WITH IT, WHEN — and only
+  // when — the producer verdict is durable across a silent turn: i.e. when
+  // `analysisStateV1` is either RETAINED (with its own staleness mark) rather
+  // than cleared on absence, or re-supplied on every turn. Until one of those
+  // holds, a consumer with no verdict has no honest alternative to asking the
+  // side-car. The condition is about the STORE'S RETENTION POLICY, not about a
+  // schema version, and no date makes it true.
   return Boolean(readiness) && !readiness!.can_run_analysis && !readinessWillScaffold(readiness)
 }
 

--- a/src/canvas/utils/composeBlockedReason.ts
+++ b/src/canvas/utils/composeBlockedReason.ts
@@ -34,6 +34,8 @@
  *       does not license must not be made.
  */
 
+import type { AnalysisBlocker } from '@talchain/schemas/boundary'
+
 import type { GraphReadiness } from '../hooks/useGraphReadiness'
 import {
   containsBannedTerm,
@@ -138,6 +140,49 @@ export const BLOCKED_REASON_COPY = {
    * it to stand in for them. It is transient by construction: the refetch it
    * describes is already debounced and in flight.
    */
+  /**
+   * ── THE CANONICAL RUNGS (19 Aug 2026) ───────────────────────────────────
+   *
+   * The three above them render the SIDE-CAR verdict's structured fields. These
+   * three render the PRODUCER's own `analysis_state.readiness.blockers`, and
+   * they exist because that list answers a question the side-car fields cannot:
+   * it is itemised, and every entry carries its own scope.
+   *
+   * ⚠ THEY DELIBERATELY DO NOT REUSE `oneOption`/`twoOptions`/`manyOptions`.
+   * Those sentences assert a SPECIFIC cause — "has no effect values yet, tell
+   * Olumi what it changes" — which an `AnalysisBlocker` may not support: the
+   * list also carries goal-scoped and factor-scoped entries. Borrowing a
+   * sentence because it is the right SHAPE is how this module acquired the
+   * false claims its header records.
+   *
+   * ⚠ AND THEY DO NOT QUOTE `blocker.message`. That is producer PROSE, and this
+   * module's founding rule is that user-facing copy is composed from STRUCTURED
+   * fields, never derived from the engine's sentences — parsing or passing
+   * through prose is the same hand-maintained mirror in a new place. What is
+   * quoted is `option_label` / `factor_label`: the user's OWN words about their
+   * own decision, vetted by `safeDisplayLabel` exactly as the option rungs vet
+   * theirs.
+   *
+   * The claim each one makes is deliberately thin — the element is not ready,
+   * and the chat can say what it needs. It is true for every blocker category
+   * the contract admits, which is what qualifies it to stand for all of them.
+   */
+  /** One blocker, scoped to an element we can quote by name. */
+  canonicalOneBlocker: (label: string) =>
+    `"${label}" is not ready for analysis yet. Ask in the chat what it needs.`,
+  /** Two blockers, both quotable. */
+  canonicalTwoBlockers: (first: string, second: string) =>
+    `"${first}" and "${second}" are not ready for analysis yet. Ask in the chat what they need.`,
+  /**
+   * Count-only rung: three or more, or any count whose scope labels could not
+   * be quoted. The number is the PRODUCER's own list length — still a fact
+   * drawn from the verdict, just a less specific one. Never zero: the caller
+   * only composes when the list is non-empty.
+   */
+  canonicalManyBlockers: (n: number) =>
+    n === 1
+      ? '1 part of your model is not ready for analysis yet. Ask in the chat what it needs.'
+      : `${n} parts of your model are not ready for analysis yet. Ask in the chat what they need.`,
   staleRecheck:
     'Your model changed since the last check. Olumi is checking again, which takes a moment.',
 } as const
@@ -367,6 +412,50 @@ export function composeReadinessBlockedReason(
   return BLOCKED_REASON_COPY.unspecified
 }
 
+/**
+ * Compose the refusal from the PRODUCER's own readiness blockers.
+ *
+ * The counterpart to `composeReadinessBlockedReason`, for the authority that
+ * supersedes it. Same rule, one layer up: name the remedy when the structured
+ * fields support it, and degrade only to a LESS SPECIFIC TRUE claim — never to
+ * a different one.
+ *
+ * ⚠ THE EMPTY LIST IS NOT A REFUSAL AND MUST NEVER REACH HERE. The contract is
+ * explicit that `blockers: []` is a POSITIVE claim — the producer assessed
+ * readiness and found nothing blocking — so a caller composing a refusal from
+ * an empty list has already decided something this function cannot justify.
+ * The guard below returns the non-committal rung rather than inventing a cause,
+ * but the real protection is `readinessObjectsToRun`, which never asks.
+ *
+ * Scope labels only, never `blocker.message`: see the rung docs above.
+ */
+export function composeAnalysisBlockedReason(
+  blockers: readonly AnalysisBlocker[],
+): string {
+  if (blockers.length === 0) return BLOCKED_REASON_COPY.unspecified
+
+  // `option_label` and `factor_label` are the two scopes the contract carries.
+  // Read in that order because an option is the more actionable of the two and
+  // the one the user chose the words for; a blocker scoped to neither has no
+  // name to give and falls to the count.
+  const labelled = blockers
+    .map((b) => b.option_label ?? b.factor_label ?? '')
+    .map((raw) => (raw.trim().length > 0 ? safeDisplayLabel(raw) : null))
+    .filter((label): label is string => label !== null)
+
+  if (blockers.length === 1 && labelled.length === 1) {
+    return BLOCKED_REASON_COPY.canonicalOneBlocker(labelled[0])
+  }
+  if (blockers.length === 2 && labelled.length === 2) {
+    return BLOCKED_REASON_COPY.canonicalTwoBlockers(labelled[0], labelled[1])
+  }
+  // A2's rule, inherited: the count published is the VERDICT's own list length,
+  // never the length of the sub-list we managed to quote. Publishing the latter
+  // would understate the work outstanding by exactly the number of entries we
+  // could not name.
+  return BLOCKED_REASON_COPY.canonicalManyBlockers(blockers.length)
+}
+
 // ══════════════════════════════════════════════════════════════════════════
 // A1 — the render path must VET this copy, never REWRITE it.
 //
@@ -433,6 +522,16 @@ function composedPatterns(): RegExp[] {
     BLOCKED_REASON_COPY.goalMissing,
     BLOCKED_REASON_COPY.tooFewOptions,
     BLOCKED_REASON_COPY.unspecified,
+    // The canonical rungs. Omitting them here would degrade every
+    // producer-sourced refusal to the footer's non-committal fallback at the
+    // render seam — i.e. it would re-create the exact false sentence this lane
+    // was opened to delete, one layer further down. The sample-matrix spec
+    // fails loud if a rung is added without a sample, which is why that spec
+    // asserts coverage of every key.
+    BLOCKED_REASON_COPY.canonicalOneBlocker(LABEL_SLOT),
+    BLOCKED_REASON_COPY.canonicalTwoBlockers(LABEL_SLOT, SECOND_LABEL_SLOT),
+    BLOCKED_REASON_COPY.canonicalManyBlockers(1),
+    BLOCKED_REASON_COPY.canonicalManyBlockers(COUNT_SLOT),
     // ROADMAP 2.635 (I-3). Omitting it here would have been the exact failure
     // this function's docstring warns about: an unrecognised composed sentence
     // classifies as `foreign` and the render path degrades it to the surface's


### PR DESCRIPTION
## The blocker, at the wire

Frozen quartet (UI `aa916511` · CEE `a61fe7f` · PLoT `fb63b03` · ISL `28fe0c95`), fresh guest, governed brief `04-conflicting-constraints`, 16-node model drafted successfully. From `useCanvasStore.getState()`:

```
analysisStateV1.readiness = { status: "ready", blockers: [] }   <- CANONICAL: ready, ZERO blockers
analysisStateV1.run_state = { kind: "never_run" }
ceeAnalysisReady.status   = "ready"   (all three options ready)
analysisRefusalNotice     = null
```

…and `[data-testid="pre-analysis-v3-analyse"]` was **`disabled: true`**, titled:

> *"Olumi needs something more from this model before the next analysis. Ask in the chat and it will explain what is missing."*

**That sentence is false**, and the escape route it named was worse: the chat's "Run analysis" produced no analysis, no refusal, no error. A fresh user with a ready model had a button that lied and a chat affordance that did nothing.

## Root cause: two readiness notions under one name (trap 21)

| | |
|---|---|
| **COMPETITOR** | `readinessStore.readiness.can_run_analysis` — a **side-car** assessment fetched from `/bff/cee/graph-readiness`. The only thing `canRunAnalysis` ever asked. It can object while naming nothing: its empty-canvas verdict carries five fields and **no structured cause**, so a retained one lands on `BLOCKED_REASON_COPY.unspecified` **by construction** — the exact sentence on the build. |
| **CANONICAL** | `analysis_state.readiness`, stated by the producer on every turn. The contract is explicit that an empty `blockers` list *"is a POSITIVE claim: the producer assessed readiness and found nothing blocking"*. It reached the store, was exposed by `analysisStateSelector` as `readinessStatus`/`readinessBlockers` — and had **zero product consumers**. Computed, delivered, unread. |

Established by elimination at the bytes: every earlier rung of `canRunAnalysis` returns a *different* sentence (`nodeCount === 0`, `analysisHeldOn`, `draftStreamPhase`, validation blockers), and inside `composeReadinessBlockedReason` only rung 4 can emit `unspecified` — reached when the verdict refuses and carries no `goal_node_valid`, no `options_total`, no not-ready options. `ceeAnalysisReady` had all options `ready`, so rung 1 was empty. Rung 4 is the only survivor.

## The convergence — name the owner, supersede the rival, add no parallel rule

`readinessObjectsToRun` stays the **one** definition of a readiness objection and gains the canonical authority as its first argument:

- when the producer has spoken, the side-car is **not consulted** — not weighted, not OR-ed, not a tiebreak;
- when the producer is silent, the side-car answers exactly as before, so every pre-0.46 fixture is byte-identical;
- the precedence lives **inside the predicate**, so the render gate, the dispatch barrier and the panel cannot drift apart;
- the blocked **sentence** is composed from whichever authority decided, never from the other one.

The predicate is `blockers.length > 0`, **not `status`**. Gating on a status whose cause cannot be named would re-create the refusal-without-a-reason this deletes — and a run the producer then declines still refuses *with a stated reason*, which beats a control that lies about why it is dead.

## Second, independent defect: the silent refusal

`ConversationPanel.handleRunAnalysis` opened with a bare `if (!runGateResult.allowed || isAnalysisRunning) return`. **Even a correctly closed gate said nothing.** It now surfaces the same sentence the composer button already shows on hover, through the same toast the canonical runner uses for the same refusal in `OutputsDock`.

It deliberately does **not** write `analysisRefusalNotice`. That slice is sourced only from a typed CEE refusal on `response.analysis_ready`; fabricating one client-side would claim the producer refused a turn that was never sent — the guarantee-theatre class, not a cure for it.

## Third surface, caught by the mounted spec

`usePreAnalysisModel` derived its own `canRun` off the side-car. The new mounted test found an **ENABLED** "Analyse first pass" sitting directly beneath the line **"Not ready for analysis yet"** — the same defect class, created by fixing it one layer up. It now asks the same predicate instead of restating it. Its stale "keyed on `readiness == null` ALONE" comment is amended rather than left to mislead.

## Evidence

**RED-first at pristine `aa916511`**, in a worktree outside the repo root, isolation proved by a **write test** (sentinel written to the worktree, asserted absent from the source clone) and distinct inodes: **22 collected, 14 failed / 8 passed**. The 8 passing are the legacy contrast controls — they prove the specs bind to the real gate and are not vacuous.

**After the fix: 25/25 green** — 17 gate + 3 mounted `OutputsDock` + 5 mounted `ConversationPanel`. Collected counts asserted **by name**, per file, not inferred from a suite total.

**Five mutants, each with a distinct red set**, applied-checked against a pristine archive (restores from the archive, never `git checkout --`), with a trailing control restoring 25/25:

| Mutant | Reds |
|---|---|
| M1 delete the supersession | the **ENABLED** tests only |
| M2 always permit (`blockers.length > 0` → `false`) | the **DISABLED/naming** tests only |
| M3 bind to `status` not `blockers` | **exactly one** test |
| M4 compose the reason from the superseded authority | the naming tests only; the gate tests still pass |
| M5 restore the silent `return` | **exactly** the three silence tests |

M1 and M2 are the acceptance pair: different mutants, different reds, neither red set containing the other's.

**Scoped suites** (no full-suite run — seven lanes were live): 2533 passed across `utils` / `pre-analysis-v3` / `state` / `stores`; 4047 passed across `components` / `conversation`.

**Required-check steps run in order at this tip**: `lint` (0 errors), `typecheck` (gate PASSED; drift **shrank** 2272 → 2263, `--update-baseline` **declined**), `ci:guard:zustand`, `ci:guard:starters`, `check:vendor`, `ci:guard:schemas-version`, `ci:guard:ds:enforce`, `build:ci` (bundle 46.84 KB gzip, within budget).

## Two findings for the record — not fixed here, deliberately

1. **A third readiness predicate exists and is untouched.** `SuggestedChips` gates a `run_analysis` chip's **visibility** on `useAnalysisStatus() === 'ready'`, i.e. `ceeAnalysisReady.status`. On the captured state that read `ready`, so the chip **rendered** — this predicate is not part of the defect. It answers a different question ("may we offer this chip?"), and converging it is a separate reviewable change. Flagged rather than widened.
2. **A cross-lane hypothesis, refuted at this tip.** `usable_for_*` gates **nothing** in the run path. Complete non-test manifest in `src/`: `analysisStateSelector.ts` (exposes them) and `lib/coherence/crossSurfaceCoherence.ts` (the diagnostic). `SuggestedChips.tsx` contains **zero** occurrences — contrast control in the same file: `READINESS_GATED_ACTIONS` returns 3, so the sweep sees the file. Consistent with the brief's own read that the post-run flags were correctly `false`.

**Scope note on the chat click.** Two production `canRunAnalysis` call sites exist at this tip (`OutputsDock`, `ConversationPanel`); both now read the canonical authority. The only chat path that can consume a click and emit *nothing* — no turn, no toast, no error — is the bare `return` fixed here, reached via `useGuidanceStore._runAnalysis`. A CEE-*suggested* `run_analysis` chip routes to `sendChip` and always sends a turn, so it cannot be silent client-side. **If a live capture shows the silent click was that path, the remaining silence is CEE-side and outside this fix** — worth one re-capture on the deployed build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
