### PR TITLE
fix(model-tab): plain-English statistical notation for non-expert users

### DIFF
--- a/src/canvas/components/model-tab/ContestedEdgeCard.tsx
+++ b/src/canvas/components/model-tab/ContestedEdgeCard.tsx
@@ -14,6 +14,7 @@ import type { Edge, Node } from '@xyflow/react'
 import { AlertTriangle, Check } from 'lucide-react'
 import { typography } from '../../../styles/typography'
 import { DetailToggleContext } from './DetailToggleContext'
+import { estimateGapText } from './statisticalNotation'
 import { focusNodeById, focusEdgeById } from '../../utils/focusHelpers'
 import { useCanvasStore } from '../../store'
 import { getDisplayEdgeId } from '../../utils/edgeIdentity'
@@ -334,8 +335,11 @@ export function ContestedEdgeCard({
       {primaryReason && !isResolved && (
         <p className={`${typography.panelMeta} text-text-light mb-1`}>
           {primaryReason}
-          <span className={`${typography.panelMeta} text-warning ml-1`}>
-            Δ {deltaMagnitude.toFixed(2)}
+          <span
+            className={`${typography.panelMeta} text-warning ml-1`}
+            data-testid={`contested-estimate-gap-${edgeId}`}
+          >
+            {estimateGapText(deltaMagnitude, showDetail)}
           </span>
         </p>
       )}

--- a/src/canvas/components/model-tab/FactorsSection.tsx
+++ b/src/canvas/components/model-tab/FactorsSection.tsx
@@ -31,6 +31,7 @@ import { InlineEdit } from './InlineEdit'
 import { SourceProvenancePill } from './SourceProvenancePill'
 import { DataBar } from '../../ui/shared/DataBar'
 import { DetailToggleContext } from './DetailToggleContext'
+import { normalisedScaleSuffix, priorRangeLabel } from './statisticalNotation'
 import { CoachingCard } from './CoachingCard'
 import type { ObservedState, FactorInfluenceMap } from './types'
 import {
@@ -394,7 +395,12 @@ function FactorCard({
         /* External: prior range */
         <div className="space-y-1">
           <div className="flex items-center gap-1.5 flex-wrap">
-            <span className={`${typography.panelMeta} text-text-light w-12 shrink-0`}>Prior</span>
+            <span
+              className={`${typography.panelMeta} text-text-light w-24 shrink-0`}
+              data-testid={`factor-${node.id}-prior-label`}
+            >
+              {priorRangeLabel(showDetail)}
+            </span>
             {hasPriorRange ? (
               <>
                 <InlineEdit
@@ -420,7 +426,7 @@ function FactorCard({
                   <span className={`${typography.panelMeta} text-text-light`}>· from model repair</span>
                 )}
                 {!obs.unit && !isSynthesisedPrior && (
-                  <span className={`${typography.panelMeta} text-text-light`} data-testid={`factor-${node.id}-normalised-range`}>(normalised)</span>
+                  <span className={`${typography.panelMeta} text-text-light`} data-testid={`factor-${node.id}-normalised-range`}>{normalisedScaleSuffix(showDetail)}</span>
                 )}
               </>
             ) : (
@@ -472,7 +478,7 @@ function FactorCard({
                   tooltip="Click to edit value"
                   testId={`factor-${node.id}-value`}
                 />
-                <span className={`${typography.panelMeta} text-text-light`} data-testid={`factor-${node.id}-normalised-label`}>(normalised)</span>
+                <span className={`${typography.panelMeta} text-text-light`} data-testid={`factor-${node.id}-normalised-label`}>{normalisedScaleSuffix(showDetail)}</span>
               </>
             ) : (
               <span

--- a/src/canvas/components/model-tab/OptionsSection.tsx
+++ b/src/canvas/components/model-tab/OptionsSection.tsx
@@ -18,6 +18,7 @@ import { focusNodeById } from '../../utils/focusHelpers'
 import { formatValueWithUnit, formatSmartNumber } from './utils'
 import { InlineEdit } from './InlineEdit'
 import { DetailToggleContext } from './DetailToggleContext'
+import { normalisedScaleSuffix } from './statisticalNotation'
 import { unwrapInterventionValue, formatRawValueWithUnit } from '../../utils/labelUtils'
 import { interventionTargetValue } from '../../domain/interventions'
 
@@ -296,7 +297,7 @@ function OptionCard({ option, allNodes, conditionalWinners, hasAnalysisData }: {
             const targetDisplay = iv.displayValue
               ? iv.displayValue
               : iv.hasRawUnit
-                ? `${iv.currentValue.toFixed(2)} (normalised)`
+                ? `${iv.currentValue.toFixed(2)} ${normalisedScaleSuffix(showDetail)}`
                 : formatRawValueWithUnit(iv.currentValue, iv.unit)
 
             return (

--- a/src/canvas/components/model-tab/__tests__/FactorsSection.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/FactorsSection.spec.tsx
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeAll } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { FactorsSection } from '../FactorsSection'
 import { DetailToggleContext } from '../DetailToggleContext'
+import { normalisedScaleSuffix } from '../statisticalNotation'
 import type { Node } from '@xyflow/react'
 
 // jsdom does not implement scrollIntoView
@@ -334,10 +335,27 @@ describe('FactorsSection', () => {
 
   // ── Normalised value display tests ─────────────────────────────────────────
 
-  it('shows (normalised) suffix when only normalised value present (no raw_value, no unit)', () => {
+  it('names the scale in words for a non-expert, and restores (normalised) in expert mode', () => {
+    // Was: asserted '(normalised)' with NO provider, i.e. it pinned the leak —
+    // a fresh guest with expert mode OFF read internal notation. Both registers
+    // are asserted so a fix that DELETES the term cannot pass either.
     const nodes = [makeFactorNode('f1', 'Score', { value: 0.5 })]
-    render(<FactorsSection factorNodes={nodes} />)
-    expect(screen.getByTestId('factor-f1-normalised-label')).toBeInTheDocument()
+    const plain = render(
+      <DetailToggleContext.Provider value={{ showDetail: false }}>
+        <FactorsSection factorNodes={nodes} />
+      </DetailToggleContext.Provider>,
+    )
+    const off = screen.getByTestId('factor-f1-normalised-label')
+    expect(off).toBeInTheDocument()
+    expect(off).toHaveTextContent(normalisedScaleSuffix(false))
+    expect(off.textContent).not.toMatch(/normalised/i)
+    plain.unmount()
+
+    render(
+      <DetailToggleContext.Provider value={{ showDetail: true }}>
+        <FactorsSection factorNodes={nodes} />
+      </DetailToggleContext.Provider>,
+    )
     expect(screen.getByTestId('factor-f1-normalised-label')).toHaveTextContent('(normalised)')
   })
 

--- a/src/canvas/components/model-tab/__tests__/OptionsSection.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/OptionsSection.spec.tsx
@@ -6,6 +6,8 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { OptionsSection } from '../OptionsSection'
 import type { Node } from '@xyflow/react'
+import { DetailToggleContext } from '../DetailToggleContext'
+import { normalisedScaleSuffix } from '../statisticalNotation'
 
 const mockUpdateNode = vi.fn()
 
@@ -202,18 +204,34 @@ describe('OptionsSection', () => {
 
   // ── Normalised intervention display ────────────────────────────────────────
 
-  it('shows normalised label when intervention target is 0-1 and factor has large raw baseline', () => {
-    // Factor with raw_value=10000 and unit=£. Intervention target is 0.8 (normalised).
+  it('marks a model-space intervention target in words, and restores (normalised) in expert mode', () => {
+    // Factor with raw_value=10000 and unit=£. Intervention target is 0.8, which
+    // `looksNormalised` (OptionsSection.tsx:93-95) classifies as model space.
+    // Was: asserted /normalised/ with NO provider — it pinned the leak.
     const factor = makeFactorNode('f1', 'Ad spend', 10000, '£')
     const option = makeOptionNode('opt1', 'Campaign', { f1: 0.8 })
-    render(<OptionsSection optionNodes={[option]} allNodes={[factor]} />)
-    // Target should show as normalised, not £0.8
-    expect(screen.getByText(/0\.80/)).toBeInTheDocument()
-    expect(screen.getByText(/normalised/)).toBeInTheDocument()
-    // Baseline should show raw value with unit
+    const plain = render(
+      <DetailToggleContext.Provider value={{ showDetail: false }}>
+        <OptionsSection optionNodes={[option]} allNodes={[factor]} />
+      </DetailToggleContext.Provider>,
+    )
+    const off = screen.getByTestId('intervention-opt1-f1-display')
+    expect(off).toHaveTextContent('0.80')
+    expect(off).toHaveTextContent(normalisedScaleSuffix(false))
+    expect(off.textContent).not.toMatch(/normalised/i)
+    // Baseline still shows the raw value with unit; no delta chip (cross-unit-space)
     expect(screen.getByText('£10,000')).toBeInTheDocument()
-    // Delta chip should NOT render (cross-unit-space)
     expect(screen.queryByText(/£9,999/)).not.toBeInTheDocument()
+    plain.unmount()
+
+    render(
+      <DetailToggleContext.Provider value={{ showDetail: true }}>
+        <OptionsSection optionNodes={[option]} allNodes={[factor]} />
+      </DetailToggleContext.Provider>,
+    )
+    const on = screen.getByTestId('intervention-opt1-f1-display')
+    expect(on).toHaveTextContent('0.80')
+    expect(on).toHaveTextContent('(normalised)')
   })
 
   it('shows raw values with units when both baseline and target are in same range', () => {

--- a/src/canvas/components/model-tab/__tests__/plainLanguageStatisticalNotation.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/plainLanguageStatisticalNotation.spec.tsx
@@ -73,12 +73,10 @@ vi.mock('../../../utils/evidenceCoverage', () => ({
   NON_EVIDENCE_PROVENANCE: ['assumption', 'template', 'ai-suggested'],
 }))
 
-let sliderOnChange: ((v: number) => void) | undefined
 vi.mock('../../../ui/inspector/SignedStrengthSlider', () => ({
-  SignedStrengthSlider: ({ value, onChange }: { value: number; onChange: (v: number) => void }) => {
-    sliderOnChange = onChange
-    return <input type="range" data-testid="mock-strength-slider" defaultValue={value} onChange={e => onChange(parseFloat(e.target.value))} />
-  },
+  SignedStrengthSlider: ({ value, onChange }: { value: number; onChange: (v: number) => void }) => (
+    <input type="range" data-testid="mock-strength-slider" defaultValue={value} onChange={e => onChange(parseFloat(e.target.value))} />
+  ),
 }))
 
 const mockStorage = new Map<string, string>()

--- a/src/canvas/components/model-tab/__tests__/plainLanguageStatisticalNotation.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/plainLanguageStatisticalNotation.spec.tsx
@@ -1,0 +1,384 @@
+/**
+ * PLAIN-LANGUAGE STATISTICAL NOTATION — both directions, bound to the ONE gate.
+ *
+ * ## What this pins
+ *
+ * A UX gate on the frozen deployed build (UI `2b6ec553`), fresh guest, expert
+ * mode OFF, read `(normalised)` ×5, `Prior` ×2 and `Δ` ×13 off the Model
+ * surface. Three render sites, all UI copy, all sitting OUTSIDE the expert gate
+ * their own components already consumed.
+ *
+ * ## Why every case is a PAIR
+ *
+ * The inverse harm is the dangerous one. A test that only asserts "the default
+ * does not say `Δ`" is satisfied by a fix that DELETES the quantity — which
+ * would leave a bare number whose meaning depends on the term just removed, and
+ * that damages the scientific credibility the surface exists to carry. So every
+ * leak gets expert-OFF **and** expert-ON, and the ON case asserts the technical
+ * term is still there. Neither direction alone is evidence.
+ *
+ * ## Binding
+ *
+ * Assertions bind by `data-testid` IDENTITY, never by a value predicate another
+ * element could satisfy — `(normalised)` appears on several rows at once, so
+ * `getByText` would silently pass on a sibling. `describe` blocks drive the REAL
+ * `DetailToggleContext` — the same provider `ModelTabHeader` uses — rather than
+ * a local stub, so a fix that invents a second gate cannot make these pass.
+ */
+
+import { describe, it, expect, vi, beforeAll } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { readFileSync, readdirSync } from 'node:fs'
+import { join, dirname, basename } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import type { Node, Edge } from '@xyflow/react'
+import { FactorsSection } from '../FactorsSection'
+import { OptionsSection } from '../OptionsSection'
+import { ContestedEdgeCard } from '../ContestedEdgeCard'
+import { ModelTabHeader } from '../ModelTabHeader'
+import { DetailToggleContext } from '../DetailToggleContext'
+import {
+  normalisedScaleSuffix,
+  priorRangeLabel,
+  estimateGapText,
+} from '../statisticalNotation'
+import type { ValidationMetadata } from '../../../domain/validation'
+import { useContext } from 'react'
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+const mockUpdateNode = vi.fn()
+const mockGraph: { nodes: unknown[]; edges: unknown[] } = { nodes: [], edges: [] }
+
+vi.mock('../../../store', () => {
+  const useCanvasStore = Object.assign(
+    vi.fn((selector: (s: unknown) => unknown) => selector({ updateNode: mockUpdateNode })),
+    { getState: () => ({ ...mockGraph, updateNode: mockUpdateNode }) },
+  )
+  return { useCanvasStore }
+})
+
+vi.mock('../../../utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusEdgeById: vi.fn(),
+}))
+
+vi.mock('../../GraphTextView', () => ({
+  SectionErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('../../../utils/evidenceCoverage', () => ({
+  NON_EVIDENCE_PROVENANCE: ['assumption', 'template', 'ai-suggested'],
+}))
+
+let sliderOnChange: ((v: number) => void) | undefined
+vi.mock('../../../ui/inspector/SignedStrengthSlider', () => ({
+  SignedStrengthSlider: ({ value, onChange }: { value: number; onChange: (v: number) => void }) => {
+    sliderOnChange = onChange
+    return <input type="range" data-testid="mock-strength-slider" defaultValue={value} onChange={e => onChange(parseFloat(e.target.value))} />
+  },
+}))
+
+const mockStorage = new Map<string, string>()
+vi.stubGlobal('sessionStorage', {
+  getItem: (k: string) => mockStorage.get(k) ?? null,
+  setItem: (k: string, v: string) => mockStorage.set(k, v),
+  removeItem: (k: string) => mockStorage.delete(k),
+  clear: () => mockStorage.clear(),
+  length: 0,
+  key: () => null,
+})
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+function withDetail(showDetail: boolean, ui: React.ReactNode) {
+  return render(
+    <DetailToggleContext.Provider value={{ showDetail }}>{ui}</DetailToggleContext.Provider>,
+  )
+}
+
+/** Observable factor whose value exists ONLY in model space (no raw_value/unit). */
+function normalisedFactor(id: string, label: string): Node {
+  return {
+    id, type: 'factor', position: { x: 0, y: 0 },
+    data: {
+      label, kind: 'factor', category: 'observable',
+      observedState: { value: 0.5, source: 'cee_inference' },
+    },
+  }
+}
+
+/** External factor carrying a prior range and NO unit. */
+function externalFactorWithPrior(id: string, label: string): Node {
+  return {
+    id, type: 'factor', position: { x: 0, y: 0 },
+    data: {
+      label, kind: 'factor', category: 'external',
+      prior: { range_min: 0.2, range_max: 0.8 },
+      observedState: { source: 'cee_inference' },
+    },
+  }
+}
+
+function optionWithNormalisedIntervention(): { option: Node; factor: Node } {
+  const factor: Node = {
+    id: 'f1', type: 'factor', position: { x: 0, y: 0 },
+    data: { label: 'Ad spend', observedState: { raw_value: 10000, unit: '£', value: 100 } },
+  }
+  const option: Node = {
+    id: 'opt1', type: 'option', position: { x: 0, y: 0 },
+    data: { label: 'Campaign', interventions: { f1: 0.8 } },
+  }
+  return { option, factor }
+}
+
+function contestedFixture() {
+  const validation: ValidationMetadata = {
+    status: 'contested',
+    contested_reasons: ['strength_band_change'],
+    pass1: { strength_mean: 0.6, strength_std: 0.08, exists_probability: 0.7 },
+    pass2: {
+      strength_mean: 0.35, strength_std: 0.12, exists_probability: 0.7,
+      reasoning: 'Typical B2B ROI shows moderate conversion effects',
+      basis: 'domain_prior', needs_user_input: false,
+    },
+    max_divergence: 0.5, distance_to_goal: 1, evoi_rank: null, evoi_impact: null,
+    was_shown: false, user_action: 'pending', resolved_value: null, resolved_by: 'default',
+  }
+  const edge: Edge = {
+    id: 'e1', source: 'a', target: 'b',
+    data: { weight: 0.6, direction: 'positive', beliefExists: 0.7, provenance: 'assumption', validation },
+  }
+  const nodes: Node[] = [
+    { id: 'a', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Ad spend' } },
+    { id: 'b', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Revenue' } },
+  ]
+  // |0.6 − 0.35| = 0.25 — the exact magnitude the copy must carry, both ways.
+  return { edge, nodes, validation, expected: '0.25' }
+}
+
+// ── 1. The wording table itself ─────────────────────────────────────────────
+
+describe('the wording table says the same thing in two registers', () => {
+  it('never returns an empty or bare-number form in either register', () => {
+    // A "plain English" fix that returns '' would satisfy every OFF-direction
+    // assertion below. Pin that the default is SUBSTANTIVE, not deleted.
+    expect(normalisedScaleSuffix(false).trim().length).toBeGreaterThan(3)
+    expect(priorRangeLabel(false).trim().length).toBeGreaterThan(3)
+    expect(estimateGapText(0.25, false)).toMatch(/0\.25/)
+    expect(estimateGapText(0.25, false).replace('0.25', '').trim().length).toBeGreaterThan(3)
+  })
+
+  it('reserves the technical term for expert mode, and keeps it there', () => {
+    expect(normalisedScaleSuffix(true)).toBe('(normalised)')
+    expect(priorRangeLabel(true)).toBe('Prior')
+    expect(estimateGapText(0.25, true)).toBe('Δ 0.25')
+  })
+
+  it('the default register carries NONE of the three technical tokens', () => {
+    for (const plain of [normalisedScaleSuffix(false), priorRangeLabel(false), estimateGapText(0.25, false)]) {
+      expect(plain).not.toMatch(/normalised/i)
+      expect(plain).not.toMatch(/Δ/)
+      expect(plain).not.toMatch(/\bPrior\b/)
+    }
+  })
+
+  it('the gap text asserts no direction — the producer is a signed-free magnitude', () => {
+    // ContestedEdgeCard.tsx:267 is Math.abs(pass1Mean - pass2Mean). Copy that
+    // said "increased by"/"fell by" would invent information (trap 13c).
+    expect(estimateGapText(0.25, false)).not.toMatch(/increase|decrease|higher|lower|rose|fell|up|down/i)
+  })
+})
+
+// ── 2. FactorsSection — (normalised) on a model-space value ─────────────────
+
+describe('FactorsSection: a model-space value names its scale in words by default', () => {
+  it('expert OFF — the suffix is plain English and does NOT say (normalised)', () => {
+    withDetail(false, <FactorsSection factorNodes={[normalisedFactor('f1', 'Score')]} />)
+    const el = screen.getByTestId('factor-f1-normalised-label')
+    expect(el).toHaveTextContent(normalisedScaleSuffix(false))
+    expect(el.textContent).not.toMatch(/normalised/i)
+  })
+
+  it('expert ON — the technical term is RESTORED, not deleted', () => {
+    withDetail(true, <FactorsSection factorNodes={[normalisedFactor('f1', 'Score')]} />)
+    expect(screen.getByTestId('factor-f1-normalised-label')).toHaveTextContent('(normalised)')
+  })
+
+  it('the quantity itself survives in BOTH registers — the number is never hidden', () => {
+    const { unmount } = withDetail(false, <FactorsSection factorNodes={[normalisedFactor('f1', 'Score')]} />)
+    expect(screen.getByTestId('factor-f1-value-display')).toBeInTheDocument()
+    unmount()
+    withDetail(true, <FactorsSection factorNodes={[normalisedFactor('f1', 'Score')]} />)
+    expect(screen.getByTestId('factor-f1-value-display')).toBeInTheDocument()
+  })
+})
+
+// ── 3. FactorsSection — Prior label + prior-range (normalised) ──────────────
+
+describe('FactorsSection: a prior is named as the starting estimate by default', () => {
+  it('expert OFF — the label is plain and the word "Prior" is absent from the row', () => {
+    withDetail(false, <FactorsSection factorNodes={[externalFactorWithPrior('x1', 'Market growth')]} />)
+    const el = screen.getByTestId('factor-x1-prior-label')
+    expect(el).toHaveTextContent(priorRangeLabel(false))
+    expect(el.textContent).not.toMatch(/\bPrior\b/)
+  })
+
+  it('expert ON — "Prior" is RESTORED', () => {
+    withDetail(true, <FactorsSection factorNodes={[externalFactorWithPrior('x1', 'Market growth')]} />)
+    expect(screen.getByTestId('factor-x1-prior-label')).toHaveTextContent('Prior')
+  })
+
+  it('expert OFF — the prior RANGE suffix is plain English', () => {
+    withDetail(false, <FactorsSection factorNodes={[externalFactorWithPrior('x1', 'Market growth')]} />)
+    const el = screen.getByTestId('factor-x1-normalised-range')
+    expect(el).toHaveTextContent(normalisedScaleSuffix(false))
+    expect(el.textContent).not.toMatch(/normalised/i)
+  })
+
+  it('expert ON — the prior RANGE suffix restores (normalised)', () => {
+    withDetail(true, <FactorsSection factorNodes={[externalFactorWithPrior('x1', 'Market growth')]} />)
+    expect(screen.getByTestId('factor-x1-normalised-range')).toHaveTextContent('(normalised)')
+  })
+
+  it('the range bounds themselves survive in BOTH registers', () => {
+    const { unmount } = withDetail(false, <FactorsSection factorNodes={[externalFactorWithPrior('x1', 'M')]} />)
+    expect(screen.getByTestId('factor-x1-prior-min-display')).toBeInTheDocument()
+    expect(screen.getByTestId('factor-x1-prior-max-display')).toBeInTheDocument()
+    unmount()
+    withDetail(true, <FactorsSection factorNodes={[externalFactorWithPrior('x1', 'M')]} />)
+    expect(screen.getByTestId('factor-x1-prior-min-display')).toBeInTheDocument()
+    expect(screen.getByTestId('factor-x1-prior-max-display')).toBeInTheDocument()
+  })
+})
+
+// ── 4. OptionsSection — normalised intervention target ──────────────────────
+
+describe('OptionsSection: a normalised intervention target names its scale in words', () => {
+  it('expert OFF — the target reads plainly and does NOT say (normalised)', () => {
+    const { option, factor } = optionWithNormalisedIntervention()
+    withDetail(false, <OptionsSection optionNodes={[option]} allNodes={[factor]} />)
+    const el = screen.getByTestId('intervention-opt1-f1-display')
+    expect(el).toHaveTextContent('0.80')
+    expect(el).toHaveTextContent(normalisedScaleSuffix(false))
+    expect(el.textContent).not.toMatch(/normalised/i)
+  })
+
+  it('expert ON — (normalised) is RESTORED alongside the same number', () => {
+    const { option, factor } = optionWithNormalisedIntervention()
+    withDetail(true, <OptionsSection optionNodes={[option]} allNodes={[factor]} />)
+    const el = screen.getByTestId('intervention-opt1-f1-display')
+    expect(el).toHaveTextContent('0.80')
+    expect(el).toHaveTextContent('(normalised)')
+  })
+})
+
+// ── 5. ContestedEdgeCard — the Δ glyph ──────────────────────────────────────
+
+describe('ContestedEdgeCard: the estimate gap is described in words by default', () => {
+  it('expert OFF — the card carries the magnitude in words and NO Δ glyph', () => {
+    const { edge, nodes, validation, expected } = contestedFixture()
+    withDetail(false, <ContestedEdgeCard edge={edge} nodes={nodes} validation={validation} isFragile={false} onResolve={vi.fn()} />)
+    const el = screen.getByTestId('contested-estimate-gap-e1')
+    expect(el).toHaveTextContent(estimateGapText(0.25, false))
+    expect(el).toHaveTextContent(expected)
+    expect(el.textContent).not.toMatch(/Δ/)
+  })
+
+  it('expert ON — the Δ glyph is RESTORED with the same magnitude', () => {
+    const { edge, nodes, validation, expected } = contestedFixture()
+    withDetail(true, <ContestedEdgeCard edge={edge} nodes={nodes} validation={validation} isFragile={false} onResolve={vi.fn()} />)
+    const el = screen.getByTestId('contested-estimate-gap-e1')
+    expect(el).toHaveTextContent('Δ')
+    expect(el).toHaveTextContent(expected)
+  })
+
+  it('the magnitude is never dropped — it is present in BOTH registers', () => {
+    const { edge, nodes, validation, expected } = contestedFixture()
+    const { unmount } = withDetail(false, <ContestedEdgeCard edge={edge} nodes={nodes} validation={validation} isFragile={false} onResolve={vi.fn()} />)
+    expect(screen.getByTestId('contested-estimate-gap-e1').textContent).toContain(expected)
+    unmount()
+    withDetail(true, <ContestedEdgeCard edge={edge} nodes={nodes} validation={validation} isFragile={false} onResolve={vi.fn()} />)
+    expect(screen.getByTestId('contested-estimate-gap-e1').textContent).toContain(expected)
+  })
+})
+
+// ── 6. THE MOUNT PATH — bind to the gate that actually ships ────────────────
+
+describe('the gate these sections read is the one the deployed flag feeds', () => {
+  function Probe() {
+    const { showDetail } = useContext(DetailToggleContext)
+    return <span data-testid="probe">{String(showDetail)}</span>
+  }
+
+  it('ModelTabHeader is the provider, and it forwards its showDetail prop verbatim', () => {
+    const { unmount } = render(
+      <ModelTabHeader factorCount={1} edgeCount={1} showDetail={false}><Probe /></ModelTabHeader>,
+    )
+    expect(screen.getByTestId('probe')).toHaveTextContent('false')
+    unmount()
+    render(<ModelTabHeader factorCount={1} edgeCount={1} showDetail><Probe /></ModelTabHeader>)
+    expect(screen.getByTestId('probe')).toHaveTextContent('true')
+  })
+
+  it('ModelTabBody binds that prop to expertMode — fails loud if the flag path moves', () => {
+    // The estate has twice shipped a feature dark because tests targeted a
+    // component the deployed posture does not render. This asserts the LINK
+    // between the persisted `olumi.expertMode` state and the context above it,
+    // so moving the flag REDs here instead of silently un-gating the copy.
+    const here = dirname(fileURLToPath(import.meta.url))
+    const body = readFileSync(join(here, '..', '..', 'ModelTabBody.tsx'), 'utf8')
+    expect(body).toMatch(/showDetail=\{\s*expertMode\s*\?\?\s*false\s*\}/)
+  })
+})
+
+// ── 7. DERIVED GUARD — no ungated technical notation left in model-tab ──────
+
+describe('the notation lives in ONE place, derived rather than mirrored', () => {
+  const here = dirname(fileURLToPath(import.meta.url))
+  const DIR = join(here, '..')
+  const OWNER = 'statisticalNotation.ts'
+
+  function sourceFiles(): string[] {
+    return readdirSync(DIR, { withFileTypes: true })
+      .filter(e => e.isFile() && /\.tsx?$/.test(e.name))
+      .map(e => join(DIR, e.name))
+  }
+
+  /** Strip block/line comments so this file's own prose cannot trip the scan. */
+  function codeOnly(src: string): string {
+    return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1')
+  }
+
+  it('POSITIVE CONTROL: the scan detects the tokens it bans', () => {
+    const sample = 'const a = "(normalised)"\nconst b = <span>Δ {x}</span>\n'
+    expect(codeOnly(sample)).toMatch(/\(normalised\)/)
+    expect(codeOnly(sample)).toMatch(/Δ/)
+  })
+
+  it('CONTRAST CONTROL: it does not fire on the plain forms', () => {
+    const honest = `const a = "${normalisedScaleSuffix(false)}"\nconst b = "${estimateGapText(0.25, false)}"\n`
+    expect(codeOnly(honest)).not.toMatch(/\(normalised\)/)
+    expect(codeOnly(honest)).not.toMatch(/Δ/)
+  })
+
+  it('the corpus is non-empty and contains the components under test, BY NAME', () => {
+    // An empty or mis-filtered directory would make the absence below vacuous.
+    const names = sourceFiles().map(f => basename(f))
+    expect(names.length).toBeGreaterThan(5)
+    expect(names).toContain('FactorsSection.tsx')
+    expect(names).toContain('OptionsSection.tsx')
+    expect(names).toContain('ContestedEdgeCard.tsx')
+    expect(names).toContain(OWNER)
+  })
+
+  it('`(normalised)` and `Δ` appear in NO model-tab source but the wording table', () => {
+    const offenders = sourceFiles()
+      .filter(f => basename(f) !== OWNER)
+      .filter(f => /\(normalised\)|Δ/.test(codeOnly(readFileSync(f, 'utf8'))))
+      .map(f => basename(f))
+    expect(offenders).toEqual([])
+  })
+})

--- a/src/canvas/components/model-tab/statisticalNotation.ts
+++ b/src/canvas/components/model-tab/statisticalNotation.ts
@@ -1,0 +1,80 @@
+/**
+ * PLAIN-LANGUAGE STATISTICAL NOTATION — one wording table, gated by the ONE
+ * expert-mode authority.
+ *
+ * ## The defect this closes
+ *
+ * A UX gate on the frozen deployed build (UI `2b6ec553`) read the Model surface
+ * as a FRESH GUEST with expert mode OFF and found `(normalised)` ×5, `Prior` ×2
+ * and `Δ` ×13. The same gate found 0 snake_case, 0 UUIDs and 0 hex ids with a
+ * positive control firing — so this was never a general rawness problem, it was
+ * a bounded leak of STATISTICAL VOCABULARY past a control that exists precisely
+ * to keep modelling internals away from a first-time reader.
+ *
+ * ## Why a formatter and NOT a new gate
+ *
+ * There is exactly ONE expert-mode authority and this module deliberately does
+ * not become a second one. The chain, derived at `2b6ec553`:
+ *
+ *   OutputsDock.tsx:1053   useState ← localStorage['olumi.expertMode']
+ *   OutputsDock.tsx:~3278  expertMode ──▶ ModelTabBody
+ *   ModelTabBody.tsx:811   showDetail={expertMode ?? false} ──▶ ModelTabHeader
+ *   ModelTabHeader.tsx:24  DetailToggleContext.Provider value={{ showDetail }}
+ *   every section          const { showDetail } = useContext(DetailToggleContext)
+ *
+ * Every function here takes that SAME `showDetail` as a parameter. It decides
+ * WORDING, never VISIBILITY — so there is no second decision to drift out of
+ * step with the first. `FactorsSection` already consumed the context (`:158`)
+ * and honoured it at `:485` and `:560`; the leaking lines simply sat outside it.
+ *
+ * ## Why the quantity is never deleted
+ *
+ * Deleting the term would be the worse failure. A normalised value genuinely is
+ * normalised, a prior genuinely is a prior, and a delta genuinely is a change —
+ * a reader who cannot tell a prior from a posterior, or a normalised score from
+ * a raw one, will MISREAD the model, and "scientific credibility" is the whole
+ * product claim. So the default says the same thing in the product's voice and
+ * expert mode restores the technical term. Both directions are pinned by tests;
+ * a single-direction test would let a fix that simply deletes the term pass.
+ *
+ * ## Why "the model's own scale" and not "a 0–1 scale"
+ *
+ * Derived, not assumed. `OptionsSection`'s `looksNormalised` predicate DOES
+ * require `0 ≤ v ≤ 1` (`OptionsSection.tsx:93-95`), but `FactorsSection`'s
+ * normalised value is `formatSmartNumber(obs.value)` with NO bound asserted
+ * anywhere (`FactorsSection.tsx:205`), and the prior min/max are free-text
+ * editable. Writing "0–1" at those two sites would be a precision the data does
+ * not carry — the exact shape of trap 13d, a guard stating more than its source
+ * supports. One honest phrase, true at all three sites, beats two phrasings for
+ * one concept.
+ */
+
+/**
+ * Suffix marking a value that is in model space rather than a real-world unit.
+ * Default names the scale in words; expert mode restores `(normalised)`.
+ */
+export function normalisedScaleSuffix(showDetail: boolean): string {
+  return showDetail ? '(normalised)' : "on the model's own scale"
+}
+
+/**
+ * Label for an external factor's prior range — the belief held BEFORE evidence.
+ * `NodeInspector.tsx:652` already glosses the same term as "(belief before
+ * evidence)"; this is that gloss promoted to the default label.
+ */
+export function priorRangeLabel(showDetail: boolean): string {
+  return showDetail ? 'Prior' : 'Starting range'
+}
+
+/**
+ * The gap between two independent estimates of the same edge strength.
+ *
+ * ⚠ The producer is `Math.abs(pass1Mean - pass2Mean)` (`ContestedEdgeCard.tsx:267`)
+ * — a MAGNITUDE, sign-free. So the plain form says "differ by" and asserts no
+ * direction. Naming a direction here would invent information the quantity does
+ * not carry, which is the same class of harm as hiding it.
+ */
+export function estimateGapText(magnitude: number, showDetail: boolean): string {
+  const value = magnitude.toFixed(2)
+  return showDetail ? `Δ ${value}` : `estimates differ by ${value}`
+}


### PR DESCRIPTION
## The defect

A UX gate on the frozen deployed build (UI `2b6ec553` · CEE `19a60fd` · PLoT `fb63b03` · ISL `28fe0c9`), fresh guest, live DOM read, **expert mode OFF**, found `(normalised)` ×5, `Prior` ×2 and `Δ` ×13 on the Model surface. The same gate read **0 snake_case, 0 UUIDs, 0 hex ids with a positive control firing** — so this is a bounded leak of *statistical vocabulary*, not general rawness.

## The expert-mode authority — there is exactly ONE

Derived at `2b6ec553`, end to end:

| Hop | Location |
|---|---|
| state + persistence | `OutputsDock.tsx:1053` — `useState` lazily seeded from `localStorage['olumi.expertMode']`; written back `:1064` |
| into the Model tab | `OutputsDock.tsx:3278` — `expertMode={expertMode}` on `<ModelTabBody>` (branch `effectiveActiveTab === 'diagnostics'`, `:3264` — the code id for the user-facing "Model") |
| into the surface gate | `ModelTabBody.tsx:811` — `showDetail={expertMode ?? false}` |
| the provider | `ModelTabHeader.tsx:24` — `DetailToggleContext.Provider value={{ showDetail }}` |
| every consumer | `const { showDetail } = useContext(DetailToggleContext)` in all nine model-tab sections |

**No competitor.** `CompareTabBody.oneExpertMode.spec.tsx` already asserts exactly one expert-mode storage key. `ModelAdjustments.tsx:190` holds a *local* `useState` also called `showDetail`, but it is a per-card "Details" disclosure — a shadowing **name**, not a second gate.

## What was actually wrong

All three leaks were **UI copy**, all on the Model tab, all sitting **outside a gate their own components already consumed**. `FactorsSection` read the context at `:158` and honoured it at `:485` and `:560`; the leaking lines simply never asked.

| Leak | Site | Now shows (expert OFF) |
|---|---|---|
| `Prior` | `FactorsSection.tsx:397` | **Starting range** |
| `(normalised)` | `FactorsSection.tsx:423` (prior range) | **on the model's own scale** |
| `(normalised)` | `FactorsSection.tsx:475` (value) | **on the model's own scale** |
| `(normalised)` | `OptionsSection.tsx:299` (intervention target) | **on the model's own scale** |
| `Δ 0.25` | `ContestedEdgeCard.tsx:338` | **estimates differ by 0.25** |

Expert ON restores every technical term unchanged.

## No second gate, and no deleted quantity

`statisticalNotation.ts` decides **wording only** and takes the *same* `showDetail` every section already consumes. It has no state, no storage, no flag — so there is no second decision that can drift out of step with the first.

The quantity is never removed. Every case is pinned in **both** directions, because the inverse harm is the dangerous one: a test that only asserted "the default does not say `Δ`" would be satisfied by a fix that deleted the number, leaving a bare figure whose meaning depends on the term just removed. Mutants **M2/M4/M6** (always-plain) and **M7** (drops the magnitude) exist to prove that cannot pass.

## Why "the model's own scale" and not "a 0–1 scale"

Derived, not assumed. `OptionsSection`'s `looksNormalised` predicate *does* require `0 ≤ v ≤ 1` (`OptionsSection.tsx:93-95`) — but `FactorsSection`'s normalised value is `formatSmartNumber(obs.value)` with **no bound asserted anywhere** (`:205`), and the prior min/max are free-text editable. Writing "0–1" at those two sites would state a precision the data does not carry. One phrase that is true at all three sites beats two phrasings for one concept.

Likewise `estimateGapText` says "differ by" and names **no direction**: the producer is `Math.abs(pass1Mean - pass2Mean)` (`ContestedEdgeCard.tsx:267`), a sign-free magnitude. Inventing a direction would be the same class of harm as hiding the number.

## Verification

- **RED-first**, 23 collected by name, 8 failed at pristine with named signatures; all 23 green after the fix.
- **13 mutants, all bitten, control exactly zero** — including the discriminating pair **M8/M11** (loosen one call site → only that site's test REDs, the other stays green), which proves each assertion binds to *its own* object rather than to any element that happens to match.
- Mutation worktree at an absolute path **outside** the repo root; isolation proven by **writing a sentinel** and checking the source hash was unchanged (inodes differ); restores read from a **pristine tar archive**, never `git checkout -- <path>`; leading **and** trailing controls both read `applied=0` and green.
- Gate step sequence run in order: **lint** (0 errors; hooks ratchet exact) → **typecheck** (within baseline, 2263/2263 — one new TS6133 was fixed at source, not baselined) → **five guards** → full suite.

## Two things this PR deliberately does NOT do

1. **`NodeInspector.tsx` is untouched.** It is the Inspector — a different surface — it is gated by nothing at all, and **#790 is open against that vertical**. Its `Prior` at `:652` already carries the gloss "(belief before evidence)", which is where this PR's default wording comes from.
2. **`RunHistory.tsx:253` renders `(Δ ±x)`** from `runHistory.ts:328` and is **not** routed through any gate — but the component has **zero importers** repo-wide (contrast control: `OutputsDock` returns 3 for the same query shape), so it is unmounted and did not contribute to the witness. Left alone under the scope rule.

## One open seam, reported rather than masked

`OptionsSection.tsx:296` renders CEE's `display_value` **verbatim** (the F.6 passthrough). The `(normalised)` string is a UI literal in the *fallback* branch, so this leak is entirely UI-owned — but the passthrough is a channel by which CEE could send notation the UI renders unfiltered, and the UI cannot gate copy it does not author. Golden-fixture `display_value`s are plain English and no upstream leak is evidenced. **Not** papered over in the view.

## Collision check

29 open PRs swept, all diffs retrieved. Nothing in flight touches `FactorsSection.tsx`, `OptionsSection.tsx` or `DetailToggleContext.tsx`. `ModelTabBody.tsx` is contended by #790/#782/#791 and this PR **does not edit it** (only a read-only source assertion in a test). ⚠ **#790 (DO-NOT-MERGE) renames `model-tab/ContestedEdgeCard.tsx` → `contested/ContestedEdgeCard.tsx`** — latent rename collision, no text conflict today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
