### PR TITLE
fix(ui): a pencil labelled "Edit value" opens the editor it names

### DIFF
--- a/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
+++ b/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
@@ -27,6 +27,8 @@ import { AnalysisSettings } from './AnalysisSettings'
 import { deriveExpertiseGroups } from './hooks/deriveExpertiseGroups'
 import { StickyFooter } from './StickyFooter'
 import { focusNodeById } from '../../utils/focusHelpers'
+// The canonical "open the editor for this node" seam — see handleSetValueForGap.
+import { openNodeInspector } from '../../nodes/shared/openNodeInspector'
 import { normaliseRawFactorValue, withObservedStateUpdate } from '../../utils/observedStateHelpers'
 import { useCanvasStore } from '../../store'
 import { biasSignal, resolveBiasSignal } from '../../shared/biasSignalTitles'
@@ -984,13 +986,31 @@ export function PreAnalysisPanel({
 
   // Phase 2B: One-click fix — "Set value" opens the inspector for a factor (non-destructive)
   const selectNodeWithoutHistory = useCanvasStore(s => s.selectNodeWithoutHistory)
+  /**
+   * THE CANONICAL RULE, shared with `TriageActionCardsBody.openValueEditor`:
+   * a control labelled "Edit value" opens the node's inspector. One owner,
+   * `openNodeInspector`; no per-consumer variant.
+   *
+   * ⚠ This handler's own comment claimed it "opens the inspector for a
+   * factor" and it never did. `selectNodeWithoutHistory` writes the selection
+   * and `focusNodeById` moves the camera; `InspectorModal` is gated on
+   * `showFullInspector`, LOCAL React state in `ReactFlowGraph` raised ONLY by
+   * the `olumi:open-full-inspector` window event, which neither call
+   * dispatches. Selection alone opens no editing surface anywhere in the app.
+   * So this panel and the post-analysis panel told the same lie, by two
+   * different routes — which is exactly why the fix is one shared owner
+   * rather than a second bespoke handler here.
+   *
+   * `openNodeInspector` performs the selection itself (without history —
+   * opening an editor is not a graph change), so the explicit select is now
+   * redundant and is gone. It fail-closes silently on a factor that is not on
+   * the canvas, replacing the previous silent no-op with the same outcome.
+   */
   const handleSetValueForGap = useCallback((factorId: string) => {
     // Note: FIX_CLICKED is also fired in GapRow.handleClick; PreAnalysisPanel is the
     // logical orchestrator so we skip double-firing here.
-    // Select the factor node to open inspector — non-destructive, no undo needed
-    selectNodeWithoutHistory(factorId)
-    focusNodeById(factorId)
-  }, [selectNodeWithoutHistory])
+    openNodeInspector(factorId)
+  }, [])
 
   // Retry handler with toast feedback
   const handleRetryDraft = useCallback(async () => {

--- a/src/canvas/components/pre-analysis/__tests__/PreAnalysisPanel.editValueOpensEditor.spec.tsx
+++ b/src/canvas/components/pre-analysis/__tests__/PreAnalysisPanel.editValueOpensEditor.spec.tsx
@@ -1,0 +1,320 @@
+/**
+ * PreAnalysisPanel — the pre-analysis half of the SAME "Edit value" lie.
+ *
+ * ## The corrected premise this file records
+ *
+ * The brief for this work held that the post-analysis pencil lied while THIS
+ * consumer was honest, and warned that a shared-label fix would therefore make
+ * an honest consumer lie. Derived at the tree, that is false: both consumers
+ * lie, by two different routes to the same dead end.
+ *
+ *   - post-analysis: `onEdit={onFocusNode}` → `useFocusCamera.handleFocusNode`
+ *   - pre-analysis:  `onEdit={handleSetValueForGap}` → `selectNodeWithoutHistory`
+ *                    + `focusNodeById` (which is `handleFocusNode` again)
+ *
+ * Neither dispatches `olumi:open-full-inspector`, and that event is the ONLY
+ * way `showFullInspector` — local React state in `ReactFlowGraph` — is ever
+ * raised. `InspectorModal` has exactly one mount site, gated on it. So
+ * selection alone opens no editing surface anywhere in the app, and this
+ * handler's own comment ("opens the inspector for a factor") described
+ * something it never did.
+ *
+ * That is why the fix is ONE owner used by both consumers, rather than a
+ * bespoke handler here: two consumers of one shared control must not resolve
+ * the same label two different ways.
+ *
+ * ## Identity binding (CLAUDE.md trap 19)
+ *
+ * Two factor cards are on screen, both carrying the pencil. The discriminating
+ * test clicks the SECOND and asserts the FIRST was not opened, so a mutant
+ * that ignores its argument cannot survive.
+ *
+ * ⚠ SCOPE (CLAUDE.md trap 3): DOM-presence, call-argument and window-event
+ * assertions only. jsdom cannot prove the inspector is visible.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, within, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { PreAnalysisPanel } from '../PreAnalysisPanel'
+import * as usePreAnalysisDataModule from '../hooks/usePreAnalysisData'
+import type { PreAnalysisData } from '../hooks/usePreAnalysisData'
+import { OPEN_FULL_INSPECTOR_EVENT } from '../../../utils/openEdgeStrengthEditor'
+
+vi.mock('../hooks/usePreAnalysisData', () => ({
+  usePreAnalysisData: vi.fn(),
+}))
+
+const mockRetryDraft = vi.fn().mockResolvedValue({ success: true })
+vi.mock('../../../hooks/useRetryDraft', () => ({
+  useRetryDraft: () => ({
+    retryDraft: mockRetryDraft,
+    canRetry: true,
+    isRetrying: false,
+    retryError: null,
+  }),
+}))
+
+vi.mock('../../../hooks/usePreRunValidation', () => ({
+  SOFT_BYPASS_STATUSES: new Set(['needs_user_mapping', 'needs_encoding']),
+}))
+
+vi.mock('../../../ToastContext', () => ({
+  useShowToast: () => vi.fn(),
+}))
+
+vi.mock('../../../../utils/clipboard', () => ({
+  copyTextToClipboard: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('../../../stores/draftStore', () => ({
+  useDraftStore: Object.assign(
+    (selector: (state: any) => any) =>
+      selector({
+        lastDraftError: null,
+        lastDraftDescription: '',
+        selectedGenerationModel: null,
+        selectedRepairModel: null,
+        selectedEnrichmentModel: null,
+        isGenerating: false,
+        fullDraftAppliedAt: null,
+      }),
+    {
+      getState: () => ({
+        lastDraftError: null,
+        lastDraftDescription: '',
+        selectedGenerationModel: null,
+        selectedRepairModel: null,
+        selectedEnrichmentModel: null,
+        isGenerating: false,
+        fullDraftAppliedAt: null,
+        setLastDraftError: vi.fn(),
+        setLastDraftDescription: vi.fn(),
+        setIsGenerating: vi.fn(),
+        setFullDraftAppliedAt: vi.fn(),
+        setSelectedGenerationModel: vi.fn(),
+        setSelectedRepairModel: vi.fn(),
+        setSelectedEnrichmentModel: vi.fn(),
+        resetModelToDefault: vi.fn(),
+        resetAllModels: vi.fn(),
+        resetDraft: vi.fn(),
+      }),
+    },
+  ),
+}))
+
+/** Card A — first in the queue. */
+const FACTOR_A_ID = 'fac_pricing_power'
+const FACTOR_A_LABEL = 'Pricing power'
+/** Card B — SECOND in the queue, and the one every click below targets. */
+const FACTOR_B_ID = 'fac_supplier_lead_time'
+const FACTOR_B_LABEL = 'Supplier lead time'
+
+/**
+ * The graph `openNodeInspector` checks against. It fail-closes on an id that is
+ * not present, so seeding both factors is what makes a positive result mean
+ * anything — without it every test would pass by opening nothing.
+ */
+const GRAPH_NODES = [
+  { id: FACTOR_A_ID, type: 'factor', position: { x: 0, y: 0 }, data: { label: FACTOR_A_LABEL } },
+  { id: FACTOR_B_ID, type: 'factor', position: { x: 0, y: 0 }, data: { label: FACTOR_B_LABEL } },
+  { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal' } },
+]
+
+const mockSelectNodeWithoutHistory = vi.fn()
+
+vi.mock('../../../store', () => {
+  const state = () => ({
+    ceeAnalysisReady: null,
+    lastDraftError: null,
+    setHighlightedNodes: vi.fn(),
+    setHighlightedEdges: vi.fn(),
+    selectNodeWithoutHistory: mockSelectNodeWithoutHistory,
+    selectEdgeWithoutHistory: vi.fn(),
+    nodes: GRAPH_NODES,
+    edges: [],
+    preAnalysisSensitivity: undefined,
+    repairsApplied: null,
+    results: null,
+    setShowDraftChat: vi.fn(),
+    updateEdgeData: vi.fn(),
+    updateNode: vi.fn(),
+    setGoalThreshold: vi.fn(),
+    setGoalThresholdAndUpdateNode: vi.fn(),
+    setCeeAnalysisReady: vi.fn(),
+    setOutcomeNode: vi.fn(),
+    addNode: vi.fn(),
+    updateEdge: vi.fn(),
+    addEdge: vi.fn(),
+  })
+  return {
+    useCanvasStore: Object.assign(
+      (selector: (s: any) => any) => selector(state()),
+      { getState: state },
+    ),
+  }
+})
+
+const mockUsePreAnalysisData = usePreAnalysisDataModule.usePreAnalysisData as ReturnType<typeof vi.fn>
+
+/**
+ * A factor triage card whose action kind maps to `edit` — the branch with NO
+ * `editorConfig`, so `TriageCard` renders the `onEdit` pencil rather than the
+ * inline spinbutton. (`mapItem` attaches `editorConfig` only for `set_value` /
+ * `confirm`, which is why those kinds are not the ones under test here.)
+ */
+function editCard(id: string, label: string) {
+  return {
+    key: `edit_${id}`,
+    category: 'strengthen' as const,
+    label,
+    detail: 'Worth a second look before you run.',
+    focus: { type: 'node' as const, id, label },
+    action: { label: 'Edit', kind: 'edit' as const, targetId: id, targetType: 'node' as const },
+    rawValue: null,
+    unit: null,
+    cap: null,
+    sourceBadge: 'ai' as const,
+  }
+}
+
+function createMockData(overrides: Partial<PreAnalysisData> = {}): PreAnalysisData {
+  const improvementsByCategory = {
+    fix: [],
+    verify: [],
+    add_evidence: [],
+    strengthen: [],
+  }
+  return {
+    improvementsByCategory,
+    tiers: {
+      mustAddress: { items: [], count: 0 },
+      reviewAssumptions: { items: [], count: 0 },
+      optional: { items: [], count: 0 },
+    },
+    totalImprovements: 0,
+    topActions: [],
+    evidenceQuality: { level: 'medium', ratio: 0.5, nonAiCount: 2, totalCount: 4 },
+    isReady: true,
+    hasBlockers: false,
+    blockerCount: 0,
+    nodesByKind: {
+      goal: [{ id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal' } }],
+      decision: [],
+      option: [
+        { id: 'o1', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Option 1' } },
+        { id: 'o2', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Option 2' } },
+      ],
+      factor: [],
+      risk: [],
+      outcome: [],
+    },
+    edgeCount: 2,
+    goalNode: { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal' } },
+    successThreshold: 60,
+    isThresholdAutoDerived: false,
+    isThresholdConfirmed: false,
+    thresholdProvenance: null,
+    isLoading: false,
+    reviewedFactorsCount: 0,
+    totalReviewableFactorsCount: 0,
+    enrichedBlockers: [],
+    informationalBlockers: [],
+    modelAdjustments: [],
+    preMortem: null,
+    goalThresholdRaw: null,
+    goalThresholdUnit: null,
+    isGoalConfirmed: false,
+    optionPreviews: [],
+    qualityChecks: [],
+    repairActions: [],
+    ceeQuality: null,
+    hasDefaultStrengths: false,
+    defaultStrengthPercent: 0,
+    contestedEdges: [],
+    coachingSummary: null,
+    thresholdSourceBadge: null,
+    assumptionsLedger: null,
+    triageActions: {
+      top3: [editCard(FACTOR_A_ID, FACTOR_A_LABEL), editCard(FACTOR_B_ID, FACTOR_B_LABEL)],
+      quickFix: [],
+    },
+    ...overrides,
+  } as unknown as PreAnalysisData
+}
+
+/**
+ * The card for a named factor, resolved as the DIRECT CHILD of the top-three
+ * container that carries the label. Only the first card has a testid
+ * (`t1-triage-emphasised`), so `closest` on the second climbs to the container
+ * holding both and silently widens every within-card query.
+ */
+function cardFor(label: string): HTMLElement {
+  const queue = screen.getByTestId('t1-triage-top-three')
+  const card = Array.from(queue.children).find(
+    child => within(child as HTMLElement).queryByText(label) != null,
+  ) as HTMLElement | undefined
+  expect(card, `no triage card found for "${label}"`).toBeDefined()
+  return card!
+}
+
+function withInspectorWatch<T>(fn: (count: () => number) => T): T {
+  let raised = 0
+  const onOpen = () => {
+    raised += 1
+  }
+  window.addEventListener(OPEN_FULL_INSPECTOR_EVENT, onOpen)
+  try {
+    return fn(() => raised)
+  } finally {
+    window.removeEventListener(OPEN_FULL_INSPECTOR_EVENT, onOpen)
+  }
+}
+
+describe('PreAnalysisPanel — "Edit value" opens the editor it names', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockUsePreAnalysisData.mockReturnValue(createMockData())
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  /**
+   * Precondition pin: the control exists on this surface at all. Without it,
+   * the behavioural tests below could pass vacuously on a panel that stopped
+   * rendering the card.
+   */
+  it('the pencil renders on the factor card', () => {
+    render(<PreAnalysisPanel onAnalyse={vi.fn()} />)
+    expect(
+      within(cardFor(FACTOR_B_LABEL)).getByRole('button', { name: 'Edit value' }),
+    ).toBeInTheDocument()
+  })
+
+  /**
+   * ⭐ THE PIN. RED at pristine: `handleSetValueForGap` selected the node and
+   * moved the camera, dispatching no inspector-raise signal at all.
+   */
+  it('clicking it RAISES THE INSPECTOR, not just the camera', () => {
+    render(<PreAnalysisPanel onAnalyse={vi.fn()} />)
+    withInspectorWatch(count => {
+      fireEvent.click(within(cardFor(FACTOR_B_LABEL)).getByRole('button', { name: 'Edit value' }))
+      expect(count()).toBe(1)
+    })
+  })
+
+  /**
+   * ⭐ THE DISCRIMINATING HALF. Card B is deliberately second: a mutant that
+   * ignores its argument and opens `nodes[0]` satisfies the test above and
+   * must fail here.
+   */
+  it('opens THIS card’s factor, not the other card’s (discriminating pair)', () => {
+    render(<PreAnalysisPanel onAnalyse={vi.fn()} />)
+    fireEvent.click(within(cardFor(FACTOR_B_LABEL)).getByRole('button', { name: 'Edit value' }))
+
+    expect(mockSelectNodeWithoutHistory).toHaveBeenCalledWith(FACTOR_B_ID)
+    expect(mockSelectNodeWithoutHistory).not.toHaveBeenCalledWith(FACTOR_A_ID)
+  })
+})

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -29,6 +29,11 @@ import {
 import { dedupTriageItems } from './utils/dedupTriageItems'
 import { TriageCard } from '@/components/shared/TriageCard'
 import type { TriageCardCategory, TriageCardAction } from '@/components/shared/TriageCard'
+// The canonical "open the editor for this node" seam. Imported here for the
+// same reason `AnalysisHeroPanel` imports `openEdgeStrengthEditor`: a surface
+// in the OutputsDock cannot reach the inspector any other way. See
+// `openValueEditor` below.
+import { openNodeInspector } from '@/canvas/nodes/shared/openNodeInspector'
 import type { ScientificEditorProps } from '@/components/shared/ScientificEditor'
 import { TargetProbabilityBars } from './TargetProbabilityBars'
 import { stripEncodingNotation, cleanFactorLabel } from './utils/cleanFactorLabel'
@@ -201,6 +206,45 @@ function mapNextActionsToCards(data: ResultsSectionDataReturn): MappedActionItem
     sourcePill: null,
     passiveLabels: undefined,
   }))
+}
+
+// ── The "Edit value" affordance: one rule, named ────────────────────────────
+
+/**
+ * THE CANONICAL RULE: a control labelled "Edit value" opens the node's
+ * inspector — the only surface in the product that can edit a factor's value.
+ * It never merely moves the camera.
+ *
+ * ## What this replaces, and why it was a lie
+ *
+ * These call sites passed `onEdit={onFocusNode}`. `onFocusNode` resolves to
+ * `useFocusCamera`'s `handleFocusNode`, which selects the node, sets a
+ * transient focus dim and conditionally fits the camera. It opens nothing:
+ * `InspectorModal` is gated on `showFullInspector`, LOCAL React state in
+ * `ReactFlowGraph` raised only by the `olumi:open-full-inspector` window
+ * event, and `handleFocusNode` never dispatches it. So the pencil promised an
+ * edit and delivered a pan, leaving the user to find the node and click it.
+ *
+ * This is the panel-side twin of the R5 defect already fixed on the canvas,
+ * where the on-node Edit pencil wrote `showInspectorPanel` — a store field
+ * with zero render consumers. Same promise, different dead end.
+ *
+ * ## Why the handler lives here and not in `TriageCard`
+ *
+ * `TriageCard` is shared UI and deliberately carries no canvas dependency (see
+ * the `aiDiscussSlot` prop comment: consumers construct canvas-coupled
+ * elements and pass them in). So the rule is applied at the SEAM — explicitly,
+ * by name — rather than being an accident of whichever handler a consumer
+ * happened to inject. `PreAnalysisPanel`, the other consumer of this
+ * component, injects this same helper for the same control.
+ *
+ * Fail-closed and silent on a node that is not on the canvas, inherited from
+ * `openNodeInspector`: a stale target must never open an empty inspector.
+ *
+ * Module-level so the reference is stable across renders of a memoised tree.
+ */
+const openValueEditor = (nodeId: string): void => {
+  openNodeInspector(nodeId)
 }
 
 // ── Section 2: Result checks (Brief 5.8B D2c — flip-risk extracted) ─────────
@@ -907,7 +951,7 @@ export const TriageActionCardsBody = memo(function TriageActionCardsBody({
                       sourcePill={item.sourcePill}
                       passiveLabels={item.passiveLabels}
                       onConfirm={onConfirm}
-                      onEdit={onFocusNode}
+                      onEdit={openValueEditor}
                       onHoverEnter={onHoverEnter}
                       onHoverLeave={onHoverLeave}
                     />
@@ -924,7 +968,7 @@ export const TriageActionCardsBody = memo(function TriageActionCardsBody({
               onHoverEnter={onHoverEnter}
               onHoverLeave={onHoverLeave}
               onConfirm={onConfirm}
-              onEdit={onFocusNode}
+              onEdit={openValueEditor}
             />
           )}
         </div>

--- a/src/components/results/__tests__/ResultsBody.editValueOpensEditor.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.editValueOpensEditor.spec.tsx
@@ -1,0 +1,342 @@
+/**
+ * ResultsBody — a pencil labelled "Edit value" MUST OPEN AN EDITOR.
+ *
+ * ## The defect this file exists to prevent, stated bluntly
+ *
+ * `TriageActionCardsBody` wired the shared `TriageCard`'s edit affordance as
+ * `onEdit={onFocusNode}`. `onFocusNode` resolves to `useFocusCamera`'s
+ * `handleFocusNode`: it selects the node, sets a transient focus dim and
+ * (conditionally) moves the camera. It opens NOTHING. The only surface that
+ * can edit a factor's value is `InspectorModal`, whose visibility is LOCAL
+ * React state in `ReactFlowGraph` (`showFullInspector`), reachable from
+ * outside only through the `olumi:open-full-inspector` window event — which
+ * `handleFocusNode` never dispatches. So a control that says "Edit value"
+ * panned the camera and left the user to find the node and click it
+ * themselves.
+ *
+ * This is the panel-side twin of the R5 defect already fixed on the canvas
+ * (see `NodeQuickActions.spec.tsx`): there the on-node Edit pencil wrote
+ * `showInspectorPanel`, a store field with zero render consumers. Same shape,
+ * different dead end.
+ *
+ * ## The canonical rule this pins
+ *
+ * "Edit value" opens the node's inspector, via `openNodeInspector` — the one
+ * owner of "raise the editor for this node". There is no per-consumer
+ * variant. It fail-closes silently on a node that is not on the canvas.
+ *
+ * ## Identity binding (CLAUDE.md trap 19)
+ *
+ * Two factors are on screen and BOTH carry an affordance. Every assertion
+ * names one of them by its `targetNodeId`, and the discriminating test clicks
+ * the SECOND card's pencil and asserts the FIRST card's node was not selected
+ * — a mutant that ignores its argument and opens `nodes[0]` must not survive.
+ *
+ * ## The honest consumer this must not break
+ *
+ * `InlineValueControls` (`TriageCard.tsx`) renders its OWN pencil, also
+ * labelled "Edit value", whose click commits the number typed into the
+ * adjacent spinbutton via `editorConfig.onSave`. That one is honest and does
+ * not route through `onEdit` at all. The third test is its control: it must be
+ * GREEN before and after the change, and it must NOT raise the inspector.
+ *
+ * ⚠ SCOPE (CLAUDE.md trap 3): DOM-presence, store-state and window-event
+ * assertions only. jsdom cannot prove the inspector is visible, or that it
+ * paints above the dock. A browser witness owns that claim.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, within, cleanup } from '@testing-library/react'
+import '@testing-library/jest-dom/vitest'
+import { ResultsBody } from '../ResultsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  EvidenceGapItem,
+  ImprovementsSectionData,
+  NextActionItem,
+  OptionResult,
+} from '../types'
+
+/**
+ * The camera seam is mocked so a pan cannot be mistaken for an open. This is
+ * deliberately NOT the assertion — see the header note on uncalled spies. The
+ * tests assert what the user GETS (the inspector-raise signal and the
+ * selection), not what was skipped.
+ */
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+  focusExistingTarget: vi.fn(),
+  focusModelTarget: vi.fn(() => true),
+}))
+
+import { useCanvasStore } from '@/canvas/store'
+import { useUIStore } from '@/stores/uiStore'
+import { OPEN_FULL_INSPECTOR_EVENT } from '@/canvas/utils/openEdgeStrengthEditor'
+
+/** Card 1 — an evidence gap. Carries the HONEST inline editor. */
+const GAP_NODE_ID = 'node_gap_ramp_up'
+const GAP_LABEL = 'Ramp-up time'
+
+/** Card 2 — a next action. Carries the pencil under test. */
+const ACTION_NODE_ID = 'node_action_channel_mix'
+const ACTION_LABEL = 'Revisit the channel mix'
+
+/** The testid of the mount path under test — the cockpit host, by identity. */
+const LIVE_MOUNT = 'hero-arm-triage-actions'
+
+function makeData(): ResultsSectionDataReturn {
+  const winner = {
+    id: 'opt_a',
+    label: 'Option A',
+    expected: 0.8,
+    outcome: { mean: 0.8, p10: 0.6, p50: 0.78, p90: 0.95 },
+    p10: 0.6,
+    p50: 0.78,
+    p90: 0.95,
+    isRecommended: true,
+    winProbability: 0.7,
+    goalProbability: 0.7,
+  } as unknown as OptionResult
+  const runnerUp = {
+    id: 'opt_b',
+    label: 'Option B',
+    expected: 0.4,
+    outcome: { mean: 0.4, p10: 0.2, p50: 0.38, p90: 0.6 },
+    p10: 0.2,
+    p50: 0.38,
+    p90: 0.6,
+    isRecommended: false,
+    winProbability: 0.3,
+    goalProbability: 0.3,
+  } as unknown as OptionResult
+
+  const recommendation = {
+    recommendedOption: winner,
+    allOptions: [winner, runnerUp],
+    goalLabel: 'Maximise success',
+    goalThreshold: 0.6,
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    recommendationStability: 0.92,
+    robustnessLevel: 'high',
+    isNormalised: false,
+    coachingReadiness: 'ready',
+    coachingReadinessDimensions: { evidence: 0.8, robustness: 0.75, clarity: 0.85 },
+  } as DecisionResultData
+
+  const drivers: DriversSectionData = {
+    drivers: [],
+    topDrivers: [],
+    driversStatus: 'computed',
+    totalCount: 0,
+    hasMagnitudeData: false,
+  }
+
+  /**
+   * An evidence gap mints a card carrying `editorConfig` (because `onSetValue`
+   * is supplied), so `TriageCard` renders `InlineValueControls` — spinbutton
+   * plus its own commit pencil. This is the honest control.
+   */
+  const gap: EvidenceGapItem = {
+    factorId: 'fac_ramp',
+    factorLabel: GAP_LABEL,
+    confidence: 40,
+    voi: 0.9,
+    suggestion: 'This estimate is the AI’s, not yours.',
+    targetNodeId: GAP_NODE_ID,
+  }
+
+  /**
+   * A next action mints a card with `action.kind === 'edit'` and
+   * `editorConfig: null` — so `TriageCard` renders the `onEdit` pencil. THIS
+   * is the control under test. `influence` is null for next actions, so it
+   * sorts below the gap (voi 0.9) and both land inside top3.
+   */
+  const nextAction: NextActionItem = {
+    action: ACTION_LABEL,
+    rationale: 'Two channels carry most of the downside.',
+    priority: 1,
+    targetType: 'node',
+    targetId: ACTION_NODE_ID,
+  }
+
+  const confidence = {
+    tier: { tier: 'strong', icon: 'Check', label: 'Tier', description: 'd' },
+    qualityScore: 80,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [gap],
+    topEvidenceGaps: [gap],
+    nextActions: [nextAction],
+    topNextActions: [nextAction],
+  } as unknown as ConfidenceSectionData
+
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  } as ImprovementsSectionData
+
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Maximise success',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+interface Handlers {
+  onConfirmFactor: ReturnType<typeof vi.fn>
+  onSetFactorValue: ReturnType<typeof vi.fn>
+}
+
+function renderBody(): Handlers {
+  const onConfirmFactor = vi.fn()
+  const onSetFactorValue = vi.fn()
+  render(
+    <ResultsBody
+      resultsSectionData={makeData()}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+      onConfirmFactor={onConfirmFactor}
+      onSetFactorValue={onSetFactorValue}
+      nodeValueLookup={{
+        [GAP_NODE_ID]: { value: 12, unit: 'weeks', cap: null },
+      }}
+    />,
+  )
+  return { onConfirmFactor, onSetFactorValue }
+}
+
+/**
+ * The triage card for a named factor, scoped to the live mount path.
+ *
+ * Resolved as the queue's DIRECT CHILD containing the label, not by
+ * `closest('[data-testid^="unified-triage-"]')`: only the FIRST card carries a
+ * testid (`unified-triage-emphasised`), so `closest` on any other card climbs
+ * past it to `unified-triage-queue` — the container holding every card — and
+ * silently widens the scope to the whole queue. The card under test here is
+ * deliberately the second one, so that widening would have made every
+ * within-card query ambiguous.
+ */
+function cardFor(label: string): HTMLElement {
+  const root = screen.getByTestId(LIVE_MOUNT)
+  const queue = within(root).getByTestId('unified-triage-queue')
+  const card = Array.from(queue.children).find(
+    child => within(child as HTMLElement).queryByText(label) != null,
+  ) as HTMLElement | undefined
+  expect(card, `no triage card found for "${label}" in the queue`).toBeDefined()
+  return card!
+}
+
+/** Counts inspector-raise signals for the duration of one assertion. */
+function withInspectorWatch<T>(fn: (count: () => number) => T): T {
+  let raised = 0
+  const onOpen = () => {
+    raised += 1
+  }
+  window.addEventListener(OPEN_FULL_INSPECTOR_EVENT, onOpen)
+  try {
+    return fn(() => raised)
+  } finally {
+    window.removeEventListener(OPEN_FULL_INSPECTOR_EVENT, onOpen)
+  }
+}
+
+describe('ResultsBody — "Edit value" opens the editor it names', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    useCanvasStore.setState({
+      analysisFreshness: null,
+      analysisFreshnessDirty: false,
+      draftCoaching: null,
+      // Both targets are on the canvas: `openNodeInspector` fail-closes on an
+      // id that is not, so a missing seed would fake a pass on the negative
+      // tests and a fail on the positive ones.
+      nodes: [
+        { id: GAP_NODE_ID, type: 'factor', position: { x: 0, y: 0 }, data: { label: GAP_LABEL } },
+        { id: ACTION_NODE_ID, type: 'factor', position: { x: 0, y: 0 }, data: { label: ACTION_LABEL } },
+      ],
+      selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    } as never)
+    useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 })
+  })
+
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+  })
+
+  /**
+   * Precondition pin (CLAUDE.md trap 13b): the control exists on the MOUNTED
+   * surface. If a flag ever moves the cockpit host, this REDs here rather than
+   * letting the behavioural tests below pass against a component the
+   * deployment does not render.
+   */
+  it('the pencil renders on the next-action card, inside the live mount path', () => {
+    renderBody()
+    expect(
+      within(cardFor(ACTION_LABEL)).getByRole('button', { name: 'Edit value' }),
+    ).toBeInTheDocument()
+  })
+
+  /**
+   * ⭐ THE PIN. RED at pristine: `onEdit={onFocusNode}` selects and pans, and
+   * dispatches no inspector-raise signal at all, so `raised` stays 0.
+   */
+  it('clicking it RAISES THE INSPECTOR — the only surface that can edit a value', () => {
+    renderBody()
+    withInspectorWatch(count => {
+      fireEvent.click(within(cardFor(ACTION_LABEL)).getByRole('button', { name: 'Edit value' }))
+      expect(count()).toBe(1)
+    })
+  })
+
+  /**
+   * ⭐ THE DISCRIMINATING HALF. The next-action card is the SECOND card in the
+   * queue, deliberately: a mutant that ignores its argument and opens
+   * `nodes[0]` would satisfy the test above and must fail here.
+   */
+  it('opens THIS card’s node, not the other card’s (discriminating pair)', () => {
+    renderBody()
+    fireEvent.click(within(cardFor(ACTION_LABEL)).getByRole('button', { name: 'Edit value' }))
+
+    const selected = useCanvasStore.getState().selection.nodeIds
+    expect(selected.has(ACTION_NODE_ID)).toBe(true)
+    expect(selected.has(GAP_NODE_ID)).toBe(false)
+  })
+
+  /**
+   * ⭐ THE HONEST CONSUMER, GREEN BEFORE AND AFTER. `InlineValueControls` has
+   * its own "Edit value" pencil that commits the adjacent spinbutton through
+   * `editorConfig.onSave`. It must keep committing, and must NOT be collapsed
+   * into the inspector route — a fix that routed every pencil through
+   * `openNodeInspector` would destroy the one affordance that already worked.
+   *
+   * The negative half is not vacuous: it is asserted in the same act as the
+   * positive commit, so a click that did nothing at all would fail the first
+   * expectation before reaching the second.
+   */
+  it('leaves the inline value editor alone — it still commits, and opens nothing', () => {
+    const { onSetFactorValue } = renderBody()
+    const card = cardFor(GAP_LABEL)
+    const input = within(card).getByRole('spinbutton', { name: `Value for ${GAP_LABEL}` })
+    fireEvent.change(input, { target: { value: '20' } })
+
+    withInspectorWatch(count => {
+      fireEvent.click(within(card).getByRole('button', { name: 'Edit value' }))
+      expect(onSetFactorValue).toHaveBeenCalledWith(GAP_NODE_ID, 20)
+      expect(count()).toBe(0)
+    })
+  })
+})

--- a/src/components/results/__tests__/ResultsBody.editValueOpensEditor.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.editValueOpensEditor.spec.tsx
@@ -198,11 +198,23 @@ function makeData(): ResultsSectionDataReturn {
 interface Handlers {
   onConfirmFactor: ReturnType<typeof vi.fn>
   onSetFactorValue: ReturnType<typeof vi.fn>
+  onFocusNode: ReturnType<typeof vi.fn>
 }
 
+/**
+ * ⚠ `onFocusNode` IS SUPPLIED DELIBERATELY, and the spec is worthless without
+ * it. At pristine the pencil's render gate was `action.kind === 'edit' &&
+ * onEdit && action.targetId`, with `onEdit` BEING `onFocusNode` — so a fixture
+ * that omitted it rendered no pencil at all, and every test here would have
+ * failed at pristine by proving the control ABSENT rather than proving it
+ * lied. The deployed parent supplies it (`OutputsDock` →
+ * `onFocusNode={handleFocusResultNode}`), so the fixture must too, or it is
+ * not testing the input space real users load.
+ */
 function renderBody(): Handlers {
   const onConfirmFactor = vi.fn()
   const onSetFactorValue = vi.fn()
+  const onFocusNode = vi.fn()
   render(
     <ResultsBody
       resultsSectionData={makeData()}
@@ -210,12 +222,13 @@ function renderBody(): Handlers {
       onSendMessage={() => {}}
       onConfirmFactor={onConfirmFactor}
       onSetFactorValue={onSetFactorValue}
+      onFocusNode={onFocusNode}
       nodeValueLookup={{
         [GAP_NODE_ID]: { value: 12, unit: 'weeks', cap: null },
       }}
     />,
   )
-  return { onConfirmFactor, onSetFactorValue }
+  return { onConfirmFactor, onSetFactorValue, onFocusNode }
 }
 
 /**


### PR DESCRIPTION
## The defect

`TriageCard`'s edit affordance — a **Pencil**, tooltip and aria-label **"Edit value"** — was wired on **both** of its consumers to a handler that selects a node and moves the camera. Neither opened an editor.

`InspectorModal` has **exactly one mount site** (`ReactFlowGraph.tsx:2310`), gated on `showFullInspector` — component-local React state raised **only** by the `olumi:open-full-inspector` window event, which has exactly two dispatchers (`openNodeInspector`, `openEdgeStrengthEditor`). **Selection alone opens no editing surface anywhere in the app.** So:

| Consumer | `onEdit` was | What it did |
|---|---|---|
| results (`TriageActionCardsBody:910,:927`) | `onFocusNode` → `useFocusCamera.handleFocusNode` | select + focus-dim + conditional camera fit |
| pre-analysis (`PreAnalysisPanel:1227`) | `handleSetValueForGap` | `selectNodeWithoutHistory` + `focusNodeById` (= `handleFocusNode` again) |

This is the **panel-side twin of the R5 defect already fixed on the canvas**, where the on-node Edit pencil wrote `showInspectorPanel` — a store field with zero render consumers. Same promise, different dead end.

## ⚠ Corrected premise

The brief held that the **pre-analysis consumer was honest**, and warned that changing the shared label would make it lie. **Derived at the tree, that is false.** Pre-analysis lies identically — its handler's own comment says *"'Set value' opens the inspector for a factor"* and it never did. There was **no honest consumer of the `onEdit` pencil at all**.

That refutation is what makes the fix clean: with no honest `onEdit` consumer to protect, one owner can serve both seams.

*(Verified with contrast controls: `<PropertiesPanel` / `<InspectorPanel` = 0 mounts while `<InspectorModal` / `<OutputsDock` / `<PreAnalysisPanel` = 1 each in the same sweep; `showInspectorPanel` renderer-reads = 0 while sibling `showResultsPanel` = 2.)*

## The canonical rule

> **A control labelled "Edit value" opens the node's inspector, via `openNodeInspector`. It never merely moves the camera.**
> One owner, no per-consumer variant. Fail-closed and silent on a node not on the canvas.

`openNodeInspector` was already the live, spec-pinned owner for the eight on-node call sites (`FactorNode`, `GoalNode`, `OptionNode`, `DecisionNode`, `NodeQuickActions`, `NodeCoachingMarker`). Both competing handlers are **removed**, not supplemented — no parallel rule added.

**When does this control edit, and when does it not?** It always edits. The only other `Edit value` pencil in `TriageCard` belongs to `InlineValueControls`, which commits the adjacent spinbutton through `editorConfig.onSave` — it never routed through `onEdit`, is honest, and is **untouched**.

### Why not the alternatives
- **Relabelling** (e.g. "Show on canvas") was rejected outright: it degrades a live capability into a weaker one, and the honest implementation already existed next door.
- **Dropping the affordance** was the brief's fallback; unnecessary once the premise was corrected — the promise can be made true instead of deleted.
- **Wiring `openNodeInspector` inside `TriageCard`** was rejected: that file explicitly bans canvas coupling (see its `aiDiscussSlot` prop comment). The rule is applied **at the seam, by name**, so it is no longer an accident of which handler a consumer injects.
- **`openNodeInspector` itself is unmodified.** It needs no dock stand-down: `InspectorModal` is `fixed z-[5000]` and the dock is `zIndex: 900`, so it paints above. (Its edge twin `openEdgeStrengthEditor` also calls `setShowResultsPanel(false)`; that asymmetry is noted, not changed — out of scope.)

## Mounted consequence, in one sentence

**A user clicking that pencil on the analysis surface now gets the factor's inspector open on that factor, instead of a camera pan and a highlight.**

## Evidence

**Mount posture derived, not assumed.** `AnalysisHeroContainer` mounts **unconditionally** in `ResultsBody` (`netlify.toml:74` records the analysis-hero fork as retired, gate has no readers); the queue reaches the DOM via `actOnItQueueSlot` → `hero-arm-triage-actions`. Both specs assert that mount path, so they RED if a flag moves.

**RED-first at pristine `3f59325a`** (final specs, source files reverted in an isolated worktree) — 7 collected by name, 3 failed:
- `clicking it RAISES THE INSPECTOR — the only surface that can edit a value` → `expected +0 to be 1`
- `opens THIS card's node, not the other card's (discriminating pair)` → `expected false to be true`
- `clicking it RAISES THE INSPECTOR, not just the camera` (pre-analysis) → `expected +0 to be 1`

The two **precondition pins passed** at pristine — the pencil *renders* on both mounted surfaces — which is what makes this a test of the lie rather than of an absence. *(An earlier draft omitted `onFocusNode` from the fixture; since the pristine render gate was `onEdit && targetId` with `onEdit` **being** `onFocusNode`, that fixture rendered no pencil and would have gone red by proving the control absent. Corrected — the deployed parent supplies it.)*

**Mutants — 5/5 bite, each on a different assertion**, applied-check = 1 each (scoped to `src/`), opening and trailing controls both 7/7 green:

| Mutant | REDs | Proves |
|---|---|---|
| M1 revert results fix | results pin + identity | the pin bites |
| M2 revert pre-analysis fix | pre-analysis pin | the pin bites |
| **M3 results opens the WRONG node** | **identity only** — inspector still raised | binding is by identity, not "an event fired" |
| **M4 pre-analysis opens the WRONG factor** | **identity only** | same, other consumer |
| **M5 route the inline editor through the inspector** | **honest-consumer test only** | that control genuinely guards the affordance it names |

M3/M5 are the load-bearing pair: a naive "some event fired" assertion survives M3, and a fix that collapsed every pencil into one route survives without M5.

**Proof the inline value editor is unaffected** — the single most likely way this goes wrong:
- new spec: `leaves the inline value editor alone — it still commits, and opens nothing` (green before *and* after; REDs under M5).
- the two pre-existing specs that click `Edit value` on an evidence-gap card — `ResultsBody.confirmEstimateLiveMount.spec.tsx` and `ResultsBody.staleMutationAffordances.spec.tsx` — **13/13 green, unchanged**.

**Worktree isolation proven by WRITING**, not by locating: distinct inodes (`677893855` vs `677907938`), a sentinel appended in the worktree read back as absent in the source, HEAD-relative restore, clean tree after. *(The worktree's only other non-clean entry was the `node_modules` **symlink**, untracked because `.gitignore` says `node_modules/` — trailing slash does not match a symlink. Applied-checks are scoped to `src/`, so it never entered a count.)*

**Gate steps run in the required order** (lint first, not skipped): `pnpm run lint` → exit 0, 0 errors, rules-of-hooks ratchet **exactly matching baseline** (229 known violations / 13 files — my `useCallback` dep-array change added none). `pnpm run typecheck` → **PASSED**, 3542/3582 tracked files loaded, ratchet green, drift **shrank 2272 → 2263 with none added**. The gate's advisory `--update-baseline` was **deliberately declined** — banking a shared baseline from a lane touching two files is a cross-lane side effect, and the gate passes without it.

## Files touched (4)

- `src/components/results/TriageActionCardsBody.tsx` — adds `openValueEditor`; two `onEdit` sites
- `src/canvas/components/pre-analysis/PreAnalysisPanel.tsx` — `handleSetValueForGap` routes to the owner
- `src/components/results/__tests__/ResultsBody.editValueOpensEditor.spec.tsx` *(new)*
- `src/canvas/components/pre-analysis/__tests__/PreAnalysisPanel.editValueOpensEditor.spec.tsx` *(new)*

No file in the lane's do-not-touch list is modified. `TriageCard.tsx` label, tooltip and icon are **unchanged**.

## Not claimed

jsdom cannot prove the inspector is *visible*, or that it paints above the dock — that rests on `z-[5000]` vs `zIndex: 900`, read from source. **A browser witness on deployed staging still owes that confirmation.** This branch was not merged and deployed staging was not driven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
