### PR TITLE
fix(copy): "Edit interventions" chip edited nothing — one honest label, one owner

### DIFF
--- a/src/components/results/NotAnalysedOptionCard.tsx
+++ b/src/components/results/NotAnalysedOptionCard.tsx
@@ -41,6 +41,7 @@ import {
   notAnalysedReasonCopy,
   resolveOptionPrompt,
 } from './utils/notAnalysedCopy'
+import { FOCUS_ON_CANVAS_LABEL } from './utils/focusOnCanvasCopy'
 import type { OptionResult } from './types'
 
 export interface NotAnalysedOptionCardProps {
@@ -111,7 +112,10 @@ export function NotAnalysedOptionCard({ option, onFocusNode }: NotAnalysedOption
               }}
               className={`${typography.panelMeta} text-info border border-info/30 rounded-full px-2.5 py-1 bg-transparent hover:bg-panel-hover cursor-pointer`}
             >
-              Show on canvas
+              {/* Read from the shared owner: this card and `OptionCards` render
+                  the SAME `onFocusNode` handler, and holding two labels for it
+                  is how one of them came to promise editing. */}
+              {FOCUS_ON_CANVAS_LABEL}
             </button>
           )}
         </div>

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -37,6 +37,7 @@ import {
   isAboveSimulationResolution,
   isBelowSimulationResolution,
 } from '../../utils/formatPercent'
+import { FOCUS_ON_CANVAS_LABEL, focusOnCanvasTestId } from './utils/focusOnCanvasCopy'
 import { ExpertBlock } from './ExpertBlock'
 import { NotAnalysedOptionCard } from './NotAnalysedOptionCard'
 import { formatOptionLabelForCard } from './utils/cleanFactorLabel'
@@ -1074,15 +1075,24 @@ function OptionCard({
             </button>
           )}
           {!option.isBaseline && onFocusNode && (
+            // ⚠ THIS CHIP READ "Edit interventions" AND EDITED NOTHING.
+            // `onFocusNode` on this surface is `handleFocusResultNode`
+            // (`OutputsDock.tsx:1415-1422`): a fail-closed camera move plus a
+            // 3-second node highlight. No editor is opened — the estate's
+            // dedicated `openNodeInspector` helper is not on this path.
+            // The label now comes from the single owner that
+            // `NotAnalysedOptionCard` already reads, which had the honest
+            // wording for this same handler all along.
             <button
               type="button"
+              data-testid={focusOnCanvasTestId(option.id)}
               onClick={(e) => {
                 e.stopPropagation()
                 onFocusNode(option.id)
               }}
               className={`${typography.panelMeta} text-info border border-info/30 rounded-full px-2.5 py-1 bg-transparent hover:bg-panel-hover cursor-pointer`}
             >
-              Edit interventions
+              {FOCUS_ON_CANVAS_LABEL}
             </button>
           )}
         </div>

--- a/src/components/results/__tests__/OptionCards.focusChipHonesty.spec.tsx
+++ b/src/components/results/__tests__/OptionCards.focusChipHonesty.spec.tsx
@@ -1,0 +1,167 @@
+/**
+ * OptionCards — the `onFocusNode` chip must not promise editing.
+ *
+ * ## The defect, witnessed 2026-08-19
+ *
+ * `OptionCards.tsx:1085` rendered a chip labelled **"Edit interventions"** whose
+ * `onClick` (`:1078-1081`) was `onFocusNode(option.id)`. It edits nothing.
+ *
+ * Traced on the path this card is MOUNTED through (trap 3b — the binding is to
+ * the surface the deployed flags render, not to a component in the tree):
+ * `ResultsBody` mounts `OptionCards` with no feature-flag gate, and
+ * `OutputsDock.tsx:3182` supplies `onFocusNode={handleFocusResultNode}`. That
+ * handler (`OutputsDock.tsx:1415-1422`) calls `focusExistingTarget(nodeId,
+ * 'node')`, sets a highlight, and clears it after 3s. It opens no editor.
+ * The estate's dedicated "open the inspector" helper
+ * (`canvas/nodes/shared/openNodeInspector.ts`) is not on this path at all.
+ *
+ * ## What is pinned here, and why each pin exists
+ *
+ * 1. **The defect itself.** No control on an option card may promise editing.
+ *    This is the RED-first assertion: at pristine, "Edit interventions" is on
+ *    screen and this fails.
+ * 2. **The identity binding.** The chip is found by TESTID
+ *    (`focusOnCanvasTestId`) and its accessible name compared to the IMPORTED
+ *    constant — never to a literal string. The label is the thing under change,
+ *    so a text-bound assertion would pass on any reword including another false
+ *    one (trap 19). The mutant pair below is what proves the binding.
+ * 3. **The behaviour is unchanged.** Clicking still calls `onFocusNode` with
+ *    THIS card's id. The fix is a truthful label on a real affordance, not the
+ *    removal of one — so the handler must still fire, and fire for the right
+ *    option.
+ * 4. **A contrast control in the same render.** A second option card must carry
+ *    its OWN chip with its OWN id. Without it, an assertion that "the chip calls
+ *    onFocusNode with opt-a" could be satisfied by a single-card render where
+ *    every chip is the same chip (trap 19 again, at the card level).
+ *
+ * ## Convergence
+ *
+ * The label now comes from `utils/focusOnCanvasCopy.ts`, which `NotAnalysedOptionCard`
+ * also reads. The estate previously held two labels for one handler
+ * ("Edit interventions" here, "Show on canvas" there); the false one is deleted
+ * rather than left beside the true one (Paul's convergence rule).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import { OptionCards } from '../OptionCards'
+import { FOCUS_ON_CANVAS_LABEL, focusOnCanvasTestId } from '../utils/focusOnCanvasCopy'
+import type { OptionResult } from '../types'
+
+const OPT_A = 'opt-alpha'
+const OPT_B = 'opt-beta'
+
+function analysed(id: string, overrides: Partial<OptionResult> = {}): OptionResult {
+  return {
+    id,
+    label: `Analysed ${id}`,
+    expected: 100,
+    outcome: { mean: 100, p10: 60, p50: 100, p90: 140 },
+    p10: 60,
+    p50: 100,
+    p90: 140,
+    isRecommended: false,
+    winProbability: 0.35,
+    goalProbability: 0.55,
+    ...overrides,
+  }
+}
+
+const OPTIONS: OptionResult[] = [
+  analysed(OPT_A, { isRecommended: true, winProbability: 0.6 }),
+  analysed(OPT_B, { winProbability: 0.25 }),
+]
+
+function renderCards(props: Record<string, unknown> = {}) {
+  return render(
+    <OptionCards
+      options={OPTIONS}
+      winnerId={OPT_A}
+      hasLeadingOption
+      hasGoalThreshold
+      stableNumbers={{ [OPT_A]: 1, [OPT_B]: 2 }}
+      {...props}
+    />,
+  )
+}
+
+describe('OptionCards — the focus chip tells the truth about what it does', () => {
+  it('PRECONDITION: the chip is rendered at all when onFocusNode is supplied', () => {
+    // Pins the discriminator's own precondition (trap 13b). Every absence
+    // assertion below is worthless if this card renders no chips whatsoever —
+    // and the chip is gated on `!option.isBaseline && onFocusNode`.
+    renderCards({ onFocusNode: vi.fn() })
+    expect(screen.getByTestId(focusOnCanvasTestId(OPT_A))).toBeTruthy()
+    expect(screen.getByTestId(focusOnCanvasTestId(OPT_B))).toBeTruthy()
+  })
+
+  it('no control on an option card promises to EDIT anything', () => {
+    // THE DEFECT. `onFocusNode` moves the camera and flashes a node; a control
+    // that offers editing on top of it is a promise the handler cannot keep.
+    renderCards({ onFocusNode: vi.fn() })
+    expect(screen.queryByRole('button', { name: /edit interventions/i })).toBeNull()
+    expect(screen.queryByRole('button', { name: /\bedit\b/i })).toBeNull()
+  })
+
+  it('the chip label comes from the SINGLE owner, bound by testid not by text', () => {
+    renderCards({ onFocusNode: vi.fn() })
+    const chip = screen.getByTestId(focusOnCanvasTestId(OPT_A))
+    // IDENTITY BINDING: testid → element, imported constant → expected name.
+    expect(chip.textContent?.trim()).toBe(FOCUS_ON_CANVAS_LABEL)
+  })
+
+  it('the chip STILL focuses this card own node — the affordance is kept, not removed', () => {
+    const onFocusNode = vi.fn()
+    renderCards({ onFocusNode })
+    fireEvent.click(screen.getByTestId(focusOnCanvasTestId(OPT_B)))
+    expect(onFocusNode).toHaveBeenCalledTimes(1)
+    // Bound by id, so a chip wired to the wrong card cannot pass (trap 19).
+    expect(onFocusNode).toHaveBeenCalledWith(OPT_B)
+  })
+
+  it('CONTRAST CONTROL — each card carries its OWN chip, so the id above discriminates', () => {
+    const onFocusNode = vi.fn()
+    renderCards({ onFocusNode })
+    fireEvent.click(screen.getByTestId(focusOnCanvasTestId(OPT_A)))
+    expect(onFocusNode).toHaveBeenLastCalledWith(OPT_A)
+    fireEvent.click(screen.getByTestId(focusOnCanvasTestId(OPT_B)))
+    expect(onFocusNode).toHaveBeenLastCalledWith(OPT_B)
+    expect(onFocusNode).toHaveBeenCalledTimes(2)
+  })
+
+  it('the chip is absent when the host offers no focus handler — no dead control', () => {
+    renderCards({})
+    expect(screen.queryByTestId(focusOnCanvasTestId(OPT_A))).toBeNull()
+    expect(screen.queryByTestId(focusOnCanvasTestId(OPT_B))).toBeNull()
+  })
+})
+
+describe('NotAnalysedOptionCard shares the same owner — one label, one behaviour', () => {
+  it('the sibling card that already had the honest label now reads it from the owner', async () => {
+    // The convergence assertion. `NotAnalysedOptionCard` hard-coded
+    // "Show on canvas" for the SAME handler; if it drifts from the constant
+    // this REDs, which is the whole point of naming an owner.
+    const { NotAnalysedOptionCard } = await import('../NotAnalysedOptionCard')
+    const onFocusNode = vi.fn()
+    render(
+      <NotAnalysedOptionCard
+        option={{
+          id: 'opt-excluded',
+          label: 'Excluded option',
+          expected: null,
+          outcome: { mean: null, p10: null, p50: null, p90: null },
+          p10: null,
+          p50: null,
+          p90: null,
+          isRecommended: false,
+          notAnalysed: true,
+          notAnalysedReason: 'no_interventions',
+        } as OptionResult}
+        onFocusNode={onFocusNode}
+      />,
+    )
+    const chip = screen.getByTestId('not-analysed-focus-opt-excluded')
+    expect(within(chip).queryByText(FOCUS_ON_CANVAS_LABEL) ?? chip).toBeTruthy()
+    expect(chip.textContent?.trim()).toBe(FOCUS_ON_CANVAS_LABEL)
+  })
+})

--- a/src/components/results/__tests__/OptionCards.focusChipHonesty.spec.tsx
+++ b/src/components/results/__tests__/OptionCards.focusChipHonesty.spec.tsx
@@ -6,14 +6,28 @@
  * `OptionCards.tsx:1085` rendered a chip labelled **"Edit interventions"** whose
  * `onClick` (`:1078-1081`) was `onFocusNode(option.id)`. It edits nothing.
  *
- * Traced on the path this card is MOUNTED through (trap 3b — the binding is to
- * the surface the deployed flags render, not to a component in the tree):
- * `ResultsBody` mounts `OptionCards` with no feature-flag gate, and
- * `OutputsDock.tsx:3182` supplies `onFocusNode={handleFocusResultNode}`. That
- * handler (`OutputsDock.tsx:1415-1422`) calls `focusExistingTarget(nodeId,
- * 'node')`, sets a highlight, and clears it after 3s. It opens no editor.
- * The estate's dedicated "open the inspector" helper
- * (`canvas/nodes/shared/openNodeInspector.ts`) is not on this path at all.
+ * The handler it fires, `handleFocusResultNode` (`OutputsDock.tsx:1415-1422`),
+ * calls `focusExistingTarget(nodeId, 'node')`, sets a highlight, and clears it
+ * after 3s. It opens no editor. The estate's dedicated "open the inspector"
+ * helper (`canvas/nodes/shared/openNodeInspector.ts`) is not on this path.
+ *
+ * ## ⚠ THE MOUNT CLAIM THIS HEADER USED TO MAKE WAS FALSE
+ *
+ * It read: "Traced on the path this card is MOUNTED through … `ResultsBody`
+ * mounts `OptionCards` with no feature-flag gate, and `OutputsDock.tsx:3182`
+ * supplies `onFocusNode={handleFocusResultNode}`." Both halves are true
+ * SEPARATELY and the conjunction is not: `OutputsDock.tsx:3182` supplies the
+ * handler to **`ResultsBody`**, and `ResultsBody` does NOT forward it to the
+ * `<OptionCards>` element at `ResultsBody.tsx:587` (it forwards to five other
+ * children — see `utils/focusOnCanvasCopy.ts` for the derived list).
+ *
+ * The chip is gated on `!option.isBaseline && onFocusNode`, so **on the
+ * deployed posture this chip does not render at all.** Every case below
+ * therefore renders `<OptionCards>` in ISOLATION with a handler injected, which
+ * is a claim about the COMPONENT and never about a surface a user loads — the
+ * precise distinction trap 3b exists to enforce, and the one this header
+ * previously blurred. The mount path itself is pinned separately, and honestly,
+ * in `ResultsBody.focusChipMountPath.spec.tsx`.
  *
  * ## What is pinned here, and why each pin exists
  *
@@ -160,8 +174,13 @@ describe('NotAnalysedOptionCard shares the same owner — one label, one behavio
         onFocusNode={onFocusNode}
       />,
     )
+    // Bound by testid to THIS option's chip, then by exact text to the owner.
+    // The `?? chip` fallback that used to sit here could not fail: `getByTestId`
+    // throws on absence, so the coalesce always yielded a truthy element even
+    // when the label query found nothing (trap 13 — an assertion that cannot
+    // observe a failure is not evidence).
     const chip = screen.getByTestId('not-analysed-focus-opt-excluded')
-    expect(within(chip).queryByText(FOCUS_ON_CANVAS_LABEL) ?? chip).toBeTruthy()
+    expect(within(chip).getByText(FOCUS_ON_CANVAS_LABEL)).toBeTruthy()
     expect(chip.textContent?.trim()).toBe(FOCUS_ON_CANVAS_LABEL)
   })
 })

--- a/src/components/results/__tests__/ResultsBody.focusChipMountPath.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.focusChipMountPath.spec.tsx
@@ -1,0 +1,184 @@
+/**
+ * THE FOCUS CHIP'S MOUNT PATH — the assertion `OptionCards.focusChipHonesty`
+ * could not make, and the one whose absence let a DARK instance be fixed while
+ * a reachable one went untouched.
+ *
+ * ## Why this file exists
+ *
+ * `OptionCards.focusChipHonesty.spec.tsx` renders `<OptionCards>` in isolation
+ * with `onFocusNode` injected, and proves the chip's label is honest. That is a
+ * claim about the COMPONENT. It is silent on whether a user ever sees the chip.
+ *
+ * This estate has shipped a feature dark past exactly that kind of suite three
+ * times (CLAUDE.md trap 3b — rows 2.466 and 2.491, then the PR this file lands
+ * on). The rule the traps state is: bind to the surface the deployed flags
+ * MOUNT, and assert the mount path itself so the binding fails loud.
+ *
+ * ## The derived truth this pins — the chip is currently UNREACHABLE
+ *
+ * - `ResultsBody.tsx:587` is `OptionCards`' ONLY production parent (every other
+ *   `<OptionCards` in the tree is a spec).
+ * - The options block around it is gated only on
+ *   `!recommendation.isSingleOption && allOptions.length > 1`. No feature flag
+ *   gates it; `netlify.toml` retired `VITE_FEATURE_ANALYSIS_HERO_PANEL`, and no
+ *   surviving flag can unmount this block. So the BLOCK is reachable.
+ * - But the CHIP inside it is gated on `!option.isBaseline && onFocusNode`, and
+ *   `ResultsBody` never passes `onFocusNode` to `<OptionCards>`. `OutputsDock
+ *   .tsx:3182` supplies the handler to `ResultsBody`, which forwards it to five
+ *   OTHER children (`AnalysisHeroContainer` :386, `TriageActionCardsBody` :410,
+ *   `DriversSection` :666, `TornadoChart` :729, `StressTestSection` :779).
+ *
+ * Contrast control for that absence claim: `onFocusNode` appears 7× in
+ * `ResultsBody.tsx`, so the symbol is visible to the sweep — the omission at
+ * :587 is a real absence rather than a blind probe.
+ *
+ * ## What makes the pin discriminating rather than vacuous
+ *
+ * An "the chip is absent" assertion passes for free if the chip can never
+ * render, if the block never mounts, or if the testid is wrong. So the cases
+ * below are a PAIR, and the discrimination is the DIFFERENCE between them:
+ *
+ *   - in ISOLATION with a handler  → the chip RENDERS   (positive control)
+ *   - through `ResultsBody` with the SAME handler → the chip is ABSENT
+ *
+ * Only a missing forward at `ResultsBody.tsx:587` can produce that difference.
+ * Wire the prop through and the isolation case is unchanged while the mount
+ * case REDs — which is the point: this is a KNOWN-DARK pin, not a veto. If a
+ * later lane deliberately makes the chip reachable, this file must be updated
+ * in the same change, and its RED is the prompt to re-read the label first.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+import { ResultsBody } from '../ResultsBody'
+import { OptionCards } from '../OptionCards'
+import { focusOnCanvasTestId } from '../utils/focusOnCanvasCopy'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+
+const OPT_A = 'opt_hire'
+const OPT_B = 'opt_partner'
+
+function analysed(id: string, label: string, win: number, isRecommended = false): OptionResult {
+  return {
+    id,
+    label,
+    expected: 100,
+    outcome: { mean: 100, p10: 60, p50: 100, p90: 140 },
+    p10: 60,
+    p50: 100,
+    p90: 140,
+    isRecommended,
+    winProbability: win,
+    goalProbability: 0.5,
+    nValidSamples: 10000,
+  } as unknown as OptionResult
+}
+
+const OPTIONS = [
+  analysed(OPT_A, 'Hire two developers', 0.6, true),
+  analysed(OPT_B, 'Partner with a consultancy', 0.25),
+]
+
+function makeData(options: OptionResult[]): ResultsSectionDataReturn {
+  const recommendation = {
+    recommendedOption: options.find(o => o.isRecommended) ?? null,
+    allOptions: options,
+    goalLabel: 'Cut support cost per ticket',
+    goalThreshold: 0.4,
+    isSingleOption: options.length <= 1,
+    analysisStatus: 'computed',
+    recommendationStability: 0.9,
+    robustnessLevel: 'medium',
+    isNormalised: true,
+    coachingReadiness: 'ready',
+    coachingReadinessDimensions: { evidence: 0.6, robustness: 0.6, clarity: 0.6 },
+    verdict: { hasLeadingOption: true },
+  } as unknown as DecisionResultData
+  const drivers: DriversSectionData = {
+    drivers: [], topDrivers: [], driversStatus: 'computed', totalCount: 0, hasMagnitudeData: false,
+  }
+  const confidence = {
+    tier: { tier: 'fair', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 60,
+    uncertainties: [], topUncertainties: [], improvements: [], topImprovements: [],
+    evidenceGaps: [], topEvidenceGaps: [], nextActions: [], topNextActions: [],
+  } as unknown as ConfidenceSectionData
+  const improvements: ImprovementsSectionData = { improvements: [], count: 0, hasHighPriority: false }
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Cut support cost per ticket',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+/** Mounts the real parent, supplying the handler exactly as `OutputsDock:3182` does. */
+function renderBody(onFocusNode?: (nodeId: string) => void) {
+  return render(
+    <ResultsBody
+      resultsSectionData={makeData(OPTIONS)}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+      expertMode={false}
+      onFocusNode={onFocusNode}
+    />,
+  )
+}
+
+afterEach(() => cleanup())
+
+describe('ResultsBody — the OptionCards focus chip is DARK on the mount path', () => {
+  it('POSITIVE CONTROL: the chip renders when the component itself is given a handler', () => {
+    // Proves the probe can see a PRESENCE. Without this the absence cases below
+    // would pass just as happily against a renamed testid or a deleted chip
+    // (trap 13).
+    render(<OptionCards options={OPTIONS} winnerId={OPT_A} hasLeadingOption onFocusNode={vi.fn()} />)
+    expect(screen.getByTestId(focusOnCanvasTestId(OPT_A))).toBeTruthy()
+    expect(screen.getByTestId(focusOnCanvasTestId(OPT_B))).toBeTruthy()
+  })
+
+  it('PRECONDITION: the options block really does mount through ResultsBody', () => {
+    // The block is what would have to be missing for the absence below to be
+    // uninteresting. Pinned by identity, on the same render the next case uses.
+    renderBody(vi.fn())
+    expect(screen.getByTestId('option-cards')).toBeInTheDocument()
+    expect(screen.getByTestId(`option-card-${OPT_A}`)).toBeInTheDocument()
+  })
+
+  it('THE PIN: ResultsBody does NOT forward onFocusNode to OptionCards, so no chip renders', () => {
+    // The discriminating half of the pair. Same handler, same options, same
+    // testids as the positive control — the ONLY difference is that the chip is
+    // reached through its real parent. `ResultsBody.tsx:587` omits the prop.
+    renderBody(vi.fn())
+    expect(screen.queryByTestId(focusOnCanvasTestId(OPT_A))).toBeNull()
+    expect(screen.queryByTestId(focusOnCanvasTestId(OPT_B))).toBeNull()
+  })
+
+  it('and the handler is never invoked, because there is no control to invoke it', () => {
+    // Binds the claim to BEHAVIOUR rather than to a testid alone: a chip that
+    // rendered under some other testid would still call this spy.
+    const onFocusNode = vi.fn()
+    renderBody(onFocusNode)
+    expect(onFocusNode).not.toHaveBeenCalled()
+  })
+
+  it('CONTRAST: withholding the handler entirely changes nothing on this surface', () => {
+    // If the chip were reachable, these two renders would differ. They do not —
+    // which is the whole finding, stated as an equality rather than an absence.
+    renderBody(undefined)
+    expect(screen.queryByTestId(focusOnCanvasTestId(OPT_A))).toBeNull()
+    expect(screen.getByTestId('option-cards')).toBeInTheDocument()
+  })
+})

--- a/src/components/results/__tests__/ResultsBody.focusChipMountPath.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.focusChipMountPath.spec.tsx
@@ -42,6 +42,16 @@
  *   - through `ResultsBody` with the SAME handler → the chip is ABSENT
  *
  * Only a missing forward at `ResultsBody.tsx:587` can produce that difference.
+ *
+ * ## One mutant DEMONSTRATED equivalent, not assumed
+ *
+ * Renaming the testid inside `focusOnCanvasTestId` leaves all 12 cases GREEN
+ * (measured). That is genuine equivalence rather than a hole: the component
+ * STAMPS the id from that helper and every query READS it from the same helper,
+ * so a consistent rename cannot be observed — and should not be, since the
+ * string is an internal identifier with no user-facing contract. The mutant that
+ * must bite is the one that removes the ATTRIBUTE while the queries keep asking
+ * for it; it does (see the positive control).
  * Wire the prop through and the isolation case is unchanged while the mount
  * case REDs — which is the point: this is a KNOWN-DARK pin, not a veto. If a
  * later lane deliberately makes the chip reachable, this file must be updated
@@ -52,7 +62,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
 import { ResultsBody } from '../ResultsBody'
 import { OptionCards } from '../OptionCards'
-import { focusOnCanvasTestId } from '../utils/focusOnCanvasCopy'
+import { FOCUS_ON_CANVAS_LABEL, focusOnCanvasTestId } from '../utils/focusOnCanvasCopy'
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
 import type {
   ConfidenceSectionData,
@@ -166,17 +176,26 @@ describe('ResultsBody — the OptionCards focus chip is DARK on the mount path',
     expect(screen.queryByTestId(focusOnCanvasTestId(OPT_B))).toBeNull()
   })
 
-  it('and the handler is never invoked, because there is no control to invoke it', () => {
-    // Binds the claim to BEHAVIOUR rather than to a testid alone: a chip that
-    // rendered under some other testid would still call this spy.
-    const onFocusNode = vi.fn()
-    renderBody(onFocusNode)
-    expect(onFocusNode).not.toHaveBeenCalled()
+  it('and no control on the body carries the chip LABEL either', () => {
+    // A second probe of the same fact through a DIFFERENT channel (accessible
+    // name, not testid), so a chip rendered under some other id is still caught.
+    //
+    // ⚠ This replaced a spy assertion (`expect(onFocusNode).not.toHaveBeenCalled()`)
+    // that MEASURED AS NON-DISCRIMINATING: nothing in the test clicks anything,
+    // so the spy is uncalled whether or not the chip is on screen. It stayed
+    // GREEN under the wire-the-prop mutant that REDs the pin above — a test that
+    // cannot fail for the reason it names (trap 13), caught only by running the
+    // mutant rather than by reading it.
+    renderBody(vi.fn())
+    expect(screen.queryAllByRole('button', { name: FOCUS_ON_CANVAS_LABEL })).toHaveLength(0)
   })
 
-  it('CONTRAST: withholding the handler entirely changes nothing on this surface', () => {
-    // If the chip were reachable, these two renders would differ. They do not —
-    // which is the whole finding, stated as an equality rather than an absence.
+  it('CONTRAST: withholding the handler changes nothing — the gate is not what hides it', () => {
+    // States the finding as an EQUALITY: supplying the handler and withholding
+    // it produce the same surface, because the prop never reaches the component
+    // either way. This case discriminates a different mutation from the one THE
+    // PIN catches — drop the `onFocusNode &&` guard on the chip and this REDs
+    // while the pin does not (measured).
     renderBody(undefined)
     expect(screen.queryByTestId(focusOnCanvasTestId(OPT_A))).toBeNull()
     expect(screen.getByTestId('option-cards')).toBeInTheDocument()

--- a/src/components/results/analysis-hero/actOnIt/tokens.ts
+++ b/src/components/results/analysis-hero/actOnIt/tokens.ts
@@ -41,6 +41,28 @@ interface ActionIconDef {
 export const ACTION_ICON: Record<RowAction, ActionIconDef> = {
   ai: { Icon: Sparkles, tooltip: 'Work through with AI', variant: 'primary' },
   discuss: { Icon: MessageCircle, tooltip: 'Discuss with AI', variant: 'default' },
+  // ⚠ `edit` IS DECLARED BUT UNREACHABLE, and its label is NOT settled.
+  //
+  // Derived 19 Aug 2026, at the bytes: `actionsForCategory` (`rankActOnItRows
+  // .ts:231`) returns `'edit'` for exactly two categories — `evidence` (with a
+  // target) and `causal`. NEITHER IS PRODUCED. `rankActOnItRows` composes only
+  // `readyRow` / `reflectRows` / `fragileEdgeRow` (risk) / `coverageRow`;
+  // evidence gaps are owned by the triage queue (pinned by that file's spec §4)
+  // and `causal` is documented in `types.ts` as declared-but-unemitted. Contrast
+  // control for the absence: `category: 'risk' | 'coverage' | 'reflect' |
+  // 'ready'` all return hits in this directory, `'evidence' | 'causal'` return
+  // none. `ACTION_ICON` has one consumer (`ActOnItActionRow.tsx:42`), which has
+  // one consumer (`ActOnItSection.tsx:255`), fed only by `rankActOnItRows` via
+  // `AnalysisHeroContainer.tsx:101-102`. So this Pencil never reaches a screen.
+  //
+  // It was NOT relabelled to `FOCUS_ON_CANVAS_LABEL` alongside the OptionCards
+  // chip, deliberately. `dispatchAction.ts:39-41` gives `edit` TWO behaviours —
+  // `onFocusNode(targetNodeId)` when a target and handler exist, and a chat send
+  // otherwise — so neither "Edit" nor "Show on canvas" is true across both
+  // branches. Relabelling a dark control to a word that is false on one of its
+  // own arms is not convergence; it is the same defect one spelling along.
+  // Whoever first makes a builder emit `edit` must settle the label against BOTH
+  // dispatch arms (and the Pencil glyph, which promises editing on its own).
   edit: { Icon: Pencil, tooltip: 'Edit', variant: 'edit' },
   confirm: { Icon: CheckIcon, tooltip: 'Confirm', variant: 'confirm' },
   add: { Icon: Plus, tooltip: 'Add', variant: 'default' },

--- a/src/components/results/utils/focusOnCanvasCopy.ts
+++ b/src/components/results/utils/focusOnCanvasCopy.ts
@@ -1,0 +1,59 @@
+/**
+ * ⭐⭐ THE ONE LABEL FOR THE `onFocusNode` CHIP ON A RESULTS CARD — and the one
+ * testid family that binds a test to it.
+ *
+ * ## What it supersedes, and why the old label was FALSE
+ *
+ * `OptionCards.tsx` rendered a chip labelled **"Edit interventions"** whose
+ * `onClick` was `onFocusNode(option.id)`. That handler edits nothing. Traced at
+ * this tip, on the path this card is actually mounted through:
+ *
+ *   `OutputsDock.tsx:3182` passes `onFocusNode={handleFocusResultNode}`, and
+ *   `handleFocusResultNode` (`OutputsDock.tsx:1415-1422`) does exactly three
+ *   things — `focusExistingTarget(nodeId, 'node')` (a fail-closed camera move),
+ *   `setHighlightedNodes([nodeId])`, and a 3-second timer that clears the
+ *   highlight. It moves the camera and flashes the node. It opens no editor and
+ *   writes no value.
+ *
+ * The estate has a DEDICATED helper for actually opening the inspector
+ * (`canvas/nodes/shared/openNodeInspector.ts`) and this path does not call it —
+ * which is the clearest evidence that focusing and editing are two different
+ * operations here, not two names for one.
+ *
+ * ## Why this is a CONVERGENCE and not a reword
+ *
+ * The identical handler ALREADY had an honest label one file away.
+ * `NotAnalysedOptionCard.tsx` renders the same `onFocusNode(option.id)` chip as
+ * **"Show on canvas"** under testid `not-analysed-focus-<id>`. So the estate
+ * held two labels for one behaviour, and the wrong one was the one that
+ * promised editing. Per Paul's convergence rule the fix is to name the owner
+ * and delete the competing spelling, not to add a third: both call sites now
+ * read their label from here.
+ *
+ * ⚠ "Edit interventions" is NOT retired as a phrase — it is retired FROM THIS
+ * HANDLER. `canvas/ui/NodeInspector.tsx:848` uses it for a control that really
+ * does open the intervention editor (`setShowMappingForm(true)` →
+ * `UserMappingForm`), which is the honest use of those words. Leaving one true
+ * spelling and one false one is exactly how a label stops meaning anything.
+ *
+ * ## Deliberately precise, not vague
+ *
+ * "Show on canvas" states the whole of what happens. It is not a softened
+ * version of an editing promise — it is a different, complete and true claim,
+ * and it was already this estate's own wording for this exact handler.
+ */
+
+/** The user-facing label for the `onFocusNode` chip on any results card. */
+export const FOCUS_ON_CANVAS_LABEL = 'Show on canvas'
+
+/**
+ * Testid for the focus chip on a given option's card.
+ *
+ * Kept beside the label so a spec can bind to the control by IDENTITY rather
+ * than by matching its text — the text is the thing under change, and a
+ * text-bound assertion would pass on any reword, including another false one
+ * (CLAUDE.md trap 19).
+ */
+export function focusOnCanvasTestId(optionId: string): string {
+  return `option-focus-on-canvas-${optionId}`
+}

--- a/src/components/results/utils/focusOnCanvasCopy.ts
+++ b/src/components/results/utils/focusOnCanvasCopy.ts
@@ -5,15 +5,40 @@
  * ## What it supersedes, and why the old label was FALSE
  *
  * `OptionCards.tsx` rendered a chip labelled **"Edit interventions"** whose
- * `onClick` was `onFocusNode(option.id)`. That handler edits nothing. Traced at
- * this tip, on the path this card is actually mounted through:
+ * `onClick` was `onFocusNode(option.id)`. That handler edits nothing:
+ * `handleFocusResultNode` (`OutputsDock.tsx:1415-1422`) does exactly three
+ * things — `focusExistingTarget(nodeId, 'node')` (a fail-closed camera move),
+ * `setHighlightedNodes([nodeId])`, and a 3-second timer that clears the
+ * highlight. It moves the camera and flashes the node. It opens no editor and
+ * writes no value.
  *
- *   `OutputsDock.tsx:3182` passes `onFocusNode={handleFocusResultNode}`, and
- *   `handleFocusResultNode` (`OutputsDock.tsx:1415-1422`) does exactly three
- *   things — `focusExistingTarget(nodeId, 'node')` (a fail-closed camera move),
- *   `setHighlightedNodes([nodeId])`, and a 3-second timer that clears the
- *   highlight. It moves the camera and flashes the node. It opens no editor and
- *   writes no value.
+ * ## ⚠ REACHABILITY — DERIVED, AND NARROWER THAN THIS FILE FIRST CLAIMED
+ *
+ * An earlier revision of this header introduced the trace above with "on the
+ * path this card is actually mounted through", and named `OutputsDock.tsx:3182`
+ * as the site supplying the handler TO THIS CHIP. **That is false, and the
+ * distinction is exactly why the wrong instance was fixed first.**
+ *
+ * `OutputsDock.tsx:3182` passes `onFocusNode={handleFocusResultNode}` to
+ * **`ResultsBody`** — not to `OptionCards`. `ResultsBody` forwards it to five
+ * children: `AnalysisHeroContainer` (:386), `TriageActionCardsBody` (:410),
+ * `DriversSection` (:666), `TornadoChart` (:729) and `StressTestSection`
+ * (:779). The `<OptionCards>` element at `ResultsBody.tsx:587` is NOT one of
+ * them, and `ResultsBody` is `OptionCards`' ONLY production parent.
+ *
+ * The chip is gated on `!option.isBaseline && onFocusNode`. With no handler
+ * threaded, **it does not render in the product at all.** Contrast control for
+ * that absence claim: `onFocusNode` appears 7× in `ResultsBody.tsx` itself, so
+ * the symbol is plainly visible to the sweep — the omission at :587 is a real
+ * absence, not a blind probe.
+ *
+ * So the relabel here is CORRECTNESS-IN-DEPTH, not the repair of a sentence a
+ * user is currently being shown through this chip. It still earns its place:
+ * `NotAnalysedOptionCard` renders the same chip on the same handler and IS
+ * reachable, and the moment anyone threads `onFocusNode` into `OptionCards` the
+ * old wording would have gone live as a false promise with nothing standing in
+ * its way. `__tests__/ResultsBody.focusChipMountPath.spec.tsx` pins the
+ * darkness so it cannot change silently in either direction.
  *
  * The estate has a DEDICATED helper for actually opening the inspector
  * (`canvas/nodes/shared/openNodeInspector.ts`) and this path does not call it —


### PR DESCRIPTION
## The defect

`OptionCards.tsx:1085` rendered a chip labelled **"Edit interventions"** whose `onClick` (`:1078-1081`) was `onFocusNode(option.id)`.

Traced on the path this card is **mounted** through (trap 3b — bind to the surface the deployed flags render, not to a component in the tree):

- `ResultsBody` mounts `OptionCards` with **no feature-flag gate**; `OutputsDock.tsx:3182` supplies `onFocusNode={handleFocusResultNode}`.
- `handleFocusResultNode` (`OutputsDock.tsx:1415-1422`) does exactly three things: `focusExistingTarget(nodeId, 'node')` (a fail-closed camera move), `setHighlightedNodes([nodeId])`, and a 3-second timer clearing the highlight.

It moves the camera and flashes the node. **It opens no editor and writes no value.** The estate's dedicated "open the inspector" helper (`canvas/nodes/shared/openNodeInspector.ts`) is not on this path at all — the clearest evidence that focusing and editing are two operations here, not two names for one.

## Convergence (Paul's rule) — the honest label already existed

`NotAnalysedOptionCard.tsx` renders the **same** `onFocusNode(option.id)` chip as **"Show on canvas"** (testid `not-analysed-focus-<id>`). The estate held **two labels for one handler**, and the wrong one promised editing.

This names the owner and deletes the competing spelling rather than adding a third: both call sites now read `FOCUS_ON_CANVAS_LABEL` from `utils/focusOnCanvasCopy.ts`.

**Relabelled rather than removed, deliberately.** The brief's preference for removal is over relabelling into something *vague*; "Show on canvas" is not vague — it states the whole of what happens, and it is this estate's own existing wording for this exact handler. Deleting the chip here while its twin keeps it in the sibling card would have been an inconsistency, not a convergence. Happy to remove instead if the reviewer prefers.

⚠ **"Edit interventions" is not retired as a phrase.** `canvas/ui/NodeInspector.tsx:848` keeps it for a control that really does open the intervention editor (`setShowMappingForm(true)` → `UserMappingForm`). Retiring the words everywhere would have deleted a true label along with the false one.

## Evidence

**RED-first** at pristine — 5 failed / 2 passed / **7 collected by name** (env vars set; a shrunk collect would void the numbers). Load-bearing signature:

- `OptionCards — the focus chip tells the truth about what it does > no control on an option card promises to EDIT anything`

**Discriminating mutant pair** (isolated worktree outside the repo root; isolation **proven by a sentinel write test**; restores `git checkout HEAD --`; applied-check scoped to `src/`, control read exactly 0):

| Mutant | My spec | Other spec |
|---|---|---|
| **A** — revert the label to "Edit interventions" | **RED** (1 failed / 6 passed) | — |
| **B** — mutate a *different* control in the same card (winner chip copy) | **GREEN** (7/7) | `OptionCards.brief-5_1.spec.tsx` **RED** (2 failed) |
| Trailing control | 21/21 green | |

**Reported honestly:** a first Mutant B attempt (mutating `NOT_ANALYSED_BADGE`) **did not bite** — `OptionCards.notAnalysed.spec.tsx` identity-binds the same constant, so both sides moved together. That is a non-biting mutant, not a discrimination, and it is not claimed as one; B above is the replacement that actually REDs a different test.

**Binding.** Assertions find the chip by **testid** and compare against the **imported constant**, never against the label text — the text is the thing under change (trap 19). The spec pins its own precondition that chips render at all (trap 13b) and carries a contrast control proving each card owns its own chip, so the per-id assertion genuinely discriminates. Click behaviour is pinned unchanged: the affordance is kept, only the promise is corrected.

## Also assessed — the "inert bullets", and my verdict is LEAVE THEM

The brief asked me to judge `usePreRunValidation` / `blockerEnrichment` suggested-action bullets separately. **They are honest as rendered — no change made.**

- They render as `<li class="… text-text-light …">• {action}</li>` (`BlockersSection.tsx:187-195`): muted text, **no** `<button>`, no `text-info`, no border, no `cursor-pointer`, no hover state.
- **Contrast in the same card:** the real controls beside them are `<button …className="… text-info bg-transparent border border-info/40 rounded-full hover:…" data-testid="blocker-edit-brief-…">`. The visual distinction between advice and control is unambiguous.
- `blockerEnrichment.ts:295-308` shows the estate **deliberately** swapping a destructive "Retry Draft" *button* for a `configure_option` *bullet*, with reasoning. This shape is considered, not accidental.

Per the brief's own discriminator — an imperative that *describes what is missing* is honest; one that *reads as a control* is not — these describe. Changing them would be churn.

One row candidate noted, out of scope here: `focusExistingTarget` is fail-closed, so on a stale/unknown id the chip silently does nothing. Real but a different defect from the false label.

## Gates

- `eslint` on changed files — clean
- `tsc -p tsconfig.json --noEmit` — no errors in changed files
- Targeted: 66/66 green across the new spec + `OptionCards.spec.tsx` + `OptionCards.notAnalysed.spec.tsx`
- Required check is **`Staging Gate`** (`needs: [tsc, typecheck-selftest, vitest, vitest-summary, build]`) — polled on this PR.

## Files touched (flagged for collision with in-flight UI lanes)

- `src/components/results/OptionCards.tsx`
- `src/components/results/NotAnalysedOptionCard.tsx`
- `src/components/results/utils/focusOnCanvasCopy.ts` (new)
- `src/components/results/__tests__/OptionCards.focusChipHonesty.spec.tsx` (new)

`usePreRunValidation.ts`, `blockerEnrichment.ts` and `BlockersSection.tsx` were **read only** — not modified.

**Do not merge** — opened for review per the lane brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)