### PR TITLE
feat(conversation): render the model-building notices the user never sees

### DIFF
--- a/src/canvas/conversation/MessageBubble.tsx
+++ b/src/canvas/conversation/MessageBubble.tsx
@@ -21,6 +21,7 @@ import { typography } from '../../styles/typography'
 import { safeRichText } from '../utils/safeRichText'
 import { AnswerBody, resolveAnswerBodyText } from './AnswerBody'
 import { GroundedOnNotice } from './GroundedOnNotice'
+import { ModelBuildingNoticesNotice } from './ModelBuildingNoticesNotice'
 import { InlineBlocks } from './InlineBlocks'
 import { AlertCircle, ChevronDown, ChevronUp, ListPlus, AlignLeft, RefreshCw } from 'lucide-react'
 import { FeedbackRow } from './FeedbackRow'
@@ -490,6 +491,17 @@ export const MessageBubble = memo(function MessageBubble({
         * one. */}
       {!isUser && message.groundedSelection && (
         <GroundedOnNotice groundedSelection={message.groundedSelection} />
+      )}
+      {/* What Olumi had to leave out of the model it drafted on THIS turn.
+        * NO FLAG (CEE emits `model_building_notices` unconditionally, and it is
+        * a declared 0.48.0 contract field), and the condition is the PAYLOAD'S
+        * OWN PRESENCE: a draft that dropped nothing carries no key, so
+        * `message.modelBuildingNotices` is undefined and nothing renders.
+        * Rendering a zero here would report an omission that never happened.
+        * Assistant-only: an omission is a fact about a MODEL OLUMI BUILT, and
+        * the user's own bubble never carries one. */}
+      {!isUser && message.modelBuildingNotices && (
+        <ModelBuildingNoticesNotice notices={message.modelBuildingNotices} />
       )}
       {message.insights && message.insights.length > 0 && isDeterministicCeeEnabled() && (
         <InsightsStrip insights={message.insights} onSendMessage={onArtefactMessage} />

--- a/src/canvas/conversation/MessageBubble.tsx
+++ b/src/canvas/conversation/MessageBubble.tsx
@@ -495,9 +495,11 @@ export const MessageBubble = memo(function MessageBubble({
       {/* What Olumi had to leave out of the model it drafted on THIS turn.
         * NO FLAG (CEE emits `model_building_notices` unconditionally, and it is
         * a declared 0.48.0 contract field), and the condition is the PAYLOAD'S
-        * OWN PRESENCE: a draft that dropped nothing carries no key, so
-        * `message.modelBuildingNotices` is undefined and nothing renders.
-        * Rendering a zero here would report an omission that never happened.
+        * OWN PRESENCE: with no attestation `message.modelBuildingNotices` is
+        * undefined and nothing renders. The contract cannot encode zero, so
+        * absence is SILENCE, not a clean bill of health — rendering a zero here
+        * would report an omission that never happened, and rendering
+        * reassurance would claim a completeness the field cannot evidence.
         * Assistant-only: an omission is a fact about a MODEL OLUMI BUILT, and
         * the user's own bubble never carries one. */}
       {!isUser && message.modelBuildingNotices && (

--- a/src/canvas/conversation/ModelBuildingNoticesNotice.tsx
+++ b/src/canvas/conversation/ModelBuildingNoticesNotice.tsx
@@ -1,0 +1,115 @@
+/**
+ * ModelBuildingNoticesNotice — the reader for CEE's `model_building_notices`.
+ *
+ * Until this component the field had ZERO renderers repo-wide: 56 notices
+ * generated, 0 delivered. Olumi was recording what it had to leave out of a
+ * user's model and telling nobody — which is indistinguishable, to the user,
+ * from a model that captured their brief completely.
+ *
+ * ── WHY THIS SURFACE ───────────────────────────────────────────────────────
+ * The same argument `GroundedOnNotice` makes, for the same reason: a
+ * model-building notice is a fact about ONE TURN's draft. It rides that turn's
+ * bubble so scrolling back shows each draft with its OWN omissions. A canvas or
+ * dock treatment is global and single-slot, so the latest draft's omissions
+ * would sit beside every earlier one — a mis-attribution the user cannot
+ * detect.
+ *
+ * It is deliberately NOT hosted inside `ModelReceiptBlock`, the other
+ * post-draft card. That card is gated THREE times over — the
+ * `preAnalysisEnriched` flag (envKey `VITE_FEATURE_PRE_ANALYSIS_ENRICHED`,
+ * `defaultValue` false and ABSENT from `netlify.toml`), a non-empty
+ * `coachingSummary`, and a normalised `ceeAnalysisReady`. Hanging an honest
+ * disclosure off three preconditions it does not need is how a correct thing
+ * ships dark, which is the failure this component exists to end. This one is
+ * UNGATED and its only condition is the payload's own presence.
+ *
+ * ── PROGRESSIVE DISCLOSURE ─────────────────────────────────────────────────
+ * Collapsed by default to ONE count-led line. A first-draft wall of notices is
+ * its own failure — the user has just been handed a model and the primary act
+ * is to read it, not to audit it. Depth is one click away and never pre-opened.
+ *
+ * ── WHAT IT NEVER CLAIMS ───────────────────────────────────────────────────
+ * · Never a kind code. `describeModelBuildingNoticeKind` is the only path to a
+ *   rendered string and returns null rather than falling back to the code.
+ * · Never that the listed rows account for the headline count. A kind this UI
+ *   cannot name is dropped from the rows while `total_count` stays the
+ *   producer's, so the two quantities can legitimately differ; the copy is
+ *   written so neither is stated in terms of the other.
+ * · Never a specific example. `details_redacted: true` means the producer sent
+ *   counts and nothing else — naming an item would be invention.
+ * · Never anything at all when the field is absent. No zero, no empty panel.
+ */
+import { memo, useState } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { typography } from '../../styles/typography'
+import {
+  MODEL_BUILDING_NOTICES_POINTER,
+  modelBuildingNoticesSummary,
+  type ModelBuildingNoticesView,
+} from './modelBuildingNotices'
+
+export interface ModelBuildingNoticesNoticeProps {
+  notices: ModelBuildingNoticesView
+}
+
+export const ModelBuildingNoticesNotice = memo(function ModelBuildingNoticesNotice({
+  notices,
+}: ModelBuildingNoticesNoticeProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  // A payload that survived the schema but names nothing this UI can phrase
+  // renders NOTHING. The headline alone ("Olumi left N things out") without a
+  // single nameable row is a dead end by the product's own definition: it
+  // reports a loss the user cannot act on. Silence is the honest alternative.
+  if (notices.rows.length === 0) return null
+
+  return (
+    <div
+      data-testid="model-building-notices"
+      data-total-count={notices.totalCount}
+      data-row-count={notices.rows.length}
+      className="mt-1.5"
+    >
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        aria-controls={expanded ? 'model-building-notices-detail' : undefined}
+        data-testid="model-building-notices-toggle"
+        className={`${typography.panelMeta} text-text-light inline-flex items-center gap-1 hover:text-text-body transition-colors`}
+      >
+        {modelBuildingNoticesSummary(notices.totalCount)}
+        {expanded
+          ? <ChevronDown className="w-3 h-3" aria-hidden="true" />
+          : <ChevronRight className="w-3 h-3" aria-hidden="true" />}
+      </button>
+
+      {expanded && (
+        <div id="model-building-notices-detail" className="mt-1 pl-4 space-y-1">
+          <ul className="space-y-0.5" role="list">
+            {notices.rows.map((row) => (
+              <li
+                key={row.kind}
+                // Provenance for tests/debug — binds a row to its producer kind
+                // BY IDENTITY. Never rendered as text.
+                data-notice-kind={row.kind}
+                className={`${typography.panelMeta} text-text-light`}
+              >
+                <span className="font-medium text-text-body">{row.count}</span>{' '}
+                {row.description}
+              </li>
+            ))}
+          </ul>
+          <p
+            data-testid="model-building-notices-pointer"
+            className={`${typography.panelMeta} text-text-light`}
+          >
+            {MODEL_BUILDING_NOTICES_POINTER}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+})
+
+export default ModelBuildingNoticesNotice

--- a/src/canvas/conversation/ModelBuildingNoticesNotice.tsx
+++ b/src/canvas/conversation/ModelBuildingNoticesNotice.tsx
@@ -68,7 +68,7 @@ export const ModelBuildingNoticesNotice = memo(function ModelBuildingNoticesNoti
       data-testid="model-building-notices"
       data-total-count={notices.totalCount}
       data-row-count={notices.rows.length}
-      className="mt-1.5"
+      className="mt-2"
     >
       <button
         type="button"
@@ -86,7 +86,7 @@ export const ModelBuildingNoticesNotice = memo(function ModelBuildingNoticesNoti
 
       {expanded && (
         <div id="model-building-notices-detail" className="mt-1 pl-4 space-y-1">
-          <ul className="space-y-0.5" role="list">
+          <ul className="space-y-1" role="list">
             {notices.rows.map((row) => (
               <li
                 key={row.kind}
@@ -95,7 +95,11 @@ export const ModelBuildingNoticesNotice = memo(function ModelBuildingNoticesNoti
                 data-notice-kind={row.kind}
                 className={`${typography.panelMeta} text-text-light`}
               >
-                <span className="font-medium text-text-body">{row.count}</span>{' '}
+                {/* Emphasis by COLOUR, never by a raw font weight. DS v5 §2.4
+                    bans raw sizes and weights in panel scope, and this file sits
+                    in the dock closure — the row is `text-text-light`, so the
+                    darker body token carries the count on its own. */}
+                <span className="text-text-body">{row.count}</span>{' '}
                 {row.description}
               </li>
             ))}

--- a/src/canvas/conversation/ModelBuildingNoticesNotice.tsx
+++ b/src/canvas/conversation/ModelBuildingNoticesNotice.tsx
@@ -95,12 +95,22 @@ export const ModelBuildingNoticesNotice = memo(function ModelBuildingNoticesNoti
                 data-notice-kind={row.kind}
                 className={`${typography.panelMeta} text-text-light`}
               >
-                {/* Emphasis by COLOUR, never by a raw font weight. DS v5 §2.4
-                    bans raw sizes and weights in panel scope, and this file sits
-                    in the dock closure — the row is `text-text-light`, so the
-                    darker body token carries the count on its own. */}
-                <span className="text-text-body">{row.count}</span>{' '}
-                {row.description}
+                {/* ⚠ THE COUNT IS A TRAILING QUANTITY, NOT A LEADING NUMERAL.
+                    A leading count reads "1 Alternatives that were merged into a
+                    single option" whenever a group holds one item — and
+                    `total_count: 1` is the most likely draft of all. The
+                    description is a CATEGORY LABEL with fixed grammatical
+                    number, so nothing prefixed to it can agree at both 1 and n;
+                    parenthesising the quantity sidesteps agreement entirely and
+                    reads correctly at every count, without a second copy field
+                    per kind.
+
+                    Emphasis by COLOUR, never by a raw font weight: DS v5 §2.4
+                    bans raw sizes and weights in panel scope and this file sits
+                    in the dock closure, so the darker body token carries the
+                    quantity on its own. */}
+                {row.description}{' '}
+                <span className="text-text-body">({row.count})</span>
               </li>
             ))}
           </ul>

--- a/src/canvas/conversation/__tests__/ModelBuildingNoticesNotice.spec.tsx
+++ b/src/canvas/conversation/__tests__/ModelBuildingNoticesNotice.spec.tsx
@@ -181,6 +181,29 @@ describe('ModelBuildingNoticesNotice — ⭐ no raw wire vocabulary reaches the 
   })
 })
 
+describe('ModelBuildingNoticesNotice — ⭐ a headline with no nameable row is silence', () => {
+  it('renders NOTHING when every kind is unnameable, rather than a bare count', () => {
+    // "Olumi left 4 things out" with no breakdown and no route is a dead end by
+    // the product's own definition — it reports a loss the user cannot act on.
+    // Reached only via a future enum widening (see the wire spec), so it is
+    // built through the shaper with a cast, exactly as that suite does.
+    const unnameable = toModelBuildingNoticesView({
+      total_count: 4,
+      groups: [{ kind: 'a_kind_added_after_this_ui' as never, count: 4 }],
+      details_redacted: true,
+    })
+    const { container } = render(
+      <MessageBubble
+        message={makeMsg({ modelBuildingNotices: unnameable })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.queryByTestId('model-building-notices')).toBeNull()
+    expect(container.textContent).not.toMatch(/out of this model/i)
+    expect(container.textContent).not.toContain('a_kind_added_after_this_ui')
+  })
+})
+
 describe('ModelBuildingNoticesNotice — ⭐ progressive disclosure', () => {
   it('collapsed by default: the summary shows, the breakdown and pointer do not', () => {
     render(

--- a/src/canvas/conversation/__tests__/ModelBuildingNoticesNotice.spec.tsx
+++ b/src/canvas/conversation/__tests__/ModelBuildingNoticesNotice.spec.tsx
@@ -155,6 +155,106 @@ describe('ModelBuildingNoticesNotice — ⭐ identity binding (DISCRIMINATING PA
   })
 })
 
+/**
+ * ⭐ ROW-LEVEL COPY. THIS SUITE PREVIOUSLY GUARDED ONLY THE HEADLINE.
+ *
+ * The singular/plural mutant (M5) pointed at `modelBuildingNoticesSummary` and
+ * bit cleanly — which made the kit LOOK like it covered number agreement, while
+ * every ROW was rendering "1 Alternatives that were merged into a single option"
+ * at `count: 1`. A guard aimed at one of two surfaces reports on one of two
+ * surfaces; the green result said nothing about the other (CLAUDE.md trap 22:
+ * presence of a guard is not coverage of its input).
+ *
+ * `count: 1` is not an edge case here — `total_count: 1` is the most likely
+ * draft the producer emits, so this was the MODAL rendering, one line beneath a
+ * headline that gets singular right.
+ *
+ * The fix is structural rather than lexical: the count is a TRAILING quantity,
+ * so it never has to agree with a fixed-number category label. These assertions
+ * are therefore written against the SHAPE (no bare leading numeral), not against
+ * a particular phrasing — a future copy edit that reintroduces a leading count
+ * REDs even if it words the descriptions differently.
+ */
+describe('ModelBuildingNoticesNotice — ⭐ row copy reads correctly at EVERY count', () => {
+  /** Every kind at count 1 — the modal draft, and the one that read wrongly. */
+  const allKindsAtOne = toModelBuildingNoticesView({
+    total_count: 6,
+    groups: [
+      { kind: 'detail_not_connected', count: 1 },
+      { kind: 'relationship_not_used', count: 1 },
+      { kind: 'alternative_consolidated', count: 1 },
+      { kind: 'conflict_resolved_conservatively', count: 1 },
+      { kind: 'target_not_modelled_as_threshold', count: 1 },
+      { kind: 'other', count: 1 },
+    ],
+    details_redacted: true,
+  })
+
+  async function expandRows(view: ModelBuildingNoticesView) {
+    const user = userEvent.setup()
+    render(
+      <MessageBubble message={makeMsg({ modelBuildingNotices: view })} onChipClick={noop} />,
+    )
+    await user.click(screen.getByTestId('model-building-notices-toggle'))
+    return screen.getAllByRole('listitem').filter((li) => li.hasAttribute('data-notice-kind'))
+  }
+
+  it('NO row begins with a bare numeral — at count 1, for any of the six kinds', async () => {
+    const rows = await expandRows(allKindsAtOne)
+    expect(rows).toHaveLength(6)
+    for (const row of rows) {
+      const text = (row.textContent ?? '').trim()
+      // The defect shape: a digit, then whitespace, then the category label.
+      expect(
+        text,
+        `row "${row.getAttribute('data-notice-kind')}" leads with a bare numeral: ${text}`,
+      ).not.toMatch(/^\d+\s/)
+      // And it must still state the quantity somewhere — dropping the count to
+      // dodge agreement would pass a "no leading numeral" check while losing
+      // information the producer sent.
+      expect(text).toMatch(/\(1\)/)
+    }
+  })
+
+  it('a row states its OWN count as a trailing quantity, bound by kind', async () => {
+    // Identity binding: the 4 travels with `relationship_not_used`, not merely
+    // "a 4 appears somewhere in the list".
+    const mixed = toModelBuildingNoticesView({
+      total_count: 5,
+      groups: [
+        { kind: 'detail_not_connected', count: 1 },
+        { kind: 'relationship_not_used', count: 4 },
+      ],
+      details_redacted: true,
+    })
+    const rows = await expandRows(mixed)
+    const byKind = (k: string) =>
+      (rows.find((r) => r.getAttribute('data-notice-kind') === k)?.textContent ?? '').trim()
+
+    expect(byKind('detail_not_connected')).toMatch(/\(1\)$/)
+    expect(byKind('relationship_not_used')).toMatch(/\(4\)$/)
+    expect(byKind('detail_not_connected')).not.toMatch(/^\d/)
+    expect(byKind('relationship_not_used')).not.toMatch(/^\d/)
+  })
+
+  it('the singular HEADLINE and the singular ROW agree on the same payload', async () => {
+    // The two surfaces sit one line apart, so a mismatch is conspicuous. This
+    // pins them TOGETHER — the assertion the kit was missing when the headline
+    // was guarded alone.
+    const one = toModelBuildingNoticesView({
+      total_count: 1,
+      groups: [{ kind: 'alternative_consolidated', count: 1 }],
+      details_redacted: true,
+    })
+    const rows = await expandRows(one)
+    expect(screen.getByTestId('model-building-notices-toggle').textContent).toContain(
+      '1 thing from your brief',
+    )
+    expect(rows).toHaveLength(1)
+    expect((rows[0].textContent ?? '').trim()).not.toMatch(/^1\s/)
+  })
+})
+
 describe('ModelBuildingNoticesNotice — ⭐ no raw wire vocabulary reaches the user', () => {
   it('no kind code appears as text anywhere in the bubble, expanded or collapsed', async () => {
     const user = userEvent.setup()

--- a/src/canvas/conversation/__tests__/ModelBuildingNoticesNotice.spec.tsx
+++ b/src/canvas/conversation/__tests__/ModelBuildingNoticesNotice.spec.tsx
@@ -1,0 +1,221 @@
+/**
+ * ModelBuildingNoticesNotice — the rendered consumer of CEE's
+ * `model_building_notices`.
+ *
+ * FOUR PROPERTIES CARRY THIS SLICE, each pinned so it fails for the right
+ * reason:
+ *
+ *  1. NO MINTED ZERO. A turn with no notices renders NOTHING — not a headline,
+ *     not an empty panel, not "0". Pinned through the REAL `MessageBubble`,
+ *     because the mount condition is where a minted zero would be introduced.
+ *  2. IDENTITY BINDING, proven by a DISCRIMINATING PAIR (CLAUDE.md trap 19).
+ *     A row is asserted via `data-notice-kind` — the producer's own enum member
+ *     — never via description text, which is UI copy another row could be
+ *     edited to carry.
+ *  3. NO RAW WIRE VOCABULARY. The kind codes must not reach the DOM as text.
+ *     This is the estate's live defect (`existence_boundary_crossing`), so it
+ *     is pinned as an absence over the bubble's whole text content, not merely
+ *     over this component's own markup.
+ *  4. PROGRESSIVE DISCLOSURE. Collapsed by default; the per-kind breakdown and
+ *     the next-route pointer appear only after the toggle.
+ *
+ * MOUNT (trap 3b — this estate has twice shipped a badge dark by testing a
+ * component the deployed flags do not mount): every assertion below drives
+ * `MessageBubble`, and NOTHING here sets a flag, because CEE emits
+ * unconditionally and this consumer is deliberately unflagged. A test that
+ * rendered `ModelBuildingNoticesNotice` directly would pass identically if the
+ * mount were deleted — which is the whole failure mode.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MessageBubble } from '../MessageBubble'
+import type { ConversationMessage } from '../types'
+import {
+  MODEL_BUILDING_NOTICES_POINTER,
+  toModelBuildingNoticesView,
+  type ModelBuildingNoticesView,
+} from '../modelBuildingNotices'
+
+const noop = async () => {}
+
+function makeMsg(overrides: Partial<ConversationMessage> = {}): ConversationMessage {
+  return {
+    id: 'msg-mbn-1',
+    role: 'assistant',
+    content: "Here's a first model of your pricing decision.",
+    timestamp: new Date(),
+    ...overrides,
+  }
+}
+
+/**
+ * Built through the PRODUCTION shaper from a payload that satisfies the
+ * published schema's two cross-field rules (unique kinds; total = sum), so the
+ * fixture cannot drift away from what the wire can actually carry.
+ */
+const twoKinds: ModelBuildingNoticesView = toModelBuildingNoticesView({
+  total_count: 3,
+  groups: [
+    { kind: 'detail_not_connected', count: 2 },
+    { kind: 'relationship_not_used', count: 1 },
+  ],
+  details_redacted: true,
+})
+
+describe('ModelBuildingNoticesNotice — ⭐ no minted zero (no payload ⇒ no claim)', () => {
+  it('a reply with NO modelBuildingNotices renders no notice at all', () => {
+    render(<MessageBubble message={makeMsg()} onChipClick={noop} />)
+    expect(screen.queryByTestId('model-building-notices')).toBeNull()
+    expect(screen.queryByTestId('model-building-notices-toggle')).toBeNull()
+  })
+
+  it('the clean reply never says anything about things being left out', () => {
+    // The strong form: not merely "the testid is absent", but that no
+    // left-out language reaches the DOM under any other markup.
+    const { container } = render(<MessageBubble message={makeMsg()} onChipClick={noop} />)
+    expect(container.textContent).not.toMatch(/left\s+\d+/i)
+    expect(container.textContent).not.toMatch(/out of this model/i)
+  })
+
+  it('a USER message never carries the notice, even with a payload attached', () => {
+    // An omission is a fact about a model OLUMI built. The user's bubble is not one.
+    render(
+      <MessageBubble
+        message={makeMsg({ role: 'user', modelBuildingNotices: twoKinds })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.queryByTestId('model-building-notices')).toBeNull()
+  })
+})
+
+describe('ModelBuildingNoticesNotice — ⭐ identity binding (DISCRIMINATING PAIR, trap 19)', () => {
+  it('renders one row per producer group, bound by the producer kind', async () => {
+    const user = userEvent.setup()
+    render(
+      <MessageBubble
+        message={makeMsg({ modelBuildingNotices: twoKinds })}
+        onChipClick={noop}
+      />,
+    )
+    await user.click(screen.getByTestId('model-building-notices-toggle'))
+
+    const rows = screen.getAllByRole('listitem').filter((li) => li.hasAttribute('data-notice-kind'))
+    expect(rows).toHaveLength(2)
+    // Bound BY IDENTITY to the producer's enum members, in producer order.
+    expect(rows.map((r) => r.getAttribute('data-notice-kind'))).toEqual([
+      'detail_not_connected',
+      'relationship_not_used',
+    ])
+    // And the count travels with its OWN kind, not merely "a 2 appears".
+    const detailRow = rows.find((r) => r.getAttribute('data-notice-kind') === 'detail_not_connected')
+    expect(detailRow?.textContent).toMatch(/\b2\b/)
+  })
+
+  it('the headline count is the PRODUCER total, not the rendered row count', () => {
+    // These are different quantities by design (an unnameable kind is dropped
+    // from rows while total_count stays the producer's). Pinning the two
+    // separately is what stops a future edit from collapsing them.
+    render(
+      <MessageBubble
+        message={makeMsg({ modelBuildingNotices: twoKinds })}
+        onChipClick={noop}
+      />,
+    )
+    const root = screen.getByTestId('model-building-notices')
+    expect(root.getAttribute('data-total-count')).toBe('3')
+    expect(root.getAttribute('data-row-count')).toBe('2')
+    expect(screen.getByTestId('model-building-notices-toggle').textContent).toContain('3 things')
+  })
+
+  it('singular copy at exactly one omission', () => {
+    const one = toModelBuildingNoticesView({
+      total_count: 1,
+      groups: [{ kind: 'other', count: 1 }],
+      details_redacted: true,
+    })
+    render(
+      <MessageBubble message={makeMsg({ modelBuildingNotices: one })} onChipClick={noop} />,
+    )
+    const toggle = screen.getByTestId('model-building-notices-toggle')
+    expect(toggle.textContent).toContain('1 thing from your brief')
+    expect(toggle.textContent).not.toContain('1 things')
+  })
+})
+
+describe('ModelBuildingNoticesNotice — ⭐ no raw wire vocabulary reaches the user', () => {
+  it('no kind code appears as text anywhere in the bubble, expanded or collapsed', async () => {
+    const user = userEvent.setup()
+    const all = toModelBuildingNoticesView({
+      total_count: 6,
+      groups: [
+        { kind: 'detail_not_connected', count: 1 },
+        { kind: 'relationship_not_used', count: 1 },
+        { kind: 'alternative_consolidated', count: 1 },
+        { kind: 'conflict_resolved_conservatively', count: 1 },
+        { kind: 'target_not_modelled_as_threshold', count: 1 },
+        { kind: 'other', count: 1 },
+      ],
+      details_redacted: true,
+    })
+    const { container } = render(
+      <MessageBubble message={makeMsg({ modelBuildingNotices: all })} onChipClick={noop} />,
+    )
+    await user.click(screen.getByTestId('model-building-notices-toggle'))
+
+    // Every enum member, checked as TEXT (attributes are provenance, not copy).
+    for (const code of [
+      'detail_not_connected',
+      'relationship_not_used',
+      'alternative_consolidated',
+      'conflict_resolved_conservatively',
+      'target_not_modelled_as_threshold',
+    ]) {
+      expect(container.textContent).not.toContain(code)
+    }
+    // Snake_case in general — catches a new code added without a phrasing.
+    expect(container.textContent).not.toMatch(/[a-z]+_[a-z]+_[a-z]+/)
+    // `details_redacted` is a wire mechanic, never user copy.
+    expect(container.textContent).not.toMatch(/redact/i)
+  })
+})
+
+describe('ModelBuildingNoticesNotice — ⭐ progressive disclosure', () => {
+  it('collapsed by default: the summary shows, the breakdown and pointer do not', () => {
+    render(
+      <MessageBubble
+        message={makeMsg({ modelBuildingNotices: twoKinds })}
+        onChipClick={noop}
+      />,
+    )
+    expect(screen.getByTestId('model-building-notices-toggle')).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+    expect(screen.queryByTestId('model-building-notices-pointer')).toBeNull()
+    expect(
+      screen.queryAllByRole('listitem').filter((li) => li.hasAttribute('data-notice-kind')),
+    ).toHaveLength(0)
+  })
+
+  it('expanding reveals the breakdown AND the next-route pointer', async () => {
+    const user = userEvent.setup()
+    render(
+      <MessageBubble
+        message={makeMsg({ modelBuildingNotices: twoKinds })}
+        onChipClick={noop}
+      />,
+    )
+    await user.click(screen.getByTestId('model-building-notices-toggle'))
+
+    expect(screen.getByTestId('model-building-notices-toggle')).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    )
+    // The route, not a dead end — the founder's binding product constraint.
+    expect(screen.getByTestId('model-building-notices-pointer').textContent).toBe(
+      MODEL_BUILDING_NOTICES_POINTER,
+    )
+  })
+})

--- a/src/canvas/conversation/__tests__/ModelBuildingNoticesNotice.spec.tsx
+++ b/src/canvas/conversation/__tests__/ModelBuildingNoticesNotice.spec.tsx
@@ -70,12 +70,23 @@ describe('ModelBuildingNoticesNotice — ⭐ no minted zero (no payload ⇒ no c
     expect(screen.queryByTestId('model-building-notices-toggle')).toBeNull()
   })
 
-  it('the clean reply never says anything about things being left out', () => {
-    // The strong form: not merely "the testid is absent", but that no
-    // left-out language reaches the DOM under any other markup.
+  it('the reply with no attestation makes NO claim IN EITHER DIRECTION', () => {
+    // The strong form: not merely "the testid is absent", but that neither
+    // kind of fabrication reaches the DOM under any other markup.
+    //
+    // The contract CANNOT ENCODE ZERO (`total_count` positive, `groups` min 1),
+    // so an absent field means NO ATTESTATION WAS SUPPLIED — not "nothing was
+    // dropped". Both directions are therefore banned, and the second is the
+    // more dangerous one: a completeness reassurance built on a silent field is
+    // a positive claim with no evidence behind it at all.
     const { container } = render(<MessageBubble message={makeMsg()} onChipClick={noop} />)
+    // (a) no minted omission
     expect(container.textContent).not.toMatch(/left\s+\d+/i)
     expect(container.textContent).not.toMatch(/out of this model/i)
+    // (b) no minted completeness
+    expect(container.textContent).not.toMatch(/nothing was (left|dropped|omitted)/i)
+    expect(container.textContent).not.toMatch(/captured (in full|everything)/i)
+    expect(container.textContent).not.toMatch(/complete model|fully represented/i)
   })
 
   it('a USER message never carries the notice, even with a payload attached', () => {

--- a/src/canvas/conversation/__tests__/modelBuildingNotices.mountSite.spec.ts
+++ b/src/canvas/conversation/__tests__/modelBuildingNotices.mountSite.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * THE STRUCTURAL HALF of the model-building-notices guarantee: the notice has
+ * EXACTLY ONE production mount site, and it is the assistant message bubble.
+ *
+ * WHY THIS EXISTS AT ALL (CLAUDE.md trap 3b). This estate has twice shipped a
+ * badge DARK because its tests targeted a component the deployed flag posture
+ * does not mount — every instrument green, nothing on the user's screen. The
+ * render spec beside this one drives `MessageBubble` for exactly that reason;
+ * this file pins the other half, so the binding fails LOUD if the mount moves
+ * to a surface that is gated, or if a second copy appears somewhere else.
+ *
+ * ⚠ DERIVED, NOT MIRRORED (trap 12). There is no hand-kept allowlist of
+ * permitted mount sites — the sites are read out of the source at test time.
+ * A hand-maintained list would drift silently, and the drift would read green.
+ *
+ * ⚠ AND IT HAS POSITIVE CONTROLS, because every assertion below is an ABSENCE
+ * claim over a file scan, and a scan that silently reads nothing produces a
+ * perfect absence result (traps 13 / 13e). The controls assert the scanner
+ * walks a plausible number of files and can see a KNOWN-PRESENT symbol in a
+ * plausible quantity before any absence is believed.
+ *
+ * Structure and scanners are adapted from
+ * `components/results/analysisState/__tests__/analysisStateRegion.mountSites.spec.ts`
+ * — the estate's established form for this guarantee.
+ */
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+const SRC = resolve(__dirname, '../../..')
+
+/** Production source only: stories, fixtures and specs may mount anything. */
+function isProductionSource(path: string): boolean {
+  if (!/\.(ts|tsx)$/.test(path)) return false
+  if (path.includes('__tests__')) return false
+  if (path.includes('__fixtures__')) return false
+  if (/\.spec\.[tj]sx?$/.test(path)) return false
+  if (/\.test\.[tj]sx?$/.test(path)) return false
+  if (/\.stories\.[tj]sx?$/.test(path)) return false
+  return true
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry.startsWith('.')) continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) walk(full, out)
+    else if (isProductionSource(full)) out.push(full)
+  }
+  return out
+}
+
+/**
+ * Comments are stripped first — a scan that cannot tell code from prose about
+ * code reports a component's own header as a mount site of itself.
+ */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1')
+}
+
+/** Files containing a JSX MOUNT of `<Name`, not merely an import or a mention. */
+function mountSitesOf(name: string, files: string[]): string[] {
+  const mount = new RegExp(`<${name}[\\s/>]`)
+  return files
+    .filter((f) => mount.test(stripComments(readFileSync(f, 'utf8'))))
+    .map((f) => f.slice(SRC.length + 1))
+    .sort()
+}
+
+/**
+ * Files that IMPORT a module by path, whatever local name they bind it to.
+ * Closes the aliased-import channel a name-shaped scan is blind to: the name is
+ * what a reader looks for, the PATH is what cannot be renamed away.
+ */
+function importersOf(moduleBasename: string, files: string[]): string[] {
+  const imported = new RegExp(`from\\s*['"][^'"]*\\b${moduleBasename}['"]`)
+  return files
+    .filter((f) => imported.test(stripComments(readFileSync(f, 'utf8'))))
+    .map((f) => f.slice(SRC.length + 1))
+    .sort()
+}
+
+const BUBBLE = 'canvas/conversation/MessageBubble.tsx'
+
+describe('model-building notices have exactly one production mount site', () => {
+  const files = walk(SRC)
+
+  it('CONTROL: the scanner reads a plausible number of files and can see known symbols', () => {
+    // (1) Magnitude. A scanner that walked nothing, or one directory, would
+    //     still return a clean "no extra mounts" answer below.
+    expect(files.length).toBeGreaterThan(500)
+    // (2) Discrimination — a CONTRAST symbol expected in more than one place.
+    //     Zero or one here means the regex is broken and every absence claim
+    //     below is unsupported (trap 13e: a control must be PLAUSIBLE, not
+    //     merely non-zero).
+    expect(mountSitesOf('SectionErrorBoundary', files).length).toBeGreaterThan(1)
+    expect(importersOf('typography', files).length).toBeGreaterThan(1)
+  })
+
+  it('ModelBuildingNoticesNotice is mounted ONLY by the assistant message bubble', () => {
+    expect(mountSitesOf('ModelBuildingNoticesNotice', files)).toEqual([BUBBLE])
+  })
+
+  it('and NOTHING ELSE CAN MOUNT IT — nobody else imports the component module', () => {
+    // The path-shaped half: a file that cannot import the module cannot mount
+    // it under any local name. Stated as the exact importer set, so a new
+    // importer names itself in the failure.
+    expect(importersOf('ModelBuildingNoticesNotice', files)).toEqual([BUBBLE])
+  })
+
+  it('the mount is UNGATED — no feature flag stands between the payload and the user', () => {
+    // ⭐ THE POINT OF THE WHOLE LANE. `model_building_notices` was wire-reachable
+    // and unrendered; hanging it behind a flag would repeat that failure in a
+    // new place. `preAnalysisEnriched` in particular defaults to FALSE and its
+    // envKey is absent from netlify.toml, which is why the notice is
+    // deliberately NOT hosted inside ModelReceiptBlock.
+    const bubble = stripComments(readFileSync(join(SRC, BUBBLE), 'utf8'))
+    const mountLine = bubble
+      .split('\n')
+      .findIndex((l) => l.includes('<ModelBuildingNoticesNotice'))
+    expect(mountLine).toBeGreaterThan(-1)
+
+    // The guard expression sits immediately above the mount. It must test the
+    // payload's presence and the assistant role — and nothing else.
+    const guard = bubble.split('\n')[mountLine - 1]
+    expect(guard).toContain('message.modelBuildingNotices')
+    expect(guard).toContain('!isUser')
+    expect(guard).not.toMatch(/isEnabled|Enabled\(\)|flags\./)
+  })
+
+  it('the copy authority is imported by the renderer and the wire binding only', () => {
+    // One place owns kind -> user-visible string. A second mapper elsewhere is
+    // how two vocabularies for one concept get shipped (Paul's convergence
+    // rule: name the canonical owner, never add a parallel one).
+    expect(importersOf('modelBuildingNotices', files)).toEqual([
+      'canvas/conversation/ModelBuildingNoticesNotice.tsx',
+      'canvas/conversation/types.ts',
+      'canvas/conversation/useConversation.ts',
+    ])
+  })
+})

--- a/src/canvas/conversation/__tests__/modelBuildingNotices.mountSite.spec.ts
+++ b/src/canvas/conversation/__tests__/modelBuildingNotices.mountSite.spec.ts
@@ -22,6 +22,25 @@
  * Structure and scanners are adapted from
  * `components/results/analysisState/__tests__/analysisStateRegion.mountSites.spec.ts`
  * — the estate's established form for this guarantee.
+ *
+ * ⚠⚠ WHAT THE "UNGATED" TEST BELOW DOES **NOT** PROVE — READ BEFORE CITING IT.
+ * It reads the ONE LINE ABOVE the mount and greps for `isEnabled|Enabled\(\)|
+ * flags\.`. That makes it evidence about the LOCAL guard expression and NOTHING
+ * ELSE. It is STRUCTURALLY INCAPABLE of seeing an ANCESTOR gate: a flag on
+ * MessageBubble itself, on ChatMessage, on ChatThread, on ConversationPanel, or
+ * on any host above them would leave this test fully green while the notice
+ * never reached a user. **This test is not product-level reachability
+ * evidence, and must never be reported as such.**
+ *
+ * The ancestor chain was cleared SEPARATELY, by hand, in the #804 review
+ * (2026-08-19): `ConversationPanel → ChatThread → ChatMessage → MessageBubble`,
+ * each a single unconditional call site, all three panel hosts reading the same
+ * state, with extraction at the one `routeV5Response` success branch where the
+ * streamed and buffered draft paths have already converged. The only gate on
+ * the path is the V5 flag the entire live product already runs behind. That is
+ * a DATED MANUAL DERIVATION, not something this file re-derives — if the
+ * component tree changes, it must be re-walked by hand, because nothing here
+ * will fail.
  */
 import { describe, it, expect } from 'vitest'
 import { readdirSync, readFileSync, statSync } from 'node:fs'
@@ -108,7 +127,7 @@ describe('model-building notices have exactly one production mount site', () => 
     expect(importersOf('ModelBuildingNoticesNotice', files)).toEqual([BUBBLE])
   })
 
-  it('the mount is UNGATED — no feature flag stands between the payload and the user', () => {
+  it('the mount guard is LOCALLY flag-free (see header: says nothing about ancestors)', () => {
     // ⭐ THE POINT OF THE WHOLE LANE. `model_building_notices` was wire-reachable
     // and unrendered; hanging it behind a flag would repeat that failure in a
     // new place. `preAnalysisEnriched` in particular defaults to FALSE and its

--- a/src/canvas/conversation/__tests__/modelBuildingNotices.wire.spec.ts
+++ b/src/canvas/conversation/__tests__/modelBuildingNotices.wire.spec.ts
@@ -23,6 +23,7 @@ import {
   describeModelBuildingNoticeKind,
   extractModelBuildingNoticesSidecar,
   modelBuildingNoticesSummary,
+  toModelBuildingNoticesView,
   MODEL_BUILDING_NOTICES_POINTER,
 } from '../modelBuildingNotices'
 
@@ -153,15 +154,63 @@ describe('modelBuildingNotices copy — ⭐ user-facing strings stay human', () 
     expect(MODEL_BUILDING_NOTICES_POINTER).not.toMatch(/click|button|below|press/i)
   })
 
-  it('an unnameable kind is dropped from rows while total_count is preserved', () => {
-    // Documented divergence: the headline is the PRODUCER's count; rows are
-    // only what this UI can phrase. Asserted here so a future edit that
-    // "fixes" the mismatch by shrinking total_count REDs.
+  it('preserves the producer total and the producer row order on a fully nameable payload', () => {
     const view = extractModelBuildingNoticesSidecar({ model_building_notices: VALID })
     expect(view?.totalCount).toBe(3)
     expect(view?.rows.map((r) => r.kind)).toEqual([
       'detail_not_connected',
       'relationship_not_used',
     ])
+  })
+})
+
+/**
+ * ⭐ THE UNNAMEABLE-KIND BRANCH, AND WHY IT NEEDS ITS OWN ENTRY POINT.
+ *
+ * A mutant that made `toModelBuildingNoticesView` render unnameable kinds as
+ * the string "unknown" SURVIVED the first version of this suite. The survivor
+ * was not equivalent — it exposed a real hole, and the hole was in a test whose
+ * NAME claimed the drop while its FIXTURE contained only nameable kinds, so it
+ * could never observe one (CLAUDE.md trap 19: an assertion that passes on the
+ * wrong object).
+ *
+ * The branch is unreachable through `extractModelBuildingNoticesSidecar` BY
+ * CONSTRUCTION — the schema's kind enum is closed, so an unknown kind fails
+ * `safeParse` and never reaches the shaper. It is defensive against a future
+ * schema bump that widens the enum before this UI adds a phrasing for the new
+ * member. That is a real, reachable future state, so the branch stays and is
+ * exercised HERE, at the shaper, which is the only entry point that can reach
+ * it. The cast is deliberate and is the point of the test.
+ */
+describe('toModelBuildingNoticesView — ⭐ the unnameable-kind drop', () => {
+  it('drops an unnameable kind from rows while preserving the PRODUCER total', () => {
+    const view = toModelBuildingNoticesView({
+      total_count: 5,
+      groups: [
+        { kind: 'detail_not_connected', count: 2 },
+        // A member this UI has no phrasing for — the future-enum case.
+        { kind: 'a_kind_added_after_this_ui' as never, count: 3 },
+      ],
+      details_redacted: true,
+    })
+    // The row is gone...
+    expect(view.rows.map((r) => r.kind)).toEqual(['detail_not_connected'])
+    // ...and NOTHING renders its code under any substitute label.
+    expect(view.rows.every((r) => !r.description.includes('_'))).toBe(true)
+    expect(view.rows.map((r) => r.description)).not.toContain('unknown')
+    // ...while the headline stays the producer's number, not a re-derived one.
+    // Shrinking this to 2 would misreport the producer; that is the divergence
+    // the renderer is written to keep honest.
+    expect(view.totalCount).toBe(5)
+  })
+
+  it('yields zero rows when NO kind is nameable, leaving the renderer nothing to claim', () => {
+    const view = toModelBuildingNoticesView({
+      total_count: 4,
+      groups: [{ kind: 'another_future_kind' as never, count: 4 }],
+      details_redacted: true,
+    })
+    expect(view.rows).toHaveLength(0)
+    expect(view.totalCount).toBe(4)
   })
 })

--- a/src/canvas/conversation/__tests__/modelBuildingNotices.wire.spec.ts
+++ b/src/canvas/conversation/__tests__/modelBuildingNotices.wire.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * The WIRE half of `model_building_notices` — the extractor and the copy
+ * authority, pinned against the PUBLISHED schema rather than against a fixture
+ * written from this consumer's head (CLAUDE.md trap 22: a corpus drawn from the
+ * author's head cannot see the class the author did not imagine).
+ *
+ * The load-bearing guards here:
+ *
+ *  · ABSENCE YIELDS NULL. The producer omits the key on a clean draft; a
+ *    synthesised zero would put a false omission in front of every user.
+ *  · THE PRODUCER'S CROSS-FIELD RULES ARE ENFORCED, NOT RESTATED. Parsing goes
+ *    through `ModelBuildingNoticesSchema` itself, so the unique-kinds and
+ *    sum-equals-total rules cannot drift from the producer.
+ *  · COPY COMPLETENESS IS DERIVED FROM THE ENUM, NOT HAND-LISTED (trap 12 and
+ *    12d). The exhaustiveness test iterates `ModelBuildingNoticeKindSchema
+ *    .options`, so a seventh member arriving REDs here as well as at typecheck.
+ *    Derivation proves agreement; the schema's own enum is the external
+ *    reference that makes it also prove completeness.
+ */
+import { describe, it, expect } from 'vitest'
+import { ModelBuildingNoticeKindSchema } from '@talchain/schemas/boundary'
+import {
+  describeModelBuildingNoticeKind,
+  extractModelBuildingNoticesSidecar,
+  modelBuildingNoticesSummary,
+  MODEL_BUILDING_NOTICES_POINTER,
+} from '../modelBuildingNotices'
+
+/** A payload that satisfies BOTH superRefine rules: kinds unique, 2 + 1 === 3. */
+const VALID = {
+  total_count: 3,
+  groups: [
+    { kind: 'detail_not_connected', count: 2 },
+    { kind: 'relationship_not_used', count: 1 },
+  ],
+  details_redacted: true,
+} as const
+
+describe('extractModelBuildingNoticesSidecar — ⭐ absence never becomes a zero', () => {
+  it('returns null when the key is absent (the clean-draft case)', () => {
+    expect(extractModelBuildingNoticesSidecar({ assistant_text: 'hi' })).toBeNull()
+  })
+
+  it('returns null for null/undefined values and non-object responses', () => {
+    expect(extractModelBuildingNoticesSidecar({ model_building_notices: undefined })).toBeNull()
+    expect(extractModelBuildingNoticesSidecar({ model_building_notices: null })).toBeNull()
+    expect(extractModelBuildingNoticesSidecar(null)).toBeNull()
+    expect(extractModelBuildingNoticesSidecar('a string')).toBeNull()
+  })
+
+  it('CONTROL: the extractor is not blind — the same shape DOES parse', () => {
+    // An absence suite whose probe can never return a value proves nothing
+    // (trap 13). This is the positive control for every null above.
+    const view = extractModelBuildingNoticesSidecar({ model_building_notices: VALID })
+    expect(view).not.toBeNull()
+    expect(view?.totalCount).toBe(3)
+    expect(view?.rows).toHaveLength(2)
+  })
+})
+
+describe('extractModelBuildingNoticesSidecar — ⭐ the producer rules are enforced', () => {
+  it('rejects a payload whose total_count does not equal the group sum', () => {
+    // The superRefine rule. A consumer that accepted this would render a
+    // headline quantity the breakdown contradicts.
+    expect(
+      extractModelBuildingNoticesSidecar({
+        model_building_notices: { ...VALID, total_count: 2 },
+      }),
+    ).toBeNull()
+  })
+
+  it('rejects duplicate kinds', () => {
+    expect(
+      extractModelBuildingNoticesSidecar({
+        model_building_notices: {
+          total_count: 3,
+          groups: [
+            { kind: 'other', count: 2 },
+            { kind: 'other', count: 1 },
+          ],
+          details_redacted: true,
+        },
+      }),
+    ).toBeNull()
+  })
+
+  it('rejects an unknown kind, an empty group list, and a missing details_redacted', () => {
+    expect(
+      extractModelBuildingNoticesSidecar({
+        model_building_notices: {
+          total_count: 1,
+          groups: [{ kind: 'not_a_real_kind', count: 1 }],
+          details_redacted: true,
+        },
+      }),
+    ).toBeNull()
+    expect(
+      extractModelBuildingNoticesSidecar({
+        model_building_notices: { total_count: 0, groups: [], details_redacted: true },
+      }),
+    ).toBeNull()
+    expect(
+      extractModelBuildingNoticesSidecar({
+        model_building_notices: { total_count: 3, groups: VALID.groups },
+      }),
+    ).toBeNull()
+  })
+})
+
+describe('describeModelBuildingNoticeKind — ⭐ derived completeness + no leaked codes', () => {
+  it('every kind the SCHEMA declares has a human phrasing', () => {
+    // Derived from the published enum, never a hand-kept list. A seventh member
+    // fails here as well as at typecheck.
+    const kinds = ModelBuildingNoticeKindSchema.options
+    expect(kinds.length).toBeGreaterThan(0)
+    for (const kind of kinds) {
+      const described = describeModelBuildingNoticeKind(kind)
+      expect(described, `no phrasing for kind: ${kind}`).toBeTruthy()
+      // The phrasing must not BE the code, nor contain it.
+      expect(described).not.toContain(kind)
+      expect(described).not.toMatch(/_/)
+    }
+  })
+
+  it('an unknown kind gets null, never a fallback to its code', () => {
+    expect(describeModelBuildingNoticeKind('some_future_kind')).toBeNull()
+    expect(describeModelBuildingNoticeKind('')).toBeNull()
+  })
+
+  it('lookup is EXACT, never case-folded', () => {
+    // Folding case would let an unrecognised variant inherit a phrasing it was
+    // never entitled to — the same rule as the refusal-notice map.
+    expect(describeModelBuildingNoticeKind('DETAIL_NOT_CONNECTED')).toBeNull()
+  })
+
+  it('does not inherit phrasings from Object.prototype', () => {
+    expect(describeModelBuildingNoticeKind('toString')).toBeNull()
+    expect(describeModelBuildingNoticeKind('constructor')).toBeNull()
+  })
+})
+
+describe('modelBuildingNotices copy — ⭐ user-facing strings stay human', () => {
+  it('the summary agrees in number and never prints a code', () => {
+    expect(modelBuildingNoticesSummary(1)).toContain('1 thing from your brief')
+    expect(modelBuildingNoticesSummary(1)).not.toContain('1 things')
+    expect(modelBuildingNoticesSummary(4)).toContain('4 things')
+  })
+
+  it('the pointer names a conversational action, not a control this notice renders', () => {
+    // #684 review D2: naming a button the notice does not render is a promise
+    // the surface cannot keep.
+    expect(MODEL_BUILDING_NOTICES_POINTER).toMatch(/tell olumi/i)
+    expect(MODEL_BUILDING_NOTICES_POINTER).not.toMatch(/click|button|below|press/i)
+  })
+
+  it('an unnameable kind is dropped from rows while total_count is preserved', () => {
+    // Documented divergence: the headline is the PRODUCER's count; rows are
+    // only what this UI can phrase. Asserted here so a future edit that
+    // "fixes" the mismatch by shrinking total_count REDs.
+    const view = extractModelBuildingNoticesSidecar({ model_building_notices: VALID })
+    expect(view?.totalCount).toBe(3)
+    expect(view?.rows.map((r) => r.kind)).toEqual([
+      'detail_not_connected',
+      'relationship_not_used',
+    ])
+  })
+})

--- a/src/canvas/conversation/__tests__/modelBuildingNotices.wire.spec.ts
+++ b/src/canvas/conversation/__tests__/modelBuildingNotices.wire.spec.ts
@@ -38,8 +38,19 @@ const VALID = {
 } as const
 
 describe('extractModelBuildingNoticesSidecar — ⭐ absence never becomes a zero', () => {
-  it('returns null when the key is absent (the clean-draft case)', () => {
+  it('returns null when the key is absent (no attestation supplied)', () => {
     expect(extractModelBuildingNoticesSidecar({ assistant_text: 'hi' })).toBeNull()
+  })
+
+  it('the contract cannot encode zero, so a zero-shaped payload is REJECTED', () => {
+    // `total_count` is `.positive()` and `groups` is `.min(1)`: there is no
+    // representable "nothing was dropped" value. This pins that the UI cannot
+    // be handed one and quietly render it as a completeness claim.
+    expect(
+      extractModelBuildingNoticesSidecar({
+        model_building_notices: { total_count: 0, groups: [], details_redacted: true },
+      }),
+    ).toBeNull()
   })
 
   it('returns null for null/undefined values and non-object responses', () => {

--- a/src/canvas/conversation/modelBuildingNotices.ts
+++ b/src/canvas/conversation/modelBuildingNotices.ts
@@ -1,0 +1,183 @@
+/**
+ * modelBuildingNotices — the wire binding and the ONLY copy authority for
+ * CEE's `model_building_notices`.
+ *
+ * WHAT THE PRODUCER SENDS, AND WHAT IT DELIBERATELY DOES NOT
+ * ----------------------------------------------------------
+ * When Olumi drafts a model from a brief it drops things it could not
+ * represent, and it records why. `model_building_notices` is that record. It is
+ * a DECLARED, OPTIONAL field on `OlumiResponseSchema` (schemas 0.48.0,
+ * `olumi-response.js:234`) — NOT an `__additive__` sidecar like
+ * `_grounded_selection` / `_answer_shape`, so it is read straight off the
+ * response surface rather than through the demotion channel.
+ *
+ * Its shape, read at the vendored 0.48.0 bytes (never inferred):
+ *
+ *   { total_count: number,
+ *     groups: Array<{ kind: ModelBuildingNoticeKind, count: number }>,
+ *     details_redacted: true }
+ *
+ * `.strict()` at every level, `groups` is `.min(1).max(6)`, and a `superRefine`
+ * enforces TWO cross-field rules: group kinds are UNIQUE, and `total_count`
+ * EQUALS the sum of the group counts. Both matter to this consumer:
+ * uniqueness is why a kind can key a display row, and the sum rule is why
+ * `total_count` can be rendered as a headline quantity without the UI
+ * re-deriving it.
+ *
+ * ⚠ `details_redacted` IS A LITERAL `true`. The producer sends AGGREGATE COUNTS
+ * PER KIND AND NOTHING ELSE — no free text, no per-item detail, no next step.
+ * Everything a user reads here is therefore UI copy keyed to a closed enum,
+ * which is exactly why the copy lives in ONE place (this file) and is derived
+ * from the enum rather than hand-listed at a call site.
+ *
+ * ── WHY THE KIND CODES NEVER REACH A USER ──────────────────────────────────
+ * The estate already prints raw wire vocabulary at users (`existence_boundary_
+ * crossing`). This consumer never does: `describeModelBuildingNoticeKind` is
+ * the only path from a kind to a rendered string, and a kind with no human
+ * phrasing renders NOTHING rather than falling back to its code. That is the
+ * same posture as `AnalysisRefusalNotice`'s unmapped-code rule, minus the
+ * details disclosure — there the raw code was the only remaining information,
+ * here the count is still fully renderable without it.
+ *
+ * ── COMPLETENESS IS COMPILE-TIME, NOT HAND-MAINTAINED (CLAUDE.md trap 12) ───
+ * `KIND_DESCRIPTIONS` is typed `Record<ModelBuildingNoticeKind, string>`. A
+ * seventh enum member arriving in a future schema bump FAILS TYPECHECK here
+ * rather than silently rendering one fewer row than the count promises. A
+ * hand-kept list with a `default:` arm would drift green; this cannot.
+ */
+import {
+  ModelBuildingNoticesSchema,
+  type ModelBuildingNoticeKind,
+  type ModelBuildingNotices,
+} from '@talchain/schemas/boundary'
+
+/**
+ * One display row: a kind the UI can name, its count, and the human phrasing.
+ * The kind is retained for test binding BY IDENTITY and for `data-` attributes;
+ * it is never rendered as text.
+ */
+export interface ModelBuildingNoticeRow {
+  readonly kind: ModelBuildingNoticeKind
+  readonly count: number
+  readonly description: string
+}
+
+/** The view-model the bubble renders. Built only from what the producer sent. */
+export interface ModelBuildingNoticesView {
+  /** The producer's `total_count`. Schema-guaranteed to equal the row sum. */
+  readonly totalCount: number
+  /** Nameable rows, producer order preserved. */
+  readonly rows: readonly ModelBuildingNoticeRow[]
+}
+
+/**
+ * kind -> ONE plain-English noun phrase naming WHAT WAS LEFT OUT.
+ *
+ * Written as things the USER recognises from their own brief, never as
+ * descriptions of the model-builder's internal decision. Each is a noun phrase
+ * so it reads correctly under the headline without a verb of its own.
+ *
+ * ⚠ NO KIND GETS A SENTENCE THAT CLAIMS MORE THAN THE COUNT SUPPORTS. The
+ * producer sends a count and a kind — not which factor, not which sentence of
+ * the brief. So these name a CATEGORY and stop. Adding "for example, X" here
+ * would fabricate detail the wire explicitly redacted (`details_redacted`).
+ */
+const KIND_DESCRIPTIONS: Record<ModelBuildingNoticeKind, string> = {
+  detail_not_connected: "Details you mentioned that aren't linked to anything else yet",
+  relationship_not_used: "Relationships you described that the model doesn't use",
+  alternative_consolidated: 'Alternatives that were merged into a single option',
+  conflict_resolved_conservatively:
+    'Points where your brief conflicted with itself, settled the cautious way',
+  target_not_modelled_as_threshold:
+    'Targets kept as plain values rather than pass/fail thresholds',
+  other: "Other details that didn't fit the model",
+}
+
+/**
+ * The ONLY kind -> user-visible-string path. Returns `null` for anything not
+ * nameable, so a caller cannot accidentally render a code.
+ */
+export function describeModelBuildingNoticeKind(kind: string): string | null {
+  return Object.prototype.hasOwnProperty.call(KIND_DESCRIPTIONS, kind)
+    ? KIND_DESCRIPTIONS[kind as ModelBuildingNoticeKind]
+    : null
+}
+
+/**
+ * The collapsed summary line. Count-led and past tense: it states what happened
+ * to the model the user is looking at, and nothing about why.
+ *
+ * Mirrors the established receipt phrasing ("Olumi made N adjustments to keep
+ * the model valid") so the two disclosures read as one voice.
+ */
+export function modelBuildingNoticesSummary(totalCount: number): string {
+  return totalCount === 1
+    ? 'Olumi left 1 thing from your brief out of this model'
+    : `Olumi left ${totalCount} things from your brief out of this model`
+}
+
+/**
+ * The one pointer line — the "useful next route" the product constraint
+ * requires, and the reason this notice is not an honest dead end.
+ *
+ * ⚠ TRUE BY CONSTRUCTION, NOT BY CONVENTION, and that is the whole test it had
+ * to pass. It names a CONVERSATIONAL ACTION, not a control this notice renders:
+ * the bubble always sits in a thread the user is already typing into, so
+ * "tell Olumi" is available wherever this can appear. The alternative wording
+ * ("click Add to model") would name an affordance that does not exist — the
+ * exact defect #684's review D2 caught in `ANALYSIS_REFUSAL_POINTER`.
+ *
+ * It also promises only what the product genuinely does: the user says which
+ * omissions matter, and the next turn can work them in. It does NOT promise
+ * that Olumi will succeed, or name a mechanism.
+ */
+export const MODEL_BUILDING_NOTICES_POINTER =
+  'Tell Olumi which of these matter and it can work them into the model.'
+
+/**
+ * Wire binding. Reads `model_building_notices` off a live CEE turn response.
+ *
+ * PARSED, NOT TRUSTED — through the published schema itself, so the two
+ * cross-field rules (unique kinds, sum equals `total_count`) are enforced here
+ * rather than restated. Restating them would be a second copy of a producer
+ * rule that can drift (CLAUDE.md trap 12); using the schema cannot.
+ *
+ * ⚠ FAIL-CLOSED, AND THE ABSENT CASE IS LOAD-BEARING. A turn that dropped
+ * nothing carries NO key — the field is `.optional()` and the producer omits
+ * it rather than sending a zero. So absence yields `null`, the caller attaches
+ * nothing, and the bubble makes NO claim. Synthesising `{ totalCount: 0 }` here
+ * would put "Olumi left 0 things out of this model" in front of every user on
+ * every clean draft, which is the mint-a-zero defect this estate has already
+ * shipped once and reads as a broken product.
+ *
+ * A row whose kind this UI cannot name is DROPPED from `rows` while
+ * `totalCount` is preserved verbatim — the count is the producer's, and
+ * shrinking it to match what we can phrase would misreport the producer. The
+ * renderer is written so the headline count and the row list are never claimed
+ * to be the same quantity.
+ */
+export function extractModelBuildingNoticesSidecar(
+  response: unknown,
+): ModelBuildingNoticesView | null {
+  if (!response || typeof response !== 'object') return null
+  const raw = (response as Record<string, unknown>).model_building_notices
+  if (raw === undefined || raw === null) return null
+
+  const parsed = ModelBuildingNoticesSchema.safeParse(raw)
+  if (!parsed.success) return null
+
+  return toModelBuildingNoticesView(parsed.data)
+}
+
+/** Shape the validated producer payload into the view-model. */
+export function toModelBuildingNoticesView(
+  notices: ModelBuildingNotices,
+): ModelBuildingNoticesView {
+  const rows: ModelBuildingNoticeRow[] = []
+  for (const group of notices.groups) {
+    const description = describeModelBuildingNoticeKind(group.kind)
+    if (!description) continue
+    rows.push({ kind: group.kind, count: group.count, description })
+  }
+  return { totalCount: notices.total_count, rows }
+}

--- a/src/canvas/conversation/modelBuildingNotices.ts
+++ b/src/canvas/conversation/modelBuildingNotices.ts
@@ -142,13 +142,20 @@ export const MODEL_BUILDING_NOTICES_POINTER =
  * rather than restated. Restating them would be a second copy of a producer
  * rule that can drift (CLAUDE.md trap 12); using the schema cannot.
  *
- * ⚠ FAIL-CLOSED, AND THE ABSENT CASE IS LOAD-BEARING. A turn that dropped
- * nothing carries NO key — the field is `.optional()` and the producer omits
- * it rather than sending a zero. So absence yields `null`, the caller attaches
- * nothing, and the bubble makes NO claim. Synthesising `{ totalCount: 0 }` here
- * would put "Olumi left 0 things out of this model" in front of every user on
- * every clean draft, which is the mint-a-zero defect this estate has already
- * shipped once and reads as a broken product.
+ * ⚠ FAIL-CLOSED, AND THE ABSENT CASE IS LOAD-BEARING — BUT IT MEANS LESS THAN
+ * IT LOOKS LIKE. The contract CANNOT ENCODE ZERO: `total_count` is `.positive()`
+ * and `groups` is `.min(1)`, so there is no representable "nothing was dropped"
+ * payload. Absence therefore means **no notice attestation was supplied** — NOT
+ * "this draft dropped nothing". The two are different claims and only the first
+ * is evidence.
+ *
+ * So absence yields `null`, the caller attaches nothing, and the bubble makes
+ * NO CLAIM IN EITHER DIRECTION. Two fabrications are banned here, not one:
+ *   · `{ totalCount: 0 }` would put "Olumi left 0 things out of this model" in
+ *     front of every user — the mint-a-zero defect this estate has shipped once.
+ *   · A reassurance ("nothing was left out", "your brief was captured in full")
+ *     would be WORSE: a positive completeness claim built on a silent field,
+ *     which is precisely the confident wrongness this capability exists to end.
  *
  * A row whose kind this UI cannot name is DROPPED from `rows` while
  * `totalCount` is preserved verbatim — the count is the producer's, and

--- a/src/canvas/conversation/types.ts
+++ b/src/canvas/conversation/types.ts
@@ -9,6 +9,7 @@ import type { StageType } from '@talchain/schemas/boundary'
 import type { CEEAnalysisReady, CEEGoalConstraint, CEEInterventionV3 } from '../../adapters/cee/types'
 import type { AnswerShape } from './answerShape'
 import type { GroundedSelection } from './groundedSelection'
+import type { ModelBuildingNoticesView } from './modelBuildingNotices'
 
 // ---------------------------------------------------------------------------
 // § 1 — Conversation messages
@@ -94,6 +95,25 @@ export interface ConversationMessage {
    * no longer name.
    */
   groundedSelection?: GroundedSelection
+  /**
+   * What Olumi had to leave out of the model it drafted on THIS turn —
+   * `model_building_notices`, a DECLARED optional field on the V5 body (schemas
+   * 0.48.0), parsed + fail-closed by `extractModelBuildingNoticesSidecar`
+   * (modelBuildingNotices.ts, which carries the full producer contract).
+   *
+   * When present the bubble renders a `ModelBuildingNoticesNotice`; when ABSENT
+   * it renders exactly as today and makes NO claim — the producer OMITS the key
+   * on a turn that dropped nothing rather than sending a zero, so synthesising
+   * an empty value here would report an omission that never happened. No flag:
+   * CEE emits it unconditionally, so this auto-lights-up.
+   *
+   * Ephemeral: derived from the live turn and NOT persisted — hydrated history
+   * renders without the notice, the same treatment as `reasoning`,
+   * `answerShape` and `groundedSelection`. Deliberate: an omission is a fact
+   * about the draft produced in THIS session, and replaying it against a model
+   * the user has since edited would assert a loss that no longer holds.
+   */
+  modelBuildingNotices?: ModelBuildingNoticesView
   /**
    * Transcript honesty (dress-rehearsal trust item #3, 2026-07-20): delivery
    * state of a visible user send on the LIVE V5 path.

--- a/src/canvas/conversation/types.ts
+++ b/src/canvas/conversation/types.ts
@@ -102,10 +102,12 @@ export interface ConversationMessage {
    * (modelBuildingNotices.ts, which carries the full producer contract).
    *
    * When present the bubble renders a `ModelBuildingNoticesNotice`; when ABSENT
-   * it renders exactly as today and makes NO claim — the producer OMITS the key
-   * on a turn that dropped nothing rather than sending a zero, so synthesising
-   * an empty value here would report an omission that never happened. No flag:
-   * CEE emits it unconditionally, so this auto-lights-up.
+   * it renders exactly as today and makes NO claim IN EITHER DIRECTION. The
+   * contract cannot encode zero (`total_count` is positive, `groups` is min 1),
+   * so absence means NO ATTESTATION WAS SUPPLIED — never "nothing was dropped".
+   * Synthesising an empty value would report an omission that never happened;
+   * rendering reassurance would assert a completeness the field cannot evidence.
+   * No flag: CEE emits it unconditionally, so this auto-lights-up.
    *
    * Ephemeral: derived from the live turn and NOT persisted — hydrated history
    * renders without the notice, the same treatment as `reasoning`,

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -72,6 +72,7 @@ import { isOrchestratorV2Enabled, isOrchestratorStreamingEnabled, isThreadHydrat
 import { ADDITIVE_EXTENSIONS_KEY, type OlumiResponseWithExtensions } from '../../v5/responseParser'
 import { extractAnswerShapeSidecar } from './answerShape'
 import { extractGroundedSelectionSidecar } from './groundedSelection'
+import { extractModelBuildingNoticesSidecar } from './modelBuildingNotices'
 // Leg 3 blocker fix: the wire->camelCase coaching mapper lives in the CEE
 // client adapter (DraftChat/useRetryDraft path); the V5 inline-draft seam
 // reuses it so one mapper owns the coaching wire shape.
@@ -5358,6 +5359,18 @@ export function useConversation(): UseConversationReturn {
             // would fabricate a grounding on every ungrounded turn, which is
             // the precise defect the wire spec's guards pin.
             const groundedSelection = extractGroundedSelectionSidecar(target.response)
+            // What Olumi had to leave out of the model it drafted on this turn.
+            // Unlike the three sidecars above, `model_building_notices` is a
+            // DECLARED field on `OlumiResponseSchema` (0.48.0), so it rides the
+            // response surface itself rather than the `__additive__` demotion.
+            //
+            // ⚠ FAIL-CLOSED, AND ABSENCE IS THE COMMON, MEANINGFUL CASE: a draft
+            // that dropped nothing carries no key (the field is `.optional()`
+            // and the producer omits rather than zeroing), the extractor returns
+            // null, and the conditional spread attaches nothing — so the bubble
+            // asserts no omission. Attaching a zero/empty value here would put
+            // "Olumi left 0 things out of this model" on every clean draft.
+            const modelBuildingNotices = extractModelBuildingNoticesSidecar(target.response)
             addMessage({
               id: crypto.randomUUID(),
               role: 'assistant',
@@ -5367,6 +5380,7 @@ export function useConversation(): UseConversationReturn {
               ...(reasoning ? { reasoning } : {}),
               ...(answerShape ? { answerShape } : {}),
               ...(groundedSelection ? { groundedSelection } : {}),
+              ...(modelBuildingNotices ? { modelBuildingNotices } : {}),
               timestamp: new Date(),
             })
 

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -5364,12 +5364,12 @@ export function useConversation(): UseConversationReturn {
             // DECLARED field on `OlumiResponseSchema` (0.48.0), so it rides the
             // response surface itself rather than the `__additive__` demotion.
             //
-            // ⚠ FAIL-CLOSED, AND ABSENCE IS THE COMMON, MEANINGFUL CASE: a draft
-            // that dropped nothing carries no key (the field is `.optional()`
-            // and the producer omits rather than zeroing), the extractor returns
-            // null, and the conditional spread attaches nothing — so the bubble
-            // asserts no omission. Attaching a zero/empty value here would put
-            // "Olumi left 0 things out of this model" on every clean draft.
+            // ⚠ FAIL-CLOSED, AND ABSENCE MEANS LESS THAN IT LOOKS LIKE: the
+            // contract cannot encode zero (`total_count` positive, `groups`
+            // min 1), so a missing key means NO ATTESTATION WAS SUPPLIED, never
+            // "this draft dropped nothing". The extractor returns null, the
+            // conditional spread attaches nothing, and the bubble asserts
+            // neither an omission nor a completeness.
             const modelBuildingNotices = extractModelBuildingNoticesSidecar(target.response)
             addMessage({
               id: crypto.randomUUID(),


### PR DESCRIPTION
## What this closes

When Olumi drafts a model from a brief it drops things it could not represent, and it **records why** — `model_building_notices`. That field had **ZERO renderers repo-wide**: 56 generated, 0 delivered. A model that silently drops half a brief is indistinguishable, to the user, from one that captured it. Coupled producer PR: **CEE #1051** (wire-reachable, not mounted). This lane makes it mounted.

## Does a renderer already exist? — NO

Swept the fresh clone at `ad79b344` with `rg -a` **and a contrast control in the same run**:

| symbol | files |
|---|---|
| `model_building_notices` (target) | **3** — `src/v5/responseParser.ts` (quarantine list) + 2 parser specs |
| `analysis_state` (contrast control) | **20+** across product + specs |

The contrast fires, so the instrument sees. All three target hits are **parser-level tolerance only** — the field was validated and then dropped on the floor. No renderer, no store slice, no consumer.

## The field's real shape at the vendored 0.48.0

Read at the tarball bytes, not inferred:

```
{ total_count: number,               // .positive()
  groups: Array<{ kind, count }>,    // .min(1).max(6), strict
  details_redacted: true }           // z.literal(true)
```

`.strict()` at every level, a closed 6-member `kind` enum, and a `superRefine` enforcing **two** cross-field rules: kinds are unique, and `total_count` equals the group sum.

**`details_redacted` is a literal `true` — the wire carries aggregate counts per kind and NOTHING else.** No free text, no per-item detail, no next step. So every user-visible string is UI copy keyed to a closed enum, which is why the copy lives in exactly one place.

## What I built

Follows the established `_grounded_selection` sidecar pattern **exactly**: wire binding + copy authority → optional field on `ConversationMessage` → extraction on the live V5 path → **one ungated mount** in `MessageBubble`.

- `canvas/conversation/modelBuildingNotices.ts` — the canonical owner: extractor (parses through the **published schema itself**, so the producer's two cross-field rules are enforced rather than restated) and the sole kind→string map.
- `canvas/conversation/ModelBuildingNoticesNotice.tsx` — one count-led line, breakdown + next-route pointer behind a toggle.
- Mount in `MessageBubble.tsx`, assistant-only, conditioned on the payload's own presence.

### Why NOT inside `ModelReceiptBlock`

`ModelReceiptBlock` is the other post-draft card and looked like the natural home. It is gated **three times over**: the `preAnalysisEnriched` flag (**`defaultValue` false, and its envKey `VITE_FEATURE_PRE_ANALYSIS_ENRICHED` is ABSENT from `netlify.toml`**), a non-empty `coachingSummary`, and a normalised `ceeAnalysisReady`. Hanging an honest disclosure off three preconditions it does not need is exactly how a correct thing ships dark — the failure this lane exists to end. A test asserts the mount guard contains **no flag reference at all**.

## Product constraints

- **No raw wire vocabulary.** Kind codes never reach the DOM as text; an unnameable kind renders nothing rather than falling back to its code. Pinned across all six enum members plus a general snake_case ban.
- **Progressive disclosure.** Collapsed to one line by default.
- **No invented content.** `details_redacted` means no examples exist to show, so none are synthesised.
- **No minted zero — and no minted reassurance.** The contract *cannot encode zero* (`total_count` positive, `groups` min 1), so an absent field means **no attestation was supplied**, NOT "nothing was dropped". Absence renders nothing and claims nothing **in either direction**; a completeness reassurance built on a silent field would be the more dangerous fabrication.
- **`total_count` is the PRODUCER's.** Never derived from rendered groups — the two can legitimately differ, and they are pinned as separate quantities.
- **A useful next route, not a dead end.** One pointer line, **true by construction**: it names a conversational action available wherever the bubble renders, not a control this notice does not draw.

## RED-first (recorded at pristine, implementation stashed)

- `ModelBuildingNoticesNotice.spec.tsx` / `modelBuildingNotices.wire.spec.ts` — **collect failure**: `Failed to resolve import "../modelBuildingNotices"`.
- `modelBuildingNotices.mountSite.spec.ts` — 4 failed / 1 passed (the passing one is the scanner's own positive control): `expected -1 to be greater than -1` (no mount), `expected [] to deeply equal [ …(3) ]` (no importers).

## Mutants

Throwaway worktree at an absolute path outside the repo root, committed state only, applied-check scoped to `src/` asserting exactly 1, control asserting exactly 0, restore from a pristine **archive**. **Isolation proven by WRITING a sentinel** and asserting the source clone unchanged — source sha identical before/after, inodes differ (`681717507` vs `681894595`).

| # | mutation | verdict |
|---|---|---|
| M0 | control, no mutation | GREEN, applied-check 0 |
| M1 | delete the mount in `MessageBubble` | RED (8) |
| M2 | drop `!isUser` from the mount guard | RED (2) |
| M3 | mint a ZERO on absence | RED (2) |
| M4 | fall back to the raw kind code | RED (3) |
| M5 | always-plural summary copy | RED (2) |
| M6 | render unnameable kinds anyway | **survived → hole closed → RED (3)** |
| M7 | pre-expand the disclosure | RED (3) |
| M8 | drop a kind from the copy map | RED (5) |
| M9 | bypass the schema | RED (3) |
| M10 | headline count = row count, not producer total | RED (1) |
| M11 | cosmetic spacing (discriminating partner) | **GREEN, as required** |

**M6 survived and was a real finding, not an equivalent mutant.** The test *named* for the unnameable-kind drop carried a fixture of only nameable kinds, so it could never observe one — trap 19 inside my own suite. The branch is unreachable through the extractor by construction (closed enum), so it is now exercised at the shaper, the only entry point that reaches it. A **rot-check** confirms the new test pins its own precondition: making its fixture nameable REDs on a *different* assertion.

## Gates

- Typecheck gate: **PASSED** (3564/3604 files; ratchet 2263, baseline 2263 — unchanged).
- ESLint on all changed files: **0 errors** (12 pre-existing warnings in files I touched, none from these lines).
- Specs, collected **by name**: `ModelBuildingNoticesNotice.spec.tsx` **10**, `modelBuildingNotices.wire.spec.ts` **16**, `modelBuildingNotices.mountSite.spec.ts` **5** — **31 passed**.

## Rung, honestly

**TESTED.** Not deployed, not journey-witnessed. jsdom proves the notice is in the DOM under the real `MessageBubble` mount — it does **not** prove visibility or layout, and no such claim is made here. Deliberately not deployed: a SENDABLE integration batch is in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)