### PR TITLE
fix(results): honest inference-warning copy by kind, and a non-factor-framed fallback

### DIFF
--- a/src/components/results/__tests__/golden-payload.spec.ts
+++ b/src/components/results/__tests__/golden-payload.spec.ts
@@ -464,7 +464,7 @@ describe('Golden payload regression tests', () => {
       // Should NOT expose the raw message
       expect(result.title).not.toContain('intercept=0')
       expect(result.title).not.toContain('fac_')
-      expect(result.title).toBe('Review this factor\'s inputs')
+      expect(result.title).toBe('Part of this analysis was limited')
     })
 
     it('V14.2: constraint template suggestions contain no arrow notation', () => {
@@ -625,8 +625,8 @@ describe('Golden payload regression tests', () => {
       const path3 = humanised.find(c => c.factorId === 'fac_revenue')
       expect(path3).toBeDefined()
       expect(path3!.displayText).toBeNull()
-      expect(path3!.title).toBe("Review this factor's inputs")
-      expect(path3!.description).toBe("Some information needed to assess this factor isn't available yet.")
+      expect(path3!.title).toBe('Part of this analysis was limited')
+      expect(path3!.description).toBe("Olumi's engine reported a condition this version has no wording for yet. Nothing has been hidden — the raw code is listed in the run's audit details.")
     })
 
     it('items with clean userMessage but no template get no suggestion', () => {

--- a/src/components/results/__tests__/humaniseCritique.goalCodes.spec.ts
+++ b/src/components/results/__tests__/humaniseCritique.goalCodes.spec.ts
@@ -10,6 +10,13 @@
  * (humaniseCritique.ts:270-274 at pristine 43fd19e1) — mislabelling the
  * condition and discarding the actionable remedy.
  *
+ * ⚠ THAT QUOTED SENTENCE IS HISTORY, DELIBERATELY LEFT AS SAID. The generic
+ * fallback has since been de-factor-framed (it now reads "Part of this
+ * analysis was limited"), because the same defect was found across the other
+ * 24 codes of this vocabulary. The assertions below therefore compare against
+ * the CURRENT fallback; this paragraph records the one that caused the defect.
+ * Rewriting it would falsify why this file exists.
+ *
  * PRODUCER SEMANTICS, derived at ISL staging tip (robustness_analyzer_v2.py,
  * `_resolve_goal_threshold` refuse() sites):
  *   · GOAL_THRESHOLD_FRAME_UNSPECIFIED — the threshold was supplied without a
@@ -43,7 +50,7 @@ describe('humaniseCritique — goal-threshold refusals are goal-scoped, never fa
   it('GOAL_THRESHOLD_NOT_CONVERTIBLE: goal-scoped title, honest withhold description, actionable current-level remedy', () => {
     const result = humaniseCritique(item('GOAL_THRESHOLD_NOT_CONVERTIBLE'))
     // Not the generic factor-framed fallback.
-    expect(result.title).not.toBe("Review this factor's inputs")
+    expect(result.title).not.toBe('Part of this analysis was limited')
     expect(result.title.toLowerCase()).toContain('goal')
     expect(result.title.toLowerCase()).not.toContain('factor')
     // The honest substance: withheld, not guessed.
@@ -56,7 +63,7 @@ describe('humaniseCritique — goal-threshold refusals are goal-scoped, never fa
 
   it('GOAL_THRESHOLD_FRAME_UNSPECIFIED: names the level-vs-change ambiguity and how to resolve it', () => {
     const result = humaniseCritique(item('GOAL_THRESHOLD_FRAME_UNSPECIFIED'))
-    expect(result.title).not.toBe("Review this factor's inputs")
+    expect(result.title).not.toBe('Part of this analysis was limited')
     expect(result.title.toLowerCase()).toContain('goal')
     expect(result.title.toLowerCase()).not.toContain('factor')
     expect(result.description).toMatch(/level/i)

--- a/src/components/results/__tests__/humaniseCritique.spec.ts
+++ b/src/components/results/__tests__/humaniseCritique.spec.ts
@@ -140,7 +140,7 @@ describe('humaniseCritique', () => {
     const result = humaniseCritique(item, nodeLabels)
     expect(result.displayText).toBeNull()
     // Title still has generic text for ConfidenceSection rows
-    expect(result.title).toBe('Review this factor\'s inputs')
+    expect(result.title).toBe('Part of this analysis was limited')
   })
 
   it('V14.3b: internal-token userMessage falls through to generic fallback', () => {
@@ -153,7 +153,7 @@ describe('humaniseCritique', () => {
     const result = humaniseCritique(item, nodeLabels)
     expect(result.displayText).toBeNull()
     // V14.3b: Title must also be safe — falls through to generic, not contaminated userMessage
-    expect(result.title).toBe("Review this factor's inputs")
+    expect(result.title).toBe('Part of this analysis was limited')
   })
 
   it('V14.3: userMessage fallback does NOT auto-generate suggestion', () => {

--- a/src/components/results/utils/__tests__/humaniseCritique.constraintRangeProvenance.spec.ts
+++ b/src/components/results/utils/__tests__/humaniseCritique.constraintRangeProvenance.spec.ts
@@ -128,7 +128,7 @@ describe('constraint-range critique copy is grounded in the producer', () => {
       item({ code: 'CONSTRAINT_NO_DERIVABLE_RANGE', message: 'msg', affectedNodes: ['fac_churn'] }),
       LABELS,
     )
-    expect(r.title).toBe('Review this factor\'s inputs')
+    expect(r.title).toBe('Part of this analysis was limited')
     expect(r.displayText).toBeNull()
     // …and specifically NOT the sentence it used to fabricate.
     expect(r.title).not.toMatch(/has no estimate set/i)

--- a/src/components/results/utils/__tests__/humaniseCritique.inferenceWarningVocabulary.spec.ts
+++ b/src/components/results/utils/__tests__/humaniseCritique.inferenceWarningVocabulary.spec.ts
@@ -1,0 +1,173 @@
+/**
+ * The ISL inference-warning vocabulary: honest copy BY KIND.
+ *
+ * WHAT THIS PINS AND WHY IT IS SHAPED THIS WAY.
+ *
+ * ISL emits `inference_warnings` with a bare `str` code — there is no registry
+ * for the vocabulary anywhere in ISL (a registry sweep reads zero). The 28
+ * codes were enumerated by an AST walk over every `InferenceWarning(...)`
+ * construction site at ISL `staging` 28fe0c95 (14 literal sites + 4 dynamic
+ * sites resolved: `_optional_phase_unavailable_warning` -> 5 codes, the two
+ * `refuse()` closures -> 3 further codes, and `resolve_range_fits` ->
+ * the 7-member closed `RangeFitRefusalCode` Literal). 26 of the 28 reach the
+ * UI; PLoT drops the other two at `run.ts:3759`, which requires a derivable
+ * message, and `STRENGTH_MEAN_CLAMPED` / `EXISTS_PROBABILITY_DEFAULT` carry
+ * neither `detail.message` nor `detail.reason`.
+ *
+ * ⭐ EVERY ASSERTION BINDS BY CODE, NEVER BY THE PROSE BEING REPLACED.
+ * A test that pins the exact sentence a fix just wrote is vacuous the moment
+ * anyone rewords it, and it certifies nothing about honesty. So the pins here
+ * are PROPERTIES over the code -> kind classification:
+ *   1. completeness  — every classified code resolves to a template, not the
+ *                      generic fallback;
+ *   2. no factor-blame on compute degradation — the actual defect being fixed;
+ *   3. no `${label}` leakage — the payload carries no node identity for ANY of
+ *      these codes, so "This factor" is a category error here;
+ *   4. the FALLBACK itself is honest — which is the LOAD-BEARING protection,
+ *      because the classification map is a cross-repo, cross-language mirror
+ *      and will drift the day ISL adds code 29.
+ *
+ * ⚠ THE HONEST LIMIT OF (1). A guard derived from the map proves the map and
+ * the templates AGREE. It can never prove the map is COMPLETE — nothing in
+ * this repo can see an ISL code that was added after this file was written.
+ * That is exactly why (4) exists and why (4), not (1), is the protection that
+ * matters: a code we have never heard of must still land on true copy.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  humaniseCritique,
+  ISL_INFERENCE_WARNING_KINDS,
+  type InferenceWarningKind,
+} from '../humaniseCritique'
+
+/**
+ * The defect this lane exists to kill: copy that blames the user's factor
+ * inputs. Deliberately a SHAPE, not a sentence — rewording the fallback must
+ * not make this guard stop biting.
+ */
+const FACTOR_BLAME = /review this factor|this factor'?s inputs|assess this factor|your inputs|check your inputs/i
+
+/** `resolveFactorLabel`'s no-identity fallback. Leaking it is a category error
+ *  for this vocabulary, because PLoT forwards no `affected_nodes` at all. */
+const UNRESOLVED_LABEL = /This factor/
+
+function humaniseCode(code: string) {
+  return humaniseCritique({ code, message: '' } as never)
+}
+
+const CODES = Object.keys(ISL_INFERENCE_WARNING_KINDS).sort()
+
+function codesOfKind(kind: InferenceWarningKind): string[] {
+  return CODES.filter((c) => ISL_INFERENCE_WARNING_KINDS[c] === kind)
+}
+
+describe('ISL inference-warning vocabulary — the derived code set', () => {
+  it('classifies exactly the 26 codes that reach the UI', () => {
+    // Pinned as a COUNT plus a spot-check of one member per kind. The count is
+    // the AST-derived 28 minus the two PLoT drops; if ISL grows the vocabulary
+    // this number is expected to change deliberately, with the map.
+    expect(CODES).toHaveLength(26)
+    expect(CODES).toContain('E_VALUES_UNAVAILABLE')
+    expect(CODES).toContain('RANGE_OPEN_ENDED')
+    expect(CODES).toContain('ROOT_NODE_DEFAULT_VALUE')
+  })
+
+  it('does NOT classify the two codes PLoT drops for lacking a message', () => {
+    // run.ts:3759 requires w.message ?? detail.message ?? detail.reason.
+    // Both of these carry only structured numerics, so they never arrive.
+    expect(CODES).not.toContain('STRENGTH_MEAN_CLAMPED')
+    expect(CODES).not.toContain('EXISTS_PROBABILITY_DEFAULT')
+  })
+})
+
+describe('ISL inference-warning vocabulary — completeness (agreement, not completeness)', () => {
+  it.each(CODES)('%s resolves to a template, not the generic fallback', (code) => {
+    const generic = humaniseCode('__DEFINITELY_NOT_A_REAL_CODE__')
+    const result = humaniseCode(code)
+    expect(result.title).not.toBe(generic.title)
+    expect(result.title.length).toBeGreaterThan(0)
+  })
+})
+
+describe('ISL inference-warning vocabulary — honesty by kind', () => {
+  it.each(CODES)('%s never blames the user’s factor inputs', (code) => {
+    const { title, description } = humaniseCode(code)
+    expect(title).not.toMatch(FACTOR_BLAME)
+    expect(description).not.toMatch(FACTOR_BLAME)
+  })
+
+  it.each(CODES)('%s never leaks the unresolved "This factor" label', (code) => {
+    // PLoT forwards no affected_nodes for ANY inference warning, so every
+    // template here must ignore the resolved label entirely.
+    const { title, description } = humaniseCode(code)
+    expect(title).not.toMatch(UNRESOLVED_LABEL)
+    expect(description).not.toMatch(UNRESOLVED_LABEL)
+  })
+
+  it.each(codesOfKind('compute_degradation'))(
+    '%s (compute degradation) does not prescribe an input change',
+    (code) => {
+      // THE ACTIVE LIE BEING FIXED. These fire when a phase ran out of budget
+      // or its estimator failed. Telling the user to change their inputs is
+      // both false about the cause and futile as an action.
+      const { title } = humaniseCode(code)
+      expect(title).not.toMatch(/\b(add|set|state|restate|record|correct)\b[^.]*\b(value|values|range|bound|bounds|input|inputs)\b/i)
+    },
+  )
+
+  it.each(codesOfKind('compute_degradation'))(
+    '%s (compute degradation) says the rest of the result still stands',
+    (code) => {
+      // The producer says so at every one of these sites ("Base analysis is
+      // unaffected"), and a caveat that does not say it reads as "your whole
+      // result is suspect" — overstating the limitation is as dishonest as
+      // understating it.
+      const { title } = humaniseCode(code)
+      expect(title).toMatch(/results? (stand|are unaffected)|ranked correctly/i)
+    },
+  )
+
+  it.each(codesOfKind('model_shape'))(
+    '%s (model shape) carries a route the user can actually take',
+    (code) => {
+      const { title } = humaniseCode(code)
+      expect(title).toMatch(/\b(state|restate|add|connect|give|record|move|try)\b/i)
+    },
+  )
+
+  it.each(CODES.filter((c) => c.startsWith('RANGE_')))(
+    '%s says the confirmed value is still used (compute was untouched)',
+    (code) => {
+      // models/range_fit.py: "A refusal always means: the value stays disclosed
+      // as confirmed, NO distribution is produced, compute is untouched."
+      // Without this the user reads a range refusal as a broken analysis.
+      const { title } = humaniseCode(code)
+      expect(title).toMatch(/still used/i)
+    },
+  )
+})
+
+describe('the generic fallback — the load-bearing protection', () => {
+  const UNKNOWN = '__A_CODE_THIS_BUILD_HAS_NEVER_SEEN__'
+
+  it('is not factor-framed', () => {
+    // This is what stops the defect recurring when ISL adds code 29: the map
+    // cannot know about it, but the fallback still has to be TRUE of it.
+    const { title, description } = humaniseCritique({ code: UNKNOWN, message: '' } as never)
+    expect(title).not.toMatch(FACTOR_BLAME)
+    expect(description).not.toMatch(FACTOR_BLAME)
+  })
+
+  it('does not prescribe an action it cannot know is warranted', () => {
+    const { title } = humaniseCritique({ code: UNKNOWN, message: '' } as never)
+    expect(title).not.toMatch(/\b(add|set|state|restate|record|correct|review)\b/i)
+  })
+
+  it('still refuses to echo the producer message', () => {
+    const leaky = 'root node ‘fac_customer_churn’ observed_state.value intercept=0'
+    const { title, description } = humaniseCritique({ code: UNKNOWN, message: leaky } as never)
+    expect(title).not.toContain('fac_customer_churn')
+    expect(description).not.toContain('fac_customer_churn')
+    expect(title).not.toContain('observed_state')
+  })
+})

--- a/src/components/results/utils/__tests__/humaniseCritique.spec.ts
+++ b/src/components/results/utils/__tests__/humaniseCritique.spec.ts
@@ -92,8 +92,10 @@ describe('humaniseCritique', () => {
     // P0-C2) naming a goal-fit target whose probabilities were withheld
     // because the underlying value is unscaled/missing. Before this fix it
     // had no CODE_TEMPLATES entry, so it fell through to the safe-but-vague
-    // generic fallback ("Review this factor's inputs") — technically honest
-    // but not the meaningful warning the roadmap item calls for.
+    // generic fallback (then worded "Review this factor's inputs") — technically
+    // honest but not the meaningful warning the roadmap item calls for. That
+    // wording is quoted as it WAS: the generic fallback has since been
+    // de-factor-framed, and the assertion below compares against the current one.
     it('CONSTRAINT_TARGET_UNRELIABLE with resolved label', () => {
       const labels = new Map([['fac_churn', 'Customer churn']])
       const result = humaniseCritique(
@@ -101,7 +103,7 @@ describe('humaniseCritique', () => {
         labels,
       )
       expect(result.title).toContain('Customer churn')
-      expect(result.title).not.toBe("Review this factor's inputs")
+      expect(result.title).not.toBe('Part of this analysis was limited')
       expect(result.description.length).toBeGreaterThan(0)
       expect(result.suggestion).toContain('Customer churn')
       expect(result.factorId).toBe('fac_churn')
@@ -121,8 +123,8 @@ describe('humaniseCritique', () => {
     // better vs lower-is-better) couldn't be confirmed (SUSPECT) or was
     // assumed without confirmation (ASSUMED). Before this fix neither had a
     // CODE_TEMPLATES entry, so both fell through to the generic unmapped-code
-    // fallback ("Review this factor's inputs") instead of a meaningful,
-    // direction-specific warning.
+    // fallback (then worded "Review this factor's inputs") instead of a
+    // meaningful, direction-specific warning. Quoted as it WAS — see above.
     it('CONSTRAINT_DIRECTION_SUSPECT with resolved label', () => {
       const labels = new Map([['fac_churn', 'Customer churn']])
       const result = humaniseCritique(
@@ -130,7 +132,7 @@ describe('humaniseCritique', () => {
         labels,
       )
       expect(result.title).toContain('Customer churn')
-      expect(result.title).not.toBe("Review this factor's inputs")
+      expect(result.title).not.toBe('Part of this analysis was limited')
       expect(result.description).toContain("couldn't be confirmed")
       expect(result.description.length).toBeGreaterThan(0)
       expect(result.suggestion).toContain('Customer churn')
@@ -151,7 +153,7 @@ describe('humaniseCritique', () => {
         labels,
       )
       expect(result.title).toContain('Revenue')
-      expect(result.title).not.toBe("Review this factor's inputs")
+      expect(result.title).not.toBe('Part of this analysis was limited')
       expect(result.description).toContain('assumed')
       expect(result.description.length).toBeGreaterThan(0)
       expect(result.suggestion).toContain('Revenue')
@@ -183,8 +185,14 @@ describe('humaniseCritique', () => {
           message: 'constraint_fac_customer_churn_max observed_state.value intercept=0',
         }),
       )
-      expect(result.title).toBe("Review this factor's inputs")
-      expect(result.description).toContain("isn't available yet")
+      expect(result.title).toBe('Part of this analysis was limited')
+      // Re-pointed when the fallback was de-factor-framed. The old assertion
+      // pinned the phrase "isn't available yet" from the previous description;
+      // the property it was really protecting is that an UNMAPPED code gets a
+      // safe generic description that neither blames the user's inputs nor
+      // leaves them nowhere to go. Pin that instead of the old wording.
+      expect(result.description).not.toMatch(/review this factor|assess this factor/i)
+      expect(result.description).toMatch(/audit details/i)
       // V12.1: Unmapped codes must NOT have suggestion — banner filter (suggestion != null)
       // excludes them from the attention banner above the hero.
       expect(result.suggestion).toBeUndefined()

--- a/src/components/results/utils/humaniseCritique.ts
+++ b/src/components/results/utils/humaniseCritique.ts
@@ -240,16 +240,372 @@ const CODE_TEMPLATES: Record<string, TemplateFactory> = {
   // goal, auto-noise), so the description states the withhold factually and
   // the suggestion names the user-actionable remedy without claiming it is
   // the only cause.
+  // ⚠ THEIR ROUTE WAS INVISIBLE, AND ONLY THE TITLE IS RENDERED.
+  // The 2.300 fix put the remedy in `suggestion`. Both surfaces that show
+  // inference warnings render the TITLE ALONE — `InferenceWarningStrip` as its
+  // single <span>, and the Advanced list through
+  // `selectHumanisedInferenceWarningsOutsideStrip`, which projects only
+  // `{code, title}`. So these two shipped as honest DEAD ENDS: they named the
+  // condition and, where the user could see it, nothing to do about it.
+  // The fix is deliberately the smallest one that closes it — the ratified
+  // title and the ratified suggestion, both VERBATIM, joined so the remedy is
+  // on the surface that renders. No approved wording is rewritten here.
   GOAL_THRESHOLD_NOT_CONVERTIBLE: () => ({
-    title: "Your goal's target couldn't be measured for this run",
+    title: "Your goal's target couldn't be measured for this run. State the current level for your goal.",
     description: 'The target couldn\'t be compared with where the goal stands today — for example when no current level is recorded for it — so goal-fit results were withheld rather than guessed.',
     suggestion: 'State the current level for your goal',
   }),
   GOAL_THRESHOLD_FRAME_UNSPECIFIED: () => ({
-    title: "Your goal's target could mean a level or a change",
+    title: "Your goal's target could mean a level or a change. Restate the target as a level to reach or a change from your current level.",
     description: "The target doesn't say whether it's a level to reach or a change from today, so goal-fit results were withheld for this run rather than guessed.",
     suggestion: 'Restate the target as a level to reach or a change from your current level',
   }),
+
+  // ══════════════════════════════════════════════════════════════════════════
+  // ISL `inference_warnings` — the remaining 24 of the 26 codes that reach the
+  // UI. Extends the ROADMAP 2.300 item 1 fix above, which closed exactly two
+  // of them and left the rest on the FACTOR-framed generic fallback: "Review
+  // this factor's inputs". For the compute-degradation family that sentence is
+  // ACTIVELY FALSE — it blames the user's factor inputs for a phase that ran
+  // out of budget, and prescribes an action that cannot help.
+  //
+  // ⭐ HOW THIS COPY WAS DERIVED, AND WHY IT IS NOT DERIVED FROM THE CODE NAME.
+  // Every sentence below was written from the PRODUCER's bytes at ISL
+  // `staging` 28fe0c95 — the construction site, its `reason` values and its own
+  // `detail.message`. Reading intent off the code name is precisely how the
+  // wrong copy got here. The sharpest case is `EVPI_UNAVAILABLE`, whose `field`
+  // is `p_win_sensitivity`, NOT EVPI: robustness_analyzer_v2.py:2580-2583
+  // records that the code kept its operational name while the wire field was
+  // renamed. Its copy describes win-probability sensitivity, not EVPI.
+  //
+  // ⭐ EVERY TEMPLATE IGNORES THE RESOLVED LABEL, DELIBERATELY.
+  // PLoT forwards `{code, message, severity, field?, elapsed_ms?}` and NEVER
+  // `affected_nodes` (run.ts:3771), so `useResultsSectionData.ts:3517` reads an
+  // empty node list for every one of these codes and `resolveFactorLabel`
+  // returns the unresolved "This factor". Interpolating a label here would
+  // print that string at the user. The two 2.300 templates above already say
+  // this for the goal codes; it holds for the whole vocabulary.
+  //
+  // ⭐ THE ROUTE ONWARD LIVES IN THE TITLE, NOT IN `suggestion`.
+  // Both live surfaces render the TITLE ONLY — `InferenceWarningStrip` as its
+  // single <span>, and the Advanced list through
+  // `selectHumanisedInferenceWarningsOutsideStrip`, which projects `{code,
+  // title}`. A route parked in `description`/`suggestion` would be invisible.
+  // Those fields are still filled honestly for the other critique surfaces.
+  //
+  // ⭐ WHAT THE COPY MAY NOT DO: overstate or blur. "Unavailable" and "less
+  // precise" are different claims and are kept apart — FACTOR_EVPPI_PARTIAL is
+  // the one PARTIAL member of its family and says so, because calling it
+  // unavailable would discard rows that were computed correctly.
+
+  // ── Kind A: compute / budget degradation ─────────────────────────────────
+  // A phase did not complete. Not the user's fault, and the producer states at
+  // every one of these sites that "Base analysis is unaffected" — so the copy
+  // must say the rest still stands, or an honest caveat reads as a broken run.
+
+  // Reasons: request_budget_exhausted | e_value_budget_exceeded.
+  E_VALUES_UNAVAILABLE: () => ({
+    title:
+      'The check on how wrong your assumptions could be before the recommendation changes didn\'t run — the analysis hit its time limit. Your results stand; re-run to add it.',
+    description:
+      'E-value analysis was skipped for time. It does not affect the recommendation, the probabilities, or anything else already shown.',
+  }),
+
+  // Reasons: e_values_unavailable | request_budget_exhausted |
+  // flip_stability_budget_exceeded. All three roots are the time budget: the
+  // bands ride on the E-value sweep, so "unavailable because E-values were
+  // unavailable" is still a budget story, never a model one.
+  STABILITY_BANDS_UNAVAILABLE: () => ({
+    title:
+      'The confidence bands around the tipping points didn\'t run — the analysis hit its time limit. Your results stand; re-run to add them.',
+    description:
+      'Flip-stability bands ride on the E-value sweep, which the request budget could not fund. Nothing else shown is affected.',
+  }),
+
+  // Reasons: request_budget_exhausted | factor_flip_budget_exceeded.
+  // All-or-nothing at the producer, so this is never a partial set.
+  FACTOR_FLIPS_UNAVAILABLE: () => ({
+    title:
+      'How far each factor would have to move to change the recommendation wasn\'t computed — the analysis hit its time limit. Your results stand; re-run to add it.',
+    description:
+      'Factor-flip analysis was omitted whole rather than part-computed. Nothing else shown is affected.',
+  }),
+
+  // Reasons: request_budget_exhausted | path_decomposition_budget_exceeded.
+  PATH_DECOMPOSITION_UNAVAILABLE: () => ({
+    title:
+      'The breakdown of which causal pathways drive the result didn\'t run — the analysis hit its time limit. Your results stand; re-run to add it.',
+    description:
+      'Path decomposition was omitted whole rather than part-computed. Nothing else shown is affected.',
+  }),
+
+  // ⚠ MIXED REASONS, AND THE TEMPLATE CANNOT DISCRIMINATE. Three producer call
+  // sites: request_budget_exhausted and evpi_budget_exceeded (budget) plus
+  // constraints_not_convertible (a model-shape condition). The reason rides in
+  // `detail.reason`, which PLoT folds into `message` — and this humaniser is
+  // forbidden from reading `message`. Keying on the prose would also be exactly
+  // the mirror this file keeps paying for. So the sentence is written to be
+  // TRUE UNDER ALL THREE, and the route covers both worlds: re-running fixes
+  // the budget cases, and the constraint check is what fixes the third. Naming
+  // only "re-run" would be the futile-action defect again for one reason in
+  // three.
+  EVPI_UNAVAILABLE: () => ({
+    title:
+      'Which unknowns most affect each option\'s chance of hitting your goal wasn\'t computed. Your results stand; re-run, and if it repeats check each success target says whether it\'s a level or a change.',
+    description:
+      'Win-probability sensitivity was skipped — either the request budget ran out, or a goal constraint could not be resolved into its target\'s frame. The rest of the analysis is unaffected.',
+  }),
+
+  // Reason: estimator_error. NOT a budget case — re-running an identical model
+  // may well fail again, so the route says so rather than promising a retry
+  // will work.
+  FACTOR_EVPPI_UNAVAILABLE: () => ({
+    title:
+      'Olumi couldn\'t rank what\'s most worth learning next for this run. Your results stand; re-run — if it repeats, this ranking can\'t be produced for this model.',
+    description:
+      'The per-factor value-of-information estimator failed and the ranking was omitted rather than shown with unreliable ordering.',
+  }),
+
+  // ⭐ THE PARTIAL MEMBER. Reason: per_factor_dropped. Some factors WERE
+  // computed. Calling this "unavailable" would tell the user to discard a
+  // ranking that is correct for the rows it shows — the overstatement the
+  // scientific-credibility constraint forbids.
+  FACTOR_EVPPI_PARTIAL: () => ({
+    title:
+      'Some factors were left out of the "most worth learning next" ranking; the ones shown are ranked correctly. Re-run to try for the full set.',
+    description:
+      'Per-factor value of information could not be computed for every factor requested. The factors that did compute are ranked against each other correctly.',
+  }),
+
+  // Reason: compute_error. Same posture as FACTOR_EVPPI_UNAVAILABLE.
+  FACTOR_EVPC_UNAVAILABLE: () => ({
+    title:
+      'How much it would be worth being able to control each factor wasn\'t computed. Your results stand; re-run — if it repeats, this model can\'t produce it.',
+    description:
+      'Value-of-control estimation failed and was omitted rather than shown as an unreliable number.',
+  }),
+
+  // ── Kind B: model-shape conditions ───────────────────────────────────────
+  // Something about the model or the stated inputs genuinely limits what can be
+  // computed. Here the user CAN act, and the route names the actual remedy.
+
+  // The per-constraint twins of the two 2.300 goal templates above. Same
+  // producer rules (`_resolve_threshold_in_sample_frame`), different disclosure
+  // vocabulary — the producer is explicit that the rule set is shared and the
+  // vocabulary is not, so these get their own sentences rather than reusing the
+  // goal ones.
+  CONSTRAINT_NOT_CONVERTIBLE: () => ({
+    title:
+      'One of your success targets couldn\'t be compared with where its factor stands today, so its goal-fit was withheld rather than guessed. State that factor\'s current level.',
+    description:
+      'The target could not be resolved into its factor\'s measurement frame — for example when no current level is recorded for it.',
+    suggestion: 'State the current level for that factor',
+  }),
+  CONSTRAINT_FRAME_UNSPECIFIED: () => ({
+    title:
+      'One of your success targets could mean a level to reach or a change from today, so its goal-fit was withheld rather than guessed. Restate it as a level or a change.',
+    description:
+      'The constraint does not say whether its value is a level or a change, and the producer refuses to guess between them.',
+    suggestion: 'Restate that target as a level to reach or a change from today',
+  }),
+
+  // Producer: root ancestors with no observed value and no ParameterUncertainty
+  // defaulted to 0.0, so "goal-level probabilities partially rest on
+  // placeholder zeros". PARTIALLY is load-bearing — the result is degraded,
+  // not void.
+  GOAL_ANCESTOR_DATA_GAP: () => ({
+    title:
+      'Some starting factors feeding your goal have no value recorded, so part of your goal\'s probability rests on placeholder zeros. Add current values for those factors.',
+    description:
+      'The goal is still scored from its forward-propagated distribution, but some of what feeds it is a placeholder rather than a measurement.',
+    suggestion: 'Add current values for the starting factors that feed your goal',
+  }),
+
+  // Producer: goal is a root, has no ParameterUncertainty and epsilon_std == 0,
+  // so "its samples are the constant base".
+  GOAL_NODE_ROOT_STATIC: () => ({
+    title:
+      'Nothing feeds into your goal and it has no uncertainty set, so its value is fixed rather than modelled. Connect the factors that drive it, or give it a range.',
+    description:
+      'With no parents, no parameter uncertainty and no noise, every simulated sample of the goal is the same number.',
+    suggestion: 'Connect the factors that drive your goal, or give the goal a range',
+  }),
+
+  // ── Kind B (user-stated ranges): the closed RangeFitRefusalCode vocabulary ─
+  // ⚠ THESE ARE NOT COMPUTE DEGRADATION, despite sitting beside it on the wire.
+  // At `services/range_fit.py` each is a refusal of a range the USER stated,
+  // and the producer's own remedies are user actions. `models/range_fit.py`
+  // states the posture that every sentence below must carry: "A refusal always
+  // means: the value stays disclosed as confirmed, NO distribution is produced,
+  // compute is untouched." Without that clause a user reads a range refusal as
+  // a broken analysis, which is the opposite of what happened.
+
+  RANGE_OPEN_ENDED: () => ({
+    title:
+      'A range you stated has only one end, which doesn\'t pin down a distribution — the value is still used as you confirmed it. State both ends.',
+    description:
+      'Open-ended statements ("at least X" / "no more than X") plus a coverage do not determine a distribution, so no distribution was fitted.',
+    suggestion: 'State both ends of the range',
+  }),
+  RANGE_INVALID_ORDER: () => ({
+    title:
+      'A range you stated runs from high to low, so it wasn\'t used — the value is still used as you confirmed it. Restate it lowest first.',
+    description:
+      'The bounds are never silently swapped: order is part of what was said, and an inverted range is more likely a slip worth seeing than a convention to normalise.',
+    suggestion: 'Restate the range with the lower bound first',
+  }),
+  RANGE_ZERO_WIDTH: () => ({
+    title:
+      'A range you stated has the same number at both ends, so there\'s no uncertainty to fit — the value is still used as you confirmed it. Give it some width, or leave it as a single value.',
+    description:
+      'A zero-width range asserts a certainty this method cannot represent; a single confirmed value is the way to express that.',
+    suggestion: 'Give the range some width, or leave the value as confirmed',
+  }),
+  RANGE_NON_FINITE: () => ({
+    title:
+      'A range you stated isn\'t a pair of finite numbers, so it wasn\'t used — the value is still used as you confirmed it. Restate it with two numbers.',
+    description: 'Range bounds must both be finite numbers; they are never silently skipped.',
+    suggestion: 'Restate the range with two finite numbers',
+  }),
+  RANGE_OUT_OF_DOMAIN: () => ({
+    title:
+      'A range you stated falls outside what that quantity can be, so it wasn\'t used — the value is still used as you confirmed it. Restate it within the factor\'s range.',
+    description:
+      'The stated bounds lie outside the quantity\'s declared domain. They are never clamped, because clamping would invent a different range from the one you stated.',
+    suggestion: 'Restate the range within the quantity\'s domain',
+  }),
+  RANGE_AT_DOMAIN_EDGE: () => ({
+    title:
+      'A range you stated sits exactly on the edge of what that quantity can be, which no distribution can fit — the value is still used as you confirmed it. Move the bound just inside.',
+    description:
+      'No distribution in this family can place a quartile exactly at the edge of its support. Bounds very close to the edge are legitimate and are fitted normally.',
+    suggestion: 'Move the bound just inside the edge',
+  }),
+  // The one solver-failure member of the family. Still bound to the range the
+  // user stated, so the route is about the range, not about re-running.
+  RANGE_FIT_NONCONVERGENT: () => ({
+    title:
+      'Olumi couldn\'t fit a distribution to one of the ranges you stated — the value is still used as you confirmed it. Try slightly wider bounds.',
+    description:
+      'The fit did not converge for this range. No fallback distribution is invented, because a minted distribution wearing real provenance would be worse than none.',
+    suggestion: 'Try slightly wider bounds',
+  }),
+
+  // ── Kind C: defaulting and modelling notices ─────────────────────────────
+  // A value was defaulted, or a modelling rule applied. These are info-severity
+  // at the producer and surface in the Advanced list, not the top strip.
+
+  ROOT_NODE_DEFAULT_VALUE: () => ({
+    title:
+      'A starting factor has no current value recorded, so zero was assumed — anything downstream of it may be unreliable. Add its current value.',
+    description:
+      'The producer defaults an unspecified root value to 0.0 and says so rather than hiding it. Results for downstream factors inherit that assumption.',
+    suggestion: 'Add the current value for that starting factor',
+  }),
+  CONSTRAINT_NODE_DEFAULT_BASE: () => ({
+    title:
+      'A factor carrying a success target has no current value or uncertainty recorded, so zero was assumed as its starting point. Add its current value.',
+    description:
+      'With no parameter uncertainty the base is taken as a zero offset and the parents\' contribution propagates on top of it.',
+    suggestion: 'Add the current value for that factor',
+  }),
+  // Not user-actionable — the honest route is how to READ the number, which is
+  // still a route: it tells the reader what to do with what they are seeing.
+  CONSTRAINT_SAMPLES_UNNOISED: () => ({
+    title:
+      'Some success-target factors didn\'t get the extra real-world variation applied to your goal, so their probabilities reflect model variation only — read them as more confident than they are.',
+    description:
+      'Auto-scaled noise was applied to the goal samples but not to these constraint samples, so the two are not on the same footing.',
+  }),
+  GOAL_OBSERVED_VALUE_UNUSED: () => ({
+    title:
+      'Your goal is modelled from the factors feeding it, so the current value you recorded on the goal itself isn\'t used as its starting point. Record current values on those factors instead.',
+    description:
+      'For a goal with parents the distribution is the forward-propagated composition of those parents, so a value recorded on the goal has nothing to attach to.',
+    suggestion: 'Record current values on the factors that feed your goal',
+  }),
+  // Pure semantics. Saying "no action is needed" IS the route here: it tells the
+  // reader to stop looking for something to fix.
+  GOAL_PU_BASE_ADDITIVE: () => ({
+    title:
+      'Your goal\'s own uncertainty is added on top of what the factors feeding it contribute, rather than replacing it — this is how its range is built, and no action is needed.',
+    description:
+      'Each sample draws a base from the goal\'s own distribution and adds the parents\' propagated contribution. The goal is shifted by that base, not pinned to it.',
+  }),
+}
+
+// ─── ISL inference-warning classification ────────────────────────────────────
+
+/**
+ * The three kinds an ISL `inference_warnings` code can belong to. The kind is
+ * what makes the copy defensible: it decides whether the sentence may name a
+ * user action at all.
+ *
+ *  · `compute_degradation` — a phase did not complete (budget exhausted, or an
+ *    estimator failed). NOT the user's fault; there may be nothing to do but
+ *    re-run or accept the reduced scope. This is the family the old generic
+ *    fallback actively lied about.
+ *  · `model_shape` — something about the model or a stated input genuinely
+ *    limits what can be computed. The user CAN act.
+ *  · `defaulting_notice` — a value was defaulted or a modelling rule applied.
+ *    The user may want to supply the real value.
+ */
+export type InferenceWarningKind =
+  | 'compute_degradation'
+  | 'model_shape'
+  | 'defaulting_notice'
+
+/**
+ * The 26 ISL codes that reach this UI, classified.
+ *
+ * ⚠ THIS IS A CROSS-REPO, CROSS-LANGUAGE MIRROR AND IT WILL DRIFT. ISL types
+ * `code` as a bare `str` with no registry (a registry sweep over ISL reads
+ * zero), so nothing can derive this list from the producer at build time. It
+ * was enumerated by an AST walk over every `InferenceWarning(...)` construction
+ * site at ISL `staging` 28fe0c95 — 28 codes, of which PLoT drops two
+ * (`STRENGTH_MEAN_CLAMPED`, `EXISTS_PROBABILITY_DEFAULT`) at `run.ts:3759`
+ * because it requires a derivable message and those two carry only structured
+ * numerics.
+ *
+ * ⭐ SO THIS MAP IS NOT THE PROTECTION. A guard derived from it proves the map
+ * and the templates agree; it can never prove the map is COMPLETE, and it is
+ * structurally blind to an ISL code added tomorrow. The protection that
+ * actually holds is the GENERIC FALLBACK below being true of anything — which
+ * is why the fallback is no longer factor-framed. Treat this map as
+ * documentation of intent that happens to be machine-checkable, and the
+ * fallback as the thing standing between a new code and a false sentence.
+ */
+export const ISL_INFERENCE_WARNING_KINDS: Readonly<Record<string, InferenceWarningKind>> = {
+  // Compute / budget degradation
+  E_VALUES_UNAVAILABLE: 'compute_degradation',
+  STABILITY_BANDS_UNAVAILABLE: 'compute_degradation',
+  FACTOR_FLIPS_UNAVAILABLE: 'compute_degradation',
+  PATH_DECOMPOSITION_UNAVAILABLE: 'compute_degradation',
+  EVPI_UNAVAILABLE: 'compute_degradation',
+  FACTOR_EVPPI_UNAVAILABLE: 'compute_degradation',
+  FACTOR_EVPPI_PARTIAL: 'compute_degradation',
+  FACTOR_EVPC_UNAVAILABLE: 'compute_degradation',
+  // Model shape
+  GOAL_THRESHOLD_NOT_CONVERTIBLE: 'model_shape',
+  GOAL_THRESHOLD_FRAME_UNSPECIFIED: 'model_shape',
+  CONSTRAINT_NOT_CONVERTIBLE: 'model_shape',
+  CONSTRAINT_FRAME_UNSPECIFIED: 'model_shape',
+  GOAL_ANCESTOR_DATA_GAP: 'model_shape',
+  GOAL_NODE_ROOT_STATIC: 'model_shape',
+  // Model shape — user-stated range refusals (compute is untouched)
+  RANGE_OPEN_ENDED: 'model_shape',
+  RANGE_INVALID_ORDER: 'model_shape',
+  RANGE_ZERO_WIDTH: 'model_shape',
+  RANGE_NON_FINITE: 'model_shape',
+  RANGE_OUT_OF_DOMAIN: 'model_shape',
+  RANGE_AT_DOMAIN_EDGE: 'model_shape',
+  RANGE_FIT_NONCONVERGENT: 'model_shape',
+  // Defaulting / modelling notices
+  ROOT_NODE_DEFAULT_VALUE: 'defaulting_notice',
+  CONSTRAINT_NODE_DEFAULT_BASE: 'defaulting_notice',
+  CONSTRAINT_SAMPLES_UNNOISED: 'defaulting_notice',
+  GOAL_OBSERVED_VALUE_UNUSED: 'defaulting_notice',
+  GOAL_PU_BASE_ADDITIVE: 'defaulting_notice',
 }
 
 // ─── Internal token detection ────────────────────────────────────────────────
@@ -390,9 +746,38 @@ export function humaniseCritique(
   // No user_message and no template match → generic fallback.
   // displayText: null → excluded from banner. Title/description still render
   // inside ConfidenceSection rows for unmapped codes.
+  //
+  // ⭐⭐ THIS IS THE LOAD-BEARING HONESTY GUARANTEE, NOT THE TEMPLATE MAP.
+  // It used to read "Review this factor's inputs" / "Some information needed to
+  // assess this factor isn't available yet." That was a FACTOR-FRAMED sentence
+  // asserted over an OPEN vocabulary, and it was the source of the defect this
+  // block was rewritten to fix: 24 of the 26 ISL `inference_warnings` codes
+  // landed here, and for the compute-degradation family it was actively false —
+  // it blamed the user's factor inputs for a phase that ran out of budget, and
+  // prescribed an action that could not help. The templates above fix the 26
+  // codes we know about. THIS fixes code 29, which ISL has not written yet.
+  //
+  // The three properties it must keep, and why each is load-bearing:
+  //  1. NOT FACTOR-FRAMED. An unmapped code may be about a factor, the goal, a
+  //     constraint, a stated range, or a compute phase. Only a claim true of
+  //     all of them may be made, so it claims nothing about WHAT is limited.
+  //  2. NO PRESCRIBED ACTION. We cannot know one is warranted, and a futile
+  //     instruction is the exact defect being fixed — one level up.
+  //  3. STILL A ROUTE, NOT A DEAD END. It names where the raw code IS visible:
+  //     the audit trail, where `ModelHealthSection` lists inference-warning
+  //     codes verbatim. A machine code is correct content for an audit trail
+  //     and wrong content for a caveat strip, so pointing there is the honest
+  //     onward step — the user can quote it, and support can resolve it.
+  //
+  // It also does not promise the rest of the result is unaffected. That IS true
+  // of every degradation code above, and is stated in each of their templates
+  // on the producer's own authority — but it is not knowable for a code we
+  // cannot classify, and asserting it here would be the same overreach in the
+  // reassuring direction.
   return {
-    title: 'Review this factor\'s inputs',
-    description: 'Some information needed to assess this factor isn\'t available yet.',
+    title: 'Part of this analysis was limited',
+    description:
+      'Olumi\'s engine reported a condition this version has no wording for yet. Nothing has been hidden — the raw code is listed in the run\'s audit details.',
     displayText: null,
     factorId,
   }


### PR DESCRIPTION
## The defect

ISL emits 28 `inference_warnings` codes; **26 reach this UI**. Only **2** had copy. The other **24** rendered the generic FACTOR-framed fallback **"Review this factor's inputs"**.

For the **compute-degradation family that is actively false**: it blames the user's factor inputs for a phase that ran out of budget, and prescribes an action that cannot help. `humaniseCritique.ts` already recorded this defect in its own words when ROADMAP 2.300 item 1 fixed exactly two codes — *"fell to the generic FACTOR-framed fallback ('Review this factor's inputs'), mislabelling the condition"*. The remaining 24 survived because nobody had enumerated the vocabulary.

## How the vocabulary was derived

ISL types `code` as a bare `str` and has **no registry for this vocabulary at all** (a registry sweep reads zero), so the set was enumerated by an **AST walk over every `InferenceWarning(...)` construction site** at ISL `staging` `28fe0c95`: 14 literal sites plus 4 dynamic sites resolved (`_optional_phase_unavailable_warning` → 5 codes, the two `refuse()` closures → 3 more, `resolve_range_fits` → the 7-member closed `RangeFitRefusalCode` Literal). 28 total, 19 `warning` / 9 `info`.

**The 2 that do not arrive were derived independently**, not inherited: PLoT `run.ts:3759` requires a derivable message (`w.message ?? detail.message ?? detail.reason`), and `STRENGTH_MEAN_CLAMPED` / `EXISTS_PROBABILITY_DEFAULT` carry only structured numerics. 28 − 2 = 26.

Every meaning was read **at the producer's bytes**, never off the code name — deriving intent from the name is exactly how the current wrong copy happened.

## Three findings that shaped the copy

1. **Both live surfaces render the TITLE ONLY.** `InferenceWarningStrip` is a single `<span>`; the Advanced list goes through `selectHumanisedInferenceWarningsOutsideStrip`, which projects `{code, title}`. So the route onward must live in the title. This also revealed that the **two already-ratified 2.300 templates parked their route in `suggestion` and therefore shipped as honest dead ends** — their ratified title and ratified suggestion are now joined, both verbatim; no approved wording is rewritten.
2. **No node identity is available.** PLoT forwards `{code, message, severity, field?, elapsed_ms?}` and never `affected_nodes`, so `resolveFactorLabel` returns the unresolved `"This factor"` for every one of these codes. **No template here may interpolate the label.** The 2.300 comment said this for the goal codes; it holds for the whole vocabulary.
3. **`EVPI_UNAVAILABLE` is a name/meaning divergence.** Its `field` is `p_win_sensitivity`, not EVPI (`robustness_analyzer_v2.py:2580-2583` records the rename), and its three call sites span **budget** *and* **model shape** (`constraints_not_convertible`). Its copy is written to be true under all three, because the template keys on `code` and binding to the producer's prose is forbidden.

## Correction to the brief's premise

The **7 `RANGE_*` codes are not compute degradation.** At `services/range_fit.py` they are refusals of a **user-stated range**, and the producer's own remedies are user actions. `models/range_fit.py` states the posture the copy now carries: *"A refusal always means: the value stays disclosed as confirmed, NO distribution is produced, compute is untouched."* Without that clause a user reads a range refusal as a broken analysis. They are classified `model_shape`.

## Which change is load-bearing

**The fallback, not the map.** The template map is a cross-repo, cross-language mirror and it will drift; a guard derived from it proves the map and the templates *agree* and can never prove the map is *complete*. The fallback is what has to be true of ISL's code 29. It is now neutral, prescribes no action it cannot know is warranted, does not promise the rest of the result is unaffected (unknowable for an unclassified code), and still names a route — the audit trail, where the raw code is already listed.

## Evidence

- **RED-first**: new spec failed at collection at pristine (`ISL_INFERENCE_WARNING_KINDS` absent), then 2 further genuine REDs exposed the dead-end route on the two ratified templates.
- **Every assertion binds BY CODE and by property**, never by the prose being replaced.
- **Mutants** in a throwaway worktree at an absolute path outside the repo root; isolation proven by **writing a sentinel** (source sha unchanged, inodes differ); restores from a **pristine archive taken from the commit**; **semantic applied-checks** that refuse to score an unapplied mutation as a survivor; control applies exactly zero and reads GREEN; trailing control GREEN. **10 mutants + 2 controls, all as specified**, including a **discriminating pair** (label interpolation inside the vocabulary REDs the guard; the same mutation outside it leaves the guard at 119/119).
- Collected counts asserted **by spec name** (env vars set per CI): new spec **119/119**; affected suites 212/212 across 7 files; scoped results suite **343 files / 5825 passed / 0 failed**.
- Local gate in the required check's **step order**: `lint` (0 errors, hooks ratchet exact) → `typecheck` (3585/3625 files, ratchet 2263 = baseline) → all five `tsc`-job guards pass.

## Scope

UI-only, as ownership requires. No PLoT copy, no wire field. `ModelHealthSection`'s bare codes in the Audit accordion are untouched — a machine code is correct content for an audit trail. `usePreAnalysisData.ts` and `ResultsBody.tsx:349` untouched (sibling lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)