### PR TITLE
fix(results): three factors at 100% cannot be 'Top driver', 'High-impact' and 'Lower influence' at once

### DIFF
--- a/src/components/results/DriversSection.tsx
+++ b/src/components/results/DriversSection.tsx
@@ -30,6 +30,7 @@ import { highlightNode, clearHighlight } from '../../canvas/utils/highlightHelpe
 import { EMPTY_STATES } from './emptyStates'
 import { FactorInsights, hasEnrichmentContent } from './FactorInsights'
 import { cleanFactorLabel } from './utils/cleanFactorLabel'
+import { INFLUENCE_TIE_EPSILON } from './driverDisplayModel'
 import { typography } from '../../styles/typography'
 import { DataBar } from '../../canvas/ui/shared/DataBar'
 import Tooltip from '../../components/Tooltip'
@@ -1002,14 +1003,22 @@ export function DriversSection({
           {DISPLAY_SAFE_DRIVER_CONFIDENCE && <div aria-hidden="true" />}
         </div>
 
-        {/* v7.10 T9: Equal-influence note when all visible drivers are within ±0.01 */}
+        {/* v7.10 T9: equal-influence note when all visible drivers are tied.
+            ⚠ THE COUNT WORD IS GONE, AND DERIVING ONE WOULD NOT HAVE FIXED IT.
+            This said "Both factors" unconditionally and printed under a section
+            headed 4 on a real user's screen. A derived count cannot settle it
+            either: this note ranges over `visibleDrivers` while the heading
+            counts the non-zero-impact total, so the two can legitimately
+            differ. Count-free copy cannot contradict any heading beside it.
+            The tie width is the shared `INFLUENCE_TIE_EPSILON`, so this note
+            and the rank badges can no longer disagree about what a tie is. */}
         {visibleDrivers.length >= 2 && (() => {
           const scores = visibleDrivers.map(d => d.displayInfluence ?? d.influenceScore ?? d.normalisedInfluence ?? 0)
           const max = Math.max(...scores)
           const min = Math.min(...scores)
-          return (max - min) <= 0.01 ? (
+          return (max - min) <= INFLUENCE_TIE_EPSILON ? (
             <p className={`${typography.panelMeta} text-text-light italic px-3 pb-2`}>
-              Both factors have similar influence on the outcome.
+              These factors have similar influence on the outcome.
             </p>
           ) : null
         })()}

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -37,6 +37,7 @@ import { openNodeInspector } from '@/canvas/nodes/shared/openNodeInspector'
 import type { ScientificEditorProps } from '@/components/shared/ScientificEditor'
 import { TargetProbabilityBars } from './TargetProbabilityBars'
 import { stripEncodingNotation, cleanFactorLabel } from './utils/cleanFactorLabel'
+import { INFLUENCE_TIE_EPSILON } from './driverDisplayModel'
 // Canonical glossary check shared with the v17 hero row builders. Used in
 // v17 mode (`useV17Copy === true`) to sanitise user-supplied labels before
 // they are interpolated into GENERATED prose, aria-labels, or titles. The
@@ -362,7 +363,11 @@ function T1DominantNudge({
   useV17Copy?: boolean
 }) {
   const drivers = data.drivers
-  const topDriver = drivers.topDrivers?.[0] ?? drivers.drivers?.[0]
+  // ⚠ ONE list, so "the top" and "the runner-up" cannot come from different
+  // orderings. Same fallback the single-driver read used before.
+  const rankedDrivers = (drivers.topDrivers?.length ? drivers.topDrivers : drivers.drivers) ?? []
+  const topDriver = rankedDrivers[0]
+  const runnerUp = rankedDrivers[1]
   // Lane 2 (policy): gate and phrase the nudge on the SAME display influence
   // the panel/hero/graph/tornado show (driverDisplayModel via the stamped
   // displayInfluence) — a raw-score read here claimed dominance the panel's
@@ -383,7 +388,18 @@ function T1DominantNudge({
         ? topDriver.displayProvenance === 'influence_score'
         : typeof topDriver.influenceScore === 'number')
     : false
-  const showNudge = absoluteBasis && topInfluence >= 0.8
+  // ⚠ DOMINANCE REQUIRES A RUNNER-UP TO BE DOMINANT OVER (2026-08-19). The
+  // gate tested only the top's own magnitude, so on a run where three factors
+  // tied at 100% it printed "Dominant factor: Cloud migration progress drives
+  // 100% of the outcome" while two other rows on the same screen also read
+  // 100%. "Dominant" is a COMPARATIVE claim; a tie cannot support one. Same
+  // `INFLUENCE_TIE_EPSILON` the panel's badges and its equal-influence note
+  // use, so all three surfaces agree on what counts as a tie.
+  const runnerUpInfluence = runnerUp
+    ? (runnerUp.displayInfluence ?? runnerUp.influenceScore ?? runnerUp.normalisedInfluence ?? 0)
+    : 0
+  const topIsClearOfRunnerUp = !runnerUp || topInfluence - runnerUpInfluence > INFLUENCE_TIE_EPSILON
+  const showNudge = absoluteBasis && topInfluence >= 0.8 && topIsClearOfRunnerUp
   const rawLabel = drivers.dominantFactorLabel ?? topDriver?.factorLabel ?? ''
   const dominantLabel = cleanFactorLabel(rawLabel).label
   if (!showNudge || !dominantLabel) return null

--- a/src/components/results/__tests__/influenceLabelsAgreeWithTheirNumbers.spec.tsx
+++ b/src/components/results/__tests__/influenceLabelsAgreeWithTheirNumbers.spec.tsx
@@ -1,0 +1,284 @@
+/**
+ * SENDABLE trust defect — the Drivers panel disagreed with its own numbers.
+ *
+ * WITNESSED (UX-gate re-run 2026-08-19T22:01–22:38Z, deployed UI `ad79b344`,
+ * fresh guest, real brief, real analysis), on ONE screen, in ONE run:
+ *
+ *   • THREE factors each displaying **Influence 100%**, badged respectively
+ *     "Top driver", "High-impact driver" and "Lower influence".
+ *   • "Both factors have similar influence on the outcome." printed under a
+ *     section headed **4**.
+ *
+ * ROOT CAUSE — TWO DIFFERENT NUMBERS ON ONE ROW. The bar, the order and the
+ * percentage all read `displayInfluence` (the `driverDisplayModel` policy).
+ * The BADGE read `normalisedInfluence` — |elasticity| / max|elasticity|, a
+ * second, unrelated basis. Under complete producer coverage the two diverge
+ * freely, so a factor the panel prints at 100% can carry an elasticity share
+ * of 0.1 and be badged "Lower influence" beside its own 100% bar.
+ *
+ * `driverDisplayModel.ts` had ALREADY declared the correct policy in its own
+ * header — "the order, the rank-1 crown, and the bar must all follow the SAME
+ * number" — and the crown/threshold half simply never moved there. So this is
+ * not a new rule: it is the existing canonical owner finally owning the badge.
+ *
+ * SECOND CAUSE — THE CROWN IGNORES TIES. Rank 1 was crowned unconditionally
+ * ("Rank 1 always gets 'biggest' (ensures uniqueness)"). At a tie the rank is
+ * decided by the comparator's elasticity/key tie-breaks — invisible to the
+ * user — so one of several equal factors is crowned "Top driver" and the rest
+ * are demoted, on identical displayed numbers. Uniqueness of the BADGE was
+ * bought by inventing a distinction the data does not contain.
+ *
+ * THIRD — THE COUNT WORD. "Both factors" is hard-coded, while the note fires
+ * whenever ALL visible drivers are within the tie epsilon, however many there
+ * are. Deriving a count here cannot fix it either: the note ranges over
+ * `visibleDrivers` and the heading counts the non-zero-impact total, so any
+ * derived count can still contradict the heading beside it. Count-free copy
+ * cannot contradict any heading by construction.
+ *
+ * CONVERGENCE (Paul's binding rule). Canonical owner named:
+ * `driverDisplayModel` owns the display value AND the label derived from it,
+ * in `resolveDriverSemanticLabels`. Competitor superseded:
+ * `getSemanticLabel(rank, normalisedInfluence)` is deleted, not wrapped, so
+ * the second basis is no longer reachable. One tie epsilon
+ * (`INFLUENCE_TIE_EPSILON`) replaces the literal that was inlined at the note.
+ *
+ * Trap-19 identity binding: every panel assertion locates its badge by the
+ * row's own `factorKey` testid, never by a value predicate another row shares
+ * — which matters especially here, where the rows carry EQUAL values.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import {
+  INFLUENCE_TIE_EPSILON,
+  resolveDriverSemanticLabels,
+} from '../driverDisplayModel'
+import { DriversSection } from '../DriversSection'
+import { TriageActionCardsBody } from '../TriageActionCardsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type { DriversSectionData, DriverItem } from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+}))
+
+function makeDriver(overrides: Partial<DriverItem> & { factorKey: string }): DriverItem {
+  return {
+    factorLabel: overrides.factorKey,
+    rawElasticity: 0.5,
+    normalisedInfluence: 0.8,
+    influenceScore: 0.8,
+    rank: 1,
+    semanticLabel: 'biggest',
+    canFocus: false,
+    direction: 'positive',
+    ...overrides,
+  }
+}
+
+function makeData(drivers: DriverItem[], totalCount?: number): DriversSectionData {
+  return {
+    drivers,
+    topDrivers: drivers.slice(0, 3),
+    driversStatus: 'computed',
+    totalCount: totalCount ?? drivers.length,
+    hasMagnitudeData: true,
+  }
+}
+
+// =============================================================================
+// The badge is derived from the number printed beside it
+// =============================================================================
+
+describe('resolveDriverSemanticLabels — one number decides the bar and the badge', () => {
+  it('THE WITNESSED ROW: three factors tied at the top share one badge, none crowned', () => {
+    const labels = resolveDriverSemanticLabels([
+      { key: 'cloud_migration_progress', value: 1 },
+      { key: 'licence_cost', value: 1 },
+      { key: 'team_capacity', value: 1 },
+    ])
+    // Bound by key identity — the whole point is that the VALUES cannot
+    // distinguish these rows, so a value predicate would prove nothing.
+    expect(labels.get('cloud_migration_progress')).toBe('strong')
+    expect(labels.get('licence_cost')).toBe('strong')
+    expect(labels.get('team_capacity')).toBe('strong')
+    // No row may be crowned when the top is not unique.
+    expect([...labels.values()]).not.toContain('biggest')
+  })
+
+  it('a UNIQUE top is still crowned — the tie rule does not cost us the crown', () => {
+    const labels = resolveDriverSemanticLabels([
+      { key: 'clear_leader', value: 1 },
+      { key: 'second', value: 0.4 },
+      { key: 'third', value: 0.1 },
+    ])
+    expect(labels.get('clear_leader')).toBe('biggest')
+    expect(labels.get('second')).toBe('moderate')
+    expect(labels.get('third')).toBe('minor')
+  })
+
+  it('a near-tie inside the epsilon is a tie; just outside it is not', () => {
+    const tied = resolveDriverSemanticLabels([
+      { key: 'a', value: 1 },
+      { key: 'b', value: 1 - INFLUENCE_TIE_EPSILON / 2 },
+    ])
+    expect(tied.get('a')).not.toBe('biggest')
+
+    const clear = resolveDriverSemanticLabels([
+      { key: 'a', value: 1 },
+      { key: 'b', value: 1 - INFLUENCE_TIE_EPSILON * 2 },
+    ])
+    expect(clear.get('a')).toBe('biggest')
+  })
+
+  it('the badge reads the DISPLAY value it is given, never a second basis', () => {
+    // The witnessed shape: a factor the panel prints at 100% must not be
+    // badged from some other number that happens to be small.
+    const labels = resolveDriverSemanticLabels([
+      { key: 'printed_at_100pct', value: 1 },
+      { key: 'runner_up', value: 0.9 },
+    ])
+    expect(labels.get('printed_at_100pct')).not.toBe('minor')
+    expect(labels.get('runner_up')).not.toBe('minor')
+  })
+
+  it('a single driver is crowned, and an empty set yields nothing', () => {
+    expect(resolveDriverSemanticLabels([{ key: 'only', value: 0.05 }]).get('only')).toBe('biggest')
+    expect(resolveDriverSemanticLabels([]).size).toBe(0)
+  })
+})
+
+// =============================================================================
+// The panel's own copy cannot contradict the heading beside it
+// =============================================================================
+
+describe('DriversSection — the equal-influence note states no count', () => {
+  it('does not say "Both" when four factors are tied', () => {
+    render(
+      <DriversSection
+        data={makeData(
+          [
+            makeDriver({ factorKey: 'f1', semanticLabel: 'strong', influenceScore: 1, normalisedInfluence: 1 }),
+            makeDriver({ factorKey: 'f2', semanticLabel: 'strong', influenceScore: 1, normalisedInfluence: 1 }),
+            makeDriver({ factorKey: 'f3', semanticLabel: 'strong', influenceScore: 1, normalisedInfluence: 1 }),
+            makeDriver({ factorKey: 'f4', semanticLabel: 'strong', influenceScore: 1, normalisedInfluence: 1 }),
+          ],
+          4,
+        )}
+        goalLabel="test"
+      />,
+    )
+    expect(screen.queryByText(/Both factors/i)).not.toBeInTheDocument()
+    expect(screen.getByText(/similar influence on the outcome/i)).toBeInTheDocument()
+  })
+
+  it('says the same count-free sentence for exactly two tied factors', () => {
+    render(
+      <DriversSection
+        data={makeData([
+          makeDriver({ factorKey: 'f1', semanticLabel: 'strong', influenceScore: 1, normalisedInfluence: 1 }),
+          makeDriver({ factorKey: 'f2', semanticLabel: 'strong', influenceScore: 1, normalisedInfluence: 1 }),
+        ])}
+        goalLabel="test"
+      />,
+    )
+    expect(screen.getByText(/similar influence on the outcome/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Both factors/i)).not.toBeInTheDocument()
+  })
+
+  // ── OPPOSITE-DIRECTION TWIN ────────────────────────────────────────────
+  // The note is genuinely useful when the factors ARE alike. Making it
+  // count-free must not make it fire when they are not.
+  it('TWIN — the note stays absent when the factors genuinely differ', () => {
+    render(
+      <DriversSection
+        data={makeData([
+          makeDriver({ factorKey: 'f1', semanticLabel: 'biggest', influenceScore: 1, normalisedInfluence: 1 }),
+          makeDriver({ factorKey: 'f2', semanticLabel: 'minor', influenceScore: 0.1, normalisedInfluence: 0.1 }),
+        ])}
+        goalLabel="test"
+      />,
+    )
+    expect(screen.queryByText(/similar influence on the outcome/i)).not.toBeInTheDocument()
+  })
+})
+
+// =============================================================================
+// "Dominant" is a comparative claim — a tie cannot support one
+// =============================================================================
+
+describe('T1 dominance nudge — no dominance claim without a margin', () => {
+  function triageData(drivers: DriverItem[]) {
+    return {
+      drivers: {
+        ...makeData(drivers),
+        dominantFactorId: drivers[0]?.factorKey,
+        dominantFactorLabel: drivers[0]?.factorLabel,
+      },
+      // Minimal siblings the body reads on its way to the nudge. Only the
+      // nudge is under test here; every other card is deliberately empty.
+      recommendation: { recommendedOption: null },
+      confidence: { recommendedOptionId: undefined },
+      assumptions: { items: [] },
+      gaps: { items: [] },
+      risks: { items: [] },
+    } as unknown as ResultsSectionDataReturn
+  }
+
+  const tiedAtTop = [
+    makeDriver({
+      factorKey: 'cloud_migration_progress',
+      factorLabel: 'Cloud migration progress',
+      semanticLabel: 'strong',
+      influenceScore: 1,
+      normalisedInfluence: 1,
+      displayInfluence: 1,
+      displayProvenance: 'influence_score',
+    }),
+    makeDriver({
+      factorKey: 'licence_cost',
+      factorLabel: 'Licence cost',
+      semanticLabel: 'strong',
+      influenceScore: 1,
+      normalisedInfluence: 1,
+      displayInfluence: 1,
+      displayProvenance: 'influence_score',
+    }),
+  ]
+
+  it('THE WITNESSED CLAIM: no factor is called dominant while another reads the same', () => {
+    render(<TriageActionCardsBody data={triageData(tiedAtTop)} suppressTriageQueue />)
+    expect(screen.queryByTestId('t1-dominant-nudge')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Dominant factor/i)).not.toBeInTheDocument()
+  })
+
+  // ── OPPOSITE-DIRECTION TWIN ────────────────────────────────────────────
+  // The nudge is the useful warning that one assumption carries the result.
+  // Requiring a margin must not silence it when the margin is real.
+  it('TWIN — a genuinely dominant factor is still named', () => {
+    const clearlyDominant = [
+      makeDriver({
+        factorKey: 'cloud_migration_progress',
+        factorLabel: 'Cloud migration progress',
+        semanticLabel: 'biggest',
+        influenceScore: 1,
+        normalisedInfluence: 1,
+        displayInfluence: 1,
+        displayProvenance: 'influence_score',
+      }),
+      makeDriver({
+        factorKey: 'licence_cost',
+        factorLabel: 'Licence cost',
+        semanticLabel: 'minor',
+        influenceScore: 0.15,
+        normalisedInfluence: 0.15,
+        displayInfluence: 0.15,
+        displayProvenance: 'influence_score',
+      }),
+    ]
+    render(<TriageActionCardsBody data={triageData(clearlyDominant)} suppressTriageQueue />)
+    expect(screen.getByTestId('t1-dominant-nudge')).toBeInTheDocument()
+    expect(screen.getByText(/Dominant factor/i)).toBeInTheDocument()
+  })
+})

--- a/src/components/results/__tests__/useResultsSectionData.spec.ts
+++ b/src/components/results/__tests__/useResultsSectionData.spec.ts
@@ -17,7 +17,6 @@ import {
   selectDriverDisplayModel,
   normaliseDirection,
   getFactorDirection,
-  getSemanticLabel,
   mapReadinessLevel,
   mapConfidenceLevel,
   getConfidenceTier,
@@ -28,6 +27,7 @@ import {
   determineWinnerSelection,
   resolveBaselineId,
 } from '../useResultsSectionData'
+import { resolveDriverSemanticLabels } from '../driverDisplayModel'
 import { useCanvasStore } from '../../../canvas/store'
 import type { RawFactorSensitivity, EdgeForDirection } from '../types'
 import { isDirectionalFactor } from '../../../lib/factorDirection'
@@ -371,29 +371,48 @@ describe('computeFactorRanks', () => {
 // 5. Semantic Label Tests
 // =============================================================================
 
-describe('getSemanticLabel', () => {
-  it('always returns "biggest" for rank 1', () => {
-    expect(getSemanticLabel(1, 1.0)).toBe('biggest')
-    expect(getSemanticLabel(1, 0.5)).toBe('biggest')
-    expect(getSemanticLabel(1, 0.1)).toBe('biggest')
+/**
+ * ⚠ `getSemanticLabel(rank, normalisedInfluence)` WAS DELETED (2026-08-19) and
+ * its policy moved to `resolveDriverSemanticLabels` in `driverDisplayModel` —
+ * the module that already owned the display value. The old function derived
+ * the badge from a SECOND basis (|elasticity| / max|elasticity|), so a factor
+ * the panel printed at Influence 100% shipped badged "Lower influence"; and
+ * its "rank 1 always wins" rule crowned one of several tied factors on a
+ * tie-break the user cannot see. The thresholds below are carried over
+ * unchanged; what changed is which number they read and that the crown now
+ * requires a real margin.
+ */
+describe('resolveDriverSemanticLabels — thresholds (carried over from getSemanticLabel)', () => {
+  const labelFor = (topValue: number, value: number) =>
+    resolveDriverSemanticLabels([
+      { key: 'top', value: topValue },
+      { key: 'subject', value },
+    ]).get('subject')
+
+  it('crowns a top that is clear of its runner-up', () => {
+    expect(resolveDriverSemanticLabels([
+      { key: 'top', value: 1.0 },
+      { key: 'other', value: 0.1 },
+    ]).get('top')).toBe('biggest')
+    expect(resolveDriverSemanticLabels([{ key: 'only', value: 0.1 }]).get('only')).toBe('biggest')
   })
 
-  it('returns "strong" for normalised >= 0.50 (rank > 1)', () => {
-    expect(getSemanticLabel(2, 0.50)).toBe('strong')
-    expect(getSemanticLabel(2, 0.75)).toBe('strong')
-    expect(getSemanticLabel(3, 0.99)).toBe('strong')
+  it('returns "strong" for a display value >= 0.50 below the top', () => {
+    expect(labelFor(1.0, 0.50)).toBe('strong')
+    expect(labelFor(1.0, 0.75)).toBe('strong')
+    expect(labelFor(1.0, 0.99)).toBe('strong')
   })
 
-  it('returns "moderate" for normalised 0.20-0.49 (rank > 1)', () => {
-    expect(getSemanticLabel(2, 0.20)).toBe('moderate')
-    expect(getSemanticLabel(2, 0.35)).toBe('moderate')
-    expect(getSemanticLabel(2, 0.49)).toBe('moderate')
+  it('returns "moderate" for a display value 0.20-0.49 below the top', () => {
+    expect(labelFor(1.0, 0.20)).toBe('moderate')
+    expect(labelFor(1.0, 0.35)).toBe('moderate')
+    expect(labelFor(1.0, 0.49)).toBe('moderate')
   })
 
-  it('returns "minor" for normalised < 0.20 (rank > 1)', () => {
-    expect(getSemanticLabel(2, 0.19)).toBe('minor')
-    expect(getSemanticLabel(2, 0.10)).toBe('minor')
-    expect(getSemanticLabel(2, 0.01)).toBe('minor')
+  it('returns "minor" for a display value < 0.20 below the top', () => {
+    expect(labelFor(1.0, 0.19)).toBe('minor')
+    expect(labelFor(1.0, 0.10)).toBe('minor')
+    expect(labelFor(1.0, 0.01)).toBe('minor')
   })
 })
 

--- a/src/components/results/driverDisplayModel.ts
+++ b/src/components/results/driverDisplayModel.ts
@@ -20,6 +20,8 @@
  * the decision.
  */
 
+import type { DriverSemanticLabel } from './types'
+
 export type DriverDisplayProvenance = 'influence_score' | 'normalised_elasticity'
 
 export interface DriverDisplayEntry {
@@ -155,4 +157,65 @@ export function compareByDisplayModel(
   if (b.value !== a.value) return b.value - a.value
   if (b.elasticity !== a.elasticity) return b.elasticity - a.elasticity
   return a.key.localeCompare(b.key)
+}
+
+/**
+ * The smallest gap in displayed influence that the panel is willing to call a
+ * DIFFERENCE. Below it, two factors are shown as equally influential and no
+ * copy may rank one above the other.
+ *
+ * ⚠ ONE OWNER, THREE CONSUMERS. This was previously an unnamed `0.01` inlined
+ * at the Drivers panel's equal-influence note, while the rank-1 crown used no
+ * tie notion at all and the dominance nudge used none either — so the same
+ * screen could print "these factors have similar influence" beside a badge
+ * crowning one of them "Top driver". A tie is one concept; it gets one number.
+ */
+export const INFLUENCE_TIE_EPSILON = 0.01
+
+/**
+ * Resolve every driver's semantic label FROM THE DISPLAY VALUES THEMSELVES.
+ *
+ * ⚠ WHY THIS LIVES HERE AND TAKES THE WHOLE SET. The badge used to be derived
+ * by `getSemanticLabel(rank, normalisedInfluence)` in `useResultsSectionData`
+ * — a SECOND basis (|elasticity| / max|elasticity|) unrelated to the number
+ * printed beside it. Under complete producer coverage the two diverge freely,
+ * and a factor the panel printed at **Influence 100%** was badged **"Lower
+ * influence"** on a real user's screen. This module's own header has always
+ * said the order, the crown and the bar must follow the SAME number; taking
+ * the resolved display values as the only input is what makes the second basis
+ * unreachable rather than merely discouraged.
+ *
+ * ⚠ THE CROWN YIELDS TO A TIE. "Rank 1 always gets 'biggest'" bought badge
+ * uniqueness by inventing a distinction the data does not contain: at a tie
+ * the winner is decided by the comparator's elasticity/key tie-breaks, which
+ * the user cannot see. Three factors at 100% were badged "Top driver",
+ * "High-impact driver" and "Lower influence". A crown is now awarded only to a
+ * top that is clear of its runner-up by more than `INFLUENCE_TIE_EPSILON`;
+ * tied factors all take the threshold label, so equal numbers read equal.
+ *
+ * Thresholds (0.50 strong / 0.20 moderate) are carried over unchanged from
+ * UI-SEM-039. Both bases are set-relative 0-1 with the top at 1.0, so moving
+ * the basis does not silently re-calibrate them.
+ */
+export function resolveDriverSemanticLabels(
+  entries: ReadonlyArray<{ key: string; value: number }>,
+): Map<string, DriverSemanticLabel> {
+  const out = new Map<string, DriverSemanticLabel>()
+  if (entries.length === 0) return out
+
+  const values = entries.map((e) => (Number.isFinite(e.value) ? e.value : 0))
+  const max = Math.max(...values)
+  // Clear of the runner-up, or there is no runner-up at all.
+  const contendersAtTop = values.filter((v) => max - v <= INFLUENCE_TIE_EPSILON).length
+  const topIsUnique = contendersAtTop === 1
+
+  entries.forEach((entry, i) => {
+    const value = values[i]
+    if (topIsUnique && value === max) {
+      out.set(entry.key, 'biggest')
+      return
+    }
+    out.set(entry.key, value >= 0.5 ? 'strong' : value >= 0.2 ? 'moderate' : 'minor')
+  })
+  return out
 }

--- a/src/components/results/useResultsSectionData.ts
+++ b/src/components/results/useResultsSectionData.ts
@@ -29,7 +29,6 @@ import type {
   DriverItem,
   UncertaintyItem,
   ImprovementItem,
-  DriverSemanticLabel,
   DriverDirection,
   ConfidenceTier,
   RawFactorSensitivity,
@@ -76,7 +75,11 @@ import {
 import { readInferenceWarnings } from './utils/readInferenceWarnings'
 import { deriveStabilityLevel } from '../../lib/stability'
 import { deriveResultCompleteness, type ResultCompleteness } from './useResultCompleteness'
-import { computeNormalisedInfluences, selectDriverDisplayModel } from './driverDisplayModel'
+import {
+  computeNormalisedInfluences,
+  resolveDriverSemanticLabels,
+  selectDriverDisplayModel,
+} from './driverDisplayModel'
 import { classifyUnit } from '../../utils/unitClassifier'
 import { buildVoiRanking, type VoiRanking } from './voi/voiRanking'
 import { readDecisionVoi, type DecisionVoiVerdict } from './voi/decisionVoi'
@@ -890,20 +893,20 @@ function getFactorDirection(
 // =============================================================================
 
 /**
- * Get semantic label for a driver.
- * Rank 1 always gets "biggest" (ensures uniqueness).
- * Ranks 2+ use threshold-based labels.
+ * ⚠ `getSemanticLabel(rank, normalisedInfluence)` WAS DELETED HERE, NOT MOVED
+ * AND NOT WRAPPED (2026-08-19). It derived the badge from |elasticity| /
+ * max|elasticity| — a SECOND basis, unrelated to the number printed beside it
+ * — so a factor the panel showed at **Influence 100%** shipped badged **"Lower
+ * influence"** to a real user, and its rank-1 crown ignored ties entirely
+ * (three factors at 100% badged "Top driver" / "High-impact driver" / "Lower
+ * influence" on one screen).
+ *
+ * The label is now resolved by `resolveDriverSemanticLabels` in
+ * `driverDisplayModel` — the module that already owned the display value and
+ * whose header already required the order, the crown and the bar to follow the
+ * SAME number. Deleting rather than delegating is the point: the second basis
+ * is no longer reachable from anywhere.
  */
-function getSemanticLabel(rank: number, normalisedValue: number): DriverSemanticLabel {
-  // Rank 1 always gets "Biggest factor"
-  if (rank === 1) return 'biggest'
-
-  // UI-SEM-039: Driver semantic label thresholds (0.50 strong, 0.20 moderate).
-  // Remove when PLoT provides semantic labels per driver.
-  if (normalisedValue >= 0.50) return 'strong'
-  if (normalisedValue >= 0.20) return 'moderate'
-  return 'minor'
-}
 
 // =============================================================================
 // Confidence Tier Derivation (CRITICAL: Full Fallback Chain)
@@ -2324,6 +2327,11 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
         displayValue: displayModel.get(f.key)?.value ?? 0,
       })),
     )
+    // ONE number decides the bar, the order AND the badge. Resolved over the
+    // whole set because the tie rule is a property of the set, not of a row.
+    const semanticLabelMap = resolveDriverSemanticLabels(
+      factorsWithKeys.map((f) => ({ key: f.key, value: displayModel.get(f.key)?.value ?? 0 })),
+    )
 
     // Step 4: Derive edges for direction mapping
     const edgesForDirection: EdgeForDirection[] = edges.map(e => ({
@@ -2430,7 +2438,7 @@ export function useResultsSectionData(): ResultsSectionDataReturn {
           outcomeNodeIds,
           f.raw.direction
         )
-        const semanticLabel = getSemanticLabel(rank, normalisedInfluence)
+        const semanticLabel = semanticLabelMap.get(f.key) ?? 'minor'
 
         // Check if factor can be focused on canvas
         const driverForMatch: Driver = { kind: 'node', id: f.key, label: f.raw.label }
@@ -3713,7 +3721,6 @@ export {
   normalizeOutcomeValues,
   normaliseDirection,
   getFactorDirection,
-  getSemanticLabel,
   mapReadinessLevel,
   mapConfidenceLevel,
   getConfidenceTier,


### PR DESCRIPTION
## What was on screen

UX gate 2026-08-19T22:01–22:38Z, deployed UI `ad79b344`. Fresh guest, real typed brief → real draft → real analysis. **One screen, one run:**

- **THREE** factors each showing **Influence 100%**, badged respectively **"Top driver"**, **"High-impact driver"** and **"Lower influence"**.
- *"**Both** factors have similar influence on the outcome."* printed under a section headed **4**.
- *"**Dominant factor:** Cloud migration progress drives **100%** of the outcome"* while two other rows also read **100%**.

All three are **deterministic**. Nothing here is model-authored. One root cause, three faces.

## Root cause — two different numbers on one row

The bar, the order and the percentage read `displayInfluence` (the `driverDisplayModel` policy). The **badge** read `normalisedInfluence` — `|elasticity| / max|elasticity|`, an unrelated second basis. Under complete producer coverage the two diverge freely, so **a factor the panel prints at 100% can carry an elasticity share of 0.1 and be badged "Lower influence" beside its own full bar.**

This is not a new rule being invented. `driverDisplayModel.ts` **already** said it, in its own header:

> the order, the rank-1 crown, and the bar must all follow the SAME number

The crown and the thresholds simply never moved there. The existing canonical owner finally owns the badge.

## Second face — the crown ignored ties

`getSemanticLabel` was documented as *"Rank 1 always gets 'biggest' (ensures uniqueness)"*. That bought **badge** uniqueness by inventing a distinction **the data does not contain**: at a tie the rank is settled by the comparator's elasticity-then-key tie-breaks, which the user cannot see. Three factors at 100% therefore came out as *Top driver* / *High-impact driver* / *Lower influence*.

## Third face — the count word

*"Both factors"* was hard-coded while the note fires whenever **all** visible drivers are within the tie epsilon, however many there are. **Deriving a count would not have fixed it either:** the note ranges over `visibleDrivers` while the heading counts the non-zero-impact total, so the two can legitimately differ and any derived count can still contradict the heading beside it. **Count-free copy cannot, by construction.**

## Convergence (Paul's binding rule)

| | |
|---|---|
| **Canonical owner named** | `resolveDriverSemanticLabels` in `driverDisplayModel`, taking the resolved display values as its **only** input |
| **Competitor superseded** | `getSemanticLabel(rank, normalisedInfluence)` is **DELETED, not wrapped** — the second basis is unreachable, not merely discouraged |
| **One concept, one number** | `INFLUENCE_TIE_EPSILON` replaces the unnamed `0.01` inlined at the note, and now also governs the crown **and** the dominance nudge — the three surfaces can no longer disagree about what a tie is |

Thresholds (0.50 / 0.20, UI-SEM-039) are carried over **unchanged**; both bases are set-relative 0-1 with the top at 1.0, so moving the basis does not silently re-calibrate them.

*"Dominant"* is a **comparative** claim, so the nudge now requires a runner-up to be dominant over.

## Every guard has its opposite-direction twin

Over-applying these fixes is its own harm: a crown nobody can earn, a note that always fires, a dominance warning that never fires. Both directions are asserted.

| direction | assertion | at pristine |
|---|---|---|
| the lie | tied factors share one badge, none crowned | RED |
| **twin** | a **unique** top is **still crowned** | **GREEN** |
| the lie | the note states no count | RED |
| **twin** | the note **stays absent** when factors genuinely differ | **GREEN** |
| the lie | nothing is called dominant while another row reads the same | RED |
| **twin** | a **genuinely dominant** factor is **still named** | **GREEN** |

RED-first: 8 collected / **7 RED**. The two dominance-nudge cases were written after their fix, so their RED-first was established separately by reverting `TriageActionCardsBody.tsx` to its `HEAD` bytes — **witnessed-claim RED, twin GREEN** — and the file restored by sha comparison. Called out rather than glossed.

## Mutants

Throwaway worktree at an absolute path outside the repo root, committed state only. **Isolation proven by WRITING** a sentinel and asserting the source clone unchanged (inodes `681371958` vs `682583405`). Restore from a pristine **archive**, never `git checkout -- <path>`.

| mutant | applied | bites |
|---|---|---|
| CONTROL | **0** | green, 10/10 |
| M1 crown every rank-1 again | 1 | witnessed badge split + the epsilon boundary |
| M2 widen the tie window to everything — **opposite** | 1 | **all three twins** |
| M3 restore the hard-coded count word | 1 | both count assertions |
| M4 fire the note always — **opposite** | 1 | **only** the note twin |
| M5 drop the dominance margin | 1 | **only** the witnessed dominance claim |
| M6 never call anything dominant — **opposite** | 1 | **only** the dominance twin |

**M1/M2, M3/M4 and M5/M6 are discriminating pairs** — each proves the guard binds the named behaviour rather than being merely sensitive to change. Trailing control: `src/` clean, all three files sha-identical to the archive.

## Gate (local)

- `pnpm lint` (`eslint .` + hooks ratchet) → **exit 0**, 0 errors; ratchet **exactly matches baseline** (229 known violations / 13 files)
- `pnpm typecheck` (ratcheted gate) → **exit 0** — 557 files / 2263 errors, **equal to baseline** (the three new errors this change first introduced were fixed at source, **not** by regenerating the baseline)
- `npx vitest run src/components/results src/canvas/hooks` → **296 files passed, 4748 tests passed, 0 failed**
- This PR's own spec asserted **by name**: `influenceLabelsAgreeWithTheirNumbers.spec.tsx` → **10 collected, 10 passed** (never inferred from the suite total)
- `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported for every run, so no spec collected zero

## Moved, not rewritten as history

The four `getSemanticLabel` threshold tests in `useResultsSectionData.spec.ts` were re-pointed at `resolveDriverSemanticLabels`. That is a **policy that moved**, not a record of what the product once emitted — no historic capture or leak corpus was touched.

## Overlap to flag for the reviewer

`useResultsSectionData.ts` is also touched by open PR **#714** (*Resolve Next strength confirmation*). Different concern, different region; flagging it so whichever lands second rebases rather than takes a side wholesale.

## Not merged, not deployed

Branched from `staging`, **do not merge** — a SENDABLE integration batch is in flight. Deployed staging was not driven. `Visual Regression (advisory)` is the known-dead advisory check (3.78% noise floor vs 0.05% tolerance) and is not waited on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
