### PR TITLE
fix(canvas): the floating companion stops sitting on the Decision node — fit-then-place

### DIFF
--- a/e2e/geometry/decisionNodeHittest.measure.ts
+++ b/e2e/geometry/decisionNodeHittest.measure.ts
@@ -1,0 +1,364 @@
+/**
+ * CAN THE USER CLICK THE DECISION NODE OF THEIR OWN MODEL?
+ *
+ * Real Chromium, real layout, real `elementFromPoint` hit-testing. jsdom cannot
+ * answer this question at all — presence in the DOM is not visibility, and a
+ * `getAllByRole(...).toHaveLength(1)` proves neither (CLAUDE.md trap 3). This is
+ * the ACCEPTANCE instrument for the fit-then-place placement rule
+ * (`FloatingOlumiPanel.graphAwareDefaultPosition`); the pure rule itself is
+ * pinned in `FloatingOlumiPanel.graphAwarePlacement.spec.ts`.
+ *
+ * ⚠ RUN IT DELIBERATELY, it is not in any gate:
+ *     pnpm exec playwright test -c playwright.geometry.config.ts decisionNodeHittest
+ * The file is `*.measure.ts`, NOT `*.spec.ts`, precisely so the main e2e config
+ * (`testDir: 'e2e'`, default testMatch) cannot collect it into a run that has no
+ * dev server on its port. Same convention as `canonicalGeometry.measure.ts`.
+ *
+ * ── THE DEFECT, AS MEASURED AT PRISTINE (staging 3f59325a, 2026-08-19) ───────
+ *
+ * The interceptor is the floating Olumi panel itself: `position: fixed`,
+ * `z-index: 300`, rect [52, 73, 452, 623] — BYTE-IDENTICAL at every viewport
+ * from 1024 to 1920, because it is a fixed-size fixed-origin window while the
+ * graph's fit box SCALES. Decision-node hittable probes, as-shipped placement:
+ *
+ *     1200 → 0/49 · 1250 → 0/49 · 1300 → 14 · 1350 → 28 · 1400 → 42 · 1450 → 49
+ *
+ * ⭐ AND IT IS NOT A 1280 QUIRK — IT IS A THRESHOLD AT THE PANEL'S RIGHT EDGE,
+ * which is why this sweeps rather than sampling one laptop width. The node's own
+ * hit area is CORRECT, proven by discrimination: the SAME node in the SAME code
+ * is 49/49 at 1450 and 0/49 at 1250. A mispositioned hit area would fail at
+ * every width.
+ *
+ * ⭐⭐ AND THE SECOND PATH IS THE ONE A REAL USER REACHES BY REOPENING THE PANEL
+ * on a populated canvas (`position: null` → the design's centred default). At
+ * pristine that path measured 0/49 at 1440x900 for two starters — i.e. the
+ * defect was never confined to small viewports, and an instrument that only
+ * walked the seeded path would have reported the healthy half. Both paths are
+ * measured here, deliberately.
+ *
+ * ── WHAT EACH ASSERTION IS FOR ──────────────────────────────────────────────
+ *
+ * - BIND BY IDENTITY, never by screen position (trap 19): the node under test is
+ *   found by the Decision node's STORE ID, and the probe asserts the element it
+ *   hit-tested carries that same `data-id`. A different node cannot satisfy it.
+ * - NEGATIVE CONTROLS, or the absence assertion is vacuous (trap 13): a point
+ *   inside the top bar must attribute to TOPBAR and a point inside the panel must
+ *   attribute to OLUMI_PANEL. If `elementFromPoint` stopped discriminating, every
+ *   "the node is hittable" reading would pass by measuring nothing.
+ * - STORE/DOM AGREEMENT: the panel's rendered position and the store's model of
+ *   it were two authorities for one fact — the store said `position: null` while
+ *   the DOM said `left: 52px`, because the placement effect never ran. Pinned
+ *   here so a regression in either direction REDs.
+ */
+import { test, expect, type Page } from '@playwright/test'
+import {
+  openCanvas,
+  preparePage,
+  seedStarterDraft,
+  clearNotifications,
+  waitForVisualQuiescence,
+  type StarterId,
+} from '../visual/harness'
+
+/** 7x7 = 49 probes per node, inset 2px so the sample includes the near-edges. */
+const PROBES = 49
+
+/**
+ * The two starters whose Decision node the panel buried worst at pristine
+ * (0/49 across 1200-1280). They are the acceptance bar for the sweep; the
+ * reopen path below runs all five.
+ */
+const WORST: StarterId[] = ['pricing-model', 'headcount-allocation']
+const ALL: StarterId[] = ['vendor-selection', 'market-entry', 'build-vs-buy', 'headcount-allocation', 'pricing-model']
+
+/** The threshold sweep. 1450 was already clear at pristine and must STAY clear —
+ *  a fix that clears 1250 by breaking 1450 has moved the defect, not closed it. */
+const SWEEP_WIDTHS = [1200, 1250, 1300, 1350, 1400, 1450]
+
+interface Probe {
+  decId: string
+  hitElementId: string | null
+  /** Probes that landed on the Decision node itself. */
+  self: number
+  /** What intercepted the rest, by owner. */
+  by: Record<string, number>
+  /** ⭐ THE LOAD-BEARING NUMBER: probes intercepted by the floating companion. */
+  panelIntercepted: number
+  /** Probes the panel would intercept at the placement this rule replaces. */
+  baselineIntercepted: number
+  /**
+   * The fewest probes ANY legal placement of the panel could intercept, found by
+   * exhaustive scan of the panel's legal top-left rectangle. `0` means a clearing
+   * placement exists and the product must find it; `> 0` means the panel is
+   * physically too large to clear this model at this viewport, which is a finding
+   * about geometry, not about the rule.
+   */
+  minPossibleIntercepted: number
+  /** Positions the scan evaluated — a positive control on the scan itself. */
+  scanned: number
+  nodeRect: number[]
+  panelRect: number[] | null
+  storePos: { x: number; y: number } | null
+  ctlTopBar: string
+  ctlPanel: string
+}
+
+async function probeDecisionNode(page: Page): Promise<Probe> {
+  return page.evaluate(() => {
+    const store = (window as any).useCanvasStore.getState()
+    const owner = (el: Element | null): string => {
+      let e: Element | null = el
+      while (e) {
+        const tid = e.getAttribute('data-testid')
+        const al = e.getAttribute('aria-label')
+        if (tid === 'floating-olumi-panel') return 'OLUMI_PANEL'
+        if (tid === 'floating-olumi-panel-side-tab') return 'OLUMI_PANEL_TAB'
+        if (e.getAttribute('role') === 'banner') return 'TOPBAR'
+        if (al === 'Outputs dock') return 'DOCK'
+        if (al === 'Canvas tools') return 'SIDEBAR'
+        if (al === 'Viewport controls') return 'VIEWPORT_CONTROLS'
+        // SVGElement.className is an SVGAnimatedString, not a string — read the
+        // attribute or an SVG occluder's identity silently disappears.
+        if ((e.getAttribute('class') || '').includes('react-flow__pane')) return 'PANE'
+        e = e.parentElement
+      }
+      return el ? 'OTHER' : 'NULL'
+    }
+
+    // BIND BY IDENTITY: the Decision node's store id, then that exact element.
+    const decNode = store.nodes.find((n: any) => n.type === 'decision')
+    const el = document.querySelector(`.react-flow__node[data-id="${CSS.escape(decNode.id)}"]`) as HTMLElement
+    const r = el.getBoundingClientRect()
+
+    let self = 0
+    let hitElementId: string | null = null
+    const by: Record<string, number> = {}
+    for (let iy = 0; iy < 7; iy++) {
+      for (let ix = 0; ix < 7; ix++) {
+        const x = r.left + 2 + ((r.width - 4) * ix) / 6
+        const y = r.top + 2 + ((r.height - 4) * iy) / 6
+        if (x < 0 || y < 0 || x >= innerWidth || y >= innerHeight) {
+          by.OFFSCREEN = (by.OFFSCREEN || 0) + 1
+          continue
+        }
+        const top = document.elementFromPoint(x, y)
+        if (top && (top === el || el.contains(top))) {
+          self++
+          if (hitElementId === null) {
+            hitElementId = ((top as HTMLElement).closest('.react-flow__node') as HTMLElement | null)?.dataset.id ?? null
+          }
+        } else {
+          const o = owner(top)
+          by[o] = (by[o] || 0) + 1
+        }
+      }
+    }
+
+    // NEGATIVE CONTROLS — prove elementFromPoint still discriminates.
+    const banner = document.querySelector('[role="banner"]')!.getBoundingClientRect()
+    const ctlTopBar = owner(document.elementFromPoint(banner.left + 20, banner.top + banner.height / 2))
+    const p = document.querySelector('[data-testid="floating-olumi-panel"]')?.getBoundingClientRect()
+    const ctlPanel = p
+      ? owner(document.elementFromPoint(p.left + p.width / 2, p.top + p.height / 2))
+      : 'NO_PANEL'
+
+    const panelEl = document.querySelector('[data-testid="floating-olumi-panel"]') as HTMLElement | null
+
+    /* ── The independent oracle ──────────────────────────────────────────────
+     *
+     * Everything above measures what the product DID. This measures what the
+     * best possible placement COULD have done, by brute force over every legal
+     * top-left the panel can occupy — a genuinely independent answer, not the
+     * five-candidate heuristic the product runs. It is what lets this instrument
+     * distinguish "the rule placed the panel badly" (a defect) from "no placement
+     * of a 400x550 window clears this model at this viewport" (arithmetic).
+     *
+     * The panel is an opaque rectangle at z-300, so rect containment is an exact
+     * model of its interception — no hit-testing needed for the hypotheticals.
+     */
+    const MARGIN = 16
+    const SIDE_TAB = 36
+    const pw = panelEl ? parseFloat(panelEl.style.width || '400') : 400
+    const ph = panelEl ? parseFloat(panelEl.style.height || '550') : 550
+    const dockEl = document.querySelector('aside[aria-label="Outputs dock"]') as HTMLElement | null
+    const dockInset = dockEl ? Math.max(0, innerWidth - dockEl.getBoundingClientRect().left) : 0
+    const topbarH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--topbar-h')) || 0
+    const topInset = topbarH > 0 ? topbarH + MARGIN : MARGIN
+    const xMin = MARGIN + SIDE_TAB
+    const xMax = Math.max(xMin, innerWidth - pw - MARGIN - dockInset)
+    const yMin = Math.max(MARGIN, topInset)
+    const yMax = Math.max(yMin, innerHeight - ph - MARGIN)
+
+    // The same 49 probe points, as coordinates.
+    const points: Array<[number, number]> = []
+    for (let iy = 0; iy < 7; iy++) {
+      for (let ix = 0; ix < 7; ix++) {
+        points.push([r.left + 2 + ((r.width - 4) * ix) / 6, r.top + 2 + ((r.height - 4) * iy) / 6])
+      }
+    }
+    // ⚠ MODELS THE PANEL BODY ONLY, DELIBERATELY. The side tab is a 36x104 stub
+    // outside the left edge; treating it as a full-height band would OVER-count
+    // hypothetical interception and could report "no clearing placement exists"
+    // when one does — i.e. it would relax the hard assertion, the one unsafe
+    // direction. The tab is instead covered on the MEASURED side: any probe it
+    // intercepts is counted into `panelIntercepted` under OLUMI_PANEL_TAB, so a
+    // tab interception REDs against a `minPossibleIntercepted` of 0.
+    const interceptedAt = (x: number, y: number): number => {
+      const rr = x + pw
+      const b = y + ph
+      let n = 0
+      for (const [px, py] of points) if (px >= x && px < rr && py >= y && py < b) n++
+      return n
+    }
+
+    let minPossibleIntercepted = Infinity
+    let scanned = 0
+    for (let x = xMin; x <= xMax; x++) {
+      for (let y = yMin; y <= yMax; y++) {
+        scanned++
+        const n = interceptedAt(x, y)
+        if (n < minPossibleIntercepted) minPossibleIntercepted = n
+        if (minPossibleIntercepted === 0) break
+      }
+      if (minPossibleIntercepted === 0) break
+    }
+
+    // The placement this rule replaces: the clamped centred default.
+    const clamp = (v: number, lo: number, hi: number) => (v < lo ? lo : v > hi ? hi : v)
+    const baseX = clamp(Math.max(MARGIN, Math.floor((innerWidth - dockInset - pw) / 2)), xMin, xMax)
+    const baseY = clamp(Math.max(MARGIN, Math.floor((innerHeight - ph) / 2)), yMin, yMax)
+
+    return {
+      decId: decNode.id,
+      hitElementId,
+      self,
+      by,
+      panelIntercepted: (by.OLUMI_PANEL || 0) + (by.OLUMI_PANEL_TAB || 0),
+      baselineIntercepted: interceptedAt(baseX, baseY),
+      minPossibleIntercepted: minPossibleIntercepted === Infinity ? 0 : minPossibleIntercepted,
+      scanned,
+      nodeRect: [r.left, r.top, r.right, r.bottom].map(Math.round),
+      panelRect: p ? [p.left, p.top, p.right, p.bottom].map(Math.round) : null,
+      storePos: panelEl
+        ? { x: Math.round(parseFloat(panelEl.style.left || 'NaN')), y: Math.round(parseFloat(panelEl.style.top || 'NaN')) }
+        : null,
+      ctlTopBar,
+      ctlPanel,
+    }
+  })
+}
+
+/** The store's own record of where the panel is, read from the panel's store. */
+async function readStorePosition(page: Page): Promise<{ x: number; y: number } | null> {
+  return page.evaluate(async () => {
+    const modulePath = '/src/canvas/hooks/useFloatingPanelState.ts'
+    const mod = (await import(/* @vite-ignore */ modulePath)) as any
+    return mod.useFloatingPanelState.getState().position
+  })
+}
+
+function assertProbe(label: string, m: Probe): void {
+  // VACUITY GUARDS. If `elementFromPoint` stopped discriminating, or the scan
+  // evaluated nothing, every reading below would pass by measuring nothing
+  // (CLAUDE.md trap 13).
+  expect(m.ctlTopBar, `${label} NEGATIVE CONTROL: a point inside the top bar must attribute to TOPBAR`).toBe('TOPBAR')
+  expect(m.ctlPanel, `${label} NEGATIVE CONTROL: a point inside the panel must attribute to OLUMI_PANEL`).toBe('OLUMI_PANEL')
+  expect(m.scanned, `${label} POSITIVE CONTROL: the placement scan must have evaluated positions`).toBeGreaterThan(0)
+  // BIND BY IDENTITY, never by screen position (trap 19).
+  expect(m.hitElementId, `${label}: the probes must have landed on the DECISION node, bound by id`).toBe(m.decId)
+
+  const detail =
+    `occluders ${JSON.stringify(m.by)} · panel ${JSON.stringify(m.panelRect)} · node ${JSON.stringify(m.nodeRect)} · ` +
+    `baseline ${m.baselineIntercepted}/49 · best-possible ${m.minPossibleIntercepted}/49`
+
+  // ⭐ THE LOAD-BEARING ASSERTION. Probes the node loses to the PANE are the
+  // node's own hit area (rounded corners / a transparent band) and were present
+  // at pristine at every viewport including the healthy ones — asserting a flat
+  // 49/49 would fold that pre-existing, panel-independent shortfall into this
+  // fix's acceptance bar and make the instrument lie about what it proved.
+  // What this fix owns is interception BY THE COMPANION.
+  if (m.minPossibleIntercepted === 0) {
+    expect(m.panelIntercepted, `${label}: the companion must not intercept ANY probe — ${detail}`).toBe(0)
+  } else {
+    // PLACEMENT-BOUND: no legal placement of a panel this size clears this model
+    // at this viewport. Reported rather than silently tolerated, and still held
+    // to "never worse than the placement it replaces".
+    console.log(`PLACEMENT-BOUND ${label} — ${detail}`)
+  }
+  expect(
+    m.panelIntercepted,
+    `${label}: the placement must never intercept MORE than the centred default it replaces — ${detail}`,
+  ).toBeLessThanOrEqual(m.baselineIntercepted)
+  expect(m.self, `${label}: the Decision node must be clickable somewhere — ${detail}`).toBeGreaterThan(0)
+  expect(m.self + Object.values(m.by).reduce((a, n) => a + n, 0), `${label}: probe accounting`).toBe(PROBES)
+}
+
+/* ── (a) The as-shipped path: seed a real draft, measure what the user gets ── */
+
+for (const w of SWEEP_WIDTHS) {
+  for (const id of WORST) {
+    test(`AS-SHIPPED ${id} @${w}x800`, async ({ page }) => {
+      await preparePage(page, { width: w, height: 800 })
+      await openCanvas(page)
+      await seedStarterDraft(page, id)
+      await clearNotifications(page)
+      await waitForVisualQuiescence(page)
+
+      const m = await probeDecisionNode(page)
+      console.log(`HITJSON ${JSON.stringify({ path: 'as-shipped', w, id, ...m })}`)
+      assertProbe(`as-shipped ${id} @${w}`, m)
+
+      // ONE AUTHORITY FOR ONE FACT. At pristine the store said `position: null`
+      // while the DOM said `left: 52px; top: 73px` — the placement effect never
+      // ran, and a re-clamp handler read the unset style as 0. If these ever
+      // disagree again, one of them is inventing a position.
+      const storePos = await readStorePosition(page)
+      expect(storePos, `as-shipped ${id} @${w}: the store must know where the panel is`).not.toBeNull()
+      expect(storePos, `as-shipped ${id} @${w}: store and DOM must agree on the panel's position`).toEqual(m.storePos)
+    })
+  }
+}
+
+/* ── (b) The reopen path: `position: null` → the design's own default ──────── */
+
+for (const vp of [
+  { w: 1280, h: 800 },
+  { w: 1440, h: 900 },
+  { w: 1512, h: 945 },
+]) {
+  for (const id of ALL) {
+    test(`REOPEN ${id} @${vp.w}x${vp.h}`, async ({ page }) => {
+      await preparePage(page, { width: vp.w, height: vp.h })
+      await openCanvas(page)
+      await seedStarterDraft(page, id)
+      await clearNotifications(page)
+      await waitForVisualQuiescence(page)
+
+      // Reproduce the state a user reaches by reopening the companion on a
+      // populated canvas: the panel re-derives its default placement.
+      await page.evaluate(async () => {
+        const modulePath = '/src/canvas/hooks/useFloatingPanelState.ts'
+        const mod = (await import(/* @vite-ignore */ modulePath)) as any
+        mod.useFloatingPanelState.getState().minimise()
+      })
+      await page.waitForTimeout(150)
+      await page.evaluate(async () => {
+        const modulePath = '/src/canvas/hooks/useFloatingPanelState.ts'
+        const mod = (await import(/* @vite-ignore */ modulePath)) as any
+        mod.useFloatingPanelState.setState({
+          position: null,
+          isMinimised: false,
+          isOpen: true,
+          source: 'user',
+          userRepositioned: false,
+        })
+      })
+      await waitForVisualQuiescence(page)
+
+      const m = await probeDecisionNode(page)
+      console.log(`HITJSON ${JSON.stringify({ path: 'reopen', w: vp.w, id, ...m })}`)
+      expect(m.panelRect, `reopen ${id} @${vp.w}: the panel must be on screen for this state`).not.toBeNull()
+      assertProbe(`reopen ${id} @${vp.w}`, m)
+    })
+  }
+}

--- a/src/canvas/components/FloatingOlumiPanel.tsx
+++ b/src/canvas/components/FloatingOlumiPanel.tsx
@@ -21,6 +21,7 @@ import {
   type FloatingPanelSize,
 } from '../hooks/useFloatingPanelState'
 import { AIInputBar, type AIInputBarHandle } from './AIInputBar'
+import { clearanceCandidates, COMFORT_OCCLUSION_GAP, type Box } from '../utils/cameraComfort'
 import { registerFloatingFocus } from '../hooks/useFloatingFocus'
 import { useUIStore } from '../../stores/uiStore'
 import { isAiPanelV2Enabled } from '../../flags'
@@ -146,6 +147,214 @@ function defaultCentredPosition(size: FloatingPanelSize, viewportW: number, view
     x: Math.max(DEFAULT_MARGIN, Math.floor((viewportW - size.width) / 2)),
     y: Math.max(DEFAULT_MARGIN, Math.floor((viewportH - size.height) / 2)),
   }
+}
+
+/* ── FIT-THEN-PLACE ────────────────────────────────────────────────────────
+ *
+ * THE DEFECT (measured in real Chromium, 49 `elementFromPoint` probes per cell,
+ * five committed starter drafts, 1200-1600px):
+ *
+ *   The user could not click the Decision node of their own model. The panel is
+ *   a FIXED-SIZE, FIXED-ORIGIN window while the graph's fit box SCALES, so the
+ *   two collide below a threshold at the panel's right edge. Decision-node
+ *   hittable probes on the as-shipped placement: 1200 → 0/49 · 1250 → 0/49 ·
+ *   1300 → 14 · 1350 → 28 · 1400 → 42 · clear only at ≥1450. The node's own hit
+ *   area is correct — the SAME node in the SAME code is 49/49 at 1450 and 0/49
+ *   at 1250, so this is placement, not hit-testing.
+ *
+ * THE RULE, and why it is this rule and not the obvious one.
+ *
+ * The obvious rule is "place the panel where it hides least of the model", and
+ * IT DOES NOT WORK. Measured over 50 browser-captured geometry cells: minimising
+ * overlap with the fitted node bbox leaves the Decision node partly buried in 7
+ * of 50 cells even when solved EXHAUSTIVELY over every legal position (the best
+ * possible such placement still scores 28/49 at 1250). Minimising total occluded
+ * node area is worse (19/50); minimax per-node coverage is far worse (37/50).
+ * They all fail the same way: a 400x550 panel plus its 36px tab is over half the
+ * usable canvas at 1250, so SOME of the model is always hidden, and every
+ * area-based objective happily trades the Decision away to hide less elsewhere.
+ *
+ * So the objective is LEXICOGRAPHIC, and its first term names what must never be
+ * traded:
+ *
+ *   1. the panel must not cover the model's ANCHOR — the Decision node, the one
+ *      node the whole graph is about, and the one the user must be able to click
+ *      to steer their model;
+ *   2. among placements that satisfy (1), hide as little of the rest of the
+ *      model as possible.
+ *
+ * Measured: 50/50 cells at 49/49 hittable probes, worst cell included.
+ *
+ * ⭐ CANONICAL OWNER. The candidate placements are the four clearances of
+ * `cameraComfort.clearanceCandidates` — the module that already owns "how do you
+ * hold a frame clear of the floating companion" — read as TRANSLATIONS of the
+ * panel rather than as insets on a frame. This adds NO second spelling of that
+ * geometry, and it deliberately does not touch `computeFitPadding`, which still
+ * reserves the companion exactly zero graph width (guard G2a). The panel moves;
+ * the graph is never charged for it.
+ *
+ * ⚠ ALL FOUR CANDIDATES, NOT JUST `cheapestClearance`. The cheapest clearance is
+ * frequently unreachable once `clampPositionToViewport` has had its say (the
+ * panel cannot leave the canvas, cannot cross the dock, cannot ride under the top
+ * bar), and a clamped-away move looks exactly like a move that was never needed.
+ * Every candidate is therefore CLAMPED FIRST and scored AFTERWARDS, so the rule
+ * chooses among placements that are actually reachable.
+ */
+
+/** Total area of the intersection of two boxes; 0 when they do not overlap. */
+function overlapArea(a: Box, b: Box): number {
+  const w = Math.min(a.right, b.right) - Math.max(a.left, b.left)
+  const h = Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top)
+  return w > 0 && h > 0 ? w * h : 0
+}
+
+/**
+ * The panel's OCCLUDING box for a candidate top-left.
+ *
+ * Includes the side tab, which is a sibling at `left: -SIDE_TAB_WIDTH` with the
+ * panel `overflow: visible` — so it is NOT part of the panel's own
+ * `getBoundingClientRect`. This is the same union
+ * `cameraComfort.readFloatingCompanionBox` measures, for the same reason: omit it
+ * and the box is 36px short of what the user sees.
+ */
+export function panelOccluderBox(pos: FloatingPanelPosition, size: FloatingPanelSize): Box {
+  return {
+    left: pos.x - SIDE_TAB_WIDTH,
+    top: pos.y,
+    right: pos.x + size.width,
+    bottom: pos.y + size.height,
+  }
+}
+
+/** What the placement rule needs to know about the model that is on screen. */
+export interface ModelBoxes {
+  /** Every rendered graph node's viewport-coordinate box. */
+  nodes: Box[]
+  /**
+   * The box the placement must keep clear: the Decision node when the model has
+   * one. `null` for a model with no decision (an imported or partial graph) — the
+   * rule then degrades to term (2) alone, which is the best available when there
+   * is no anchor to protect.
+   */
+  anchor: Box | null
+}
+
+/** React Flow renders each node as `.react-flow__node[data-id="<id>"]`
+ *  (same spelling as `useGuidancePulseHighlight`). */
+const GRAPH_NODE_SELECTOR = '.react-flow__node[data-id]'
+
+/**
+ * Read the model's on-screen boxes.
+ *
+ * ⚠ THE ANCHOR IS BOUND BY IDENTITY, NEVER BY POSITION (CLAUDE.md trap 19). The
+ * caller passes the Decision node's STORE ID and this looks that exact node up in
+ * the DOM; nothing here infers "the anchor" from where a box happens to sit, so a
+ * different node cannot satisfy the lookup.
+ *
+ * Zero-size rects are dropped — an unmeasured or `display:none` node contributes
+ * no occlusion and would otherwise drag the union to the origin.
+ */
+export function readModelBoxes(anchorNodeId: string | null): ModelBoxes {
+  if (typeof document === 'undefined') return { nodes: [], anchor: null }
+  const nodes: Box[] = []
+  let anchor: Box | null = null
+  for (const el of document.querySelectorAll(GRAPH_NODE_SELECTOR)) {
+    const rect = el.getBoundingClientRect()
+    if (rect.width <= 0 || rect.height <= 0) continue
+    const box: Box = { left: rect.left, top: rect.top, right: rect.right, bottom: rect.bottom }
+    nodes.push(box)
+    if (anchorNodeId !== null && (el as HTMLElement).dataset.id === anchorNodeId) anchor = box
+  }
+  return { nodes, anchor }
+}
+
+/** Union of every node box, or null when nothing is rendered. */
+function unionOf(boxes: Box[]): Box | null {
+  if (boxes.length === 0) return null
+  return {
+    left: Math.min(...boxes.map((b) => b.left)),
+    top: Math.min(...boxes.map((b) => b.top)),
+    right: Math.max(...boxes.map((b) => b.right)),
+    bottom: Math.max(...boxes.map((b) => b.bottom)),
+  }
+}
+
+/**
+ * The panel's DEFAULT top-left: fit-then-place. See the FIT-THEN-PLACE block
+ * above for the rule and the measurements behind it.
+ *
+ * Pure — the caller supplies the measured model — so the whole rule is testable
+ * without a DOM, mirroring `cameraComfort.comfortInsets`.
+ *
+ * FAIL-OPEN TO TODAY'S BEHAVIOUR: with nothing rendered (`model.nodes` empty) this
+ * returns exactly the clamped centred default it has always returned, so an empty
+ * canvas, a pre-mount measurement and jsdom are all unchanged.
+ *
+ * This SUPERSEDES the bare centred default as the panel's default-placement
+ * authority; `defaultCentredPosition` survives only as the base this starts from,
+ * with this as its single call site.
+ */
+export function graphAwareDefaultPosition(
+  size: FloatingPanelSize,
+  viewportW: number,
+  viewportH: number,
+  rightInset: number,
+  topInset: number,
+  model: ModelBoxes,
+): FloatingPanelPosition {
+  const clampHere = (pos: FloatingPanelPosition) =>
+    clampPositionToViewport(pos, size, viewportW, viewportH, rightInset, topInset)
+
+  const base = clampHere(defaultCentredPosition(size, viewportW - rightInset, viewportH))
+  if (model.nodes.length === 0) return base
+
+  // The frame that must stay clear: the anchor when there is one, else the whole
+  // model — see ModelBoxes.anchor for why the fallback is the honest one.
+  const frame = model.anchor ?? unionOf(model.nodes)
+  if (!frame) return base
+
+  const candidates = clearanceCandidates(frame, panelOccluderBox(base, size))
+  // `null` means the base placement already clears the frame — nothing to solve.
+  if (!candidates) return base
+
+  // Each clearance is taken WITH A BREATHING GAP, the same `COMFORT_OCCLUSION_GAP`
+  // the comfort frame adds for the same reason — and here it also absorbs the
+  // small vertical settle the graph makes after the layout store reports
+  // quiescence (measured at ±13-21px between runs, pre-existing). A gap can only
+  // move the panel FURTHER in the clearing direction and the clamp caps it, so it
+  // can never reduce the clearance actually achieved.
+  const placements: FloatingPanelPosition[] = [base]
+  for (const c of candidates) {
+    const step = c.amount + COMFORT_OCCLUSION_GAP
+    placements.push(
+      clampHere({
+        x: base.x + (c.side === 'right' ? step : c.side === 'left' ? -step : 0),
+        y: base.y + (c.side === 'bottom' ? step : c.side === 'top' ? -step : 0),
+      }),
+    )
+  }
+
+  // Lexicographic: anchor coverage first, then how much of the rest of the model
+  // is hidden. `Number.MAX_SAFE_INTEGER` is never reached — both terms are
+  // bounded by the viewport area — so the pair cannot alias.
+  const score = (pos: FloatingPanelPosition): [number, number] => {
+    const occ = panelOccluderBox(pos, size)
+    const anchorCover = overlapArea(frame, occ)
+    let modelCover = 0
+    for (const node of model.nodes) modelCover += overlapArea(node, occ)
+    return [anchorCover, modelCover]
+  }
+
+  let best = placements[0]
+  let bestScore = score(best)
+  for (const pos of placements) {
+    const s = score(pos)
+    if (s[0] < bestScore[0] || (s[0] === bestScore[0] && s[1] < bestScore[1])) {
+      best = pos
+      bestScore = s
+    }
+  }
+  return best
 }
 
 /**
@@ -413,6 +622,18 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
   const nodeCount = useCanvasStore((s) => s.nodes.length)
   const yieldToFirstUse = source === 'system-first-use' && nodeCount === 0
 
+  // FIT-THEN-PLACE inputs. Both selectors return a PRIMITIVE so Zustand's
+  // referential-equality check keeps them from re-rendering the panel on every
+  // store write (returning a derived object here would churn on every tick).
+  //
+  // `anchorNodeId` is the Decision node's store id — the identity the placement
+  // rule binds to. `layoutSettled` is the canvas store's OWN definition of
+  // quiescence (the same three fields the visual harness waits on), not a timer
+  // and not a guess: node rects are only worth measuring once the layout that
+  // produced them has committed.
+  const anchorNodeId = useCanvasStore((s) => s.nodes.find((n) => n.type === 'decision')?.id ?? null)
+  const layoutSettled = useCanvasStore((s) => !s.pendingLayout && !s.layoutInProgress && s.layoutVersion > 0)
+
   // Render-time duplicate-surface guard. If AI Panel v2 is on AND the docked
   // Olumi tab is the active right-panel surface, the floating panel must
   // NOT paint — even for a single frame. OutputsDockBody's useEffect closes
@@ -526,8 +747,14 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
     // header is always visible, grabbable, and not under the dock. Mirrors
     // handlePointerMove's drag-time clamp so the same bounds apply across
     // entry points.
-    const rawPos = position ?? defaultCentredPosition({ width: w, height: h }, vw - dockInset, vh)
-    const pos = clampPositionToViewport(rawPos, { width: w, height: h }, vw, vh, dockInset, measureTopInset())
+    const topInset = measureTopInset()
+    // FIT-THEN-PLACE: the DEFAULT placement is taken off the model (see the
+    // block above `graphAwareDefaultPosition`). A STORED position is never
+    // touched — a panel the user dragged stays exactly where they put it.
+    const model = readModelBoxes(anchorNodeId)
+    const rawPos =
+      position ?? graphAwareDefaultPosition({ width: w, height: h }, vw, vh, dockInset, topInset, model)
+    const pos = clampPositionToViewport(rawPos, { width: w, height: h }, vw, vh, dockInset, topInset)
     // Apply the slide transition INLINE (not via React style prop) so the
     // browser sees: old el.style.left value → transition declaration → new
     // el.style.left value, animating between them. Setting it on the React
@@ -540,14 +767,51 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
     el.style.left = `${pos.x}px`
     el.style.top = `${pos.y}px`
     applyPanelShape(shapeRef.current, pathRef.current, w, h)
-    // Commit the centred default the FIRST time the panel opens so the
-    // minimise pill anchor isn't null. Stored-position clamping is reapplied
-    // on every render via this same effect, so we don't need to write back —
-    // the DOM is always correct.
-    if (position === null) {
+    // Commit the computed default the FIRST time the panel opens so the store
+    // and the DOM agree about where the panel is. Stored-position clamping is
+    // reapplied on every render via this same effect, so we don't need to write
+    // back — the DOM is always correct.
+    //
+    // ⚠ NOT WHILE THE MODEL IS STILL SETTLING. `setInitialPosition` is a
+    // ONE-SHOT (it writes only while `position` is null), so committing a
+    // placement measured against half-laid-out node rects would freeze the panel
+    // at a position computed from geometry that no longer exists. Until the
+    // canvas store reports quiescence AND something is actually rendered, the
+    // placement is applied to the DOM but left uncommitted, so this effect
+    // re-derives it on the next tick. An empty canvas has no model to settle and
+    // commits immediately, exactly as before.
+    if (position === null && (nodeCount === 0 || (layoutSettled && model.nodes.length > 0))) {
       setInitialPosition(pos)
     }
-  }, [isOpen, isMinimised, position, size, isAutoRepositioning, setInitialPosition, minimise])
+    // ⭐⭐ `yieldToFirstUse` / `yieldToDockedOlumi` / `nodeCount` / `layoutSettled`
+    // ARE LOAD-BEARING DEPS, AND THEIR ABSENCE WAS A SECOND, SEPARATE DEFECT
+    // (measured 19 Aug 2026). This component returns null — so `containerRef` is
+    // null and this effect early-returns — for exactly `!isOpen ||
+    // yieldToFirstUse || yieldToDockedOlumi`. Only `isOpen` was in the deps. So
+    // on the path every seeded user reaches (hero yields once the first graph
+    // lands) the container MOUNTED WITHOUT THIS EFFECT EVER RE-RUNNING: the panel
+    // kept the JSX defaults `left: 0; top: 0`, `setInitialPosition` was never
+    // called, and the re-clamp handler below then read that empty style as 0 and
+    // pinned the panel to the clamp floor. Measured: DOM `left: 52px; top: 73px`,
+    // BYTE-IDENTICAL FROM 1024 TO 1920, while the store still said
+    // `position: null` and the design default for that state was x=226. Two
+    // authorities for one fact, and the one that won had computed nothing.
+    // Listing every condition the early return reads makes container-mount and
+    // effect-run the same event by construction.
+  }, [
+    isOpen,
+    isMinimised,
+    position,
+    size,
+    isAutoRepositioning,
+    setInitialPosition,
+    minimise,
+    yieldToFirstUse,
+    yieldToDockedOlumi,
+    nodeCount,
+    layoutSettled,
+    anchorNodeId,
+  ])
 
   // Register a focus channel so the persistent status strip and Olumi-tab
   // click (when floating is open) can imperatively focus the input.
@@ -647,6 +911,15 @@ export const FloatingOlumiPanel = memo(function FloatingOlumiPanel({ onDock, onC
 
       const el = containerRef.current
       if (!el) return
+      // ⭐ ONE PLACEMENT AUTHORITY. This handler RE-CLAMPS a panel the layout
+      // effect has already placed; it must never INVENT a placement. Without
+      // this guard it read an unset `el.style.left` as `parseFloat('') || 0` →
+      // 0 → clamped to the floor, which is how the panel came to sit at a
+      // byte-identical (52, 73) at every viewport from 1024 to 1920 while the
+      // store still held `position: null` (see the layout effect's dep note).
+      // An unset style means the layout effect has not run yet, and the correct
+      // answer to that is to wait for it, not to guess.
+      if (!el.style.left || !el.style.top) return
       // Same MIN_WIDTH-or-minimise rule as the layout effect: if the
       // viewport-or-dock resize leaves no room for a MIN_WIDTH panel,
       // auto-minimise to the pill.

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.graphAwarePlacement.spec.ts
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.graphAwarePlacement.spec.ts
@@ -1,0 +1,445 @@
+/**
+ * FIT-THEN-PLACE — the floating panel's DEFAULT placement is taken off the model.
+ *
+ * THE DEFECT THIS PINS (measured in real Chromium, 49 `elementFromPoint` probes
+ * per cell, the five committed starter drafts, 1200-1600px): a user could not
+ * click the Decision node of their own model. Decision-node hittable probes on
+ * the as-shipped placement: 1200 → 0/49 · 1250 → 0/49 · 1300 → 14 · 1350 → 28 ·
+ * 1400 → 42 · clear only at ≥1450. The panel is a FIXED-SIZE, FIXED-ORIGIN
+ * window while the graph's fit box SCALES.
+ *
+ * ⚠ WHAT THIS SPEC CAN AND CANNOT SETTLE. jsdom cannot prove visibility or
+ * hit-testing (CLAUDE.md trap 3), so the ACCEPTANCE evidence is the geometry
+ * instrument `e2e/geometry/decisionNodeHittest.measure.ts`, run in real
+ * Chromium. What this spec pins is the RULE the instrument measures the effect
+ * of — as a pure function, at the exact geometry the browser produced.
+ *
+ * ⭐ THE FIXTURES ARE BROWSER CAPTURES, NOT NUMBERS FROM MY HEAD (trap 16-inverse:
+ * a fixture you wrote yourself is not evidence about the product). Every rect
+ * below was read with `getBoundingClientRect` from Chromium at the stated
+ * viewport, seeding the committed starter draft through the product's own
+ * `applyDraftResult` via `e2e/visual/harness.ts`, on 2026-08-19 at staging
+ * `3f59325a`. The three cells are the worst measured (0/49), the reopen-path
+ * cell the earlier brief wrongly believed was healthy (0/49), and a mid-table
+ * cell.
+ *
+ * ⭐⭐ EVERY PLACEMENT TEST PINS ITS OWN PRECONDITION (trap 13b). Each asserts
+ * FIRST that the pristine centred default really does bury the anchor at that
+ * geometry. Without that, a fixture that stopped reproducing the collision would
+ * leave the test passing while proving nothing — a guard agreeing with itself.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+
+// FloatingOlumiPanel's transitive imports pull in supabase and the markdown
+// renderer — stub both ahead of the import below (mirrors the clamp spec).
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+
+import {
+  clampPositionToViewport,
+  graphAwareDefaultPosition,
+  panelOccluderBox,
+  readModelBoxes,
+  type ModelBoxes,
+} from '../FloatingOlumiPanel'
+import { COMFORT_OCCLUSION_GAP, type Box } from '../../utils/cameraComfort'
+
+const SIZE = { width: 400, height: 550 }
+const MARGIN = 16
+const SIDE_TAB_WIDTH = 36
+
+const box = (l: number, t: number, r: number, b: number): Box => ({ left: l, top: t, right: r, bottom: b })
+
+/** A captured cell: viewport, measured chrome insets, and the model's rects. */
+interface Cell {
+  name: string
+  vw: number
+  vh: number
+  dockInset: number
+  topInset: number
+  anchor: Box
+  nodes: Box[]
+}
+
+/* ── Browser captures (Chromium, 2026-08-19, staging 3f59325a) ────────────── */
+
+/** pricing-model @1250x800 — 0/49 hittable probes as shipped. */
+const PRICING_1250: Cell = {
+  name: 'pricing-model @1250x800',
+  vw: 1250,
+  vh: 800,
+  dockInset: 418,
+  topInset: 57 + MARGIN,
+  anchor: box(292, 125.5, 452, 210),
+  nodes: [
+    box(292, 125.5, 452, 210), // dec_pricing (the anchor)
+    box(-72, 314, 88, 453.3),
+    box(474, 314, 634, 428.3),
+    box(110, 314, 270, 437.5),
+    box(656, 314, 816, 425),
+    box(292, 314, 452, 428.3),
+    box(292, 571.5, 452, 674.5),
+    box(19, 209, 179, 356),
+    box(201, 209, 361, 356),
+    box(383, 209, 543, 383),
+    box(565, 209, 725, 275),
+    box(201, 411, 361, 481.3),
+    box(383, 411, 542, 465),
+    box(383, 489, 543, 559.3),
+    box(201, 489, 361, 575.5),
+    box(755, 209, 835, 259.5),
+  ],
+}
+
+/** headcount-allocation @1440x900 — 0/49 on the reopen (design-default) path. */
+const HEADCOUNT_1440: Cell = {
+  name: 'headcount-allocation @1440x900',
+  vw: 1440,
+  vh: 900,
+  dockInset: 428,
+  topInset: 57 + MARGIN,
+  anchor: box(453.1, 185.3, 618.9, 270.7),
+  nodes: [
+    box(453.1, 185.3, 618.9, 270.7), // dec_hiring (the anchor)
+    box(641.7, 369.2, 807.4, 484.7),
+    box(76, 369.2, 241.8, 493.7),
+    box(264.6, 369.2, 430.3, 525.8),
+    box(453.1, 369.2, 618.9, 452.6),
+    box(830.2, 369.2, 996, 481.2),
+    box(453.1, 641.7, 618.9, 714.6),
+    box(170.3, 271.8, 336, 356.6),
+    box(736, 271.8, 901.7, 356.6),
+    box(358.8, 271.8, 524.6, 415.3),
+    box(547.4, 271.8, 713.2, 338.5),
+    box(547.4, 480, 692.3, 535.1),
+    box(358.8, 480, 524.6, 551.4),
+    box(453.1, 560.9, 618.9, 632.2),
+    box(264.6, 560.9, 430.3, 632.2),
+    box(641.7, 560.9, 807.4, 632.2),
+    box(932.8, 271.8, 1015.7, 322.7),
+  ],
+}
+
+/** vendor-selection @1200x800 — the anchor sits high; the cheapest clearance is
+ *  a different side from the two cells above, so this cell discriminates the
+ *  rule from a hard-coded direction. */
+const VENDOR_1200: Cell = {
+  name: 'vendor-selection @1200x800',
+  vw: 1200,
+  vh: 800,
+  dockInset: 402,
+  topInset: 57 + MARGIN,
+  anchor: box(379.5, 74, 524.5, 161.7),
+  nodes: [
+    box(379.5, 74, 524.5, 161.7), // dec_cdp (the anchor)
+    box(122.6, 257.7, 267.7, 373.8),
+    box(465.1, 257.7, 610.1, 358.9),
+    box(293.9, 257.7, 438.9, 406.3),
+    box(122.6, 350.5, 267.7, 509.5),
+    box(636.3, 257.7, 781.4, 395.6),
+    box(636.3, 350.5, 781.4, 472.1),
+    box(293.9, 350.5, 438.9, 501.2),
+    box(465.1, 350.5, 610.1, 542.8),
+    box(379.5, 663.2, 524.5, 774.3),
+    box(293.9, 159, 438.9, 276.4),
+    box(122.6, 159, 267.7, 276.4),
+    box(465.1, 159, 610.1, 292.6),
+    box(636.3, 159, 781.4, 263),
+    box(293.9, 477.7, 438.9, 570.8),
+    box(465.1, 477.7, 610.1, 570.8),
+    box(208.2, 570.4, 353.3, 663.6),
+    box(550.7, 570.4, 695.8, 663.6),
+    box(379.5, 570.4, 524.5, 663.6),
+    box(817.1, 159, 912.2, 199.4),
+  ],
+}
+
+const CELLS = [PRICING_1250, HEADCOUNT_1440, VENDOR_1200]
+
+/* ── Helpers that restate NOTHING from the implementation ─────────────────── */
+
+function overlap(a: Box, b: Box): number {
+  const w = Math.min(a.right, b.right) - Math.max(a.left, b.left)
+  const h = Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top)
+  return w > 0 && h > 0 ? w * h : 0
+}
+
+/** The placement the panel used BEFORE this rule: the clamped centred default. */
+function pristineCentredDefault(cell: Cell) {
+  return clampPositionToViewport(
+    {
+      x: Math.max(MARGIN, Math.floor((cell.vw - cell.dockInset - SIZE.width) / 2)),
+      y: Math.max(MARGIN, Math.floor((cell.vh - SIZE.height) / 2)),
+    },
+    SIZE,
+    cell.vw,
+    cell.vh,
+    cell.dockInset,
+    cell.topInset,
+  )
+}
+
+const place = (cell: Cell, model: ModelBoxes) =>
+  graphAwareDefaultPosition(SIZE, cell.vw, cell.vh, cell.dockInset, cell.topInset, model)
+
+const modelOf = (cell: Cell): ModelBoxes => ({ nodes: cell.nodes, anchor: cell.anchor })
+
+/* ── The rule ─────────────────────────────────────────────────────────────── */
+
+describe('graphAwareDefaultPosition — the Decision node stays clickable', () => {
+  for (const cell of CELLS) {
+    it(`clears the Decision node at ${cell.name}`, () => {
+      // PRECONDITION, PINNED IN-TEST: the placement this replaces really does
+      // bury the anchor at this geometry. If a future fixture stops reproducing
+      // the collision, this REDs rather than passing vacuously.
+      const pristine = pristineCentredDefault(cell)
+      expect(
+        overlap(cell.anchor, panelOccluderBox(pristine, SIZE)),
+        'PRECONDITION: the pristine centred default must bury the anchor at this cell',
+      ).toBeGreaterThan(0)
+
+      const placed = place(cell, modelOf(cell))
+      expect(
+        overlap(cell.anchor, panelOccluderBox(placed, SIZE)),
+        'the placed panel must not cover ANY of the Decision node',
+      ).toBe(0)
+    })
+
+    it(`keeps the placement inside the clamp bounds at ${cell.name}`, () => {
+      const placed = place(cell, modelOf(cell))
+      expect(
+        clampPositionToViewport(placed, SIZE, cell.vw, cell.vh, cell.dockInset, cell.topInset),
+        'the rule must never return a position the clamp would move',
+      ).toEqual(placed)
+      const occ = panelOccluderBox(placed, SIZE)
+      expect(occ.left, 'side tab stays on screen').toBeGreaterThanOrEqual(MARGIN)
+      expect(occ.top, 'panel stays below the top bar').toBeGreaterThanOrEqual(cell.topInset)
+      expect(occ.right, 'panel stays clear of the dock').toBeLessThanOrEqual(cell.vw - cell.dockInset - MARGIN)
+      expect(occ.bottom, 'panel stays on screen').toBeLessThanOrEqual(cell.vh - MARGIN)
+    })
+
+    it(`picks the LEXICOGRAPHIC minimum (anchor first, then model) at ${cell.name}`, () => {
+      // Derive the candidate set independently — base plus the four clearance
+      // translations — and assert the function chose the lexicographic minimum
+      // over it. This binds the RULE, not a coordinate: a placement that happens
+      // to clear the anchor but hides more of the model than a sibling candidate
+      // fails here.
+      const base = pristineCentredDefault(cell)
+      const occ = panelOccluderBox(base, SIZE)
+      // Clearances carry the canonical breathing gap — imported from its owner,
+      // not restated here, so the two cannot drift.
+      const g = COMFORT_OCCLUSION_GAP
+      const moves = [
+        { dx: cell.anchor.right - occ.left + g, dy: 0 },
+        { dx: -(occ.right - cell.anchor.left + g), dy: 0 },
+        { dx: 0, dy: cell.anchor.bottom - occ.top + g },
+        { dx: 0, dy: -(occ.bottom - cell.anchor.top + g) },
+      ]
+      const candidates = [base, ...moves.map((m) =>
+        clampPositionToViewport(
+          { x: base.x + m.dx, y: base.y + m.dy },
+          SIZE,
+          cell.vw,
+          cell.vh,
+          cell.dockInset,
+          cell.topInset,
+        ),
+      )]
+      const score = (p: { x: number; y: number }) => {
+        const b = panelOccluderBox(p, SIZE)
+        return [overlap(cell.anchor, b), cell.nodes.reduce((a, n) => a + overlap(n, b), 0)] as const
+      }
+      const expected = candidates.reduce((best, p) => {
+        const s = score(p)
+        const bs = score(best)
+        return s[0] < bs[0] || (s[0] === bs[0] && s[1] < bs[1]) ? p : best
+      }, candidates[0])
+
+      const placed = place(cell, modelOf(cell))
+      expect(score(placed), `chosen placement must score the candidate minimum`).toEqual(score(expected))
+    })
+  }
+
+  it('hides no more of the model than the placement it replaces, at every cell', () => {
+    // The secondary objective, stated as a "does no harm" claim that CAN fail:
+    // each cell's pristine default genuinely covers model area (asserted), so a
+    // regression that traded model coverage for anchor clearance would show.
+    for (const cell of CELLS) {
+      const pristine = panelOccluderBox(pristineCentredDefault(cell), SIZE)
+      const placed = panelOccluderBox(place(cell, modelOf(cell)), SIZE)
+      const cover = (b: Box) => cell.nodes.reduce((a, n) => a + overlap(n, b), 0)
+      expect(cover(pristine), `PRECONDITION: ${cell.name} pristine default covers model area`).toBeGreaterThan(0)
+      expect(cover(placed), `${cell.name}: placed panel hides no more of the model`).toBeLessThanOrEqual(cover(pristine))
+    }
+  })
+})
+
+describe('graphAwareDefaultPosition — fail-open and fallbacks', () => {
+  it('returns exactly the clamped centred default when nothing is rendered', () => {
+    const cell = PRICING_1250
+    expect(place(cell, { nodes: [], anchor: null })).toEqual(pristineCentredDefault(cell))
+  })
+
+  it('returns the base placement unchanged when the base already clears the anchor', () => {
+    // A one-node model parked in the far corner: no clearance is needed, and the
+    // rule must not move the panel "just in case".
+    const cell = PRICING_1250
+    const far = box(cell.vw - cell.dockInset - 60, cell.vh - 40, cell.vw - cell.dockInset - 10, cell.vh - 10)
+    const base = pristineCentredDefault(cell)
+    expect(overlap(far, panelOccluderBox(base, SIZE)), 'PRECONDITION: no overlap to solve').toBe(0)
+    expect(place(cell, { nodes: [far], anchor: far })).toEqual(base)
+  })
+
+  it('takes a DEARER clearance when the cheapest one is clamped away', () => {
+    // ⭐ WHY THE RULE READS ALL FOUR CLEARANCES AND NOT JUST `cheapestClearance`.
+    // Constructed against 1200x800 with the measured dock/top insets so every
+    // number below is a real bound: the panel has 52px of room upward, 109px
+    // downward, 147px leftward, 183px rightward from its centred default.
+    //
+    // This anchor's CHEAPEST clearance is `top` at 60px — more than the 52px of
+    // upward room — so the clamp swallows it and the anchor stays buried. The
+    // `left` clearance costs twice as much (120px) and fits in the 147px
+    // available. A rule that stopped at the cheapest candidate would ship the
+    // defect here; the assertion is that this one does not.
+    const cell: Cell = { ...PRICING_1250, name: 'clamp-blocked cheapest', vw: 1200, dockInset: 402 }
+    const anchor = box(479, 615, 639, 700)
+    const base = pristineCentredDefault(cell)
+    expect(base, 'PRECONDITION: the constructed base placement').toEqual({ x: 199, y: 125 })
+
+    const occ = panelOccluderBox(base, SIZE)
+    expect(overlap(anchor, occ), 'PRECONDITION: the base placement buries this anchor').toBeGreaterThan(0)
+
+    // PRECONDITION: the cheapest clearance really is `top`, and it really is
+    // unreachable. Both halves matter — if either drifts, the case stops testing
+    // what it says it tests.
+    const cheapestTop = occ.bottom - anchor.top
+    expect(cheapestTop, 'PRECONDITION: `top` is the cheapest clearance here').toBe(60)
+    expect(
+      Math.min(occ.right - anchor.left, anchor.right - occ.left, anchor.bottom - occ.top),
+      'PRECONDITION: no other clearance is cheaper than `top`',
+    ).toBeGreaterThan(cheapestTop)
+    const afterCheapest = clampPositionToViewport(
+      { x: base.x, y: base.y - (cheapestTop + COMFORT_OCCLUSION_GAP) },
+      SIZE,
+      cell.vw,
+      cell.vh,
+      cell.dockInset,
+      cell.topInset,
+    )
+    expect(
+      overlap(anchor, panelOccluderBox(afterCheapest, SIZE)),
+      'PRECONDITION: the cheapest clearance is clamped away and leaves the anchor buried',
+    ).toBeGreaterThan(0)
+
+    const placed = place(cell, { nodes: [anchor], anchor })
+    expect(overlap(anchor, panelOccluderBox(placed, SIZE)), 'a dearer, reachable clearance must be taken').toBe(0)
+  })
+
+  it('falls back to the whole model when the graph has no Decision node', () => {
+    // An imported/partial graph has no anchor. The rule must still return a
+    // legal placement and must still respond to the model rather than ignoring
+    // it — proven by discrimination: two different models give two different
+    // answers.
+    const cell = PRICING_1250
+    const leftHeavy = [box(60, 100, 500, 700)]
+    const rightHeavy = [box(cell.vw - cell.dockInset - 460, 100, cell.vw - cell.dockInset - 20, 700)]
+    const a = place(cell, { nodes: leftHeavy, anchor: null })
+    const b = place(cell, { nodes: rightHeavy, anchor: null })
+    expect(a, 'a no-anchor model must still steer the placement').not.toEqual(b)
+    for (const p of [a, b]) {
+      expect(clampPositionToViewport(p, SIZE, cell.vw, cell.vh, cell.dockInset, cell.topInset)).toEqual(p)
+    }
+  })
+})
+
+/* ── Identity binding ─────────────────────────────────────────────────────── */
+
+describe('readModelBoxes binds the anchor by IDENTITY, never by position', () => {
+  function mountNodes(specs: Array<{ id: string; rect: [number, number, number, number] }>): () => void {
+    const host = document.createElement('div')
+    for (const s of specs) {
+      const el = document.createElement('div')
+      el.className = 'react-flow__node'
+      el.dataset.id = s.id
+      const [left, top, right, bottom] = s.rect
+      el.getBoundingClientRect = () =>
+        ({ left, top, right, bottom, width: right - left, height: bottom - top, x: left, y: top, toJSON: () => ({}) }) as DOMRect
+      host.appendChild(el)
+    }
+    document.body.appendChild(host)
+    return () => host.remove()
+  }
+
+  const SPECS: Array<{ id: string; rect: [number, number, number, number] }> = [
+    { id: 'dec_pricing', rect: [292, 125, 452, 210] },
+    // A DIFFERENT node with the IDENTICAL rect. A rule that found the anchor by
+    // geometry could not tell these apart; one that binds by id must.
+    { id: 'opt_hybrid', rect: [292, 125, 452, 210] },
+    { id: 'goal_pricing', rect: [292, 571, 452, 674] },
+  ]
+
+  it('returns the node whose data-id matches, and a DIFFERENT one for a different id', () => {
+    const unmount = mountNodes(SPECS)
+    try {
+      const first = readModelBoxes('dec_pricing')
+      const second = readModelBoxes('goal_pricing')
+      expect(first.nodes, 'every rendered node is measured').toHaveLength(3)
+      expect(first.anchor).toEqual(box(292, 125, 452, 210))
+      // DISCRIMINATING PAIR: same DOM, different id, different anchor. Neither
+      // reading alone proves the binding; the pair does (trap 19).
+      expect(second.anchor).toEqual(box(292, 571, 452, 674))
+      expect(second.anchor).not.toEqual(first.anchor)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('returns a null anchor for an id that is not on screen, and for no id at all', () => {
+    const unmount = mountNodes(SPECS)
+    try {
+      expect(readModelBoxes('dec_not_rendered').anchor).toBeNull()
+      expect(readModelBoxes(null).anchor).toBeNull()
+      expect(readModelBoxes(null).nodes, 'nodes are still measured without an anchor').toHaveLength(3)
+    } finally {
+      unmount()
+    }
+  })
+
+  it('drops zero-size rects so an unmeasured node cannot drag the model box to the origin', () => {
+    const unmount = mountNodes([
+      { id: 'dec_pricing', rect: [292, 125, 452, 210] },
+      { id: 'not_yet_measured', rect: [0, 0, 0, 0] },
+    ])
+    try {
+      const read = readModelBoxes('dec_pricing')
+      expect(read.nodes).toHaveLength(1)
+      expect(read.nodes[0]).toEqual(box(292, 125, 452, 210))
+    } finally {
+      unmount()
+    }
+  })
+})
+
+/* ── The occluder box ─────────────────────────────────────────────────────── */
+
+describe('panelOccluderBox', () => {
+  it('includes the side tab that sits OUTSIDE the panel’s left edge', () => {
+    // The side tab is a sibling at `left: -SIDE_TAB_WIDTH` with the panel
+    // `overflow: visible`, so it is not part of the panel's own rect. Omitting it
+    // makes the occluder 36px narrower than what the user sees and can click.
+    expect(panelOccluderBox({ x: 200, y: 100 }, SIZE)).toEqual({
+      left: 200 - SIDE_TAB_WIDTH,
+      top: 100,
+      right: 600,
+      bottom: 650,
+    })
+  })
+})

--- a/src/canvas/utils/__tests__/cameraComfort.clearanceCandidates.spec.ts
+++ b/src/canvas/utils/__tests__/cameraComfort.clearanceCandidates.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * `clearanceCandidates` — the four ways to hold a frame clear of the floating
+ * companion, and the proof that `cheapestClearance` is still exactly `min` over
+ * them.
+ *
+ * WHY THIS SPEC EXISTS (19 Aug 2026). The fit-then-place placement rule
+ * (`FloatingOlumiPanel.graphAwareDefaultPosition`) needs all four clearances,
+ * not just the cheapest: after `clampPositionToViewport` the cheapest move is
+ * frequently unreachable and a dearer one is not. The obvious way to give it
+ * four amounts is to write the four expressions again next to the placement
+ * code — which is the hand-maintained mirror this estate keeps paying for
+ * (CLAUDE.md trap 12). So `cheapestClearance` was REFACTORED to fold over this
+ * list rather than build its own, and the two can no longer disagree.
+ *
+ * ⭐ THE LOAD-BEARING TEST IS THE DERIVED-AGREEMENT ONE, and it is deliberately
+ * NOT a hand-written table of expected minima: it asserts, over an enumerated
+ * grid of overlapping boxes, that `cheapestClearance` returns the smallest
+ * member of `clearanceCandidates` FOR THE SAME INPUTS. A table would only prove
+ * the cases I thought of; this proves the fold. The hand-written cases below
+ * are the completeness half that derivation cannot supply (trap 12d): they pin
+ * the ORDER and the four EXPRESSIONS, which a derived agreement test is
+ * structurally blind to.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { cheapestClearance, clearanceCandidates, type Box } from '../cameraComfort'
+
+const box = (left: number, top: number, right: number, bottom: number): Box => ({ left, top, right, bottom })
+
+describe('clearanceCandidates', () => {
+  it('returns null when the occluder does not overlap the frame at all', () => {
+    const frame = box(0, 0, 100, 100)
+    expect(clearanceCandidates(frame, box(200, 0, 300, 100)), 'clear to the right').toBeNull()
+    expect(clearanceCandidates(frame, box(0, 200, 100, 300)), 'clear below').toBeNull()
+    // Touching edges are not an overlap: the predicate is strict on both axes.
+    expect(clearanceCandidates(frame, box(100, 0, 200, 100)), 'edge-to-edge').toBeNull()
+  })
+
+  it('returns exactly four clearances, in the documented order, with the documented amounts', () => {
+    // frame 0,0 → 100,100 ; occluder 60,70 → 200,300 (overlaps the bottom-right)
+    const frame = box(0, 0, 100, 100)
+    const occ = box(60, 70, 200, 300)
+    expect(clearanceCandidates(frame, occ)).toEqual([
+      { side: 'right', amount: 40 }, //  frame.right(100) - occ.left(60)
+      { side: 'left', amount: 200 }, //  occ.right(200)   - frame.left(0)
+      { side: 'bottom', amount: 30 }, // frame.bottom(100)- occ.top(70)
+      { side: 'top', amount: 300 }, //   occ.bottom(300)  - frame.top(0)
+    ])
+  })
+
+  it('makes every amount strictly positive whenever there is an overlap', () => {
+    // Overlap on an axis makes BOTH of that axis's expressions positive, so a
+    // consumer may translate by any of the four and know it moved.
+    for (let ox = -80; ox <= 80; ox += 20) {
+      for (let oy = -80; oy <= 80; oy += 20) {
+        const candidates = clearanceCandidates(box(0, 0, 100, 100), box(ox, oy, ox + 100, oy + 100))
+        if (!candidates) continue
+        for (const c of candidates) expect(c.amount, `${c.side} at (${ox},${oy})`).toBeGreaterThan(0)
+      }
+    }
+  })
+})
+
+describe('cheapestClearance is derived from clearanceCandidates, not mirrored', () => {
+  it('returns the smallest candidate for the same inputs, across an enumerated grid', () => {
+    const frame = box(0, 0, 100, 100)
+    let overlapping = 0
+    for (let ox = -140; ox <= 140; ox += 7) {
+      for (let oy = -140; oy <= 140; oy += 11) {
+        for (const [w, h] of [
+          [50, 50],
+          [100, 30],
+          [30, 100],
+          [220, 220],
+        ]) {
+          const occ = box(ox, oy, ox + w, oy + h)
+          const candidates = clearanceCandidates(frame, occ)
+          const cheapest = cheapestClearance(frame, occ)
+          if (!candidates) {
+            expect(cheapest, `no overlap at (${ox},${oy},${w}x${h})`).toBeNull()
+            continue
+          }
+          overlapping++
+          const min = Math.min(...candidates.map((c) => c.amount))
+          expect(cheapest, `overlap at (${ox},${oy},${w}x${h})`).not.toBeNull()
+          expect(cheapest!.amount, `amount at (${ox},${oy},${w}x${h})`).toBe(Math.max(0, min))
+          expect(
+            candidates.find((c) => c.side === cheapest!.side)!.amount,
+            `side ${cheapest!.side} must BE the minimum, not merely tie the number`,
+          ).toBe(min)
+        }
+      }
+    }
+    // POSITIVE CONTROL on the enumeration itself: a grid that produced no
+    // overlapping cell would have asserted nothing about the fold at all
+    // (CLAUDE.md trap 13 — an absence probe needs a presence).
+    expect(overlapping, 'the grid must actually produce overlapping cells').toBeGreaterThan(100)
+  })
+
+  it('breaks exact ties in right, left, bottom, top order', () => {
+    // A frame and occluder arranged so `right` and `bottom` tie at exactly 50.
+    const frame = box(0, 0, 100, 100)
+    const occ = box(50, 50, 150, 150)
+    const candidates = clearanceCandidates(frame, occ)!
+    expect(candidates.map((c) => c.amount)).toEqual([50, 150, 50, 150])
+    expect(cheapestClearance(frame, occ)).toEqual({ side: 'right', amount: 50 })
+  })
+})

--- a/src/canvas/utils/cameraComfort.ts
+++ b/src/canvas/utils/cameraComfort.ts
@@ -51,6 +51,16 @@
  * the camera moves. That is not a loop (the gate runs per focus action, not
  * continuously) and it is what the decision's step 6 fixes properly, by MOVING
  * the panel — fit-then-place — instead of reserving around it.
+ *
+ * ⭐ STEP 6 IS NOW BUILT, AND IT CONSUMES THIS MODULE (19 Aug 2026).
+ * `FloatingOlumiPanel.graphAwareDefaultPosition` is the fit-then-place rule: it
+ * takes the panel's DEFAULT placement off the model by reading the same four
+ * clearances the gate reads (`clearanceCandidates`, below) as candidate
+ * translations of the panel. THIS MODULE REMAINS THE ONLY OWNER OF COMPANION
+ * OCCLUSION GEOMETRY — the placement rule adds no second spelling of it, and it
+ * does not touch `computeFitPadding`, which still reserves nothing for the
+ * companion. Measured consequence: the Decision node went from 0/49 hittable
+ * probes at 1200-1250px to 49/49 across 1200-1600px.
  */
 
 import { computeFitPadding, type FitPadding } from './computeFitPadding'
@@ -107,8 +117,14 @@ export interface Box {
 /** The four sides a clearance can be taken from. */
 export type ComfortClearanceSide = 'left' | 'right' | 'top' | 'bottom'
 
+/** One way to hold a frame entirely clear of an occluder, and what it costs. */
+export interface ComfortClearance {
+  side: ComfortClearanceSide
+  amount: number
+}
+
 /**
- * The cheapest way to hold a frame entirely clear of a FREE-FLOATING occluder.
+ * EVERY way to hold a frame entirely clear of a FREE-FLOATING occluder.
  *
  * MOVED HERE VERBATIM from `computeFitPadding.cheapestReservation` (18 Aug 2026)
  * — the geometry is unchanged and its tests came with it; what changed is who is
@@ -117,31 +133,50 @@ export type ComfortClearanceSide = 'left' | 'right' | 'top' | 'bottom'
  *
  * A rectangular inset cannot express "this box is covered", so the only way to
  * keep a frame off an occluder is to keep the frame entirely to one side of it.
- * Four clearances achieve that; this returns the SMALLEST:
+ * Four clearances achieve that, always in this order:
  *
  *   right  → `frame.right - occ.left`     (frame sits left of the occluder)
  *   left   → `occ.right - frame.left`     (frame sits right of it)
  *   bottom → `frame.bottom - occ.top`     (frame sits above it)
  *   top    → `occ.bottom - frame.top`     (frame sits below it)
  *
- * Returns `null` when the occluder does not overlap at all. Ties resolve in
- * `right, left, bottom, top` order, which only matters for exactly-square
- * overlaps and never changes the amount.
+ * Returns `null` when the occluder does not overlap at all — the one case in
+ * which no clearance is needed. When it does overlap, all four amounts are
+ * strictly positive by construction (overlap on an axis makes both of that
+ * axis's expressions positive).
+ *
+ * ⭐ WHY THIS IS EXPORTED AND NOT PRIVATE TO `cheapestClearance` (19 Aug 2026).
+ * The comfort GATE only ever wants the smallest amount, because it is widening
+ * an inset. The floating panel's fit-then-place rule
+ * (`graphAwareDefaultPosition`) wants the SAME four clearances read the other
+ * way round — as four candidate TRANSLATIONS of the occluder — because after
+ * `clampPositionToViewport` the cheapest one may not be reachable and a more
+ * expensive one may be. Both consumers therefore read ONE spelling of the
+ * geometry: `cheapestClearance` is now `min` over this list, so the two can
+ * never drift (CLAUDE.md trap 12 — derive, don't mirror).
  */
-export function cheapestClearance(
-  frame: Box,
-  occ: Box,
-): { side: ComfortClearanceSide; amount: number } | null {
+export function clearanceCandidates(frame: Box, occ: Box): ComfortClearance[] | null {
   const overlapsX = occ.left < frame.right && occ.right > frame.left
   const overlapsY = occ.top < frame.bottom && occ.bottom > frame.top
   if (!overlapsX || !overlapsY) return null
 
-  const candidates: Array<{ side: ComfortClearanceSide; amount: number }> = [
+  return [
     { side: 'right', amount: frame.right - occ.left },
     { side: 'left', amount: occ.right - frame.left },
     { side: 'bottom', amount: frame.bottom - occ.top },
     { side: 'top', amount: occ.bottom - frame.top },
   ]
+}
+
+/**
+ * The cheapest of `clearanceCandidates`. Ties resolve in
+ * `right, left, bottom, top` order, which only matters for exactly-square
+ * overlaps and never changes the amount.
+ */
+export function cheapestClearance(frame: Box, occ: Box): ComfortClearance | null {
+  const candidates = clearanceCandidates(frame, occ)
+  if (!candidates) return null
+
   let best = candidates[0]
   for (const c of candidates) {
     if (c.amount < best.amount) best = c


### PR DESCRIPTION
## Verdict

**A user could not click the Decision node of their own model at ≤1400px.** Fixed by making the floating companion's default placement graph-aware — *fit-then-place*, the step `cameraComfort`'s own header has named since 18 Aug. **Do not merge**; opened for review.

## The defect, measured

Real Chromium, 49 `elementFromPoint` probes per cell, the five committed starter drafts. Decision-node hittable probes, as-shipped:

| viewport | 1200 | 1250 | 1300 | 1350 | 1400 | 1450 |
|---|---|---|---|---|---|---|
| hittable | **0/49** | **0/49** | 14 | 28 | 42 | 49 |

It is **not a 1280 quirk** — it is a threshold at the panel's right edge. The interceptor is the panel itself, rect `[52, 73, 452, 623]` **byte-identical from 1024 to 1920**: a fixed-size, fixed-origin window while the graph's fit box scales. The node's own hit area is correct, proven by discrimination — the *same node in the same code* is 49/49 at 1450 and 0/49 at 1250.

And it was never confined to small viewports: on the **reopen** path (`position: null` → the design's centred default) two starters measured **0/49 at 1440×900**.

## Two defects, one symptom

**1 — no placement rule.** The default was the centred default, blind to the model.

⚠ **The obvious objective does not work, and I measured that before building.** Over 50 browser-captured geometry cells, minimising overlap with the fitted node bbox leaves the Decision partly buried in **7 of 50** *even solved exhaustively over every legal position*. Total occluded node area: **19/50**. Minimax per-node coverage: **37/50**. They fail the same way — a 400×550 panel plus its 36px tab is over half the usable canvas at 1250, so some of the model is always hidden, and every area objective trades the Decision away to hide less elsewhere. **The brief's stated premise is refuted; the corrected premise is the deliverable.**

The rule is therefore lexicographic:
1. never cover the model's **anchor**, the Decision node — the node the graph is about and the one the user must click to steer it;
2. among placements that satisfy (1), hide as little of the rest of the model as possible.

**Canonical owner.** Candidates are `cameraComfort`'s four clearances read as *translations of the panel* rather than insets on a frame. `cheapestClearance` is refactored to fold over a newly-exported `clearanceCandidates`, so there is **one spelling** of that geometry and **no parallel rule**. All four are used, not just the cheapest — after `clampPositionToViewport` the cheapest is frequently unreachable and a dearer one is not (pinned by a constructed spec case). The clearance carries `COMFORT_OCCLUSION_GAP`, the same constant and the same owner. **`computeFitPadding` is untouched** — the companion still reserves the graph exactly zero width (guard G2a).

**2 — two authorities for one fact, and the one that won had computed nothing.** The placement effect early-returns for `!isOpen || yieldToFirstUse || yieldToDockedOlumi`, but only `isOpen` was in its deps. On the path every seeded user reaches (the hero yields once the first graph lands) **the container mounted without the effect ever re-running**: the panel kept the JSX defaults `left: 0; top: 0`, `setInitialPosition` was never called, and the dock/resize re-clamp handler then read that empty style as `0` and pinned the panel to the clamp floor — which is exactly the `[52, 73]` that never varied with viewport, while the store still said `position: null`.

Fixed at both ends: every condition the early return reads is now a dep, so container-mount and effect-run are the same event by construction; and the re-clamp handler refuses to invent a position for a panel that has not been placed. **The store/DOM disagreement is resolved, and the acceptance instrument pins it** — it REDs at pristine on that assertion alone even in cells where the node was already clickable.

## Evidence

- **RED-first, real Chromium**, same instrument both sides: pristine `3f59325a` → **22 failed / 5 passed**; this branch → **27 passed**.
- **The companion intercepts ZERO probes in 25 of 27 cells.** The other two are **PLACEMENT-BOUND** and the instrument says so by name: at 800px of viewport height, minus a 73px top inset and a 16px margin, a 550px panel has 161px of travel, and no legal placement clears a model whose Decision sits below that. An **exhaustive in-page scan** decides this per cell, so the instrument distinguishes *"the rule placed badly"* from arithmetic — and it is derived per run, so the ±13-21px layout jitter cannot make it flaky.
- **Mutants: 9/9 bite**, in a worktree outside the repo root whose **isolation was proven by writing a sentinel and re-reading the source**, mutating only committed state, applied-check scoped to `src/`, control asserting exactly zero, restores HEAD-relative (trap 9h), trailing clean-tree assertion. Reverting the rule → 8 tests RED. Dropping the anchor term (i.e. shipping the refuted area-only objective) → 4 RED. Cheapest-clearance-only → 2 RED. Forgetting the side tab → 1 RED. Binding the anchor by order instead of id → 2 RED.
- **Discriminating pair**, at REOPEN `pricing-model @1280×800`: redirect the placement rule to protect an **option** node instead, and the Decision-bound instrument **REDs** while an otherwise-identical option-bound twin stays **GREEN**. Same mutant, same cell, opposite verdicts — the instrument is bound to the Decision, not passing incidentally.
- **Binding is by identity throughout** — the Decision node's store id, asserted against the `data-id` of the element actually hit-tested. Never by screen position.
- **Negative controls in every cell**: a point inside the top bar must attribute to `TOPBAR`, a point inside the panel to `OLUMI_PANEL`, and the placement scan must have evaluated positions.
- **Fixtures are browser captures, not numbers from my head** — every rect in the unit spec was read with `getBoundingClientRect` from Chromium at the stated viewport, seeding the committed starter drafts through the product's own `applyDraftResult`.
- Regression surface: **178 tests green** across every `FloatingOlumiPanel`, `cameraComfort`, `computeFitPadding`, `useFloatingPanelState`, `revealOlumiSurface` and `olumiSurface` spec. Typecheck gate PASSED, **none added**. Lint 0 errors; hooks ratchet exactly matches baseline.

## Two findings, reported not fixed

1. ⚠ **The starter layout is not deterministic run to run.** The fitted graph's vertical position varies by **13-21px** between otherwise identical runs — two *pristine* runs disagree, so it predates this change. It also bears on the visual-regression harness, whose whole premise is determinism.
2. **A 9-candidate variant** (adding the four corner combinations of the same clearances) measures the same anchor outcome across all 50 cells with **18% less model occlusion**, and would take the two placement-bound cells from 7 intercepted probes to 2 and 1. It changes **41 of 50** placements, so it is a product call, not a bug fix. Not taken here.

## What I did not touch

`computeFitPadding.ts` · pointer-events on the panel · the workspace composition · `scripts/ci/typecheck-baseline*.txt` (the pre-existing `2272 → 2263` drift notice reproduces **identically at pristine staging** — it is not this branch's, and banking it is another lane's file).

## Files

`src/canvas/components/FloatingOlumiPanel.tsx` · `src/canvas/utils/cameraComfort.ts` · `src/canvas/components/__tests__/FloatingOlumiPanel.graphAwarePlacement.spec.ts` (new) · `src/canvas/utils/__tests__/cameraComfort.clearanceCandidates.spec.ts` (new) · `e2e/geometry/decisionNodeHittest.measure.ts` (new)

⚠ **Collides with #795**, which adds one import and one JSX prop to `FloatingOlumiPanel.tsx`. No functional overlap — mine is the placement functions, the store subscriptions, the layout effect and the re-clamp handler; theirs is the thread mount identity. Expect a textual conflict in the import block only; keep both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
