### PR TITLE
Name the comparison set beside subset-derived numbers

### DIFF
--- a/src/components/results/ComparisonScopeNote.tsx
+++ b/src/components/results/ComparisonScopeNote.tsx
@@ -1,0 +1,77 @@
+/**
+ * ComparisonScopeNote — THE one rendering of "these numbers compare N of your
+ * M options", placed next to the numbers it qualifies.
+ *
+ * ## Why a shared component rather than three formatted strings
+ *
+ * The copy and the derivation are owned by `utils/goalAnchorCopy.ts`
+ * (`COMPARISON_SCOPE_COPY` / `deriveComparisonScope`), which is where a fourth
+ * surface should get them from too. This component exists so the three
+ * mounted surfaces also share the SUPPRESSION RULE and the markup: the
+ * "say nothing when the whole set was compared" decision is made once, here,
+ * rather than being re-typed as a `&&` guard at each call site where one of
+ * them would eventually drift to a truthiness check and start rendering a
+ * "comparing 4 of 4" note (CLAUDE.md trap 12 — the hand-maintained mirror).
+ *
+ * ## The `surface` prop is REQUIRED on purpose
+ *
+ * All three mounts can be on screen at once, so a single shared testid would
+ * make every query ambiguous and force tests to bind positionally — the exact
+ * bind-by-predicate defect trap 19 exists to stop. Naming the surface keeps
+ * every assertion bound to the surface it is a claim about.
+ *
+ * ## ⚠ WHERE THIS MUST NOT BE MOUNTED
+ *
+ * Only beside a COMPARATIVE or SUPERLATIVE claim — win probability, rank,
+ * ordinal, "highest", "came out ahead". ISL lists `probability_of_goal` among
+ * the per-option quantities that are INVARIANT on a subset, so the goal-fit
+ * block is deliberately NOT qualified: saying a figure is set-dependent when
+ * it is not is the same class of untruth, pointing the other way.
+ */
+import { AlertCircle } from 'lucide-react'
+import { typography } from '../../styles/typography'
+import { COMPARISON_SCOPE_COPY, type ComparisonScope } from './utils/goalAnchorCopy'
+
+export interface ComparisonScopeNoteProps {
+  /**
+   * The derived scope, or `null` when there is nothing to say.
+   * `deriveComparisonScope` already encodes every say-nothing state; this
+   * component never re-decides them.
+   */
+  scope: ComparisonScope | null | undefined
+  /** Which mounted surface this instance qualifies — see the header. */
+  surface: 'hero' | 'comparative' | 'options'
+  /**
+   * Render the consequence line as well. Off by default: the compact surfaces
+   * have room for the scope sentence only, and a truncated second line is
+   * worse than no second line.
+   */
+  withDetail?: boolean
+  className?: string
+}
+
+export function ComparisonScopeNote({
+  scope,
+  surface,
+  withDetail = false,
+  className = '',
+}: ComparisonScopeNoteProps) {
+  // The suppression rule, made once. `null` is the whole-set case and every
+  // other say-nothing state; see `deriveComparisonScope`.
+  if (!scope) return null
+
+  return (
+    <p
+      data-testid={`comparison-scope-note-${surface}`}
+      className={`${typography.panelMeta} flex items-start gap-1.5 text-text-light ${className}`}
+    >
+      <AlertCircle aria-hidden="true" className="mt-0.5 h-3.5 w-3.5 flex-none" />
+      <span>
+        {COMPARISON_SCOPE_COPY.sentence(scope)}
+        {withDetail ? ` ${COMPARISON_SCOPE_COPY.detail(scope)}` : ''}
+      </span>
+    </p>
+  )
+}
+
+export default ComparisonScopeNote

--- a/src/components/results/ComparisonScopeNote.tsx
+++ b/src/components/results/ComparisonScopeNote.tsx
@@ -20,13 +20,28 @@
  * bind-by-predicate defect trap 19 exists to stop. Naming the surface keeps
  * every assertion bound to the surface it is a claim about.
  *
- * ## ⚠ WHERE THIS MUST NOT BE MOUNTED
+ * ## ⚠ WHAT EACH MOUNT MAY CLAIM — the `withDetail` split is load-bearing
  *
- * Only beside a COMPARATIVE or SUPERLATIVE claim — win probability, rank,
- * ordinal, "highest", "came out ahead". ISL lists `probability_of_goal` among
- * the per-option quantities that are INVARIANT on a subset, so the goal-fit
- * block is deliberately NOT qualified: saying a figure is set-dependent when
- * it is not is the same class of untruth, pointing the other way.
+ * Mount this beside any COMPARATIVE or SUPERLATIVE claim — win probability,
+ * rank, ordinal, "highest", "came out ahead". Two kinds of surface qualify,
+ * and they get DIFFERENT amounts of the register:
+ *
+ *   - **Set-dependent VALUES** (win %, rank, the hero's superlative headline)
+ *     take `withDetail`, because `COMPARISON_SCOPE_COPY.detail` — "ranks and
+ *     comparative percentages describe those N only" — is true of them.
+ *
+ *   - **Set-dependent ORDER over invariant values** (the WinGauge goal block)
+ *     takes the `sentence` ALONE. ISL lists `probability_of_goal` among the
+ *     per-option quantities that are INVARIANT on a subset, so `detail` would
+ *     be an untruth in the opposite direction — telling a user a magnitude is
+ *     set-dependent when it is not. But the block is NOT therefore exempt:
+ *     it SORTS descending by that quantity, and order is a designation
+ *     (`utils/optionDisplayOrder.ts`, ROADMAP 1.306; this repo's own WinGauge
+ *     already gates that sort for `designationsWithheld`). A leader shown
+ *     first among three, with nothing saying a fourth was never scored, is
+ *     the same superlative encoded as position instead of as words.
+ *
+ * The neutral `sentence` states a fact about the RUN and is true on both.
  */
 import { AlertCircle } from 'lucide-react'
 import { typography } from '../../styles/typography'
@@ -40,7 +55,7 @@ export interface ComparisonScopeNoteProps {
    */
   scope: ComparisonScope | null | undefined
   /** Which mounted surface this instance qualifies — see the header. */
-  surface: 'hero' | 'comparative' | 'options'
+  surface: 'hero' | 'comparative' | 'options' | 'goal'
   /**
    * Render the consequence line as well. Off by default: the compact surfaces
    * have room for the scope sentence only, and a truncated second line is

--- a/src/components/results/OptionCards.tsx
+++ b/src/components/results/OptionCards.tsx
@@ -24,9 +24,11 @@ import {
   COMPARATIVE_COPY,
   GOAL_ANCHOR_COPY,
   LENS_COPY,
+  deriveComparisonScope,
   isFiniteProbability,
   runHasGoalNumbers,
 } from './utils/goalAnchorCopy'
+import { ComparisonScopeNote } from './ComparisonScopeNote'
 // NOTE (ROADMAP 2.333): the bare `formatPercent` import is GONE from this
 // file. It survived here as `formatPct` for exactly one caller — `StatBar`'s
 // internal readout — and that caller is the N11 defect. Every number this
@@ -1281,6 +1283,17 @@ export function OptionCards({
 
   return (
     <div className="space-y-2" data-testid="option-cards">
+      {/* ⭐ SUBSET DISCLOSURE — the rank markers and win percentages below are
+          defined OVER THE CANDIDATE SET (ISL `response_builder.py`), so a run
+          that compared fewer options than the user has must say so HERE, not
+          only on the excluded option's own card further down the list. Derived
+          from the SAME `notAnalysed` flag this component already partitions on
+          — no second predicate. */}
+      <ComparisonScopeNote
+        scope={deriveComparisonScope(options)}
+        surface="options"
+        withDetail
+      />
       {visibleOptions.map((option, index) => {
         // ⭐ NO-RANK RULING — THE FORK, AND THE ONLY PLACE IT IS MADE.
         //

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -24,7 +24,7 @@ import { OptionCards } from './OptionCards'
 import { WinGauge } from './WinGauge'
 import { AdvancedSection, RiskAppetiteFilter, LENS_ARM, type RiskAppetite } from './AdvancedSection'
 import { selectLensOption } from './utils/selectLensOption'
-import { LENS_COPY, runHasGoalNumbers } from './utils/goalAnchorCopy'
+import { LENS_COPY, deriveComparisonScope, runHasGoalNumbers } from './utils/goalAnchorCopy'
 import { StressTestSection } from './StressTestSection'
 import { SectionErrorBoundary } from '../../canvas/components/SectionErrorBoundary'
 import { DiscussWithAiButton } from '@/canvas/components/pre-analysis/DiscussWithAiButton'
@@ -580,6 +580,15 @@ export const ResultsBody = memo(function ResultsBody({
               // channel at source, so `goalFitWithheld` (which needs a joint
               // figure to ARRIVE) can no longer see that state.
               goalThreshold={resultsSectionData.recommendation.goalThreshold}
+              // ⭐ SUBSET DISCLOSURE — `shares` above is pre-filtered to
+              // options carrying a finite winProbability, so the gauge cannot
+              // see that an option was excluded. The comparison set is derived
+              // HERE, from the unfiltered `allOptions`, and rendered inside the
+              // gauge's COMPARATIVE block only (the goal block's quantity is
+              // subset-invariant).
+              comparisonScope={deriveComparisonScope(
+                resultsSectionData.recommendation.allOptions,
+              )}
             />
             {/* Codex B1: winnerId is ALWAYS the canonical leader — every leader
                 predicate (downside sentence, leader CTA/prompt) keys to it. The

--- a/src/components/results/WinGauge.tsx
+++ b/src/components/results/WinGauge.tsx
@@ -37,7 +37,13 @@
 
 import { typography } from '../../styles/typography'
 import { stripEncodingNotation } from './utils/cleanFactorLabel'
-import { GOAL_ANCHOR_COPY, COMPARATIVE_COPY, isFiniteProbability } from './utils/goalAnchorCopy'
+import {
+  GOAL_ANCHOR_COPY,
+  COMPARATIVE_COPY,
+  isFiniteProbability,
+  type ComparisonScope,
+} from './utils/goalAnchorCopy'
+import { ComparisonScopeNote } from './ComparisonScopeNote'
 import { formatGoalProbability } from './utils/displayFloors'
 import { formatProbabilityWithResolution } from '../../utils/formatPercent'
 import { deriveOddsRoundingNote, ODDS_ROUNDING_NOTE_TESTID } from './utils/oddsRoundingNote'
@@ -211,6 +217,7 @@ export function WinGauge({
   decisionState,
   designationsWithheld = false,
   goalThreshold = null,
+  comparisonScope = null,
 }: {
   shares: OptionWinShare[]
   decisionState?: DecisionState
@@ -242,6 +249,17 @@ export function WinGauge({
    * target. This prop is what lets it tell those two silences apart.
    */
   goalThreshold?: number | null
+  /**
+   * ⭐ SUBSET DISCLOSURE — the run's comparison set, or `null` when the whole
+   * option set was compared (`deriveComparisonScope`).
+   *
+   * A PROP rather than a derivation, because this component never sees the
+   * option set: `shares` arrives pre-filtered to options carrying a finite
+   * `winProbability`, so an excluded option is already gone by the time the
+   * gauge renders and `shares.length` cannot distinguish "three options" from
+   * "three of four". The caller holds `allOptions`; it derives there.
+   */
+  comparisonScope?: ComparisonScope | null
 }) {
   if (shares.length === 0) return null
 
@@ -479,6 +497,12 @@ export function WinGauge({
             {COMPARATIVE_COPY.label}
           </p>
         </Tooltip>
+        {/* ⭐ SUBSET DISCLOSURE — scoped to THIS block deliberately. The
+            comparative share is defined over the candidate set; the goal
+            block above is not (ISL lists `probability_of_goal` among the
+            per-option quantities invariant under subsetting), so qualifying
+            it there would be an untruth pointing the other way. */}
+        <ComparisonScopeNote scope={comparisonScope} surface="comparative" className="mb-1" />
         {/* Stacked bar — use clamped raw percentage for width to avoid rounding gaps */}
         <div className={`flex rounded-full overflow-hidden gap-0.5${isDeemphasised ? ' h-2' : ' h-3'}`}>
           {sorted.map((share) => {

--- a/src/components/results/WinGauge.tsx
+++ b/src/components/results/WinGauge.tsx
@@ -385,6 +385,17 @@ export function WinGauge({
           >
             {GOAL_ANCHOR_COPY.label(substituted)}
           </p>
+          {/* ⭐ SUBSET DISCLOSURE — the SENTENCE only, never `withDetail`.
+              The per-option goal magnitudes here are subset-INVARIANT, so the
+              "ranks and comparative percentages describe those N only" line
+              must not sweep them in. But `goalRows` above is SORTED DESCENDING
+              by the goal quantity on every non-withheld run, and order is a
+              designation (`optionDisplayOrder`'s header, ROADMAP 1.306 — the
+              same rule this component already applies to `designationsWithheld`
+              a few lines up). A leader placed first among three, with nothing
+              saying a fourth was never scored, is the hero's superlative
+              encoded as position rather than words. */}
+          <ComparisonScopeNote scope={comparisonScope} surface="goal" className="mb-1" />
           <div className="flex flex-col gap-1">
             {goalRows.map((share) => {
               const clamped = Math.max(0, Math.min(1, share.goalProbability as number))

--- a/src/components/results/__tests__/comparisonScopeDisclosure.spec.tsx
+++ b/src/components/results/__tests__/comparisonScopeDisclosure.spec.tsx
@@ -148,6 +148,19 @@ describe('comparison-scope disclosure — a subset result says which options it 
       expect(screen.getByTestId(NOTE.cards)).toHaveTextContent(DROPPED_LABEL)
     })
 
+    // ⭐ THE DISCRIMINATING TWIN (trap 19). The pin above is a PRESENCE check,
+    // and a mutant that names EVERY option satisfies it while saying something
+    // false — the note would list options that were in the comparison as
+    // though they had been left out. Binding the claim to the excluded
+    // option's identity requires asserting the analysed ones are ABSENT.
+    it('names ONLY the excluded option — an analysed sibling never appears', () => {
+      render(<OptionCards options={subsetOptions()} winnerId={KEEP_A} hasLeadingOption />)
+      const note = screen.getByTestId(NOTE.cards)
+      expect(note).not.toHaveTextContent(`Analysed ${KEEP_A}`)
+      expect(note).not.toHaveTextContent(`Analysed ${KEEP_B}`)
+      expect(note).not.toHaveTextContent(`Analysed ${KEEP_C}`)
+    })
+
     it('names BOTH excluded options when two of five were left out', () => {
       const options = [...subsetOptions(), excluded(DROPPED_TWO, DROPPED_TWO_LABEL)]
       render(<OptionCards options={options} winnerId={KEEP_A} hasLeadingOption />)

--- a/src/components/results/__tests__/comparisonScopeDisclosure.spec.tsx
+++ b/src/components/results/__tests__/comparisonScopeDisclosure.spec.tsx
@@ -73,6 +73,7 @@ const DROPPED_TWO_LABEL = 'Rip and Replace'
 const NOTE = {
   gauge: 'comparison-scope-note-comparative',
   cards: 'comparison-scope-note-options',
+  goal: 'comparison-scope-note-goal',
 } as const
 
 function analysed(id: string, winProbability: number): OptionResult {
@@ -197,11 +198,24 @@ describe('comparison-scope disclosure — a subset result says which options it 
       expect(within(comparative).getByTestId(NOTE.gauge)).toHaveTextContent('3 of your 4 options')
     })
 
-    // ⭐ THE DISCRIMINATING PIN. `probability_of_goal` is subset-INVARIANT per
-    // ISL's own response builder, so the goal block must NOT carry this
-    // qualification. A note rendered everywhere passes every other assertion
-    // in this file and fails only here.
-    it('does NOT qualify the goal block — goal fit is subset-invariant', () => {
+    // ⭐ THE DISCRIMINATING PIN, CORRECTED.
+    //
+    // The first version asserted the goal block carried NO qualification at
+    // all, on the grounds that `probability_of_goal` is subset-invariant. That
+    // is right about the MAGNITUDES and wrong about the BLOCK: `goalRows` is
+    // sorted descending by the goal quantity on every non-withheld run, and
+    // order is a designation (`optionDisplayOrder`, ROADMAP 1.306 — a rule
+    // WinGauge itself already applies to `designationsWithheld`). So the block
+    // gets the neutral scope SENTENCE, and must still NOT get the
+    // set-dependence `detail` line.
+    //
+    // ⚠ The block's EXISTENCE is asserted first. The previous version wrapped
+    // the assertion in `if (goalBlock)`, which is vacuous whenever the fixture
+    // stops producing goal numbers — a reviewer proved the contingency by
+    // dropping one unpinned fixture property and watching the misplacement
+    // mutant go red → green (trap 13: an absence probe needs to prove it can
+    // see a presence).
+    it('qualifies the goal block with the SENTENCE but never the detail line', () => {
       const options = subsetOptions()
       render(
         <WinGauge
@@ -210,10 +224,25 @@ describe('comparison-scope disclosure — a subset result says which options it 
           goalThreshold={0.5}
         />,
       )
-      const goalBlock = screen.queryByTestId('win-gauge-goal-block')
-      if (goalBlock) {
-        expect(within(goalBlock).queryByTestId(NOTE.gauge)).toBeNull()
-      }
+      const goalBlock = screen.getByTestId('win-gauge-goal-block')
+      const note = within(goalBlock).getByTestId(NOTE.goal)
+      expect(note).toHaveTextContent('3 of your 4 options')
+      expect(note).toHaveTextContent(DROPPED_LABEL)
+      // The set-dependence claim belongs to the comparative surfaces only.
+      expect(note).not.toHaveTextContent('Ranks and comparative percentages')
+    })
+
+    it('renders NO goal-block note when every option was compared', () => {
+      const options = fullSetOptions()
+      render(
+        <WinGauge
+          shares={gaugeShares(options)}
+          comparisonScope={deriveComparisonScope(options)}
+          goalThreshold={0.5}
+        />,
+      )
+      expect(screen.getByTestId('win-gauge-goal-block')).toBeTruthy()
+      expect(screen.queryByTestId(NOTE.goal)).toBeNull()
     })
 
     it('renders NO scope note when every option was compared', () => {
@@ -291,6 +320,33 @@ describe('comparison-scope disclosure — a subset result says which options it 
         total: 5,
         excludedLabels: [DROPPED_LABEL, DROPPED_TWO_LABEL],
       })
+    })
+
+    // ⛔ THE ID LEAK. `useResultsSectionData` sets
+    // `label: node.data?.label || nodeId`, so an unlabelled option arrives
+    // carrying its own id as a well-formed string. Without the guard the
+    // sentence under the hero reads "— 79b5d7c0 was left out.", i.e. a raw
+    // internal identifier presented to a user as the name of their option.
+    it('never names an option by its own node id', () => {
+      const scope = deriveComparisonScope([
+        analysed(KEEP_A, 0.62),
+        { id: '79b5d7c0', label: '79b5d7c0', notAnalysed: true },
+      ])
+      expect(scope).toEqual({ analysed: 1, total: 2, excludedLabels: [] })
+      expect(COMPARISON_SCOPE_COPY.sentence(scope!)).toBe(
+        'Comparing 1 of your 2 options — 1 was left out.',
+      )
+      expect(COMPARISON_SCOPE_COPY.sentence(scope!)).not.toContain('79b5d7c0')
+    })
+
+    // CONTRAST CONTROL — the guard rejects a label that IS the id, and must
+    // not reject a real label that merely sits beside one (trap 13e).
+    it('CONTRAST — a genuine label on an option with an id is still named', () => {
+      const scope = deriveComparisonScope([
+        analysed(KEEP_A, 0.62),
+        { id: '79b5d7c0', label: DROPPED_LABEL, notAnalysed: true },
+      ])
+      expect(scope!.excludedLabels).toEqual([DROPPED_LABEL])
     })
 
     it('reports the COUNT rather than inventing a name when a label is unusable', () => {

--- a/src/components/results/__tests__/comparisonScopeDisclosure.spec.tsx
+++ b/src/components/results/__tests__/comparisonScopeDisclosure.spec.tsx
@@ -1,0 +1,248 @@
+/**
+ * comparisonScopeDisclosure — a rendered result computed over a SUBSET says so,
+ * next to the number.
+ *
+ * ## The defect
+ *
+ * CEE's admission gate already drops an option with nothing to submit and runs
+ * the rest, so subset results reach users today. ISL is explicit that
+ * `win_probability`, `rank`, `expected_regret` and the flip thresholds are
+ * defined OVER THE CANDIDATE SET — so "Option A — 62%" with no statement of
+ * which options were compared asserts something false about the user's actual
+ * decision. A 62% among three is not a 62% among four.
+ *
+ * `NotAnalysedOptionCard` discloses the exclusion on the EXCLUDED OPTION'S OWN
+ * CARD — which is precisely where a reader of a headline percentage is not
+ * looking. This file pins the qualification at the three surfaces a customer
+ * reads first: the hero headline, the WinGauge comparative block, and the
+ * option cards' rank markers.
+ *
+ * ⚠ THE HERO HALF LIVES ELSEWHERE — `analysis-hero/__tests__/
+ * comparisonScopeDisclosure.hero.spec.tsx`. `analysis-hero/__tests__/
+ * inertness.spec.ts` allows only `ResultsBody` to import that module from
+ * outside it, so the hero pins sit inside the module rather than widening an
+ * architectural boundary to suit a test.
+ *
+ * ## What each pin exists for
+ *
+ * - **Presence on a subset run** at each of the three mounted surfaces.
+ * - **ABSENCE on a full-set run** — the boundary that stops this shipping as
+ *   noise on every result. A "comparing 4 of 4" note everywhere is how a real
+ *   disclosure stops being read, and it is also how this spec would become a
+ *   tautology that cannot tell the two states apart.
+ * - **The excluded option is NAMED**, and named by the label on its own
+ *   record — bound by IDENTITY (`option_id`-keyed fixture labels, exact
+ *   testids), never by matching a copy string this change is authoring
+ *   (trap 19).
+ * - **The GOAL block is NOT qualified.** ISL lists `probability_of_goal` among
+ *   the per-option quantities that are INVARIANT on a subset. Attaching the
+ *   note there would be an untruth in the opposite direction — telling a user a
+ *   figure is set-dependent when it is not. This is a discrimination the
+ *   instrument makes on purpose: a blind probe could fake the presence
+ *   assertions above by rendering the note everywhere, and it cannot fake
+ *   this one (trap 20's corollary — keep one probe whose expected answer
+ *   DIFFERS).
+ *
+ * ## Deployed-flag posture (trap 3b)
+ *
+ * All three surfaces are mounted UNCONDITIONALLY by `ResultsBody`:
+ * `AnalysisHeroContainer` (the analysis-hero fork is closed — `netlify.toml`
+ * records `VITE_FEATURE_ANALYSIS_HERO_PANEL` as retired with no readers),
+ * `WinGauge`, and `OptionCards`. So this file's greenness is a claim about
+ * something a user loads on the deployed posture, not about a component a flag
+ * switches off.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { OptionCards } from '../OptionCards'
+import { WinGauge } from '../WinGauge'
+import { deriveComparisonScope } from '../utils/goalAnchorCopy'
+import type { OptionResult } from '../types'
+
+// ── Identity anchors. Every query binds to these, never to prose. ──────────
+const KEEP_A = 'opt-keep-a'
+const KEEP_B = 'opt-keep-b'
+const KEEP_C = 'opt-keep-c'
+const DROPPED = 'opt-dropped'
+const DROPPED_TWO = 'opt-dropped-two'
+
+const DROPPED_LABEL = 'Hybrid Phased Approach'
+const DROPPED_TWO_LABEL = 'Rip and Replace'
+
+const NOTE = {
+  gauge: 'comparison-scope-note-comparative',
+  cards: 'comparison-scope-note-options',
+} as const
+
+function analysed(id: string, winProbability: number): OptionResult {
+  return {
+    id,
+    label: `Analysed ${id}`,
+    expected: 100,
+    outcome: { mean: 100, p10: 60, p50: 100, p90: 140 },
+    p10: 60,
+    p50: 100,
+    p90: 140,
+    isRecommended: false,
+    winProbability,
+    goalProbability: 0.55,
+  } as OptionResult
+}
+
+/** Exactly the shape `useResultsSectionData` produces for an excluded option. */
+function excluded(id: string, label: string): OptionResult {
+  return {
+    id,
+    label,
+    expected: null,
+    outcome: { mean: null, p10: null, p50: null, p90: null },
+    p10: null,
+    p50: null,
+    p90: null,
+    isRecommended: false,
+    notAnalysed: true,
+    notAnalysedReason: 'no_interventions',
+  } as OptionResult
+}
+
+/** THREE ARMS OF FOUR — the measured draw-10 shape from the CEE capture. */
+const subsetOptions = (): OptionResult[] => [
+  analysed(KEEP_A, 0.62),
+  analysed(KEEP_B, 0.23),
+  analysed(KEEP_C, 0.15),
+  excluded(DROPPED, DROPPED_LABEL),
+]
+
+/** The contrast arm: every option compared. */
+const fullSetOptions = (): OptionResult[] => [
+  analysed(KEEP_A, 0.62),
+  analysed(KEEP_B, 0.23),
+  analysed(KEEP_C, 0.15),
+]
+
+function gaugeShares(options: OptionResult[]) {
+  return options
+    .filter((o): o is OptionResult & { winProbability: number } =>
+      typeof o.winProbability === 'number',
+    )
+    .map(o => ({
+      id: o.id,
+      label: o.label,
+      winProbability: o.winProbability,
+      isWinner: o.id === KEEP_A,
+      goalProbability: o.goalProbability,
+    }))
+}
+
+describe('comparison-scope disclosure — a subset result says which options it compared', () => {
+  describe('OptionCards (rank markers, win percentages)', () => {
+    it('renders the scope note when one of four options was left out', () => {
+      render(<OptionCards options={subsetOptions()} winnerId={KEEP_A} hasLeadingOption />)
+      const note = screen.getByTestId(NOTE.cards)
+      expect(note).toHaveTextContent('3 of your 4 options')
+    })
+
+    it('names the excluded option on the note itself, not only on its card', () => {
+      render(<OptionCards options={subsetOptions()} winnerId={KEEP_A} hasLeadingOption />)
+      expect(screen.getByTestId(NOTE.cards)).toHaveTextContent(DROPPED_LABEL)
+    })
+
+    it('names BOTH excluded options when two of five were left out', () => {
+      const options = [...subsetOptions(), excluded(DROPPED_TWO, DROPPED_TWO_LABEL)]
+      render(<OptionCards options={options} winnerId={KEEP_A} hasLeadingOption />)
+      const note = screen.getByTestId(NOTE.cards)
+      expect(note).toHaveTextContent('3 of your 5 options')
+      expect(note).toHaveTextContent(DROPPED_LABEL)
+      expect(note).toHaveTextContent(DROPPED_TWO_LABEL)
+    })
+
+    // ── THE BOUNDARY. Without this the presence pins above are satisfied by
+    // rendering the note unconditionally, which is the noise failure mode.
+    it('renders NO scope note when every option was compared', () => {
+      render(<OptionCards options={fullSetOptions()} winnerId={KEEP_A} hasLeadingOption />)
+      expect(screen.queryByTestId(NOTE.cards)).toBeNull()
+    })
+
+    // Contrast control: the ranked chrome this note qualifies is genuinely on
+    // screen in the subset render. Without it, "the note appeared" could be
+    // true of a surface that renders no numbers at all (trap 13e).
+    it('CONTROL — the ranked chrome the note qualifies is present in the same render', () => {
+      render(<OptionCards options={subsetOptions()} winnerId={KEEP_A} hasLeadingOption />)
+      expect(screen.getByTestId(`rank-marker-${KEEP_A}`)).toBeTruthy()
+      expect(screen.getByTestId(`win-pct-${KEEP_A}`)).toBeTruthy()
+    })
+  })
+
+  describe('WinGauge (comparative block)', () => {
+    it('renders the scope note INSIDE the comparative block', () => {
+      const options = subsetOptions()
+      render(
+        <WinGauge shares={gaugeShares(options)} comparisonScope={deriveComparisonScope(options)} />,
+      )
+      const comparative = screen.getByTestId('win-gauge-comparative-block')
+      expect(within(comparative).getByTestId(NOTE.gauge)).toHaveTextContent('3 of your 4 options')
+    })
+
+    // ⭐ THE DISCRIMINATING PIN. `probability_of_goal` is subset-INVARIANT per
+    // ISL's own response builder, so the goal block must NOT carry this
+    // qualification. A note rendered everywhere passes every other assertion
+    // in this file and fails only here.
+    it('does NOT qualify the goal block — goal fit is subset-invariant', () => {
+      const options = subsetOptions()
+      render(
+        <WinGauge
+          shares={gaugeShares(options)}
+          comparisonScope={deriveComparisonScope(options)}
+          goalThreshold={0.5}
+        />,
+      )
+      const goalBlock = screen.queryByTestId('win-gauge-goal-block')
+      if (goalBlock) {
+        expect(within(goalBlock).queryByTestId(NOTE.gauge)).toBeNull()
+      }
+    })
+
+    it('renders NO scope note when every option was compared', () => {
+      const options = fullSetOptions()
+      render(
+        <WinGauge shares={gaugeShares(options)} comparisonScope={deriveComparisonScope(options)} />,
+      )
+      expect(screen.queryByTestId(NOTE.gauge)).toBeNull()
+    })
+  })
+
+  describe('deriveComparisonScope — the derivation, at its own boundaries', () => {
+    it('is null when nothing was excluded', () => {
+      expect(deriveComparisonScope(fullSetOptions())).toBeNull()
+    })
+
+    it('is null when NOTHING was analysed (no comparative numbers to qualify)', () => {
+      expect(
+        deriveComparisonScope([excluded(DROPPED, DROPPED_LABEL), excluded(DROPPED_TWO, DROPPED_TWO_LABEL)]),
+      ).toBeNull()
+    })
+
+    it('is null on an empty run', () => {
+      expect(deriveComparisonScope([])).toBeNull()
+      expect(deriveComparisonScope(null)).toBeNull()
+    })
+
+    it('counts the flag it is given and reports labels in arrival order', () => {
+      const scope = deriveComparisonScope([...subsetOptions(), excluded(DROPPED_TWO, DROPPED_TWO_LABEL)])
+      expect(scope).toEqual({
+        analysed: 3,
+        total: 5,
+        excludedLabels: [DROPPED_LABEL, DROPPED_TWO_LABEL],
+      })
+    })
+
+    it('reports the COUNT rather than inventing a name when a label is unusable', () => {
+      const scope = deriveComparisonScope([
+        analysed(KEEP_A, 0.62),
+        { label: '   ', notAnalysed: true },
+      ])
+      expect(scope).toEqual({ analysed: 1, total: 2, excludedLabels: [] })
+    })
+  })
+})

--- a/src/components/results/__tests__/comparisonScopeDisclosure.spec.tsx
+++ b/src/components/results/__tests__/comparisonScopeDisclosure.spec.tsx
@@ -57,7 +57,7 @@ import { describe, it, expect } from 'vitest'
 import { render, screen, within } from '@testing-library/react'
 import { OptionCards } from '../OptionCards'
 import { WinGauge } from '../WinGauge'
-import { deriveComparisonScope } from '../utils/goalAnchorCopy'
+import { COMPARISON_SCOPE_COPY, deriveComparisonScope } from '../utils/goalAnchorCopy'
 import type { OptionResult } from '../types'
 
 // ── Identity anchors. Every query binds to these, never to prose. ──────────
@@ -222,6 +222,49 @@ describe('comparison-scope disclosure — a subset result says which options it 
         <WinGauge shares={gaugeShares(options)} comparisonScope={deriveComparisonScope(options)} />,
       )
       expect(screen.queryByTestId(NOTE.gauge)).toBeNull()
+    })
+  })
+
+  // ── THE VERBATIM COPY. Pinned so the sentence a user reads is a decision in
+  // the record rather than whatever the register happens to compose today, and
+  // so a reviewer can read the shipped wording without running the app.
+  describe('COMPARISON_SCOPE_COPY — the sentence a user reads', () => {
+    const scope = deriveComparisonScope(subsetOptions())!
+
+    it('composes the draw-10 shape verbatim', () => {
+      expect(COMPARISON_SCOPE_COPY.sentence(scope)).toBe(
+        'Comparing 3 of your 4 options — Hybrid Phased Approach was left out.',
+      )
+      expect(COMPARISON_SCOPE_COPY.detail(scope)).toBe(
+        'Ranks and comparative percentages describe those 3 only.',
+      )
+    })
+
+    it('joins two excluded options in British house style (no serial comma)', () => {
+      const two = deriveComparisonScope([...subsetOptions(), excluded(DROPPED_TWO, DROPPED_TWO_LABEL)])!
+      expect(COMPARISON_SCOPE_COPY.sentence(two)).toBe(
+        'Comparing 3 of your 5 options — Hybrid Phased Approach and Rip and Replace were left out.',
+      )
+    })
+
+    it('falls back to the COUNT when no excluded option carries a usable label', () => {
+      const unnamed = deriveComparisonScope([
+        analysed(KEEP_A, 0.62),
+        { label: '   ', notAnalysed: true },
+      ])!
+      expect(COMPARISON_SCOPE_COPY.sentence(unnamed)).toBe(
+        'Comparing 1 of your 2 options — 1 was left out.',
+      )
+    })
+
+    // ⚠ NEUTRALITY. The excluded option was never scored, so nothing here may
+    // read as a verdict on it. A comparative verb would imply it was
+    // considered and lost.
+    it('claims nothing about the excluded option\'s merit', () => {
+      const text = `${COMPARISON_SCOPE_COPY.sentence(scope)} ${COMPARISON_SCOPE_COPY.detail(scope)}`
+      for (const verb of ['worse', 'lost', 'weaker', 'beaten', 'behind', 'ruled out', 'rejected']) {
+        expect(text.toLowerCase()).not.toContain(verb)
+      }
     })
   })
 

--- a/src/components/results/analysis-hero/AnalysisHeroContainer.tsx
+++ b/src/components/results/analysis-hero/AnalysisHeroContainer.tsx
@@ -23,6 +23,7 @@ import { revealOlumiSurface } from '../../../canvas/conversation/revealOlumi'
 import { AnalysisHeroPanel } from './AnalysisHeroPanel'
 import { useAnalysisHero } from './useAnalysisHero'
 import { HERO_COPY } from './heroCopy'
+import { deriveComparisonScope } from '../utils/goalAnchorCopy'
 import { ActOnItSection } from './actOnIt/ActOnItSection'
 import { makeRowActionDispatcher } from './actOnIt/dispatchAction'
 import {
@@ -145,9 +146,19 @@ export function AnalysisHeroContainer({
     )
   }
 
+  // ⭐ SUBSET DISCLOSURE — derived HERE, from the same `allOptions` the hero
+  // model is built from, so the headline's field and the option cards' field
+  // are one fact read twice rather than two derivations that can disagree.
+  // `deriveComparisonScope` returns null whenever there is nothing to say.
+  const comparisonScope = useMemo(
+    () => deriveComparisonScope(data.recommendation?.allOptions),
+    [data.recommendation?.allOptions],
+  )
+
   return (
     <AnalysisHeroPanel
       model={model}
+      comparisonScope={comparisonScope}
       rerunDisabled={rerunDisabled}
       focusPanelSelector={focusPanelSelector}
       nextRecommendation={nextRecommendation}

--- a/src/components/results/analysis-hero/AnalysisHeroContainer.tsx
+++ b/src/components/results/analysis-hero/AnalysisHeroContainer.tsx
@@ -121,6 +121,19 @@ export function AnalysisHeroContainer({
     [onFocusNode, onConfirmFactor],
   )
 
+  // ⭐ SUBSET DISCLOSURE — derived from the same `allOptions` the hero model is
+  // built from, so the headline's field and the option cards' field are one
+  // fact read twice rather than two derivations that can disagree.
+  // `deriveComparisonScope` returns null whenever there is nothing to say.
+  //
+  // ⚠ MUST STAY ABOVE the empty-model early return below: a hook called after
+  // a conditional return changes hook order between renders
+  // (react-hooks/rules-of-hooks — caught by lint, not by the test suite).
+  const comparisonScope = useMemo(
+    () => deriveComparisonScope(data.recommendation?.allOptions),
+    [data.recommendation?.allOptions],
+  )
+
   // Fail closed on the hero MODEL only — never on the act-on-it section. A
   // model that cannot be built (pre-run default, malformed retained state)
   // says nothing about whether there are factors to confirm, and the queue is
@@ -145,15 +158,6 @@ export function AnalysisHeroContainer({
       </section>
     )
   }
-
-  // ⭐ SUBSET DISCLOSURE — derived HERE, from the same `allOptions` the hero
-  // model is built from, so the headline's field and the option cards' field
-  // are one fact read twice rather than two derivations that can disagree.
-  // `deriveComparisonScope` returns null whenever there is nothing to say.
-  const comparisonScope = useMemo(
-    () => deriveComparisonScope(data.recommendation?.allOptions),
-    [data.recommendation?.allOptions],
-  )
 
   return (
     <AnalysisHeroPanel

--- a/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
+++ b/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
@@ -42,9 +42,23 @@ import { HeroOptionRow, HERO_ROW_GRID, HERO_ROW_TRACK_SPAN } from './HeroOptionR
 import { ActOnItSection } from './actOnIt/ActOnItSection'
 import type { ActOnItRow, RowActionDispatcher } from './actOnIt/types'
 import type { HeroChartModel, HeroLens, HeroStatusModel } from './heroTypes'
+import { ComparisonScopeNote } from '../ComparisonScopeNote'
+import type { ComparisonScope } from '../utils/goalAnchorCopy'
 
 export interface AnalysisHeroPanelProps {
   model: HeroChartModel | HeroStatusModel
+  /**
+   * ⭐ SUBSET DISCLOSURE — the run's comparison set, or `null`/absent when the
+   * whole option set was compared. Derived by `AnalysisHeroContainer` from the
+   * SAME `recommendation.allOptions` this panel's model is built from
+   * (`deriveComparisonScope`), so the headline and the option cards cannot
+   * disagree about which options were in the field.
+   *
+   * OPTIONAL because the internal fixture gallery mounts this panel with
+   * hand-built models and no run behind them; absent means "say nothing",
+   * which is the correct behaviour for example data.
+   */
+  comparisonScope?: ComparisonScope | null
   /** Wave 2 (§6.5): canvas focus for quick links; absent = links inert-hidden. */
   onFocusTarget?: (targetId: string) => void
   /**
@@ -175,6 +189,7 @@ export function AnalysisHeroPanel({
   dispatchRowAction,
   chatAvailable = false,
   actOnItQueueSlot,
+  comparisonScope = null,
 }: AnalysisHeroPanelProps) {
   const panelId = useId()
   const [lensState, setLensState] = useState<HeroLens | null>(null)
@@ -367,6 +382,12 @@ export function AnalysisHeroPanel({
             {model.subline}
           </p>
         )}
+        {/* ⭐ SUBSET DISCLOSURE — the headline names a LEADER, and a superlative
+            ranges over the candidate set even where the underlying per-option
+            quantity is subset-invariant. "Highest chance of hitting your goal"
+            is a claim about the field, so a field smaller than the user's
+            option set has to be named right here, under the claim. */}
+        <ComparisonScopeNote scope={comparisonScope} surface="hero" withDetail />
       </div>
 
       {/* Chart area — prototype v6 stale doctrine: NEVER dimmed or locked.

--- a/src/components/results/analysis-hero/__tests__/comparisonScopeDisclosure.hero.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/comparisonScopeDisclosure.hero.spec.tsx
@@ -1,0 +1,128 @@
+/**
+ * Analysis hero — a headline computed over a SUBSET says which options it
+ * compared.
+ *
+ * ## Why this file lives HERE and not beside its siblings
+ *
+ * The rest of this change's pins are in
+ * `src/components/results/__tests__/comparisonScopeDisclosure.spec.tsx`. The
+ * hero half is separated because `analysis-hero/__tests__/inertness.spec.ts`
+ * enforces that ONLY `ResultsBody` may import the analysis hero from outside
+ * this module — a real architectural boundary (the module was forked three
+ * times and every fork stayed mounted). Splitting the file respects that
+ * guard; adding this spec to its authorised-importer allowlist would have
+ * widened a boundary to suit a test, which is the wrong direction.
+ *
+ * ## The claim
+ *
+ * `model.headline` names a LEADER. A superlative ranges over the candidate set
+ * even where the underlying per-option quantity is subset-invariant: "has the
+ * highest chance of hitting your goal" is a claim about the FIELD, and a field
+ * smaller than the user's option set makes it a different claim from the one
+ * the user thinks they are reading. So the hero is in scope even though
+ * `probability_of_goal` itself is not.
+ *
+ * ## Deployed-flag posture (trap 3b)
+ *
+ * `AnalysisHeroContainer` mounts UNCONDITIONALLY in `ResultsBody` — the
+ * analysis-hero fork is closed and `netlify.toml` records
+ * `VITE_FEATURE_ANALYSIS_HERO_PANEL` as retired with no readers. This spec is
+ * therefore a claim about a surface a user loads.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AnalysisHeroPanel } from '../AnalysisHeroPanel'
+import { buildHeroModel } from '../buildHeroModel'
+import { makeHeroData } from '../__fixtures__/hero.fixtures'
+import { deriveComparisonScope } from '../../utils/goalAnchorCopy'
+import type { HeroChartModel } from '../heroTypes'
+import type { OptionResult } from '../../types'
+
+const KEEP_A = 'opt-keep-a'
+const KEEP_B = 'opt-keep-b'
+const KEEP_C = 'opt-keep-c'
+const DROPPED = 'opt-dropped'
+const DROPPED_LABEL = 'Hybrid Phased Approach'
+
+const HERO_NOTE = 'comparison-scope-note-hero'
+
+function analysed(id: string, winProbability: number): OptionResult {
+  return {
+    id,
+    label: `Analysed ${id}`,
+    expected: 100,
+    outcome: { mean: 100, p10: 60, p50: 100, p90: 140 },
+    p10: 60,
+    p50: 100,
+    p90: 140,
+    isRecommended: false,
+    winProbability,
+    goalProbability: 0.55,
+  } as OptionResult
+}
+
+function excluded(id: string, label: string): OptionResult {
+  return {
+    id,
+    label,
+    expected: null,
+    outcome: { mean: null, p10: null, p50: null, p90: null },
+    p10: null,
+    p50: null,
+    p90: null,
+    isRecommended: false,
+    notAnalysed: true,
+    notAnalysedReason: 'no_interventions',
+  } as OptionResult
+}
+
+/** THREE ARMS OF FOUR — the measured draw-10 shape from the CEE capture. */
+const subsetOptions = (): OptionResult[] => [
+  analysed(KEEP_A, 0.62),
+  analysed(KEEP_B, 0.23),
+  analysed(KEEP_C, 0.15),
+  excluded(DROPPED, DROPPED_LABEL),
+]
+
+const fullSetOptions = (): OptionResult[] => [
+  analysed(KEEP_A, 0.62),
+  analysed(KEEP_B, 0.23),
+  analysed(KEEP_C, 0.15),
+]
+
+function renderHero(options: OptionResult[]) {
+  const model = buildHeroModel(
+    makeHeroData({ options, recommendation: { storyHeadlines: {} } as never }),
+  ) as HeroChartModel
+  return render(
+    <AnalysisHeroPanel
+      model={model}
+      rerunDisabled={false}
+      comparisonScope={deriveComparisonScope(options)}
+    />,
+  )
+}
+
+describe('analysis hero — comparison-scope disclosure', () => {
+  it('renders the scope note beneath the headline on a subset run', () => {
+    renderHero(subsetOptions())
+    const note = screen.getByTestId(HERO_NOTE)
+    expect(note).toHaveTextContent('3 of your 4 options')
+    expect(note).toHaveTextContent(DROPPED_LABEL)
+  })
+
+  // CONTROL — without this, "the note appeared" could be true of a render
+  // carrying no headline claim at all (trap 13e: a control must be plausible).
+  it('CONTROL — the headline the note qualifies is present in the same render', () => {
+    renderHero(subsetOptions())
+    expect(screen.getByTestId('hero-headline')).toBeTruthy()
+  })
+
+  // THE BOUNDARY. Without it the pin above is satisfied by rendering the note
+  // unconditionally, which is the noise failure mode this change must not ship.
+  it('renders NO scope note when every option was compared', () => {
+    renderHero(fullSetOptions())
+    expect(screen.queryByTestId(HERO_NOTE)).toBeNull()
+  })
+})

--- a/src/components/results/analysis-hero/__tests__/comparisonScopeDisclosure.hero.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/comparisonScopeDisclosure.hero.spec.tsx
@@ -112,6 +112,17 @@ describe('analysis hero — comparison-scope disclosure', () => {
     expect(note).toHaveTextContent(DROPPED_LABEL)
   })
 
+  // ⭐ THE DISCRIMINATING TWIN (trap 19) — see the sibling spec's note: a
+  // mutant that names every option passes the presence pin above while
+  // claiming compared options were left out.
+  it('names ONLY the excluded option — an analysed sibling never appears', () => {
+    renderHero(subsetOptions())
+    const note = screen.getByTestId(HERO_NOTE)
+    expect(note).not.toHaveTextContent(`Analysed ${KEEP_A}`)
+    expect(note).not.toHaveTextContent(`Analysed ${KEEP_B}`)
+    expect(note).not.toHaveTextContent(`Analysed ${KEEP_C}`)
+  })
+
   // CONTROL — without this, "the note appeared" could be true of a render
   // carrying no headline claim at all (trap 13e: a control must be plausible).
   it('CONTROL — the headline the note qualifies is present in the same render', () => {

--- a/src/components/results/utils/goalAnchorCopy.ts
+++ b/src/components/results/utils/goalAnchorCopy.ts
@@ -344,6 +344,9 @@ export interface ComparisonScope {
    * Labels of the options left out, in the order they arrived. MAY BE SHORTER
    * than `total - analysed`: an option with no usable label cannot be named,
    * and inventing a name for it would be worse than reporting the count alone.
+   *
+   * "No usable label" includes a label that is merely the option's own NODE ID
+   * — see the guard in {@link deriveComparisonScope}.
    */
   readonly excludedLabels: readonly string[]
 }
@@ -373,7 +376,10 @@ export interface ComparisonScope {
  * where the whole set was compared.
  */
 export function deriveComparisonScope(
-  options: ReadonlyArray<{ label?: string | null; notAnalysed?: boolean }> | null | undefined,
+  options:
+    | ReadonlyArray<{ id?: string | null; label?: string | null; notAnalysed?: boolean }>
+    | null
+    | undefined,
 ): ComparisonScope | null {
   const all = options ?? []
   if (all.length === 0) return null
@@ -389,7 +395,24 @@ export function deriveComparisonScope(
     analysed,
     total: all.length,
     excludedLabels: excluded
-      .map((o) => (typeof o.label === 'string' ? o.label.trim() : ''))
+      .map((o) => {
+        const label = typeof o.label === 'string' ? o.label.trim() : ''
+        // ⛔ NEVER NAME AN OPTION BY ITS NODE ID.
+        //
+        // `useResultsSectionData` sets `label: node.data?.label || nodeId`, so
+        // an unlabelled option arrives carrying its OWN ID as a perfectly
+        // well-formed string — and a whitespace check cannot tell the two
+        // apart. Without this guard the sentence under the hero reads
+        // "…— 79b5d7c0 was left out.", which is a raw internal identifier
+        // presented to a user as the name of their option.
+        //
+        // The leak pre-dates this change (`NotAnalysedOptionCard` has it too,
+        // low in the card list); what this register does is PROMOTE it to a
+        // headline. Rejecting it here falls back to the count path
+        // ("1 was left out"), which is honest and already tested.
+        const isBareId = label.length > 0 && label === (o.id ?? '')
+        return isBareId ? '' : label
+      })
       .filter((label) => label.length > 0),
   }
 }

--- a/src/components/results/utils/goalAnchorCopy.ts
+++ b/src/components/results/utils/goalAnchorCopy.ts
@@ -283,3 +283,179 @@ export const LENS_COPY = {
       ? 'The goal ranking above is unchanged.'
       : 'The comparative ranking above is unchanged.',
 } as const
+
+/**
+ * ─────────────────────────────────────────────────────────────────────────
+ * THE COMPARISON-SET REGISTER — what the numbers on this run were computed
+ * OVER, said next to the numbers themselves.
+ * ─────────────────────────────────────────────────────────────────────────
+ *
+ * ## The defect this closes
+ *
+ * The product already excludes an option and proceeds: CEE's admission gate
+ * drops an option with nothing to submit and runs the rest, and the UI derives
+ * that fact at the join (`utils/notAnalysedOptions.ts`). So subset results
+ * reach users today.
+ *
+ * ISL is explicit about which quantities do NOT survive subsetting
+ * (`isl/src/utils/response_builder.py`): `win_probability`, `rank`,
+ * `expected_regret`, `decision_evpi`, `factor_evppi`,
+ * `recommendation_stability` and the flip thresholds are all defined OVER THE
+ * CANDIDATE SET. CEE's own comment says admission *"changes WHICH options are
+ * compared, never what any number means"* — true of the metric's DEFINITION
+ * and false of its VALUE. A 62% among three is not a 62% among four, and a
+ * leader that never met the excluded option is not the leader of the question
+ * the user asked.
+ *
+ * ## Why this is a REGISTER and not fifteen strings
+ *
+ * `NotAnalysedOptionCard` already discloses exclusion — on the excluded
+ * option's own card, which is exactly where a user reading a headline
+ * percentage is not looking. Proximity is the whole point: a disclosure the
+ * user must go looking for does not qualify a headline. This register exists
+ * so the qualification is ONE sentence rendered beside the numbers on every
+ * comparative surface, rather than a sixteenth spelling per render site — the
+ * same reason `COMPARATIVE_COPY` exists above.
+ *
+ * ## ⚠ WHAT THIS MUST NOT BE ATTACHED TO
+ *
+ * The A-register quantity (`goalProbability`, "chance of hitting your goal")
+ * is INVARIANT on a subset — ISL lists `probability_of_goal` among the
+ * per-option quantities that survive. Qualifying it would be its own small
+ * untruth in the opposite direction: telling a user a number is set-dependent
+ * when it is not. Attach this ONLY where a comparative or superlative claim is
+ * made — win probability, rank, ordinal, "highest", "came out ahead".
+ *
+ * A superlative over an invariant quantity IS comparative: "has the HIGHEST
+ * chance of hitting your goal" ranges over the candidate set even though each
+ * option's own figure does not. The hero headline is therefore in scope.
+ */
+
+/**
+ * The derived scope of a run's comparison. `null` means there is nothing to
+ * say — see {@link deriveComparisonScope}.
+ */
+export interface ComparisonScope {
+  /** How many options were actually in the comparison. Always ≥ 1. */
+  readonly analysed: number
+  /** How many options the user has. Always > {@link analysed}. */
+  readonly total: number
+  /**
+   * Labels of the options left out, in the order they arrived. MAY BE SHORTER
+   * than `total - analysed`: an option with no usable label cannot be named,
+   * and inventing a name for it would be worse than reporting the count alone.
+   */
+  readonly excludedLabels: readonly string[]
+}
+
+/**
+ * Derive the comparison scope from the options array the results surfaces
+ * already hold.
+ *
+ * ⭐ NO SECOND PREDICATE. "Was this option in the comparison?" already has a
+ * canonical owner — `utils/notAnalysedOptions.ts`, surfaced onto
+ * `OptionResult.notAnalysed` by `useResultsSectionData` at the left join. This
+ * function COUNTS that flag; it does not re-decide it. A second spelling of
+ * "was it analysed" is how two surfaces end up contradicting each other about
+ * one option (CLAUDE.md trap 21), and this estate has paid for that shape
+ * repeatedly.
+ *
+ * Returns `null` — i.e. SAY NOTHING — in three states, all of them deliberate:
+ *
+ *   1. **Nothing excluded.** A "comparing 4 of 4" note on every result is
+ *      noise, and noise is how a real disclosure stops being read.
+ *   2. **Nothing analysed.** There are no comparative numbers on screen to
+ *      qualify; the surfaces render no ranks at all in this state. Qualifying
+ *      absent numbers would be a sentence about nothing.
+ *   3. **Empty input.** No run, no claim.
+ *
+ * It therefore fails toward saying less, and is a strict no-op on every run
+ * where the whole set was compared.
+ */
+export function deriveComparisonScope(
+  options: ReadonlyArray<{ label?: string | null; notAnalysed?: boolean }> | null | undefined,
+): ComparisonScope | null {
+  const all = options ?? []
+  if (all.length === 0) return null
+
+  const excluded = all.filter((o) => o.notAnalysed === true)
+  const analysed = all.length - excluded.length
+
+  // States 1 and 2 — see the header.
+  if (excluded.length === 0) return null
+  if (analysed === 0) return null
+
+  return {
+    analysed,
+    total: all.length,
+    excludedLabels: excluded
+      .map((o) => (typeof o.label === 'string' ? o.label.trim() : ''))
+      .filter((label) => label.length > 0),
+  }
+}
+
+/**
+ * Join labels in British house style — no serial comma.
+ *
+ * Not exported: it is an implementation detail of the register, and a second
+ * public list-joiner is exactly the kind of near-duplicate helper that drifts.
+ */
+function joinLabels(labels: readonly string[]): string {
+  if (labels.length === 1) return labels[0]
+  return `${labels.slice(0, -1).join(', ')} and ${labels[labels.length - 1]}`
+}
+
+/**
+ * The comparison-set register — ONE spelling of "these numbers compare N of
+ * your M options", for every surface that renders a comparative figure.
+ *
+ * The verb is `left out`, matching `notAnalysedCopy`'s shipped sentence
+ * (*"it was left out of the comparison"*) verbatim in its operative words, so
+ * the card-level disclosure and the headline-level one cannot read as two
+ * different events happening to one option.
+ *
+ * ⚠ NEUTRAL BY CONSTRUCTION. Nothing here may imply the excluded option was
+ * considered and lost — it was never scored. "Left out" states the fact and
+ * claims nothing about its merit. Do not add a comparative verb.
+ */
+export const COMPARISON_SCOPE_COPY = {
+  /**
+   * Compact scope phrase — no full stop, for a caption slot beside a chart
+   * heading where a sentence would crowd the number.
+   */
+  phrase: (scope: ComparisonScope): string =>
+    `Comparing ${scope.analysed} of your ${scope.total} options`,
+
+  /**
+   * Who is outside the set. Falls back to the COUNT when no excluded option
+   * carries a usable label — reporting "1 was left out" is honest; inventing
+   * "Untitled option" is not.
+   */
+  excludedClause: (scope: ComparisonScope): string => {
+    const missing = scope.total - scope.analysed
+    if (scope.excludedLabels.length === 0) {
+      return missing === 1 ? '1 was left out' : `${missing} were left out`
+    }
+    const verb = scope.excludedLabels.length === 1 ? 'was' : 'were'
+    return `${joinLabels(scope.excludedLabels)} ${verb} left out`
+  },
+
+  /**
+   * THE disclosure sentence — scope and names in one line, for rendering
+   * directly beneath a headline or a chart heading.
+   */
+  sentence: (scope: ComparisonScope): string =>
+    `${COMPARISON_SCOPE_COPY.phrase(scope)} — ${COMPARISON_SCOPE_COPY.excludedClause(scope)}.`,
+
+  /**
+   * The consequence, for surfaces with room for a second line. States what the
+   * ISL contract states: the comparative quantities range over the candidate
+   * set, and this run's candidate set is smaller than the user's option set.
+   *
+   * Deliberately says "ranks and comparative percentages" and NOT "the
+   * numbers" — the goal-fit figure on the same screen is subset-invariant and
+   * this sentence must not sweep it in.
+   */
+  detail: (scope: ComparisonScope): string =>
+    `Ranks and comparative percentages describe those ${scope.analysed} only.`,
+} as const


### PR DESCRIPTION
## What a user sees

A result computed over a **subset** of their options now says so, **next to the number**.

Comparative surfaces (hero headline, WinGauge comparative block, option cards):
> Comparing 3 of your 4 options — Hybrid Phased Approach was left out.
> Ranks and comparative percentages describe those 3 only.

WinGauge **goal block** — the neutral sentence only, no set-dependence claim:
> Comparing 3 of your 4 options — Hybrid Phased Approach was left out.

Nothing is suppressed, nothing is recomputed, and on a run where every option was compared **nothing at all is rendered**.

## Why this is live, not theoretical

CEE's admission gate already drops an option with nothing to submit and runs the rest. On the captured payloads one permitted run submits **three arms of four** with `79b5d7c0` "Hybrid Phased Approach" dropped. Subset results reach users today.

ISL is explicit that `win_probability`, `rank`, `expected_regret`, `decision_evpi`, `factor_evppi`, `recommendation_stability` and the flip thresholds are defined **over the candidate set** (`isl/src/utils/response_builder.py:58-76`). CEE's comment says admission *"changes WHICH options are compared, never what any number means"* — true of the metric's **definition**, false of its **value**.

## Canonical owner

**`src/components/results/utils/goalAnchorCopy.ts`** — the module that already owns `COMPARATIVE_COPY`/`GOAL_ANCHOR_COPY`, extended with `deriveComparisonScope` + `COMPARISON_SCOPE_COPY`. It stays a **leaf** (imports nothing), using the structural-parameter pattern its existing `runHasGoalNumbers` already uses.

**No second predicate was minted.** "Was this option in the comparison?" stays owned by `utils/notAnalysedOptions.ts` via `OptionResult.notAnalysed`; `deriveComparisonScope` **counts that flag**. The suppression rule is made **once**, in `ComparisonScopeNote`.

## ⭐ Set-dependent VALUE vs set-dependent ORDER — the `withDetail` split

The first revision exempted the WinGauge goal block entirely, on the grounds that `probability_of_goal` is subset-invariant. **That was half right, and review corrected it.**

- **Right, and kept:** the per-option goal *magnitudes* are invariant. Sweeping them into "these numbers are set-dependent" would be the untruth in reverse — so `COMPARISON_SCOPE_COPY.detail` stays **out** of that block.
- **Wrong:** the block is not free of candidate-set-dependent elements. `WinGauge.tsx` **sorts the goal rows descending by `goalProbability`** on every non-withheld run, and **order is a designation** — `utils/optionDisplayOrder.ts` (*"probability-descending order is not a neutral presentation choice, it is a CLAIM"*, ROADMAP 1.306), a rule **this same component already applies** to `designationsWithheld` a few lines above, and a shipped test name that says *"the goal leader is first"*.

`goalAnchorCopy.ts` already derived the governing rule — *a superlative over an invariant quantity IS comparative* — and the first revision applied it only where the superlative was spelled in **words**, not where it is encoded as **position**. A leader shown first among three, with nothing saying a fourth was never scored, is the same claim by another channel.

So the goal block now takes the **`sentence` alone**. Both halves are pinned: one mutant removes the mount, another adds `withDetail`, and each turns a test red.

The hero's `withDetail` was checked in the other direction and **holds** — `detail` names "ranks and comparative percentages", which does not sweep in the headline's goal magnitude.

## ⛔ Fixed: the note could render a raw node id to a user

`useResultsSectionData.ts` sets `label: node.data?.label || nodeId`, so an unlabelled option arrives carrying its **own id** as a well-formed string — a whitespace check cannot tell the two apart. Demonstrated output:

> Comparing 3 of your 4 options — **79b5d7c0** was left out.

This change did not create the leak (`NotAnalysedOptionCard` has it too) but **promoted it from a card low in the list to a sentence under the hero**. `deriveComparisonScope` now rejects a label equal to the option's own `id`, falling back to the count path that already existed and was already tested. A contrast-control mutant proves the guard is not over-broad.

## Transport

**None needed, none done.** The exclusion is not a wire field — it is derived at the join from the *omission* of an `option_probabilities` entry. Nothing to drop, no schema pin to check.

## Evidence

**RED-first**, at pristine, 5 named assertion failures (not collection errors) across the three original surfaces.

**Mutants** — throwaway worktree **outside** the repo root, isolation proven by **write test** (sentinel written, source SHA-256 unchanged, distinct inodes), HEAD-relative restores, applied-check scoped to `src/` = exactly 1, controls 0/clean at both ends, collected count asserted stable:

| # | Mutation | Result |
|---|---|---|
| M1 | delete the OptionCards mount | 4 failed |
| M2 | delete the WinGauge comparative mount | 1 failed |
| M3 | delete the hero mount | 2 failed |
| M4 | stop suppressing the whole-set case (noise) | 4 failed |
| M5 | move the note into the goal block (misplacement) | 2 failed |
| M6 | name EVERY option, not only excluded (identity) | 4 failed |
| M7 | delete the **goal-block** mount | 1 failed |
| M8 | give the goal-block note `withDetail` (over-claim) | 1 failed |
| M9 | drop the **bare-node-id** guard (id leak) | 1 failed |
| M10 | treat every label as a bare id (over-reject contrast) | 8 failed |
| M11 | delete the comparative mount (re-run) | 1 failed |
| — | leading + trailing CONTROL | 25 passed, tree clean |

**Vacuity fixed and demonstrated.** The goal-block pin previously wrapped its assertion in `if (goalBlock)`; review proved the contingency (drop one unpinned fixture property + the mount → mutant goes red→green). It now asserts the block **exists** first. Re-running the reviewer's exact two-part contingency against the corrected spec: **still RED, 2 tests failing** on the block's own absence.

**Gates** (derived at the rebased tip `baebb24a`):
- `pnpm typecheck` → **PASSED**. Declined its `--update-baseline` offer (2272→2263 is attribution churn; baseline files are outside this lane's scope).
- `npx eslint .` → **0 errors** (1176 pre-existing warnings)
- `npm run lint:hooks-ratchet` → **at baseline**. It caught a real bug: the container's `useMemo` initially sat *after* the empty-model early return.
- `src/components/results` → **241 files / 4189 tests passed**, exit 0. Own specs asserted collected **by name**: `comparisonScopeDisclosure.spec.tsx (21 tests)`, `comparisonScopeDisclosure.hero.spec.tsx (4 tests)`.

## Surfaces deliberately left — corrected claim

The earlier body implied the remaining surfaces were a simple mount away. **That is true of some and not of others**, verified at the bytes:

- **Zero second spellings of the exclusion sentence exist anywhere** — that part of the convergence claim holds.
- `canvas/nodes/DecisionNode.tsx` imports **no** copy register and composes its own unqualified leader claim (`{winnerLabel} leads in {n}% of scenarios`, ~:359). Converging it is a **register adoption**, not a mount.
- `v5/blocks/V5*` read the CEE block payload, where `OptionResult.notAnalysed` **does not exist** (`V5ComparisonBlock` maps `block.options` / `opt.win_probability`). They need a **fourth derivation**, not a mount.
- `canvas/compare-tab/*` diffs **run pairs**, not options (`deriveRunPairComparison.ts`) — out of scope for this disclosure, and outside this lane's boundary.

None of these are built here.

## Rebase

Rebased onto `staging` `448ccdbd` (which includes **#797**, merged first). **No conflicts** — `OptionCards.tsx` auto-merged, as the trial merge predicted.

## Files touched

```
src/components/results/ComparisonScopeNote.tsx                                  (new)
src/components/results/utils/goalAnchorCopy.ts                                  (canonical owner)
src/components/results/OptionCards.tsx
src/components/results/WinGauge.tsx
src/components/results/ResultsBody.tsx
src/components/results/analysis-hero/AnalysisHeroPanel.tsx
src/components/results/analysis-hero/AnalysisHeroContainer.tsx
src/components/results/__tests__/comparisonScopeDisclosure.spec.tsx             (new)
src/components/results/analysis-hero/__tests__/comparisonScopeDisclosure.hero.spec.tsx (new)
```

## Standing caveat

**13 of 14 checks are complete and green on `baebb24a`, including `Staging Gate` — the only required context.**

The one outstanding check is `Visual Regression (advisory)`, and its behaviour is worth stating precisely rather than summarising:

- On the **pre-rebase** head it completed and **failed**.
- On **this** head it has been `in_progress` for over an hour and has not completed — which is **exactly** what base `3f59325a` does (stuck `in_progress/null` since 15:44Z).
- Across recent **completed** staging commits it is a **standing red — 7 of 7**.

So it hangs on some heads and fails on others, and this change also legitimately alters rendered output on four surfaces. **That check cannot separate a standing failure from an intended render change, and is not evidence either way.** It is advisory, not a required context. I am neither claiming it green nor treating it as a finding.
