### PR TITLE
fix(chips): map analysis_readiness so CEE's readiness recovery chip can render

### DIFF
--- a/src/canvas/conversation/__tests__/analysisReadinessChipRenders.spec.tsx
+++ b/src/canvas/conversation/__tests__/analysisReadinessChipRenders.spec.tsx
@@ -1,0 +1,106 @@
+/**
+ * ⭐ A CEE-EMITTED `analysis_readiness` CHIP MUST REACH THE USER.
+ *
+ * WITNESSED (deployed, fresh guest, 2026-08-20): a fresh user was refused an
+ * analysis and every offered route ended in a refusal. CEE's recovery chip
+ * carried no `action_type`, so it reached CEE as ordinary chat, the LLM router
+ * elected `run_analysis`, and the election gate DEMOTED it: "I have not run the
+ * analysis, because I did not read that as a request to run one." The product
+ * refused its own CTA.
+ *
+ * The CEE half of the fix types that chip `analysis_readiness` — the one
+ * `action_type` route-v2 routes to the readiness arm without an LLM round-trip,
+ * so it cannot be demoted.
+ *
+ * ⚠ BUT THE UI WOULD HAVE DELETED IT, AND THAT IS STRICTLY WORSE THAN THE
+ * MISROUTE. `analysis_readiness` has no `ACTION_TO_TURN_TYPE` mapping, so it is
+ * absent from the DERIVED `V5_ENABLED_ACTIONS`, and `SuggestedChips` filters out
+ * any chip whose bound `action_type` is not V5-known. A chip that misroutes at
+ * least gives the user something to click; a chip that never renders gives them
+ * nothing. Typing the chip in CEE without this mapping would have shipped half a
+ * capability.
+ *
+ * The wire was ALREADY ready — `analysis_readiness` is published in
+ * `ActionType`, present in `CEE_ACCEPTED_ACTION_TYPES` (`buildPayload.ts:948`),
+ * and a bound action_type promotes `source` to `chip_click`
+ * (`buildPayload.ts:159-160`). Only the client's own dispatch vocabulary was
+ * short — which is why the fix is a mapping, never a filter bypass:
+ * `SuggestedChips`'s filter is DERIVED and correct, and patching it would leave
+ * the click routing by accidental fall-through instead of by decision.
+ *
+ * ⭐ The existing vocabulary spec anticipated exactly this
+ * (`explainChips.vocabulary.spec.ts:85-89`): "Add the mapping and the chip
+ * lights up on its own; nobody has to remember to edit a list."
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import { ACTION_TO_TURN_TYPE, DISPATCHABLE_ACTION_TYPES } from '../actionTurnTypes'
+import { V5_ENABLED_ACTIONS } from '../chipActionVocabulary'
+import { buildSuggestedActionChips } from '../../../v5/blocks/suggestedActionChips'
+import { buildV5Payload } from '../../../v5/buildPayload'
+import { buildChipMeta } from '../chipMeta'
+
+/** The chip CEE emits on `analysis_not_ready`, verbatim from the CEE branch. */
+const CEE_CHIP = {
+  id: 'chip_prompt_fix_before_analysis',
+  label: 'Prepare first analysis',
+  message: 'What should I check before running the first analysis?',
+  action_type: 'analysis_readiness',
+} as const
+
+describe('CEE analysis_readiness recovery chip — reaches the user and routes by type', () => {
+  it('⭐ is dispatchable, so the derived render filter admits it', () => {
+    // Bound by IDENTITY to the action_type, never to "the set is non-empty".
+    expect(DISPATCHABLE_ACTION_TYPES.has('analysis_readiness')).toBe(true)
+    expect(V5_ENABLED_ACTIONS.has('analysis_readiness')).toBe(true)
+  })
+
+  it('routes by a DELIBERATE turn type, not by default fall-through', () => {
+    // The reason the fix is a mapping and not a filter bypass: `dispatchAction`
+    // reads this map, and a missing key leaves `turnType` at its default while
+    // the chip still advertises an action.
+    expect(ACTION_TO_TURN_TYPE.analysis_readiness).toBe('conversation')
+  })
+
+  it('survives ingest from a producer suggested_action', () => {
+    const chips = buildSuggestedActionChips([], [{ ...CEE_CHIP }])
+    const chip = chips.find((c) => c.id === CEE_CHIP.id)
+    expect(chip).toBeDefined()
+    expect(chip?.action_type).toBe('analysis_readiness')
+    expect(chip?.message).toBe(CEE_CHIP.message)
+  })
+
+  it('⭐ reaches the wire as source=chip_click with the type intact', () => {
+    const result = buildV5Payload({
+      message: CEE_CHIP.message,
+      source: 'chip',
+      chipMeta: buildChipMeta({
+        id: CEE_CHIP.id,
+        action_type: CEE_CHIP.action_type,
+      }),
+      scenarioId: 's1',
+      stage: 'frame',
+    } as Parameters<typeof buildV5Payload>[0])
+    // `BuildV5PayloadResult` is a discriminated union: narrowing on `ok` also
+    // pins that the payload builds at all, rather than reading `payload` off a
+    // failure branch.
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error(`payload did not build: ${result.reason}`)
+    // Both halves by identity: the type is what route-v2 keys on, and
+    // `source: 'chip_click'` is the other half of that route's condition.
+    // `OrchestratorTurnPayload` is itself a union (message vs system-event), so
+    // read the two fields through one narrow local view rather than asserting a
+    // key the system-event arm does not carry.
+    const sent = result.payload as { source?: string; chip?: { action_type?: string } }
+    expect(sent.source).toBe('chip_click')
+    expect(sent.chip?.action_type).toBe('analysis_readiness')
+  })
+
+  it('OPPOSITE DIRECTION — an unmapped action_type is still refused', () => {
+    // Proves the admission above is a real discrimination and not a filter that
+    // now says yes to everything. `explain_from_structure` remains unmapped.
+    expect(DISPATCHABLE_ACTION_TYPES.has('explain_from_structure')).toBe(false)
+    expect(V5_ENABLED_ACTIONS.has('explain_from_structure')).toBe(false)
+  })
+})

--- a/src/canvas/conversation/__tests__/dispatchAction.spec.ts
+++ b/src/canvas/conversation/__tests__/dispatchAction.spec.ts
@@ -40,6 +40,11 @@ describe('ACTION_TO_TURN_TYPE mapping', () => {
     adjust_edge_strength: 'conversation',
     remove_factor: 'conversation',
     set_goal_target: 'conversation',
+    // Added 2026-08-20 with the CEE `analysis_not_ready` recovery chip, which is
+    // now typed `analysis_readiness` so it routes to the readiness arm instead
+    // of being demoted by the analysis-election gate. Without the mapping the
+    // chip is filtered out at render and the user sees nothing at all.
+    analysis_readiness: 'conversation',
     run_premortem: 'explain',
     draft_graph: 'explicit_generate',
   }

--- a/src/canvas/conversation/actionTurnTypes.ts
+++ b/src/canvas/conversation/actionTurnTypes.ts
@@ -44,6 +44,16 @@ export const ACTION_TO_TURN_TYPE: Record<string, Exclude<TurnType, 'system_event
   adjust_edge_strength: 'conversation',
   remove_factor: 'conversation',
   set_goal_target: 'conversation',
+  // ⭐ Readiness coaching is a conversational answer, so 'conversation' is the
+  // honest turn type — the same one the UI's own `prepare_first_analysis` spark
+  // already gets. Added 2026-08-20 because CEE's `analysis_not_ready` recovery
+  // chip is now typed `analysis_readiness` (the one action_type route-v2 routes
+  // to the readiness arm without an LLM round-trip, so it cannot be demoted by
+  // the analysis-election gate). Without a mapping here that chip is absent from
+  // the DERIVED `V5_ENABLED_ACTIONS` and `SuggestedChips` deletes it outright —
+  // strictly worse than the misroute it replaces, because a chip that never
+  // renders gives the user nothing to click.
+  analysis_readiness: 'conversation',
   run_premortem: 'explain',
   draft_graph: 'explicit_generate',
 }

--- a/src/v5/__tests__/explainChips.vocabulary.spec.ts
+++ b/src/v5/__tests__/explainChips.vocabulary.spec.ts
@@ -81,15 +81,22 @@ describe('explain-chips vocabulary — parser → filter seam (V-P0-2)', () => {
     // them on arrival, and this test certified the deletion as correct.
     // `compare_options` was excluded on the same false ground.
     //
-    // Two exclusions remain and both are now DERIVED rather than remembered:
-    // `explain_from_structure` and `analysis_readiness` have no
-    // ACTION_TO_TURN_TYPE mapping, so a click would fall through to the default
-    // turn type — the "promises action, delivers default routing" case the old
-    // comment named. Add the mapping and the chip lights up on its own; nobody
-    // has to remember to edit a list. The general form of this assertion lives
-    // in chipActionVocabulary.spec.ts ("excluded for a DERIVABLE reason").
+    // ONE exclusion remains, and it is DERIVED rather than remembered:
+    // `explain_from_structure` has no ACTION_TO_TURN_TYPE mapping, so a click
+    // would fall through to the default turn type — the "promises action,
+    // delivers default routing" case the old comment named. Add the mapping and
+    // the chip lights up on its own; nobody has to remember to edit a list. The
+    // general form of this assertion lives in chipActionVocabulary.spec.ts
+    // ("excluded for a DERIVABLE reason").
+    //
+    // ⭐ `analysis_readiness` LEFT THIS SET ON 2026-08-20, exactly as this
+    // comment's own instruction anticipated. CEE's `analysis_not_ready` recovery
+    // chip is now typed `analysis_readiness`, so the chip must render; the
+    // mapping was added to `ACTION_TO_TURN_TYPE` and this assertion narrowed by
+    // derivation, not by hand-editing a list. See
+    // `canvas/conversation/__tests__/analysisReadinessChipRenders.spec.tsx`.
     const excluded = ActionType.options.filter((t) => !V5_ENABLED_ACTIONS.has(t))
-    expect(new Set(excluded)).toEqual(new Set(['explain_from_structure', 'analysis_readiness']))
+    expect(new Set(excluded)).toEqual(new Set(['explain_from_structure']))
   })
 
   it('the debug-bundle turn selector recognises the explain chip vocabulary (review fold)', () => {


### PR DESCRIPTION
**Paired with CEE #1059. Land both or neither — CEE #1059 alone is strictly worse than the bug it fixes.**

## Why

CEE's `analysis_not_ready` recovery chip is now typed `analysis_readiness` — the one `action_type` `route-v2.ts:2789` routes to the readiness arm without an LLM round-trip, so it **cannot** be demoted by the analysis-election gate.

Witnessed on the deployed build (fresh guest, 2026-08-20T00:00Z, UI `2b6ec553` / CEE `19a60fd`): as an **untyped** chip it reached CEE as ordinary chat, the LLM router elected `run_analysis`, and `analysis-election-gate.ts` demoted it — so the product's own **"Review the model"** CTA answered *"I have not run the analysis, because I did not read that as a request to run one."* The product refused its own affordance.

## ⚠ Without this, the CEE half makes things worse

`analysis_readiness` had **no `ACTION_TO_TURN_TYPE` mapping**, so it was absent from the derived `V5_ENABLED_ACTIONS`, and `SuggestedChips.tsx:194` filtered the chip out **entirely**. A chip that misroutes at least gives the user something to click; a chip that never renders gives them nothing. This is the "do not build half a capability" case, caught by tracing the chip hop by hop before landing CEE #1059.

## The fix is the mapping, not a filter bypass

`SuggestedChips`'s filter is **derived and correct** — do not patch it. Patching it would leave the click routing by accidental fall-through, because `dispatchAction` (`useConversation.ts:6524-6526`) reads the same map and its keyword-heuristic branch is `else if (!opts.action_type)`, which a typed chip skips. One line in `ACTION_TO_TURN_TYPE` self-repairs the whole chain by derivation:

`DISPATCHABLE_ACTION_TYPES` → `isHonestlyDispatchableAction` → `V5_ENABLED_ACTIONS` → chip renders → `dispatchAction` routes **deliberately** → `buildV5Payload` emits `source: 'chip_click'` + `chip.action_type: 'analysis_readiness'`.

`'conversation'` is the honest turn type: readiness coaching **is** a conversational answer, and it is what the UI's own `prepare_first_analysis` spark (`pre-analysis-v3/constants.ts:525-533`, the same prompt string) already gets.

## The wire was already ready — this PR does not touch it

- `analysis_readiness` is published in `ActionType` (vendored `@talchain/schemas` 0.48.0, `dist/boundary/enums.js:96-108`)
- it is in `CEE_ACCEPTED_ACTION_TYPES` (`buildPayload.ts:948`, CEE #578, deploy-confirmed 2026-07-20)
- a bound `action_type` promotes `source` `'chip'` → `'chip_click'` (`buildPayload.ts:159-160`)
- ingest already forwards it (`suggestedActionChips.ts:78-84`)

**Only the client's own dispatch vocabulary was short.**

## Evidence

- **RED-first at pristine**: 5 collected by name, 2 failed on named signatures (`DISPATCHABLE_ACTION_TYPES.has` and the turn-type mapping). **The wire assertion PASSED at pristine** — that is the positive control proving the gap was vocabulary, not plumbing.
- **Opposite-direction assertion**: `explain_from_structure` must STILL be refused, so the admission is a real discrimination and not a filter that now says yes to everything.
- `explainChips.vocabulary.spec.ts` **anticipated exactly this** (its own comment: *"Add the mapping and the chip lights up on its own; nobody has to remember to edit a list"*). Its excluded set narrows to `{explain_from_structure}` **by derivation**.
- `dispatchAction.spec.ts`'s hand-kept key mirror is updated **deliberately**, at source.
- **Typecheck ratchet clean at baseline** (2263 errors, +0). Two type errors in my own test were fixed at source, never by `--update-baseline`.
- `src/canvas/conversation` + `src/v5`: **281 files / 3928 passed, 0 failed.**

⚠ Suites were run with **real-shaped** `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`. Placeholder values silently shrank collection from **3949 → 3135** tests (trap 2b) while still reporting zero failures; every number above is from the healthy run.

## Not done

Not merged, and deployed staging was not driven (frozen for the Milestone A witness). No test yet covers a **producer-supplied** `analysis_readiness` chip driven through `SuggestedChips` to a real click — `sparkIntentContract.spec.ts` covers the UI-owned sparks, which bypass `SuggestedChips` entirely. Adding a producer-chip case to `proposeConfirmChipRender.spec.tsx` would close that blind spot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
