### PR TITLE
feat(chips): render Run on the turn that offers it — gate on CEE's may_run

### DIFF
--- a/src/adapters/cee/types.ts
+++ b/src/adapters/cee/types.ts
@@ -443,6 +443,23 @@ export interface CEEAnalysisReady {
    */
   blocked_reason?: string
   /**
+   * CEE's OWN admission answer for this turn — will the analysis proceed if
+   * asked, right now? (cee `src/orchestrator/types.ts`,
+   * `GraphPatchBlockData.analysis_ready.may_run`, `resolveRunAdmission(...)
+   * .willProceed` — the boolean CEE's own run path throws on.)
+   *
+   * ⚠ NOT A RESTATEMENT OF `status`. `status` is the stricter *"is this model
+   * ready as it stands?"*; `may_run` is ALSO true when the run will proceed by
+   * excluding options the user left open. One `status` value
+   * (`needs_user_input`) carries BOTH verdicts, so `status` cannot be read to
+   * recover this — which is the whole reason the field exists.
+   *
+   * ABSENT means a pre-`may_run` CEE, never "no". Consumers must fall back to
+   * their existing behaviour when it is missing, so the two services can deploy
+   * in either order.
+   */
+  may_run?: boolean
+  /**
    * User-facing questions explaining issues when status is not 'ready'.
    * E.g., "The factor 'Price' doesn't have a path to the goal. Is this correct?"
    */

--- a/src/canvas/conversation/__tests__/SuggestedChips.mayRunGate.spec.tsx
+++ b/src/canvas/conversation/__tests__/SuggestedChips.mayRunGate.spec.tsx
@@ -1,0 +1,125 @@
+/**
+ * `analysis_ready.may_run` — the Run chip must render on the turn that offers it.
+ *
+ * ## THE DEFECT
+ *
+ * The readiness answer loop's payoff turn says *"that's enough to run — two
+ * options have effects set, I'll leave the others out and say so"*. At exactly
+ * that turn CEE's `analysis_ready.status` is `needs_user_input` (the model is not
+ * ready AS IT STANDS) while the run path WILL admit it (it proceeds by excluding
+ * the open options). The chip gate read only `status === 'ready'`, so the
+ * affordance the turn had just promised was filtered out of the chip row.
+ *
+ * Measured in CEE on the `live-4day-week` capture: ONE status value
+ * (`needs_user_input`) carries BOTH admission verdicts, depending on how many
+ * options are unconfigured. No reading of `status` can recover the answer —
+ * which is why the producer now publishes its own verdict as `may_run`.
+ *
+ * ## THE GATE IS A DISJUNCTION, AND THAT IS DELIBERATE
+ *
+ *     admitted = status === 'ready' || may_run === true
+ *
+ * A strict WIDENING. Every chip that renders today still renders: the old term
+ * is untouched and the new term can only ever add. An older CEE that sends no
+ * `may_run` is byte-for-byte today's behaviour, so the two services may deploy
+ * in either order. `=== true` is strict, so a malformed or unexpected value can
+ * never widen the gate by accident.
+ *
+ * ## OPPOSITE DIRECTION, ASSERTED IN THE SAME RUN
+ *
+ * A model that must NOT run must still not offer the chip. `may_run: false` and
+ * absent-`may_run` are both pinned below; without them this spec would certify a
+ * gate that had simply been thrown open.
+ */
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+import { SuggestedChips } from '../zones/SuggestedChips'
+import { useCanvasStore } from '../../store'
+import type { ActionChip } from '../types'
+
+function makeChip(overrides: Partial<ActionChip> = {}): ActionChip {
+  return {
+    id: overrides.id ?? 'chip_1',
+    label: 'Run analysis',
+    intent: 'primary',
+    message: 'Please run the analysis now',
+    ...overrides,
+  }
+}
+
+/** Seed the slice exactly as the wire delivers it, including an absent `may_run`. */
+function setReadiness(status: string | null, mayRun?: boolean) {
+  const payload = status
+    ? {
+        goal_node_id: 'goal_1',
+        status,
+        options: [{ id: 'opt_1', label: 'A', status: 'ready', interventions: {} }],
+        ...(mayRun === undefined ? {} : { may_run: mayRun }),
+      }
+    : null
+  useCanvasStore.setState({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ceeAnalysisReady: payload as any,
+  })
+}
+
+function renderRunChip() {
+  render(<SuggestedChips chips={[makeChip({ action_type: 'run_analysis' })]} onChipClick={vi.fn()} />)
+  return screen.queryByTestId('suggested-chip-chip_1')
+}
+
+describe('SuggestedChips — may_run gate', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_ENABLE_V5_ORCHESTRATOR', 'true')
+    setReadiness(null)
+  })
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    setReadiness(null)
+  })
+
+  it('THE PAYOFF TURN — renders run_analysis when status is needs_user_input but may_run is true', () => {
+    // Precondition stated in the fixture itself: the status is one the OLD gate
+    // rejects, so a pass here is provably the new term's doing.
+    setReadiness('needs_user_input', true)
+    expect(renderRunChip()).toBeInTheDocument()
+  })
+
+  it('OPPOSITE DIRECTION — a model that must NOT run keeps the chip hidden (may_run false)', () => {
+    setReadiness('needs_user_input', false)
+    expect(renderRunChip()).toBeNull()
+  })
+
+  it('FALLBACK — an older CEE that sends no may_run keeps today behaviour exactly (unready → hidden)', () => {
+    setReadiness('needs_user_input')
+    expect(renderRunChip()).toBeNull()
+  })
+
+  it('FALLBACK — an older CEE that sends no may_run keeps today behaviour exactly (ready → shown)', () => {
+    setReadiness('ready')
+    expect(renderRunChip()).toBeInTheDocument()
+  })
+
+  it('WIDENING, NEVER NARROWING — a strictly-ready model still renders whatever may_run says', () => {
+    // CEE proves `status === 'ready'` implies `may_run === true`, so the second
+    // arm is unreachable in production. It is pinned anyway: if that invariant
+    // ever broke, this gate must still not REMOVE a chip that renders today.
+    setReadiness('ready', true)
+    expect(renderRunChip()).toBeInTheDocument()
+    cleanup()
+    setReadiness('ready', false)
+    expect(renderRunChip()).toBeInTheDocument()
+  })
+
+  it('a non-boolean may_run never widens the gate — strict === true', () => {
+    // Guards against a rogue/legacy producer stringifying the field.
+    setReadiness('needs_user_input', 'true' as unknown as boolean)
+    expect(renderRunChip()).toBeNull()
+  })
+
+  it('may_run does not resurrect a chip when the whole slice is missing', () => {
+    setReadiness(null)
+    expect(renderRunChip()).toBeNull()
+  })
+})

--- a/src/canvas/conversation/zones/SuggestedChips.tsx
+++ b/src/canvas/conversation/zones/SuggestedChips.tsx
@@ -20,7 +20,11 @@ import { typography } from '../../../styles/typography'
 import { isV5Eligible } from '../../../v5/eligibility'
 import { logV5StateEvent } from '../../../v5/debugLog'
 import { isAiPanelV2Enabled } from '../../../flags'
-import { useAnalysisStatus } from '../../hooks/useAnalysisReady'
+import {
+  admitsRunAffordance,
+  useAnalysisMayRun,
+  useAnalysisStatus,
+} from '../../hooks/useAnalysisReady'
 import { useCanvasStore } from '../../store'
 import { type FreshnessDisplaySemantic } from '../../store/analysisFreshness'
 import { useAnalysisTrust } from '../../hooks/useAnalysisTrust'
@@ -141,6 +145,9 @@ export function SuggestedChips({
   // fly; hoisting the two subscribers keeps React's dispatcher aligned.
   const [chipError, setChipError] = useState<string | null>(null)
   const analysisStatus = useAnalysisStatus()
+  // CEE's own admission verdict for this turn. `undefined` on a pre-`may_run`
+  // CEE, which `admitsRunAffordance` reads as "fall back to `status`".
+  const analysisMayRun = useAnalysisMayRun()
   // aiPanelV2 polish: once an analysis has been RUN (results exist), the
   // canonical place for re-running it is the Analysis/readiness panel.
   // Decision is via `decideRunAnalysisPolish` (product rule, see helper above):
@@ -177,7 +184,9 @@ export function SuggestedChips({
     : 'keep'
 
   // Filter rule (V5 active):
-  //   action_type === 'run_analysis' → gated by analysisStatus === 'ready',
+  //   action_type === 'run_analysis' → gated by `admitsRunAffordance`, i.e.
+  //                                    analysisStatus === 'ready' OR CEE's own
+  //                                    may_run === true,
   //                                    EXCEPT when aiPanelV2 will relabel to
   //                                    "Rerun" (stale/cannot-confirm), in which
   //                                    case the chip must survive the gate so the
@@ -193,7 +202,13 @@ export function SuggestedChips({
         const isV5Known = V5_ENABLED_ACTIONS.has(c.action_type)
         if (!isV5Known) return false
         const needsReadiness = READINESS_GATED_ACTIONS.has(c.action_type)
-        if (needsReadiness && analysisStatus !== 'ready') {
+        // WIDENED (was `analysisStatus !== 'ready'`): CEE now publishes its own
+        // admission verdict, which is ALSO true when the run will proceed by
+        // excluding the options the user left open. That is the readiness loop's
+        // payoff turn — `needs_user_input` AND runnable — where the old gate hid
+        // the very affordance the turn had just offered. Disjunction, so nothing
+        // that rendered before stops rendering; see `admitsRunAffordance`.
+        if (needsReadiness && !admitsRunAffordance(analysisStatus, analysisMayRun)) {
           // Single bypass: run_analysis survives when the polish will
           // relabel it. The decision is upstream (`runAnalysisPolish`).
           if (c.action_type === 'run_analysis' && runAnalysisPolish === 'relabel-rerun') {
@@ -213,7 +228,11 @@ export function SuggestedChips({
         c.action_type &&
         V5_ENABLED_ACTIONS.has(c.action_type) &&
         READINESS_GATED_ACTIONS.has(c.action_type) &&
-        analysisStatus !== 'ready' &&
+        // Mirrors the gate above, INCLUDING the may_run term — a dev log that
+        // reported a chip as "removed for unreadiness" while the gate had in
+        // fact admitted it would be a mirror telling a different story from the
+        // code beside it.
+        !admitsRunAffordance(analysisStatus, analysisMayRun) &&
         // Mirror the bypass — a chip that survived shouldn't show up as
         // "removed" in the dev log.
         !(c.action_type === 'run_analysis' && runAnalysisPolish === 'relabel-rerun'),
@@ -229,6 +248,7 @@ export function SuggestedChips({
         count: removedUnready.length,
         action_types: removedUnready.map((c) => c.action_type ?? 'null'),
         analysis_status: analysisStatus,
+        analysis_may_run: analysisMayRun ?? null,
       })
     }
   }

--- a/src/canvas/hooks/useAnalysisReady.ts
+++ b/src/canvas/hooks/useAnalysisReady.ts
@@ -31,6 +31,54 @@ export function useIsAnalysisReady(): boolean {
 }
 
 /**
+ * CEE's own admission verdict for this turn (`analysis_ready.may_run`), or
+ * `undefined` when the producer did not send one.
+ *
+ * `undefined` is load-bearing and must not be collapsed to `false`: it means a
+ * pre-`may_run` CEE, and the consumer's job is then to fall back to whatever it
+ * did before. See {@link admitsRunAffordance}.
+ */
+export function useAnalysisMayRun(): boolean | undefined {
+  return useCanvasStore((s) => s.ceeAnalysisReady?.may_run)
+}
+
+/**
+ * May a Run affordance be offered on this turn?
+ *
+ *     admitted = status === 'ready' || may_run === true
+ *
+ * ⭐ A DISJUNCTION, ON PURPOSE — THIS IS A WIDENING, NOT A REPLACEMENT.
+ *
+ * `status === 'ready'` is the historical gate and is left exactly as it was, so
+ * every affordance that renders today still renders — including when CEE sends
+ * no `may_run` at all, which makes the two services deploy-order independent.
+ * The second term can only ever ADD, never remove.
+ *
+ * WHY THE SECOND TERM IS NEEDED. `status` answers *"is this model ready as it
+ * stands?"*; `may_run` answers *"will the run proceed if asked?"* — which is
+ * also true when the run proceeds by excluding the options the user left open.
+ * That is the readiness loop's payoff turn: `needs_user_input` AND admissible.
+ * Measured in CEE on the `live-4day-week` capture, ONE status value carries BOTH
+ * admission verdicts, so no reading of `status` can recover the answer.
+ *
+ * WHY `=== true` AND NOT `!== false`. The route-level `may_run` is three-valued
+ * (`true | false | 'unknown'`) because a caller can fail to REACH that route; on
+ * the turn payload there is no such case, and ABSENCE already carries "producer
+ * did not say". Strict `=== true` therefore means an unexpected or malformed
+ * value can never widen the gate by accident.
+ *
+ * ⚠ It is deliberately NOT this function's job to decide that a run is a good
+ * idea — only that CEE would accept it. `may_run` IS the predicate CEE's own run
+ * path admits on, so a chip shown on it cannot lead to a refusal.
+ */
+export function admitsRunAffordance(
+  analysisStatus: string,
+  mayRun: boolean | undefined,
+): boolean {
+  return analysisStatus === 'ready' || mayRun === true
+}
+
+/**
  * Returns the option array from the slice, or `null` when no readiness
  * state is present. Consumers that need option count / status breakdown
  * (e.g. pre-analysis panel) use this instead of reading the whole slice.


### PR DESCRIPTION
## The defect

The readiness answer loop's payoff turn says *"that's enough to run — two options have effects set, I'll leave the others out and say so"*. **At exactly that turn the Run chip was filtered out.**

The gate read `analysis_ready.status === 'ready'` (`SuggestedChips.tsx:196`). But `status` answers the **stricter** question *"is this model ready as it stands?"*. The payoff turn is `needs_user_input` **with an admitting run path**, because the run proceeds by excluding the options the user left open.

Measured in CEE on the real `live-4day-week` capture — **one status value carries both verdicts**:

| unconfigured options | `status` | `willProceed` |
|---|---|---|
| 1 | `needs_user_input` | **true** |
| 2 | `needs_user_input` | false |
| 3 | `needs_user_input` | false |

So no reading of `status` can recover admissibility. CEE now publishes its own verdict as `analysis_ready.may_run`.

## The change

```
admitted = status === 'ready' || may_run === true
```

A **strict widening**, deliberately a disjunction:

- The old term is untouched, so **everything that renders today still renders**.
- When CEE sends no `may_run`, behaviour is byte-for-byte today's — so **the two services may deploy in either order**.
- `=== true` is strict, so a malformed value can never widen the gate by accident.

`may_run` is `resolveRunAdmission(...).willProceed` — literally the boolean CEE's own run path throws `AnalysisNotReadyError` on — so **a chip shown on it cannot lead to a refusal**.

The DEV filter log mirrors the same predicate: a mirror reporting a chip as "removed for unreadiness" while the gate had admitted it would tell a different story from the code beside it.

## No contract change

`may_run` rides inside `analysis_ready`, which is `.passthrough()` in the pinned `@talchain/schemas` 0.48.0 — **no re-vendor, no schemas release**. Proven by executing the vendored schema; the same field at *top level* is rejected `unrecognized_keys`, which is why it rides inside.

## Evidence

**RED-first** (`SuggestedChips.mayRunGate.spec.tsx`, 7 tests): 1 failing at pristine — the payoff turn — and **6 passing**. The opposite-direction and fallback guards already held, which is what shows the gate was *widened*, not thrown open.

**Mutants** (throwaway worktree outside the repo root; isolation proven by writing a sentinel and asserting the source was byte-identical; distinct inodes; restore from a pristine archive, never `git checkout -- <path>`; applied-check scoped to `src/`, control exactly 0; trailing control green):

| mutant | expect | result |
|---|---|---|
| drop the `may_run` term | RED | RED — bit **only** the payoff test |
| drop the `status` term | RED | RED — bit both fallback / no-narrowing tests |
| `=== true` → `!== false` | RED | RED ×3 incl. the strict-true guard |
| always admit | RED | RED ×4 incl. opposite-direction |
| **unrelated fn (discriminator)** | **GREEN** | **GREEN 7/7** |

The last row is the discriminating pair: mutating a *different* function in the *same file* leaves the spec green, so the spec is bound to `admitsRunAffordance` by identity rather than merely sensitive to any edit.

**Gates:** `pnpm typecheck` PASSED (coverage + ratchet, 3570/3610 files). `pnpm lint` 0 errors; rules-of-hooks ratchet exactly matches baseline (229 known / 13 files) despite the added hook. All four `SuggestedChips` specs green together — **71 tests, 0 failures** — so the existing readiness-gate and aiPanelV2-polish specs are unregressed. My own spec's collected count asserted **by name**: 7.

## Land order

**CEE first, then this.** Both halves are safe alone: CEE's field is unread until this lands, and this falls back to today's behaviour until CEE ships. Cross-linked to the CEE PR below.

⚠ **Do not merge** — cross-repo, and a staging witness is running.
