### PR TITLE
fix(run-gate): count only ACTIONABLE blockers, not raw length

### DIFF
--- a/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
@@ -10,7 +10,11 @@
 import { useEffect, useMemo } from 'react'
 import { useCanvasStore } from '../../../store'
 import { useGraphReadiness } from '../../../hooks/useGraphReadiness'
-import { readinessObjectsToRun, readinessWillScaffold } from '../../../utils/canRunAnalysis'
+import {
+  actionableBlockers,
+  readinessObjectsToRun,
+  readinessWillScaffold,
+} from '../../../utils/canRunAnalysis'
 import { useAnalysisReadinessAuthority } from '../../../state/analysisStateSelector'
 import { composeAnalysisBlockedReason } from '../../../utils/composeBlockedReason'
 import { resolveStarterId } from '../../../starters/loadStarter'
@@ -434,7 +438,15 @@ export function usePreAnalysisModel(): PreAnalysisModel {
         return {
           dot: 'muted' as const,
           headline: FOOTER_COPY.notReady,
-          subline: composeAnalysisBlockedReason(analysisReadiness.blockers),
+          // ...and from the same LIST that authority decided on. `canRun` is
+          // the run gate's verdict, and that gate counts only ACTIONABLE
+          // blockers; composing from the raw list here would name an advisory
+          // blocker the gate had already ruled out, and send the user to fix
+          // something that cannot open the run. One filter, one owner:
+          // `actionableBlockers` in `canRunAnalysis`.
+          subline: composeAnalysisBlockedReason(
+            actionableBlockers(analysisReadiness.blockers),
+          ),
         }
       }
       const explanation = readiness?.confidence_explanation?.trim()

--- a/src/canvas/utils/__tests__/canonicalReadinessAuthority.spec.ts
+++ b/src/canvas/utils/__tests__/canonicalReadinessAuthority.spec.ts
@@ -539,3 +539,177 @@ describe("CEE's `unknown` sentinel behaves IDENTICALLY to an absent verdict", ()
     }
   })
 })
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ADVISORY BLOCKERS RIDE ALONG ON A READY PAYLOAD — AND MUST NOT CLOSE THE GATE
+//
+// ── THE DEFECT THIS PINS (derived at CEE `a61fe7ff`, the deployed build) ────
+// #792 made `blockers` the predicate, as a RAW COUNT. But the producer's list
+// is not homogeneous. CEE's own header says so
+// (`orchestrator-v5/context/canonical-analysis-state.ts:47-56`):
+//
+//   "`status === 'ready'` carrying advisory `constraint_dropped` blockers is a
+//    BY-DESIGN combination on the shared contract (the egress boundary injects
+//    informational constraint-drop blockers onto an already-ready payload
+//    without recomputing status). It must NOT downgrade usability."
+//
+// The chain, at the bytes: `extractConstraintDropBlockers`
+// (`cee/transforms/analysis-ready.ts:1474`) mints the blocker →
+// `cee/unified-pipeline/stages/boundary.ts:198` pushes it onto an already-ready
+// `analysis_ready.blockers` WITHOUT recomputing status →
+// `orchestrator/tools/draft-graph.ts:907` carries `blockers` through verbatim →
+// `orchestrator-v5/compose/analysis-state-v1.ts:322` `mapWireBlockers` maps it
+// onto the wire with NO actionability filter, as
+// `code: 'CONSTRAINT_REVIEW_REQUIRED'` (`analysis-ready-helper.ts:705`, the sole
+// emitter of that code).
+//
+// So a raw count refuses a model the producer JUST CALLED READY — the 2.635
+// defect in a new spelling. Worse, the same payload's `usable_for_prose` and
+// `usable_for_chips` stay TRUE, so the product contradicts itself on one turn.
+//
+// ── WHAT EACH TEST IS FOR ──────────────────────────────────────────────────
+// · RED-FIRST REDs at pristine (the gate refuses a ready model).
+// · ACTIONABLE STILL REFUSES is the DISCRIMINATING PARTNER: it stays green at
+//   pristine and REDs the moment the filter is widened to drop an actionable
+//   code — proving the fix narrows the count to a named class rather than
+//   simply counting fewer things.
+// · The DRIFT PIN REDs if CEE renames or reclassifies the code we restate.
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * The producer's advisory blocker code, restated from CEE
+ * `orchestrator/tools/analysis-ready-helper.ts:705` — the `constraint_dropped`
+ * case of `blockerIssue`, and the only branch in that repo that emits it.
+ */
+const ADVISORY_CODE = 'CONSTRAINT_REVIEW_REQUIRED'
+
+/**
+ * The ACTIONABLE codes `blockerIssue` emits, restated from the same switch
+ * (`analysis-ready-helper.ts:683-702`). These are the images of CEE's
+ * `ACTIONABLE_BLOCKER_TYPES` (`canonical-analysis-state.ts:130`:
+ * `missing_value`, `ambiguous_value`, `missing_connection`) — the set
+ * difference against the schema's four-member `AnalysisBlockerType` enum
+ * (`src/schemas/analysis-ready.ts:140`) is exactly `constraint_dropped`, which
+ * is what `ADVISORY_CODE` above is the wire spelling of.
+ */
+const ACTIONABLE_CODES = [
+  'MISSING_OPTION_VALUE',
+  'AMBIGUOUS_OPTION_VALUE',
+  'MISSING_OPTION_CONNECTION',
+] as const
+
+/**
+ * The advisory blocker AS CEE SHIPS IT — the `common` fields of `blockerIssue`
+ * (`repairability: 'human_input_required'`), the `option_values` category that
+ * `constraint_dropped` shares with `missing_value`, and the producer-authored
+ * message. The shared category is the point: `category` CANNOT discriminate
+ * here, which is why the fix keys on `code`.
+ */
+function advisoryBlocker(overrides: Partial<AnalysisBlocker> = {}): AnalysisBlocker {
+  return blocker({
+    code: ADVISORY_CODE,
+    category: 'option_values',
+    message: 'Review the unresolved constraint for "Cut burn rate by 30%".',
+    repairability: 'human_input_required',
+    factor_id: 'fac_burn_rate',
+    factor_label: 'Cut burn rate by 30%',
+    ...overrides,
+  })
+}
+
+describe('advisory blockers on a READY payload do not close the gate', () => {
+  it('RED-FIRST — a ready model carrying only a constraint_dropped advisory is RUNNABLE', () => {
+    // The exact combination CEE documents as by-design. At pristine the raw
+    // count refuses this, which is the defect.
+    const result = gate({
+      analysisReadiness: { status: 'ready', blockers: [advisoryBlocker()] },
+    })
+
+    expect(result.allowed).toBe(true)
+    // And it must not manufacture a refusal sentence about a model the producer
+    // called ready — the 2.635 failure mode, which was a FALSE sentence as much
+    // as a dead control.
+    expect(result.reason).toBeUndefined()
+    expect(result.blockingReasons ?? []).not.toContain(BLOCKED_REASON_COPY.unspecified)
+  })
+
+  it('goes through the REAL selector seam, not a hand-built authority', () => {
+    // Bound to `selectAnalysisReadinessAuthority` for the same reason the rest
+    // of this file is: a guard living in the selector would otherwise be
+    // invisible to every assertion here.
+    const authority = selectAnalysisReadinessAuthority(
+      wireState({ status: 'ready', blockers: [advisoryBlocker()] }),
+    )
+    expect(authority).not.toBeNull()
+    expect(authority!.blockers.map((b) => b.code)).toEqual([ADVISORY_CODE])
+    expect(readinessObjectsToRun(SIDE_CAR_OBJECTS, authority)).toBe(false)
+    expect(gate({ analysisReadiness: authority }).allowed).toBe(true)
+  })
+
+  it('DISCRIMINATING PARTNER — every ACTIONABLE code still closes the gate on a ready payload', () => {
+    // Green at pristine, and the half that REDs if the filter is widened to
+    // drop an actionable code. Without it, "stop counting blockers entirely"
+    // would satisfy the RED-FIRST case above and delete the gate.
+    for (const code of ACTIONABLE_CODES) {
+      const result = gate({
+        analysisReadiness: { status: 'ready', blockers: [blocker({ code })] },
+      })
+      expect(result.allowed, code).toBe(false)
+    }
+  })
+
+  it('an advisory blocker does not MASK an actionable one sharing the list', () => {
+    // Bound by code IDENTITY, never by array position: the advisory sits FIRST
+    // here, so a fix that inspected only `blockers[0]` would wrongly permit.
+    const result = gate({
+      analysisReadiness: {
+        status: 'ready',
+        blockers: [advisoryBlocker(), blocker({ code: 'MISSING_OPTION_VALUE' })],
+      },
+    })
+    expect(result.allowed).toBe(false)
+  })
+
+  it('an UNRECOGNISED code still refuses — the denylist fails CLOSED', () => {
+    // `code` is an OPEN vocabulary by contract ("a closed enum here would
+    // reject codes a newer producer legitimately emits"). An allowlist of
+    // actionable codes would fail OPEN on a newly-minted actionable code; this
+    // asserts the chosen direction, which is the safe one.
+    const result = gate({
+      analysisReadiness: {
+        status: 'ready',
+        blockers: [blocker({ code: 'SOME_FUTURE_PRODUCER_CODE' })],
+      },
+    })
+    expect(result.allowed).toBe(false)
+  })
+
+  it('`blocked` still refuses even when every blocker is advisory', () => {
+    // Clause (a) is untouched by this change and must stay untouched: a
+    // refusal turn emits `status: 'blocked'`, and the gate must not reopen one
+    // turn later just because the list happens to hold nothing actionable.
+    expect(
+      gate({ analysisReadiness: { status: 'blocked', blockers: [advisoryBlocker()] } }).allowed,
+    ).toBe(false)
+    expect(gate({ analysisReadiness: { status: 'blocked', blockers: [] } }).allowed).toBe(false)
+  })
+
+  it('DRIFT PIN — the restated advisory code is the one CEE actually emits', () => {
+    // The UI cannot import `ACTIONABLE_BLOCKER_TYPES`; this constant is a
+    // hand-restatement, so it gets the same treatment
+    // `ANALYSIS_READINESS_BLOCKED` gets. If CEE renames the code, reclassifies
+    // `constraint_dropped` as actionable, or routes it through a different
+    // code, this REDs and names the seam.
+    expect(ADVISORY_CODE).toBe('CONSTRAINT_REVIEW_REQUIRED')
+    // The advisory code must NOT appear among the actionable ones — the two
+    // sets are disjoint by construction, and a rename that collided them would
+    // otherwise pass silently.
+    expect(ACTIONABLE_CODES).not.toContain(ADVISORY_CODE as never)
+    // And exactly ONE code is waived. A second entry appearing here without a
+    // derivation at the producer is the hand-maintained mirror drifting.
+    const waived = ACTIONABLE_CODES.filter(
+      (c) => gate({ analysisReadiness: { status: 'ready', blockers: [blocker({ code: c })] } }).allowed,
+    )
+    expect(waived).toEqual([])
+  })
+})

--- a/src/canvas/utils/__tests__/canonicalReadinessAuthority.spec.ts
+++ b/src/canvas/utils/__tests__/canonicalReadinessAuthority.spec.ts
@@ -61,7 +61,7 @@
 import { describe, it, expect } from 'vitest'
 import type { AnalysisBlocker, AnalysisStateV1 } from '@talchain/schemas/boundary'
 
-import { canRunAnalysis, readinessObjectsToRun } from '../canRunAnalysis'
+import { actionableBlockers, canRunAnalysis, readinessObjectsToRun } from '../canRunAnalysis'
 import { selectAnalysisReadinessAuthority } from '../../state/analysisStateSelector'
 import { BLOCKED_REASON_COPY } from '../composeBlockedReason'
 import type { GraphReadiness } from '../../hooks/useGraphReadiness'
@@ -694,12 +694,17 @@ describe('advisory blockers on a READY payload do not close the gate', () => {
     expect(gate({ analysisReadiness: { status: 'blocked', blockers: [] } }).allowed).toBe(false)
   })
 
-  it('DRIFT PIN — the restated advisory code is the one CEE actually emits', () => {
-    // The UI cannot import `ACTIONABLE_BLOCKER_TYPES`; this constant is a
-    // hand-restatement, so it gets the same treatment
-    // `ANALYSIS_READINESS_BLOCKED` gets. If CEE renames the code, reclassifies
-    // `constraint_dropped` as actionable, or routes it through a different
-    // code, this REDs and names the seam.
+  it('DRIFT PIN — UI-side only: this spec and the gate waive the same one code', () => {
+    // ⚠ SCOPE, CORRECTED 19 Aug 2026. This case claimed it REDs "if CEE renames
+    // the code". It cannot: nothing in this repo observes the producer, and a
+    // CEE-side rename lands green here. Read it as a UI-side pin and nothing
+    // more — the producer half needs a live capture or a CEE-side guard.
+    //
+    // The literal below is deliberately kept as DOCUMENTATION of the wire
+    // spelling, and it is NOT the discriminating assertion: it compares a local
+    // const to its own literal and can never fail. The two assertions after it
+    // are the ones with teeth, because both derive their answer from the
+    // SOURCE's `ADVISORY_BLOCKER_CODES` by running the gate.
     expect(ADVISORY_CODE).toBe('CONSTRAINT_REVIEW_REQUIRED')
     // The advisory code must NOT appear among the actionable ones — the two
     // sets are disjoint by construction, and a rename that collided them would
@@ -711,5 +716,118 @@ describe('advisory blockers on a READY payload do not close the gate', () => {
       (c) => gate({ analysisReadiness: { status: 'ready', blockers: [blocker({ code: c })] } }).allowed,
     )
     expect(waived).toEqual([])
+  })
+})
+
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ACCEPTANCE — THE SENTENCE DESCRIBES THE LIST THE GATE DECIDED ON.
+//
+// Finding 794-1. The gate counts only ACTIONABLE blockers; the refusal beneath
+// it was composed from the RAW list. With one actionable blocker and one
+// advisory one the product refused over the first and then named BOTH:
+//
+//   "Launch in Q1" and "Burn rate" are not ready for analysis yet.
+//   Ask in the chat what they need.
+//
+// `Burn rate` is the blocker the gate has JUST RULED OUT. The user is sent to
+// fix something that cannot open the run — and the file's own rule one line up
+// says the reason comes from whichever authority decided. It did; it then
+// described a different list than the decision was made on.
+//
+// ⚠ NOT A REGRESSION: the pre-#794 gate named both too, because it counted
+// both. #794 is the change that made the two lists differ, so the sentence
+// becomes its problem.
+//
+// THE PAIR IS THE EVIDENCE, and neither half alone is:
+//  · MIXED asserts the ONE-blocker rung naming ONLY the actionable label.
+//  · TWO-ACTIONABLE TWIN asserts the TWO-blocker rung naming BOTH. Without it,
+//    "always compose from the first blocker" or "always emit the one-blocker
+//    rung" would satisfy MIXED — the assertion would pass by naming FEWER
+//    things rather than by naming the RIGHT things.
+// Both bind by the label's IDENTITY through the copy factories, never by a
+// substring another rung could satisfy.
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** The actionable blocker AS CEE SHIPS IT, scoped to a quotable option. */
+function actionableBlocker(overrides: Partial<AnalysisBlocker> = {}): AnalysisBlocker {
+  return blocker({
+    code: 'MISSING_OPTION_VALUE',
+    category: 'option_values',
+    message: 'Choose the missing effect value for "Launch in Q1".',
+    repairability: 'human_input_required',
+    option_id: 'opt_launch_q1',
+    option_label: 'Launch in Q1',
+    ...overrides,
+  })
+}
+
+describe('the refusal names the blockers the gate actually decided on', () => {
+  it('MIXED — one actionable + one advisory names ONLY the actionable one', () => {
+    const result = gate({
+      analysisReadiness: {
+        status: 'needs_user_input',
+        blockers: [actionableBlocker(), advisoryBlocker({ factor_label: 'Burn rate' })],
+      },
+    })
+
+    // Precondition, pinned in-test: this payload must genuinely be the mixed
+    // case, or the assertion below could pass because the fixture stopped
+    // reproducing anything rather than because the code is right.
+    expect(actionableBlockers([actionableBlocker(), advisoryBlocker()]).map((b) => b.code)).toEqual([
+      'MISSING_OPTION_VALUE',
+    ])
+
+    expect(result.allowed).toBe(false)
+    // Bound by IDENTITY through the factory: the one-blocker rung, quoting the
+    // ACTIONABLE element's own label.
+    expect(result.reason).toBe(BLOCKED_REASON_COPY.canonicalOneBlocker('Launch in Q1'))
+    // And the advisory element is named NOWHERE — not in the primary sentence,
+    // not in a `+N more` tail, not in any other blocking reason.
+    expect(result.reason).not.toContain('Burn rate')
+    for (const line of result.blockingReasons ?? []) {
+      expect(line).not.toContain('Burn rate')
+    }
+  })
+
+  it('TWO-ACTIONABLE TWIN — two actionable blockers still name BOTH', () => {
+    // The discriminating partner. It REDs if the fix degrades to "name one
+    // thing" or "name the first thing", which is how a narrowing assertion
+    // passes for the wrong reason.
+    const result = gate({
+      analysisReadiness: {
+        status: 'needs_user_input',
+        blockers: [
+          actionableBlocker(),
+          actionableBlocker({
+            code: 'AMBIGUOUS_OPTION_VALUE',
+            option_id: 'opt_hold',
+            option_label: 'Hold until Q3',
+          }),
+        ],
+      },
+    })
+
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toBe(
+      BLOCKED_REASON_COPY.canonicalTwoBlockers('Launch in Q1', 'Hold until Q3'),
+    )
+  })
+
+  it('ADVISORY-ONLY ON A `blocked` STATUS degrades to the non-committal rung', () => {
+    // The domain case the fix must not get wrong. Here the gate is closed by
+    // clause (a) — the STATUS — and the actionable list is EMPTY, so there is
+    // no blocker entitled to be named. The honest answer is the less-specific
+    // TRUE rung, never the advisory element the status did not refuse over.
+    const result = gate({
+      analysisReadiness: {
+        status: 'blocked',
+        blockers: [advisoryBlocker({ factor_label: 'Burn rate' })],
+      },
+    })
+
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toBe(BLOCKED_REASON_COPY.unspecified)
+    expect(result.reason).not.toContain('Burn rate')
   })
 })

--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -343,8 +343,23 @@ const ANALYSIS_READINESS_BLOCKED = 'blocked'
  * (`analysis-ready-helper.ts:665-707`). `repairability` is `human_input_required`
  * for all four. **`code` is the only discriminator the producer actually ships**,
  * and `CONSTRAINT_REVIEW_REQUIRED` is emitted from exactly one branch —
- * `analysis-ready-helper.ts:705`, the `constraint_dropped` case — so the
- * mapping is 1:1 and not a guess.
+ * `analysis-ready-helper.ts:705`, the `constraint_dropped` case.
+ *
+ * ⚠ THAT HOLDS IN ONE DIRECTION ONLY, AND THIS COMMENT SAID "1:1" (corrected
+ * 19 Aug 2026, derived at CEE `a7ee21e9`). CODE → CASE is exact: nothing but
+ * `constraint_dropped` can produce this code, which is all the denylist needs.
+ * CASE → CODE is NOT: `blockerIssue` has an EARLY RETURN above the switch
+ * (`analysis-ready-helper.ts:672-679`) that codes a blocker
+ * `UNREACHABLE_CONTROLLABLE_FACTOR` whenever
+ * `status === 'needs_user_mapping' && !optionId && factorId` — and
+ * `extractConstraintDropBlockers` (`cee/transforms/analysis-ready.ts:1488-1495`)
+ * ALWAYS sets `factor_id` and NEVER `option_id`. So on a `needs_user_mapping`
+ * turn a constraint drop reaches this wire under the OTHER code and is counted
+ * as actionable.
+ *
+ * That direction FAILS CLOSED — an unwaived code still refuses the run — so it
+ * is no regression and no reason to widen the set. It is recorded because the
+ * "1:1" shorthand would license exactly the widening that WOULD be one.
  *
  * A DENYLIST, not an allowlist of actionable codes, and the direction is
  * load-bearing. The contract states `code` is a deliberately OPEN vocabulary
@@ -357,8 +372,21 @@ const ANALYSIS_READINESS_BLOCKED = 'blocked'
  *
  * ⚠ HAND-RESTATED, ONCE, AT THE SINGLE SEAM THAT READS IT — the same
  * concession `ANALYSIS_READINESS_BLOCKED` above makes, for the same reason:
- * the constant lives in CEE and the UI cannot import it. It is pinned by a
- * test that REDs if the producer renames or reclassifies the code.
+ * the constant lives in CEE and the UI cannot import it.
+ *
+ * ⚠ AND BE PRECISE ABOUT WHAT PINS IT (corrected 19 Aug 2026). This said the
+ * pin "REDs if the producer renames or reclassifies the code". It does not, and
+ * cannot: NOTHING IN THIS REPO OBSERVES CEE. A producer-side rename lands green
+ * here and silently reopens the defect — the unrecognised code simply refuses
+ * the run again, which is the fail-closed direction but is still the wrong
+ * answer on a payload CEE calls ready.
+ *
+ * What the pin actually catches is UI-SIDE DRIFT: this set and the spec's
+ * fixtures moving apart, a second code being waived here without a derivation,
+ * or the waived code colliding with an actionable one. That is worth having.
+ * The producer-side half is only detectable at a live capture or a CEE-side
+ * guard, and neither exists — so do not read a green suite as evidence about
+ * CEE's vocabulary.
  */
 const ADVISORY_BLOCKER_CODES: ReadonlySet<string> = new Set(['CONSTRAINT_REVIEW_REQUIRED'])
 
@@ -368,9 +396,30 @@ const ADVISORY_BLOCKER_CODES: ReadonlySet<string> = new Set(['CONSTRAINT_REVIEW_
  * Bound by the blocker's own `code` IDENTITY, never by position or by raw
  * length — a value predicate another blocker could satisfy is how a gate ends
  * up counting the wrong object.
+ *
+ * ⭐ THE ARRAY IS THE OWNER, AND THE COUNT IS DERIVED FROM IT (19 Aug 2026).
+ *
+ * This returned a COUNT until now, and the gate was the only caller — so the
+ * SENTENCE beneath the gate was still composed from the RAW list. With one
+ * actionable blocker and one advisory one the product refused the run over the
+ * first and then named BOTH: `"Launch in Q1" and "Burn rate" are not ready for
+ * analysis yet.` `Burn rate` is the blocker this predicate has just decided is
+ * NOT blocking, and the sentence sent the user to fix something that cannot
+ * unblock the run — a dead end of exactly the kind POC-DONE's PC1 bans.
+ *
+ * It also contradicted the rule stated at the composition site itself: the
+ * reason comes from WHICHEVER AUTHORITY DECIDED. It did — and then described a
+ * different list than the one the decision was made on.
+ *
+ * So the filter is expressed ONCE, as the list, and every consumer derives
+ * from it: the gate takes `.length`, the composers take the array. A second
+ * filter written beside this one — or a caller that keeps reaching past it to
+ * `readiness.blockers` — is the parallel rule this seam exists to abolish.
  */
-function actionableBlockerCount(blockers: readonly AnalysisBlocker[]): number {
-  return blockers.filter((blocker) => !ADVISORY_BLOCKER_CODES.has(blocker.code)).length
+export function actionableBlockers(
+  blockers: readonly AnalysisBlocker[],
+): readonly AnalysisBlocker[] {
+  return blockers.filter((blocker) => !ADVISORY_BLOCKER_CODES.has(blocker.code))
 }
 
 export function readinessObjectsToRun(
@@ -410,7 +459,7 @@ export function readinessObjectsToRun(
     //     this clause the Analyse control would turn ENABLED one turn after CEE
     //     refused the run. The user clicks, and is refused again.
     //
-    // (b) `actionableBlockerCount(...) > 0` — the itemised impediments that
+    // (b) `actionableBlockers(...).length > 0` — the itemised impediments that
     //     genuinely stand in the way, for every other stated status.
     //
     // ⚠ (b) WAS A RAW `blockers.length > 0` UNTIL THIS CHANGE, AND THAT WAS THE
@@ -456,7 +505,7 @@ export function readinessObjectsToRun(
     // we cannot name would re-create the original defect in a new spelling.
     return (
       analysisReadiness.status === ANALYSIS_READINESS_BLOCKED ||
-      actionableBlockerCount(analysisReadiness.blockers) > 0
+      actionableBlockers(analysisReadiness.blockers).length > 0
     )
   }
 
@@ -658,8 +707,15 @@ export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResu
     // pre-derived here, for the same reason `draftStreamPhase` is (2.122): a
     // predicate re-derived at each call site is a hand-maintained mirror, and
     // the mutant that drops one clause from it survives.
+    //
+    // ⚠ AND THE SAME LIST, NOT JUST THE SAME AUTHORITY (19 Aug 2026). Choosing
+    // the right authority is only half of it: this composed from
+    // `analysisReadiness.blockers` RAW while the gate one line up decided on
+    // the ACTIONABLE subset, so the sentence named blockers the gate had just
+    // ruled out. `actionableBlockers` is the one filter both now read — see its
+    // header for the sentence that shipped.
     const composed = analysisReadiness
-      ? composeAnalysisBlockedReason(analysisReadiness.blockers)
+      ? composeAnalysisBlockedReason(actionableBlockers(analysisReadiness.blockers))
       : composeReadinessBlockedReason(readiness, optionsNeedingValues, readinessStale)
     if (!blockingReasons.includes(composed)) {
       blockingReasons.push(composed)

--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -302,6 +302,77 @@ export function readinessWillScaffold(readiness: GraphReadiness | null | undefin
  */
 const ANALYSIS_READINESS_BLOCKED = 'blocked'
 
+/**
+ * The producer's ADVISORY blocker codes — itemised entries that ride along on
+ * an otherwise READY payload and do NOT stand between the model and a run.
+ *
+ * ── WHY THIS EXISTS (derived at CEE `a61fe7ff`, the deployed build) ─────────
+ * `blockers` is the gate's predicate, and until this constant existed it was a
+ * RAW COUNT. But the producer's blocker list is not homogeneous, and CEE says
+ * so in its own words at
+ * `orchestrator-v5/context/canonical-analysis-state.ts:47-56`:
+ *
+ *   "`status === 'ready'` carrying advisory `constraint_dropped` blockers is a
+ *    BY-DESIGN combination on the shared contract (the egress boundary injects
+ *    informational constraint-drop blockers onto an already-ready payload
+ *    without recomputing status). It must NOT downgrade usability."
+ *
+ * The chain that produces it, end to end:
+ *   · `cee/transforms/analysis-ready.ts:1474` `extractConstraintDropBlockers`
+ *     turns an STRP `CONSTRAINT_DROPPED` mutation into a blocker whose
+ *     `blocker_type` is `constraint_dropped`;
+ *   · `cee/unified-pipeline/stages/boundary.ts:198` PUSHES it onto
+ *     `analysis_ready.blockers` and DOES NOT recompute `status` — its own
+ *     comment: "dropped constraints mean the graph is still runnable";
+ *   · `orchestrator/tools/draft-graph.ts:907` carries `blockers` through
+ *     VERBATIM onto `DraftGraphResult.analysisReady`;
+ *   · `orchestrator-v5/compose/analysis-state-v1.ts:322` `mapWireBlockers`
+ *     maps it onto the wire with NO actionability filter.
+ *
+ * So a raw count refuses a model the producer has just called ready — the
+ * original 2.635 defect in a new spelling, and the reason this is a COUNT
+ * change rather than a second clause (Paul's convergence rule: one run-gate
+ * predicate, superseded in place, never a parallel rule).
+ *
+ * ── WHY KEYED ON `code`, AND WHY A DENYLIST ────────────────────────────────
+ * ⚠ `blocker_type` IS NOT ON THIS WIRE. `AnalysisBlockerSchema`
+ * (`@talchain/schemas/boundary`, 0.48.0) is `.strict()` and carries only
+ * `code` / `category` / `message` / `repairability` / the four scope fields.
+ * `category` cannot discriminate either: `constraint_dropped` maps to
+ * `option_values`, the SAME category as `missing_value` and `ambiguous_value`
+ * (`analysis-ready-helper.ts:665-707`). `repairability` is `human_input_required`
+ * for all four. **`code` is the only discriminator the producer actually ships**,
+ * and `CONSTRAINT_REVIEW_REQUIRED` is emitted from exactly one branch —
+ * `analysis-ready-helper.ts:705`, the `constraint_dropped` case — so the
+ * mapping is 1:1 and not a guess.
+ *
+ * A DENYLIST, not an allowlist of actionable codes, and the direction is
+ * load-bearing. The contract states `code` is a deliberately OPEN vocabulary
+ * ("a closed enum here would reject codes a newer producer legitimately
+ * emits"). An allowlist would therefore FAIL OPEN: a new actionable code would
+ * go uncounted and the gate would let through a run the producer meant to
+ * stop. This denylist fails CLOSED — an unrecognised code still refuses. It is
+ * the same fail-safe direction CEE argues for its own sibling set at
+ * `orchestrator-v5/tools/handlers/analysis-ready-core.ts:371-375`.
+ *
+ * ⚠ HAND-RESTATED, ONCE, AT THE SINGLE SEAM THAT READS IT — the same
+ * concession `ANALYSIS_READINESS_BLOCKED` above makes, for the same reason:
+ * the constant lives in CEE and the UI cannot import it. It is pinned by a
+ * test that REDs if the producer renames or reclassifies the code.
+ */
+const ADVISORY_BLOCKER_CODES: ReadonlySet<string> = new Set(['CONSTRAINT_REVIEW_REQUIRED'])
+
+/**
+ * The blockers that genuinely stand between this model and a run.
+ *
+ * Bound by the blocker's own `code` IDENTITY, never by position or by raw
+ * length — a value predicate another blocker could satisfy is how a gate ends
+ * up counting the wrong object.
+ */
+function actionableBlockerCount(blockers: readonly AnalysisBlocker[]): number {
+  return blockers.filter((blocker) => !ADVISORY_BLOCKER_CODES.has(blocker.code)).length
+}
+
 export function readinessObjectsToRun(
   readiness: GraphReadiness | null | undefined,
   analysisReadiness?: AnalysisReadinessAuthority | null,
@@ -339,8 +410,26 @@ export function readinessObjectsToRun(
     //     this clause the Analyse control would turn ENABLED one turn after CEE
     //     refused the run. The user clicks, and is refused again.
     //
-    // (b) `blockers.length > 0` — the itemised impediments, for every other
-    //     stated status.
+    // (b) `actionableBlockerCount(...) > 0` — the itemised impediments that
+    //     genuinely stand in the way, for every other stated status.
+    //
+    // ⚠ (b) WAS A RAW `blockers.length > 0` UNTIL THIS CHANGE, AND THAT WAS THE
+    // SAME DEFECT IN A NEW SPELLING. The comment below already cited CEE's
+    // integrity guard as corroboration — but read only its first half. The
+    // guard flags `status_ready_with_actionable_blockers` and deliberately
+    // EXCLUDES advisory blockers precisely BECAUSE those "ride along on
+    // otherwise ready payloads by design"; the exclusion is evidence the
+    // combination OCCURS, not that it cannot. Derived at CEE `a61fe7ff`: a
+    // `constraint_dropped` blocker is injected onto an already-`ready` payload
+    // without recomputing status, and reaches this wire unfiltered (the full
+    // chain is on `ADVISORY_BLOCKER_CODES` above). A raw count therefore
+    // refuses a model the producer has just called ready — while the SAME
+    // payload's `usable_for_prose` / `usable_for_chips` stay true, so the
+    // product would contradict itself on one turn.
+    //
+    // The count is CHANGED, not supplemented: there is exactly one run-gate
+    // predicate, and an actionability check bolted beside the old count would
+    // be the parallel rule this seam exists to abolish.
     //
     // ⚠ WHY NOT THE SIMPLER `status !== 'ready'`. It was proposed, and it is
     // REFUTED at the producer: two non-ready statuses describe models that ARE
@@ -365,7 +454,10 @@ export function readinessObjectsToRun(
     // So the honest predicate refuses what is provably unrunnable and lets the
     // producer's itemised list decide the rest. Refusing on a status whose cause
     // we cannot name would re-create the original defect in a new spelling.
-    return analysisReadiness.status === ANALYSIS_READINESS_BLOCKED || analysisReadiness.blockers.length > 0
+    return (
+      analysisReadiness.status === ANALYSIS_READINESS_BLOCKED ||
+      actionableBlockerCount(analysisReadiness.blockers) > 0
+    )
   }
 
   // ⏳ REMOVAL TRIGGER for the side-car fallback below.


### PR DESCRIPTION
## Verdict: the gate is WRONG by the contract — but its trigger is currently DISARMED upstream

**Do not merge on urgency.** This is a **latent** correctness defect, not a live SENDABLE blocker. Both halves of that sentence are derived below.

### 1. The wire combination is real and by-design

`#792` made this the sole run-gate predicate:

```ts
status === 'blocked' || analysisReadiness.blockers.length > 0   // RAW COUNT
```

CEE's blocker list is **not homogeneous**. Derived at CEE `a61fe7ff` (the deployed build):

- `ACTIONABLE_BLOCKER_TYPES` (`orchestrator-v5/context/canonical-analysis-state.ts:130`) = `{missing_value, ambiguous_value, missing_connection}`
- `AnalysisBlockerType` (`src/schemas/analysis-ready.ts:140`) = those **plus `constraint_dropped`**
- **Set difference = `{constraint_dropped}` — the advisory set is NON-EMPTY.**

CEE states the combination is intended, in its own header (`canonical-analysis-state.ts:47-56`):

> "`status === 'ready'` carrying advisory `constraint_dropped` blockers is a BY-DESIGN combination on the shared contract (the egress boundary injects informational constraint-drop blockers onto an already-ready payload without recomputing status). It must NOT downgrade usability."

The chain reaches the UI **unfiltered**:

| # | Site | What happens |
|---|---|---|
| 1 | `cee/transforms/analysis-ready.ts:1474` | mints `blocker_type: 'constraint_dropped'` |
| 2 | `cee/unified-pipeline/stages/boundary.ts:198` | pushes onto an already-`ready` payload, **status not recomputed** |
| 3 | `orchestrator/tools/draft-graph.ts:907` | `blockers` carried through **verbatim** |
| 4 | `orchestrator-v5/compose/analysis-state-v1.ts:322` | `mapWireBlockers` — **no actionability filter** |
| 5 | `orchestrator/tools/analysis-ready-helper.ts:705` | maps it to `code: 'CONSTRAINT_REVIEW_REQUIRED'` (returns non-null, so it is **not** dropped by the mapper) |
| 6 | UI `canRunAnalysis.ts` | raw count → **REFUSES a model the producer just called ready** |

**Mounted consequence:** the Analyse control dies on a payload whose own `usable_for_prose` and `usable_for_chips` are `true` — the product contradicts itself within one turn. That is the 2.635 defect in a new spelling.

`#792`'s own comment cited the integrity guard as corroboration but read only its first half: the guard **excludes** advisory blockers *because they ride along on ready payloads*, which is evidence the combination **occurs**.

### 2. …but the producer is structurally unreachable on a first draft

Derived at the same commit. `CONSTRAINT_DROPPED` needs STRP **Rule 3**, which only late STRP arms (`repair/late-strp.ts:27`). Every constraint row reaching it has already been filtered to **exact existing node ids**:

- LLM-authored rows — `compound-goals.ts:352-355`, `existingNodeIds.has(c.node_id)`; a hallucinated id is dropped here and logged as `cee.compound_goal.llm_dropped`, never as a blocker
- regex rows — every survivor of `extractor.ts:1283-1348` is drawn from the live node set

`runCompoundGoals` (`repair/index.ts:133`) and `runLateStrp` (`repair/index.ts:136`) are **adjacent lines with no graph mutation between them**, so the exact-match step (`structural-reconciliation.ts:472`) hits for every row and `dropped` stays 0.

Corroborated empirically: `#792`'s own wire capture on brief `04-conflicting-constraints` — the brief most likely to produce constraints — read `{ status: 'ready', blockers: [] }`.

**Caveat, stated honestly:** this is a control-flow read, not an execution, and **the invariant is incidental — nothing asserts it**. Reordering `repair/index.ts:133/136`, inserting a node-mutating substep between them, or seeding `ctx.goalConstraints` from request input re-arms it silently.

### 3. The fix

Per Paul's convergence rule the **count is changed, not supplemented** — there remains exactly one run-gate predicate.

- **Keyed on `code`, because `blocker_type` is not on this wire.** `AnalysisBlockerSchema` (0.48.0) is `.strict()` and carries only `code`/`category`/`message`/`repairability` + scope fields. `category` cannot discriminate (`constraint_dropped` shares `option_values` with `missing_value`); `repairability` is `human_input_required` for all four. A derived read was preferred and **is not available** — hence one hand-restatement, at the single seam that reads it, with a drift test, following the `ANALYSIS_READINESS_BLOCKED` precedent.
- **A denylist, not an allowlist, and the direction is load-bearing.** The contract states `code` is deliberately open. An allowlist would **fail OPEN** on a newly-minted actionable code; this fails **CLOSED**.

### Evidence

- **RED-first** — against the pristine gate, 2 named failures, 31 collected in this spec by name:
  - `advisory blockers on a READY payload do not close the gate > RED-FIRST — a ready model carrying only a constraint_dropped advisory is RUNNABLE` — `expected false to be true`
  - `… > goes through the REAL selector seam, not a hand-built authority` — `expected true to be false`
- **Discriminating mutant pair** (throwaway worktree **outside** the repo root; isolation proven **by writing** a sentinel and by distinct inodes `674826823` vs `674743388`; applied-check scoped to `src/` = exactly 1):
  - (a) revert to raw count → the new RED-FIRST test **REDs**
  - (b) widen the filter to also drop `MISSING_OPTION_VALUE` → RED-FIRST **stays GREEN** while **3 different tests RED** (`DISCRIMINATING PARTNER`, `does not MASK`, `DRIFT PIN`) — proving the fix narrows to a named class rather than simply counting fewer things
- **Bound by IDENTITY** — the blocker's `code` literal; the MASK test puts the advisory **first** in the array so a positional fix would wrongly permit
- `pnpm typecheck` **PASSED**. `--update-baseline` deliberately **declined**: the 9-diagnostic shrink is churn in files this PR never touched
- eslint clean; hooks ratchet exactly at baseline
- **All 30 specs bound to `canRunAnalysis`/`readinessObjectsToRun` — 664 tests, green**
- `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported for every run

### Files changed (2)

- `src/canvas/utils/canRunAnalysis.ts`
- `src/canvas/utils/__tests__/canonicalReadinessAuthority.spec.ts`

⚠ `canRunAnalysis.ts` is high-collision (three other UI lanes live; `#792` landed an hour before). Branched from `staging` `3f59325a`; the predicate is a single-line change plus two additions above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
