### PR TITLE
Remove dead ISL inference-warning loop reading a slot no producer writes

### DIFF
--- a/src/canvas/components/pre-analysis/hooks/usePreAnalysisData.ts
+++ b/src/canvas/components/pre-analysis/hooks/usePreAnalysisData.ts
@@ -59,26 +59,6 @@ import type { DiversifiedTriage } from '../utils/diversifyTriageItems'
 // other test specs still exercise it directly.
 
 // ============================================================================
-// ISL inference warning labels (Task 8)
-// ============================================================================
-
-/** Maps ISL critique codes to user-facing labels for Model quality section */
-const ISL_CRITIQUE_LABELS: Record<string, { title: string; description: string }> = {
-  IDENTIFIABILITY_WARNING: {
-    title: 'Causal identification concern',
-    description: 'Some effects in the model may not be uniquely identifiable from the available data.',
-  },
-  UNMEASURED_CONFOUNDING_WARNING: {
-    title: 'Potential unmeasured confounders',
-    description: 'Some causal paths may share hidden common causes, affecting reliability.',
-  },
-  WEAK_INSTRUMENT_WARNING: {
-    title: 'Weak causal pathway',
-    description: 'A causal path has low statistical power, making its effect estimate unreliable.',
-  },
-}
-
-// ============================================================================
 // Types
 // ============================================================================
 
@@ -620,8 +600,6 @@ export function usePreAnalysisData(_coaching?: CoachingPayload): PreAnalysisData
     const fromTopLevel = report?.critiques as Array<{ code: string; message?: string; affected_nodes?: string[]; affectedNodes?: string[] }> | undefined
     return fromRun ?? fromTopLevel ?? undefined
   })
-  // Results report for ISL inference warnings (Task 8)
-  const resultsReport = useCanvasStore(s => s.results?.report)
   // Task 7: Quality scores from CEE draft
   const ceeQuality = useCanvasStore(s => s.ceeQuality)
   // Task 6: Pipeline trace for repair_summary
@@ -1788,28 +1766,12 @@ export function usePreAnalysisData(_coaching?: CoachingPayload): PreAnalysisData
       }
     }
 
-    // ISL inference warnings → validity category
-    const islWarnings = (resultsReport as Record<string, unknown> | undefined)?.run as Record<string, unknown> | undefined
-    const inferenceWarnings = (islWarnings?.inference_warnings ?? []) as Array<{ code: string; message?: string; affected_nodes?: string[] }>
-    for (const w of inferenceWarnings) {
-      const mapping = ISL_CRITIQUE_LABELS[w.code]
-      checks.push({
-        id: `isl_${w.code}`,
-        message: mapping?.title ?? w.code,
-        detail: mapping?.description ?? 'Scientific concern detected',
-        cta: 'Ask AI to explain',
-        ctaAction: `ask_ai_isl_${w.code}`,
-        pill: 'verify',
-        category: 'validity',
-      })
-    }
-
     // Sort by category: structure → bias → validity
     const CATEGORY_ORDER: Record<string, number> = { structure: 0, bias: 1, validity: 2 }
     checks.sort((a, b) => (CATEGORY_ORDER[a.category] ?? 9) - (CATEGORY_ORDER[b.category] ?? 9))
 
     return checks
-  }, [nodesByKind, edges, ceeAnalysisReady?.options, ceeAnalysisReady?.bias_findings, successThreshold, goalNode, totalReviewableFactorsCount, plotCritiques, nodes, resultsReport])
+  }, [nodesByKind, edges, ceeAnalysisReady?.options, ceeAnalysisReady?.bias_findings, successThreshold, goalNode, totalReviewableFactorsCount, plotCritiques, nodes])
 
   // =========================================================================
   // Task 6: Model adjustments with resolved labels + repair actions from trace

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -347,8 +347,11 @@ export const ResultsBody = memo(function ResultsBody({
 
       {/* Roadmap 1.12 (provisional_doctrine_v0): warning-severity producer
           inference_warnings surface as a compact honest-caveat strip beside
-          the freshness area. Producer message verbatim; info-severity stays
-          hidden; renders nothing when no warning-severity entries exist. */}
+          the freshness area. Copy is HUMANISED via humaniseInferenceWarningTitle
+          (the V14.3 no-message-render guard — the strip keys off producer `code`
+          and never renders the raw producer `message`; see
+          InferenceWarningStrip.tsx:11-17,70). Info-severity stays hidden;
+          renders nothing when no warning-severity entries exist. */}
       <InferenceWarningStrip warnings={resultsSectionData.confidence.inferenceWarnings} />
 
       {/* Lane 3 Car 1 residual (ROADMAP 2.358 closure): WARNING-severity


### PR DESCRIPTION
## What

Deletes a loop in `usePreAnalysisData.ts` that was **dead by contract** and would have rendered a **bare machine code** to a user had it ever woken up:

```ts
message: mapping?.title ?? w.code,   // bare ISL code as a user-visible pre-analysis check
```

Net: **−41 / +6**.

## Why — two independent defects

**1. The read targets a slot nothing writes.** The loop read `report.run.inference_warnings`.

Complete writer manifest for the report-shaped `run` slot in production code (`src/**`, excluding `__tests__`/`*.spec.*`/fixtures), re-derived at `de8af49a`:

| # | Site | Keys emitted |
|---|------|--------------|
| 1 | `src/v5/mapV5AnalysisToReport.ts:1491` | `responseHash`, `critique` |
| 2 | `src/adapters/plot/v2/responseMapper.ts:578` | `responseHash`, `critique`, `bands` |
| 3 | `src/adapters/plot/v2/responseMapper.ts:1323` | `responseHash`, `critique` |

**None emits `inference_warnings`.** Contrast control in the same manifest: the sibling key `critique` is present in **all three** — so the probe is sighted, and the target's absence is real rather than blindness.

The type agrees: `CanonicalRun` (`src/adapters/plot/types.ts:317-332`) declares exactly `responseHash`, `bands?`, `confidence?`, `critique?` — no `inference_warnings`. The deleted read cast through `Record<string, unknown>` to bypass that type.

⚠ **`inference_warnings` itself is very much alive — this PR does not touch it.** Producers write two *other* slots, and both keep working untouched:
- report **ROOT** — `mapV5AnalysisToReport.ts:1466` (`widened` is the report root, declared `:1430`)
- **`robustness`** — `responseMapper.ts:567` (inside the `robustness:` builder)

Read by `readInferenceWarnings.ts:61-62` (root ?? robustness) and `analysisSnapshotFactory.ts:198-199`. A measured staging census recorded in `persistedRunSnapshotFactory.ts:23-29` confirms the shape: `inference_warnings root 773/773, robustness 0/773`. **`run` is a third slot that never existed.**

**2. The lookup map was a fabricated vocabulary.** `ISL_CRITIQUE_LABELS` held three codes with **zero overlap** against ISL's real `InferenceWarning` vocabulary; two of the three (`IDENTIFIABILITY_WARNING`, `UNMEASURED_CONFOUNDING_WARNING`) are PLoT *critique* codes — copied from the wrong channel entirely. So every real code would have missed the map and fallen through to `?? w.code`.

Dead today, and a loaded gun behind a fiction map.

## Also fixed — a false comment

`ResultsBody.tsx:349` claimed **"Producer message verbatim"** of `InferenceWarningStrip`. That is false: the strip humanises via `humaniseInferenceWarningTitle` and never renders the raw producer `message` — its own header (`InferenceWarningStrip.tsx:11-17`) and JSX comment (`:70`) both say so, and the JSX renders the humanised title. Comment corrected to match the code.

## Evidence

**No behavioural test was written, deliberately.** This cannot be tested into safety: any test would need a self-authored fixture asserting behaviour over a slot the producer never fills — a fixture outside the producer's output domain, which proves nothing about the wire. The evidence is the **writer manifest + the type**, not a test.

**Positive control — nothing depended on the deleted code** (demonstrated, not asserted). Re-introducing a reference to each deleted symbol REDs the gate:

| Mutant | Result |
|---|---|
| reference `ISL_CRITIQUE_LABELS` | ❌ `TS2304: Cannot find name 'ISL_CRITIQUE_LABELS'` — baseline 0 → 1, exit 1 |
| reference `resultsReport` | ❌ `TS2304: Cannot find name 'resultsReport'` — baseline 0 → 1, exit 1 |
| trailing control (restored) | ✅ PASSED, 2263 errors = baseline 2263, exit 0 |

Applied-check scoped to `src/` read exactly 1 for each mutant; restores were HEAD-relative from a pristine archive; isolation proven by a sentinel **write** test, not by locating paths.

**Coverage probe (controlled).** The deleted path's distinctive tokens (`ask_ai_isl`, `Scientific concern detected`, the three code names) return **zero** across all of `src/` post-deletion; contrast controls in the same probe are sighted (`INBOUND_STRENGTH_SUM_EXCEEDED` 3 files, `MIXED_RANGE_DERIVATION` 2, `ROOT_NODE_DEFAULT_VALUE` 5), and the same probe returns 3 hits at the pristine tip. Notably the *adjacent* live branches in the same function are spec-covered while the deleted branch had **no test coverage at all** — consistent with it being unreachable.

**Gates.**
- `npm run typecheck` ✅ PASSED — 3584/3624 files, 557 files / 2263 errors = baseline
- `npx eslint` on both changed files — **0 errors**; 9 warnings, identical set to the pristine tip at the same path (line numbers shifted only), so no new warnings
- Specs, collection asserted **by name** (not inferred from a total): `usePreAnalysisData.spec.ts` **127 tests**, `DecisionQualityChecks.spec.tsx` **6**, `InferenceWarningStrip.spec.tsx` **8**, `ResultsBody.critiqueWarningStripMountPath.spec.tsx` **4** — 145 passed. Wider scoped run: 96 files / 1446 tests passed, 0 failures.

**Collision check.** All **23** open PRs iterated (count asserted, `while read`, hard-error on fetch failure) — none touches `usePreAnalysisData.ts` or `ResultsBody.tsx`. Diff-content scan for `ISL_CRITIQUE_LABELS`/`inference_warnings` across all 23 hit only #788, in an unrelated root/robustness snapshot spec.

## Scope held

No copy authored for inference-warning codes (a separate lane owns that). `humaniseCritique.ts` and `humaniseInferenceWarning.ts` untouched. `ModelHealthSection.tsx:318` untouched — bare codes are correct content for a collapsed audit trail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
