### PR TITLE
fix(canvas): undo stops resurrecting a node the server durably deleted

### DIFF
--- a/scripts/ci/typecheck-baseline-identities.txt
+++ b/scripts/ci/typecheck-baseline-identities.txt
@@ -506,7 +506,7 @@
 2	src/canvas/conversation/useConversation.ts	TS2339	Property 'graph_state' does not exist on type 'TurnRequestPayload'.
 1	src/canvas/conversation/useConversation.ts	TS2339	Property 'message' does not exist on type 'TurnRequestPayload'.
 2	src/canvas/conversation/useConversation.ts	TS2339	Property 'selected_elements' does not exist on type 'TurnRequestPayload'.
-1	src/canvas/conversation/useConversation.ts	TS2345	Argument of type '{ currentResultsHash: null | string; backfillGoalThreshold: (analysisReady: { goal_node_id?: string; goal_threshold_raw?: null | number; goal_threshold_unit?: null | string; goal_threshold_cap?: null | number; } | null) => void; ... 261 more ...; clearClarifierPreview: () => void; }' is not assignable to parameter of type 'V5ApplicatorStore'.
+1	src/canvas/conversation/useConversation.ts	TS2345	Argument of type '{ currentResultsHash: null | string; backfillGoalThreshold: (analysisReady: { goal_node_id?: string; goal_threshold_raw?: null | number; goal_threshold_unit?: null | string; goal_threshold_cap?: null | number; } | null) => void; ... 265 more ...; clearClarifierPreview: () => void; }' is not assignable to parameter of type 'V5ApplicatorStore'.
 2	src/canvas/conversation/useConversation.ts	TS2352	Conversion of type 'OrchestratorResponseEnvelopeV2' to type 'Record<string, unknown>' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
 1	src/canvas/conversation/useGraphEditEvents.ts	TS6133	'op' is declared but its value is never read.
 1	src/canvas/conversation/useGraphEditEvents.ts	TS6133	'ops' is declared but its value is never read.

--- a/src/canvas/__tests__/store.undoDurableDelete.spec.ts
+++ b/src/canvas/__tests__/store.undoDurableDelete.spec.ts
@@ -1,0 +1,260 @@
+/**
+ * Undo may not resurrect an element the SERVER has durably deleted.
+ *
+ * THE DEFECT, measured at deployed UI `aa916511`: `structural_delete` made a
+ * canvas delete durable, but `undo()` restores `history.past[n]` verbatim and
+ * knows nothing about the receipt — so Cmd+Z put the node back on the canvas
+ * while the saved model still held it deleted. That is the founder's original
+ * complaint (*"it keeps adding the option that I deleted back"*) re-opened on
+ * screen, one keystroke after the wire fix closed it.
+ *
+ * ⚠ EVERY ASSERTION BINDS BY NODE ID, NEVER BY COUNT (CLAUDE.md trap 19). A
+ * count assertion is satisfied by a different node than the one the server
+ * removed — which is exactly the assertion that passes on the wrong object.
+ *
+ * ⚠ THE OPPOSITE-DIRECTION TWIN IS MANDATORY HERE (trap 22b). This guard sits
+ * between two harms: resurrecting a durably-deleted node (a lie) and refusing
+ * to restore a node that was never durably deleted (silently eating the user's
+ * undo). Every withhold case below has a restore case beside it.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import type { Edge, Node } from '@xyflow/react'
+import type { EdgeData } from '../domain/edges'
+import { useCanvasStore } from '../store'
+
+/** The option the founder deletes. Its ID is what every assertion binds to. */
+const EU = 'opt-eu'
+/** A sibling option that is NEVER deleted — the discriminator for identity binding. */
+const US = 'opt-us'
+const GOAL = 'goal-1'
+
+function seedGraph(): void {
+  const nodes: Node[] = [
+    { id: GOAL, type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Grow revenue' } },
+    { id: EU, type: 'option', position: { x: 100, y: 0 }, data: { label: 'Expand into the EU' } },
+    { id: US, type: 'option', position: { x: 200, y: 0 }, data: { label: 'Expand into the US' } },
+  ]
+  const edges: Edge<EdgeData>[] = [
+    { id: 'e-eu-goal', source: EU, target: GOAL },
+    { id: 'e-us-goal', source: US, target: GOAL },
+  ]
+  useCanvasStore.setState({
+    nodes,
+    edges,
+    history: { past: [], future: [] },
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    durablyDeletedElements: { nodeIds: [], edgeIds: [] },
+    durableDeletionNotice: null,
+  })
+}
+
+const nodeIds = (): string[] => useCanvasStore.getState().nodes.map((n) => n.id)
+const edgeIds = (): string[] => useCanvasStore.getState().edges.map((e) => e.id)
+
+/**
+ * Mark a deletion as PROVEN by the server, exactly as `resolveStructuralDelete`
+ * does on a `'proven'` receipt. Set directly rather than through the action so
+ * the undo tests below fail on BEHAVIOUR at pristine (the node comes back)
+ * rather than on a missing function — a red about the defect, not about an API.
+ */
+function serverProvedDeleted(ids: { nodeIds?: string[]; edgeIds?: string[] }): void {
+  useCanvasStore.setState({
+    durablyDeletedElements: { nodeIds: ids.nodeIds ?? [], edgeIds: ids.edgeIds ?? [] },
+  })
+}
+
+describe('undo vs. durable deletion — the canvas may not contradict the saved model', () => {
+  beforeEach(() => {
+    seedGraph()
+  })
+
+  it('does NOT bring back a node whose deletion the server proved', () => {
+    useCanvasStore.getState().deleteNodeById(EU)
+    expect(nodeIds()).not.toContain(EU)
+    serverProvedDeleted({ nodeIds: [EU] })
+
+    useCanvasStore.getState().undo()
+
+    // THE ASSERTION. Bound to the deleted node's own id.
+    expect(nodeIds()).not.toContain(EU)
+    // And the graph is still coherent: no edge dangles off the withheld node.
+    expect(edgeIds()).not.toContain('e-eu-goal')
+  })
+
+  it('DOES bring back a node whose deletion was never proven — a local-only delete stays undoable', () => {
+    // The opposite-direction twin. `captureStructuralDelete` stands down when no
+    // CEE graph_hash is held (its KNOWN GAP), so this delete never became
+    // durable and undo must behave exactly as it always has.
+    useCanvasStore.getState().deleteNodeById(EU)
+    expect(nodeIds()).not.toContain(EU)
+
+    useCanvasStore.getState().undo()
+
+    expect(nodeIds()).toContain(EU)
+    expect(edgeIds()).toContain('e-eu-goal')
+  })
+
+  it('withholds ONLY the proven node and restores its sibling from the SAME snapshot', () => {
+    // THE IDENTITY DISCRIMINATOR. Both options leave in ONE gesture, so both sit
+    // in ONE history snapshot and one undo restores both — a guard keyed on
+    // anything weaker than the id (a count, "the deleted ones", the snapshot
+    // itself) either brings EU back or eats US. Only an id-bound guard splits
+    // them, and this test fails in BOTH directions if it is not.
+    useCanvasStore.setState({
+      selection: { nodeIds: new Set([EU, US]), edgeIds: new Set(), anchorPosition: null },
+    })
+    useCanvasStore.getState().deleteSelected()
+    expect(nodeIds()).not.toContain(EU)
+    expect(nodeIds()).not.toContain(US)
+    serverProvedDeleted({ nodeIds: [EU] })
+
+    useCanvasStore.getState().undo()
+
+    expect(nodeIds()).toContain(US) // the un-proven sibling must come back
+    expect(nodeIds()).not.toContain(EU) // the proven one must not
+    // US's edge rides back with it; EU's must not dangle.
+    expect(edgeIds()).toContain('e-us-goal')
+    expect(edgeIds()).not.toContain('e-eu-goal')
+  })
+
+  it('holds the line across MULTI-STEP undo, back past the delete', () => {
+    // The defect's real shape: the entry that resurrects is not the first undo.
+    useCanvasStore.getState().deleteNodeById(EU)
+    serverProvedDeleted({ nodeIds: [EU] })
+    // A later, unrelated edit — its snapshot post-dates the delete.
+    useCanvasStore.getState().pushHistory()
+    useCanvasStore.setState({
+      nodes: useCanvasStore
+        .getState()
+        .nodes.map((n) => (n.id === US ? { ...n, data: { label: 'Expand into the US (v2)' } } : n)),
+    })
+
+    useCanvasStore.getState().undo() // step 1 — back to the post-delete state
+    expect(nodeIds()).not.toContain(EU)
+    useCanvasStore.getState().undo() // step 2 — back PAST the delete
+    expect(nodeIds()).not.toContain(EU)
+    useCanvasStore.getState().undo() // step 3 — exhausts the stack
+    expect(nodeIds()).not.toContain(EU)
+  })
+
+  it('holds the line through REDO as well', () => {
+    useCanvasStore.getState().deleteNodeById(EU)
+    serverProvedDeleted({ nodeIds: [EU] })
+    useCanvasStore.getState().undo()
+    expect(nodeIds()).not.toContain(EU)
+
+    useCanvasStore.getState().redo()
+
+    expect(nodeIds()).not.toContain(EU)
+  })
+
+  it('tells the user, by name, that undo declined — and says nothing when it did not', () => {
+    useCanvasStore.getState().deleteNodeById(EU)
+    serverProvedDeleted({ nodeIds: [EU] })
+    useCanvasStore.getState().undo()
+
+    const notice = useCanvasStore.getState().durableDeletionNotice
+    expect(notice).not.toBeNull()
+    expect(notice?.kind).toBe('withheld')
+    expect(notice?.nodeIds).toContain(EU)
+    expect(notice?.labels).toContain('Expand into the EU')
+
+    // Silence when the guard did not fire — an undo that restored everything
+    // must not tell the user something was held back.
+    seedGraph()
+    useCanvasStore.getState().deleteNodeById(EU)
+    useCanvasStore.getState().undo()
+    expect(useCanvasStore.getState().durableDeletionNotice).toBeNull()
+  })
+
+  it('re-fires the notice on a SECOND declined undo (two presses, two events)', () => {
+    // TWO snapshots that both pre-date the delete, so both undos are declined.
+    // (`historyHash` keys on the label, so relabelling makes a distinct entry.)
+    useCanvasStore.getState().pushHistory()
+    useCanvasStore.setState({
+      nodes: useCanvasStore
+        .getState()
+        .nodes.map((n) => (n.id === US ? { ...n, data: { label: 'Expand into the US (v2)' } } : n)),
+    })
+    useCanvasStore.getState().pushHistory()
+    useCanvasStore.getState().deleteNodeById(EU)
+    serverProvedDeleted({ nodeIds: [EU] })
+
+    useCanvasStore.getState().undo()
+    const first = useCanvasStore.getState().durableDeletionNotice
+    useCanvasStore.getState().undo()
+    const second = useCanvasStore.getState().durableDeletionNotice
+
+    expect(first).not.toBeNull()
+    expect(second).not.toBeNull()
+    // Without a monotonic seq a value-comparing subscriber swallows the second
+    // and the user is told once for two presses.
+    expect(second!.seq).toBeGreaterThan(first!.seq)
+  })
+})
+
+describe('recordDurableDeletion — the receipt arriving AFTER an undo already restored the node', () => {
+  beforeEach(() => {
+    seedGraph()
+  })
+
+  it('takes the node back off the canvas and says so', () => {
+    // The race: delete, undo before the turn returns, THEN the receipt proves it.
+    useCanvasStore.getState().deleteNodeById(EU)
+    useCanvasStore.getState().undo()
+    expect(nodeIds()).toContain(EU) // the un-proven undo legitimately restored it
+
+    useCanvasStore.getState().recordDurableDeletion({ nodeIds: [EU], edgeIds: [] })
+
+    expect(nodeIds()).not.toContain(EU)
+    expect(edgeIds()).not.toContain('e-eu-goal')
+    const notice = useCanvasStore.getState().durableDeletionNotice
+    expect(notice?.kind).toBe('reconciled')
+    expect(notice?.nodeIds).toContain(EU)
+  })
+
+  it('is silent when the node had already gone — the ordinary case', () => {
+    useCanvasStore.getState().deleteNodeById(EU)
+
+    useCanvasStore.getState().recordDurableDeletion({ nodeIds: [EU], edgeIds: [] })
+
+    expect(nodeIds()).not.toContain(EU)
+    expect(nodeIds()).toContain(US)
+    // Nothing was taken off the canvas, so there is nothing to announce.
+    expect(useCanvasStore.getState().durableDeletionNotice).toBeNull()
+  })
+
+  it('never removes a node it was not told about', () => {
+    useCanvasStore.getState().recordDurableDeletion({ nodeIds: [EU], edgeIds: [] })
+    expect(nodeIds()).toContain(US)
+    expect(nodeIds()).toContain(GOAL)
+  })
+})
+
+describe('the record does not outlive the graph whose ids it names', () => {
+  it('reset() clears it — because reset REISSUES the same node ids', () => {
+    // ⚠ NOT HOUSEKEEPING. `createNodeId` returns `String(nextNodeId)` and
+    // `reset()` sets `nextNodeId: 1`, so the next graph reuses the ids the last
+    // one had. A surviving record would match a BRAND-NEW node by id and
+    // withhold it from undo — eating work the server never deleted, which is
+    // the opposite-direction harm of the defect this guard closes.
+    seedGraph()
+    useCanvasStore.getState().recordDurableDeletion({ nodeIds: ['1'], edgeIds: [] })
+    expect(useCanvasStore.getState().durablyDeletedElements.nodeIds).toContain('1')
+
+    useCanvasStore.getState().reset()
+
+    expect(useCanvasStore.getState().durablyDeletedElements.nodeIds).toHaveLength(0)
+    expect(useCanvasStore.getState().durableDeletionNotice).toBeNull()
+
+    // ...and the reissued id is genuinely undoable again.
+    const fresh: Node[] = [
+      { id: '1', type: 'option', position: { x: 0, y: 0 }, data: { label: 'A brand-new option' } },
+    ]
+    useCanvasStore.setState({ nodes: fresh, edges: [], history: { past: [], future: [] } })
+    useCanvasStore.getState().deleteNodeById('1')
+    useCanvasStore.getState().undo()
+    expect(nodeIds()).toContain('1')
+  })
+})

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -2999,7 +2999,28 @@ export function useConversation(): UseConversationReturn {
 
       if (outcome.kind === 'response') {
         const receipt = readStructuralDeleteReceipt(intent, outcome.response)
-        if (receipt === 'proven') return
+        if (receipt === 'proven') {
+          // 0.48.0 — THE RECEIPT NOW BINDS UNDO. `proven` means CEE re-read the
+          // COMMITTED bytes and found these ids absent, so the deletion is a
+          // fact about the saved model. Until this call existed the receipt had
+          // exactly one consumer (the revert, on its negative arm) and history
+          // restoration ignored it entirely — so Cmd+Z put the node back and
+          // the canvas asserted a model state the server had durably declined.
+          // Recorded ONLY here: the `refuted`/`unproven`/409/transport arms all
+          // fall through to the revert below, and their elements stay undoable.
+          //
+          // Scenario-gated for the same reason `revertStructuralDelete` is —
+          // these are canvas ids in ONE decision's graph, and applying them to a
+          // scenario the user has since switched to could withhold an unrelated
+          // node that happens to share an id.
+          if ((store.currentScenarioId ?? null) === capturedScenarioId) {
+            store.recordDurableDeletion({
+              nodeIds: intent.claimedNodeIds,
+              edgeIds: intent.claimedEdgeIds,
+            })
+          }
+          return
+        }
         shouldRevert = true
         const spoke =
           typeof outcome.response.assistant_text === 'string' &&

--- a/src/canvas/hooks/useDurableDeletionToast.ts
+++ b/src/canvas/hooks/useDurableDeletionToast.ts
@@ -1,0 +1,49 @@
+/**
+ * useDurableDeletionToast — says, in the product's own voice, that undo declined.
+ *
+ * WHY A TOAST AND NOT THE ASSISTANT BUBBLE. `STRUCTURAL_DELETE_NOTICE` speaks
+ * through a synthetic assistant message because those outcomes arrive on a TURN
+ * — the user is reading the chat when the server answers. This one arrives on a
+ * CANVAS GESTURE, at the moment of the keystroke, and it must reach the user
+ * wherever that gesture came from. It also has to be ungated: the bubble needs a
+ * `ConversationProvider`, which `ReactFlowGraph` mounts only when
+ * `isAiPanelV2Enabled()`, whereas all four undo entry points
+ * (Cmd+Z, the left-rail Undo button, the pane context menu, and the delete
+ * toast's own Undo action) are unconditional. A notice that could go dark on the
+ * surface that triggers it would re-open the defect quietly.
+ *
+ * ⚠ SUBSCRIBES BY `seq`, NOT BY VALUE. `ToastProvider` shows one toast at a
+ * time and a second identical decline is value-equal to the first, so a
+ * value-comparing subscriber would tell the user once for two Cmd+Z presses —
+ * exactly the silence this lane exists to remove.
+ *
+ * ⚠ NO ACTION BUTTON. The sibling history toast offers "Undo"; this one offers
+ * nothing, because there is no restore verb in the UI→CEE vocabulary
+ * (`WIRE_SYSTEM_EVENT_TYPES`) and every control we could render here would
+ * terminate in refusal — the P8 trap `STRUCTURAL_DELETE_NOTICE.base_hash_
+ * diverged` documents at length. It states what happened and stops.
+ */
+
+import { useEffect, useRef } from 'react'
+import { useCanvasStore } from '../store'
+import { describeDurableDeletionNotice } from '../store/durableDeletionGuard'
+import { useShowToastSafe } from '../ToastContext'
+
+export function useDurableDeletionToast(): void {
+  const showToast = useShowToastSafe()
+  const lastSeqRef = useRef<number>(0)
+
+  useEffect(() => {
+    const unsub = useCanvasStore.subscribe((state) => {
+      const notice = state.durableDeletionNotice
+      if (notice === null || notice.seq <= lastSeqRef.current) return
+      lastSeqRef.current = notice.seq
+      // 'warning', so it auto-dismisses: this is a declined gesture, not a
+      // failure the user must acknowledge (ToastContext holds `error` on screen
+      // until dismissed, which would be a heavier claim than the facts support).
+      showToast(describeDurableDeletionNotice(notice), 'warning')
+    })
+    lastSeqRef.current = useCanvasStore.getState().durableDeletionNotice?.seq ?? 0
+    return unsub
+  }, [showToast])
+}

--- a/src/canvas/hooks/useHistoryToast.ts
+++ b/src/canvas/hooks/useHistoryToast.ts
@@ -5,14 +5,32 @@
  * entry has a label, fires a toast with the label and an "Undo" action button.
  *
  * Graph Editing Experience Task 8d.
+ *
+ * ⚠ IT ALSO MOUNTS `useDurableDeletionToast`, AND THAT IS A DELIBERATE CHOICE
+ * WITH A REASON, not tidiness. Both hooks answer the same question — *what does
+ * the canvas tell the user about what just happened to graph history?* — and
+ * they are siblings: this one announces a history entry being PUSHED (offering
+ * Undo), the other announces a history entry being RESTORED ONLY IN PART,
+ * because the server had durably deleted something in it.
+ *
+ * The mechanical reason it is composed here rather than called beside this hook
+ * in `ReactFlowGraph`: every hook in that region of `ReactFlowGraph` sits after
+ * an early return, so all 117 are rules-of-hooks violations held by an explicit
+ * ratchet (`scripts/ci/assert-rules-of-hooks-ratchet.mjs`) — *"an exception for
+ * its EXISTING violations, not a licence to add more. Each one is a render-time
+ * crash."* A second call site there would have added the 118th and failed the
+ * gate. Composing costs no new violation and no new mount to keep in sync.
  */
 
 import { useEffect, useRef } from 'react'
 import { useCanvasStore } from '../store'
 import { useShowToast } from '../ToastContext'
+import { useDurableDeletionToast } from './useDurableDeletionToast'
 
 export function useHistoryToast() {
   const showToast = useShowToast()
+  // Sibling notice, same surface, same mount — see the header.
+  useDurableDeletionToast()
   const prevLengthRef = useRef<number>(0)
 
   useEffect(() => {

--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -29,6 +29,15 @@ import {
   mergeStructuralDeleteIntents,
   type StructuralDeleteIntent,
 } from './mutations/structuralDelete'
+import {
+  EMPTY_DURABLE_DELETION_RECORD,
+  addDurableDeletion,
+  buildDurableDeletionNotice,
+  reconcileDurableDeletions,
+  withholdDurableDeletions,
+  type DurableDeletionNotice,
+  type DurableDeletionRecord,
+} from './store/durableDeletionGuard'
 import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
 import * as scenarios from './store/scenarios'
 import type { ScenarioFraming } from './store/scenarios'
@@ -625,6 +634,25 @@ interface CanvasState {
    * by `useStructuralDeleteEvents`, which is the ONE sender.
    */
   pendingStructuralDeletes: StructuralDeleteIntent[]
+  /**
+   * Canvas ids the server has PROVEN removed from the saved model — written
+   * ONLY from a `'proven'` `structural_delete` receipt.
+   *
+   * ⚠ THIS IS NOT A SECOND DIVERGENCE AUTHORITY. It is the existing receipt's
+   * verdict, recorded so the ONE consumer that was ignoring it — history
+   * restoration — can honour it. Undo restored `history.past[n]` verbatim, so
+   * Cmd+Z put back a node the server had durably deleted and the canvas
+   * asserted a model state the server declined to hold. Nothing here decides
+   * durability; `resolveStructuralDelete` does, and a refused or unconfirmed
+   * delete records NOTHING (its elements are legitimately undoable).
+   *
+   * NEVER PERSISTED — the same discipline as `analysisRefusalNotice`. History
+   * itself is session-local, so a record that outlived it would guard snapshots
+   * that no longer exist.
+   */
+  durablyDeletedElements: DurableDeletionRecord
+  /** What the guard last did, for the canvas to announce. Null = it did nothing. */
+  durableDeletionNotice: DurableDeletionNotice | null
   // CEE Pipeline trace from last draft-graph response (for debug panel)
   ceePipelineTrace: CeePipelineTrace | null
   // CEE V3: Per-node LLM reasoning (node ID → why text) for rationale tooltips
@@ -1021,6 +1049,22 @@ interface CanvasState {
     nodes: readonly Node[]
     edges: readonly Edge<EdgeData>[]
   }) => void
+  /**
+   * 0.48.0: record that the server PROVED these elements gone from the saved
+   * model, so history restoration stops bringing them back.
+   *
+   * ⚠ CALL THIS ONLY FROM A `'proven'` RECEIPT. It is the twin of
+   * `applyStructuralDeleteRevert` — that one handles "the server did NOT remove
+   * these", this one "the server DID". A refused or unconfirmed delete must
+   * reach neither: its elements are legitimately undoable, and recording them
+   * here would make the product refuse to restore something it still holds.
+   */
+  recordDurableDeletion: (removed: {
+    readonly nodeIds: readonly string[]
+    readonly edgeIds: readonly string[]
+  }) => void
+  /** Dismiss the durable-deletion notice once the canvas has shown it. */
+  clearDurableDeletionNotice: () => void
   setCeePipelineTrace: (trace: CeePipelineTrace | null) => void
   setCeeQuality: (quality: CeeQualityDimensions | null) => void
   // Phase 1b actions
@@ -1407,6 +1451,12 @@ const DECISION_CONTEXT_CLEAR = {
   // never edited. (Typed rather than left to `as const`, which would infer
   // `readonly []` and refuse to satisfy the mutable store field.)
   pendingStructuralDeletes: [] as StructuralDeleteIntent[],
+  // 0.48.0: the durable-delete record names ids in ONE decision's graph.
+  // Carrying it across a context replacement would guard a new canvas against
+  // deletions made in a decision the user has left — and could withhold a node
+  // that merely shares an id.
+  durablyDeletedElements: EMPTY_DURABLE_DELETION_RECORD as DurableDeletionRecord,
+  durableDeletionNotice: null as DurableDeletionNotice | null,
 } as const
 
 /**
@@ -1540,6 +1590,20 @@ function markAnalysisFreshnessDirty(
  * `mergeStructuralDeleteIntents` for why the fold is only sound inside it.
  */
 let structuralDeleteTickOpen = false
+
+/**
+ * Monotonic id for durable-deletion notices.
+ *
+ * ⚠ NOT DECORATION. The canvas announces the notice by SUBSCRIBING to this
+ * field, and two identical outcomes in a row are value-equal — so without a
+ * changing member the second press is swallowed and the user is told once for
+ * two Cmd+Z's. Same defect shape as a toast keyed on a message string.
+ */
+let durableNoticeSeq = 0
+function nextDurableNoticeSeq(): number {
+  durableNoticeSeq += 1
+  return durableNoticeSeq
+}
 
 /**
  * Record a user delete gesture for the wire, BEFORE the removal is applied.
@@ -1920,6 +1984,9 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
   lastServerGraphHash: null,
   // 0.48.0: no delete gestures awaiting the wire.
   pendingStructuralDeletes: [],
+  // 0.48.0: no deletion has been proven durable yet, so undo is unconstrained.
+  durablyDeletedElements: EMPTY_DURABLE_DELETION_RECORD,
+  durableDeletionNotice: null,
   // CEE Pipeline trace from last draft
   ceePipelineTrace: null,
   // CEE V3: Per-node LLM reasoning for rationale tooltips
@@ -2503,7 +2570,13 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     // still forwards to PLoT. Re-derive it from the reverted graph's goal node so
     // the scalar and the node stay in lockstep (an undo past the target-set
     // restores null).
-    set({ nodes: prev.nodes, edges: prev.edges, history: { past, future }, ...READINESS_CLEAR_FIELDS, ...deriveGoalThresholdFromNode(prev.nodes, get().outcomeNodeId), analysisFreshnessDirty: true, lens: createDefaultLensState() })
+    // 0.48.0 — a restore may not resurrect what the server durably deleted.
+    // The snapshot predates the receipt, so it is filtered against it rather
+    // than applied verbatim; `withholdDurableDeletions` is a no-op (a copy)
+    // whenever nothing has been proven deleted, which is the common case.
+    const guarded = withholdDurableDeletions(prev, get().durablyDeletedElements, { nodes, edges })
+    const notice = buildDurableDeletionNotice('withheld', guarded, prev, nextDurableNoticeSeq())
+    set({ nodes: guarded.nodes, edges: guarded.edges, history: { past, future }, ...READINESS_CLEAR_FIELDS, ...deriveGoalThresholdFromNode(guarded.nodes, get().outcomeNodeId), analysisFreshnessDirty: true, lens: createDefaultLensState(), durableDeletionNotice: notice })
     // Reset hash after undo
     const { nodes: newNodes, edges: newEdges } = get()
     set(() => ({ _internal: { lastHistoryHash: historyHash(newNodes, newEdges) } }))
@@ -2520,7 +2593,15 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     logConstraintClearIfPresent(get, 'redo')
     // P0-1: mirror undo — re-derive the goal-threshold scalar from the reapplied
     // graph's goal node so it cannot outlive the node it describes.
-    set({ nodes: next.nodes, edges: next.edges, history: { past, future }, ...READINESS_CLEAR_FIELDS, ...deriveGoalThresholdFromNode(next.nodes, get().outcomeNodeId), analysisFreshnessDirty: true, lens: createDefaultLensState() })
+    // 0.48.0 — mirror of undo, and NOT defensive padding. `pushToHistory`
+    // clears `future` on every mutation, so a future entry captured BEFORE a
+    // durable delete is not reachable today; the guard is here so the invariant
+    // is a property of history RESTORATION rather than of one direction, and so
+    // a later change to the redo stack's lifecycle cannot quietly re-open the
+    // defect on the other side.
+    const guarded = withholdDurableDeletions(next, get().durablyDeletedElements, { nodes, edges })
+    const notice = buildDurableDeletionNotice('withheld', guarded, next, nextDurableNoticeSeq())
+    set({ nodes: guarded.nodes, edges: guarded.edges, history: { past, future }, ...READINESS_CLEAR_FIELDS, ...deriveGoalThresholdFromNode(guarded.nodes, get().outcomeNodeId), analysisFreshnessDirty: true, lens: createDefaultLensState(), durableDeletionNotice: notice })
     // Reset hash after redo
     const { nodes: newNodes, edges: newEdges } = get()
     set(() => ({ _internal: { lastHistoryHash: historyHash(newNodes, newEdges) } }))
@@ -3370,6 +3451,17 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
       selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
       nextNodeId: 1,
       nextEdgeId: 1,
+      // 0.48.0 — MUST be cleared here, and `nextNodeId: 1` above is exactly
+      // why. Canvas node ids are sequential integers (`createNodeId` returns
+      // `String(nextNodeId)`), so a reset makes the NEXT graph reissue the same
+      // ids the previous one used. A durable-delete record surviving that would
+      // match a brand-new, never-deleted node by id and withhold it from undo —
+      // silently eating the user's work, which is the exact opposite-direction
+      // harm this guard exists to avoid. (`resetCanvas`, `importCanvas` and
+      // `hydrateGraphSlice` clear it via DECISION_CONTEXT_CLEAR; this action
+      // does not apply that block, so it clears them itself.)
+      durablyDeletedElements: EMPTY_DURABLE_DELETION_RECORD,
+      durableDeletionNotice: null,
       _internal: { lastHistoryHash: historyHash(initialNodes, initialEdges) },
       hasCompletedFirstRun: false,
       showDraftChat: false,
@@ -4915,6 +5007,43 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
     if (queued.length === 0) return []
     set({ pendingStructuralDeletes: [] })
     return queued
+  },
+
+  recordDurableDeletion: (removed) => {
+    if (removed.nodeIds.length === 0 && removed.edgeIds.length === 0) return
+    const record = addDurableDeletion(get().durablyDeletedElements, removed)
+    // The receipt can land AFTER an undo has already put the elements back (the
+    // send is a round-trip; Cmd+Z is instant). Reconcile the LIVE canvas so it
+    // cannot keep asserting a node the server has proven gone — this is a no-op
+    // in the ordinary case, where the elements left on the delete and never
+    // returned.
+    const { nodes, edges } = get()
+    const reconciled = reconcileDurableDeletions({ nodes, edges }, record)
+    const notice = buildDurableDeletionNotice(
+      'reconciled',
+      reconciled,
+      { nodes, edges },
+      nextDurableNoticeSeq(),
+    )
+    if (notice === null) {
+      // Nothing came off the canvas: record the verdict and say nothing. A
+      // notice here would announce a removal the user never saw happen.
+      set({ durablyDeletedElements: record })
+      return
+    }
+    set((s) => ({
+      durablyDeletedElements: record,
+      nodes: reconciled.nodes,
+      edges: reconciled.edges,
+      durableDeletionNotice: notice,
+      ...deriveGoalThresholdFromNode(reconciled.nodes, s.outcomeNodeId),
+    }))
+    markAnalysisFreshnessDirty(get, set)
+  },
+
+  clearDurableDeletionNotice: () => {
+    if (get().durableDeletionNotice === null) return
+    set({ durableDeletionNotice: null })
   },
 
   applyStructuralDeleteRevert: (restore) => {

--- a/src/canvas/store/durableDeletionGuard.ts
+++ b/src/canvas/store/durableDeletionGuard.ts
@@ -1,0 +1,300 @@
+/**
+ * durableDeletionGuard — a history restore may not resurrect an element the
+ * SERVER has durably removed.
+ *
+ * THE DEFECT THIS CLOSES. `structural_delete` (schemas 0.48.0) made a canvas
+ * delete DURABLE: `resolveStructuralDelete` reads a receipt CEE stamps only
+ * after re-reading the COMMITTED bytes, so a `'proven'` receipt is evidence the
+ * element is gone from the saved model. Undo, however, restores
+ * `history.past[n]` VERBATIM in one `set()` — it predates the removal verb and
+ * knows nothing about it. So Cmd+Z put the node back on the canvas while the
+ * server still held it deleted, and the product asserted a model state the
+ * server had durably declined to hold. That is the founder's original complaint
+ * — *"it keeps adding the option that I deleted back"* — re-opened on screen,
+ * one keystroke after `structural_delete` closed it on the wire.
+ *
+ * ⚠ THIS INVENTS NO NEW NOTION OF DIVERGENCE, and that is deliberate (Paul's
+ * convergence rule). The estate already has exactly one authority on whether a
+ * removal reached the saved model: the `structural_delete` RECEIPT, read by
+ * `readStructuralDeleteReceipt` and adjudicated in `resolveStructuralDelete`'s
+ * three states. This module does not re-derive that judgement, does not compare
+ * hashes, and does not ask the server anything. It consumes the SAME receipt —
+ * `'proven'` and only `'proven'` — and extends its authority over the one
+ * consumer that was ignoring it. `refuted` / `unproven` / 409 / transport
+ * already have their own owner (`revertStructuralDelete` puts the elements
+ * back), and none of them records anything here: an element whose deletion was
+ * refused is NOT durably deleted and undo may restore it freely.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * TWO OPERATIONS, DELIBERATELY NAMED APART (CLAUDE.md trap 21 — two questions
+ * must not share one name). They differ by exactly one guard and collapsing
+ * them would break one of the two:
+ *
+ *   · `withholdDurableDeletions` answers *"which elements of this SNAPSHOT may
+ *     be restored?"* — for undo/redo. It withholds a durably-deleted element
+ *     only when that element is ABSENT from the live canvas, because withholding
+ *     one that is currently on screen would DELETE something the user can see
+ *     rather than decline to resurrect something they cannot.
+ *   · `reconcileDurableDeletions` answers *"which elements of the LIVE CANVAS
+ *     does the server say are gone?"* — for the race below. It has no
+ *     present-guard, because being present is precisely its trigger.
+ *
+ * THE RACE, and why the second operation exists. The receipt is asynchronous:
+ * the delete leaves the canvas immediately and the proof lands a turn later. A
+ * user who deletes and reflexively hits Cmd+Z inside that window undoes against
+ * an EMPTY record — nothing is withheld, the node returns, and the receipt then
+ * proves it gone. Without reconciliation the canvas would lie for the rest of
+ * the session, in a narrower window but in exactly the original way. So when a
+ * receipt is proven, anything it names that is currently on the canvas is
+ * removed, and the user is told.
+ *
+ * ⚠ EDGES CASCADE WITH THEIR NODE, ALWAYS. Restoring a node's incident edge
+ * without the node is the dangling-edge hazard the server refuses and the
+ * store's own `addEdge` guardrails forbid. Both operations therefore drop every
+ * edge incident to a withheld/removed node, whether or not that edge was itself
+ * named — which mirrors CEE's `applyRemoveNode`, the owner of the cascade
+ * server-side.
+ *
+ * ⚠ BY IDENTITY, NEVER BY COUNT OR SHAPE. Every decision here keys on the
+ * element's own id. A predicate over node count, label or kind would be
+ * satisfied by a DIFFERENT element than the one the server removed.
+ */
+
+import type { Edge, Node } from '@xyflow/react'
+
+/**
+ * The canvas ids the server has PROVEN removed from the saved model.
+ *
+ * Canvas ids, not canonical wire refs — the history snapshots this guards hold
+ * canvas elements, so the join has to be in canvas-id space.
+ * `StructuralDeleteIntent.claimedNodeIds` / `.claimedEdgeIds` are exactly that,
+ * and they already include the edges the gesture cascaded (structuralDelete.ts
+ * :223-232), so no incidence has to be re-derived at record time.
+ */
+export interface DurableDeletionRecord {
+  readonly nodeIds: readonly string[]
+  readonly edgeIds: readonly string[]
+}
+
+export const EMPTY_DURABLE_DELETION_RECORD: DurableDeletionRecord = {
+  nodeIds: [],
+  edgeIds: [],
+}
+
+/**
+ * A graph the guard reads or rewrites — the shape both history and the live
+ * store use.
+ *
+ * ⚠ GENERIC OVER THE EDGE TYPE, deliberately. The store's edges are
+ * `Edge<EdgeData>` while history snapshots and React Flow's own callbacks carry
+ * plain `Edge`; pinning this to either one forces a cast at the other call site,
+ * and a cast is where an edge's `data` silently stops being checked. The guard
+ * never reads `data`, so it has no reason to know.
+ */
+export interface GuardedGraph<E extends Edge = Edge> {
+  readonly nodes: readonly Node[]
+  readonly edges: readonly E[]
+}
+
+/**
+ * What the guard did, in identities.
+ *
+ * `nodes`/`edges` are the graph to apply. `withheldNodeIds`/`withheldEdgeIds`
+ * name what was kept out and are what the user-facing notice is built from —
+ * empty arrays mean the guard did nothing and NO notice is owed.
+ */
+export interface DurableGuardResult<E extends Edge = Edge> {
+  readonly nodes: Node[]
+  readonly edges: E[]
+  readonly withheldNodeIds: string[]
+  readonly withheldEdgeIds: string[]
+}
+
+/** Merge a newly-proven deletion into the record, deduped and order-stable. */
+export function addDurableDeletion(
+  record: DurableDeletionRecord,
+  added: { readonly nodeIds: readonly string[]; readonly edgeIds: readonly string[] },
+): DurableDeletionRecord {
+  return {
+    nodeIds: [...new Set([...record.nodeIds, ...added.nodeIds])],
+    edgeIds: [...new Set([...record.edgeIds, ...added.edgeIds])],
+  }
+}
+
+/**
+ * Strip named elements from a graph, cascading each removed node's incident
+ * edges. The shared core of both operations — the ONLY difference between them
+ * is which ids the caller passes in.
+ */
+function stripByIdentity<E extends Edge>(
+  graph: GuardedGraph<E>,
+  nodeIdsToStrip: ReadonlySet<string>,
+  edgeIdsToStrip: ReadonlySet<string>,
+): DurableGuardResult<E> {
+  const withheldNodeIds: string[] = []
+  const nodes = graph.nodes.filter((n) => {
+    if (!nodeIdsToStrip.has(n.id)) return true
+    withheldNodeIds.push(n.id)
+    return false
+  })
+
+  const strippedNodeIds = new Set(withheldNodeIds)
+  const withheldEdgeIds: string[] = []
+  const edges = graph.edges.filter((e) => {
+    // The cascade is not optional: an edge whose endpoint is being withheld
+    // cannot be restored without dangling.
+    const cascades =
+      strippedNodeIds.has(String(e.source)) || strippedNodeIds.has(String(e.target))
+    if (!edgeIdsToStrip.has(e.id) && !cascades) return true
+    withheldEdgeIds.push(e.id)
+    return false
+  })
+
+  return { nodes, edges, withheldNodeIds, withheldEdgeIds }
+}
+
+/**
+ * UNDO / REDO. Restore `snapshot`, minus anything the server has durably
+ * deleted that is not already on the canvas.
+ *
+ * `present` is the LIVE graph, and it is the guard that keeps this honest in
+ * both directions: an element the canvas currently shows is not a resurrection,
+ * so it is restored normally even if the record names it. Only an element that
+ * is both durably deleted AND absent is withheld.
+ */
+export function withholdDurableDeletions<E extends Edge>(
+  snapshot: GuardedGraph<E>,
+  record: DurableDeletionRecord,
+  present: GuardedGraph<E>,
+): DurableGuardResult<E> {
+  if (record.nodeIds.length === 0 && record.edgeIds.length === 0) {
+    return {
+      nodes: [...snapshot.nodes],
+      edges: [...snapshot.edges],
+      withheldNodeIds: [],
+      withheldEdgeIds: [],
+    }
+  }
+
+  const presentNodeIds = new Set(present.nodes.map((n) => n.id))
+  const presentEdgeIds = new Set(present.edges.map((e) => e.id))
+
+  return stripByIdentity(
+    snapshot,
+    new Set(record.nodeIds.filter((id) => !presentNodeIds.has(id))),
+    new Set(record.edgeIds.filter((id) => !presentEdgeIds.has(id))),
+  )
+}
+
+/**
+ * RECEIPT-TIME RECONCILIATION. Remove from the LIVE canvas anything this
+ * record proves the server deleted.
+ *
+ * No present-guard, by design — see the header's race note. A no-op in the
+ * overwhelmingly common case (the element left on delete and never came back),
+ * and it fires only when an undo beat the receipt home.
+ */
+export function reconcileDurableDeletions<E extends Edge>(
+  current: GuardedGraph<E>,
+  record: DurableDeletionRecord,
+): DurableGuardResult<E> {
+  if (record.nodeIds.length === 0 && record.edgeIds.length === 0) {
+    return {
+      nodes: [...current.nodes],
+      edges: [...current.edges],
+      withheldNodeIds: [],
+      withheldEdgeIds: [],
+    }
+  }
+  return stripByIdentity(current, new Set(record.nodeIds), new Set(record.edgeIds))
+}
+
+/**
+ * What the canvas must say when the guard fires. Session-local, never persisted
+ * — the same discipline as `analysisRefusalNotice`: a fact about one gesture,
+ * and restoring it into a later session would assert a refusal that did not
+ * happen there.
+ */
+export interface DurableDeletionNotice {
+  /**
+   * `withheld`   — an undo/redo declined to bring elements back.
+   * `reconciled` — the receipt landed after an undo had already restored them,
+   *                so they were removed from the canvas again.
+   */
+  readonly kind: 'withheld' | 'reconciled'
+  /** Labels of the withheld NODES, for copy. Empty when only edges were withheld. */
+  readonly labels: readonly string[]
+  /** Identities — what the copy is actually about. Never a count-based claim. */
+  readonly nodeIds: readonly string[]
+  readonly edgeIds: readonly string[]
+  /**
+   * Monotonic, so two identical outcomes in a row are still two events. Without
+   * it a subscriber comparing by value would swallow the second — the user
+   * would press Cmd+Z twice and be told once.
+   */
+  readonly seq: number
+}
+
+/** A node's display label, or its id when it has none. Never invented. */
+function labelOf(node: Node): string {
+  const label = (node.data as Record<string, unknown> | undefined)?.label
+  return typeof label === 'string' && label.trim().length > 0 ? label.trim() : node.id
+}
+
+/**
+ * Build the notice for a guard result, or `null` when nothing was withheld.
+ *
+ * `withheldFrom` is the graph the withheld elements were read out of, so the
+ * labels are the ones the user last saw rather than a lookup against a canvas
+ * that no longer contains them.
+ */
+export function buildDurableDeletionNotice<E extends Edge>(
+  kind: DurableDeletionNotice['kind'],
+  result: DurableGuardResult<E>,
+  withheldFrom: GuardedGraph<E>,
+  seq: number,
+): DurableDeletionNotice | null {
+  if (result.withheldNodeIds.length === 0 && result.withheldEdgeIds.length === 0) {
+    return null
+  }
+  const withheld = new Set(result.withheldNodeIds)
+  return {
+    kind,
+    labels: withheldFrom.nodes.filter((n) => withheld.has(n.id)).map(labelOf),
+    nodeIds: [...result.withheldNodeIds],
+    edgeIds: [...result.withheldEdgeIds],
+    seq,
+  }
+}
+
+/**
+ * The sentence the canvas shows.
+ *
+ * ⚠ IT CLAIMS ONLY WHAT THE RECEIPT ESTABLISHES. The receipt proves the element
+ * is absent from the COMMITTED bytes — so "deleted from your saved model" is
+ * grounded, and the copy stops there. It does not tell the user to reload, retry
+ * or re-sync: there is no restore verb in the wire vocabulary, so every such
+ * instruction would be an affordance terminating in refusal (the P8 trap
+ * `STRUCTURAL_DELETE_NOTICE.base_hash_diverged` documents at length). It says
+ * what happened and what is true now, and offers no action it cannot honour.
+ *
+ * ⚠ NAMING THE USER'S OWN NODE IS GROUNDED, unlike naming one in the analysis-
+ * refusal notice: this label is read from the very snapshot being withheld, not
+ * inferred from a bare code.
+ */
+export function describeDurableDeletionNotice(notice: DurableDeletionNotice): string {
+  const named = notice.labels.length > 0 ? `"${notice.labels[0]}"` : null
+  const extra =
+    notice.labels.length > 1 ? ` and ${notice.labels.length - 1} more` : ''
+
+  if (notice.kind === 'reconciled') {
+    return named === null
+      ? 'Those connections were already deleted from your saved model, so they have been taken off the canvas again.'
+      : `${named}${extra} was already deleted from your saved model, so it has been taken off the canvas again.`
+  }
+
+  if (named === null) {
+    return 'Those connections are deleted from your saved model, so undo cannot bring them back. Everything else in that step was undone.'
+  }
+  return `${named}${extra} is deleted from your saved model, so undo cannot bring it back. Everything else in that step was undone.`
+}


### PR DESCRIPTION
## Cmd+Z resurrected a node the server had durably deleted

Measured at deployed UI `aa916511`. `structural_delete` (schemas 0.48.0) made a canvas delete **durable** — `resolveStructuralDelete` reads a receipt CEE stamps only after re-reading the *committed bytes*. `undo()` predates that verb: it restored `history.past[n]` verbatim in one `set()` and knew nothing about the receipt. So the node came back on screen while the saved model still held it deleted.

That is the founder's original complaint — *"it keeps adding the option that I deleted back"* — re-opened **on screen**, one keystroke after `structural_delete` closed it on the wire. Cmd+Z is a reflex, not an advanced action.

### Premise correction

The brief said *"no restore verb exists"* **and** that no removal verb existed. At this tip the first is true and the second is not: `structural_delete` **is** in `WIRE_SYSTEM_EVENT_TYPES` (`conversation/types.ts:961`) and the delete is genuinely durable, which is precisely *why* undo lies. There is still **no restore verb**, so canonical undo remains out of scope.

Undo emits **no outbound message** — it mutates the store only, and `useGraphEditEvents` treats the restore as a producer-side change. So no send had to be stopped; the fix is entirely local.

## What this does

**Option 2 — undo re-syncs against canonical state**, using the receipt we already hold rather than a fetch. A restore is applied *minus* anything the server has proven deleted; everything else in that step is restored normally.

- **Option 1 (skip the entry) was rejected as incoherent.** *Every* history entry older than the delete contains the deleted node, so "skip" cascades to the same wall and silently eats unrelated work. It would make all history before the delete unreachable.
- **Option 3 (restore + diverged banner) was rejected** because a "you are out of sync" state a customer must reason about is a worse demo than an undo that quietly does the right thing — and it is unnecessary here, since the receipt already tells us exactly which elements are gone.

## Canonical owner — no second divergence concept

There was no pre-existing "is this graph diverged" authority in the UI (swept `src/canvas/**` for `diverg|canonical|out of sync|resync`; only unrelated hits). **This PR introduces none.**

The canonical owner is the one that already existed: the **`structural_delete` receipt**, read by `readStructuralDeleteReceipt` and adjudicated in `resolveStructuralDelete`. It had exactly one consumer (the revert, on its *negative* arm). This PR gives it its missing consumer — history restoration — and consumes **only** `'proven'`. `refuted` / `unproven` / 409 / transport keep their existing owner (`revertStructuralDelete` puts the elements back) and record nothing, so a delete the server refused stays fully undoable.

**Nothing is superseded**; one authority gains one consumer.

## The mounted consequence

**A customer who presses Cmd+Z after deleting an option now keeps the deletion, gets the rest of that step rolled back, and sees one plain sentence: `"Expand into the EU" is deleted from your saved model, so undo cannot bring it back. Everything else in that step was undone.`**

All four undo entry points are ungated and route through the store's `undo()`, so all four are covered by one fix:

| Surface | Site |
|---|---|
| Cmd/Ctrl+Z | `useKeyboardShortcuts.ts:137-149` |
| Left-rail Undo/Redo buttons | `LeftSidebar.tsx:110-131` |
| Pane context menu | `contextMenu/useMenuItems.ts:173-192` |
| **The delete toast's own "Undo" button** | `useHistoryToast.ts:28` |

The notice is a **toast**, not an assistant bubble: the gesture is a canvas gesture, and the bubble needs a `ConversationProvider` that `ReactFlowGraph` mounts only under `isAiPanelV2Enabled()` — a notice that could go dark on the surface that triggers it would re-open the defect quietly. It carries **no action button**, because there is no restore verb and every control would terminate in refusal (the P8 trap `STRUCTURAL_DELETE_NOTICE.base_hash_diverged` documents at length).

## Redo and multi-step

- **Multi-step: covered and tested.** The resurrecting undo is *not* the first press — the first goes back to the post-delete state; the *second* goes back past the delete. Test walks three presses to stack exhaustion.
- **Redo: covered.** `pushToHistory` clears `future` on every mutation, so a pre-delete future entry is not reachable today. The guard is applied to `redo()` anyway so the invariant is a property of history **restoration**, not of one direction — a later change to the redo stack's lifecycle cannot quietly re-open it on the other side.
- **The receipt race is closed too.** The send is a round-trip; Cmd+Z is instant. A user who undoes before the receipt lands undoes against an empty record and the node legitimately returns — then the receipt proves it gone. `recordDurableDeletion` reconciles the live canvas at that moment and says so, so the canvas cannot keep asserting a node the server proved gone.

## Evidence

**RED-first at pristine `aa916511`** (behavioural, not a missing-API error):

```
FAIL src/canvas/__tests__/store.undoDurableDelete.spec.ts
  > does NOT bring back a node whose deletion the server proved
AssertionError: expected [ 'goal-1', 'opt-eu', 'opt-us' ] to not include 'opt-eu'
```

11 tests collected **by name**, non-zero, asserted every run (`Tests 11 passed (11)`).

**Bound by identity, never by count.** Every assertion keys on the deleted node's own id. The discriminating test deletes two options in *one* gesture — so both sit in *one* snapshot — and requires `opt-eu` withheld while `opt-us` returns. A guard keyed on anything weaker (a count, "the deleted ones", the snapshot itself) fails in one direction or the other.

**Discriminating mutant pair** (isolated worktree at an absolute path outside the repo root; isolation **proven by writing a sentinel** and asserting the source hash unchanged — distinct inodes confirmed; restores HEAD-relative; applied-check scoped to `src/`; leading and trailing controls in both worktrees read exactly **0** modified files, all green — 10/10 for A+B, 11/11 for C after the `reset()` test was added):

| Mutant | Headline test | Effect |
|---|---|---|
| **A** — guard removed, restore verbatim | **RED** | 6 tests red — proves sensitivity |
| **B** — guard fires on a *different* object (any absent node, not the named one) | **GREEN** | the twin *"DOES bring back a node whose deletion was never proven"* and the identity discriminator go **RED** — proves the tests bind to the **named** node |
| **C** — `reset()` no longer clears the record | n/a | exactly the `reset()` test REDs (`expected [ '1' ] to have a length of +0`), and only that one |

Neither A nor B alone shows binding; the pair does, and they fail on **different assertions**.

⚠ Mutant C's **first attempt did not apply** (anchor miss). The applied-check read `0` and caught it — otherwise an unmutated tree would have been read as a surviving mutant. Reported because that is the failure mode the check exists for.

**Opposite-direction twins throughout** (trap 22b). This guard sits between two harms — resurrecting a durably-deleted node (a lie) and refusing to restore one that was never durably deleted (silently eating the user's undo). Every withhold case has a restore case beside it, including a test that a **local-only delete stays fully undoable** (`captureStructuralDelete` stands down when no CEE `graph_hash` is held — its KNOWN GAP).

**The absence assertion is not vacuous.** The authority consumed (`readStructuralDeleteReceipt`) already carries its own positive control at the same seam: PROVEN when the ids are absent from the committed bytes, **REFUTED when the node survives in them** (`mutations/__tests__/structuralDelete.spec.ts:307-326`) — its `proven` fixture contains other nodes that *are* present. And in this PR's own tests the same probe that asserts `opt-eu` absent asserts `opt-us` present in the same run.

**Gates**, run in the `Staging Gate`'s own step order (lint → typecheck → tests):

- `pnpm run lint` — **0 errors** (1177 pre-existing warnings).
- `pnpm run lint:hooks-ratchet` — **caught a real regression from an earlier revision of this PR** and it was fixed at source, not baselined: a second hook call site in `ReactFlowGraph.tsx` took its rules-of-hooks count 117 → 118. That region sits after an early return, so every hook there is a held violation and *"an exception for its EXISTING violations, not a licence to add more."* The notice is now composed into the already-mounted sibling `useHistoryToast`, which adds no call site. **`ReactFlowGraph.tsx` is out of this diff entirely.** Ratchet now reports 229, exactly matching baseline.
- `pnpm run typecheck` — **PASSED**. Three real type errors were fixed at source (the guard is now generic over the edge type so neither `Edge` nor `Edge<EdgeData>` needs a cast). ⚠ **This bullet previously said "No `--update-baseline`". That is no longer true and the correction matters:** the identity baseline *has* now been re-keyed in this PR, deliberately and with every byte accounted for. The count ratchet still moves not at all. Full derivation, the honesty checks, and the adjudication that cleared it are in **“The typecheck identity baseline”** below — read that rather than this line.

## A second hole, found and closed while checking the invariant

`reset()` clears history but is the **one** clear site that does *not* apply `DECISION_CONTEXT_CLEAR`, and it sets `nextNodeId: 1`. Canvas node ids are sequential integers (`createNodeId` returns `String(nextNodeId)`), so **the next graph reissues the same ids the last one used.** A durable-delete record surviving a reset would therefore match a brand-new, never-deleted node by id and withhold it from undo — silently eating work the server never deleted, which is precisely the opposite-direction harm this guard exists to avoid.

`reset()` now clears both fields, with a test pinned by mutant C. The other three sites (`resetCanvas`, `importCanvas`, `hydrateGraphSlice`) clear it via `DECISION_CONTEXT_CLEAR`, and all three reset history in the same update — so there is no window where the record is dropped while restorable history survives. That is what makes the invariant total: **no history restoration, in either direction, can resurrect a durably-deleted element.**

## Files changed (for harvest sequencing)

| File | Note |
|---|---|
| `src/canvas/store/durableDeletionGuard.ts` | **new** — pure module, 128 code lines |
| `src/canvas/hooks/useDurableDeletionToast.ts` | **new** — 18 code lines |
| `src/canvas/store.ts` | ⚠ high-collision — 2 fields, 2 actions, guard in `undo`/`redo`, clear in `reset` |
| `src/canvas/conversation/useConversation.ts` | ⚠ high-collision — **one call** on the `'proven'` branch |
| `src/canvas/hooks/useHistoryToast.ts` | composes the sibling hook (no new mount) |
| `src/canvas/__tests__/store.undoDurableDelete.spec.ts` | **new** — 11 tests |

`src/canvas/store.ts` and `useConversation.ts` are touched deliberately minimally. **Source delta: +509 / −3** across five source files, of which **216 are code** and the rest documentation in this codebase's house style.

## Not in this PR

Delete-then-rerun (`analysis_blocked` / `MISSING_OPTION_VALUE`) was assessed separately and is **reported, not fixed here** — it is a second finding with its own owner and is not folded in.

---

## The typecheck identity baseline — re-keyed, not absorbed

This PR is the one that had to accept the gate's `--update-baseline` invitation. Here is every byte of it, because a
regenerated baseline is exactly where an absorbed error hides.

### Why the self-test went red while `pnpm typecheck` stayed green

Derived at this tip, not inherited:

- This PR adds **exactly four** `CanvasState` interface members — `durablyDeletedElements`, `durableDeletionNotice`,
  `recordDurableDeletion`, `clearDurableDeletionNotice`.
- A **pre-existing** `TS2345` at `useConversation.ts:5012` renders the store's type in its message, and tsc elides the tail
  as `... N more ...`. N therefore moves **261 → 265** (measured: the baseline held `... 261 more ...`, this tree emits
  `... 265 more ...`; 261 + 4 = 265).
- The gate's identity key is `<file><TAB><TS-code><TAB><message>`, so the **identity string** changes while the
  **per-(file, TS-code) count** does not move at all.

That is why `pnpm typecheck` PASSED throughout and only `typecheck:selftest` went red: its scenario 1/7 green control asserts
the added-diagnostic notice is **silent** on a clean tree, and the notice was firing. CI confirmed the diagnosis verbatim —
`FAIL  no added-diagnostics notice on a clean tree`, 17 passed / 1 failed.

### The honesty checks that distinguish a re-key from an absorbed error

| Check | Result |
|---|---|
| `scripts/ci/typecheck-baseline.txt` across the regeneration | **BYTE-IDENTICAL** — `f97ab137…` before *and* after. The per-file count artefact did not change at all. |
| Identity rows | **1360 → 1360**; exactly **one added, one removed** |
| That pair | same file, same TS code, same count (1), and two **362-character** messages differing in **exactly one character** — the `1` of `261` becoming the `5` of `265`. Substituting `265 more` → `261 more` reproduces the old message **byte-for-byte**. |
| **1** — no file's error count increased | **PASS** (and none decreased) |
| **2** — no new erroring file appeared | **PASS** (and none left) |
| **4** — total | **2263 → 2263, delta +0** |

⚠ **Say it plainly: the total did not move, in either direction.** This PR banks no improvement and earned none —
**100% of the change is attribution churn** on one diagnostic's wording. A green gate here must not be read as this PR having
fixed anything.

### Check 3 — reworded as the delta test it actually is (adjudicated)

The check was originally worded *"none of the PR's own files carries a baselined error."* On that literal reading it **fails**:
`useConversation.ts` carries 14 baselined errors.

**That wording is unsatisfiable rather than strict** — no PR that edits a file with pre-existing baselined errors can ever
pass it, and binding the durable-delete receipt to undo **genuinely requires editing that file** (the `'proven'` branch is
where the receipt is read). Restated as the question the check exists to answer:

> **Did this PR add a baselined error to a file it touched?**

| File this PR touches | baselined before | after | delta |
|---|---|---|---|
| `src/canvas/conversation/useConversation.ts` | 14 | 14 | **0** |
| `src/canvas/store.ts` (largest change here) | 0 | 0 | 0 |
| `src/canvas/store/durableDeletionGuard.ts` *(new)* | 0 | 0 | 0 |
| `src/canvas/hooks/useDurableDeletionToast.ts` *(new)* | 0 | 0 | 0 |
| `src/canvas/hooks/useHistoryToast.ts` | 0 | 0 | 0 |
| `src/canvas/__tests__/store.undoDurableDelete.spec.ts` *(new)* | 0 | 0 | 0 |

`useConversation.ts` is the **only** one of the six in the baseline at all, and it carried those 14 on `staging` before this PR
existed. **Passes on the delta test. Adjudicated and approved** — recorded here so the next reviewer inherits the reasoning
rather than re-deriving it.

### Verified by content, never by `git status`

The self-test's cleanup trap runs `git checkout` on **every** exit path — including its dirty-tree refusal, where it mutated
nothing — which can silently revert a legitimate regeneration while typecheck still reports green. `git status` is precisely
the instrument that defect defeats, so the artefacts were checked by **content**:

- worktree, committed `HEAD`, and the **pushed blob** all hash to `02749bcd…` (identities) and `f97ab137…` (counts);
- **cross-artefact sums agree: identity rows 2263, count file 2263**, both declaring `# count=2263`.

The trap **did** run during this work. It had not reverted anything.

### Two rebases, and why the second was not optional

Rebased onto `1bacfbe4` (#797, #794, #795, #793), then onto `9c7574f0` (#798).

- Only `store.ts` overlaps a merged PR: **#793** changed `updateNodeLabel` alone, stamping `provenance: 'user_set'` on a
  human-authored goal label. This PR's store change is the durable-deletion slice. Disjoint actions, and they compose —
  history entries capture `data.provenance`, so an undo correctly restores the prior stamp, and this PR only ever
  **withholds** durably-deleted elements from that restore.
- **#798** shares no files, but its new `OptionCards.tsx` and `ResultsBody.tsx` both **import `canvas/store`** — the exact
  file this PR changes — and the baseline had been derived without them. Re-running `--update-baseline` at the new tip
  produced **byte-identical** artefacts, which *proves* no further re-key was needed rather than assuming it.

### Result at `29c02b62`

`Staging Gate` **success**, `Typecheck Gate Self-Test` **success**, all four shards, summary, build and TypeScript + Lint
green; local self-test independently **18 passed / 0 failed**, including `PASS  no added-diagnostics notice on a clean tree`.

`Visual Regression (advisory)` fails. It is **not** in `Staging Gate`'s `needs` list, and `staging`'s own visual job was
**cancelled**, so there is no clean baseline to compare against — deliberately called neither way.

