### PR TITLE
DO NOT MERGE ALONE — fix(readiness): send scenario_id so the panel and the run assess the same model

### DIFF
--- a/src/canvas/stores/__tests__/readinessStore.invalidation.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.invalidation.spec.ts
@@ -649,7 +649,7 @@ describe('readinessStore — invalidation on mutation (ROADMAP 2.332)', () => {
 
     it('names every root the subscription watches', () => {
       expect([...WATCHED_ROOTS].sort()).toEqual(
-        ['ceeAnalysisReady', 'currentBriefText', 'edges', 'nodes'].sort(),
+        ['ceeAnalysisReady', 'currentBriefText', 'currentScenarioId', 'edges', 'nodes'].sort(),
       )
     })
   })

--- a/src/canvas/stores/__tests__/readinessStore.optionInterventions.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.optionInterventions.spec.ts
@@ -47,7 +47,7 @@ function factorNode(id: string, label: string, data: Record<string, unknown> = {
 
 function wireNodes(nodes: Node[], edges: Edge[] = []): WireNode[] {
   const payload = JSON.parse(
-    buildReadinessPayload({ nodes, edges, ceeAnalysisReady: null, currentBriefText: null }),
+    buildReadinessPayload({ nodes, edges, ceeAnalysisReady: null, currentBriefText: null, currentScenarioId: null }),
   )
   return payload.graph.nodes as WireNode[]
 }
@@ -159,7 +159,7 @@ describe('buildReadinessPayload — option interventions reach the wire', () => 
     ]
 
     const payload = JSON.parse(
-      buildReadinessPayload({ nodes, edges, ceeAnalysisReady: null, currentBriefText: null }),
+      buildReadinessPayload({ nodes, edges, ceeAnalysisReady: null, currentBriefText: null, currentScenarioId: null }),
     )
 
     // Factor projection intact, field for field.

--- a/src/canvas/stores/__tests__/readinessStore.scenarioIdConvergence.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.scenarioIdConvergence.spec.ts
@@ -1,0 +1,245 @@
+/**
+ * readinessStore — the readiness panel and the run path must assess the SAME
+ * model (ROADMAP: readiness/run convergence).
+ *
+ * THE MECHANISM, derived at CEE `cbc3ea3d` (`src/routes/assist.v1.graph-readiness.ts`)
+ * and at this UI tip, not inherited:
+ *
+ *   const GraphReadinessInput = z.object({
+ *     graph: Graph,
+ *     analysis_ready: AnalysisReadyPayload.optional(),
+ *     scenario_id: z.string().min(1).optional(),
+ *   });
+ *   ...
+ *   let assessedGraph: unknown = input.graph;
+ *   let assessedFrom = "request_graph";
+ *   if (input.scenario_id) {
+ *     const persisted = await loadPersistedScenarioStateStrict(input.scenario_id);
+ *     if (persisted.graph != null) { assessedGraph = persisted.graph; assessedFrom = "persisted"; }
+ *   }
+ *
+ * So CEE runs ONE predicate (`assessRouteAdmission` →
+ * `assessCanonicalAnalysisReadiness`, the same whole-model authority the TURN
+ * path uses) over one of TWO inputs, and the caller picks which by supplying
+ * `scenario_id` or not. The run path always reads the PERSISTED scenario. This
+ * projection has never sent `scenario_id`, so the panel has always been
+ * answered over `request_graph` — the browser's LOCAL copy. Same predicate,
+ * two inputs, and the divergence is exactly how the panel can read "3/3 ready"
+ * about a model the analysis turn never sees.
+ *
+ * ⚠ STATE-CLASS, and it is load-bearing rather than a nicety (CLAUDE.md
+ * fixture state-class rule). A guest, or a canvas drafted but not yet saved,
+ * has NO scenario id. For those callers `request_graph` is the CORRECT input —
+ * CEE's own comment says so ("the fallback is not a failure path"). Two things
+ * therefore have to hold at once, and they are tested separately below:
+ *   · a SAVED canvas sends the id, so both authorities read the persisted model;
+ *   · an UNSAVED canvas sends NO `scenario_id` KEY AT ALL. Not an empty string:
+ *     CEE's schema is `z.string().min(1)`, so `""` is a validation failure, not
+ *     a benign no-op — it would 400 every guest readiness request.
+ *
+ * ⚠ WHAT THIS CHANGE ALONE DOES TO THE PANEL, stated because it reads as a
+ * regression and is not one: where the persisted graph lags the canvas, the
+ * panel will start reporting the value MISSING — which is what the run path
+ * has been seeing all along. Agreement is the point; the remedy for the lag is
+ * the coupled CEE `options[]`-sync work, not a projection that flatters.
+ *
+ * Scope note (CLAUDE.md trap 3): every assertion here is on the built payload,
+ * on the request body, or on module/store state. Nothing here is a visibility
+ * claim — jsdom cannot make one.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Node, Edge } from '@xyflow/react'
+import {
+  buildReadinessPayload,
+  useReadinessStore,
+  WATCHED_ROOTS,
+  type ReadinessPayloadInputs,
+} from '../readinessStore'
+import { useCanvasStore } from '../../store'
+import { clearInflightCache } from '../../hooks/useGraphReadiness'
+
+// ── Pure-builder half ──────────────────────────────────────────────
+
+function factorNode(id: string, label: string): Node {
+  return {
+    id,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { kind: 'factor', label },
+  } as Node
+}
+
+/**
+ * Build the payload with EXACTLY the declared input slice. Typed as
+ * `ReadinessPayloadInputs` rather than cast to `any` deliberately: the
+ * interface is half of this change, so a projection that emitted the field
+ * without declaring the input would fail the typecheck gate here.
+ */
+function payloadFor(currentScenarioId: string | null | undefined): Record<string, unknown> {
+  const nodes: Node[] = [factorNode('fac_price', 'Price'), factorNode('fac_churn', 'Churn')]
+  const edges: Edge[] = []
+  const inputs: ReadinessPayloadInputs = {
+    nodes,
+    edges,
+    ceeAnalysisReady: null,
+    currentBriefText: null,
+    currentScenarioId,
+  }
+  return JSON.parse(buildReadinessPayload(inputs)) as Record<string, unknown>
+}
+
+const hasKey = (o: Record<string, unknown>, k: string): boolean =>
+  Object.prototype.hasOwnProperty.call(o, k)
+
+describe('buildReadinessPayload — scenario_id reaches CEE so both authorities read the persisted model', () => {
+  // ── Positive control first (CLAUDE.md trap 13) ───────────────────
+  //
+  // Three assertions below are ABSENCE claims. They are worth nothing until
+  // the same helper is shown capable of producing a PRESENCE, and until the
+  // payload it parses is shown to be a real payload rather than `{}` — an
+  // absence probe over an empty object passes forever.
+  it('positive control: the helper builds a real payload and CAN emit scenario_id', () => {
+    const saved = payloadFor('scn_control_9f2a')
+    expect(((saved.graph as { nodes: unknown[] }).nodes ?? []).length).toBe(2)
+    expect(hasKey(saved, 'scenario_id')).toBe(true)
+  })
+
+  it('sends the scenario_id the store holds, by identity, when the canvas IS saved', () => {
+    // Bound by IDENTITY to the exact id under test, and asserted for TWO
+    // distinct ids. A single id would also be satisfied by a hardcoded
+    // constant or by any other string the builder happened to have to hand;
+    // two distinct ids can only be satisfied by reading the input.
+    expect(payloadFor('scn_alpha_7c31').scenario_id).toBe('scn_alpha_7c31')
+    expect(payloadFor('scn_beta_4e08').scenario_id).toBe('scn_beta_4e08')
+  })
+
+  it('omits the scenario_id KEY entirely for a guest canvas that was never saved', () => {
+    // `null` is the canvas store's initial value (`store.ts` — currentScenarioId
+    // is set only by save/load). CEE assesses `request_graph` for this caller,
+    // which is the correct answer for it.
+    const guest = payloadFor(null)
+    expect(hasKey(guest, 'scenario_id')).toBe(false)
+    expect(guest.scenario_id).toBeUndefined()
+    // …and the rest of the payload is still fully formed, so the absence above
+    // is an absence of ONE key, not of the whole request.
+    expect(((guest.graph as { nodes: unknown[] }).nodes ?? []).length).toBe(2)
+  })
+
+  it('omits the scenario_id KEY when the id is undefined (pre-hydration canvas)', () => {
+    const preHydration = payloadFor(undefined)
+    expect(hasKey(preHydration, 'scenario_id')).toBe(false)
+  })
+
+  it('never sends an empty string — CEE types the field z.string().min(1), so "" is a 400', () => {
+    const empty = payloadFor('')
+    expect(hasKey(empty, 'scenario_id')).toBe(false)
+    expect(empty.scenario_id).not.toBe('')
+  })
+
+  it('names currentScenarioId as a watched root, so saving re-asks the question', () => {
+    expect([...WATCHED_ROOTS]).toContain('currentScenarioId')
+  })
+})
+
+// ── Wire half: the body CEE actually receives ──────────────────────
+//
+// The builder tests above prove the projection. These prove the REQUEST — a
+// correct builder whose output never reaches `fetch` would satisfy every
+// assertion above (CLAUDE.md trap 16: a symbol proves presence-in-repo, never
+// presence-on-the-wire).
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
+
+function okResponse() {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 88,
+        readiness_level: 'ready',
+        can_run_analysis: true,
+        confidence_explanation: 'Ready to analyse',
+        improvements: [],
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+function requestBody(callIndex: number): Record<string, unknown> {
+  const init = mockFetch.mock.calls[callIndex]?.[1]
+  return JSON.parse(String(init?.body ?? '{}')) as Record<string, unknown>
+}
+
+function seedCanvas(currentScenarioId: string | null) {
+  useCanvasStore.setState({
+    nodes: [factorNode('fac_price', 'Price'), factorNode('fac_churn', 'Churn')] as never,
+    edges: [] as never,
+    ceeAnalysisReady: null,
+    currentBriefText: null,
+    currentScenarioId,
+  } as never)
+}
+
+describe('readinessStore request — the wire carries the scenario id, and only when there is one', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mockFetch.mockReset()
+    mockFetch.mockResolvedValue(okResponse())
+    useReadinessStore.getState().reset()
+    clearInflightCache()
+  })
+
+  afterEach(() => {
+    useReadinessStore.getState().reset()
+    clearInflightCache()
+    vi.useRealTimers()
+  })
+
+  it('posts scenario_id for a SAVED canvas, bound to that canvas’s id', async () => {
+    seedCanvas('scn_wire_1d4b')
+    useReadinessStore.getState().startListening()
+    await vi.runAllTimersAsync()
+
+    // Positive control: a request was actually made. Zero requests would make
+    // every body assertion below vacuous.
+    expect(mockFetch).toHaveBeenCalled()
+    expect(requestBody(0).scenario_id).toBe('scn_wire_1d4b')
+  })
+
+  it('posts NO scenario_id key for a guest canvas', async () => {
+    seedCanvas(null)
+    useReadinessStore.getState().startListening()
+    await vi.runAllTimersAsync()
+
+    expect(mockFetch).toHaveBeenCalled()
+    const body = requestBody(0)
+    // The request is real and fully formed…
+    expect(((body.graph as { nodes: unknown[] }).nodes ?? []).length).toBe(2)
+    // …and carries no scenario_id at all, so CEE assesses request_graph.
+    expect(hasKey(body, 'scenario_id')).toBe(false)
+  })
+
+  it('asks again when an unsaved canvas is SAVED, because the assessed model changes', async () => {
+    // This is the behavioural reason `currentScenarioId` must be a watched
+    // root. Nothing else about the model moves here: the same nodes, the same
+    // edges, the same brief. Only the assessed SOURCE changes — guest/local to
+    // persisted — and that is a different question, so it must be re-asked.
+    seedCanvas(null)
+    useReadinessStore.getState().startListening()
+    await vi.runAllTimersAsync()
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(hasKey(requestBody(0), 'scenario_id')).toBe(false)
+
+    clearInflightCache()
+    useCanvasStore.setState({ currentScenarioId: 'scn_saved_88ac' } as never)
+    await vi.runAllTimersAsync()
+
+    expect(mockFetch).toHaveBeenCalledTimes(2)
+    expect(requestBody(1).scenario_id).toBe('scn_saved_88ac')
+  })
+})

--- a/src/canvas/stores/readinessStore.ts
+++ b/src/canvas/stores/readinessStore.ts
@@ -238,6 +238,11 @@ export const WATCHED_ROOTS = [
   'edges',
   'ceeAnalysisReady',
   'currentBriefText',
+  // Saving an unsaved canvas changes NOTHING about the model and EVERYTHING
+  // about the question: CEE switches from assessing the request graph to
+  // assessing the persisted scenario. A different question has to be re-asked,
+  // so this root is watched like any other payload input.
+  'currentScenarioId',
 ] as const
 
 /** The slice of canvas state the readiness request is a function of. */
@@ -246,6 +251,12 @@ export interface ReadinessPayloadInputs {
   edges: Edge[]
   ceeAnalysisReady: { options?: unknown[] } | null | undefined
   currentBriefText: string | null | undefined
+  /**
+   * The saved scenario this canvas IS, or `null`/`undefined` when it is not
+   * saved yet. It is an input to the payload because it selects WHICH MODEL
+   * CEE assesses — see the `scenario_id` block in `buildReadinessPayload`.
+   */
+  currentScenarioId: string | null | undefined
 }
 
 /**
@@ -272,7 +283,7 @@ export interface ReadinessPayloadInputs {
  * the payload.
  */
 export function buildReadinessPayload(s: ReadinessPayloadInputs): string {
-  const { nodes, edges, ceeAnalysisReady, currentBriefText } = s
+  const { nodes, edges, ceeAnalysisReady, currentBriefText, currentScenarioId } = s
 
   const payload: Record<string, unknown> = {
     graph: {
@@ -372,6 +383,42 @@ export function buildReadinessPayload(s: ReadinessPayloadInputs): string {
     const { model_adjustments: _strip, ...analysisReadyForPayload } =
       ceeAnalysisReady as Record<string, unknown>
     payload.analysis_ready = analysisReadyForPayload
+  }
+
+  // ── The two readiness authorities must assess the SAME model ──────
+  //
+  // Derived at CEE `cbc3ea3d`, `src/routes/assist.v1.graph-readiness.ts`:
+  //
+  //   scenario_id: z.string().min(1).optional()
+  //   ...
+  //   let assessedGraph = input.graph; let assessedFrom = "request_graph";
+  //   if (input.scenario_id) {
+  //     const persisted = await loadPersistedScenarioStateStrict(input.scenario_id);
+  //     if (persisted.graph != null) { assessedGraph = persisted.graph; assessedFrom = "persisted"; }
+  //   }
+  //
+  // CEE runs ONE predicate (`assessRouteAdmission` →
+  // `assessCanonicalAnalysisReadiness`, the same whole-model authority the TURN
+  // path uses) over one of TWO inputs, and the CALLER picks which. The run path
+  // always reads the persisted scenario. This projection never sent the id, so
+  // the panel was always answered over `request_graph` — the browser's LOCAL
+  // copy. Same predicate, two inputs: that is how the panel can read "3/3
+  // ready" about a model the analysis turn never sees.
+  //
+  // ⚠ STATE-CLASS, and it is a correctness constraint rather than a nicety.
+  // A guest, or a canvas drafted but not yet saved, HAS no scenario. For those
+  // callers `request_graph` is the right input and CEE says so itself ("the
+  // fallback is not a failure path"). So the field is omitted ENTIRELY rather
+  // than sent empty: CEE types it `z.string().min(1)`, so `""` is a validation
+  // failure, not a benign no-op — it would 400 every guest readiness request.
+  //
+  // ⚠ AND WHAT THIS DOES TO THE PANEL, recorded because it reads as a
+  // regression and is not one: where the persisted graph lags the canvas, the
+  // panel starts reporting the value MISSING — which is what the run path has
+  // been seeing all along. Agreement is the point; the lag is fixed by the
+  // coupled CEE `options[]`-sync work, not by a projection that flatters.
+  if (typeof currentScenarioId === 'string' && currentScenarioId.length > 0) {
+    payload.scenario_id = currentScenarioId
   }
 
   return JSON.stringify(payload)


### PR DESCRIPTION
## ⛔ DO NOT MERGE ALONE

**This change on its own makes the readiness panel agree by reporting the value MISSING too — which is CORRECT, but reads as a regression to a tester.** Where the persisted scenario graph lags the canvas, the panel will begin reporting what the analysis turn has been seeing all along. Agreement is the point; the lag is closed by the coupled CEE `options[]`-sync change, not by a projection that flatters.

**It therefore lands WITH the coupled CEE PR, not before.**

**Coupled CEE PR: Talchain/olumi-assistants-service#1049** — `fix/options-interventions-sync-at-persist` (required check `Lint, TypeCheck, Unit Tests` = success; `Typecheck Drift (ratchet)` = success).

---

## The defect

Two readiness authorities disagree because the UI has never sent `scenario_id` to CEE's graph-readiness endpoint.

Derived at CEE `cbc3ea3d44e0f117872b2fc7a0faa2efafcecc9f`, `src/routes/assist.v1.graph-readiness.ts`:

```ts
const GraphReadinessInput = z.object({
  graph: Graph,
  analysis_ready: AnalysisReadyPayload.optional(),
  scenario_id: z.string().min(1).optional(),          // :118
});
...
let assessedGraph: unknown = input.graph;             // :312
let assessedFrom = "request_graph";
if (input.scenario_id) {
  const persisted = await loadPersistedScenarioStateStrict(input.scenario_id);
  if (persisted.graph != null) { assessedGraph = persisted.graph; assessedFrom = "persisted"; }
}
const admission = assessRouteAdmission(assessedGraph);
```

CEE runs **one predicate** (`assessRouteAdmission` → `assessCanonicalAnalysisReadiness`, the same whole-model authority the turn path uses) over **one of two inputs**, and the **caller** picks which. The run path always reads the persisted scenario. This projection never sent the id, so the panel has always been answered over `request_graph` — the browser's local copy. Same predicate, two inputs. That is how the panel can read "3/3 ready" about a model the analysis turn never sees.

## The change

`src/canvas/stores/readinessStore.ts` (verified line numbers, at `70adaa39`):

| What | Pristine lines | Now |
|---|---|---|
| `WATCHED_ROOTS` | 236–241 | gains `'currentScenarioId'` |
| `ReadinessPayloadInputs` | 244–249 | gains `currentScenarioId: string \| null \| undefined` |
| `buildReadinessPayload` | 274–377 (sole production call site of the projection) | emits `payload.scenario_id` |

`currentScenarioId` is already on the object passed in — `src/canvas/store.ts:430` (`currentScenarioId: string | null  // Active scenario ID`), so no new plumbing. The brief's pointer said `store.ts:421`; the field is at **`src/canvas/store.ts:430`**, and the file is `src/canvas/store.ts`, not `src/canvas/stores/store.ts`.

## State-class: the guest case is a correctness constraint, not a nicety

A guest, or a canvas drafted but not yet saved, **has no scenario id**. For those callers `request_graph` is the correct input, and CEE says so in its own comment ("the fallback is not a failure path"). So:

- **the key is omitted entirely** when there is no id — `null`, `undefined`, or `''`;
- **an empty string is never sent.** CEE types the field `z.string().min(1)`, so `""` is a validation failure, not a benign no-op — it would 400 every guest readiness request.

Both halves are tested separately, and the mutant that removes the guard (M2) REDs the guest tests, so those absence assertions are not vacuous.

## The `WATCHED_ROOTS` completeness guard fired, as designed

`readinessStore.invalidation.spec.ts` Proxy-wraps the state handed to `buildReadinessPayload`, records every top-level property read, and asserts that set is a subset of `WATCHED_ROOTS`. Adding the read without the watcher REDs it — measured, not assumed:

```
FAIL  ... > the watched-root list is derived from the payload builder, not from memory
      > reads nothing from canvas state that is not a watched root
AssertionError: expected [ 'currentScenarioId' ] to deeply equal []
```

Saving an unsaved canvas changes **nothing** about the model and **everything** about the question — CEE switches from assessing the request graph to assessing the persisted scenario — so it must be re-asked. That behaviour is pinned by a test, not just by the list.

## Evidence

**RED-first at pristine** (source untouched, new spec only), 9/9 collected by name, **5 failed | 4 passed**:

| Test | Failure at pristine |
|---|---|
| positive control: the helper builds a real payload and CAN emit scenario_id | `expected false to be true` |
| sends the scenario_id the store holds, by identity, when the canvas IS saved | `expected undefined to be 'scn_alpha_7c31'` |
| names currentScenarioId as a watched root, so saving re-asks the question | `expected [ 'nodes', 'edges', …(2) ] to include 'currentScenarioId'` |
| posts scenario_id for a SAVED canvas, bound to that canvas's id | `expected undefined to be 'scn_wire_1d4b'` |
| asks again when an unsaved canvas is SAVED, because the assessed model changes | `expected "spy" to be called 2 times, but got 1 times` |

The four that passed at pristine are the guest/absence guards — correctly green, because at pristine nothing ever sent the field. They are made non-vacuous by M2/M3 below.

**Mutation check** — throwaway worktree at an absolute path outside the repo root, mutating only committed state, restores HEAD-relative (`git checkout HEAD -- <path>`, never index-relative), clean-tree assertion before and after every mutant, applied-check scoped to `src/` (exactly 1 changed path per mutant, exactly 0 for the controls), per-spec collect counts asserted **by name** (`scenarioIdConvergence=9/9`, `invalidation=19/19`) on every run. Isolation was proven **by writing** a sentinel into the worktree and asserting the source's SHA-256 was unchanged, plus an APFS inode comparison — not by locating the path.

| Mutant | Result |
|---|---|
| **Control** (pristine) | exit 0, 28 passed |
| **M1** revert the emission | 4 RED — every presence assertion; guest assertions correctly stay green |
| **M2** drop the state-class guard (send unconditionally) | 4 RED — guest, empty-string, wire-guest, save-reasks |
| **M3** send `''` instead of omitting | 5 RED — guest, undefined, empty-string, wire-guest, save-reasks |
| **M4** hardcode one id (**discriminating pair**, trap 19) | 3 RED — the `scn_alpha_7c31` half stays **GREEN**, the `scn_beta_4e08` half REDs with `expected 'scn_alpha_7c31' to be 'scn_beta_4e08'`. That RED/GREEN pair is what proves the assertion binds by IDENTITY rather than by a value predicate any string could satisfy |
| **M5** drop the watched root, keep the emission | 4 RED — the Proxy completeness guard, the hardcoded-list guard, the watched-root assertion, and the behavioural save-reasks test |
| **Trailing control** | exit 0, 28 passed — identical to the first control |

**Gates run locally at this tip** (derived from `package.json`, not habit):
- `pnpm run typecheck` → **PASSED**. Coverage 3562/3602 tracked TS files loaded (40 declared out of scope); ratchet 557 files / 2263 errors against a 2263 baseline — no new diagnostics.
- `pnpm run lint` → **0 errors** (1176 pre-existing warnings), plus `lint:hooks-ratchet` exactly at its 229-violation baseline.
- Every spec in the repo that references `readinessStore` / `WATCHED_ROOTS` / `useReadinessStore` — **33 files, 335 tests, all passing** (arg count asserted at 33 before the run; `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported throughout).

The named local gate is a fast proxy, not the authority — **`Staging Gate` is.**

## Blast radius

`buildReadinessPayload` has exactly four call sites, all inside `readinessStore.ts` (`:453`, `:490`, `:879`, `:992`) — the projection, the empty-canvas arm, the post-fetch identity re-check, and the change detector. All four take the canvas store state whole, so all four pick the field up. `POST /bff/cee/graph-readiness` is the only route that receives this payload, and `readinessStore.ts:530` is its only caller in `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

