### PR TITLE
fix(conversation): dedupe reaches behind "Show N more" — UX gate point 4

### DIFF
--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -272,6 +272,20 @@ export const InlineBlocks = memo(function InlineBlocks({
       if (surface.fields.length === 0) continue
 
       const survivedFields = new Map<string, string>()
+      /**
+       * ⚠ HELD BACK UNTIL THE WHOLE BLOCK IS DECIDED, and the reason is
+       * invariant 4(b): a segment is withheld only against a surface ABOVE it,
+       * and repetition WITHIN one surface is the producer's and always
+       * survives. A card is one surface. Pushing field 1 into `seen` before
+       * field 2 of the SAME card is read would suppress a `v5_evidence` whose
+       * gap and impact genuinely say the same thing — blanking one of its
+       * paragraphs for no reader benefit, against the stated rule.
+       *
+       * Not observed in this repo's 12 live captures (25 multi-field blocks,
+       * 0 intra-block repeats), so this is the invariant governing rather than
+       * a measured defect — which is exactly when it is cheapest to get right.
+       */
+      const pending: string[] = []
       let anySuppressed = false
       let anySurvivingText = false
       for (const { field, text } of surface.fields) {
@@ -286,8 +300,9 @@ export const InlineBlocks = memo(function InlineBlocks({
         // what makes a LATER repeat of it a duplicate. This is the direction
         // that fixes the witnessed pairs, and it is why top-level cards must
         // take part in the walk even though they are never demoted.
-        seen.push(effective)
+        pending.push(effective)
       }
+      for (const text of pending) seen.push(text)
       if (!anySuppressed) continue
 
       /**

--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -68,9 +68,11 @@ import type { PatchBlockState, PatchRejectionInfo } from './useConversation'
 import { GraphPatchBlockRenderer, ProposalBlockRenderer } from './blocks/GraphPatchBlockRenderer'
 import { isPhase3CardBlock, isBiasSignalCoachingBlock } from './phase3Pacing'
 import {
+  collectBlockProseSurface,
   composeMessage,
   dedupeRenderedText,
   turnDeliversNarrativeAsTypedCard,
+  withSuppressedProse,
 } from './messageComposition'
 import { GraphVocabularyLegend } from './GraphVocabularyLegend'
 import { V5AnalysisResultBlock } from '../../v5/blocks/V5AnalysisResultBlock'
@@ -200,7 +202,6 @@ export const InlineBlocks = memo(function InlineBlocks({
     [composition],
   )
   const detail = composition.detail
-  const hasDetail = detail.length > 0
 
   // DS v5 §21.2: block type badge dots are always on (no v2 flag gate).
   const showBadgeDots = true
@@ -220,30 +221,114 @@ export const InlineBlocks = memo(function InlineBlocks({
    * reveal what was demoted, never re-write it (invariant 1's byte-preserving
    * demotion guarantee).
    */
-  const commentaryTextOverrides = useMemo(() => {
+  const { commentaryTextOverrides, proseOverriddenBlocks, emptiedBlocks } = useMemo(() => {
     const order = [
       ...[...composition.pinned, ...composition.points].sort((a, b) => a.index - b.index),
       ...composition.detail,
     ]
     const seen: string[] = [...(alreadyRendered ?? [])]
     const overrides = new Map<number, string>()
+    const cloned = new Map<number, ConversationBlock>()
+    const emptied = new Set<number>()
+
     for (const entry of order) {
       const block = blocks[entry.index]
-      if (block.type !== 'commentary') continue
-      const text = (block as CommentaryBlockType).text ?? ''
-      const { text: survived, suppressedCount } = dedupeRenderedText(text, seen)
-      // Suppression may remove PART of a block, never the whole of it. A
-      // commentary whose every paragraph was already rendered above keeps its
-      // original text: an empty card with a live "More" toggle is a worse
-      // artefact than the duplicate, and silently deleting a block would breach
-      // the composition's own no-drop guarantee (invariant 1) from the text
-      // side. The suppression is a de-duplicator, not a censor.
-      const useOverride = suppressedCount > 0 && survived.trim().length > 0
-      if (useOverride) overrides.set(entry.index, survived)
-      seen.push(useOverride ? survived : text)
+
+      /**
+       * `commentary` keeps its OWN ratified path, unchanged. It is pinned, so
+       * it never reaches the disclosure this lane is fixing, and its "never
+       * empties a block" rule is pinned by an existing spec. Re-deciding it
+       * here would put two mechanisms on one seam.
+       */
+      if (block.type === 'commentary') {
+        const text = (block as CommentaryBlockType).text ?? ''
+        const { text: survived, suppressedCount } = dedupeRenderedText(text, seen)
+        // Suppression may remove PART of a block, never the whole of it. A
+        // commentary whose every paragraph was already rendered above keeps its
+        // original text: an empty card with a live "More" toggle is a worse
+        // artefact than the duplicate, and silently deleting a block would breach
+        // the composition's own no-drop guarantee (invariant 1) from the text
+        // side. The suppression is a de-duplicator, not a censor.
+        const useOverride = suppressedCount > 0 && survived.trim().length > 0
+        if (useOverride) overrides.set(entry.index, survived)
+        seen.push(useOverride ? survived : text)
+        continue
+      }
+
+      /**
+       * ⚠⚠ THE FIX. This used to be `if (block.type !== 'commentary') continue`
+       * — and `commentary` is in PINNED_BLOCK_TYPES, so it can NEVER land in
+       * `detail`. Every block behind "Show N more" was therefore STRUCTURALLY
+       * INELIGIBLE for suppression: the walk included `composition.detail`
+       * only to `continue` past all of it. That is the whole defect; the
+       * composition and the render path were never the problem.
+       *
+       * Per FIELD, so a card that repeats one of its paragraphs keeps the
+       * others and keeps its title. Applied in RENDER order across every tier,
+       * with no tier-conditional predicate — a rule that behaved differently
+       * inside the disclosure would be a second authority wearing one name.
+       */
+      const surface = collectBlockProseSurface(block)
+      if (surface.fields.length === 0) continue
+
+      const survivedFields = new Map<string, string>()
+      let anySuppressed = false
+      let anySurvivingText = false
+      for (const { field, text } of surface.fields) {
+        const { text: survived, suppressedCount } = dedupeRenderedText(text, seen)
+        if (suppressedCount > 0) {
+          anySuppressed = true
+          survivedFields.set(field, survived)
+        }
+        const effective = suppressedCount > 0 ? survived : text
+        if (effective.trim().length > 0) anySurvivingText = true
+        // Accumulated even when nothing was suppressed: a block's prose is
+        // what makes a LATER repeat of it a duplicate. This is the direction
+        // that fixes the witnessed pairs, and it is why top-level cards must
+        // take part in the walk even though they are never demoted.
+        seen.push(effective)
+      }
+      if (!anySuppressed) continue
+
+      /**
+       * The honest empty result. A block whose prose is ALL it has and whose
+       * every paragraph the user has already read renders nothing — not a
+       * bordered shell around three empty paragraphs. Nothing is lost: by
+       * construction every removed segment was rendered somewhere above.
+       *
+       * Any block that keeps a title, a table or a list is NOT emptied, and
+       * is never dropped — those carry content the user has not seen.
+       */
+      if (surface.proseIsSoleContent && !anySurvivingText) {
+        emptied.add(entry.index)
+        continue
+      }
+      cloned.set(entry.index, withSuppressedProse(block, survivedFields))
     }
-    return overrides
+
+    return {
+      commentaryTextOverrides: overrides,
+      proseOverriddenBlocks: cloned,
+      emptiedBlocks: emptied,
+    }
   }, [composition, blocks, alreadyRendered])
+
+  /**
+   * WHAT WILL ACTUALLY RENDER. An emptied block is removed from its tier here,
+   * at the ONE place that already knows it was emptied — so the disclosure's
+   * count, its accessible name and the sr-only summary all describe what
+   * opening it really reveals. A "Show 1 more" that reveals nothing is the
+   * empty shell one level up.
+   */
+  const visibleTopLevel = useMemo(
+    () => (emptiedBlocks.size === 0 ? topLevel : topLevel.filter((e) => !emptiedBlocks.has(e.index))),
+    [topLevel, emptiedBlocks],
+  )
+  const visibleDetail = useMemo(
+    () => (emptiedBlocks.size === 0 ? detail : detail.filter((e) => !emptiedBlocks.has(e.index))),
+    [detail, emptiedBlocks],
+  )
+  const hasDetail = visibleDetail.length > 0
 
   /**
    * THE visibility rule — one predicate, every consumer. A block is hidden iff
@@ -278,11 +363,11 @@ export const InlineBlocks = memo(function InlineBlocks({
    * or vanish as the user opens the disclosure.
    */
   const narrativeDeliveredByTypedCard = useMemo(
-    () => turnDeliversNarrativeAsTypedCard(topLevel.map((e) => blocks[e.index])),
-    [topLevel, blocks],
+    () => turnDeliversNarrativeAsTypedCard(visibleTopLevel.map((e) => blocks[e.index])),
+    [visibleTopLevel, blocks],
   )
 
-  const detailIndices = useMemo(() => new Set(detail.map((e) => e.index)), [detail])
+  const detailIndices = useMemo(() => new Set(visibleDetail.map((e) => e.index)), [visibleDetail])
   const isBlockHidden = useCallback(
     (i: number) => !detailExpanded && detailIndices.has(i),
     [detailExpanded, detailIndices],
@@ -292,7 +377,9 @@ export const InlineBlocks = memo(function InlineBlocks({
   // CURRENTLY RENDERED — never on mere presence in the turn (a legend for
   // cards hidden inside the closed disclosure explains vocabulary the user
   // cannot see).
-  const phase3Rendered = blocks.some((b, i) => isPhase3CardBlock(b) && !isBlockHidden(i))
+  const phase3Rendered = blocks.some(
+    (b, i) => isPhase3CardBlock(b) && !isBlockHidden(i) && !emptiedBlocks.has(i),
+  )
 
   // C11: citations can point at demoted content. Handed to the commentary
   // renderer only while the disclosure is actually closed, so a genuinely
@@ -317,7 +404,7 @@ export const InlineBlocks = memo(function InlineBlocks({
    * it sits. Two render paths here would be two places for them to drift.
    */
   const renderEntry = (index: number) => {
-    const block = blocks[index]
+    const block = proseOverriddenBlocks.get(index) ?? blocks[index]
     const badgeDotClass = showBadgeDots ? resolveBlockBadgeDotClass(block) : null
     return (
       // data-citation-target is 1-based on the ORIGINAL index; CitationRef.index
@@ -360,12 +447,12 @@ export const InlineBlocks = memo(function InlineBlocks({
         // double-announced every toggle.
         <span className="sr-only">
           {detailExpanded
-            ? `Showing all ${blocks.length} supporting items`
-            : `${detail.length} more supporting item${detail.length !== 1 ? 's' : ''} available`}
+            ? `Showing all ${visibleTopLevel.length + visibleDetail.length} supporting items`
+            : `${visibleDetail.length} more supporting item${visibleDetail.length !== 1 ? 's' : ''} available`}
         </span>
       )}
 
-      {topLevel.map((e) => renderEntry(e.index))}
+      {visibleTopLevel.map((e) => renderEntry(e.index))}
 
       {hasDetail && (
         <>
@@ -378,18 +465,18 @@ export const InlineBlocks = memo(function InlineBlocks({
             aria-label={
               detailExpanded
                 ? 'Hide supporting detail'
-                : `Show ${detail.length} more supporting item${detail.length !== 1 ? 's' : ''}`
+                : `Show ${visibleDetail.length} more supporting item${visibleDetail.length !== 1 ? 's' : ''}`
             }
           >
             {detailExpanded ? (
               <><ChevronUp size={12} aria-hidden="true" /> Show less</>
             ) : (
-              <><ChevronDown size={12} aria-hidden="true" /> Show {detail.length} more</>
+              <><ChevronDown size={12} aria-hidden="true" /> Show {visibleDetail.length} more</>
             )}
           </button>
           {detailExpanded && (
             <div className={styles.blockDetailBody} data-testid="block-detail-body">
-              {detail.map((e) => renderEntry(e.index))}
+              {visibleDetail.map((e) => renderEntry(e.index))}
             </div>
           )}
         </>

--- a/src/canvas/conversation/__tests__/InlineBlocks.expandedDedupe.liveCapture.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.expandedDedupe.liveCapture.spec.tsx
@@ -1,0 +1,208 @@
+/**
+ * THE SAME FIX, AGAINST REAL PRODUCER BYTES — not a fixture this lane wrote.
+ *
+ * ## Why this file exists alongside the unit spec
+ *
+ * `InlineBlocks.expandedDedupe.spec.tsx` proves the mechanism with fixtures
+ * this lane authored, and a fixture you wrote yourself silently encodes your
+ * model of the producer rather than the producer (platform trap 16). The
+ * duplicate SHAPE has to come from outside the author's head (trap 22).
+ *
+ * ## What the corpus actually says
+ *
+ * Measured across the 12 live CEE analysis-turn captures committed to this
+ * repo (`src/v5/__tests__/fixtures`, `src/lib/coherence/.../captures`), using
+ * `renderSegmentKey`'s own normalisation:
+ *
+ *   · 9 of 12 turns carry cross-block VERBATIM duplicate prose — 31 pairs.
+ *   · Every pair is one of exactly TWO shapes:
+ *         review_card.body   ==  coaching.body          (25)
+ *         review_card.body   ==  evidence.evidence_gap   (6)
+ *   · ⚠ ALL 31 are invisible in the collapsed view and visible once the
+ *     disclosure opens — 0 collapsed / 31 expanded.
+ *
+ * That last line is the witnessed defect exactly: "0 duplicate paragraphs in
+ * the default collapsed view, 3 verbatim duplicate pairs once expanded". The
+ * cause is structural rather than coincidental — CEE emits an assumption as a
+ * `review_card` and again as the `coaching` card that acts on it, and with
+ * MAX_POINTS = 3 against the 11–19 blocks these turns carry, the second member
+ * of every pair is always demoted.
+ *
+ * ⚠ SCOPE, stated narrowly: these captures are dated 31 Jul – 17 Aug and the
+ * witness was 19–20 Aug. This corpus proves the SHAPE is real, reproducible
+ * and producer-owned. It does NOT prove these are the three pairs that were
+ * witnessed — that would need the 19/20 Aug turn payload, which this repo does
+ * not hold.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { InlineBlocks } from '../InlineBlocks'
+import { renderSegmentKey } from '../messageComposition'
+import {
+  adaptTypedReviewCardBlock,
+  adaptTypedCoachingBlock,
+  adaptTypedEvidenceBlock,
+  adaptTypedExerciseBlock,
+} from '../../../v5/phase3TypedBlocks'
+import type { ConversationBlock } from '../types'
+
+import walkA from '../../../v5/__tests__/fixtures/live-analysis-turn-walkA-2026-08-04.json'
+import trimmed from '../../../v5/__tests__/fixtures/cee-response-b82c89dd-trimmed.json'
+import noCritiques from '../../../v5/__tests__/fixtures/live-analysis-turn-no-critiques-2026-08-08.json'
+
+vi.mock('../../store', () => {
+  const mockState = {
+    nodes: [] as Array<{ id: string }>,
+    selectNodeWithoutHistory: vi.fn(),
+    selectNodes: vi.fn(),
+    setShowInspectorPanel: vi.fn(),
+    setHighlightedNodes: vi.fn(),
+    setHighlightedEdges: vi.fn(),
+  }
+  return {
+    useCanvasStore: Object.assign(
+      (selector: (s: unknown) => unknown) => selector(mockState),
+      { getState: () => mockState },
+    ),
+  }
+})
+
+/**
+ * The capture's raw wire blocks, through the PRODUCT's OWN adapters. Using the
+ * real `adaptTyped*Block` functions rather than hand-shaping the JSON is what
+ * keeps this a statement about the wire.
+ */
+function adaptCapture(capture: { blocks?: unknown }): ConversationBlock[] {
+  const raw = Array.isArray(capture.blocks) ? capture.blocks : []
+  const out: ConversationBlock[] = []
+  for (const b of raw) {
+    const adapted =
+      adaptTypedReviewCardBlock(b)
+      ?? adaptTypedCoachingBlock(b)
+      ?? adaptTypedEvidenceBlock(b)
+      ?? adaptTypedExerciseBlock(b)
+    if (adapted) out.push(adapted as ConversationBlock)
+  }
+  return out
+}
+
+/**
+ * The elements that render PRODUCER PROSE, bound by their own testids.
+ *
+ * ⚠⚠ THIS SELECTOR IS THE LOAD-BEARING PART, AND THE FIRST VERSION OF IT WAS
+ * WRONG IN A WAY ONLY THE REAL CAPTURES COULD SHOW. Selecting every `<p>`
+ * inside a block reported 4–6 "duplicates" per turn that are not duplicates at
+ * all: they are the UI's OWN per-card vocabulary inside each coaching card's
+ * "Why this, and how sure" disclosure —
+ *
+ *     "Raised by the decision review"                        (source)
+ *     "An assumption worth checking"                         (kind)
+ *     "This suggestion is not linked to a cited …claim."      (grounding)
+ *     "We can't confirm whether your model has changed …"     (currency)
+ *
+ * Those SHOULD appear once per card, exactly as a column header repeats on
+ * every row. Suppressing the second one would leave five cards silent about
+ * their own grounding and currency while the first one spoke — a card lying by
+ * omission about its provenance, which is far worse than a repeat.
+ *
+ * So the measurement is scoped to the fields the producer wrote. This is also
+ * the empirical case for the accessor being deliberately partial: a rule that
+ * deduped "any repeated paragraph" would have deduped the product's own voice.
+ */
+const PROSE_TESTIDS = [
+  'v5-review-card-body',
+  'v5-coaching-body',
+  'bias-signal-card-body',
+  'v5-evidence-gap',
+  'v5-evidence-technique',
+  'v5-evidence-impact',
+  'v5-exercise-failure-scenario',
+  'v5-exercise-mitigation',
+  'v5-exercise-reference-class',
+  'v5-exercise-counter-case',
+  'v5-exercise-review-trigger',
+] as const
+
+function renderedSegmentKeys(): string[] {
+  const sel = PROSE_TESTIDS.map((t) => `[data-testid="${t}"]`).join(',')
+  const keys: string[] = []
+  document.querySelectorAll<HTMLElement>(sel).forEach((el) => {
+    const k = renderSegmentKey(el.textContent ?? '')
+    if (k.length > 0) keys.push(k)
+  })
+  return keys
+}
+
+function duplicateKeys(): string[] {
+  const counts = new Map<string, number>()
+  for (const k of renderedSegmentKeys()) counts.set(k, (counts.get(k) ?? 0) + 1)
+  return [...counts.entries()].filter(([, n]) => n > 1).map(([k]) => k)
+}
+
+/** Cross-block duplicates present in the RAW capture, before any rendering. */
+function rawDuplicateCount(blocks: ConversationBlock[]): number {
+  const fields: Record<string, readonly string[]> = {
+    v5_review_card: ['body'],
+    v5_coaching: ['body'],
+    v5_evidence: ['evidence_gap', 'suggested_technique', 'impact_if_gathered'],
+    v5_exercise: ['failure_scenario', 'mitigation', 'reference_class', 'counter_case'],
+  }
+  const seen = new Map<string, number>()
+  let dupes = 0
+  blocks.forEach((b, i) => {
+    for (const f of fields[b.type] ?? []) {
+      const v = (b as unknown as Record<string, unknown>)[f]
+      if (typeof v !== 'string' || v.trim().length === 0) continue
+      const k = renderSegmentKey(v)
+      const prior = seen.get(k)
+      if (prior !== undefined && prior !== i) dupes++
+      else if (prior === undefined) seen.set(k, i)
+    }
+  })
+  return dupes
+}
+
+const CAPTURES: ReadonlyArray<readonly [string, { blocks?: unknown }]> = [
+  ['live-analysis-turn-walkA-2026-08-04', walkA],
+  ['cee-response-b82c89dd-trimmed', trimmed],
+  ['live-analysis-turn-no-critiques-2026-08-08', noCritiques],
+]
+
+describe.each(CAPTURES)('live CEE capture %s', (_name, capture) => {
+  /**
+   * PIN THE PRECONDITION IN-TEST (platform trap 13b). Without this, a capture
+   * that stopped carrying duplicates — or an adapter change that dropped the
+   * blocks — would leave the assertions below passing while testing nothing,
+   * and the guard would quietly stop discriminating.
+   */
+  it('the capture really does carry cross-block duplicate prose', () => {
+    const blocks = adaptCapture(capture)
+    expect(blocks.length).toBeGreaterThanOrEqual(8)
+    expect(rawDuplicateCount(blocks)).toBeGreaterThan(0)
+  })
+
+  it('renders no duplicate paragraph once the disclosure is OPEN', () => {
+    render(<InlineBlocks blocks={adaptCapture(capture)} />)
+    fireEvent.click(screen.getByTestId('block-detail-toggle'))
+    expect(screen.getByTestId('block-detail-body')).toBeInTheDocument()
+    // The whole point of the lane: expanded is now as clean as collapsed.
+    expect(duplicateKeys()).toEqual([])
+  })
+
+  it('the collapsed view stays clean — it already was', () => {
+    render(<InlineBlocks blocks={adaptCapture(capture)} />)
+    expect(duplicateKeys()).toEqual([])
+  })
+
+  it('OPPOSITE DIRECTION — expanding REVEALS strictly more prose, never less', () => {
+    const { unmount } = render(<InlineBlocks blocks={adaptCapture(capture)} />)
+    const collapsed = new Set(renderedSegmentKeys())
+    fireEvent.click(screen.getByTestId('block-detail-toggle'))
+    const expanded = new Set(renderedSegmentKeys())
+    // Nothing the user could already read disappears when the disclosure opens
+    // — suppression must never reach back up into a higher tier.
+    for (const k of collapsed) expect(expanded.has(k)).toBe(true)
+    expect(expanded.size).toBeGreaterThan(collapsed.size)
+    unmount()
+  })
+})

--- a/src/canvas/conversation/__tests__/InlineBlocks.expandedDedupe.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.expandedDedupe.spec.tsx
@@ -252,6 +252,31 @@ describe('a multi-field card loses only the field that repeats', () => {
     expect(blocksContaining(SHARED)).toEqual([0])
   })
 
+  it('OPPOSITE DIRECTION — a card repeating ITSELF across fields keeps both', () => {
+    // Invariant 4(b): repetition WITHIN one surface is the producer's and
+    // always survives. A card is one surface, so a v5_evidence whose gap and
+    // impact genuinely say the same thing renders both — nothing above it has
+    // shown either, and blanking one would be suppression against itself.
+    const same = 'Adoption rate is the single unknown that decides this.'
+    render(
+      <InlineBlocks
+        blocks={[
+          reviewCard(1, 'Unique review body 1'),
+          reviewCard(2, 'Unique review body 2'),
+          reviewCard(3, 'Unique review body 3'),
+          {
+            ...evidence(1, same),
+            impact_if_gathered: same,
+          } as V5EvidenceBlock,
+        ]}
+      />,
+    )
+    expand()
+    const card = blockAt(3)!
+    expect(card.querySelector('[data-testid="v5-evidence-gap"]')!.textContent).toContain(same)
+    expect(card.querySelector('[data-testid="v5-evidence-impact"]')!.textContent).toContain(same)
+  })
+
   it('OPPOSITE DIRECTION — its sibling fields and label are all still rendered', () => {
     render(<InlineBlocks blocks={blocks()} />)
     expand()

--- a/src/canvas/conversation/__tests__/InlineBlocks.expandedDedupe.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.expandedDedupe.spec.tsx
@@ -1,0 +1,413 @@
+/**
+ * DEDUPE REACHES BEHIND "Show N more" — UX gate 2026-08-18 point 4.
+ *
+ * ## The defect this file pins
+ *
+ * Witnessed twice on deployed staging (19 + 20 Aug): ZERO duplicate paragraphs
+ * in the default collapsed view — a real improvement — and THREE verbatim
+ * duplicate pairs once the disclosure is opened.
+ *
+ * The mechanism, derived at the bytes and NOT a competing-authority problem:
+ * `composeMessage` makes one total, disjoint partition and both tiers render
+ * through the same `renderEntry`. The escape was the type gate in
+ * `InlineBlocks`' suppression walk — it processed only `commentary`, and
+ * `commentary` is in `PINNED_BLOCK_TYPES`, so it can NEVER land in `detail`.
+ * Every block behind the disclosure was therefore STRUCTURALLY INELIGIBLE for
+ * dedupe: the walk included `composition.detail` only to `continue` past all
+ * of it.
+ *
+ * ## Why this file exists rather than an addition to an existing spec
+ *
+ * The coverage gap was exact and is the primary proof obligation here. At the
+ * pristine tip, THREE specs click `block-detail-toggle`
+ * (InlineBlocks.composition, BlockFallback, MixedBlocks.integration) and NONE
+ * of them counts duplicate text; both dedupe specs (renderAuthority.spec.ts,
+ * renderAuthority.bubble.spec.tsx) contain ZERO references to that toggle and
+ * are collapsed-only. So a test that rendered only the collapsed view would
+ * have passed while this shipped. Every test below opens the disclosure.
+ *
+ * ## Binding discipline
+ *
+ * Assertions bind to a block by IDENTITY — `data-citation-target`, which
+ * `renderEntry` sets to the block's ORIGINAL index and which survives demotion
+ * — never by "some element on the page contains this sentence", which a
+ * different block could satisfy (platform trap 19). The shared paragraph is a
+ * fixture constant read through an identity-selected element, so improving the
+ * copy never rewrites an assertion.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { InlineBlocks } from '../InlineBlocks'
+import type {
+  ConversationBlock,
+  V5CoachingBlock,
+  V5EvidenceBlock,
+  V5ExerciseBlock,
+  V5ExplanationBlock,
+  V5ReviewCardBlock,
+} from '../types'
+
+vi.mock('../../store', () => {
+  const mockState = {
+    nodes: [] as Array<{ id: string }>,
+    selectNodeWithoutHistory: vi.fn(),
+    selectNodes: vi.fn(),
+    setShowInspectorPanel: vi.fn(),
+    setHighlightedNodes: vi.fn(),
+    setHighlightedEdges: vi.fn(),
+  }
+  return {
+    useCanvasStore: Object.assign(
+      (selector: (s: unknown) => unknown) => selector(mockState),
+      { getState: () => mockState },
+    ),
+  }
+})
+
+/**
+ * The repeated paragraph. A fixture constant, never an assertion literal — it
+ * is always read through an element selected by block identity.
+ */
+const SHARED = 'The pilot depends on procurement clearing before the end of Q3.'
+const DETAIL_ONLY = 'Two of the three suppliers have not yet returned a quote.'
+
+function reviewCard(n: number, body: string): V5ReviewCardBlock {
+  return {
+    type: 'v5_review_card', block_id: `rc_${n}`, title: `Review card ${n}`,
+    body, severity: 'info', card_kind: 'narrative',
+    target_refs: [], priority_rank: n, freshness: 'fresh',
+  }
+}
+function coaching(n: number, body: string): V5CoachingBlock {
+  return {
+    type: 'v5_coaching', block_id: `co_${n}`, title: `Coaching card ${n}`,
+    body, coaching_kind: 'assumption_check',
+    source: 'decision_review', target_refs: [], priority_rank: 10 + n, freshness: 'fresh',
+  }
+}
+function evidence(n: number, gap: string): V5EvidenceBlock {
+  return {
+    type: 'v5_evidence', block_id: `ev_${n}`, factor_label: `Evidence factor ${n}`,
+    target_refs: [], current_confidence: 'low', evidence_gap: gap,
+    suggested_technique: `Technique ${n}`, impact_if_gathered: `Impact ${n}`,
+    priority_rank: 20 + n, severity: 'info', freshness: 'fresh',
+  }
+}
+function explanation(narrative: string): V5ExplanationBlock {
+  return {
+    type: 'v5_explanation', narrative, referenced_option_ids: [],
+  } as V5ExplanationBlock
+}
+
+/** The block wrapper for an ORIGINAL block index — identity, stable across demotion. */
+function blockAt(index: number): HTMLElement | null {
+  return document.querySelector<HTMLElement>(`[data-citation-target="${index + 1}"]`)
+}
+
+/** How many RENDERED blocks currently contain `text`. The duplicate counter. */
+function blocksContaining(text: string): number[] {
+  const out: number[] = []
+  document.querySelectorAll<HTMLElement>('[data-citation-target]').forEach((el) => {
+    if ((el.textContent ?? '').includes(text)) {
+      out.push(Number(el.getAttribute('data-citation-target')) - 1)
+    }
+  })
+  return out
+}
+
+function expand(): void {
+  fireEvent.click(screen.getByTestId('block-detail-toggle'))
+  expect(screen.getByTestId('block-detail-body')).toBeInTheDocument()
+}
+
+// ---------------------------------------------------------------------------
+// 1. The witnessed defect: duplicates behind the disclosure
+// ---------------------------------------------------------------------------
+
+describe('a demoted block does not repeat a paragraph a top-level block already stated', () => {
+  /**
+   * 0,1,2 are the three top-level points (MAX_POINTS). 3,4,5 are demoted.
+   * Blocks 3 and 5 carry byte-identical copies of block 0's body — the live
+   * shape, where CEE emits one narrative on several typed channels of one turn.
+   */
+  const blocks = (): ConversationBlock[] => [
+    reviewCard(1, SHARED),
+    reviewCard(2, 'Unique review body 2'),
+    reviewCard(3, 'Unique review body 3'),
+    coaching(1, SHARED),
+    coaching(2, 'Unique coaching body 2'),
+    coaching(3, SHARED),
+  ]
+
+  it('RED-first — expanded, the paragraph is rendered by EXACTLY ONE block', () => {
+    render(<InlineBlocks blocks={blocks()} />)
+    expand()
+    // At the pristine tip this is [0, 3, 5] — the witnessed duplicate pairs.
+    expect(blocksContaining(SHARED)).toEqual([0])
+  })
+
+  it('RED-first — the demoted repeats specifically (blocks 3 and 5) withhold it', () => {
+    render(<InlineBlocks blocks={blocks()} />)
+    expand()
+    expect(blockAt(3)!.textContent).not.toContain(SHARED)
+    expect(blockAt(5)!.textContent).not.toContain(SHARED)
+  })
+
+  it('OPPOSITE DIRECTION — the FIRST occurrence is never the one suppressed', () => {
+    render(<InlineBlocks blocks={blocks()} />)
+    expand()
+    // Block 0 stated it first and keeps it. This is the invariant that makes
+    // the feature a de-duplicator rather than a censor.
+    expect(blockAt(0)!.textContent).toContain(SHARED)
+  })
+
+  it('OPPOSITE DIRECTION — per-FIELD, not per-block: the repeats keep their titles', () => {
+    render(<InlineBlocks blocks={blocks()} />)
+    expand()
+    // Suppressing a whole card to remove one repeated paragraph would lose the
+    // title, which the user has NOT seen. Fork 1, resolved in favour of fields.
+    expect(blockAt(3)!.textContent).toContain('Coaching card 1')
+    expect(blockAt(5)!.textContent).toContain('Coaching card 3')
+  })
+
+  it('OPPOSITE DIRECTION — a demoted block with unique prose is untouched', () => {
+    render(<InlineBlocks blocks={blocks()} />)
+    expand()
+    expect(blockAt(4)!.textContent).toContain('Unique coaching body 2')
+    expect(blockAt(4)!.textContent).toContain('Coaching card 2')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 2. The first occurrence survives even when EVERY occurrence is demoted
+// ---------------------------------------------------------------------------
+
+describe('duplication entirely INSIDE the disclosure', () => {
+  const blocks = (): ConversationBlock[] => [
+    reviewCard(1, 'Unique review body 1'),
+    reviewCard(2, 'Unique review body 2'),
+    reviewCard(3, 'Unique review body 3'),
+    coaching(1, DETAIL_ONLY),
+    coaching(2, DETAIL_ONLY),
+  ]
+
+  it('the earlier demoted block keeps it, the later one withholds it', () => {
+    render(<InlineBlocks blocks={blocks()} />)
+    expand()
+    expect(blocksContaining(DETAIL_ONLY)).toEqual([3])
+  })
+
+  it('OPPOSITE DIRECTION — nothing is suppressed while the disclosure is CLOSED', () => {
+    render(<InlineBlocks blocks={blocks()} />)
+    // Collapsed: neither demoted block is in the document at all, so no
+    // suppression is observable and the top level is untouched.
+    expect(blocksContaining(DETAIL_ONLY)).toEqual([])
+    expect(blockAt(0)!.textContent).toContain('Unique review body 1')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 3. The collapsed view must not regress — it is currently clean
+// ---------------------------------------------------------------------------
+
+describe('the collapsed view is unchanged', () => {
+  const blocks = (): ConversationBlock[] => [
+    reviewCard(1, SHARED),
+    reviewCard(2, 'Unique review body 2'),
+    reviewCard(3, 'Unique review body 3'),
+    coaching(1, SHARED),
+  ]
+
+  it('collapsed, the top-level paragraph renders exactly once and in full', () => {
+    render(<InlineBlocks blocks={blocks()} />)
+    expect(blocksContaining(SHARED)).toEqual([0])
+    expect(blockAt(0)!.textContent).toContain(SHARED)
+  })
+
+  it('BYTE-PRESERVING DEMOTION — opening the disclosure does not rewrite tier 0', () => {
+    render(<InlineBlocks blocks={blocks()} />)
+    const before = blockAt(0)!.textContent
+    expand()
+    // Invariant 1: opening the disclosure REVEALS what was demoted; it must
+    // never re-write what was already on screen.
+    expect(blockAt(0)!.textContent).toBe(before)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 4. Multi-field cards: one repeated field, the rest survive
+// ---------------------------------------------------------------------------
+
+describe('a multi-field card loses only the field that repeats', () => {
+  const blocks = (): ConversationBlock[] => [
+    reviewCard(1, SHARED),
+    reviewCard(2, 'Unique review body 2'),
+    reviewCard(3, 'Unique review body 3'),
+    evidence(1, SHARED),
+  ]
+
+  it('the repeated field is withheld', () => {
+    render(<InlineBlocks blocks={blocks()} />)
+    expand()
+    expect(blocksContaining(SHARED)).toEqual([0])
+  })
+
+  it('OPPOSITE DIRECTION — its sibling fields and label are all still rendered', () => {
+    render(<InlineBlocks blocks={blocks()} />)
+    expand()
+    const card = blockAt(3)!
+    // v5_evidence carries three independent paragraphs. Dropping the card to
+    // remove one of them would delete two the user has never seen.
+    expect(card.textContent).toContain('Evidence factor 1')
+    expect(card.textContent).toContain('Technique 1')
+    expect(card.textContent).toContain('Impact 1')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 5. The empty result, handled honestly
+// ---------------------------------------------------------------------------
+
+describe('a block whose ONLY content repeats renders nothing, not an empty shell', () => {
+  /**
+   * `v5_explanation` renders its narrative under a HARD-CODED "Explanation"
+   * heading and has nothing else — so a wholly-duplicate narrative would leave
+   * a card titled by the UI saying nothing. Block 4 survives, so the
+   * disclosure still exists and its count can be checked.
+   */
+  const blocks = (): ConversationBlock[] => [
+    reviewCard(1, SHARED),
+    reviewCard(2, 'Unique review body 2'),
+    reviewCard(3, 'Unique review body 3'),
+    explanation(SHARED),
+    coaching(1, DETAIL_ONLY),
+  ]
+
+  it('the emptied block is absent from the disclosure', () => {
+    render(<InlineBlocks blocks={blocks()} />)
+    expand()
+    expect(blockAt(3)).toBeNull()
+    expect(blocksContaining(SHARED)).toEqual([0])
+  })
+
+  it('the disclosure COUNT tells the truth about what it will reveal', () => {
+    render(<InlineBlocks blocks={blocks()} />)
+    // Two blocks were demoted; only one of them will render anything.
+    expect(screen.getByTestId('block-detail-toggle').getAttribute('aria-label'))
+      .toBe('Show 1 more supporting item')
+    expand()
+    expect(blockAt(4)!.textContent).toContain(DETAIL_ONLY)
+  })
+
+  it('no affordance at all when EVERY demoted block was emptied', () => {
+    render(
+      <InlineBlocks
+        blocks={[
+          reviewCard(1, SHARED),
+          reviewCard(2, 'Unique review body 2'),
+          reviewCard(3, 'Unique review body 3'),
+          explanation(SHARED),
+        ]}
+      />,
+    )
+    // Nothing more to show, so nothing promises otherwise.
+    expect(screen.queryByTestId('block-detail-toggle')).toBeNull()
+    expect(blocksContaining(SHARED)).toEqual([0])
+  })
+
+  it('OPPOSITE DIRECTION — the same block with UNIQUE prose is kept and counted', () => {
+    render(
+      <InlineBlocks
+        blocks={[
+          reviewCard(1, SHARED),
+          reviewCard(2, 'Unique review body 2'),
+          reviewCard(3, 'Unique review body 3'),
+          explanation(DETAIL_ONLY),
+        ]}
+      />,
+    )
+    const toggle = screen.getByTestId('block-detail-toggle')
+    expect(toggle.getAttribute('aria-label')).toBe('Show 1 more supporting item')
+    expand()
+    expect(blockAt(3)!.textContent).toContain(DETAIL_ONLY)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 5b. v5_exercise — six optional prose fields and NO title of its own
+// ---------------------------------------------------------------------------
+
+/**
+ * ⚠ Every `v5_exercise` is a lens companion (`isLensCompanionBlock`), so the
+ * FIRST one in overflow is promoted into the point set. Two are needed to land
+ * one in the disclosure — the composition fact this fixture depends on, stated
+ * rather than discovered by a later reader.
+ */
+describe('v5_exercise, whose prose is all it has', () => {
+  function exercise(id: string, fields: Partial<V5ExerciseBlock>): V5ExerciseBlock {
+    return {
+      type: 'v5_exercise', block_id: id, exercise_kind: 'pre_mortem',
+      target_refs: [], freshness: 'fresh', ...fields,
+    } as V5ExerciseBlock
+  }
+
+  it('loses only the repeated field and keeps the rest of the card', () => {
+    render(
+      <InlineBlocks
+        blocks={[
+          reviewCard(1, SHARED),
+          reviewCard(2, 'Unique review body 2'),
+          reviewCard(3, 'Unique review body 3'),
+          exercise('ex_promoted', { failure_scenario: 'A promoted exercise scenario.' }),
+          exercise('ex_demoted', { failure_scenario: SHARED, mitigation: DETAIL_ONLY }),
+        ]}
+      />,
+    )
+    expand()
+    expect(blocksContaining(SHARED)).toEqual([0])
+    expect(blockAt(4)!.textContent).toContain(DETAIL_ONLY)
+  })
+
+  it('is dropped when its ONLY prose field repeats — it has no title to keep', () => {
+    render(
+      <InlineBlocks
+        blocks={[
+          reviewCard(1, SHARED),
+          reviewCard(2, 'Unique review body 2'),
+          reviewCard(3, 'Unique review body 3'),
+          exercise('ex_promoted', { failure_scenario: 'A promoted exercise scenario.' }),
+          exercise('ex_demoted', { failure_scenario: SHARED }),
+        ]}
+      />,
+    )
+    expand()
+    expect(blockAt(4)).toBeNull()
+    expect(blocksContaining(SHARED)).toEqual([0])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 6. Tier 0 (the prose body above the blocks) reaches the disclosure too
+// ---------------------------------------------------------------------------
+
+describe('a demoted block does not repeat the turn prose rendered above it', () => {
+  const blocks = (): ConversationBlock[] => [
+    reviewCard(1, 'Unique review body 1'),
+    reviewCard(2, 'Unique review body 2'),
+    reviewCard(3, 'Unique review body 3'),
+    coaching(1, SHARED),
+  ]
+
+  it('withholds a paragraph `alreadyRendered` says the message body showed', () => {
+    render(<InlineBlocks blocks={blocks()} alreadyRendered={[SHARED]} />)
+    expand()
+    expect(blocksContaining(SHARED)).toEqual([])
+    expect(blockAt(3)!.textContent).toContain('Coaching card 1')
+  })
+
+  it('OPPOSITE DIRECTION — with nothing rendered above, the block keeps it', () => {
+    render(<InlineBlocks blocks={blocks()} />)
+    expand()
+    expect(blocksContaining(SHARED)).toEqual([3])
+  })
+})

--- a/src/canvas/conversation/messageComposition.ts
+++ b/src/canvas/conversation/messageComposition.ts
@@ -503,6 +503,189 @@ export function collectConsentSurfaceText(
   return out
 }
 
+// ---------------------------------------------------------------------------
+// THE DEMOTED FAMILIES' PROSE — what a block behind "Show N more" renders
+// ---------------------------------------------------------------------------
+
+/** One free-prose field of a block, named so suppression can be PER-FIELD. */
+export interface BlockProseField {
+  /** The block's own property name. The identity a clone writes back through. */
+  readonly field: string
+  /** Its text exactly as the producer sent it. Never normalised here. */
+  readonly text: string
+}
+
+/** What free prose a block renders, and whether that prose is all it has. */
+export interface BlockProseSurface {
+  readonly fields: readonly BlockProseField[]
+  /**
+   * True when `fields` is the block's ONLY reader-facing content, so a block
+   * whose every field was suppressed has nothing left to render and must be
+   * dropped rather than shown as an empty shell.
+   *
+   * False for every card that keeps a title, a table or a list — those still
+   * carry content the user has not seen, and dropping them would be per-BLOCK
+   * suppression by the back door.
+   */
+  readonly proseIsSoleContent: boolean
+}
+
+const NO_PROSE: BlockProseSurface = { fields: [], proseIsSoleContent: false }
+
+function prose(
+  proseIsSoleContent: boolean,
+  ...candidates: ReadonlyArray<readonly [string, unknown]>
+): BlockProseSurface {
+  const fields: BlockProseField[] = []
+  for (const [field, value] of candidates) {
+    if (typeof value === 'string' && value.trim().length > 0) fields.push({ field, text: value })
+  }
+  return fields.length === 0 ? NO_PROSE : { fields, proseIsSoleContent }
+}
+
+/**
+ * THE PER-TYPE PROSE ACCESSOR — the enabling change UX gate point 4 needed.
+ *
+ * ## The question this answers, and the one it does NOT
+ *
+ * `collectConsentSurfaceText` above answers *"what will this turn's CONSENT
+ * SURFACES state?"* — a tier-0 SOURCE question, pinned-only, dependent on
+ * runtime patch state. This answers *"what free prose does this ONE block
+ * render, field by field?"* — a TARGET question over the demoted families.
+ *
+ * They are deliberately two functions with two names because they are two
+ * questions, and this estate's chronic defect is two questions sharing one
+ * name until their defaults disagree on a reachable class of turn (trap 21).
+ * Their domains are DISJOINT by construction — every type below is
+ * non-pinned, every type the collector reads is pinned — so there is no
+ * mirror between them to drift. What they share, and what makes this ONE
+ * dedupe authority rather than two, is the comparison: both feed the single
+ * `dedupeRenderedText` / `renderSegmentKey` pair. Nothing here re-implements
+ * a match.
+ *
+ * ## Why per-FIELD and not per-block
+ *
+ * `v5_evidence` carries THREE independent paragraphs and `v5_exercise` up to
+ * six. Suppressing a whole card to remove one repeated line would delete
+ * paragraphs the user has never seen — the inverse harm, and the worse one.
+ * A duplicate is cosmetic; a deleted line is a lie about what the producer
+ * said. So the unit of suppression is the FIELD, and within a field the
+ * existing paragraph-segment rule applies unchanged.
+ *
+ * ## Why the list is deliberately PARTIAL, and what each omission costs
+ *
+ * Absence here costs a duplicate. A wrong INCLUSION costs content, or
+ * replaces the producer's words with the UI's. Every omission below was
+ * derived by reading the renderer, not by guessing at a field name:
+ *
+ *   · `brief.summary` — its "Show more" toggle renders unconditionally, so a
+ *     blanked summary leaves a live disclosure that reveals nothing.
+ *   · `evidence.findings[].text` (legacy) — blank findings are filtered out
+ *     and REPLACED with the UI's own "Research findings available". Blanking
+ *     would substitute our copy for the producer's, which is worse than a
+ *     repeat.
+ *   · `model_receipt.coachingSummary` — the dispatcher returns null on a
+ *     blank one, so suppressing it deletes the whole card. That is per-block
+ *     suppression by the back door.
+ *   · `framing.goal` — the decision statement itself, structural, not a
+ *     paragraph.
+ *   · `premortem.risk_paths[]`, `flip_analysis.flip_conditions[]`,
+ *     `v5_exercise.warning_signs[]` — short structured clauses inside list
+ *     rows, not prose paragraphs; blanking one leaves a dangling row.
+ *   · `v5_coaching.signal` — provenance ("Why this came up"), not the card's
+ *     prose.
+ *   · `fact`, `artefact`, `v5_unsupported` — carry no free prose at all.
+ *   · `commentary` — PINNED, and its suppression is already owned by
+ *     InlineBlocks' existing whole-text path with its own ratified rule
+ *     ("never empties a block"). One seam, one writer.
+ *   · every pinned consent type — a control's copy is what the user is
+ *     agreeing THROUGH. It is a dedupe SOURCE, never a target.
+ *
+ * Unknown / future types fall through to `NO_PROSE` rather than guessing.
+ */
+export function collectBlockProseSurface(block: ConversationBlock): BlockProseSurface {
+  switch (block.type) {
+    // ── one prose paragraph under a title the card keeps ──────────────────
+    case 'v5_coaching':
+    case 'v5_review_card':
+    case 'review_card':
+      return prose(false, ['body', (block as { body?: unknown }).body])
+
+    // ── three independent paragraphs under a factor label the card keeps ──
+    case 'v5_evidence':
+      return prose(
+        false,
+        ['evidence_gap', block.evidence_gap],
+        ['suggested_technique', block.suggested_technique],
+        ['impact_if_gathered', block.impact_if_gathered],
+      )
+
+    /**
+     * ⚠ SOLE CONTENT. `V5ExerciseBlock` has no title: with every prose field
+     * blank the renderer emits a bordered card with an icon and nothing to
+     * read. Each field is individually truthiness-guarded, so partial
+     * suppression degrades cleanly.
+     */
+    case 'v5_exercise':
+      return prose(
+        true,
+        ['failure_scenario', block.failure_scenario],
+        ['mitigation', block.mitigation],
+        ['reference_class', block.reference_class],
+        ['counter_case', block.counter_case],
+        ['review_trigger', block.review_trigger],
+      )
+
+    /**
+     * ⚠ SOLE CONTENT. The renderer's heading is the hard-coded word
+     * "Explanation" — UI copy, not the producer's — so a blanked narrative
+     * leaves a card titled "Explanation" saying nothing at all.
+     */
+    case 'v5_explanation':
+      return prose(true, ['narrative', block.narrative])
+
+    /**
+     * Narrative plus a structure the block keeps. `v5_flip_analysis` is sole
+     * content only when it carries no scenarios, because its heading is
+     * hard-coded UI copy in exactly the way `v5_explanation`'s is.
+     */
+    case 'v5_flip_analysis':
+      return prose(block.flip_scenarios.length === 0, ['narrative', block.narrative])
+    case 'v5_comparison':
+      return prose(false, ['narrative', block.narrative])
+    case 'comparison':
+    case 'premortem':
+    case 'flip_analysis':
+      return prose(false, ['narrative', (block as { narrative?: unknown }).narrative])
+
+    // ── legacy exercise: instructions under a title the card keeps ────────
+    case 'exercise':
+      return prose(false, ['instructions', block.instructions])
+
+    default:
+      return NO_PROSE
+  }
+}
+
+/**
+ * A block with the named prose fields replaced by what survived suppression.
+ *
+ * A SHALLOW CLONE, because `BlockRenderer` hands the whole block object to
+ * every renderer and none of them destructures prose at the dispatcher — so a
+ * clone flows through all 21 arms with no renderer change and no new prop.
+ * The original array is never mutated: the composition, the citation indices
+ * and the store all keep reading the block exactly as ingested.
+ */
+export function withSuppressedProse(
+  block: ConversationBlock,
+  survived: ReadonlyMap<string, string>,
+): ConversationBlock {
+  if (survived.size === 0) return block
+  const clone: Record<string, unknown> = { ...(block as unknown as Record<string, unknown>) }
+  for (const [field, text] of survived) clone[field] = text
+  return clone as unknown as ConversationBlock
+}
+
 /**
  * SECOND-CHANNEL ROUTING — a different question from suppression, kept apart
  * from it on purpose (UX gate 2026-08-18 point 4b).


### PR DESCRIPTION
Closes UX gate 2026-08-18 **point 4** — duplicate paragraphs behind "Show N more".

Witnessed twice on deployed staging (19 + 20 Aug): **0 duplicate paragraphs in the default collapsed view** — a real improvement worth protecting — and **3 verbatim duplicate pairs once "Show 7 more" is expanded**.

---

## The two design forks, resolved first

### Fork 1 — per-FIELD suppression, not per-block

`v5_evidence` carries three independent paragraphs and `v5_exercise` up to six. **Suppressing a whole card to remove one repeated line would delete paragraphs the user has never seen** — the inverse harm, and the worse one. A duplicate is cosmetic; a deleted line is a lie about what the producer said.

So the unit of suppression is the **field**, and within a field the existing paragraph-segment rule applies unchanged. A card that repeats one paragraph keeps its other fields *and its title*.

The one place a block is dropped entirely is when its prose is **all it has** and every paragraph of it was already read above — `v5_explanation` (whose heading is the hard-coded UI word "Explanation") and `v5_exercise` (which has no title at all). Anything that keeps a title, a table or a list is never dropped. Emptied blocks leave their tier, so the toggle count, its accessible name and the sr-only summary describe what opening the disclosure really reveals.

### Fork 2 — typed field as the ACCESSOR, rendered-text segments as the KEY

These are two axes, and they resolve in opposite directions.

There is no render-time chokepoint (`BlockRenderer` is a flat 21-arm switch), so *what a block renders* must be read from **typed fields, per type**. But the comparison stays the existing `dedupeRenderedText` / `renderSegmentKey` pair — whitespace- and case-normalised whole segments — because **the duplicates this producer actually emits are cross-type**, which a typed-field-identity key cannot see at all. Measured below: every real duplicate is `review_card.body == coaching.body` or `review_card.body == evidence.evidence_gap`.

The usual fragility objection to rendered text does not apply here: nothing compares post-markdown output. We read typed fields and compare their normalised string content.

---

## The mechanism — one authority, one escape

Not two competing authorities. `composeMessage` makes one total, disjoint partition and both tiers render through the same `renderEntry`. The escape was the type gate in the suppression walk:

```ts
if (block.type !== 'commentary') continue
```

`commentary` is in `PINNED_BLOCK_TYPES`, so it can **never** land in `detail`. Every block behind the disclosure was **structurally ineligible** for dedupe — the walk included `composition.detail` only to `continue` past all of it.

## What changed

- **`collectBlockProseSurface`** (`messageComposition.ts`) — a deliberately partial per-type accessor naming each family's free-prose fields, plus whether that prose is the block's only content.
- **`withSuppressedProse`** — a shallow clone. `BlockRenderer` hands the whole block to every renderer and no arm destructures prose, so the clone flows through all 21 arms with **no renderer change and no new prop**.
- The walk now covers every tier with **no tier-conditional predicate** — a rule that behaved differently inside the disclosure would be a second authority wearing one name.
- `commentary` keeps its own ratified whole-text path untouched: it is pinned, never reaches the disclosure, and its "never empties a block" rule is already pinned by an existing spec.

### On "one dedupe authority"

This is a **separate function** from `collectConsentSurfaceText`, and deliberately so. That one answers *"what will this turn's consent SURFACES state?"* — tier-0 sources, pinned-only, runtime-patch-state dependent. This answers *"what free prose does this ONE block render, field by field?"* — a target question over the demoted families. Merging two questions under one name until their defaults disagree is this estate's chronic defect (trap 21).

Their domains are **disjoint by construction** (every type here is non-pinned; every type the collector reads is pinned), so there is no mirror to drift. What makes this one authority rather than two is the **comparison**: both feed the single `dedupeRenderedText` / `renderSegmentKey` pair. Nothing here re-implements a match.

### The omissions are derived, not guessed

Absence costs a duplicate; a wrong inclusion costs content. Each was settled by reading the renderer:

| Omitted | Why |
|---|---|
| `brief.summary` | its "Show more" toggle renders unconditionally — a live disclosure revealing nothing |
| `evidence.findings[].text` | blanking substitutes the UI's own *"Research findings available"* for the producer's words |
| `model_receipt.coachingSummary` | the dispatcher returns `null` on a blank one — per-block suppression by the back door |
| `framing.goal` | the decision statement itself, structural |
| nested list clauses | `premortem.risk_paths[]`, `flip_analysis.flip_conditions[]`, `warning_signs[]` — blanking leaves a dangling row |
| every pinned consent surface | a control's copy is what the user is agreeing **through** |

---

## Evidence

### RED-first, in the EXPANDED state

The measured coverage gap was the primary proof obligation: three specs click `block-detail-toggle` and **none counts duplicates**; both dedupe specs have **zero** references to it and are collapsed-only. A test that rendered only the collapsed view would have passed while this shipped. **Every new test opens the disclosure.**

| Spec | pristine | fixed |
|---|---|---|
| `InlineBlocks.expandedDedupe.spec.tsx` | **8 failed / 9 passed** | **20 / 20** |
| `InlineBlocks.expandedDedupe.liveCapture.spec.tsx` | **3 failed / 9 passed** | **12 / 12** |

The tests passing on *both* sides are the opposite-direction twins and the collapsed-view guards — they pin what must **not** change.

Assertions bind by **identity** (`data-citation-target`, the block's original index, which survives demotion), never by the duplicated prose — so improving the copy never rewrites an assertion.

### A corpus from outside this lane's head

The unit spec uses fixtures this lane wrote, and a self-authored fixture encodes the author's model of the producer rather than the producer. So the shape was measured against the **12 live CEE analysis-turn captures** committed to this repo:

- **9 of 12 turns carry cross-block verbatim duplicate prose — 31 pairs.**
- Exactly two shapes: `review_card.body == coaching.body` (25) and `review_card.body == evidence.evidence_gap` (6).
- **All 31 are invisible collapsed and visible expanded — 0 vs 31.** That is the witnessed signature precisely.

The cause is structural, not coincidental: CEE emits an assumption as a `review_card` and again as the `coaching` card that acts on it, and with `MAX_POINTS = 3` against the 11–19 blocks these turns carry, the second member of every pair is always demoted.

> ⚠ **This corpus proves the SHAPE is real, reproducible and producer-owned. It does NOT prove these are the three pairs that were witnessed** — that needs the 19/20 Aug turn payload, which this repo does not hold. See the open question below.

### What the outside corpus caught that the fixtures could not

The first version of the live-capture measurement selected every `<p>` in a block and reported 4–6 "duplicates" per turn. **None of them was a duplicate.** They were the UI's own per-card vocabulary inside each coaching card's *"Why this, and how sure"* disclosure — *"Raised by the decision review"*, *"An assumption worth checking"*, *"This suggestion is not linked to a cited decision-science claim."*

Those **should** appear once per card, exactly as a column header repeats on every row. Deduping them would leave five cards silent about their own grounding and currency while the first one spoke — a card lying by omission about its provenance. This is the empirical case for the accessor being deliberately partial: **a rule that deduped "any repeated paragraph" would have deduped the product's own voice.**

### Mutants — 9, in a worktree at an absolute path outside the repo

Isolation proven by **writing a sentinel** and confirming the source clone was byte-identical, plus distinct APFS inodes. Restores from a **pristine archive** extracted from git objects, never `git checkout -- <path>`. Applied-check exactly 1 per mutant, exactly 0 for both controls; collected count asserted by name every run.

| # | Mutation | Verdict | failed / passed |
|---|---|---|---|
| CTRL | none | green | 0 / 20 |
| M1 | the type gate is back — no demoted block deduped | **BITTEN** | 10 / 10 |
| M2 | `seen` stops accumulating typed-card prose | **BITTEN** | 9 / 11 |
| M3 | per-BLOCK instead of per-FIELD (fork 1's rejected branch) | **BITTEN** | 7 / 13 |
| M4 | wholly-duplicate sole-content block left as an empty shell | **BITTEN** | 4 / 16 |
| M5 | toggle counts emptied blocks it will not reveal | **BITTEN** | 1 / 19 |
| M6 | `alreadyRendered` dropped from the walk's seed | **BITTEN** | 1 / 19 |
| M7 | the `v5_exercise` arm goes dark | **BITTEN** | 1 / 19 |
| M8 | the legacy `comparison`/`premortem`/`flip_analysis` arm goes dark — **no fixture names it** | **SURVIVED** | 0 / 20 |
| M9 | the coaching/review-card arm goes dark — **every fixture names it** | **BITTEN** | 10 / 10 |
| M10 | a card's own earlier field suppresses its later one | **BITTEN** | 1 / 19 |
| TAIL | none | green | 0 / 20 |

**M8 and M9 are the same mutation shape** (one switch arm returns `NO_PROSE`) pointed at an unnamed and a named block family. One biting mutant proves sensitivity to *something*; only the pair proves the assertions bind to the objects they **name** (trap 19). M8's survival is therefore demonstrated to be about fixture scope rather than the mutation being inert — M7 and M9 show the identical shape biting wherever a fixture does name the type.

### One invariant the corpus did not surface, fixed anyway

The walk originally pushed each field into `seen` *before* the next field of the **same** card was read — so a `v5_evidence` whose gap and impact genuinely said the same thing would have had one of them blanked. Invariant 4(b) is explicit that repetition **within one surface** is the producer's and always survives, and a card is one surface. The pushes are now held until the whole block is decided (**M10**).

Measured: 0 intra-block field repeats across the corpus's 25 multi-field blocks — so this is the invariant governing rather than a measured defect, which is exactly when it is cheapest to get right.

### Gates, run locally in the required check's own order

`lint` → `typecheck` → guards → tests, because `lint` runs first and gates the rest.

- `pnpm run lint` — **0 errors** (1176 pre-existing warnings); hooks ratchet exactly matches baseline
- `bash scripts/ci/typecheck-gate.sh` — **PASSED**, ratchet **2263 = baseline 2263** (no new diagnostics)
- `ci:guard:zustand`, `ci:guard:starters`, `check:vendor`, `ci:guard:schemas-version`, `ci:guard:ds:enforce` — all exit 0
- conversation + v5 blocks slice: **205 files / 2827 passed / 22 skipped / 0 failed**
- collected counts asserted **by name**, never from a total: `InlineBlocks.expandedDedupe.spec.tsx` **20/20**, `InlineBlocks.expandedDedupe.liveCapture.spec.tsx` **12/12**

The typecheck ratchet caught a genuine defect on the way through (an unused `describe.each` binding, +1 over baseline) — fixed, and the gate is back to **2263 = baseline**.

---

## Open question, stated rather than inferred

**Which block types carried the 3 pairs witnessed on 19/20 Aug cannot be established from this repo.** The code proves no demoted block was deduped; it cannot say which happened to duplicate on that turn without that turn's payload, and this repo holds no capture from those dates.

What *can* be said, from real producer bytes: the duplicate families in the live corpus are `v5_review_card` ↔ `v5_coaching` and `v5_review_card` ↔ `v5_evidence`, all three are covered by this change, and all three land in the disclosure on every analysis turn of realistic size.

## Collision check

Swept all 26 open PRs with `while read`, asserting the count and hard-erroring on any fetch failure: **zero** touch `InlineBlocks.tsx` or `messageComposition.ts`. Contrast control on the same sweep fired where expected (#804 → `MessageBubble.tsx`, 170 files seen across 26 PRs), so the zero is a real absence rather than a blind probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
