### PR TITLE
fix(canvas): the panel-aware fit never runs on a restored graph — UX gate point 7, narrowed

### DIFF
--- a/e2e/geometry/viewportRestoreFit.measure.ts
+++ b/e2e/geometry/viewportRestoreFit.measure.ts
@@ -1,0 +1,387 @@
+/**
+ * THE RESTORE FIT — real Chromium, real reload, real geometry.
+ *
+ * ⚠ RUN IT DELIBERATELY. It is a `*.measure.ts`, so the main e2e config cannot
+ * collect it, and **`Staging Gate` runs no Playwright job at all** (the gate is
+ * `tsc` / `typecheck-selftest` / `vitest` / `vitest-summary` / `build` —
+ * `.github/workflows/staging-full-tests.yml`). Nothing here gates a merge; the
+ * gated half of this fix is
+ * `src/canvas/__tests__/useFitViewOnLayoutVersion.restore.spec.tsx`.
+ *
+ *     pnpm exec playwright test -c playwright.geometry.config.ts \
+ *       e2e/geometry/viewportRestoreFit.measure.ts
+ *
+ * WHY IT EXISTS. jsdom cannot prove a rendered transform or a node's position on
+ * screen (CLAUDE.md trap 3), and presence assertions are exactly what stayed
+ * green while this shipped. The postcondition here is BEHAVIOURAL and PIXEL-LEVEL:
+ * after a reload the camera must have been aimed at the restored model, the frame
+ * must follow the window, and no model node may sit off-screen or behind the
+ * floating header banner.
+ *
+ * ⚠ READ THE SCOPE OF EACH ARM. Two lanes measured this build and appeared to
+ * disagree; the third test in this file reconciles them, and BOTH readings are
+ * recorded here as true. What is NOT true, and must not be repeated: "the
+ * viewport controls are inert after a reload" and "the restore never re-fits".
+ * The second test below asserts the controls ARE live, precisely so this file
+ * cannot be cited for the refuted claim.
+ *
+ * MEASURED AT PRISTINE (frozen base `2b6ec553`), headed, instrument asserted
+ * live: `layoutVersion` stays 0 on every restore path, which latches off both
+ * of the fit owner's triggers, so the graph keeps whatever xyflow's own
+ * `fitView` PROP produced at mount — with xyflow's DEFAULT padding, carrying
+ * none of `computeFitPadding`'s reservations. Reloading AT each size, the
+ * Decision node lands behind the floating header banner at 1280x800 (clean at
+ * 1440x900 and 1512x982); reloading once and then RESIZING, the frame does not
+ * follow the window at all.
+ *
+ * STATE CLASS IS NAMED, NEVER ASSUMED (status-ladder fixture rule): the FRESH
+ * case is the POSITIVE CONTROL — it passed at pristine and must keep passing, so
+ * a failure in the RESTORE case is about the restore and not about the probe.
+ */
+import { test, expect, type Page } from '@playwright/test'
+import { posturePins } from '../visual/flagPosture'
+import {
+  openCanvas,
+  freezeMotion,
+  seedStarterDraft,
+  clearNotifications,
+  minimiseFloatingOlumiPanel,
+  waitForVisualQuiescence,
+  FROZEN_TIME,
+} from '../visual/harness'
+
+const GHOST = '__ghost-option__'
+const SIZES = [
+  { width: 1280, height: 800 },
+  { width: 1440, height: 900 },
+  { width: 1512, height: 982 },
+]
+
+/**
+ * `harness.preparePage` clears storage on EVERY navigation, which would wipe the
+ * autosave the product's own restore path reads — so a reload after it is not the
+ * restore state class at all. This clears once per tab: `sessionStorage` survives
+ * a reload and `localStorage.clear()` does not touch it, so it is the marker.
+ */
+async function prepareKeepingStorage(page: Page, vp: { width: number; height: number }) {
+  const pins = posturePins()
+  await page.addInitScript(
+    ({ flagPins }: { flagPins: Array<{ storageKey: string; value: string }> }) => {
+      try {
+        if (!sessionStorage.getItem('__restoreProbePrepared')) {
+          localStorage.clear()
+          sessionStorage.clear()
+          sessionStorage.setItem('__restoreProbePrepared', '1')
+        }
+        for (const p of flagPins) localStorage.setItem(p.storageKey, p.value)
+        localStorage.setItem('olumi_keys_seen', '1')
+        localStorage.setItem('olumi-canvas-onboarding-dismissed', '1')
+        localStorage.setItem('canvas-empty-state-dismissed', '1')
+      } catch { /* the visible-anchor assertions below catch a dead storage */ }
+    },
+    { flagPins: pins.map((p) => ({ storageKey: p.storageKey, value: p.value })) },
+  )
+  await page.setViewportSize(vp)
+  await page.emulateMedia({ reducedMotion: 'reduce', colorScheme: 'light' })
+  await page.clock.setFixedTime(FROZEN_TIME)
+  await page.route('**/bff/**', (r) => r.fulfill({ status: 503, contentType: 'application/json', body: '{}' }))
+  await page.route('**/api/**', (r) => r.fulfill({ status: 503, contentType: 'application/json', body: '{}' }))
+  await page.route('**/*', (r) => {
+    const u = new URL(r.request().url())
+    return u.hostname === 'localhost' || u.hostname === '127.0.0.1' ? r.fallback() : r.abort()
+  })
+}
+
+interface Frame {
+  transform: string
+  layoutVersion: number
+  storeNodeCount: number
+  modelNodeCount: number
+  flowCount: number
+  /** Model nodes whose rendered box leaves the pane. */
+  offPane: string[]
+  /** Model nodes whose rendered box intersects the floating header banner. */
+  behindBanner: string[]
+  bannerFound: boolean
+}
+
+async function frameOf(page: Page): Promise<Frame> {
+  return page.evaluate((ghost: string) => {
+    const vpEl = document.querySelector('.react-flow__viewport') as HTMLElement | null
+    const flow = document.querySelector('.react-flow')!.getBoundingClientRect()
+    const banner = document.querySelector('[role="banner"]')?.getBoundingClientRect() ?? null
+    const store = (window as unknown as { useCanvasStore: { getState: () => { nodes: Array<{ id: string }>; layoutVersion: number } } }).useCanvasStore.getState()
+    const els = [...document.querySelectorAll('.react-flow__node[data-id]')] as HTMLElement[]
+    const model = els.filter((e) => e.dataset.id !== ghost)
+    const offPane: string[] = []
+    const behindBanner: string[] = []
+    for (const el of model) {
+      const r = el.getBoundingClientRect()
+      if (r.left < flow.left || r.top < flow.top || r.right > flow.right || r.bottom > flow.bottom) {
+        offPane.push(el.dataset.id!)
+      }
+      if (banner && r.left < banner.right && r.right > banner.left && r.top < banner.bottom && r.bottom > banner.top) {
+        behindBanner.push(el.dataset.id!)
+      }
+    }
+    return {
+      transform: vpEl ? getComputedStyle(vpEl).transform : 'NO-VIEWPORT-EL',
+      layoutVersion: store.layoutVersion,
+      storeNodeCount: store.nodes.length,
+      modelNodeCount: model.length,
+      flowCount: document.querySelectorAll('.react-flow').length,
+      offPane,
+      behindBanner,
+      bannerFound: banner !== null,
+    }
+  }, GHOST)
+}
+
+function report(phase: string, extra: Record<string, unknown>) {
+  // eslint-disable-next-line no-console
+  console.log(`RESTOREFIT ${JSON.stringify({ phase, ...extra })}`)
+}
+
+test('the restored model is framed, and the frame follows the window', async ({ page }) => {
+  test.setTimeout(600_000)
+  await prepareKeepingStorage(page, SIZES[0])
+  await openCanvas(page)
+
+  /* ── POSITIVE CONTROL: the FRESH state class ──────────────────────────── */
+  const seeded = await seedStarterDraft(page, 'vendor-selection')
+  await clearNotifications(page)
+  await minimiseFloatingOlumiPanel(page)
+  await waitForVisualQuiescence(page)
+
+  /* ── INSTRUMENT VALIDITY — PROVE THE BROWSER IS ALIVE BEFORE TRUSTING A WORD
+   * OF IT (added 20 Aug 2026 after a sibling instrument was refuted).
+   *
+   * A page rendered in a PERMANENTLY HIDDEN tab reproduces the exact symptom
+   * this file exists to measure: `requestAnimationFrame` never fires, so every
+   * camera move — which xyflow drives through a d3 transition on rAF —
+   * silently no-ops, and the viewport transform reads BYTE-IDENTICAL at every
+   * window size. A blind instrument and a broken product are indistinguishable
+   * from the output alone. So the instrument is asserted first, and loudly.
+   */
+  const liveness = await page.evaluate(async () => {
+    let frames = 0
+    await new Promise<void>((resolve) => {
+      const t0 = performance.now()
+      const tick = () => {
+        frames += 1
+        if (performance.now() - t0 >= 600) resolve()
+        else requestAnimationFrame(tick)
+      }
+      requestAnimationFrame(tick)
+    })
+    return { frames, visibility: document.visibilityState, innerWidth: window.innerWidth, innerHeight: window.innerHeight }
+  })
+  report('instrument', liveness)
+  expect(liveness.visibility, 'the page is in a HIDDEN tab — rAF is starved and every camera measurement below is worthless').toBe('visible')
+  expect(liveness.innerWidth, 'window.innerWidth is 0 — this surface is not laying the page out').toBeGreaterThan(0)
+  expect(liveness.frames, 'requestAnimationFrame produced almost no frames in 600ms — the render loop is starved, so an unchanged transform proves NOTHING').toBeGreaterThan(20)
+
+  const fresh = await frameOf(page)
+  report('fresh', { seeded, ...fresh })
+  // The probe must be able to SEE the properties it will assert about, or an
+  // absence of complaints proves nothing (trap 13).
+  expect(fresh.bannerFound, 'no [role="banner"] — the behind-banner check would be vacuous').toBe(true)
+  expect(fresh.modelNodeCount, 'no model nodes rendered — every geometry check below would be vacuous').toBeGreaterThan(0)
+  expect(fresh.layoutVersion, 'fresh draft never laid out — this is not the fresh state class').toBeGreaterThan(0)
+  expect(fresh.flowCount, 'more than one .react-flow — the measurements would be ambiguous').toBe(1)
+  expect(fresh.behindBanner, 'FRESH: a model node sits behind the header banner — the control itself is broken').toEqual([])
+  // ⚠ REPORTED, NOT FIXED, AND DELIBERATELY NOT ASSERTED TO BE EMPTY.
+  // Measured 20 Aug 2026 on the FRESH path at 1280x800, with a completed layout
+  // and the canonical panel-aware fit: `offPane: ["goal_cdp"]` in two of three
+  // runs. It tracks the fresh fit zoom, which itself varied run to run
+  // (0.622103 vs 0.594549) — i.e. the fresh path's own last fit sometimes lands
+  // against a reserved box that has since moved. So "no model node is ever
+  // off-screen at fit" is NOT a property this product currently has, on either
+  // state class, and asserting it here would be this lane silently adopting a
+  // second defect (and an intermittent one, which is how a harness gets muted).
+  // The restore case below is therefore held to the product's OWN standard —
+  // no worse than its fresh fit at the same window — which is exactly the claim
+  // this lane is entitled to make.
+  const freshOffPane = new Set(fresh.offPane)
+
+  /* ── THE SUBJECT: the RESTORE state class ─────────────────────────────── */
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await expect(page.locator('.react-flow')).toBeVisible({ timeout: 30_000 })
+  await page.waitForFunction(
+    () => typeof (window as unknown as { useCanvasStore?: { getState?: () => unknown } }).useCanvasStore?.getState === 'function',
+    undefined, { timeout: 30_000 },
+  )
+  await page.evaluate(() => document.fonts?.ready)
+  await freezeMotion(page)
+  await page.waitForFunction(
+    () => ((window as unknown as { useCanvasStore: { getState: () => { nodes: unknown[] } } }).useCanvasStore.getState().nodes.length) > 0,
+    undefined, { timeout: 30_000 },
+  )
+  await clearNotifications(page).catch(() => undefined)
+  await minimiseFloatingOlumiPanel(page).catch(() => undefined)
+  await waitForVisualQuiescence(page)
+
+  const frames: Frame[] = []
+  for (const vp of SIZES) {
+    await page.setViewportSize(vp)
+    await page.waitForTimeout(1_500)
+    const f = await frameOf(page)
+    report('restore', { vp: `${vp.width}x${vp.height}`, ...f })
+    frames.push(f)
+  }
+
+  // PIN THE PRECONDITION: this must still be the state class the defect lives
+  // in. If a layout ran, the LAYOUT trigger aimed the camera and this proves
+  // nothing about the restore path.
+  expect(frames[0].layoutVersion, 'a layout ran on reload — no longer the restore state class').toBe(0)
+  expect(frames[0].storeNodeCount, 'nothing was restored — the reload did not reproduce the restore path')
+    .toBe(seeded.nodeCount)
+  expect(frames[0].modelNodeCount, 'no model nodes rendered after restore').toBeGreaterThan(0)
+  expect(frames[0].bannerFound).toBe(true)
+
+  // (a) THE FRAME FOLLOWS THE WINDOW. At pristine all three were the byte-identical
+  //     `matrix(0.666667, 0, 0, 0.666667, 196, 20)`.
+  const transforms = frames.map((f) => f.transform)
+  expect(new Set(transforms).size, `viewport transform never changed with the window: ${JSON.stringify(transforms)}`)
+    .toBe(SIZES.length)
+
+  // (b) NOTHING BEHIND THE HEADER BANNER, at every size. The UX gate measured
+  //     the Decision node 31px / 24.4% behind it on the restore path, with 2 of 4
+  //     hit-test probes returning the banner's own controls. `computeFitPadding`
+  //     has reserved the banner since #786 (`a3938981`) — it simply was never
+  //     APPLIED on this path, because no fit ever ran.
+  for (let i = 0; i < SIZES.length; i++) {
+    const size = `${SIZES[i].width}x${SIZES[i].height}`
+    expect(frames[i].behindBanner, `RESTORE @${size}: model nodes behind the header banner`).toEqual([])
+  }
+
+  // (c) NO WORSE OFF-SCREEN THAN THE PRODUCT'S OWN FRESH FIT at the same window.
+  //     At pristine the restored graph was framed by xyflow's DEFAULT padding and
+  //     the UX gate measured 1 node fully hidden and 4 more >=5% clipped at
+  //     1280x800; the fresh fit at that size hides `freshOffPane` and no more.
+  const restoreOffPane1280 = frames[0].offPane
+  report('offPaneComparison', { fresh: [...freshOffPane], restore: restoreOffPane1280 })
+  expect(
+    restoreOffPane1280.filter((id) => !freshOffPane.has(id)),
+    `RESTORE @1280x800: model nodes off-screen that the fresh fit at the same window keeps on-screen`,
+  ).toEqual([])
+})
+
+/**
+ * The four viewport controls, after a reload.
+ *
+ * ⚠ ACTIVATED BY KEYBOARD. A mouse click is intercepted by the Tooltip portal the
+ * previous hover leaves behind — measured in this harness: `.click()` retried 230
+ * times against `div[role="tooltip"]` and never landed. Keyboard activation is a
+ * real user path and routes round it, so an inert result here is the control's
+ * doing and not the tooltip's. (Same occlusion class `harness.minimiseFloatingOlumiPanel`
+ * records; it is why a mouse-driven probe can report a working control as dead.)
+ */
+test('the four viewport controls move the camera after a reload', async ({ page }) => {
+  test.setTimeout(600_000)
+  await prepareKeepingStorage(page, SIZES[0])
+  await openCanvas(page)
+  await seedStarterDraft(page, 'vendor-selection')
+  await clearNotifications(page)
+  await minimiseFloatingOlumiPanel(page)
+  await waitForVisualQuiescence(page)
+
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await expect(page.locator('.react-flow')).toBeVisible({ timeout: 30_000 })
+  await page.waitForFunction(
+    () => ((window as unknown as { useCanvasStore?: { getState?: () => { nodes: unknown[] } } }).useCanvasStore?.getState?.().nodes.length ?? 0) > 0,
+    undefined, { timeout: 30_000 },
+  )
+  await page.evaluate(() => document.fonts?.ready)
+  await freezeMotion(page)
+  await clearNotifications(page).catch(() => undefined)
+  await minimiseFloatingOlumiPanel(page).catch(() => undefined)
+  await waitForVisualQuiescence(page)
+
+  const nav = page.locator('nav[aria-label="Viewport controls"]')
+  const controls: Array<{ label: string; name: string | RegExp }> = [
+    { label: 'Fit to view', name: 'Fit to view' },
+    { label: 'Zoom in', name: 'Zoom in' },
+    { label: 'Zoom out', name: 'Zoom out' },
+    { label: 'Zoom reset', name: /Click to reset to 100%/ },
+  ]
+
+  for (const { label, name } of controls) {
+    const before = (await frameOf(page)).transform
+    const btn = nav.getByRole('button', { name })
+    await expect(btn, `${label}: not found`).toHaveCount(1)
+    await expect(btn, `${label}: disabled`).toBeEnabled()
+    await btn.focus()
+    await page.keyboard.press('Enter')
+    await page.waitForTimeout(700)
+    const after = (await frameOf(page)).transform
+    report('control', { control: label, before, after, changed: before !== after })
+    expect(after, `${label} did not move the camera after a reload (inert control)`).not.toBe(before)
+  }
+})
+
+/**
+ * THE ARRIVE-AT-SIZE PROTOCOL — the same question asked the other way, because
+ * two lanes measured this build and appeared to disagree (20 Aug 2026).
+ *
+ * The other lane RELOADED AT each viewport and found the arrival transform
+ * DIFFERENT at every size, concluding "it is a per-viewport auto-fit, the
+ * restore does re-fit". This lane reloaded ONCE and then RESIZED, and found the
+ * transform BYTE-IDENTICAL at every size.
+ *
+ * BOTH ARE TRUE, AND ONE MECHANISM EXPLAINS BOTH: xyflow's own `fitView` PROP
+ * fits once at mount, against whatever the pane measured at that instant — so
+ * arriving at a different size gives a different frame — while the PRODUCT's
+ * fit owner (`useFitViewOnLayoutVersion`) never runs at all on a restored
+ * graph, so nothing re-frames when the window later changes. A per-viewport
+ * arrival fit is not evidence that the product re-fits; it is evidence that
+ * xyflow mounted.
+ *
+ * ⭐ AND THE HARM DOES NOT DEPEND ON WHICH PROTOCOL YOU USE, which is why this
+ * arm exists: xyflow's prop fit uses xyflow's DEFAULT padding and knows nothing
+ * about `[role="banner"]`, the OutputsDock or the LeftSidebar. The banner inset
+ * added in #786 lives in `computeFitPadding`, and `computeFitPadding` is only
+ * ever reached through the fit owner. So on the restore path the top row of the
+ * model lands under the floating header at EVERY viewport, however you arrive.
+ */
+test('arriving at a size still lands the model under the header banner (the other lane\'s protocol)', async ({ page }) => {
+  test.setTimeout(600_000)
+  await prepareKeepingStorage(page, SIZES[0])
+  await openCanvas(page)
+  await seedStarterDraft(page, 'vendor-selection')
+  await clearNotifications(page)
+  await minimiseFloatingOlumiPanel(page)
+  await waitForVisualQuiescence(page)
+
+  const arrivals: Frame[] = []
+  for (const vp of SIZES) {
+    // Size FIRST, then reload — so each arrival gets its own mount-time fit.
+    await page.setViewportSize(vp)
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await expect(page.locator('.react-flow')).toBeVisible({ timeout: 30_000 })
+    await page.waitForFunction(
+      () => ((window as unknown as { useCanvasStore?: { getState?: () => { nodes: unknown[] } } }).useCanvasStore?.getState?.().nodes.length ?? 0) > 0,
+      undefined, { timeout: 30_000 },
+    )
+    await page.evaluate(() => document.fonts?.ready)
+    await freezeMotion(page)
+    await clearNotifications(page).catch(() => undefined)
+    await minimiseFloatingOlumiPanel(page).catch(() => undefined)
+    await waitForVisualQuiescence(page)
+    const f = await frameOf(page)
+    report('arrive', { vp: `${vp.width}x${vp.height}`, ...f })
+    arrivals.push(f)
+  }
+
+  // The arrival transform DOES vary by size — xyflow's prop fit ran at each
+  // mount. Asserted so this file records the other lane's finding as TRUE.
+  expect(new Set(arrivals.map((a) => a.transform)).size,
+    'arrival transforms did not vary by viewport — then even xyflow\'s own mount fit is not running').toBe(SIZES.length)
+  // …and every arrival is still a restore (no product layout ran).
+  for (const a of arrivals) expect(a.layoutVersion, 'a layout ran — not the restore state class').toBe(0)
+
+  // THE CLAIM THAT SURVIVES BOTH PROTOCOLS.
+  for (let i = 0; i < SIZES.length; i++) {
+    expect(arrivals[i].behindBanner, `ARRIVE @${SIZES[i].width}x${SIZES[i].height}: model nodes behind the header banner`).toEqual([])
+  }
+})

--- a/src/canvas/__tests__/ReactFlowGraph.layoutLifecycle.integration.spec.tsx
+++ b/src/canvas/__tests__/ReactFlowGraph.layoutLifecycle.integration.spec.tsx
@@ -188,7 +188,38 @@ describe('Layout lifecycle — guard ↔ measurement ↔ applyLayout ↔ fitView
     expect(useCanvasStore.getState().layoutVersion).toBeGreaterThan(0)
   })
 
-  it('saved-position scenario → guard, applyLayout, and fitView all stay quiet (acceptance #2)', async () => {
+  /**
+   * ⚠⚠ ACCEPTANCE #2 WAS AMENDED ON 20 Aug 2026, AND THE AMENDMENT IS THE POINT
+   * OF THE TEST — a reviewer should read this before the assertions.
+   *
+   * It used to assert `fitViewSpy` was NOT called here, alongside the layout
+   * assertions, under the single word "quiet". That bundled TWO DIFFERENT
+   * QUESTIONS under one name (CLAUDE.md trap 21):
+   *
+   *   (a) may the product move the NODES of a saved-position graph?  — NO.
+   *   (b) may the product aim the CAMERA at it?                      — YES, and
+   *       it MUST, because nothing else ever will.
+   *
+   * Every clause answering (a) is UNCHANGED and still asserted below: no
+   * `applyLayout`, `layoutVersion` still 0, and the saved x-positions still
+   * exactly 0 and 320. Aiming the camera moves no node — it changes the
+   * viewport only.
+   *
+   * (b) was refuted at the deployed product. A restored graph reaches the
+   * canvas through `hydrateGraphSlice` / `loadScenario`, which correctly never
+   * set `pendingLayout`, so `layoutVersion` stayed 0 and the fit owner's
+   * triggers were latched off for the whole page session. Measured in real
+   * Chromium at `ad79b344` after a reload: the viewport transform was
+   * `matrix(0.666667, 0, 0, 0.666667, 196, 20)` — byte-identical at 1280x800,
+   * 1440x900 and 1512x982 — carrying xyflow's DEFAULT padding rather than
+   * `computeFitPadding`'s, with the Decision node behind the header banner at
+   * all three sizes and the Goal node off-screen at 1280x800.
+   *
+   * So "quiet" now means quiet about the MODEL, not blind about the CAMERA.
+   * See `useFitViewOnLayoutVersion`'s restore trigger and
+   * `useFitViewOnLayoutVersion.restore.spec.tsx`.
+   */
+  it('saved-position scenario → guard and applyLayout stay quiet, and the camera IS aimed (acceptance #2, amended)', async () => {
     const applySpy = mockApplyLayoutWithSpread()
 
     const ids = ['a', 'b', 'c']
@@ -206,14 +237,23 @@ describe('Layout lifecycle — guard ↔ measurement ↔ applyLayout ↔ fitView
     renderHook(() => useLayoutLifecycle())
     await flushPipeline()
 
-    expect(applySpy).not.toHaveBeenCalled()
-    expect(fitViewSpy).not.toHaveBeenCalled()
+    // (a) THE MODEL IS UNTOUCHED — every original clause, unchanged.
+    expect(applySpy, 'a saved-position graph must never be re-laid-out').not.toHaveBeenCalled()
     expect(useCanvasStore.getState().pendingLayout).toBe(false)
     expect(useCanvasStore.getState().layoutVersion).toBe(0)
 
     const final = useCanvasStore.getState().nodes
     expect((final[0].position as { x: number }).x).toBe(0)
     expect((final[1].position as { x: number }).x).toBe(320)
+
+    // (b) THE CAMERA IS AIMED — the amended clause, with the same contract the
+    // layout fit uses, so the two triggers cannot drift into two different fits.
+    expect(fitViewSpy, 'the restored model was never framed — the reload defect').toHaveBeenCalledTimes(1)
+    expect(fitViewSpy).toHaveBeenCalledWith({
+      padding: FIT_PADDING,
+      minZoom: LABEL_LEGIBLE_ZOOM,
+      duration: 400,
+    })
   })
 
   it('locked nodes are preserved through the full pipeline (acceptance #3)', async () => {
@@ -274,9 +314,14 @@ describe('Layout lifecycle — guard ↔ measurement ↔ applyLayout ↔ fitView
     renderHook(() => useLayoutLifecycle())
     await flushPipeline()
 
-    // A had meaningful positions — nothing fired.
-    expect(applySpy).not.toHaveBeenCalled()
-    expect(fitViewSpy).not.toHaveBeenCalled()
+    // A had meaningful positions — no LAYOUT fired. The camera is aimed at A
+    // once (the restore trigger; see acceptance #2's amendment note), so the
+    // count is captured rather than assumed, and B's fit is asserted as a
+    // DELTA below. That keeps this test's subject — "fires fitView once FOR B"
+    // — bound to B, instead of to a running total any other trigger can move.
+    expect(applySpy, 'A had saved positions — it must not be re-laid-out').not.toHaveBeenCalled()
+    const fitsAfterA = fitViewSpy.mock.calls.length
+    expect(fitsAfterA, 'A was restored and should have been framed exactly once').toBe(1)
 
     // Switch to a stacked scenario B (mimics ScenarioSwitcher click /
     // useScenario.loadScenario → hydrateGraphSlice).
@@ -297,7 +342,9 @@ describe('Layout lifecycle — guard ↔ measurement ↔ applyLayout ↔ fitView
     const final = useCanvasStore.getState().nodes
     const xs = final.map((n) => (n.position as { x: number }).x)
     expect(Math.max(...xs) - Math.min(...xs)).toBeGreaterThan(40)
-    expect(fitViewSpy).toHaveBeenCalledTimes(1)
-    expect(fitViewSpy).toHaveBeenCalledWith({ padding: FIT_PADDING, minZoom: LABEL_LEGIBLE_ZOOM, duration: 400 })
+    // EXACTLY ONE MORE fit, and it is B's: the layout trigger's, after B was
+    // laid out. A delta, not a total — see the note above.
+    expect(fitViewSpy.mock.calls.length - fitsAfterA, 'B was not framed exactly once after its layout').toBe(1)
+    expect(fitViewSpy).toHaveBeenLastCalledWith({ padding: FIT_PADDING, minZoom: LABEL_LEGIBLE_ZOOM, duration: 400 })
   })
 })

--- a/src/canvas/__tests__/useFitViewOnLayoutVersion.restore.spec.tsx
+++ b/src/canvas/__tests__/useFitViewOnLayoutVersion.restore.spec.tsx
@@ -1,0 +1,305 @@
+/**
+ * THE RESTORE TRIGGER — the camera must be aimed at a graph that arrives
+ * WITHOUT a layout pass (UX gate point 7, 2026-08-19/20).
+ *
+ * THE DEFECT THIS PINS — stated narrowly, because the first version of this
+ * paragraph was WIDER THAN THE EVIDENCE AND WAS REFUTED (20 Aug 2026).
+ *
+ * ⚠ NOT the defect: "the viewport controls are inert after a reload" (refuted
+ * by two independent lanes) and "the restore never re-fits" (refuted — xyflow's
+ * own `fitView` PROP fits at every mount, so arriving at a different window
+ * size genuinely does give a different frame; measured 0.6667 / 0.7509 / 0.8187
+ * at 1280 / 1440 / 1512 on the frozen base). Do not repeat either claim.
+ *
+ * THE DEFECT: on a restored graph the PRODUCT's own fit never runs, so no
+ * arrival carries `computeFitPadding`'s reservations — no header-banner inset,
+ * no dock, no sidebar — because `computeFitPadding` is only ever reached
+ * through the fit owner. Measured headed, real Chromium, on the frozen base
+ * `2b6ec553`, reloading AT each size: the Decision node sits behind the
+ * floating header banner at **1280x800**, the smallest desktop this product
+ * commits to, while the FRESH path at that same size is clean. A second, lesser
+ * consequence: the frame does not follow a window RESIZE on a restored graph.
+ *
+ * THE MECHANISM, derived at the bytes and reproduced:
+ *   - every restore path ends at `hydrateGraphSlice` (`store.ts:5954`) or
+ *     `loadScenario` (`store.ts:4233`) — the guest-autosave branch
+ *     (`ReactFlowGraph.tsx:1545`), the scenario branch (`:1644`) and the DEV
+ *     fall-through (`:1685`);
+ *   - NONE of them sets `pendingLayout` or bumps `layoutVersion`, because a
+ *     restored graph already has real positions and must not be re-laid-out;
+ *   - `useInitialLayoutGuard` is the only safety net and it is gated on
+ *     `graphNeedsInitialLayout` — deliberately inert on a correctly-positioned
+ *     graph;
+ *   - so `layoutVersion` stays `0` for the whole page session, and BOTH of the
+ *     fit owner's triggers were latched off by it.
+ *
+ * `layoutVersion === 0` was doing two different jobs under one name (trap 21).
+ * On the layout trigger it means "this effect run is the mount, not a layout
+ * completion" — correct, and unchanged. On the reserved-box trigger it was
+ * standing in for "there is nothing to fit" — and that proxy is FALSE for a
+ * restored graph, which is the whole defect.
+ *
+ * WHAT THIS SPEC CAN AND CANNOT PROVE. jsdom cannot prove a rendered transform
+ * (CLAUDE.md trap 3), so this binds to the postcondition the fit OWNER is
+ * responsible for: that `fitView` is CALLED, with the canonical contract, for
+ * the restored graph's own node ids. The pixel postcondition — that the
+ * transform DIFFERS across window sizes after a reload, and that no model node
+ * lands off-screen or behind the banner — is real Chromium and is pinned in
+ * `e2e/geometry/viewportRestoreFit.measure.ts`. ⚠ That file is NOT in `Staging
+ * Gate` (the gate is tsc / typecheck-selftest / vitest / vitest-summary /
+ * build — no Playwright job), so it must be run deliberately.
+ *
+ * Every positive case below has its OPPOSITE-DIRECTION TWIN (trap 22b): an
+ * empty canvas and a graph still awaiting its first layout must NOT be fitted,
+ * or the fix would trade "never aims" for "aims at a pile at the origin".
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useCanvasStore } from '../store'
+import { useFitViewOnLayoutVersion } from '../hooks/useFitViewOnLayoutVersion'
+import { LABEL_LEGIBLE_ZOOM } from '../utils/zoomLegibility'
+import { GHOST_OPTION_NODE_ID } from '../utils/fitTargets'
+import { STACKED_SPREAD_PX, getGraphIdentityKey } from '../utils/graphNeedsInitialLayout'
+
+/**
+ * The restore payload type, DERIVED from `hydrateGraphSlice` itself rather than
+ * re-spelled here — a hand-written `Edge[]` was already one drift away from the
+ * store's `Edge<EdgeData>[]` (CLAUDE.md trap 12).
+ */
+type HydrateArg = Parameters<ReturnType<typeof useCanvasStore.getState>['hydrateGraphSlice']>[0]
+type RestoreGraph = {
+  nodes: NonNullable<HydrateArg['nodes']>
+  edges: NonNullable<HydrateArg['edges']>
+}
+
+const fitViewSpy = vi.fn()
+
+/** Collect RAF callbacks so each trigger's frame can be flushed deliberately. */
+function spyOnRaf(sink: Array<() => void>) {
+  return vi
+    .spyOn(globalThis, 'requestAnimationFrame')
+    .mockImplementation((cb: FrameRequestCallback) => {
+      sink.push(cb as () => void)
+      return sink.length
+    })
+}
+
+const FIT_PADDING = { top: '73px', right: '68px', bottom: '29px', left: '68px' }
+let currentPadding: { top: string; right: string; bottom: string; left: string } = FIT_PADDING
+/** What the mocked ReactFlow instance reports for `getNodes()`. */
+let currentNodes: Array<{ id: string }> = []
+
+vi.mock('@xyflow/react', () => ({
+  useReactFlow: () => ({ fitView: fitViewSpy, getNodes: () => currentNodes }),
+}))
+
+vi.mock('../utils/computeFitPadding', () => ({
+  computeFitPadding: () => currentPadding,
+}))
+
+/**
+ * A RESTORED graph: real ELK-style positions, spread well beyond
+ * `STACKED_SPREAD_PX`, exactly as `hydrateGraphSlice` receives it from the
+ * autosave slot. The ghost placeholder rides along because the live canvas
+ * carries one and the fit must exclude it (`utils/fitTargets.ts`).
+ */
+function restoredGraph(): RestoreGraph {
+  const nodes = [
+    { id: 'n-decision', type: 'decision', position: { x: 400, y: 0 }, data: { label: 'Pick a vendor' } },
+    { id: 'n-option-a', type: 'option', position: { x: 120, y: 260 }, data: { label: 'Vendor A' } },
+    { id: 'n-option-b', type: 'option', position: { x: 680, y: 260 }, data: { label: 'Vendor B' } },
+    { id: 'n-goal', type: 'goal', position: { x: 400, y: 540 }, data: { label: 'Lower total cost' } },
+    { id: GHOST_OPTION_NODE_ID, type: 'option', position: { x: 940, y: 260 }, data: { label: 'Add an option' } },
+  ] as unknown as RestoreGraph['nodes']
+  const edges = [
+    { id: 'e-1', source: 'n-decision', target: 'n-option-a' },
+    { id: 'e-2', source: 'n-decision', target: 'n-option-b' },
+    { id: 'e-3', source: 'n-option-a', target: 'n-goal' },
+  ] as unknown as RestoreGraph['edges']
+  return { nodes, edges }
+}
+
+/** The SAME graph as a fresh draft would arrive: every node stacked at the origin. */
+function stackedGraph(): RestoreGraph {
+  const { nodes, edges } = restoredGraph()
+  return {
+    nodes: nodes.map((n, i) => ({ ...n, position: { x: i, y: i } })) as RestoreGraph['nodes'],
+    edges,
+  }
+}
+
+/** Drive the PRODUCT's own restore entry point, not a hand-written `setState`. */
+function restore(graph: RestoreGraph) {
+  currentNodes = graph.nodes.map((n) => ({ id: n.id }))
+  useCanvasStore.getState().hydrateGraphSlice({ nodes: graph.nodes, edges: graph.edges })
+}
+
+describe('useFitViewOnLayoutVersion — the restore trigger', () => {
+  let rafCallbacks: Array<() => void>
+  let rafSpy: ReturnType<typeof spyOnRaf>
+
+  beforeEach(() => {
+    useCanvasStore.getState().resetCanvas()
+    useCanvasStore.setState({ layoutVersion: 0, pendingLayout: false, layoutInProgress: false } as never)
+    fitViewSpy.mockReset()
+    currentPadding = FIT_PADDING
+    currentNodes = []
+    rafCallbacks = []
+    rafSpy = spyOnRaf(rafCallbacks)
+  })
+
+  afterEach(() => {
+    rafSpy.mockRestore()
+    vi.restoreAllMocks()
+  })
+
+  const flushFrames = () => act(() => { rafCallbacks.splice(0).forEach((cb) => cb()) })
+
+  it('aims the camera at a graph restored WITHOUT a layout pass, with the canonical contract', () => {
+    renderHook(() => useFitViewOnLayoutVersion())
+    expect(fitViewSpy, 'nothing to fit on an empty canvas at mount').not.toHaveBeenCalled()
+
+    const graph = restoredGraph()
+    act(() => { restore(graph) })
+    flushFrames()
+
+    // PIN THE PRECONDITION IN-TEST (trap 13b): if a layout had run, this fit
+    // would be the layout trigger's and the test would prove nothing about the
+    // restore path. Assert the state that makes the restore trigger the only
+    // possible author of the call.
+    const s = useCanvasStore.getState()
+    expect(s.layoutVersion, 'a layout ran — this is no longer the restore state class').toBe(0)
+    expect(s.pendingLayout, 'a layout is pending — the restored graph is not the quiescent restore state').toBe(false)
+    expect(s.layoutInProgress).toBe(false)
+    expect(s.nodes.map((n) => n.id)).toEqual(graph.nodes.map((n) => n.id))
+
+    expect(fitViewSpy).toHaveBeenCalledTimes(1)
+    const args = fitViewSpy.mock.calls[0][0]
+    // BIND BY IDENTITY (trap 19): the exact restored MODEL node ids, ghost
+    // excluded — not "some non-empty node array" that any other graph satisfies.
+    expect(args.nodes.map((n: { id: string }) => n.id)).toEqual([
+      'n-decision', 'n-option-a', 'n-option-b', 'n-goal',
+    ])
+    // ONE contract, shared with the layout trigger and the reserved-box trigger.
+    expect(args.padding).toEqual(FIT_PADDING)
+    expect(args.minZoom).toBe(LABEL_LEGIBLE_ZOOM)
+    expect(args.duration).toBe(400)
+  })
+
+  it('re-fits a RESTORED graph when the window changes size, though no layout has ever run', () => {
+    // The half the UX gate measured directly: the transform was byte-identical
+    // at 1280 / 1440 / 1512 because the reserved-box trigger was latched off by
+    // `layoutVersion === 0` just like the load fit.
+    renderHook(() => useFitViewOnLayoutVersion())
+    act(() => { restore(restoredGraph()) })
+    flushFrames()
+    expect(fitViewSpy).toHaveBeenCalledTimes(1)
+    const loadFit = fitViewSpy.mock.calls[0][0]
+
+    // The window grows: the reserved box changes.
+    currentPadding = { top: '73px', right: '68px', bottom: '33px', left: '68px' }
+    act(() => { window.dispatchEvent(new Event('resize')) })
+    flushFrames()
+
+    expect(useCanvasStore.getState().layoutVersion, 'still the restore state class').toBe(0)
+    expect(fitViewSpy).toHaveBeenCalledTimes(2)
+    const refit = fitViewSpy.mock.calls[1][0]
+    // ONE contract: only the measured padding may differ between triggers.
+    expect(refit.padding).toEqual(currentPadding)
+    expect(refit.minZoom).toBe(loadFit.minZoom)
+    expect(refit.duration).toBe(loadFit.duration)
+    expect(refit.nodes.map((n: { id: string }) => n.id)).toEqual(
+      loadFit.nodes.map((n: { id: string }) => n.id),
+    )
+  })
+
+  it('aims once per restored graph — a user dragging a node does not yank the camera', () => {
+    // ⚠ THIS TEST WAS REWRITTEN BECAUSE ITS FIRST VERSION WAS A TAUTOLOGY, and
+    // the mutant kit is the only reason that was noticed (trap 13c: a SURVIVOR
+    // is a claim, not a pass). It changed `isDirty`, which is in none of the
+    // restore effect's dependencies — so the effect never re-ran, the
+    // once-per-identity check was never REACHED, and deleting that check left
+    // the test GREEN. A guard the suite cannot see is a guard that is not there.
+    //
+    // A user DRAG is the case that matters and the case that discriminates: it
+    // produces a NEW `nodes` array (so the effect re-runs) with the SAME
+    // structural identity (so only the identity check can stop the re-fit).
+    // Without it, every drag on a restored graph would re-frame the canvas
+    // under the user's hand.
+    renderHook(() => useFitViewOnLayoutVersion())
+    act(() => { restore(restoredGraph()) })
+    flushFrames()
+    expect(fitViewSpy).toHaveBeenCalledTimes(1)
+
+    const before = useCanvasStore.getState()
+    const keyBefore = getGraphIdentityKey(before.currentScenarioId, before.nodes, before.edges)
+
+    act(() => {
+      useCanvasStore.setState((s) => ({
+        nodes: s.nodes.map((n) => (n.id === 'n-option-a' ? { ...n, position: { x: 240, y: 300 } } : n)),
+      }) as never)
+    })
+
+    // PIN THE PRECONDITION (trap 13b): the effect must actually have re-run —
+    // a fresh `nodes` reference — and the identity must be UNCHANGED, or this
+    // test is passing for a reason that has nothing to do with the guard.
+    const after = useCanvasStore.getState()
+    expect(after.nodes, 'the drag did not produce a new nodes array — the effect never re-ran').not.toBe(before.nodes)
+    expect(
+      getGraphIdentityKey(after.currentScenarioId, after.nodes, after.edges),
+      'the drag changed the graph IDENTITY — then a re-fit would be correct and this proves nothing',
+    ).toBe(keyBefore)
+
+    flushFrames()
+    expect(fitViewSpy, 'the camera was yanked by a user drag on a restored graph').toHaveBeenCalledTimes(1)
+  })
+
+  /* ── OPPOSITE-DIRECTION TWINS (trap 22b) ──────────────────────────────── */
+
+  it('does NOT aim at an empty canvas', () => {
+    renderHook(() => useFitViewOnLayoutVersion())
+    act(() => { restore({ nodes: [], edges: [] }) })
+    flushFrames()
+    expect(fitViewSpy).not.toHaveBeenCalled()
+  })
+
+  it('does NOT aim at a canvas holding only the ghost placeholder', () => {
+    renderHook(() => useFitViewOnLayoutVersion())
+    const ghostOnly = {
+      nodes: [{ id: GHOST_OPTION_NODE_ID, type: 'option', position: { x: 940, y: 260 }, data: { label: 'Add an option' } }] as unknown as RestoreGraph['nodes'],
+      edges: [] as unknown as RestoreGraph['edges'],
+    }
+    act(() => { restore(ghostOnly) })
+    flushFrames()
+    expect(fitViewSpy, 'the ghost is not part of the user model — there is nothing to frame').not.toHaveBeenCalled()
+  })
+
+  it('does NOT aim at a graph still awaiting its FIRST layout — the layout trigger owns that fit', () => {
+    // A fresh draft arrives stacked at the origin. Aiming here would frame a
+    // pile, and the layout that is already coming will aim it correctly.
+    const stacked = stackedGraph()
+    const spread = Math.max(...stacked.nodes.map((n) => n.position.x)) - Math.min(...stacked.nodes.map((n) => n.position.x))
+    expect(spread, 'fixture is not actually stacked — this twin would prove nothing').toBeLessThan(STACKED_SPREAD_PX)
+
+    renderHook(() => useFitViewOnLayoutVersion())
+    act(() => { restore(stacked) })
+    flushFrames()
+    expect(fitViewSpy).not.toHaveBeenCalled()
+
+    // …and the layout trigger still does its job when the layout lands.
+    act(() => { useCanvasStore.setState({ layoutVersion: 1 } as never) })
+    flushFrames()
+    expect(fitViewSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT aim while a layout is pending or in progress', () => {
+    renderHook(() => useFitViewOnLayoutVersion())
+    act(() => {
+      restore(restoredGraph())
+      useCanvasStore.setState({ pendingLayout: true } as never)
+    })
+    flushFrames()
+    expect(fitViewSpy, 'a fit landed mid-layout — the positions are about to move').not.toHaveBeenCalled()
+  })
+})

--- a/src/canvas/hooks/useFitViewOnLayoutVersion.ts
+++ b/src/canvas/hooks/useFitViewOnLayoutVersion.ts
@@ -7,6 +7,51 @@ import { watchReservedBox } from '../utils/reservedBoxWatcher'
 import { usePrefersReducedMotion } from './usePrefersReducedMotion'
 import { cameraDuration } from '../utils/cameraMotion'
 import { LABEL_LEGIBLE_ZOOM } from '../utils/zoomLegibility'
+import { getGraphIdentityKey, graphNeedsInitialLayout } from '../utils/graphNeedsInitialLayout'
+
+/** The slice of canvas state the camera's readiness questions are asked of. */
+type CameraReadinessState = Pick<
+  ReturnType<typeof useCanvasStore.getState>,
+  'nodes' | 'layoutVersion' | 'pendingLayout' | 'layoutInProgress'
+>
+
+/**
+ * Is there a RESTORED model on the canvas that the product has never aimed the
+ * camera at? True exactly in the state a page reload lands in.
+ *
+ * Deliberately reuses `graphNeedsInitialLayout` — `useInitialLayoutGuard`'s own
+ * predicate and the estate's authority on "are these positions meaningful" —
+ * rather than minting a second answer to the same question.
+ */
+function isRestoredModelReady(s: CameraReadinessState): boolean {
+  // A layout is about to move every position; fitting now frames a graph that
+  // is already obsolete.
+  if (s.pendingLayout || s.layoutInProgress) return false
+  // `excludeNonModelNodes` is the fit's own target set, so a canvas holding
+  // only the `__ghost-option__` affordance correctly reads as empty.
+  if (excludeNonModelNodes(s.nodes).length === 0) return false
+  // Stacked at the origin means a fresh draft whose layout is already on its
+  // way. The LAYOUT trigger owns that fit; aiming here frames a pile.
+  if (graphNeedsInitialLayout(s.nodes)) return false
+  return true
+}
+
+/**
+ * Has the product a model it may aim the camera at?
+ *
+ * ⚠ THIS REPLACES A `layoutVersion === 0` TEST THAT WAS ANSWERING A DIFFERENT
+ * QUESTION FROM THE ONE ITS CALLER ASKED (CLAUDE.md trap 21). On the reserved-box
+ * trigger, `layoutVersion === 0` was standing in for *"there is nothing to fit"*
+ * — and that proxy is FALSE for a restored graph, which is the whole of UX gate
+ * point 7. On the LAYOUT trigger the same expression means *"this effect run is
+ * the mount, not a layout completion"*, which is correct and is left alone.
+ */
+function cameraHasATarget(s: CameraReadinessState): boolean {
+  // A completed layout stays authoritative: the product laid this graph out, so
+  // it owns the camera for it, whatever the positions now look like.
+  if (s.layoutVersion > 0) return true
+  return isRestoredModelReady(s)
+}
 
 /**
  * Schedule a single RAF-synchronised fitView every time `layoutVersion`
@@ -36,6 +81,13 @@ import { LABEL_LEGIBLE_ZOOM } from '../utils/zoomLegibility'
  * which is the intended asymmetry: the user may choose the overview, the
  * product may not choose it for them. See `utils/zoomLegibility.ts`.
  *
+ * ⭐⭐ THREE TRIGGERS, ONE CONTRACT. The third — THE RESTORE TRIGGER — landed
+ * 20 Aug 2026 (UX gate point 7); see the effect itself for the measurement.
+ * ⚠ This count is a hand-maintained mirror of the effects below (CLAUDE.md
+ * trap 12): it said TWO while a third was being added. Count the effects, not
+ * this sentence. What IS derived is that all three pass the SAME `fitNow`
+ * closure, so the contract cannot fork however many triggers there are.
+ *
  * ⭐ TWO TRIGGERS, ONE CONTRACT (18 Aug 2026,
  * `WORKSPACE-COMPOSITION-DECISION-2026-08-18.md` §5.1). The hook used to fit
  * once per completed layout and never again, so every pixel of canvas won back
@@ -56,6 +108,14 @@ import { LABEL_LEGIBLE_ZOOM } from '../utils/zoomLegibility'
  */
 export function useFitViewOnLayoutVersion(): void {
   const layoutVersion = useCanvasStore((s) => s.layoutVersion)
+  // Restore-trigger inputs. Selected individually and as stable references /
+  // primitives — a selector returning a fresh object here is the React #185
+  // shape `ci:guard:zustand` exists to catch.
+  const restoreNodes = useCanvasStore((s) => s.nodes)
+  const restoreEdges = useCanvasStore((s) => s.edges)
+  const restorePendingLayout = useCanvasStore((s) => s.pendingLayout)
+  const restoreLayoutInProgress = useCanvasStore((s) => s.layoutInProgress)
+  const restoreScenarioId = useCanvasStore((s) => s.currentScenarioId)
   const { fitView, getNodes } = useReactFlow()
   const fitViewRef = useRef(fitView)
   fitViewRef.current = fitView
@@ -93,13 +153,61 @@ export function useFitViewOnLayoutVersion(): void {
     return () => cancelAnimationFrame(raf)
   }, [layoutVersion])
 
-  // Re-fit when the RESERVED BOX changes. Gated on a layout having happened, so
-  // this never fits an empty canvas; the watcher derives the change from
+  // ⭐ TRIGGER 3 — THE RESTORE TRIGGER (UX gate point 7, 20 Aug 2026).
+  //
+  // A restored graph reaches the canvas through `hydrateGraphSlice` /
+  // `loadScenario` with its positions ALREADY REAL, so nothing sets
+  // `pendingLayout`, `applyLayout` never runs, and `layoutVersion` stays 0 for
+  // the whole page session. Before this, that latched off both triggers above
+  // and the camera was never aimed at a reloaded model AT ALL: the graph kept
+  // whatever xyflow's own `fitView` PROP produced at mount, with xyflow's
+  // DEFAULT padding — no header-banner inset, no dock, no sidebar.
+  //
+  // ⚠ STATE THE HARM NARROWLY, because a wider version of this sentence was
+  // written first and was REFUTED (20 Aug 2026). xyflow's prop fit DOES run at
+  // each mount, so arriving at a different window size does give a different
+  // frame — "the restore never re-fits" is FALSE and must not be repeated. What
+  // is true is that the PRODUCT's panel-aware fit never runs, so no arrival on
+  // this path carries the reservations `computeFitPadding` exists to apply.
+  // Measured headed, real Chromium, on the frozen base `2b6ec553`, reloading AT
+  // each size: `behindBanner: ["dec_cdp"]` at 1280x800 — the Decision node under
+  // the floating header at the smallest desktop this product commits to — and
+  // clean at 1440x900 / 1512x982. The fresh path at 1280x800 is clean, which is
+  // the contrast that makes it the restore's defect and not the graph's.
+  //
+  // Fires ONCE PER GRAPH IDENTITY, keyed by `getGraphIdentityKey` (the key
+  // `useInitialLayoutGuard` already uses, and structural rather than
+  // positional, so a user's own pan/drag never re-arms it). A graph that goes
+  // on to be laid out is handled by trigger 1 and returns early here.
+  const aimedIdentityRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (layoutVersion > 0) return
+    const s = useCanvasStore.getState()
+    if (!isRestoredModelReady(s)) return
+    const key = getGraphIdentityKey(s.currentScenarioId, s.nodes, s.edges)
+    if (aimedIdentityRef.current === key) return
+    aimedIdentityRef.current = key
+    const raf = requestAnimationFrame(() => {
+      fitNow.current()
+    })
+    return () => cancelAnimationFrame(raf)
+  }, [
+    layoutVersion,
+    restoreNodes,
+    restoreEdges,
+    restorePendingLayout,
+    restoreLayoutInProgress,
+    restoreScenarioId,
+  ])
+
+  // Re-fit when the RESERVED BOX changes — including a window resize, which is
+  // the half the UX gate measured directly. Gated on the camera having a target
+  // so this never fits an empty canvas; the watcher derives the change from
   // `computeFitPadding` itself rather than from a list of things that move it
   // (see `reservedBoxWatcher.ts`).
   useEffect(() => {
     return watchReservedBox(() => {
-      if (useCanvasStore.getState().layoutVersion === 0) return
+      if (!cameraHasATarget(useCanvasStore.getState())) return
       fitNow.current()
     })
   }, [])


### PR DESCRIPTION
## Verdict: the briefed premise is **partly refuted**. A narrower, real defect survives.

I was asked to stop and check my premise. I did, in a **headed** browser with the instrument's own liveness asserted. Two of the briefed claims are refuted; one real defect remains, and it is not the one the brief described.

### ✗ Refuted — "the four viewport controls are inert after a reload"

Measured live in real Chromium **six times** — headless and headed, reduced-motion on and off, before and after this change. Fit to view, Zoom in, Zoom out and Zoom reset moved the camera **every time**, including on the untouched base.

Also ruled out by measurement, not argument: comparison mode unmounting the canvas · a stale `CANVAS_DEBUG_MODE` · unmeasured nodes (`nodesInitialized`) · `onlyRenderVisibleElements` (not set) · a second `.react-flow` in the DOM (`flowCount` was `1` in every sample).

This agrees with the coordinator's A/B/A control: a **permanently hidden tab** reproduces the symptom exactly, because rAF never fires and every camera move silently no-ops. "Verified four ways" was four ways inside one blind instrument.

### ✗ Refuted as stated — "the restore never re-fits"

xyflow's own `fitView` **prop** fits at **every mount**, so arriving at a different window size genuinely does give a different frame. Measured on the frozen base, headed, reloading *at* each size:

| viewport | arrival scale (base, no fix) |
|---|---|
| 1280x800 | `0.666667` |
| 1440x900 | `0.750916` |
| 1512x982 | `0.818681` |

**The coordinator's lane is right.** My earlier byte-identical reading came from a *different protocol* — reload **once**, then **resize** — not from a blind instrument. My surface asserts its own liveness in-test now: `visibilityState "visible"`, `innerWidth 1280`, **37–38 rAF frames per 600ms**. Both readings are true; the third test in the measure file records and reconciles them.

### ✓ Survives — the **panel-aware fit never runs on a restored graph**

Derivable at the bytes, no instrument required. Every restore path ends at `hydrateGraphSlice` (`store.ts:5954`) or `loadScenario` (`store.ts:4233`) — guest-autosave (`ReactFlowGraph.tsx:1545`), scenario (`:1644`), DEV fall-through (`:1685`). None sets `pendingLayout` or bumps `layoutVersion`, **correctly**: a restored graph's positions are already real. `useInitialLayoutGuard` is gated on `graphNeedsInitialLayout`, so it is deliberately inert on a correctly-positioned graph.

So `layoutVersion` stays `0` for the whole page session, both of the fit owner's triggers are latched off — and **the fit owner is the only path to `computeFitPadding`**. No arrival on this path carries the reservations that function exists to apply: no header-banner inset (#786), no OutputsDock, no LeftSidebar.

**It is a padding-authority defect, not a "no fit happens" defect.**

#### Measured, headed, frozen base `2b6ec553`, reloading *at* each size

| viewport | base (no fix) | with this change |
|---|---|---|
| **1280x800** | `behindBanner: ["dec_cdp"]` | `[]` |
| 1440x900 | `[]` | `[]` |
| 1512x982 | `[]` | `[]` |

The Decision node sits under the floating header **at 1280x800 — the smallest desktop this product commits to**. The **fresh** path at that same size is clean in the same run: that contrast is what makes it the restore's defect and not the graph's. A second, lesser consequence, also fixed: on a restored graph the frame did not follow a window **resize** at all.

The harm is **narrower than the brief claimed** — one node, at one viewport — and I would rather say that than inherit the wider framing.

## The fix — canonical owner, no parallel fit path

`useFitViewOnLayoutVersion` keeps its ONE contract and gains a third trigger:

- **the restore trigger** — once per graph identity, when a model is present, quiescent, and not awaiting its first layout. Reuses `getGraphIdentityKey` and `graphNeedsInitialLayout`, the predicates `useInitialLayoutGuard` already owns, rather than minting second answers to the same questions.
- **the reserved-box gate becomes `cameraHasATarget`** — *"has the product a model it may aim the camera at"* — instead of the `layoutVersion` proxy, which was answering a different question from the one that caller asked (trap 21).

`src/canvas/utils/computeFitPadding.ts` is **untouched**: the floating Olumi panel is not reintroduced as an occluder, guard G2a is unaffected. The header-banner inset needed no new work — #786 (`a3938981`) already reserves `[role="banner"]`; it simply could never be *applied* on this path.

## ⚠ An existing acceptance criterion is amended — look here first

CI caught this, which is the system working. `ReactFlowGraph.layoutLifecycle.integration.spec.tsx` acceptance #2 asserted that on a saved-position scenario *"guard, applyLayout, and fitView all stay quiet"*. That one word bundled two questions:

- **(a) may the product move the NODES of a saved graph?** — No. Every clause answering (a) is **unchanged and still asserted**: no `applyLayout`, `layoutVersion` still `0`, saved x-positions still exactly `0` and `320`.
- **(b) may it aim the CAMERA at it?** — the old test said no, and that is exactly what leaves the Decision node under the banner. Aiming moves no node.

Acceptance #5+#6 now asserts *"fires fitView once for B"* as a **delta** across the A→B switch rather than a running total, so it stays bound to B.

## Tests

**Gated** (vitest is in `Staging Gate`; no Playwright job is): `useFitViewOnLayoutVersion.restore.spec.tsx` — 7 tests, driven through the product's own `hydrateGraphSlice`, bound by identity to the restored node ids. RED-first at pristine: **3 failed / 4 passed of 7 collected by name**; the 4 that passed are the opposite-direction twins, correctly green before the fix.

**Not gated, run deliberately**: `e2e/geometry/viewportRestoreFit.measure.ts`. It now (i) asserts **its own instrument is live** before believing a single transform, (ii) asserts the four controls **are** live, so this file can never be cited for the refuted claim, and (iii) carries **both** measurement protocols side by side with the reconciliation written out.

### Mutants — 8 applied, 8 bite, 0 survivors (21-test corpus)

Throwaway worktree at an absolute path outside the repo; isolation proved by **writing a sentinel** and asserting the source clone's SHA-256 unchanged (inodes `682670876` vs `682683031`); restores from a pristine archive, never `git checkout -- <path>`; applied-check scoped to `src/`, control exactly `0`, trailing control `0`; every run asserted to collect exactly 21 tests.

| mutant | result |
|---|---|
| M0 control | applied=0, 0 failed |
| M1 drop pending/in-progress guard | bites (1) |
| M2 drop the "is there a model" guard | bites (13) |
| M3 drop awaiting-first-layout guard | bites (1) |
| M4 drop once-per-identity check | bites (1) |
| M5 revert reserved-box gate to the `layoutVersion` proxy | bites (1) |
| M6 **delete the fix** | bites (5) — incl. both amended acceptance criteria |
| M7 drop the legibility floor | bites (6) |
| M8 stop constraining the fit to the model node set | bites (3) |

**M4 survived on the first pass, and that is the most useful thing the kit did.** The "aims once" test originally changed `isDirty`, which is in none of the restore effect's dependencies — the effect never re-ran, the identity check was never *reached*, and deleting the guard left the test green. Rewritten to use a **user drag**: a new `nodes` array with the *same* structural identity, so only the identity check can stop a re-fit. It now pins its own precondition in-test.

## Status

`Staging Gate` **passed** on the previous head `439dc965` (all four shards green). This head `a632a864` differs from it only in the corrected claims plus the new instrument-validity and arrive-at-size arms; the gate is re-running and I am polling it to conclusion.

`Visual Regression (advisory)` is red on base and on every open PR — not evidence either way.

## Not merged, staging not driven

Branch only; rebased onto the frozen base `2b6ec553`. Deployed staging was not touched — all verification is against a local dev server.