### PR TITLE
fix(thread): pin the conversation to its newest content, and split the two hosts' mount identity

### DIFF
--- a/e2e/geometry/threadAutoScroll.measure.ts
+++ b/e2e/geometry/threadAutoScroll.measure.ts
@@ -58,7 +58,8 @@ test('MOUNT geometry — chat-thread mounts, their boxes and hit-testability', a
       })
     }
     return {
-      chatThread: { count: document.querySelectorAll('[data-testid="chat-thread"]').length, mounts: probe('[data-testid="chat-thread"]') },
+      chatThreadCanonical: { count: document.querySelectorAll('[data-testid="chat-thread"]').length, mounts: probe('[data-testid="chat-thread"]') },
+      chatThreadFloating: { count: document.querySelectorAll('[data-testid="chat-thread-floating"]').length, mounts: probe('[data-testid="chat-thread-floating"]') },
       floatingPanel: probe('[data-testid="floating-olumi-panel"]'),
       olumiTabWrapper: probe('[data-testid="olumi-tab-wrapper"]'),
     }

--- a/e2e/geometry/threadAutoScroll.measure.ts
+++ b/e2e/geometry/threadAutoScroll.measure.ts
@@ -1,0 +1,91 @@
+/**
+ * THREAD AUTO-SCROLL + MOUNT GEOMETRY — a MEASUREMENT instrument, not a gate.
+ *
+ * Real Chromium, real layout, real CSS. jsdom cannot prove that content is on
+ * screen (CLAUDE.md trap 3), and a 0x0 opacity-0 element is "present" and
+ * useless — that trap is exactly what produced the false "dead affordance"
+ * finding this lane was sent to explain. Every visibility claim in the PR body
+ * comes from HERE; the jsdom specs make only trigger/mount-count claims.
+ *
+ * Run deliberately (it is in no gate):
+ *   pnpm exec playwright test -c playwright.geometry.config.ts
+ *
+ * Output: one `SCROLLJSON {...}` / `MOUNTJSON {...}` line per cell on stdout.
+ */
+import { test } from '@playwright/test'
+import { openCanvas, preparePage, seedStarterDraft } from '../visual/harness'
+
+const VP = { width: 1440, height: 900 }
+
+/**
+ * PART 1 — mount geometry on the REAL product.
+ *
+ * The COUNT claim is made by the jsdom spec (a count is not a visibility
+ * claim). What only a browser can settle is whether a mount is HIT-TESTABLE:
+ * `display:none` generates no box, so a testid selector still resolves to it
+ * while a human click cannot possibly land on it. Those are different claims
+ * and the fix for each is different.
+ */
+test('MOUNT geometry — chat-thread mounts, their boxes and hit-testability', async ({ page }) => {
+  await preparePage(page, VP)
+  await openCanvas(page)
+  await seedStarterDraft(page, 'vendor-selection')
+  await page.waitForTimeout(1200)
+
+  const m = await page.evaluate(() => {
+    const probe = (sel: string) => {
+      const nodes = [...document.querySelectorAll(sel)] as HTMLElement[]
+      return nodes.map((el) => {
+        const r = el.getBoundingClientRect()
+        const cs = getComputedStyle(el)
+        const hit =
+          r.width > 0 && r.height > 0
+            ? document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2)
+            : null
+        const chain: string[] = []
+        for (let p: HTMLElement | null = el.parentElement; p && chain.length < 8; p = p.parentElement) {
+          const tid = p.getAttribute('data-testid')
+          if (tid) chain.push(tid)
+        }
+        return {
+          rect: { w: Math.round(r.width), h: Math.round(r.height), x: Math.round(r.left), y: Math.round(r.top) },
+          display: cs.display,
+          opacity: cs.opacity,
+          visibility: cs.visibility,
+          hitTestable: hit !== null && el.contains(hit),
+          ancestorTestids: chain,
+        }
+      })
+    }
+    return {
+      chatThread: { count: document.querySelectorAll('[data-testid="chat-thread"]').length, mounts: probe('[data-testid="chat-thread"]') },
+      floatingPanel: probe('[data-testid="floating-olumi-panel"]'),
+      olumiTabWrapper: probe('[data-testid="olumi-tab-wrapper"]'),
+    }
+  })
+  // eslint-disable-next-line no-console
+  console.log(`MOUNTJSON ${JSON.stringify(m)}`)
+})
+
+/**
+ * PART 2 — is content that grows ON AN EXISTING MESSAGE scrolled to?
+ *
+ * Mounts the REAL `ChatThread` (real `useSmartScroll`, real stylesheet) through
+ * Vite's dev module graph. See `threadMountProbe.ts` for why that indirection
+ * exists and for the derivation of the growth shape.
+ */
+test('SCROLL — content growing on an existing message', async ({ page }) => {
+  await preparePage(page, VP)
+  await openCanvas(page)
+
+  const out = await page.evaluate(async () => {
+    const path = '/e2e/geometry/threadMountProbe.ts'
+    const mod = (await import(/* @vite-ignore */ path)) as {
+      measureThreadGrowth: () => Promise<unknown>
+    }
+    return mod.measureThreadGrowth()
+  })
+
+  // eslint-disable-next-line no-console
+  console.log(`SCROLLJSON ${JSON.stringify(out)}`)
+})

--- a/e2e/geometry/threadMountProbe.ts
+++ b/e2e/geometry/threadMountProbe.ts
@@ -1,0 +1,142 @@
+/**
+ * Browser-side probe for the thread's auto-scroll, mounted through Vite.
+ *
+ * ⚠ WHY THIS IS A MODULE AND NOT `page.evaluate` SOURCE. `page.evaluate` source
+ * is never processed by Vite, so a bare `react` specifier fails to resolve in
+ * the page (measured: "Failed to resolve module specifier 'react'"). A module
+ * under the Vite root IS transformed, so its imports resolve — which is what
+ * lets the probe mount the REAL `ChatThread` with the REAL `useSmartScroll`
+ * rather than a fixture of the thread written by hand (CLAUDE.md trap 16: a
+ * self-authored fixture encodes the author's model of the producer).
+ *
+ * Not collected by any test config: it exports a function and asserts nothing.
+ */
+import { createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { ChatThread } from '../../src/canvas/conversation/zones/ChatThread'
+import type { ConversationMessage } from '../../src/canvas/conversation/types'
+
+export interface ThreadReading {
+  domLen: number
+  testids: (string | null)[]
+  scrollTop: number
+  scrollHeight: number
+  clientHeight: number
+  distanceFromBottom: number
+  chip: {
+    rect: { w: number; h: number; y: number }
+    inView: boolean
+    hitTestable: boolean
+    label: string | null
+  } | null
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 450))
+
+function read(): ThreadReading | null {
+  const el = document.querySelector('#measure-host [data-testid="chat-thread"]') as HTMLElement | null
+  if (!el) return null
+  const listRect = el.getBoundingClientRect()
+  // Bind to the chip BY ITS OWN TESTID, never by index or position — another
+  // button in the thread could satisfy a positional predicate (trap 19).
+  const chipBtn = el.querySelector('[data-testid="suggested-chip-run_analysis"]') as HTMLElement | null
+  let chip: ThreadReading['chip'] = null
+  if (chipBtn) {
+    const r = chipBtn.getBoundingClientRect()
+    const hit = r.width > 0 && r.height > 0
+      ? document.elementFromPoint(r.left + r.width / 2, r.top + r.height / 2)
+      : null
+    chip = {
+      rect: { w: Math.round(r.width), h: Math.round(r.height), y: Math.round(r.top) },
+      // IN VIEW = the chip's box lies within the thread's visible band.
+      inView: r.height > 0 && r.top >= listRect.top - 1 && r.bottom <= listRect.bottom + 1,
+      hitTestable: hit !== null && chipBtn.contains(hit),
+      label: chipBtn.textContent?.trim().slice(0, 40) ?? null,
+    }
+  }
+  return {
+    domLen: el.innerHTML.length,
+    testids: [...el.querySelectorAll('[data-testid]')].map(n => n.getAttribute('data-testid')).slice(0, 25),
+    scrollTop: Math.round(el.scrollTop),
+    scrollHeight: Math.round(el.scrollHeight),
+    clientHeight: Math.round(el.clientHeight),
+    distanceFromBottom: Math.round(el.scrollHeight - el.clientHeight - el.scrollTop),
+    chip,
+  }
+}
+
+/**
+ * Mount the real thread, then grow the reply the way the producer grows it.
+ *
+ * Growth shape derived from `useConversation`, not invented: the streaming path
+ * creates ONE placeholder assistant message (`isStreaming: true`,
+ * useConversation.ts:5928) and then grows it by MUTATION — `text_delta` →
+ * `scheduleStreamFlush` → content, `block` → `updateMessage(msgId, {blocks})`
+ * (useConversation.ts:5962-5985). `messages.length` is constant across every
+ * one of those commits, and so is ChatThread's `renderedMessageCount`.
+ */
+export async function measureThreadGrowth(): Promise<Record<string, unknown>> {
+  const host = document.createElement('div')
+  host.id = 'measure-host'
+  host.style.cssText =
+    'position:fixed;top:0;left:0;width:420px;height:600px;display:flex;flex-direction:column;z-index:99999;background:#fff'
+  document.body.appendChild(host)
+
+  const LONG = 'The board wants a decision by Friday and the numbers disagree. '.repeat(45)
+
+  const msgs = (assistantContent: string, chips: unknown[]): ConversationMessage[] =>
+    ([
+      { id: 'u1', role: 'user', content: 'Should we replace our CRM?' },
+      { id: 'a1', role: 'assistant', content: assistantContent, isStreaming: false, actionChips: chips },
+    ] as unknown as ConversationMessage[])
+
+  const props = (messages: ConversationMessage[]) =>
+    ({
+      messages,
+      isThinking: false,
+      longRunningHint: null,
+      nodeCount: 12,
+      patchBlockStates: new Map(),
+      patchRejections: new Map(),
+      onChipClick: async () => {},
+      onPatchAccept: () => {},
+      onPatchDismiss: () => {},
+      onFeedback: () => {},
+      onRetry: () => {},
+      compact: true,
+    }) as unknown as React.ComponentProps<typeof ChatThread>
+
+  const errs: string[] = []
+  const origErr = console.error
+  console.error = (...a: unknown[]) => { errs.push(String(a[0]).slice(0, 300)); origErr(...a) }
+  ;(window as unknown as { __probeErrs: string[] }).__probeErrs = errs
+
+  const root = createRoot(host)
+
+  // Commit 1 — the reply exists and is short. This is the commit the count
+  // trigger CAN see (renderedMessageCount 0 → 2).
+  root.render(createElement(ChatThread, props(msgs('Here is a first read of your decision.', []))))
+  await settle()
+  const afterShort = read()
+
+  // Commit 2 — THE COMMIT THAT MATTERS. Same message id, same array length: the
+  // reply grows and the chips arrive on it.
+  root.render(
+    createElement(
+      ChatThread,
+      props(msgs('Here is a first read of your decision.\n\n' + LONG, [
+        { id: 'run_analysis', label: 'Run analysis', intent: 'primary', message: 'Run the analysis' },
+      ])),
+    ),
+  )
+  await settle()
+  await settle()
+  const afterGrowth = read()
+
+  const outerLen = host.innerHTML.length
+  const outerHead = host.innerHTML.slice(0, 400)
+  console.error = origErr
+  root.unmount()
+  host.remove()
+  return { afterShort, afterGrowth, errs: errs.slice(0, 5), outerLen, outerHead }
+}

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -14,6 +14,7 @@ import { typo } from '../../styles/typography'
 import { useCanvasStore } from '../store'
 import { useConversationContext } from '../conversation/ConversationContext'
 import { ConversationPanel } from '../conversation/ConversationPanel'
+import { THREAD_TESTID_FLOATING } from '../conversation/zones/ChatThread'
 import {
   useFloatingPanelState,
   revealWouldImposeFloating,
@@ -1084,6 +1085,11 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
           onAttach={noop}
           hideComposer
           compact
+          /* Mount identity: this host and the docked Olumi tab can both be
+             mounted at once, so they must not answer to one `data-testid`.
+             The rationale and the canonical assignment live in one place —
+             the note beside these constants in `zones/ChatThread.tsx`. */
+          threadTestId={THREAD_TESTID_FLOATING}
         />
         <AIInputBar ref={inputBarRef} variant="floating" onCogClick={onCogClick} hideChevron />
       </div>

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.threadIdentity.spec.tsx
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.threadIdentity.spec.tsx
@@ -1,0 +1,129 @@
+/**
+ * MOUNT IDENTITY, LINK 3 — the floating host names its thread as the FLOATING
+ * surface, not the canonical one.
+ *
+ * Links 1 and 2 (ChatThread honours the identity; ConversationPanel forwards
+ * it) are pinned in `src/canvas/conversation/__tests__/threadMountIdentity.spec.tsx`.
+ * This file closes the chain at the host, because a chain with an untested link
+ * is exactly where the drift goes: the prop could be threaded perfectly and the
+ * floating panel simply never pass it, and every other test would stay green.
+ *
+ * ConversationPanel is stubbed by a PROP-CAPTURING spy rather than rendered:
+ * the claim is about which identity the host hands down, and a deep render
+ * would drag in tens of transitive deps to observe one string. Mock layout
+ * mirrors `FloatingOlumiPanel.dockInset.spec.tsx`.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+
+const canvasMockState = {
+  nodes: [{ id: 'n1' }],
+  edges: [] as Array<unknown>,
+  results: { status: 'idle' as const },
+  _internal: {} as Record<string, unknown>,
+  selection: null as null | { id: string; label: string; kind: string },
+  ceeAnalysisReady: null as unknown,
+  graphHealth: null as unknown,
+  runMeta: {} as unknown,
+}
+vi.mock('../../store', () => {
+  const useCanvasStore: unknown = (selector: (s: unknown) => unknown) => selector(canvasMockState)
+  const s = useCanvasStore as { getState: unknown; setState: unknown; subscribe: unknown }
+  s.getState = () => canvasMockState
+  s.setState = (patch: Record<string, unknown>) => Object.assign(canvasMockState, patch)
+  s.subscribe = () => () => {}
+  return {
+    useCanvasStore,
+    selectResultsStatus: (x: { results?: { status?: unknown } }) => x.results?.status,
+    selectReport: (x: { results?: { report?: unknown } }) => x.results?.report,
+    selectError: (x: { results?: { error?: unknown } }) => x.results?.error,
+    selectResultsSource: (x: { results?: { source?: unknown } }) => x.results?.source,
+  }
+})
+
+/** THE CAPTURE: every identity the host hands to a ConversationPanel. */
+const handedDownTestIds: Array<string | undefined> = []
+vi.mock('../../conversation/ConversationPanel', () => ({
+  ConversationPanel: (props: { threadTestId?: string }) => {
+    handedDownTestIds.push(props.threadTestId)
+    return null
+  },
+}))
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Ask',
+}))
+vi.mock('../../conversation/useConversation', async () => {
+  const { useState } = await import('react')
+  return {
+    useConversation: () => {
+      const [sendMessage] = useState(() => vi.fn())
+      return {
+        messages: [],
+        isThinking: false,
+        longRunningHint: null,
+        sendMessage,
+        sendSystemEvent: vi.fn(),
+        sendChip: vi.fn(),
+        retryLast: vi.fn(),
+        patchBlockStates: new Map(),
+        setPatchBlockState: vi.fn(),
+        patchRejections: new Map(),
+        setPatchRejection: vi.fn(),
+      }
+    },
+    isNonConversationalContent: () => false,
+  }
+})
+
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { FloatingOlumiPanel } from '../FloatingOlumiPanel'
+import { useFloatingPanelState } from '../../hooks/useFloatingPanelState'
+import { THREAD_TESTID_DOCKED, THREAD_TESTID_FLOATING } from '../../conversation/zones/ChatThread'
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ConversationProvider>{children}</ConversationProvider>
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { value: 1440, configurable: true })
+  Object.defineProperty(window, 'innerHeight', { value: 900, configurable: true })
+  useFloatingPanelState.getState().reset()
+  handedDownTestIds.length = 0
+})
+
+describe('FloatingOlumiPanel — the identity it gives its thread', () => {
+  it('LINK 3 — hands its ConversationPanel the FLOATING identity, never the canonical one', () => {
+    useFloatingPanelState.getState().open('user')
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+
+    // Pin the precondition in-test: if the panel did not render a
+    // ConversationPanel at all, the assertions below would pass vacuously
+    // (CLAUDE.md trap 13b — a discriminator must pin its own precondition).
+    expect(
+      handedDownTestIds.length,
+      'the floating panel rendered no ConversationPanel — this case proves nothing about identity',
+    ).toBeGreaterThan(0)
+
+    expect(
+      handedDownTestIds,
+      'the floating host left its thread answering to the canonical testid — both surfaces ' +
+        'respond to one selector again, and a probe cannot tell which one it measured',
+    ).not.toContain(THREAD_TESTID_DOCKED)
+    expect(handedDownTestIds).toContain(THREAD_TESTID_FLOATING)
+    expect(
+      handedDownTestIds,
+      'the floating host passed NO identity, so ChatThread falls back to the canonical one',
+    ).not.toContain(undefined)
+  })
+})

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.threadIdentity.spec.tsx
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.threadIdentity.spec.tsx
@@ -111,11 +111,20 @@ describe('FloatingOlumiPanel — the identity it gives its thread', () => {
    * easiest of all to lose silently.
    */
   it('COLLECTION GUARD — both cases in this file were collected, by name', (ctx) => {
-    const names = (ctx.task.suite?.tasks ?? []).map((t) => t.name)
+    const siblings = ctx.task.suite?.tasks ?? []
+    const names = siblings.map((t) => t.name)
     expect(names).toEqual([
       'COLLECTION GUARD — both cases in this file were collected, by name',
       'LINK 3 — hands its ConversationPanel the FLOATING identity, never the canonical one',
     ])
+    // A skipped case is still COLLECTED, so the name list alone cannot see
+    // one being quietly parked — measured: `it.skip` left the list identical
+    // and the guard green. Assert the mode too, or the guard is narrower than
+    // its own name (CLAUDE.md trap 13b — a guard agreeing with itself).
+    expect(
+      siblings.filter((t) => t.mode !== 'run').map((t) => t.name),
+      'a case in this file is skipped/todo — it is collected but it is not evidence',
+    ).toEqual([])
   })
 
   it('LINK 3 — hands its ConversationPanel the FLOATING identity, never the canonical one', () => {

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.threadIdentity.spec.tsx
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.threadIdentity.spec.tsx
@@ -103,6 +103,21 @@ beforeEach(() => {
 })
 
 describe('FloatingOlumiPanel — the identity it gives its thread', () => {
+  /**
+   * ⭐ COLLECTION GUARD — this file's OWN cases, by name. This file already
+   * mocks `lib/supabase`, so it collects without the env vars; the guard is
+   * here because a suite total can never tell you whether THIS file
+   * contributed anything (CLAUDE.md trap 2b), and a one-case file is the
+   * easiest of all to lose silently.
+   */
+  it('COLLECTION GUARD — both cases in this file were collected, by name', (ctx) => {
+    const names = (ctx.task.suite?.tasks ?? []).map((t) => t.name)
+    expect(names).toEqual([
+      'COLLECTION GUARD — both cases in this file were collected, by name',
+      'LINK 3 — hands its ConversationPanel the FLOATING identity, never the canonical one',
+    ])
+  })
+
   it('LINK 3 — hands its ConversationPanel the FLOATING identity, never the canonical one', () => {
     useFloatingPanelState.getState().open('user')
     render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })

--- a/src/canvas/components/__tests__/OutputsDock.runReturnsToOlumi.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.runReturnsToOlumi.spec.tsx
@@ -31,6 +31,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import type { ConversationMessage } from '../../conversation/types'
+import { THREAD_SCROLL_SENTINEL_TESTID } from '../../conversation/zones/ChatThread'
 import type { ReportV1 } from '../../../adapters/plot/types'
 
 // ---------------------------------------------------------------------------
@@ -583,16 +584,27 @@ describe('ROADMAP 2.204-R3 — the return lands on the arriving card', () => {
     try {
       landAnalysisTurn(rerender)
 
-      // useSmartScroll took its scrollToBottom branch: the listEndRef sentinel
-      // (ChatThread.tsx:213), `{ behavior: 'smooth' }`, no `block`.
+      // useSmartScroll took its scrollToBottom branch: the `listEndRef`
+      // sentinel, `{ behavior: 'smooth' }`, no `block`.
+      //
+      // ⚠ THIS USED TO IDENTIFY THE SENTINEL AS "the scrolled element with NO
+      // `data-testid`" — a predicate ANY untagged element satisfies, so it
+      // bound to a description rather than to the object (CLAUDE.md trap 19).
+      // It was also silently coupled to the sentinel staying anonymous: giving
+      // that element an identity turned this assertion red without anything
+      // about the scroll behaviour changing. Bound to the exported constant now,
+      // so the spec and the component cannot drift apart.
       const bottomPin = probe.calls.find(
         (c) =>
-          c.target.getAttribute('data-testid') === null &&
+          c.target.getAttribute('data-testid') === THREAD_SCROLL_SENTINEL_TESTID &&
           typeof c.opts === 'object' &&
           c.opts !== null &&
           (c.opts as ScrollIntoViewOptions).block === undefined,
       )
-      expect(bottomPin).toBeDefined()
+      expect(
+        bottomPin,
+        'no scroll was aimed at the thread-end sentinel — the diagnosis this case pins no longer holds',
+      ).toBeDefined()
       // …and it was asked for while the wrapper still carried `hidden`. In a
       // real browser that subtree has no layout box, so this call does nothing.
       expect(bottomPin?.wrapperHidden).toBe(true)

--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -74,6 +74,12 @@ interface ConversationPanelProps {
    * smart-scroll runs unchanged.
    */
   scrollListRef?: React.MutableRefObject<HTMLDivElement | null>
+  /**
+   * Which conversation surface this panel IS, forwarded to ChatThread so the
+   * two hosts never share one `data-testid`. See the mount-identity note in
+   * `zones/ChatThread.tsx`. Defaults to the canonical docked identity.
+   */
+  threadTestId?: string
 }
 
 function createPanelInteractionSnapshot(messagesCount: number): InteractionStateSnapshot {
@@ -129,6 +135,7 @@ export const ConversationPanel = memo(function ConversationPanel({
   prefillChat: prefillChatOverride,
   compact = false,
   scrollListRef,
+  threadTestId,
 }: ConversationPanelProps) {
   const {
     messages, isThinking, longRunningHint,
@@ -791,6 +798,7 @@ export const ConversationPanel = memo(function ConversationPanel({
         onProposalConfirm={handleProposalConfirm}
         compact={compact}
         scrollListRef={scrollListRef}
+        testId={threadTestId}
       />
 
       {!hideComposer && (

--- a/src/canvas/conversation/__tests__/ChatThread.contentGrowthScroll.spec.tsx
+++ b/src/canvas/conversation/__tests__/ChatThread.contentGrowthScroll.spec.tsx
@@ -32,7 +32,63 @@ import { render, act } from '@testing-library/react'
 import { ChatThread } from '../zones/ChatThread'
 import type { ConversationMessage } from '../types'
 
-const scrollIntoView = vi.fn()
+/**
+ * ⚠ WITHOUT THIS MOCK THIS FILE COLLECTS ZERO TESTS AND THE SUITE STAYS GREEN.
+ *
+ * `ChatThread` reaches `src/services/threadService.ts`, which imports
+ * `src/lib/supabase.ts`, which THROWS at module scope when
+ * `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` are absent (`supabase.ts:38`).
+ * That is a COLLECTION-time failure, so none of the cases below exist to fail —
+ * and in a multi-file run the aggregate total is dominated by files that did
+ * collect, so a healthy-looking total and a zero-failure line are both fully
+ * consistent with this file's entire scroll evidence never having run
+ * (CLAUDE.md trap 2b). Measured on this branch before the mock was added: this
+ * file and `threadMountIdentity.spec.tsx` both failed at collect.
+ *
+ * Mirrors the mock in the sibling `FloatingOlumiPanel.threadIdentity.spec.tsx`.
+ * The COLLECTION GUARD below is the second half: the mock stops the file dying,
+ * the guard makes a silent shrink impossible.
+ */
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+
+/**
+ * The stub is installed on `Element.prototype`, so EVERY element satisfies a
+ * bare call-count assertion. Bind to the sentinel BY IDENTITY via the recorded
+ * `this` of each call (CLAUDE.md trap 19) — counting calls proves a scroll
+ * happened somewhere, never that it was aimed at the thread's end.
+ *
+ * ⚠ Captured HERE rather than read from `scrollIntoView.mock.contexts`: that
+ * field is declared in @vitest/spy's TYPINGS but does not exist in the 1.6.1
+ * RUNTIME this repo pins (`node_modules/.pnpm/@vitest+spy@1.6.1`, zero
+ * occurrences in `dist/index.js`; the 3.2.4 copy that also sits in the store
+ * does have it). Reading the wrong installed copy's `.d.ts` typechecks and
+ * then throws at run time — so the context is recorded explicitly and the
+ * assertion cannot depend on which copy resolves.
+ */
+const scrollTargets: unknown[] = []
+const scrollIntoView = vi.fn(function (this: unknown) {
+  scrollTargets.push(this)
+})
+
+/** The element `useSmartScroll` actually scrolls to (`useSmartScroll.ts:63,70`). */
+const SENTINEL_TESTID = 'thread-scroll-sentinel'
+
+function sentinelIn(root: ParentNode): Element {
+  const el = root.querySelector(`[data-testid="${SENTINEL_TESTID}"]`)
+  expect(
+    el,
+    'precondition: the scroll sentinel is not in the DOM, so every assertion below would be vacuous',
+  ).not.toBeNull()
+  return el as Element
+}
+
+/** How many times the scroll was aimed at THIS element, not at any element. */
+function scrollsTo(el: Element): number {
+  return scrollTargets.filter((c) => c === el).length
+}
 
 /** Flush the rAF the content sensor coalesces on. */
 async function flushFrames() {
@@ -82,17 +138,38 @@ const assistantMsg = (
 describe('ChatThread — content growing on an existing message is scrolled to', () => {
   beforeEach(() => {
     scrollIntoView.mockClear()
+    scrollTargets.length = 0
     Element.prototype.scrollIntoView = scrollIntoView
   })
   afterEach(() => {
     vi.useRealTimers()
   })
 
+  /**
+   * ⭐ COLLECTION GUARD — asserts this file's OWN cases by name.
+   *
+   * A suite total, an exit code and a zero-failure count are all consistent
+   * with this file contributing nothing (CLAUDE.md trap 2b). This is a
+   * hand-written list on purpose: it cannot be derived from the thing it
+   * checks, and it FAILS LOUD if the set grows OR shrinks, which is the
+   * sanctioned form of a mirror (trap 12).
+   */
+  it('COLLECTION GUARD — all four cases in this file were collected, by name', (ctx) => {
+    const names = (ctx.task.suite?.tasks ?? []).map((t) => t.name)
+    expect(names).toEqual([
+      'COLLECTION GUARD — all four cases in this file were collected, by name',
+      'scrolls when the reply BODY grows on the same message id — messages.length identical',
+      'scrolls when the CHIPS arrive on an already-rendered reply — the affordance the user needs',
+      'does NOT scroll when the user has deliberately scrolled up — it raises the pill instead',
+    ])
+  })
+
   it('scrolls when the reply BODY grows on the same message id — messages.length identical', async () => {
     const before = [userMsg('u1'), assistantMsg('a1', 'Here is a first read.')]
-    const { rerender } = render(<ChatThread {...props(before)} />)
+    const { rerender, container } = render(<ChatThread {...props(before)} />)
     await flushFrames()
-    const scrollsBeforeGrowth = scrollIntoView.mock.calls.length
+    const sentinel = sentinelIn(container)
+    const scrollsBeforeGrowth = scrollsTo(sentinel)
 
     // THE COMMIT THAT MATTERS: same id 'a1', body grows the way `text_delta`
     // grows it. Pin the defect's whole mechanism in-test rather than assuming
@@ -104,18 +181,22 @@ describe('ChatThread — content growing on an existing message is scrolled to',
     rerender(<ChatThread {...props(after)} />)
     await flushFrames()
 
+    // The sentinel is the SAME DOM node across the rerender (React reuses it),
+    // so this is a before/after count on one identified element.
+    expect(sentinelIn(container)).toBe(sentinel)
     expect(
-      scrollIntoView.mock.calls.length,
-      'the reply body grew below the fold and nothing scrolled to it — the user is left ' +
+      scrollsTo(sentinel),
+      'the reply body grew below the fold and nothing scrolled to the thread end — the user is left ' +
         'looking at the top of a reply whose remainder, and whose chips, are off screen',
     ).toBeGreaterThan(scrollsBeforeGrowth)
   })
 
   it('scrolls when the CHIPS arrive on an already-rendered reply — the affordance the user needs', async () => {
     const before = [userMsg('u1'), assistantMsg('a1', 'Here is a first read.')]
-    const { rerender } = render(<ChatThread {...props(before)} />)
+    const { rerender, container } = render(<ChatThread {...props(before)} />)
     await flushFrames()
-    const scrollsBeforeChips = scrollIntoView.mock.calls.length
+    const sentinel = sentinelIn(container)
+    const scrollsBeforeChips = scrollsTo(sentinel)
 
     const after = [
       userMsg('u1'),
@@ -131,14 +212,19 @@ describe('ChatThread — content growing on an existing message is scrolled to',
 
     // Bind to the chip BY ITS OWN TESTID — never by index or by "the last
     // button", which another element could satisfy (CLAUDE.md trap 19).
+    // ⚠ Scoped to THIS thread's container, not the document. `suggested-chip-*`
+    // testids are built from chip data alone and are NOT split per host (see
+    // the mount-identity note in `zones/ChatThread.tsx`), so a document-wide
+    // query for one is ambiguous the moment a second thread is mounted.
     expect(
-      document.querySelector('[data-testid="suggested-chip-run_analysis"]'),
+      container.querySelector('[data-testid="suggested-chip-run_analysis"]'),
       'precondition: the chip must actually be in the DOM, or this case proves nothing',
     ).not.toBeNull()
 
+    expect(sentinelIn(container)).toBe(sentinel)
     expect(
-      scrollIntoView.mock.calls.length,
-      'the suggested chips landed and nothing scrolled to them — this is the "dead affordance": ' +
+      scrollsTo(sentinel),
+      'the suggested chips landed and nothing scrolled to the thread end — this is the "dead affordance": ' +
         'the chip works, the user simply cannot see it',
     ).toBeGreaterThan(scrollsBeforeChips)
   })
@@ -148,8 +234,9 @@ describe('ChatThread — content growing on an existing message is scrolled to',
     // simply re-pinned on every mutation would satisfy both cases above while
     // stealing scroll from someone reading history — its own defect.
     const before = [userMsg('u1'), assistantMsg('a1', 'Here is a first read.')]
-    const { rerender, getByTestId, queryByTestId } = render(<ChatThread {...props(before)} />)
+    const { rerender, getByTestId, queryByTestId, container } = render(<ChatThread {...props(before)} />)
     await flushFrames()
+    const sentinel = sentinelIn(container)
 
     const thread = getByTestId('chat-thread')
     // A container the user has scrolled well away from the bottom.
@@ -162,7 +249,7 @@ describe('ChatThread — content growing on an existing message is scrolled to',
       thread.dispatchEvent(new Event('scroll'))
     })
 
-    const scrollsAfterUserScrolledUp = scrollIntoView.mock.calls.length
+    const scrollsAfterUserScrolledUp = scrollsTo(sentinel)
 
     rerender(
       <ChatThread
@@ -171,8 +258,9 @@ describe('ChatThread — content growing on an existing message is scrolled to',
     )
     await flushFrames()
 
+    expect(sentinelIn(container)).toBe(sentinel)
     expect(
-      scrollIntoView.mock.calls.length,
+      scrollsTo(sentinel),
       'the thread yanked a reader who had deliberately scrolled up back to the bottom',
     ).toBe(scrollsAfterUserScrolledUp)
     expect(

--- a/src/canvas/conversation/__tests__/ChatThread.contentGrowthScroll.spec.tsx
+++ b/src/canvas/conversation/__tests__/ChatThread.contentGrowthScroll.spec.tsx
@@ -29,7 +29,7 @@
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, act } from '@testing-library/react'
-import { ChatThread } from '../zones/ChatThread'
+import { ChatThread, THREAD_SCROLL_SENTINEL_TESTID } from '../zones/ChatThread'
 import type { ConversationMessage } from '../types'
 
 /**
@@ -73,11 +73,8 @@ const scrollIntoView = vi.fn(function (this: unknown) {
   scrollTargets.push(this)
 })
 
-/** The element `useSmartScroll` actually scrolls to (`useSmartScroll.ts:63,70`). */
-const SENTINEL_TESTID = 'thread-scroll-sentinel'
-
 function sentinelIn(root: ParentNode): Element {
-  const el = root.querySelector(`[data-testid="${SENTINEL_TESTID}"]`)
+  const el = root.querySelector(`[data-testid="${THREAD_SCROLL_SENTINEL_TESTID}"]`)
   expect(
     el,
     'precondition: the scroll sentinel is not in the DOM, so every assertion below would be vacuous',

--- a/src/canvas/conversation/__tests__/ChatThread.contentGrowthScroll.spec.tsx
+++ b/src/canvas/conversation/__tests__/ChatThread.contentGrowthScroll.spec.tsx
@@ -1,0 +1,183 @@
+/**
+ * ChatThread — content that grows ON AN EXISTING MESSAGE must be scrolled to.
+ *
+ * ⚠ WHAT THIS SPEC CAN AND CANNOT PROVE, STATED UP FRONT. jsdom has no layout,
+ * so it CANNOT prove the new content is on screen (CLAUDE.md trap 3) — a 0x0
+ * element is "present" and useless, and believing otherwise is precisely what
+ * produced the false "dead affordance" finding this lane was sent to explain.
+ * The on-screen claim is made only by the real-Chromium instrument
+ * (`e2e/geometry/threadAutoScroll.measure.ts`), whose pristine numbers are in
+ * the PR body: scrollTop 0 / scrollHeight 1194 / clientHeight 600, with the
+ * "Run analysis" chip at y=1126, `inView: false`, `hitTestable: false`.
+ * What jsdom CAN prove, and what the defect is, is that the scroll is
+ * TRIGGERED on the commit that puts that content in the DOM.
+ *
+ * THE DEFECT. `useSmartScroll`'s trigger is `{ messageCount, isThinking }` —
+ * a PROXY for content, not content. Derived at the producer
+ * (`useConversation.ts`): the streaming path creates ONE placeholder assistant
+ * message (`isStreaming: true`, :5928) and then grows it by MUTATION —
+ * `text_delta` → `scheduleStreamFlush` → content, and `block` →
+ * `updateMessage(msgId, { blocks })` (:5962-5985). Across EVERY one of those
+ * commits `messages.length` is constant, `renderedMessageCount` is constant and
+ * `isThinking` is constant — so the trigger is structurally incapable of
+ * observing the arrival of the reply's body, its blocks, or its chips.
+ *
+ * That is why every case below MUTATES an existing message and keeps the array
+ * length identical. An append-shaped test would pass at pristine and prove
+ * nothing — the sibling spec `ChatThread.firstReplyScroll.spec.tsx` already
+ * covers the append/reveal transitions and passes at pristine.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, act } from '@testing-library/react'
+import { ChatThread } from '../zones/ChatThread'
+import type { ConversationMessage } from '../types'
+
+const scrollIntoView = vi.fn()
+
+/** Flush the rAF the content sensor coalesces on. */
+async function flushFrames() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 0))
+    await new Promise((r) => setTimeout(r, 0))
+  })
+}
+
+function props(messages: ConversationMessage[], nodeCount = 12) {
+  return {
+    messages,
+    isThinking: false,
+    longRunningHint: null,
+    nodeCount,
+    patchBlockStates: new Map(),
+    patchRejections: new Map(),
+    onChipClick: vi.fn(),
+    onPatchAccept: vi.fn(),
+    onPatchDismiss: vi.fn(),
+    onFeedback: vi.fn(),
+    onRetry: vi.fn(),
+  } as unknown as React.ComponentProps<typeof ChatThread>
+}
+
+const userMsg = (id: string): ConversationMessage =>
+  ({ id, role: 'user', content: 'Should we replace our CRM?' }) as ConversationMessage
+
+/**
+ * The assistant reply. `id` is FIXED by the caller and never derived from
+ * content — the assertions below bind to the message BY IDENTITY, never by a
+ * value predicate another message could satisfy (CLAUDE.md trap 19).
+ */
+const assistantMsg = (
+  id: string,
+  content: string,
+  chips?: Array<Record<string, unknown>>,
+): ConversationMessage =>
+  ({
+    id,
+    role: 'assistant',
+    content,
+    isStreaming: false,
+    ...(chips ? { actionChips: chips } : {}),
+  }) as unknown as ConversationMessage
+
+describe('ChatThread — content growing on an existing message is scrolled to', () => {
+  beforeEach(() => {
+    scrollIntoView.mockClear()
+    Element.prototype.scrollIntoView = scrollIntoView
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('scrolls when the reply BODY grows on the same message id — messages.length identical', async () => {
+    const before = [userMsg('u1'), assistantMsg('a1', 'Here is a first read.')]
+    const { rerender } = render(<ChatThread {...props(before)} />)
+    await flushFrames()
+    const scrollsBeforeGrowth = scrollIntoView.mock.calls.length
+
+    // THE COMMIT THAT MATTERS: same id 'a1', body grows the way `text_delta`
+    // grows it. Pin the defect's whole mechanism in-test rather than assuming
+    // it (CLAUDE.md trap 13b — a discriminator must pin its own precondition).
+    const after = [userMsg('u1'), assistantMsg('a1', 'Here is a first read.\n\n' + 'x'.repeat(4000))]
+    expect(after.length).toBe(before.length)
+    expect(after[1].id).toBe(before[1].id)
+
+    rerender(<ChatThread {...props(after)} />)
+    await flushFrames()
+
+    expect(
+      scrollIntoView.mock.calls.length,
+      'the reply body grew below the fold and nothing scrolled to it — the user is left ' +
+        'looking at the top of a reply whose remainder, and whose chips, are off screen',
+    ).toBeGreaterThan(scrollsBeforeGrowth)
+  })
+
+  it('scrolls when the CHIPS arrive on an already-rendered reply — the affordance the user needs', async () => {
+    const before = [userMsg('u1'), assistantMsg('a1', 'Here is a first read.')]
+    const { rerender } = render(<ChatThread {...props(before)} />)
+    await flushFrames()
+    const scrollsBeforeChips = scrollIntoView.mock.calls.length
+
+    const after = [
+      userMsg('u1'),
+      assistantMsg('a1', 'Here is a first read.', [
+        { id: 'run_analysis', label: 'Run analysis', intent: 'primary', message: 'Run the analysis' },
+      ]),
+    ]
+    expect(after.length).toBe(before.length)
+    expect(after[1].id).toBe(before[1].id)
+
+    rerender(<ChatThread {...props(after)} />)
+    await flushFrames()
+
+    // Bind to the chip BY ITS OWN TESTID — never by index or by "the last
+    // button", which another element could satisfy (CLAUDE.md trap 19).
+    expect(
+      document.querySelector('[data-testid="suggested-chip-run_analysis"]'),
+      'precondition: the chip must actually be in the DOM, or this case proves nothing',
+    ).not.toBeNull()
+
+    expect(
+      scrollIntoView.mock.calls.length,
+      'the suggested chips landed and nothing scrolled to them — this is the "dead affordance": ' +
+        'the chip works, the user simply cannot see it',
+    ).toBeGreaterThan(scrollsBeforeChips)
+  })
+
+  it('does NOT scroll when the user has deliberately scrolled up — it raises the pill instead', async () => {
+    // The courtesy twin, and the discriminating case. Without it, a sensor that
+    // simply re-pinned on every mutation would satisfy both cases above while
+    // stealing scroll from someone reading history — its own defect.
+    const before = [userMsg('u1'), assistantMsg('a1', 'Here is a first read.')]
+    const { rerender, getByTestId, queryByTestId } = render(<ChatThread {...props(before)} />)
+    await flushFrames()
+
+    const thread = getByTestId('chat-thread')
+    // A container the user has scrolled well away from the bottom.
+    Object.defineProperties(thread, {
+      scrollTop: { value: 0, writable: true, configurable: true },
+      clientHeight: { value: 400, configurable: true },
+      scrollHeight: { value: 4000, configurable: true },
+    })
+    await act(async () => {
+      thread.dispatchEvent(new Event('scroll'))
+    })
+
+    const scrollsAfterUserScrolledUp = scrollIntoView.mock.calls.length
+
+    rerender(
+      <ChatThread
+        {...props([userMsg('u1'), assistantMsg('a1', 'Here is a first read.\n\n' + 'x'.repeat(4000))])}
+      />,
+    )
+    await flushFrames()
+
+    expect(
+      scrollIntoView.mock.calls.length,
+      'the thread yanked a reader who had deliberately scrolled up back to the bottom',
+    ).toBe(scrollsAfterUserScrolledUp)
+    expect(
+      queryByTestId('new-messages-pill'),
+      'nothing told the scrolled-up reader that new content had arrived',
+    ).not.toBeNull()
+  })
+})

--- a/src/canvas/conversation/__tests__/ChatThread.contentGrowthScroll.spec.tsx
+++ b/src/canvas/conversation/__tests__/ChatThread.contentGrowthScroll.spec.tsx
@@ -155,13 +155,22 @@ describe('ChatThread — content growing on an existing message is scrolled to',
    * sanctioned form of a mirror (trap 12).
    */
   it('COLLECTION GUARD — all four cases in this file were collected, by name', (ctx) => {
-    const names = (ctx.task.suite?.tasks ?? []).map((t) => t.name)
+    const siblings = ctx.task.suite?.tasks ?? []
+    const names = siblings.map((t) => t.name)
     expect(names).toEqual([
       'COLLECTION GUARD — all four cases in this file were collected, by name',
       'scrolls when the reply BODY grows on the same message id — messages.length identical',
       'scrolls when the CHIPS arrive on an already-rendered reply — the affordance the user needs',
       'does NOT scroll when the user has deliberately scrolled up — it raises the pill instead',
     ])
+    // A skipped case is still COLLECTED, so the name list alone cannot see
+    // one being quietly parked — measured: `it.skip` left the list identical
+    // and the guard green. Assert the mode too, or the guard is narrower than
+    // its own name (CLAUDE.md trap 13b — a guard agreeing with itself).
+    expect(
+      siblings.filter((t) => t.mode !== 'run').map((t) => t.name),
+      'a case in this file is skipped/todo — it is collected but it is not evidence',
+    ).toEqual([])
   })
 
   it('scrolls when the reply BODY grows on the same message id — messages.length identical', async () => {

--- a/src/canvas/conversation/__tests__/threadMountIdentity.spec.tsx
+++ b/src/canvas/conversation/__tests__/threadMountIdentity.spec.tsx
@@ -1,0 +1,145 @@
+/**
+ * MOUNT IDENTITY — the two conversation surfaces must not share one testid.
+ *
+ * ⚠ WHAT IS AND IS NOT CLAIMED HERE. A COUNT of mounts is not a visibility
+ * claim, so jsdom can make it (CLAUDE.md trap 3 bans the other kind). The
+ * geometry — that the hidden twin is `display:none`, 0x0 and NOT hit-testable —
+ * is measured only in real Chromium by
+ * `e2e/geometry/threadAutoScroll.measure.ts`, and it matters because it splits
+ * the original hypothesis in two: a human click can never land on the twin
+ * (no box, no hit target), but anything selecting BY TESTID can, and the "dead
+ * affordance" sighting that started this lane came from an instrumented
+ * session, not a finger.
+ *
+ * THE DEFECT, derived at the bytes. `ConversationPanel` has two production
+ * hosts — `OlumiTabBody.tsx:106` (docked) and `FloatingOlumiPanel.tsx:1079`
+ * (floating) — and they are NOT mutually exclusive. `dockHostsOlumi`
+ * (`olumiSurface.ts:80-84`) pre-empts the floating host only when the dock is
+ * open AND its tab is `olumi`; on every other tab the docked host stays mounted
+ * behind `hidden` (`OutputsDock.tsx:3271-3279`) while the floating one renders.
+ * `olumiSurface.ts:4-5` claims "exactly one may be VISIBLE" — never that only
+ * one may be MOUNTED. Both threads answered to `chat-thread`.
+ *
+ * The chain has three links and each one is pinned below, because a chain with
+ * an untested link is where the drift goes.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { ChatThread, THREAD_TESTID_DOCKED, THREAD_TESTID_FLOATING } from '../zones/ChatThread'
+import { ConversationPanel } from '../ConversationPanel'
+import type { ConversationMessage } from '../types'
+import type { UseConversationReturn } from '../useConversation'
+
+vi.mock('../../../adapters/plot', () => ({
+  plot: { validatePatch: vi.fn() },
+}))
+
+const messages: ConversationMessage[] = [
+  { id: 'a1', role: 'assistant', content: 'Here is a first read.' } as ConversationMessage,
+]
+
+function threadProps(testId?: string) {
+  return {
+    messages,
+    isThinking: false,
+    longRunningHint: null,
+    nodeCount: 12,
+    patchBlockStates: new Map(),
+    patchRejections: new Map(),
+    onChipClick: vi.fn(),
+    onPatchAccept: vi.fn(),
+    onPatchDismiss: vi.fn(),
+    onFeedback: vi.fn(),
+    onRetry: vi.fn(),
+    ...(testId ? { testId } : {}),
+  } as unknown as React.ComponentProps<typeof ChatThread>
+}
+
+function conversationStub(): UseConversationReturn {
+  return {
+    messages,
+    isThinking: false,
+    longRunningHint: null,
+    sendMessage: vi.fn(),
+    sendSystemEvent: vi.fn(),
+    sendChip: vi.fn(),
+    retryLast: vi.fn(),
+    patchBlockStates: new Map(),
+    setPatchBlockState: vi.fn(),
+    patchRejections: new Map(),
+    setPatchRejection: vi.fn(),
+  } as unknown as UseConversationReturn
+}
+
+describe('the two conversation hosts do not share one data-testid', () => {
+  beforeEach(() => {
+    // jsdom implements no layout and therefore no scrollIntoView; useSmartScroll
+    // calls it on commit. Stubbing it keeps this file's claims about IDENTITY
+    // and never about geometry.
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  it('the two identities are DIFFERENT strings — the whole point, asserted before anything relies on it', () => {
+    expect(THREAD_TESTID_DOCKED).not.toBe(THREAD_TESTID_FLOATING)
+  })
+
+  it('LINK 1 — ChatThread answers to the identity it is given, and to no other', () => {
+    // Both surfaces mounted at once, exactly as the reachable state produces
+    // them. Bind by the EXACT testid, never by index or by "the first thread"
+    // (CLAUDE.md trap 19).
+    const { container } = render(
+      <>
+        <ChatThread {...threadProps()} />
+        <ChatThread {...threadProps(THREAD_TESTID_FLOATING)} />
+      </>,
+    )
+
+    expect(
+      container.querySelectorAll(`[data-testid="${THREAD_TESTID_DOCKED}"]`).length,
+      'two live threads answer to the canonical testid — every probe that selects it is ambiguous, ' +
+        'and one of the two is the invisible twin',
+    ).toBe(1)
+    expect(
+      container.querySelectorAll(`[data-testid="${THREAD_TESTID_FLOATING}"]`).length,
+      'the floating thread has no identity of its own',
+    ).toBe(1)
+  })
+
+  it('LINK 2 — ConversationPanel forwards the identity through to its thread', () => {
+    const { container } = render(
+      <ConversationPanel
+        conversation={conversationStub()}
+        onCollapse={vi.fn()}
+        onAttach={vi.fn()}
+        hideComposer
+        compact
+        threadTestId={THREAD_TESTID_FLOATING}
+      />,
+    )
+
+    expect(
+      container.querySelector(`[data-testid="${THREAD_TESTID_FLOATING}"]`),
+      'ConversationPanel swallowed the surface identity — the floating host cannot name its own thread',
+    ).not.toBeNull()
+    expect(
+      container.querySelector(`[data-testid="${THREAD_TESTID_DOCKED}"]`),
+      'the panel rendered the CANONICAL identity for a host that is not the canonical surface',
+    ).toBeNull()
+  })
+
+  it('LINK 2b — and defaults to the canonical identity when no surface is named', () => {
+    // The discriminating twin for LINK 2: without it, a panel that hardcoded
+    // the floating id would satisfy the case above.
+    const { container } = render(
+      <ConversationPanel
+        conversation={conversationStub()}
+        onCollapse={vi.fn()}
+        onAttach={vi.fn()}
+        hideComposer
+        compact
+      />,
+    )
+    expect(container.querySelector(`[data-testid="${THREAD_TESTID_DOCKED}"]`)).not.toBeNull()
+    expect(container.querySelector(`[data-testid="${THREAD_TESTID_FLOATING}"]`)).toBeNull()
+  })
+})

--- a/src/canvas/conversation/__tests__/threadMountIdentity.spec.tsx
+++ b/src/canvas/conversation/__tests__/threadMountIdentity.spec.tsx
@@ -1,5 +1,13 @@
 /**
- * MOUNT IDENTITY — the two conversation surfaces must not share one testid.
+ * MOUNT IDENTITY — the two conversation surfaces' thread CONTAINERS must not
+ * share one testid.
+ *
+ * ⚠ SCOPE, STATED SO NOTHING LARGER IS READ INTO A GREEN RUN HERE: every case
+ * below is about the container's own `data-testid`. Descendant testids are
+ * built from content alone and are NOT split per host — `suggested-chip-*`
+ * included — so a document-wide query for a descendant is still ambiguous
+ * while both hosts are mounted. The full statement, and the reason the broad
+ * fix was not taken, is in the mount-identity note in `zones/ChatThread.tsx`.
  *
  * ⚠ WHAT IS AND IS NOT CLAIMED HERE. A COUNT of mounts is not a visibility
  * claim, so jsdom can make it (CLAUDE.md trap 3 bans the other kind). The
@@ -29,6 +37,21 @@ import { ChatThread, THREAD_TESTID_DOCKED, THREAD_TESTID_FLOATING } from '../zon
 import { ConversationPanel } from '../ConversationPanel'
 import type { ConversationMessage } from '../types'
 import type { UseConversationReturn } from '../useConversation'
+
+/**
+ * ⚠ WITHOUT THIS MOCK THIS FILE COLLECTS ZERO TESTS AND THE SUITE STAYS GREEN.
+ * `ChatThread`/`ConversationPanel` reach `services/threadService.ts` →
+ * `lib/supabase.ts`, which THROWS at module scope without
+ * `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` (`supabase.ts:38`) — a
+ * COLLECTION-time death that a multi-file run's aggregate total hides
+ * (CLAUDE.md trap 2b). Measured on this branch before the mock was added: this
+ * file failed at collect. Mirrors the sibling
+ * `FloatingOlumiPanel.threadIdentity.spec.tsx`.
+ */
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
 
 vi.mock('../../../adapters/plot', () => ({
   plot: { validatePatch: vi.fn() },
@@ -77,6 +100,22 @@ describe('the two conversation hosts do not share one data-testid', () => {
     // calls it on commit. Stubbing it keeps this file's claims about IDENTITY
     // and never about geometry.
     Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  /**
+   * ⭐ COLLECTION GUARD — this file's OWN cases, by name. A hand-written list
+   * on purpose: it cannot be derived from the thing it checks, and it fails
+   * loud if the set grows OR shrinks (CLAUDE.md trap 12's sanctioned form).
+   */
+  it('COLLECTION GUARD — all five cases in this file were collected, by name', (ctx) => {
+    const names = (ctx.task.suite?.tasks ?? []).map((t) => t.name)
+    expect(names).toEqual([
+      'COLLECTION GUARD — all five cases in this file were collected, by name',
+      'the two identities are DIFFERENT strings — the whole point, asserted before anything relies on it',
+      'LINK 1 — ChatThread answers to the identity it is given, and to no other',
+      'LINK 2 — ConversationPanel forwards the identity through to its thread',
+      'LINK 2b — and defaults to the canonical identity when no surface is named',
+    ])
   })
 
   it('the two identities are DIFFERENT strings — the whole point, asserted before anything relies on it', () => {

--- a/src/canvas/conversation/__tests__/threadMountIdentity.spec.tsx
+++ b/src/canvas/conversation/__tests__/threadMountIdentity.spec.tsx
@@ -108,7 +108,8 @@ describe('the two conversation hosts do not share one data-testid', () => {
    * loud if the set grows OR shrinks (CLAUDE.md trap 12's sanctioned form).
    */
   it('COLLECTION GUARD — all five cases in this file were collected, by name', (ctx) => {
-    const names = (ctx.task.suite?.tasks ?? []).map((t) => t.name)
+    const siblings = ctx.task.suite?.tasks ?? []
+    const names = siblings.map((t) => t.name)
     expect(names).toEqual([
       'COLLECTION GUARD — all five cases in this file were collected, by name',
       'the two identities are DIFFERENT strings — the whole point, asserted before anything relies on it',
@@ -116,6 +117,14 @@ describe('the two conversation hosts do not share one data-testid', () => {
       'LINK 2 — ConversationPanel forwards the identity through to its thread',
       'LINK 2b — and defaults to the canonical identity when no surface is named',
     ])
+    // A skipped case is still COLLECTED, so the name list alone cannot see
+    // one being quietly parked — measured: `it.skip` left the list identical
+    // and the guard green. Assert the mode too, or the guard is narrower than
+    // its own name (CLAUDE.md trap 13b — a guard agreeing with itself).
+    expect(
+      siblings.filter((t) => t.mode !== 'run').map((t) => t.name),
+      'a case in this file is skipped/todo — it is collected but it is not evidence',
+    ).toEqual([])
   })
 
   it('the two identities are DIFFERENT strings — the whole point, asserted before anything relies on it', () => {

--- a/src/canvas/conversation/hooks/useSmartScroll.ts
+++ b/src/canvas/conversation/hooks/useSmartScroll.ts
@@ -1,9 +1,16 @@
 /**
- * useSmartScroll — auto-scroll logic for the conversation thread.
+ * useSmartScroll — THE scroll authority for the conversation thread.
  *
- * Auto-scrolls to bottom when new messages arrive, unless the user has
- * scrolled up more than 60px from the bottom. Shows a "New messages"
- * indicator when new content arrives while scrolled up.
+ * Keeps the thread pinned to its newest content, unless the user has
+ * deliberately scrolled more than 60px up from the bottom — in which case it
+ * never steals their position and raises the "New messages" pill instead.
+ *
+ * ⭐ ONE DECISION, SEVERAL SENSORS. The courtesy rule lives exactly once, in
+ * `pinOrNotify`. Three sensors feed it — a message arrived, the surface was
+ * revealed, the content grew — because those are three different ways the same
+ * event becomes observable, not three different rules. `ChatThread` owns no
+ * scroll logic of its own; if you are about to add scroll handling to this
+ * surface, add a sensor here rather than a second controller beside it.
  */
 
 import { useRef, useState, useCallback, useEffect } from 'react'
@@ -29,21 +36,46 @@ export function useSmartScroll({ messageCount, isThinking }: UseSmartScrollDeps)
   const [showNewMessageIndicator, setShowNewMessageIndicator] = useState(false)
   const userScrolledUpRef = useRef(false)
 
-  const scrollToBottom = useCallback(() => {
-    listEndRef.current?.scrollIntoView({ behavior: 'smooth' })
-    setShowNewMessageIndicator(false)
-    userScrolledUpRef.current = false
-  }, [])
-
-  useEffect(() => {
-    if (messageCount === 0) return
-
+  /**
+   * ⭐ THE ONE SCROLL-COURTESY DECISION FOR THIS SURFACE.
+   *
+   * "New content has arrived: is the reader pinned to the bottom, or are they
+   * reading history?" — pin, or raise the pill; never both, never neither.
+   *
+   * This rule used to be WRITTEN OUT THREE TIMES in this file — the message
+   * effect's if/else, the reveal observer's inline `scrollIntoView` +
+   * `setShowNewMessageIndicator(false)`, and `scrollToBottom` — which is the
+   * hand-maintained mirror this estate pays for repeatedly (CLAUDE.md trap 12):
+   * three copies that agree today diverge at the next tweak, and the drift
+   * reads as green. Every sensor below now routes through THIS function, so a
+   * change to the courtesy rule cannot land in one copy and miss the others.
+   *
+   * The sensors are deliberately several — a message arrived, the surface was
+   * revealed, the content grew — because those are three different ways the
+   * same event becomes observable. They are SENSORS, not rules: the decision
+   * exists once, here.
+   */
+  const pinOrNotify = useCallback((behavior: ScrollBehavior) => {
     if (userScrolledUpRef.current) {
       setShowNewMessageIndicator(true)
-    } else {
-      scrollToBottom()
+      return
     }
-  }, [messageCount, isThinking, scrollToBottom])
+    listEndRef.current?.scrollIntoView({ behavior })
+    setShowNewMessageIndicator(false)
+  }, [])
+
+  /** The pill's own action: the user ASKED to go to the bottom, so it always goes. */
+  const scrollToBottom = useCallback(() => {
+    userScrolledUpRef.current = false
+    listEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+    setShowNewMessageIndicator(false)
+  }, [])
+
+  // Sensor 1 — a message arrived (or the thinking state settled).
+  useEffect(() => {
+    if (messageCount === 0) return
+    pinOrNotify('smooth')
+  }, [messageCount, isThinking, pinOrNotify])
 
   // ── L-83: re-pin to bottom when the thread is REVEALED ────────────────────
   //
@@ -64,6 +96,7 @@ export function useSmartScroll({ messageCount, isThinking }: UseSmartScrollDeps)
   // initiated), and only when the user has not deliberately scrolled up —
   // a reveal must never steal the position of someone reading history (their
   // "New messages" pill already handles that case).
+  // Sensor 2 — the surface was REVEALED.
   useEffect(() => {
     const el = listRef.current
     if (!el || typeof ResizeObserver === 'undefined') return
@@ -71,16 +104,57 @@ export function useSmartScroll({ messageCount, isThinking }: UseSmartScrollDeps)
     const observer = new ResizeObserver((entries) => {
       for (const entry of entries) {
         const height = entry.contentRect.height
-        if (lastHeight === 0 && height > 0 && !userScrolledUpRef.current) {
-          listEndRef.current?.scrollIntoView({ behavior: 'auto' })
-          setShowNewMessageIndicator(false)
-        }
+        if (lastHeight === 0 && height > 0) pinOrNotify('auto')
         lastHeight = height
       }
     })
     observer.observe(el)
     return () => observer.disconnect()
-  }, [])
+  }, [pinOrNotify])
+
+  // ── Sensor 3: the CONTENT GREW inside an existing message ─────────────────
+  //
+  // ⚠ WHY A COUNT OF MESSAGES CANNOT SEE THE REPLY ARRIVE. Sensor 1's
+  // `messageCount` is a PROXY for content, and on the single most important
+  // turn in the product the proxy is constant while the content is everything.
+  // Derived at the producer (`useConversation.ts`): the streaming path creates
+  // ONE placeholder assistant message (`isStreaming: true`, :5928) and then
+  // grows it by MUTATION — `text_delta` → `scheduleStreamFlush` → content, and
+  // `block` → `updateMessage(msgId, { blocks })` (:5962-5985). A first-time
+  // user's brief comes back as one message that grows for tens of seconds, and
+  // the suggested chips land on it at the very end. Across every one of those
+  // commits `messages.length`, `renderedMessageCount` and `isThinking` are all
+  // IDENTICAL, so sensors 1 and 2 are structurally incapable of observing any
+  // of it.
+  //
+  // Measured at pristine `aa916511` in real Chromium
+  // (`e2e/geometry/threadAutoScroll.measure.ts` — jsdom cannot prove this,
+  // CLAUDE.md trap 3): after the reply grew, `scrollTop 0`, `scrollHeight
+  // 1194`, `clientHeight 600`, and the "Run analysis" chip sat at y=1126 with
+  // `inView: false` and `hitTestable: false`. The chip was never dead. It was
+  // 526 px below the bottom of a thread that had stopped following its own
+  // content.
+  //
+  // So this sensor observes the content ITSELF rather than a proxy for it. A
+  // MutationObserver fires on exactly the commits above (text, blocks, chips)
+  // and on nothing the user did — `scrollIntoView` mutates no DOM, so there is
+  // no feedback loop, and `setShowNewMessageIndicator` bails out on an
+  // unchanged value rather than re-rendering. Records are already batched at
+  // the microtask checkpoint, and the producer itself commits on rAF, so this
+  // is one re-pin per frame at worst.
+  //
+  // INSTANT, not smooth, and that is load-bearing: a smooth flight is animated
+  // over several frames, during which `handleScroll` sees a mid-flight
+  // scrollTop, concludes the user has scrolled up, and cancels the very pin
+  // that is in progress. Instant lands in one event, at the bottom, where
+  // `handleScroll` correctly reads "near bottom".
+  useEffect(() => {
+    const el = listRef.current
+    if (!el || typeof MutationObserver === 'undefined') return
+    const observer = new MutationObserver(() => pinOrNotify('auto'))
+    observer.observe(el, { childList: true, subtree: true, characterData: true })
+    return () => observer.disconnect()
+  }, [pinOrNotify])
 
   const handleScroll = useCallback(() => {
     const el = listRef.current

--- a/src/canvas/conversation/zones/ChatThread.tsx
+++ b/src/canvas/conversation/zones/ChatThread.tsx
@@ -68,6 +68,17 @@ import { SETTLING_STAGES, SETTLING_AFTER_COACHING_STAGES } from '../../component
 export const THREAD_TESTID_DOCKED = 'chat-thread'
 export const THREAD_TESTID_FLOATING = 'chat-thread-floating'
 
+/**
+ * The element `useSmartScroll` aims `scrollIntoView` at (`useSmartScroll.ts:63`
+ * and `:70` — the only two call sites). Exported so no spec has to identify it
+ * by a property other elements share: `OutputsDock.runReturnsToOlumi.spec.tsx`
+ * used to find it as "the scrolled element that has NO `data-testid`", which
+ * any untagged element satisfied and which this constant's very existence
+ * would have broken (it did — that spec is updated in the same commit).
+ * One literal, one place (CLAUDE.md trap 12).
+ */
+export const THREAD_SCROLL_SENTINEL_TESTID = 'thread-scroll-sentinel'
+
 interface ChatThreadProps {
   messages: ConversationMessage[]
   isThinking: boolean
@@ -362,7 +373,7 @@ export const ChatThread = memo(function ChatThread({
           element by identity, rather than counting calls on a globally stubbed
           `Element.prototype.scrollIntoView` that any element would satisfy
           (CLAUDE.md trap 19). */}
-      <div ref={listEndRef} data-testid="thread-scroll-sentinel" />
+      <div ref={listEndRef} data-testid={THREAD_SCROLL_SENTINEL_TESTID} />
     </div>
   )
 })

--- a/src/canvas/conversation/zones/ChatThread.tsx
+++ b/src/canvas/conversation/zones/ChatThread.tsx
@@ -22,8 +22,26 @@ import { useDraftStore, draftStreamPhaseFor } from '../../stores/draftStore'
 import { SETTLING_STAGES, SETTLING_AFTER_COACHING_STAGES } from '../../components/DraftLoadingAnimation'
 
 /**
- * ⭐ MOUNT IDENTITY — the two conversation surfaces must never answer to the
- * same name.
+ * ⭐ MOUNT IDENTITY — the two conversation surfaces' THREAD CONTAINERS must
+ * never answer to the same name.
+ *
+ * ⚠ READ THE SCOPE BEFORE RELYING ON THIS. What is split is the container, and
+ * ONLY the container. `testId` is consumed at exactly one place in this file
+ * (the `data-testid` on the scroll container below) and is forwarded to no
+ * child, so EVERY descendant testid is still built from content alone and is
+ * still duplicated across the two hosts. The concrete case that started this
+ * lane is among them: the run chip's id comes from chip data
+ * (`SuggestedChips.tsx`, `` `suggested-chip-${chip.id}` ``), so
+ * `suggested-chip-run_analysis` STILL resolves to two live elements whenever
+ * both hosts are mounted, and a probe selecting it is still ambiguous.
+ *
+ * So the honest claim is narrow: a probe can now name WHICH THREAD it means,
+ * and it must scope any descendant query to that container
+ * (`within(getByTestId(THREAD_TESTID_DOCKED))`) rather than querying the
+ * document. Unscoped descendant selectors are exactly as ambiguous as they
+ * were before this change. Threading a host prefix through every descendant
+ * testid is the fix that would make the broad claim true; it is not done here,
+ * and it would be a repo-wide change to selectors and e2e specs.
  *
  * `ConversationPanel` has two production hosts (`OlumiTabBody.tsx:106`, the
  * docked Olumi tab, and `FloatingOlumiPanel.tsx:1079`), and they are NOT
@@ -35,8 +53,8 @@ import { SETTLING_STAGES, SETTLING_AFTER_COACHING_STAGES } from '../../component
  * too. That guard was written for VISIBLE exclusivity — `olumiSurface.ts:4-5`
  * says "exactly one may be visible" — and mount exclusivity was never claimed.
  *
- * So both hosts really do mount a thread at once, and until now both answered
- * to `chat-thread`. Measured consequence, in real Chromium: the hidden twin is
+ * So both hosts really do mount a thread at once, and until now both CONTAINERS
+ * answered to `chat-thread`. Measured consequence, in real Chromium: the hidden twin is
  * `display:none`, 0x0, `hitTestable: false` — which means it can never take a
  * click from a HUMAN, but it absolutely can take one from anything selecting by
  * testid. A probe that resolves `chat-thread` to the wrong twin measures an
@@ -339,7 +357,12 @@ export const ChatThread = memo(function ChatThread({
         </button>
       )}
 
-      <div ref={listEndRef} />
+      {/* The scroll sentinel `useSmartScroll` calls `scrollIntoView` on. It
+          carries a testid so a spec can assert the scroll was aimed at THIS
+          element by identity, rather than counting calls on a globally stubbed
+          `Element.prototype.scrollIntoView` that any element would satisfy
+          (CLAUDE.md trap 19). */}
+      <div ref={listEndRef} data-testid="thread-scroll-sentinel" />
     </div>
   )
 })

--- a/src/canvas/conversation/zones/ChatThread.tsx
+++ b/src/canvas/conversation/zones/ChatThread.tsx
@@ -21,6 +21,35 @@ import { useCanvasStore } from '../../store'
 import { useDraftStore, draftStreamPhaseFor } from '../../stores/draftStore'
 import { SETTLING_STAGES, SETTLING_AFTER_COACHING_STAGES } from '../../components/DraftLoadingAnimation'
 
+/**
+ * ⭐ MOUNT IDENTITY — the two conversation surfaces must never answer to the
+ * same name.
+ *
+ * `ConversationPanel` has two production hosts (`OlumiTabBody.tsx:106`, the
+ * docked Olumi tab, and `FloatingOlumiPanel.tsx:1079`), and they are NOT
+ * mutually exclusive. `olumiSurface.ts`'s guard (`dockHostsOlumi`) yields the
+ * floating panel only when the dock is open AND its tab is `olumi`; on every
+ * other tab the docked host stays MOUNTED behind `hidden`
+ * (`OutputsDock.tsx:3271-3279`, kept mounted on purpose so scroll position and
+ * `useSmartScroll` state survive a tab switch) while the floating panel renders
+ * too. That guard was written for VISIBLE exclusivity — `olumiSurface.ts:4-5`
+ * says "exactly one may be visible" — and mount exclusivity was never claimed.
+ *
+ * So both hosts really do mount a thread at once, and until now both answered
+ * to `chat-thread`. Measured consequence, in real Chromium: the hidden twin is
+ * `display:none`, 0x0, `hitTestable: false` — which means it can never take a
+ * click from a HUMAN, but it absolutely can take one from anything selecting by
+ * testid. A probe that resolves `chat-thread` to the wrong twin measures an
+ * element no user is looking at and reports a working affordance as dead.
+ *
+ * The DOCKED tab is canonical and keeps the plain name, because it is the host
+ * `dockHostsOlumi` already makes the winner whenever both could serve, and the
+ * one deliberately kept alive across tab switches. Both names live HERE, once,
+ * so a rename cannot land on one host and miss the other.
+ */
+export const THREAD_TESTID_DOCKED = 'chat-thread'
+export const THREAD_TESTID_FLOATING = 'chat-thread-floating'
+
 interface ChatThreadProps {
   messages: ConversationMessage[]
   isThinking: boolean
@@ -55,6 +84,12 @@ interface ChatThreadProps {
    * at the trigger below).
    */
   scrollListRef?: React.MutableRefObject<HTMLDivElement | null>
+  /**
+   * Which conversation surface this thread IS. Defaults to the canonical
+   * docked identity; the floating host passes `THREAD_TESTID_FLOATING`.
+   * See the mount-identity note above.
+   */
+  testId?: string
 }
 
 /**
@@ -116,6 +151,7 @@ export const ChatThread = memo(function ChatThread({
   onProposalConfirm,
   compact,
   scrollListRef,
+  testId = THREAD_TESTID_DOCKED,
 }: ChatThreadProps) {
   // Has the conversation produced any finalized (non-streaming) assistant messages?
   const hasFinalizedAssistant = messages.some(m => m.role === 'assistant' && !m.isStreaming)
@@ -225,7 +261,7 @@ export const ChatThread = memo(function ChatThread({
       role="log"
       aria-label="Conversation"
       aria-live="polite"
-      data-testid="chat-thread"
+      data-testid={testId}
     >
       {showEmptyState && (
         <EmptyState


### PR DESCRIPTION
## Verdict

**Both halves of the premise are confirmed, one with an important correction.** The thread does have an auto-scroll authority and it *was* fixed once before — but its trigger is a **count of messages**, which is a proxy for content, and on the first turn the proxy is constant while the content is everything. The duplicate mount is real. The "ghost click" is real **for probes and not for humans**, and that distinction changes what the fix is.

## 1 · The scroll defect, derived at the producer

`useSmartScroll` fires on `{ messageCount, isThinking }`. Derived at `useConversation.ts`: the streaming path creates **one** placeholder assistant message (`isStreaming: true`, `:5928`) and then grows it by **mutation** — `text_delta` → `scheduleStreamFlush` → content, and `block` → `updateMessage(msgId, { blocks })` (`:5962-5985`). Across every one of those commits `messages.length`, `renderedMessageCount` and `isThinking` are all identical. The trigger is structurally incapable of observing the arrival of the reply's body, its blocks, or its chips.

A previous lane fixed the *reveal* transitions (`renderedMessageCount`, `ChatThread.firstReplyScroll.spec.tsx`). Those still pass at pristine. They were never the whole defect.

### Measured in real Chromium at pristine `aa916511`

`e2e/geometry/threadAutoScroll.measure.ts` mounts the **real** `ChatThread` with the **real** hook and real CSS, then grows the reply the way the producer grows it. jsdom cannot prove any of this (trap 3), and a 0×0 element is "present" and useless — the exact trap that produced the false "dead affordance" finding.

| | `scrollTop` | `scrollHeight` | `clientHeight` | `Run analysis` chip |
|---|---|---|---|---|
| **pristine** | `0` | `1194` | `600` | y=1126 · `inView: false` · `hitTestable: false` |
| **fixed** | `594` | `1194` | `600` | y=532 · `inView: true` · `hitTestable: true` |

`scrollHeight` is identical in both rows — same content, only the scroll position differs.

**The chip was never dead. It was 526 px below the bottom of a thread that had stopped following its own content.**

## 2 · The duplicate mount — real, and it is `chat-thread`

`ConversationPanel` has two production hosts, `OlumiTabBody.tsx:106` (docked) and `FloatingOlumiPanel.tsx:1079` (floating), and `ConversationPanel` is the only renderer of `ChatThread`. They are **not** mutually exclusive: `dockHostsOlumi` (`olumiSurface.ts:80-84`) pre-empts the floating host only when the dock is open **and** its tab is `olumi`; on every other tab the docked host stays mounted behind `hidden` (`OutputsDock.tsx:3271-3279` — kept mounted on purpose so scroll position and `useSmartScroll` state survive a tab switch) while the floating one renders. `olumiSurface.ts:4-5` claims "exactly one may be **visible**" — mount exclusivity was never claimed, and `guidanceStore.ts:292-306` already concedes the coexistence in prose.

**Correction to the brief's hypothesis.** The hidden twin is `display:none` → no layout box → measured `hitTestable: false`. A **human click cannot land on it**. What *can* land on it is anything selecting by testid — and the 19 Aug "no analysis, no refusal, no error" sighting came from an instrumented session. So the ambiguity is real and worth fixing, but the user-facing failure on that turn was the scroll, not a ghost click.

Both surfaces genuinely exist and removing one would be a redesign (out of scope), so per the brief's fallback they no longer share a name.

## 3 · Convergence — what was superseded

**Canonical owner: `useSmartScroll`.** `ChatThread` owns no scroll logic; no second controller was added.

The courtesy rule — *pin if the reader is at the bottom, else raise the pill* — was **written out three times** in that file (the message effect's if/else, the reveal observer's inline copy, `scrollToBottom`). It now exists **once**, in `pinOrNotify`, and all three sensors route through it. Sensors are not rules: a message arrived, the surface was revealed, the content grew are three ways the *same* event becomes observable.

**Canonical mount: the docked Olumi tab keeps `chat-thread`** (the host `dockHostsOlumi` already makes the winner, and the one deliberately kept alive across tab switches). The floating host now names its thread `chat-thread-floating`. Both strings are defined **once**, in `ChatThread.tsx`, so a rename cannot land on one host and miss the other.

## 4 · Scroll courtesy when the user has scrolled up

Unchanged and pinned in both directions: past the existing 60 px threshold the thread **never** re-pins — it raises the existing "New messages" pill, which is the only thing that moves them. Sensor 3 re-pins **instantly**, not smoothly, and that is load-bearing: a smooth flight is animated over several frames, during which `handleScroll` reads a mid-flight `scrollTop`, concludes the user scrolled up, and cancels the very pin in progress.

## 5 · Evidence

- **RED-first at pristine**, named signatures, 3/3 failing: *"the reply body grew below the fold and nothing scrolled to it"*, *"the suggested chips landed and nothing scrolled to them"*, *"nothing told the scrolled-up reader that new content had arrived"*.
- **Bound by identity** — message id `a1` with `messages.length` asserted identical across the commit; the chip by `data-testid="suggested-chip-run_analysis"`, never by index or position.
- **Discriminating mutant pairs**, throwaway worktree at an absolute path outside the repo root, isolation **proven by writing a sentinel** (source SHA-256 unchanged; inodes differ), HEAD-relative restores, applied-check scoped to `src/` reading exactly 1 during each mutation and 0 in both controls:

| mutant | `contentGrowthScroll` | `useSmartScroll.spec` |
|---|---|---|
| A — content sensor removed | **RED** | GREEN |
| B — sensor 1 fires on a different event | GREEN | **RED** |

| mutant | `threadMountIdentity` | `FloatingOlumiPanel.threadIdentity` |
|---|---|---|
| C — floating host stops passing the identity | GREEN | **RED** |
| D — `ConversationPanel` swallows the identity | **RED** | GREEN |

- ⚠ **The first identity-mutant run was VOID and is disclosed here.** An unquoted `$IDENT` under zsh (which does not word-split) sent vitest one bogus path; it found no tests, exited 0, and **both mutants read as survivors**. The tell was the missing `Tests` line, not the verdicts. Re-run with quoted args and a hard assertion that the collected count equals 5 — the numbers above are from that run.
- **Gate** (derived from `staging-full-tests.yml`, `needs: [tsc, typecheck-selftest, vitest, vitest-summary, build]`): typecheck **PASS** · typecheck-selftest **18/18** · build **PASS** · full suite **25,015 passed / 0 failed** (1736 files) · eslint 0 errors on changed files.
- Own specs asserted **by name**: `contentGrowthScroll` 3, `threadMountIdentity` 4, `FloatingOlumiPanel.threadIdentity` 1.
- I did **not** accept the typecheck gate's `--update-baseline` shrink prompt (2272 → 2263). 9 diagnostics my change cannot account for reads as attribution churn (trap 2b).

## 6 · Files touched — sequencing note for the harvest

**⚠ `ConversationPanel.tsx` IS touched** — 8 lines, purely additive: one optional prop in the interface, one in the destructuring, one forwarded to `ChatThread`. No behaviour change when the prop is absent. **`useConversation.ts` is NOT touched.**

| file | lines | kind |
|---|---|---|
| `src/canvas/conversation/hooks/useSmartScroll.ts` | +108 −18 | the fix (mostly the derivation comment) |
| `src/canvas/conversation/zones/ChatThread.tsx` | +38 | testid prop + identity constants |
| `src/canvas/conversation/ConversationPanel.tsx` | **+8** | **additive prop pass-through — high-collision file** |
| `src/canvas/components/FloatingOlumiPanel.tsx` | +6 | passes the floating identity |

**Source delta: 4 files, +142 / −18** (the majority is the derivation comment). Plus 3 new spec files and 2 new `e2e/geometry` instruments. `computeFitPadding.ts` and fit padding: untouched.

## The mounted consequence, in one sentence

A first-time user who sends their brief now watches the reply, its blocks and its suggested chips arrive **in view**, on the surface the deployed flags actually mount — instead of staring at the top of a reply whose "Run analysis" chip sits ~500 px below the fold.

---

## CI at `b302b969`

**`Staging Gate` = SUCCESS**, polled to conclusion with `running = 0`. All four Full Test Suite shards green, Full Test Suite Summary green, Production Build green, TypeScript + Lint green, Typecheck Gate Self-Test green.

`Visual Regression (advisory)` is **RED and pre-existing** — not caused by this branch and not in the gate's `needs`. Derived rather than assumed: it fails on the last five `staging` commits **including `aa916511`, this PR's own pristine baseline**.
