### PR TITLE
test(canvas): pin #800's placement-commit invariants — three surviving mutants now bite; two instrument defects corrected

### DIFF
--- a/e2e/geometry/decisionNodeHittest.measure.ts
+++ b/e2e/geometry/decisionNodeHittest.measure.ts
@@ -45,6 +45,11 @@
  *   inside the top bar must attribute to TOPBAR and a point inside the panel must
  *   attribute to OLUMI_PANEL. If `elementFromPoint` stopped discriminating, every
  *   "the node is hittable" reading would pass by measuring nothing.
+ * - PLACEMENT-BOUND IS RUN-DEPENDENT (19 Aug 2026). A cell reporting `> 0`
+ *   best-possible interception is reporting on THIS RUN's layout draw, which moves
+ *   ±13-21px. Two runs of the same commit produced two bound cells and zero bound
+ *   cells respectively. Quote a bound cell as a finding about that run; never quote
+ *   the COUNT as a property of the product.
  * - STORE/DOM AGREEMENT: the panel's rendered position and the store's model of
  *   it were two authorities for one fact — the store said `position: null` while
  *   the DOM said `left: 52px`, because the placement effect never ran. Pinned
@@ -89,13 +94,34 @@ interface Probe {
   /**
    * The fewest probes ANY legal placement of the panel could intercept, found by
    * exhaustive scan of the panel's legal top-left rectangle. `0` means a clearing
-   * placement exists and the product must find it; `> 0` means the panel is
-   * physically too large to clear this model at this viewport, which is a finding
-   * about geometry, not about the rule.
+   * placement exists and the product must find it; `> 0` means no legal placement
+   * clears this model at this viewport — a PLACEMENT-BOUND cell.
+   *
+   * ⚠⚠ PLACEMENT-BOUND IS A PROPERTY OF THE RUN, NOT A GEOMETRIC FACT ABOUT THE
+   * CELL — corrected 19 Aug 2026, and #800's own body says otherwise. The author's
+   * run reported TWO bound cells; an independent reviewer's run reported ZERO —
+   * all 27 cells solvable and fully cleared. The cells are genuinely marginal
+   * (at `reopen headcount @1440` the rule clears the anchor by 1.1px), and the
+   * layout draw moves by ±13-21px between runs, so which side of the boundary a
+   * cell lands on moves with it. The scan is exhaustive over integer positions
+   * and conservative, so WHEN a cell reports bound the reading is trustworthy —
+   * but the COUNT of bound cells is not reproducible and must never be quoted as
+   * one. #800's claim that "it is derived per run, so the layout jitter cannot
+   * make it flaky" has the implication backwards: derived per run is exactly WHY
+   * the count moves.
    */
   minPossibleIntercepted: number
-  /** Positions the scan evaluated — a positive control on the scan itself. */
+  /**
+   * Positions the scan evaluated. The scan BREAKS the moment it finds a clearing
+   * placement, so this equals `legalBoxArea` only when it found none.
+   */
   scanned: number
+  /** Every integer top-left the panel may legally occupy: the scan's whole domain. */
+  legalBoxArea: number
+  /** The legal box itself, so the shipped placement can be checked against it. */
+  legalBox: { xMin: number; xMax: number; yMin: number; yMax: number }
+  /** The panel's ACTUAL top-left, unrounded. `null` when the panel is unplaced. */
+  shippedTopLeft: { x: number; y: number } | null
   nodeRect: number[]
   panelRect: number[] | null
   storePos: { x: number; y: number } | null
@@ -181,7 +207,14 @@ async function probeDecisionNode(page: Page): Promise<Probe> {
     const pw = panelEl ? parseFloat(panelEl.style.width || '400') : 400
     const ph = panelEl ? parseFloat(panelEl.style.height || '550') : 550
     const dockEl = document.querySelector('aside[aria-label="Outputs dock"]') as HTMLElement | null
-    const dockInset = dockEl ? Math.max(0, innerWidth - dockEl.getBoundingClientRect().left) : 0
+    // Mirrors `measureDockInset` EXACTLY, zero-size rule included. Without that
+    // rule an unmeasured dock would shrink `xMax` below the product's own maxX,
+    // and the legal-box containment assertion below would RED on a healthy run.
+    const dockRect = dockEl ? dockEl.getBoundingClientRect() : null
+    const dockInset =
+      dockRect && dockRect.width !== 0 && dockRect.height !== 0
+        ? Math.max(0, innerWidth - dockRect.left)
+        : 0
     const topbarH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--topbar-h')) || 0
     const topInset = topbarH > 0 ? topbarH + MARGIN : MARGIN
     const xMin = MARGIN + SIDE_TAB
@@ -223,6 +256,14 @@ async function probeDecisionNode(page: Page): Promise<Probe> {
       if (minPossibleIntercepted === 0) break
     }
 
+    // The placement the product ACTUALLY chose, read unrounded off the element
+    // the hit-test attributed to. Read from the inline style rather than the
+    // rect for the same reason `pw`/`ph` are: it is the exact number the
+    // placement rule wrote, with no sub-pixel compositing in between.
+    const finite = (v: number): number | null => (Number.isFinite(v) ? v : null)
+    const shippedX = panelEl ? finite(parseFloat(panelEl.style.left)) : null
+    const shippedY = panelEl ? finite(parseFloat(panelEl.style.top)) : null
+
     // The placement this rule replaces: the clamped centred default.
     const clamp = (v: number, lo: number, hi: number) => (v < lo ? lo : v > hi ? hi : v)
     const baseX = clamp(Math.max(MARGIN, Math.floor((innerWidth - dockInset - pw) / 2)), xMin, xMax)
@@ -237,6 +278,9 @@ async function probeDecisionNode(page: Page): Promise<Probe> {
       baselineIntercepted: interceptedAt(baseX, baseY),
       minPossibleIntercepted: minPossibleIntercepted === Infinity ? 0 : minPossibleIntercepted,
       scanned,
+      legalBoxArea: (xMax - xMin + 1) * (yMax - yMin + 1),
+      legalBox: { xMin, xMax, yMin, yMax },
+      shippedTopLeft: shippedX !== null && shippedY !== null ? { x: shippedX, y: shippedY } : null,
       nodeRect: [r.left, r.top, r.right, r.bottom].map(Math.round),
       panelRect: p ? [p.left, p.top, p.right, p.bottom].map(Math.round) : null,
       storePos: panelEl
@@ -263,7 +307,29 @@ function assertProbe(label: string, m: Probe): void {
   // (CLAUDE.md trap 13).
   expect(m.ctlTopBar, `${label} NEGATIVE CONTROL: a point inside the top bar must attribute to TOPBAR`).toBe('TOPBAR')
   expect(m.ctlPanel, `${label} NEGATIVE CONTROL: a point inside the panel must attribute to OLUMI_PANEL`).toBe('OLUMI_PANEL')
-  expect(m.scanned, `${label} POSITIVE CONTROL: the placement scan must have evaluated positions`).toBeGreaterThan(0)
+  // ⚠ REPLACES A CONTROL THAT COULD NOT FAIL. `expect(m.scanned).toBeGreaterThan(0)`
+  // was guaranteed by `xMax = Math.max(xMin, …)` / `yMax = Math.max(yMin, …)`:
+  // the loop always runs at least once. A reviewer measured `scanned: 1` in 15 of
+  // 27 cells — the early break — and the control read green on every one of them.
+  // The scan breaks the instant it finds a clearing placement, so `scanned` is
+  // only informative when it did NOT break, and there it must equal the WHOLE
+  // legal box: a "no legal placement clears this model" verdict from an under-run
+  // scan is an artefact, and that verdict is what downgrades the assertion below.
+  if (m.minPossibleIntercepted > 0) {
+    expect(
+      m.scanned,
+      `${label} POSITIVE CONTROL: a scan reporting NO clearing placement must have evaluated every legal position — ` +
+        `${m.scanned} of ${m.legalBoxArea} (${JSON.stringify(m.legalBox)})`,
+    ).toBe(m.legalBoxArea)
+  } else {
+    // Broke early, legitimately. What is still checkable is that the loop and the
+    // independently-computed area agree about the domain.
+    expect(
+      m.scanned,
+      `${label} POSITIVE CONTROL: the scan cannot have evaluated more positions than the legal box holds — ` +
+        `${m.scanned} of ${m.legalBoxArea}`,
+    ).toBeLessThanOrEqual(m.legalBoxArea)
+  }
   // BIND BY IDENTITY, never by screen position (trap 19).
   expect(m.hitElementId, `${label}: the probes must have landed on the DECISION node, bound by id`).toBe(m.decId)
 
@@ -281,9 +347,44 @@ function assertProbe(label: string, m: Probe): void {
     expect(m.panelIntercepted, `${label}: the companion must not intercept ANY probe — ${detail}`).toBe(0)
   } else {
     // PLACEMENT-BOUND: no legal placement of a panel this size clears this model
-    // at this viewport. Reported rather than silently tolerated, and still held
-    // to "never worse than the placement it replaces".
-    console.log(`PLACEMENT-BOUND ${label} — ${detail}`)
+    // at this viewport. ⚠ RUN-DEPENDENT, NOT A GEOMETRIC FACT about the cell —
+    // see `minPossibleIntercepted`'s doc. Reported rather than silently tolerated,
+    // and still held to "never worse than the placement it replaces".
+    console.log(`PLACEMENT-BOUND (run-dependent) ${label} — ${detail}`)
+
+    // ⭐ AND THE SOFTER BRANCH STILL ASSERTS. Otherwise the instrument's STRICTNESS
+    // is decided by the same run-dependent draw as the verdict: a run that happens
+    // to place the model lower gets `minPossible > 0`, and with it a `console.log`
+    // where the neighbouring run got a hard assertion. What this branch owes is the
+    // condition that makes its own verdict mean anything about the PRODUCT: the
+    // exhaustive scan searched the box the product is clamped into. If the shipped
+    // placement sits outside the scanned box, then "no legal placement clears this
+    // model" is a statement about a region the product cannot reach, and the
+    // downgrade above was bought with a mis-derived box. Bounds are compared
+    // exactly — `clampPositionToViewport` writes `xMin`/`maxX` verbatim, so a
+    // sub-pixel placement cannot straddle them.
+    expect(
+      m.shippedTopLeft,
+      `${label}: the panel must be PLACED for a placement-bound verdict to mean anything — ${detail}`,
+    ).not.toBeNull()
+    const { xMin, xMax, yMin, yMax } = m.legalBox
+    const box = `legal box x[${xMin}, ${xMax}] y[${yMin}, ${yMax}]`
+    expect(
+      m.shippedTopLeft!.x,
+      `${label}: the shipped placement must lie inside the box the scan searched, or the scan's verdict is about a region the product cannot use — shipped x ${m.shippedTopLeft!.x}, ${box}`,
+    ).toBeGreaterThanOrEqual(xMin)
+    expect(
+      m.shippedTopLeft!.x,
+      `${label}: shipped x ${m.shippedTopLeft!.x} is outside the scanned ${box}`,
+    ).toBeLessThanOrEqual(xMax)
+    expect(
+      m.shippedTopLeft!.y,
+      `${label}: shipped y ${m.shippedTopLeft!.y} is outside the scanned ${box}`,
+    ).toBeGreaterThanOrEqual(yMin)
+    expect(
+      m.shippedTopLeft!.y,
+      `${label}: shipped y ${m.shippedTopLeft!.y} is outside the scanned ${box}`,
+    ).toBeLessThanOrEqual(yMax)
   }
   expect(
     m.panelIntercepted,

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.placementCommit.spec.tsx
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.placementCommit.spec.tsx
@@ -1,0 +1,344 @@
+/**
+ * ONE PLACEMENT AUTHORITY — the two halves of UI #800 that no gate could see.
+ *
+ * #800 fixed two defects in `FloatingOlumiPanel`. The first (the fit-then-place
+ * rule itself) is pinned by `FloatingOlumiPanel.graphAwarePlacement.spec.ts`.
+ * The second was NOT pinned anywhere: an adversarial reviewer ran three mutants
+ * against the entire 26-spec / 287-test floating-panel neighbourhood and ALL
+ * THREE SURVIVED — 287 passed, every time.
+ *
+ *   M1  revert the layout effect's deps to the pre-#800 list                SURVIVED
+ *   M2  delete the re-clamp handler's `!el.style.left` guard                SURVIVED
+ *   M3  revert the settle guard to a bare `if (position === null)`          SURVIVED
+ *
+ * A `react-hooks/exhaustive-deps` autofix — or anyone tidying that deps array —
+ * would therefore reintroduce the measured `[52, 73]`-at-every-viewport defect
+ * under a fully green required check. The only instrument that catches it today
+ * is `e2e/geometry/decisionNodeHittest.measure.ts`, a `*.measure.ts` that is
+ * provably OUTSIDE the vitest gate (`vitest.config.ts` collects `src/**` and
+ * `tests/**` only) and is run deliberately, by hand.
+ *
+ * ⚠ WHY jsdom IS SUFFICIENT AND THIS IS NOT A TRAP-3 VIOLATION. Every claim
+ * below is about STRING AGREEMENT between two authorities for one fact — the
+ * store's `position` and the panel's inline `style.left`/`style.top` — plus the
+ * absence of a write. Nothing here asserts that anything is VISIBLE, laid out,
+ * or clear of the model; those are the browser instrument's job and stay there.
+ *
+ * Mock layout mirrors `FloatingOlumiPanel.dockInset.spec.tsx`, with ONE
+ * difference: the canvas store mock is a REAL zustand store rather than a frozen
+ * object, because the defect only exists on the transition `nodeCount 0 -> 1`
+ * and a non-subscribable mock cannot produce it.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, render } from '@testing-library/react'
+import type { ReactNode } from 'react'
+
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+
+interface CanvasMockNode { id: string; type?: string }
+interface CanvasMockState {
+  nodes: CanvasMockNode[]
+  edges: unknown[]
+  results: { status: string }
+  _internal: Record<string, unknown>
+  selection: unknown
+  ceeAnalysisReady: unknown
+  graphHealth: unknown
+  runMeta: unknown
+  pendingLayout: boolean
+  layoutInProgress: boolean
+  layoutVersion: number
+}
+
+vi.mock('../../store', async () => {
+  const { create } = await import('zustand')
+  const useCanvasStore = create<CanvasMockState>(() => ({
+    nodes: [],
+    edges: [],
+    results: { status: 'idle' },
+    _internal: {},
+    selection: null,
+    ceeAnalysisReady: null,
+    graphHealth: null,
+    runMeta: {},
+    pendingLayout: false,
+    layoutInProgress: false,
+    layoutVersion: 0,
+  }))
+  return {
+    useCanvasStore,
+    selectResultsStatus: (s: CanvasMockState) => s.results?.status,
+    selectReport: (s: { results?: { report?: unknown } }) => s.results?.report,
+    selectError: (s: { results?: { error?: unknown } }) => s.results?.error,
+    selectResultsSource: (s: { results?: { source?: unknown } }) => s.results?.source,
+  }
+})
+
+vi.mock('../../conversation/ConversationPanel', () => ({ ConversationPanel: () => null }))
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({ useStageAwarePlaceholder: () => 'Ask' }))
+vi.mock('../../conversation/useConversation', async () => {
+  const { useState } = await import('react')
+  return {
+    useConversation: () => {
+      const [sendMessage] = useState(() => vi.fn())
+      return {
+        messages: [],
+        isThinking: false,
+        longRunningHint: null,
+        sendMessage,
+        sendSystemEvent: vi.fn(),
+        sendChip: vi.fn(),
+        retryLast: vi.fn(),
+        patchBlockStates: new Map(),
+        setPatchBlockState: vi.fn(),
+        patchRejections: new Map(),
+        setPatchRejection: vi.fn(),
+      }
+    },
+    isNonConversationalContent: () => false,
+  }
+})
+
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { FloatingOlumiPanel } from '../FloatingOlumiPanel'
+import { useFloatingPanelState } from '../../hooks/useFloatingPanelState'
+import { useCanvasStore } from '../../store'
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return <ConversationProvider>{children}</ConversationProvider>
+}
+
+const VIEWPORT_W = 1440
+const VIEWPORT_H = 900
+
+interface StubBox { left: number; top: number; width: number; height: number }
+
+/** Mount a React Flow node stub the placement rule can measure.
+ *  `readModelBoxes` looks nodes up by `.react-flow__node[data-id]` and drops
+ *  zero-size rects, so the rect has to be mocked — jsdom runs no layout. */
+function mountGraphNode(id: string, box: StubBox): (next: StubBox) => void {
+  const el = document.createElement('div')
+  el.className = 'react-flow__node'
+  el.setAttribute('data-id', id)
+  document.body.appendChild(el)
+  let b = box
+  el.getBoundingClientRect = () =>
+    ({
+      left: b.left,
+      top: b.top,
+      right: b.left + b.width,
+      bottom: b.top + b.height,
+      width: b.width,
+      height: b.height,
+      x: b.left,
+      y: b.top,
+      toJSON: () => ({}),
+    }) as DOMRect
+  return (next: StubBox) => {
+    b = next
+  }
+}
+
+const panelEl = () => document.querySelector('[data-testid="floating-olumi-panel"]') as HTMLElement | null
+
+beforeEach(() => {
+  Object.defineProperty(window, 'innerWidth', { value: VIEWPORT_W, configurable: true })
+  Object.defineProperty(window, 'innerHeight', { value: VIEWPORT_H, configurable: true })
+  useFloatingPanelState.getState().reset()
+  document.body.querySelectorAll('.react-flow__node').forEach((el) => el.remove())
+  useCanvasStore.setState({ nodes: [], layoutVersion: 0, pendingLayout: false, layoutInProgress: false })
+})
+
+describe('FloatingOlumiPanel — the store and the DOM agree about where the panel is', () => {
+  /**
+   * M1. THE HERO-YIELD BOUNDARY, which is the path every seeded user reaches.
+   *
+   * The component returns `null` for exactly `!isOpen || yieldToFirstUse ||
+   * yieldToDockedOlumi`, so `containerRef` is null and the layout effect
+   * early-returns. Pre-#800 only `isOpen` was in that effect's deps, so when the
+   * first graph landed and `yieldToFirstUse` flipped false, the container
+   * MOUNTED WITHOUT THE EFFECT EVER RE-RUNNING: the panel kept its JSX defaults,
+   * `setInitialPosition` was never called, and the store still said
+   * `position: null` while the DOM had been pinned to the clamp floor.
+   */
+  it('commits a placement when the first graph lands and the hero stops yielding', () => {
+    useFloatingPanelState.setState({
+      isOpen: true,
+      source: 'system-first-use',
+      userRepositioned: false,
+      isMinimised: false,
+      position: null,
+      size: { width: 400, height: 500 },
+    } as never)
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+
+    // PRECONDITION, PINNED IN-TEST: we really are on the yielding side of the
+    // boundary. Without this the transition below could be a no-op and every
+    // assertion after it would pass by measuring nothing.
+    expect(panelEl(), 'PRECONDITION: the hero must be yielding, so no panel is mounted yet').toBeNull()
+    expect(useFloatingPanelState.getState().position, 'PRECONDITION: nothing is committed yet').toBeNull()
+
+    // The first graph lands: store nodes appear, React Flow renders them, the
+    // canvas store reports quiescence. `yieldToFirstUse` flips false and the
+    // container mounts.
+    act(() => {
+      mountGraphNode('dec-1', { left: 300, top: 200, width: 220, height: 90 })
+      mountGraphNode('fac-1', { left: 640, top: 430, width: 200, height: 80 })
+      useCanvasStore.setState({
+        nodes: [{ id: 'dec-1', type: 'decision' }, { id: 'fac-1', type: 'factor' }],
+        layoutVersion: 1,
+      })
+    })
+
+    const panel = panelEl()
+    expect(panel, 'the container must mount once the hero stops yielding').not.toBeNull()
+
+    const committed = useFloatingPanelState.getState().position
+    expect(committed, 'the store must know where the panel is: expected null not to be null').not.toBeNull()
+    expect(panel!.style.left, 'store and DOM must agree on the panel position (x)').toBe(`${committed!.x}px`)
+    expect(panel!.style.top, 'store and DOM must agree on the panel position (y)').toBe(`${committed!.y}px`)
+    // Not the untouched JSX default, and not the clamp floor the defect produced.
+    expect(panel!.style.left, 'the placement must be COMPUTED, not the JSX default').not.toBe('0px')
+  })
+
+  /**
+   * M1, second face. The measured symptom was a placement BYTE-IDENTICAL from
+   * 1024 to 1920 — a fixed-origin window standing in for a computed one. A
+   * committed placement is viewport-derived, so two different viewports must not
+   * produce the same x. This discriminates a real computation from any constant.
+   */
+  it('derives the committed placement from the live viewport, not a constant', () => {
+    const commitAt = (vw: number): number => {
+      Object.defineProperty(window, 'innerWidth', { value: vw, configurable: true })
+      useFloatingPanelState.getState().reset()
+      useCanvasStore.setState({ nodes: [], layoutVersion: 0 })
+      document.body.querySelectorAll('.react-flow__node').forEach((el) => el.remove())
+      useFloatingPanelState.setState({
+        isOpen: true,
+        source: 'system-first-use',
+        userRepositioned: false,
+        isMinimised: false,
+        position: null,
+        size: { width: 400, height: 500 },
+      } as never)
+      const { unmount } = render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+      act(() => {
+        mountGraphNode('dec-1', { left: 120, top: 180, width: 220, height: 90 })
+        useCanvasStore.setState({ nodes: [{ id: 'dec-1', type: 'decision' }], layoutVersion: 1 })
+      })
+      const pos = useFloatingPanelState.getState().position
+      expect(pos, `the store must know where the panel is at ${vw}px`).not.toBeNull()
+      unmount()
+      return pos!.x
+    }
+
+    const narrow = commitAt(1200)
+    const wide = commitAt(1800)
+    expect(wide, 'the committed x must move with the viewport, not sit at a fixed origin').not.toBe(narrow)
+  })
+
+  /**
+   * M3. THE SETTLE GUARD. `setInitialPosition` is a ONE-SHOT (it writes only
+   * while `position` is null), so committing a placement measured against
+   * half-laid-out node rects freezes the panel at a position derived from
+   * geometry that no longer exists. Until the canvas store reports quiescence
+   * AND something is rendered, the placement is applied to the DOM but left
+   * UNCOMMITTED so the effect can re-derive it.
+   */
+  it('does not commit a placement measured against a model that is still settling', () => {
+    // Nodes exist in the store, React Flow has rendered them at their
+    // pre-layout rects, and the canvas store has NOT reported quiescence.
+    const movePre = mountGraphNode('dec-1', { left: 20, top: 20, width: 220, height: 90 })
+    const moveFac = mountGraphNode('fac-1', { left: 30, top: 130, width: 200, height: 80 })
+    useCanvasStore.setState({
+      nodes: [{ id: 'dec-1', type: 'decision' }, { id: 'fac-1', type: 'factor' }],
+      layoutVersion: 0,
+      layoutInProgress: true,
+    })
+    useFloatingPanelState.setState({
+      isOpen: true,
+      source: 'user',
+      userRepositioned: false,
+      isMinimised: false,
+      position: null,
+      size: { width: 400, height: 500 },
+    } as never)
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+
+    const panel = panelEl()
+    expect(panel, 'PRECONDITION: the panel is mounted while the model settles').not.toBeNull()
+    // PRECONDITION: the placement IS applied to the DOM — the claim is about the
+    // COMMIT, not about the panel being unplaced.
+    expect(panel!.style.left, 'PRECONDITION: the DOM is placed even while settling').not.toBe('')
+    const whileSettling = panel!.style.left
+
+    expect(
+      useFloatingPanelState.getState().position,
+      'a placement measured against a settling model must NOT be committed — setInitialPosition is a one-shot',
+    ).toBeNull()
+
+    // Layout commits: the nodes move to their laid-out rects and the store
+    // reports quiescence. NOW the placement is committed.
+    act(() => {
+      movePre({ left: 700, top: 520, width: 220, height: 90 })
+      moveFac({ left: 980, top: 640, width: 200, height: 80 })
+      useCanvasStore.setState({ layoutVersion: 1, layoutInProgress: false })
+    })
+
+    const committed = useFloatingPanelState.getState().position
+    expect(committed, 'once the model has settled the placement must be committed').not.toBeNull()
+    expect(panel!.style.left, 'store and DOM must agree on the committed placement').toBe(`${committed!.x}px`)
+    // NON-VACUITY: the two geometries must actually disagree, or "committed the
+    // settled one" would hold trivially for the settling one too.
+    expect(panel!.style.left, 'the committed placement must be the SETTLED geometry, not the settling one').not.toBe(
+      whileSettling,
+    )
+  })
+
+  /**
+   * M2. ONE PLACEMENT AUTHORITY. The viewport/dock re-clamp handler RE-CLAMPS a
+   * panel the layout effect has already placed; it must never INVENT one.
+   * Without its guard it read an unset `el.style.left` as `parseFloat('') || 0`
+   * -> 0 -> clamped to the floor, which is how the panel came to sit at a
+   * byte-identical (52, 73) at every viewport while the store held `null`.
+   */
+  it('the re-clamp handler refuses to invent a position for an unplaced panel', () => {
+    mountGraphNode('dec-1', { left: 300, top: 200, width: 220, height: 90 })
+    useCanvasStore.setState({ nodes: [{ id: 'dec-1', type: 'decision' }], layoutVersion: 1 })
+    useFloatingPanelState.setState({
+      isOpen: true,
+      source: 'user',
+      userRepositioned: true,
+      isMinimised: false,
+      position: { x: 300, y: 120 },
+      size: { width: 400, height: 500 },
+    } as never)
+    render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
+    const panel = panelEl()!
+    expect(panel.style.left, 'PRECONDITION: the layout effect has placed the panel').not.toBe('')
+
+    // Reproduce the one state the guard exists for: the container is mounted but
+    // the layout effect has not written to it, so the inline style is unset. The
+    // handler's only honest answer is to wait for the effect, not to guess.
+    panel.style.left = ''
+    panel.style.top = ''
+    expect(panel.style.left, 'PRECONDITION: the panel is unplaced when the handler runs').toBe('')
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'))
+      window.dispatchEvent(new Event('outputs-dock-opened'))
+    })
+
+    expect(panel.style.left, 'the re-clamp handler must not invent an x for an unplaced panel').toBe('')
+    expect(panel.style.top, 'the re-clamp handler must not invent a y for an unplaced panel').toBe('')
+  })
+})

--- a/src/canvas/components/__tests__/FloatingOlumiPanel.placementCommit.spec.tsx
+++ b/src/canvas/components/__tests__/FloatingOlumiPanel.placementCommit.spec.tsx
@@ -111,7 +111,19 @@ vi.mock('../../conversation/useConversation', async () => {
 import { ConversationProvider } from '../../conversation/ConversationContext'
 import { FloatingOlumiPanel } from '../FloatingOlumiPanel'
 import { useFloatingPanelState } from '../../hooks/useFloatingPanelState'
-import { useCanvasStore } from '../../store'
+import { useCanvasStore as realCanvasStore } from '../../store'
+
+/**
+ * `vi.mock` is a RUNTIME substitution — TypeScript still resolves this import to
+ * the real canvas store, whose `Node` type this fixture deliberately does not
+ * satisfy (the placement rule reads only `id` and `type`). Narrow the handle to
+ * the mock's own shape rather than widening the fixture to a full `Node`, which
+ * would be a lie about what the rule actually consumes.
+ */
+const canvasStore = realCanvasStore as unknown as {
+  setState: (patch: Partial<CanvasMockState>) => void
+  getState: () => CanvasMockState
+}
 
 function Wrapper({ children }: { children: ReactNode }) {
   return <ConversationProvider>{children}</ConversationProvider>
@@ -155,7 +167,7 @@ beforeEach(() => {
   Object.defineProperty(window, 'innerHeight', { value: VIEWPORT_H, configurable: true })
   useFloatingPanelState.getState().reset()
   document.body.querySelectorAll('.react-flow__node').forEach((el) => el.remove())
-  useCanvasStore.setState({ nodes: [], layoutVersion: 0, pendingLayout: false, layoutInProgress: false })
+  canvasStore.setState({ nodes: [], layoutVersion: 0, pendingLayout: false, layoutInProgress: false })
 })
 
 describe('FloatingOlumiPanel — the store and the DOM agree about where the panel is', () => {
@@ -193,7 +205,7 @@ describe('FloatingOlumiPanel — the store and the DOM agree about where the pan
     act(() => {
       mountGraphNode('dec-1', { left: 300, top: 200, width: 220, height: 90 })
       mountGraphNode('fac-1', { left: 640, top: 430, width: 200, height: 80 })
-      useCanvasStore.setState({
+      canvasStore.setState({
         nodes: [{ id: 'dec-1', type: 'decision' }, { id: 'fac-1', type: 'factor' }],
         layoutVersion: 1,
       })
@@ -220,7 +232,7 @@ describe('FloatingOlumiPanel — the store and the DOM agree about where the pan
     const commitAt = (vw: number): number => {
       Object.defineProperty(window, 'innerWidth', { value: vw, configurable: true })
       useFloatingPanelState.getState().reset()
-      useCanvasStore.setState({ nodes: [], layoutVersion: 0 })
+      canvasStore.setState({ nodes: [], layoutVersion: 0 })
       document.body.querySelectorAll('.react-flow__node').forEach((el) => el.remove())
       useFloatingPanelState.setState({
         isOpen: true,
@@ -233,7 +245,7 @@ describe('FloatingOlumiPanel — the store and the DOM agree about where the pan
       const { unmount } = render(<FloatingOlumiPanel onDock={() => {}} onCogClick={() => {}} />, { wrapper: Wrapper })
       act(() => {
         mountGraphNode('dec-1', { left: 120, top: 180, width: 220, height: 90 })
-        useCanvasStore.setState({ nodes: [{ id: 'dec-1', type: 'decision' }], layoutVersion: 1 })
+        canvasStore.setState({ nodes: [{ id: 'dec-1', type: 'decision' }], layoutVersion: 1 })
       })
       const pos = useFloatingPanelState.getState().position
       expect(pos, `the store must know where the panel is at ${vw}px`).not.toBeNull()
@@ -259,7 +271,7 @@ describe('FloatingOlumiPanel — the store and the DOM agree about where the pan
     // pre-layout rects, and the canvas store has NOT reported quiescence.
     const movePre = mountGraphNode('dec-1', { left: 20, top: 20, width: 220, height: 90 })
     const moveFac = mountGraphNode('fac-1', { left: 30, top: 130, width: 200, height: 80 })
-    useCanvasStore.setState({
+    canvasStore.setState({
       nodes: [{ id: 'dec-1', type: 'decision' }, { id: 'fac-1', type: 'factor' }],
       layoutVersion: 0,
       layoutInProgress: true,
@@ -291,7 +303,7 @@ describe('FloatingOlumiPanel — the store and the DOM agree about where the pan
     act(() => {
       movePre({ left: 700, top: 520, width: 220, height: 90 })
       moveFac({ left: 980, top: 640, width: 200, height: 80 })
-      useCanvasStore.setState({ layoutVersion: 1, layoutInProgress: false })
+      canvasStore.setState({ layoutVersion: 1, layoutInProgress: false })
     })
 
     const committed = useFloatingPanelState.getState().position
@@ -313,7 +325,7 @@ describe('FloatingOlumiPanel — the store and the DOM agree about where the pan
    */
   it('the re-clamp handler refuses to invent a position for an unplaced panel', () => {
     mountGraphNode('dec-1', { left: 300, top: 200, width: 220, height: 90 })
-    useCanvasStore.setState({ nodes: [{ id: 'dec-1', type: 'decision' }], layoutVersion: 1 })
+    canvasStore.setState({ nodes: [{ id: 'dec-1', type: 'decision' }], layoutVersion: 1 })
     useFloatingPanelState.setState({
       isOpen: true,
       source: 'user',


### PR DESCRIPTION
Follow-on to #800 (merged, staging `70adaa39`). Two independent problems, both surfaced by the adversarial review of that PR, neither reachable from any gate. **No product code changes.**

---

## 1 · Three surviving mutants — the second defect #800 fixed was in no gate at all

The reviewer ran three mutants — one per change #800 made for its *second* defect — against the whole floating-panel neighbourhood. **All three survived a fully green run.**

| mutant | `FloatingOlumiPanel.tsx` | reviewer's run | **this PR** |
|---|---|---|---|
| M1 revert the layout effect's deps to the pre-#800 list | `:802-815` | 287 passed — **SURVIVES** | **BITES** (3 failing) |
| M2 delete `if (!el.style.left \|\| !el.style.top) return` | `:923` | 287 passed — **SURVIVES** | **BITES** (1 failing) |
| M3 revert the settle guard to a bare `if (position === null)` | `:784` | 287 passed — **SURVIVES** | **BITES** (1 failing) |

So a `react-hooks/exhaustive-deps` autofix — or anyone tidying that deps array — would have reintroduced the measured `[52, 73]`-at-every-viewport defect **under a green required check**. The only instrument that could see it is `e2e/geometry/decisionNodeHittest.measure.ts`, a `*.measure.ts` file provably outside the vitest gate (`vitest.config.ts` collects `src/**` and `tests/**` only) and run by hand.

**Each mutant REDs on its own assertion**, re-derived at this PR's head `59354541`, leading and trailing controls green, applied-check exactly 1 changed file under `src/` per mutant and exactly 0 on both controls:

```
M1  the store must know where the panel is: expected null not to be null
M2  the re-clamp handler must not invent an x for an unplaced panel: expected '52px' to be ''
M3  a placement measured against a settling model must NOT be committed —
    setInitialPosition is a one-shot: expected { x: 520, y: 200 } to be null
```

M2 reproduces the measured symptom exactly: **`52px`**, the clamp floor, from an unset style read as `parseFloat('') || 0`.

**New file:** `src/canvas/components/__tests__/FloatingOlumiPanel.placementCommit.spec.tsx` — 4 tests, ~40 lines of assertions in the repo's existing pattern (`FloatingOlumiPanel.dockInset.spec.tsx`).

- **Half A** drives `nodeCount 0 → 1` across the hero-yield boundary and asserts the store position is non-null **and the DOM agrees** — the two authorities for one fact that #800's dep note describes. A second test pins the same claim by *discrimination*: the committed `x` must **move with the viewport**, because the measured defect was a placement byte-identical from 1024 to 1920.
- **Half B** pins the re-clamp handler refusing to invent a position for an unplaced panel.
- **M3's test** pins the settle guard: uncommitted while the model settles, committed once it has — and the committed value must be the **settled** geometry, not the settling one.

Every test **pins its own precondition in-test** (the hero really is yielding; the DOM really is placed while settling; the panel really is unplaced when the handler runs), so none of them can pass by measuring nothing.

⚠ **jsdom is sufficient and this is not a trap-3 violation.** Every claim is **string agreement** between `useFloatingPanelState.position` and the panel's inline `style.left`/`style.top`, plus the absence of a write. Nothing here asserts anything is *visible*, laid out, or clear of the model — that stays with the browser instrument.

One mock difference from `dockInset.spec.tsx`, and it is load-bearing: the canvas store mock is a **real zustand store** rather than a frozen object, because the defect exists only on the `nodeCount 0 → 1` transition and a non-subscribable mock cannot produce it.

---

## 2 · Two instrument defects in `decisionNodeHittest.measure.ts`

**(a) `PLACEMENT-BOUND` is run-dependent, not a geometric fact — and #800's body says otherwise.**

The author's run reported **two** bound cells. The reviewer's run reported **zero** — all 27 cells solvable and fully cleared. The cells are genuinely marginal (at `reopen headcount @1440` the rule clears the anchor by **1.1px**) and the layout draw moves ±13-21px between runs. #800's claim that *"it is derived per run, so the layout jitter cannot make it flaky"* has the implication backwards: **derived per run is exactly why the count moves.** The scan is exhaustive over integer positions and conservative, so *when* a cell reports bound the reading is trustworthy — but the **count** is not reproducible and must never be quoted as a property of the product. Corrected in the header, in `minPossibleIntercepted`'s doc, and in the log line itself.

**And the strictness moved with it.** The instrument hard-asserts when `minPossible === 0` and downgrades to a `console.log` when `> 0` — so **a run that happens to draw a lower layout gets a softer instrument.** The softer branch now asserts the condition that makes its own verdict mean anything about the *product*: **the shipped placement lies inside the box the scan searched.** If it does not, "no legal placement clears this model" is a statement about a region the product cannot reach, and the downgrade was bought with a mis-derived box. Bounds are compared exactly — `clampPositionToViewport` writes the same `xMin`/`maxX`/`yMin`/`yMax` verbatim, so a sub-pixel placement cannot straddle them.

*Smallest enabling change, called out rather than slipped in:* the instrument's `dockInset` now mirrors `measureDockInset`'s zero-size rule. Without it an unmeasured dock would shrink `xMax` below the product's own `maxX` and the new containment assertion would RED on a healthy run.

**(b) A control that cannot fail.** `expect(m.scanned).toBeGreaterThan(0)` at `:264` was guaranteed by `xMax = Math.max(xMin, …)` / `yMax = Math.max(yMin, …)` — the loop always runs at least once — and the reviewer measured `scanned: 1` in **15 of 27 cells** (the early break), green every time. The scan breaks the instant it finds a clearing placement, so `scanned` is only informative when it did **not** break. Now:

- `minPossible > 0` → `expect(m.scanned).toBe(m.legalBoxArea)`. **A "no legal placement clears this" verdict from an under-run scan is an artefact — and that verdict is what downgrades the assertion above.** This can fail.
- `minPossible === 0` → `expect(m.scanned).toBeLessThanOrEqual(m.legalBoxArea)`, cross-checking the loop bounds against the independently computed area.

⚠ **Scope of the evidence, stated precisely.** I could not *run* this instrument — it needs Chromium and a live app. It is **type-verified**: `tsconfig.tooling.json` loads it (proven by `--listFilesOnly`), it is not in the gate's uncovered list, and the typecheck gate passes at this head. Every new assertion was chosen to be **exactly comparable and sub-pixel-safe** for that reason; I deliberately did **not** add the more valuable `panelIntercepted >= minPossibleIntercepted` cross-check, because `panelIntercepted` comes from live `elementFromPoint` attribution and could legitimately fall below the geometric minimum (an occluder above the panel, or a fractional placement beating the integer grid) — a false RED on an instrument I cannot run.

**#800's merged body is left untouched** — it is a record, and rewriting it would falsify one. The correction lives in the instrument, where the next reader meets it.

---

## Out of scope, deliberately

- **`computeFitPadding.ts` untouched** — not in #800's diff, pinned by guard G2a, correct as-is.
- **The secondary-objective headroom is not chased.** The shipped 5-candidate rule hides **24-59%** more of the model than the exhaustive best anchor-clearing placement (155k vs 103k px² at `pricing@1250`). That is a product decision, rowed, not this lane's.
- **The layout non-determinism is not fixed.** Rowed separately, and bigger than this lane.

---

## Gates

- `bash scripts/ci/typecheck-gate.sh` → **PASSED** (coverage 3563/3603 + ratchet 557 files / 2263 errors, unchanged). It caught a real error on the first attempt — `vi.mock` is runtime-only, so TS still resolved the fixture against the real store's `Node` type; fixed by narrowing the handle to the mock's shape rather than widening the fixture into a lie about what the placement rule consumes.
- `pnpm run lint` → **0 errors**, none on either touched file; rules-of-hooks ratchet exactly at baseline.
- Floating-panel neighbourhood, run as a superset of the reviewer's sweep — `FloatingOlumiPanel.* · cameraComfort.* · computeFitPadding.* · useFloatingPanelState · revealOlumiSurface · olumiSurface · FirstUseComposer · aiPanelV2.* · OutputsDock.*` → **48 files / 483 tests passed**, spec count asserted ≥20 before the run.
- New spec asserted to collect **exactly 4 tests by name** on every one of the 8 mutant-harness runs; a shrunk collect is a hard error in the harness, not a warning.
- Mutation isolation proven **by writing** a sentinel into the throwaway worktree and asserting the source clone was unchanged, plus an APFS inode comparison; restores read from a pristine archive outside both trees, never `git checkout -- <path>`.
- ⚠ `Visual Regression (advisory)` is **ignored** and is not evidence either way — its own self-test reports a 3.78% noise floor against a 0.05% tolerance and it has hung 46-85 minutes on several heads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
