### PR TITLE
fix(dock): carry the readiness statement to the surface the advice sends the user to

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -126,6 +126,7 @@ import { focusExistingTarget } from '../utils/focusHelpers'
 import { normaliseRawFactorValue, withObservedStateUpdate } from '../utils/observedStateHelpers'
 import { ModelTabBody } from './ModelTabBody'
 import { ReanalyseBar } from './model-tab/ReanalyseBar'
+import { AnalysisReadinessBar } from './workspaceShell/AnalysisReadinessBar'
 import { JourneyTabBody } from '../journey/JourneyTabBody'
 import { CompareTabBody as CompareTabBodyV2 } from '../compare-tab/CompareTabBody'
 // Results Panel Redesign: v7 four-section layout components
@@ -3324,9 +3325,50 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
             the footer stack below is flag-gated, and hosting the control there
             would make it vanish entirely on rollback. The bar renders its own
             null when the analysis is not stale. */}
-        {effectiveIsOpen && surfaceFor(effectiveActiveTab).footerBar === 'reanalyse' ? (
+        {effectiveIsOpen && surfaceFor(effectiveActiveTab).footerBar !== 'none' ? (
           <div className="flex-shrink-0" data-testid="shell-surface-footer-bar">
-            <ReanalyseBar onReanalyse={handleRunAnalysis} />
+            {/* ⭐ ONE OWNER, TWO BARS. The gate reads the SURFACE DESCRIPTOR's
+                `footerBar` and switches on its value; it does not test a tab id
+                and it does not grow a second, parallel condition beside the
+                first. Adding a value to that union without handling it here is
+                a TYPE ERROR (the `never` arm below), which is the same
+                mechanism `scroll`/`padding` use.
+
+                `readiness` exists because of a measured coherence defect: the
+                blocked Analysis footer tells the user *"Ask in the chat what
+                they need"*, and acting on it fronts the Olumi tab, whose
+                selection UNMOUNTS the pre-analysis subtree at
+                `effectiveActiveTab === 'results'` above. The advice removed its
+                own context. `AnalysisReadinessBar`'s header carries the
+                witness; `shellContract.ts`'s `footerBar` doc carries why the
+                fix is a footer declaration and NOT a change to that mount. */}
+            {(() => {
+              const bar = surfaceFor(effectiveActiveTab).footerBar
+              switch (bar) {
+                case 'reanalyse':
+                  return <ReanalyseBar onReanalyse={handleRunAnalysis} />
+                case 'readiness':
+                  return (
+                    <AnalysisReadinessBar
+                      preRunWithModel={isPreRun && nodes.length > 0}
+                      canRun={canRunAnalysis}
+                      blockedReason={runBlockedTooltip}
+                      isAnalysing={isRunning}
+                      onAnalyse={handleRunAnalysis}
+                    />
+                  )
+                // Unreachable through the guard above, and handled anyway so
+                // the `never` arm keeps meaning "a value was added to the union
+                // and nobody wired it" rather than "TypeScript cannot see the
+                // guard's narrowing through the second lookup".
+                case 'none':
+                  return null
+                default: {
+                  const exhaustive: never = bar
+                  return exhaustive
+                }
+              }
+            })()}
           </div>
         ) : null}
 

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -127,6 +127,10 @@ import { normaliseRawFactorValue, withObservedStateUpdate } from '../utils/obser
 import { ModelTabBody } from './ModelTabBody'
 import { ReanalyseBar } from './model-tab/ReanalyseBar'
 import { AnalysisReadinessBar } from './workspaceShell/AnalysisReadinessBar'
+import {
+  deriveReadinessCheck,
+  readinessNothingHasAnswered,
+} from './pre-analysis-v3/footer/readinessDisplay'
 import { JourneyTabBody } from '../journey/JourneyTabBody'
 import { CompareTabBody as CompareTabBodyV2 } from '../compare-tab/CompareTabBody'
 // Results Panel Redesign: v7 four-section layout components
@@ -1085,7 +1089,17 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
 
   // ROADMAP 2.635 — `stale` feeds the gate's COPY (I-3) and `verdictAtMs`
   // identifies WHICH verdict licensed a run (I-4).
-  const { readiness, stale: readinessStale, verdictAtMs: readinessVerdictAtMs } = useGraphReadiness()
+  const {
+    readiness,
+    stale: readinessStale,
+    verdictAtMs: readinessVerdictAtMs,
+    // `error` and `refresh` feed the readiness bar the shell hosts on the
+    // Olumi surface: the CHECK-failed arm outranks the gate copy there for
+    // the same reason it does on the Analysis footer, and Retry is the
+    // recovery that goes with it.
+    error: readinessError,
+    refresh: refreshReadiness,
+  } = useGraphReadiness()
   // ⭐ The CANONICAL readiness authority — `analysis_state.readiness`, stated by
   // the producer on the turn. Read beside the side-car verdict deliberately: the
   // two used to be one name with two meanings, and seeing them on adjacent lines
@@ -1175,6 +1189,23 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   )
   const canRunAnalysis = runGateResult.allowed
   const runBlockedTooltip = getRunButtonTooltip(runGateResult)
+  // ── INPUTS FOR THE SHELL-HOSTED READINESS BAR ──────────────────────────────
+  // Both are DERIVED THROUGH THE PANEL'S OWN OWNER (`readinessDisplay.ts`), not
+  // restated here. `usePreAnalysisModel` builds the identical two values from
+  // the identical store fields; a second expression in this file is exactly the
+  // mirror that let the bar and the footer disagree in the first place.
+  const readinessCheckForBar = useMemo(
+    () =>
+      deriveReadinessCheck({
+        error: readinessError,
+        verdictRetained: readiness != null,
+        stale: readinessStale,
+        verdictAtMs: readinessVerdictAtMs,
+        retry: refreshReadiness,
+      }),
+    [readinessError, readiness, readinessStale, readinessVerdictAtMs, refreshReadiness],
+  )
+  const readinessUnanswered = readinessNothingHasAnswered(readiness, analysisReadiness)
   const showToast = useShowToastSafe()
 
   // Handle Run button click
@@ -3354,6 +3385,8 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                       canRun={canRunAnalysis}
                       blockedReason={runBlockedTooltip}
                       isAnalysing={isRunning}
+                      readinessCheck={readinessCheckForBar}
+                      nothingHasAnswered={readinessUnanswered}
                       onAnalyse={handleRunAnalysis}
                     />
                   )

--- a/src/canvas/components/__tests__/OutputsDock.readinessSurvivesTabChange.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.readinessSurvivesTabChange.spec.tsx
@@ -1,0 +1,520 @@
+/**
+ * THE ADVICE MUST NOT DESTROY ITS OWN CONTEXT.
+ *
+ * ── THE WITNESS (fresh guest, real headful Chrome, 20 Aug 2026, UI `7153fbd7`) ─
+ * With the run blocked, the Analysis footer prints, verbatim:
+ *
+ *     "4 parts of your model are not ready for analysis yet.
+ *      Ask in the chat what they need."
+ *
+ * Selecting the Olumi tab — doing exactly what the product just said — takes
+ * both the sentence and the `Analyse first pass` control OUT OF THE DOM.
+ * `OutputsDock.tsx` renders the entire pre-analysis subtree under
+ * `{effectiveActiveTab === 'results' && …}`, a bare conditional render, while
+ * the sibling Olumi subtree is kept mounted and merely `hidden`. The user
+ * arrives in the chat with nothing on screen saying what they came to ask
+ * about, and no control to run once the answer lands.
+ *
+ * ── WHY jsdom CAN PIN THIS AND WHAT IT STILL CANNOT (trap 3) ───────────────
+ * The button is PRESENT until the tab changes, so no presence assertion taken
+ * at one moment can see this defect: a spec that rendered the dock and found
+ * the control would have passed happily while this shipped. What is pinned here
+ * is therefore a POSTCONDITION ACROSS A TAB CHANGE — the same mounted dock,
+ * before and after a click on the Olumi tab, with the store untouched in
+ * between. That is a claim about MOUNTING, which is exactly what jsdom is
+ * authoritative about. It is not a claim about pixels, layout or the fold; the
+ * live witness above owns those.
+ *
+ * ── THE MOUNT PATH IS ASSERTED, NOT ASSUMED ───────────────────────────────
+ * This estate has twice shipped a feature dark because its tests targeted a
+ * component the deployed flag posture does not render. So `MOUNT PATH` below
+ * asserts the posture itself — `aiPanelV2` at its production default (ON,
+ * `netlify.toml:57`), `preAnalysisV3` forced ON (`netlify.toml:161`), Olumi
+ * genuinely `presentedAsTab`, and the surface's own `footerBar` declaration —
+ * so the whole file REDs loudly if a flag or a declaration moves, rather than
+ * passing against a surface no user loads.
+ *
+ * Every element is bound by `data-testid` — identity, never a value predicate
+ * another element could satisfy.
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+import type { ConversationMessage } from '../../conversation/types'
+
+// ---------------------------------------------------------------------------
+// Heavy-import stubs — must precede any OutputsDock evaluation. Layout mirrors
+// OutputsDock.runReturnsToOlumi.spec.tsx (the established aiPanelV2 dock
+// harness) crossed with OutputsDock.canonicalReadinessWiring.spec.tsx (the
+// established readiness-gate harness).
+// ---------------------------------------------------------------------------
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) }
+})
+vi.mock('../pre-analysis', () => ({ PreAnalysisPanel: () => null }))
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Describe your decision…',
+}))
+
+/**
+ * Flags: `importOriginal` and SPREAD, never a hand-listed factory — a factory
+ * REPLACES the module and silently drops every flag it forgot (trap 12, which
+ * killed 51 tests in this repo once).
+ *
+ * ⚠ `isAiPanelV2Enabled` IS DELIBERATELY NOT OVERRIDDEN. The Olumi tab exists
+ * only under it, and its production default (ON) is part of what is under test.
+ * Overriding it to `true` here would make this spec pass on a posture the file
+ * asserted rather than on the one the product ships.
+ */
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isTelemetryEnabled: () => false,
+    isCompareTabEnabled: () => false,
+    isJourneyTabEnabled: () => false,
+    isOrchestratorV2Enabled: () => false,
+    isV5CanonicalAnalysisEnabled: () => false,
+    isPreAnalysisV3Enabled: () => true,
+  }
+})
+
+const conversationBase = {
+  messages: [] as ConversationMessage[],
+  isThinking: false,
+  longRunningHint: null as unknown,
+  sendMessage: vi.fn(),
+  sendSystemEvent: vi.fn(),
+  sendChip: vi.fn(),
+  retryLast: vi.fn(),
+  patchBlockStates: new Map(),
+  setPatchBlockState: vi.fn(),
+  patchRejections: new Map(),
+  setPatchRejection: vi.fn(),
+}
+vi.mock('../../conversation/useConversation', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../conversation/useConversation')>()
+  return { ...actual, useConversation: () => conversationBase }
+})
+
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { OutputsDock, OUTPUTS_DOCK_STORAGE_KEY } from '../OutputsDock'
+import { AnalysisReadinessBar } from '../workspaceShell/AnalysisReadinessBar'
+import { ToastProvider } from '../../ToastContext'
+import { useCanvasStore } from '../../store'
+import { useReadinessStore } from '../../stores/readinessStore'
+import { useUIStore } from '../../../stores/uiStore'
+import { useFloatingPanelState } from '../../hooks/useFloatingPanelState'
+import { clearInflightCache } from '../../hooks/useGraphReadiness'
+import { BLOCKED_REASON_COPY } from '../../utils/composeBlockedReason'
+import { FOOTER_COPY } from '../pre-analysis-v3/constants'
+import { WORKSPACE_SURFACES, presentedSurfaces } from '../workspaceShell/shellContract'
+import { isAiPanelV2Enabled, isPreAnalysisV3Enabled } from '../../../flags'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** The witnessed sentence, DERIVED from the producer's own copy factory rather
+ *  than re-typed — 4 blockers is what `composeAnalysisBlockedReason` turns into
+ *  the count rung, and the count rung is what the fresh guest read on screen. */
+const WITNESSED_REASON = BLOCKED_REASON_COPY.canonicalManyBlockers(4)
+
+const OPTION_LABELS: Record<string, string> = {
+  opt_extend: 'Extend the free trial',
+  opt_hold: 'Hold the current price',
+  opt_bundle: 'Bundle onboarding in',
+}
+
+/** Side-car verdict that objects without naming a cause — held in the store AND
+ *  served from the stubbed transport so its own debounced refetch cannot swap
+ *  the fixture out mid-assertion. */
+const SIDE_CAR_OBJECTS = {
+  readiness_score: 0,
+  readiness_level: 'needs_work' as const,
+  can_run_analysis: false,
+  confidence_explanation: 'Add some nodes to get started',
+  improvements: [],
+}
+
+/** ⚠ `readiness_level: 'ready'`, not an invented band. The producer's set is
+ *  exactly `ready | fair | needs_work` (`useGraphReadiness.ts`,
+ *  `ACCEPTED_READINESS_LEVELS`), and a fixture outside the producer's output
+ *  domain proves nothing about a branch the producer can reach. */
+const SIDE_CAR_AGREES = {
+  readiness_score: 90,
+  readiness_level: 'ready' as const,
+  can_run_analysis: true,
+  confidence_explanation: 'Ready',
+  improvements: [],
+}
+
+function analysisState(readiness: AnalysisStateV1['readiness']): AnalysisStateV1 {
+  return {
+    run_state: { kind: 'never_run' },
+    readiness,
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: false,
+    blocked_unusable: false,
+    contradictions: [],
+  } as AnalysisStateV1
+}
+
+/** Four blockers, each scoped to a named element — the shape that produces the
+ *  witnessed count sentence. */
+function fourBlockers(): AnalysisStateV1['readiness'] {
+  return {
+    status: 'not_ready',
+    blockers: [
+      { code: 'OPTION_NOT_READY', category: 'options', message: 'no effect values', repairability: 'user_repairable', option_id: 'opt_extend', option_label: OPTION_LABELS.opt_extend },
+      { code: 'OPTION_NOT_READY', category: 'options', message: 'no effect values', repairability: 'user_repairable', option_id: 'opt_hold', option_label: OPTION_LABELS.opt_hold },
+      { code: 'OPTION_NOT_READY', category: 'options', message: 'no effect values', repairability: 'user_repairable', option_id: 'opt_bundle', option_label: OPTION_LABELS.opt_bundle },
+      { code: 'FACTOR_NOT_READY', category: 'factors', message: 'no observed value', repairability: 'user_repairable', factor_id: 'f1', factor_label: 'Support headcount' },
+    ],
+  } as AnalysisStateV1['readiness']
+}
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+
+function ensureScrollIntoView() {
+  if (typeof Element.prototype.scrollIntoView !== 'function') {
+    Element.prototype.scrollIntoView = vi.fn()
+  }
+}
+
+/** A decision, a goal, three options, one factor — the drafted model a fresh
+ *  guest is looking at when the blocked footer appears. */
+function seedCanvasWithModel() {
+  const nodes = [
+    { id: 'd1', type: 'decision', position: { x: 0, y: 0 }, data: { kind: 'decision', label: 'How do we protect retention?' } },
+    { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { kind: 'goal', label: 'Grow retained revenue' } },
+    ...Object.entries(OPTION_LABELS).map(([id, label], i) => ({
+      id, type: 'option', position: { x: 10 * i, y: 0 }, data: { kind: 'option', label },
+    })),
+    { id: 'f1', type: 'factor', position: { x: 0, y: 0 }, data: { kind: 'factor', label: 'Support headcount' } },
+  ]
+  useCanvasStore.setState({
+    nodes: nodes as never,
+    edges: [{ id: 'e1', source: 'f1', target: 'g1', data: { weight: 0.5, direction: 'positive' } }] as never,
+    graphHealth: { status: 'healthy', score: 100, issues: [] },
+    hasCompletedFirstRun: false,
+    results: { status: 'idle', progress: 0 },
+    showDraftChat: false,
+    v5AnalysisFact: null,
+    analysisFreshness: null,
+    ceeAnalysisReady: {
+      goal_node_id: 'g1',
+      status: 'ready',
+      options: Object.keys(OPTION_LABELS).map((id) => ({ id, status: 'ready' })),
+    },
+  } as never)
+}
+
+function seedSideCar(verdict: typeof SIDE_CAR_OBJECTS | typeof SIDE_CAR_AGREES) {
+  clearInflightCache()
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({ ...verdict }),
+      text: async () => '',
+      headers: new Headers(),
+    })),
+  )
+  useReadinessStore.setState({
+    readiness: verdict,
+    loading: false,
+    error: null,
+    stale: false,
+    verdictAtMs: null,
+  })
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  return (
+    <ToastProvider>
+      <ConversationProvider>{children}</ConversationProvider>
+    </ToastProvider>
+  )
+}
+
+/** The dock's own derivation of "the Olumi tab is showing" — its wrapper drops
+ *  `hidden` and flips `aria-hidden`. */
+function olumiIsFronted(): boolean {
+  const wrapper = screen.getByTestId('olumi-tab-wrapper')
+  return !wrapper.classList.contains('hidden') && wrapper.getAttribute('aria-hidden') === 'false'
+}
+
+/** Click the Olumi tab BY IDENTITY — the strip stamps
+ *  `outputs-dock-tab-${surface.id}` from the surface registry itself. */
+function clickOlumiTab() {
+  fireEvent.click(screen.getByTestId('outputs-dock-tab-olumi'))
+}
+
+beforeAll(async () => {
+  await import('../pre-analysis-v3')
+}, 30_000)
+
+/**
+ * ⚠ EVERY SINGLETON THE TAB ARBITRATION READS IS RESET — AND THE URL IS ONE OF
+ * THEM. See the note on `history.replaceState` below for the leak that was
+ * actually load-bearing and how it was traced.
+ */
+beforeEach(() => {
+  ensureMatchMedia()
+  ensureScrollIntoView()
+  try {
+    sessionStorage.removeItem(OUTPUTS_DOCK_STORAGE_KEY)
+    sessionStorage.clear()
+  } catch { /* jsdom quirk */ }
+  // ⭐ THE URL IS A SINGLETON TOO, AND IT IS THE ONE THAT ACTUALLY LEAKED.
+  // `handleTabClick` syncs the selection into a `?tab=` deep link
+  // (`OutputsDock.tsx:2209-2219`, `history.replaceState`), and jsdom keeps one
+  // `window.location` for the whole FILE. So the first test's click on Olumi
+  // left `?tab=olumi` in the URL and EVERY later mount read it back through the
+  // one-time init effect at `OutputsDock.tsx:1698` — every subsequent test
+  // opened on the Olumi tab and failed on "cannot find
+  // `pre-analysis-v3-analyse`", a signature with nothing to do with the defect
+  // under test. Traced to that line by instrumenting where the state update was
+  // QUEUED rather than where it was applied; sessionStorage and both stores
+  // were provably clean at the time. A leak that turns honest assertions into
+  // misattributed ones is worse than a flake — it is a spec that cannot say
+  // what it measured.
+  window.history.replaceState({}, '', '/')
+  useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 } as never)
+  useFloatingPanelState.setState({ isOpen: false, isMinimised: false, source: 'user' } as never)
+})
+
+afterEach(() => {
+  useReadinessStore.getState().reset()
+  useCanvasStore.setState({ analysisStateV1: null } as never)
+  vi.unstubAllGlobals()
+  vi.unstubAllEnvs()
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('MOUNT PATH — the surface the deployed flags actually mount', () => {
+  it('the posture under test is the deployed posture, and the declaration is live', () => {
+    // A flag move must RED here rather than silently retargeting every
+    // assertion below at a surface no user loads.
+    expect(isAiPanelV2Enabled, 'aiPanelV2 must be a real flag, not a stub').toBeTypeOf('function')
+    expect(isAiPanelV2Enabled()).toBe(true)
+    expect(isPreAnalysisV3Enabled()).toBe(true)
+    // Olumi is genuinely offered as a tab (Compare and Journey are the live
+    // counter-examples: declared, flagged, and NOT presented).
+    expect(WORKSPACE_SURFACES.olumi.presentedAsTab).toBe(true)
+    expect(presentedSurfaces().map(s => s.id)).toContain('olumi')
+    // …and the Olumi surface is the one that asks the shell to carry readiness.
+    expect(WORKSPACE_SURFACES.olumi.footerBar).toBe('readiness')
+    // CONTRAST CONTROL: not every surface declares it, so "some surface does"
+    // cannot satisfy the assertion above.
+    expect(WORKSPACE_SURFACES.results.footerBar).toBe('none')
+    expect(WORKSPACE_SURFACES.diagnostics.footerBar).toBe('reanalyse')
+  })
+})
+
+describe('the witnessed defect — following the advice removes the control', () => {
+  beforeEach(() => {
+    seedSideCar(SIDE_CAR_OBJECTS)
+    seedCanvasWithModel()
+    useCanvasStore.setState({ analysisStateV1: analysisState(fourBlockers()) } as never)
+  })
+
+  it('MECHANISM — the Analysis pre-run subtree is UNMOUNTED by the tab change, not hidden', async () => {
+    // Pins the mechanism itself so the fix below cannot be mistaken for having
+    // changed it. If a later lane makes the results branch survive the switch,
+    // this REDs and the change gets read rather than absorbed.
+    render(<Wrapper><OutputsDock /></Wrapper>)
+
+    const analyse = await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
+    expect(analyse).toBeDisabled()
+    expect(analyse).toHaveAttribute('title', WITNESSED_REASON)
+    expect(screen.getByTestId('pre-analysis-v3-footer')).toHaveTextContent(WITNESSED_REASON)
+
+    clickOlumiTab()
+
+    expect(olumiIsFronted()).toBe(true)
+    // GONE FROM THE DOM — not merely `hidden`. This is the asymmetry.
+    expect(screen.queryByTestId('pre-analysis-v3-analyse')).toBeNull()
+    expect(screen.queryByTestId('pre-analysis-v3-footer')).toBeNull()
+  }, 30_000)
+
+  it('THE FIX — the reason and a run control survive the tab change the advice asks for', async () => {
+    // ⭐ THE POSTCONDITION. Before the fix this REDs on the first line after the
+    // click: nothing on the Olumi surface carried the sentence the user was
+    // just told to go and ask about.
+    render(<Wrapper><OutputsDock /></Wrapper>)
+
+    await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
+    const beforeText = screen.getByTestId('pre-analysis-v3-footer').textContent ?? ''
+    expect(beforeText).toContain(WITNESSED_REASON)
+
+    clickOlumiTab()
+    expect(olumiIsFronted()).toBe(true)
+
+    const bar = screen.getByTestId('analysis-readiness-bar')
+    expect(bar).toHaveAttribute('data-blocked', 'true')
+    expect(bar).toHaveTextContent(FOOTER_COPY.notReady)
+
+    // SAME SENTENCE, not merely a plausible one: the string on the chat surface
+    // is the string the Analysis surface was showing a moment earlier.
+    const reason = screen.getByTestId('analysis-readiness-bar-reason').textContent ?? ''
+    expect(reason.length).toBeGreaterThan(20)
+    expect(reason).toBe(WITNESSED_REASON)
+    expect(beforeText).toContain(reason)
+
+    // …and a run control the user can see the state of, still honest.
+    const barAnalyse = screen.getByTestId('analysis-readiness-bar-analyse')
+    expect(barAnalyse).toBeDisabled()
+    expect(barAnalyse).toHaveAttribute('title', WITNESSED_REASON)
+  }, 30_000)
+
+  it('OLUMI STAYS MOUNTED — the fix must not be bought by unmounting the other tab', async () => {
+    // The prohibition, pinned. Olumi's mount is deliberate and load-bearing
+    // (ChatThread scroll + `useSmartScroll`; `OlumiTabBody` registers its
+    // guidance-store callbacks with NO cleanup precisely because it survives).
+    // "Consistency" in that direction is symmetry at the cost of the user.
+    render(<Wrapper><OutputsDock /></Wrapper>)
+
+    await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
+    const wrapper = screen.getByTestId('olumi-tab-wrapper')
+    expect(wrapper).toBeInTheDocument()
+    expect(wrapper).toHaveClass('hidden')
+
+    clickOlumiTab()
+    expect(screen.getByTestId('olumi-tab-wrapper')).not.toHaveClass('hidden')
+  }, 30_000)
+})
+
+describe('the bar is honest in both directions', () => {
+  it('READY — the same control on the same surface ENABLES when the gate opens', async () => {
+    // The discriminating half. A bar that were merely always-disabled decoration
+    // would satisfy the blocked case above and fail here.
+    seedSideCar(SIDE_CAR_AGREES)
+    seedCanvasWithModel()
+    useCanvasStore.setState({
+      analysisStateV1: analysisState({ status: 'ready', blockers: [] } as AnalysisStateV1['readiness']),
+    } as never)
+
+    render(<Wrapper><OutputsDock /></Wrapper>)
+
+    const analyse = await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
+    expect(analyse).toBeEnabled()
+
+    clickOlumiTab()
+
+    const bar = screen.getByTestId('analysis-readiness-bar')
+    expect(bar).toHaveAttribute('data-blocked', 'false')
+    expect(bar).toHaveTextContent(FOOTER_COPY.ready)
+    // No reason is claimed when nothing is refusing.
+    expect(screen.queryByTestId('analysis-readiness-bar-reason')).toBeNull()
+
+    const barAnalyse = screen.getByTestId('analysis-readiness-bar-analyse')
+    expect(barAnalyse).toBeEnabled()
+    expect(barAnalyse).not.toHaveAttribute('title')
+  }, 30_000)
+
+  it('POST-RUN — the bar makes NO claim once an analysis has completed', async () => {
+    // The boundary that keeps this from becoming a THIRD freshness surface in
+    // one dock. After a run, staleness is the freshness strip's and
+    // `ReanalyseBar`'s question; a pre-run readiness claim here would be the
+    // duplicate-authority defect that got `StaleAnalysisBadge` retired.
+    //
+    // Non-vacuous by construction: the dock is fully open on a populated canvas
+    // and the Olumi tab is fronted, so the bar's absence is a decision rather
+    // than a surface that never rendered.
+    seedSideCar(SIDE_CAR_OBJECTS)
+    seedCanvasWithModel()
+    useCanvasStore.setState({
+      hasCompletedFirstRun: true,
+      analysisStateV1: analysisState(fourBlockers()),
+    } as never)
+
+    render(<Wrapper><OutputsDock /></Wrapper>)
+
+    // Proof we are on the Analysis surface POST-run: the pre-run panel is gone
+    // for a reason that is not "the dock failed to mount".
+    await screen.findByTestId('outputs-dock-body', {}, { timeout: 20_000 })
+    expect(screen.queryByTestId('pre-analysis-v3-analyse')).toBeNull()
+
+    clickOlumiTab()
+    expect(olumiIsFronted()).toBe(true)
+    expect(screen.queryByTestId('analysis-readiness-bar')).toBeNull()
+  }, 30_000)
+})
+
+describe('the bar itself — the pre-run window is a guard, not a decoration', () => {
+  /**
+   * Bound directly to the component for the one input the mounted dock cannot
+   * reach without fighting the first-use rail: an EMPTY canvas collapses the
+   * dock to a 40px rail, so the footer region never renders and the bar's
+   * absence there would be vacuous — an absence proved by looking nowhere.
+   * `preRunWithModel` is the single predicate the shell hands it, so it is
+   * tested where it can actually be varied.
+   */
+  it('renders NOTHING outside the pre-run-with-a-model window', () => {
+    const { container } = render(
+      <AnalysisReadinessBar
+        preRunWithModel={false}
+        canRun={false}
+        blockedReason={WITNESSED_REASON}
+        isAnalysing={false}
+        onAnalyse={() => {}}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+    expect(screen.queryByTestId('analysis-readiness-bar')).toBeNull()
+  })
+
+  it('…and DOES render inside it, on the same props (the discriminating twin)', () => {
+    // Without this pair, the assertion above is satisfied by a component that
+    // renders null unconditionally.
+    render(
+      <AnalysisReadinessBar
+        preRunWithModel
+        canRun={false}
+        blockedReason={WITNESSED_REASON}
+        isAnalysing={false}
+        onAnalyse={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('analysis-readiness-bar')).toHaveAttribute('data-blocked', 'true')
+    expect(screen.getByTestId('analysis-readiness-bar-reason')).toHaveTextContent(WITNESSED_REASON)
+  })
+})

--- a/src/canvas/components/__tests__/OutputsDock.readinessSurvivesTabChange.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.readinessSurvivesTabChange.spec.tsx
@@ -495,6 +495,7 @@ describe('the bar itself — the pre-run window is a guard, not a decoration', (
         canRun={false}
         blockedReason={WITNESSED_REASON}
         isAnalysing={false}
+        nothingHasAnswered={false}
         onAnalyse={() => {}}
       />,
     )
@@ -511,10 +512,127 @@ describe('the bar itself — the pre-run window is a guard, not a decoration', (
         canRun={false}
         blockedReason={WITNESSED_REASON}
         isAnalysing={false}
+        nothingHasAnswered={false}
         onAnalyse={() => {}}
       />,
     )
     expect(screen.getByTestId('analysis-readiness-bar')).toHaveAttribute('data-blocked', 'true')
     expect(screen.getByTestId('analysis-readiness-bar-reason')).toHaveTextContent(WITNESSED_REASON)
   })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * ⭐ THE TWO SURFACES AGREE — an EQUALITY guard, not two copy assertions.
+ *
+ * This block exists because the first version of this PR shipped the bar with
+ * its own two-arm expression beside `PanelFooter`'s four-arm ladder, and an
+ * independent review drove the mounted dock into a state where they said
+ * different things: with neither readiness authority having answered, the
+ * Analysis footer said *"Readiness not checked yet"* (warning) while the Olumi
+ * bar said *"Analysis available"* (green) — the confident claim, on the surface
+ * the advice sends the user to.
+ *
+ * ⚠ NOTE THE DATES. The footer's `nothingHasAnswered` arm landed 19 Aug; the
+ * bar landed 20 Aug. Two fixes for one harm, one day apart, each correct in
+ * isolation, NEITHER ONE'S TESTS ABLE TO SEE THE OTHER. Nothing inside either
+ * diff could have surfaced it.
+ *
+ * So these assertions are deliberately EQUALITIES between the two surfaces
+ * rather than checks that each says the right thing. An equality cannot pass
+ * while they disagree, and it fails loudly if either surface later grows an arm
+ * the other lacks — which is exactly how this arrived. Both are read across a
+ * tab change with the store untouched in between, because the results subtree
+ * unmounts and the two can never be on screen at once.
+ */
+describe('THE TWO SURFACES AGREE — headline equality, not two copies', () => {
+  it('PENDING — neither authority has answered: the same headline on both', async () => {
+    // The cold-load / starvation state: the check has not answered YET and has
+    // not failed. A fetch that never settles is what produces it honestly —
+    // resolving gives a verdict, rejecting gives the outage arm.
+    clearInflightCache()
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+    useReadinessStore.setState({
+      readiness: null, loading: true, error: null, stale: false, verdictAtMs: null,
+    })
+    seedCanvasWithModel()
+    useCanvasStore.setState({ analysisStateV1: null } as never)
+
+    render(<Wrapper><OutputsDock /></Wrapper>)
+
+    await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
+    // The precondition is PINNED IN-TEST: without it this could pass because
+    // the state never arrived, not because the surfaces agree (trap 13b).
+    expect(useReadinessStore.getState().readiness).toBeNull()
+    expect(useReadinessStore.getState().error).toBeNull()
+    const footerHeadline = screen.getByTestId('pre-analysis-v3-footer-headline').textContent ?? ''
+    expect(footerHeadline).toBe(FOOTER_COPY.readinessPending)
+
+    clickOlumiTab()
+    expect(olumiIsFronted()).toBe(true)
+
+    const barHeadline = screen.getByTestId('analysis-readiness-bar-headline').textContent ?? ''
+    // ⭐ THE EQUALITY. Written against the OTHER SURFACE, not against a constant:
+    // a constant would let both drift together and still pass.
+    expect(barHeadline).toBe(footerHeadline)
+    // …and the specific claim that was wrong is named, so a future reader can
+    // see which direction the defect ran.
+    expect(barHeadline).not.toBe(FOOTER_COPY.ready)
+  }, 30_000)
+
+  it('OUTAGE — the check failed: the same headline on both, and Retry on both', async () => {
+    // A network rejection is what sets `readinessStore.error` and KEEPS it set:
+    // the mount fetch fails again rather than clearing it.
+    clearInflightCache()
+    vi.stubGlobal('fetch', vi.fn(() => Promise.reject(new TypeError('Failed to fetch'))))
+    seedCanvasWithModel()
+    useCanvasStore.setState({ analysisStateV1: null } as never)
+
+    render(<Wrapper><OutputsDock /></Wrapper>)
+
+    const outageRow = await screen.findByTestId(
+      'pre-analysis-v3-readiness-outage', {}, { timeout: 20_000 },
+    )
+    // Precondition pinned in-test: the store really is in the failed state.
+    expect(useReadinessStore.getState().error).not.toBeNull()
+    expect(useReadinessStore.getState().readiness).toBeNull()
+    expect(outageRow).toBeInTheDocument()
+    const footerHeadline = screen.getByTestId('pre-analysis-v3-footer-headline').textContent ?? ''
+    expect(footerHeadline.length).toBeGreaterThan(0)
+
+    clickOlumiTab()
+    expect(olumiIsFronted()).toBe(true)
+
+    expect(screen.getByTestId('analysis-readiness-bar-outage')).toBeInTheDocument()
+    expect(screen.getByTestId('analysis-readiness-bar-headline').textContent ?? '').toBe(
+      footerHeadline,
+    )
+    // The gate stays OPEN through an outage (`canRunAnalysis` blocks only on
+    // `readiness && !can_run_analysis`), which is exactly why the bar would
+    // otherwise have rendered a green "Analysis available" here.
+    expect(screen.getByTestId('analysis-readiness-bar-headline').textContent ?? '').not.toBe(
+      FOOTER_COPY.ready,
+    )
+    // The recovery goes with the claim: the route stays usable on whichever
+    // surface the user is standing on.
+    expect(screen.getByTestId('analysis-readiness-bar-retry')).toBeEnabled()
+  }, 30_000)
+
+  it('BLOCKED — the gate arm too, so the guard is not pinned to the new arms alone', async () => {
+    seedSideCar(SIDE_CAR_OBJECTS)
+    seedCanvasWithModel()
+    useCanvasStore.setState({ analysisStateV1: analysisState(fourBlockers()) } as never)
+
+    render(<Wrapper><OutputsDock /></Wrapper>)
+
+    await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
+    const footerHeadline = screen.getByTestId('pre-analysis-v3-footer-headline').textContent ?? ''
+    expect(footerHeadline).toBe(FOOTER_COPY.notReady)
+
+    clickOlumiTab()
+    expect(screen.getByTestId('analysis-readiness-bar-headline').textContent ?? '').toBe(
+      footerHeadline,
+    )
+  }, 30_000)
 })

--- a/src/canvas/components/__tests__/OutputsDock.readinessSurvivesTabChange.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.readinessSurvivesTabChange.spec.tsx
@@ -40,7 +40,7 @@
 
 import '@testing-library/jest-dom/vitest'
 import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
 import type { ConversationMessage } from '../../conversation/types'
@@ -634,5 +634,118 @@ describe('THE TWO SURFACES AGREE — headline equality, not two copies', () => {
     expect(screen.getByTestId('analysis-readiness-bar-headline').textContent ?? '').toBe(
       footerHeadline,
     )
+  }, 30_000)
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * ⭐ THE RESTING ARM — the one the ladder does NOT share, and therefore the one
+ * that can still drift.
+ *
+ * The delta review measured the asymmetry and it ran the wrong way: making the
+ * SHELL's resting headline diverge REDs (the READY test's copy assertion bites),
+ * but making the PANEL's diverge SURVIVED — 11/11 green while the two surfaces
+ * contradicted each other in the resting state. The guarded half is a frozen
+ * constant (`RESTING_AVAILABLE`); the unguarded half is a four-branch memo that
+ * has been edited repeatedly (scaffold arm, success-unset arm, estimates arm).
+ *
+ * That is trap 22b in miniature — one direction tested, the other open, suite
+ * green throughout — and leaving it would half-close the exact defect class this
+ * PR exists to close, in the change written to close it. So resting gets the
+ * same equality treatment as PENDING / OUTAGE / BLOCKED, and the mutant battery
+ * proves it bites in BOTH directions.
+ */
+describe('THE TWO SURFACES AGREE — the resting arm too', () => {
+  it('RESTING — a verdict exists and nothing objects: the same headline on both', async () => {
+    seedSideCar(SIDE_CAR_AGREES)
+    seedCanvasWithModel()
+    useCanvasStore.setState({
+      analysisStateV1: analysisState({ status: 'ready', blockers: [] } as AnalysisStateV1['readiness']),
+    } as never)
+
+    render(<Wrapper><OutputsDock /></Wrapper>)
+
+    await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
+    // Preconditions pinned in-test: this really is RESTING and not one of the
+    // three arms above wearing its clothes (trap 13b — a guard whose
+    // discrimination depends on a fixture that nothing pins).
+    expect(useReadinessStore.getState().error).toBeNull()
+    expect(useReadinessStore.getState().readiness).not.toBeNull()
+    expect(screen.queryByTestId('pre-analysis-v3-readiness-outage')).toBeNull()
+    expect(screen.getByTestId('pre-analysis-v3-analyse')).toBeEnabled()
+
+    const footerHeadline = screen.getByTestId('pre-analysis-v3-footer-headline').textContent ?? ''
+    expect(footerHeadline).toBe(FOOTER_COPY.ready)
+
+    clickOlumiTab()
+    expect(olumiIsFronted()).toBe(true)
+
+    // ⭐ THE EQUALITY, against the OTHER SURFACE rather than a constant.
+    expect(screen.getByTestId('analysis-readiness-bar-headline').textContent ?? '').toBe(
+      footerHeadline,
+    )
+  }, 30_000)
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * ⭐ ENABLE IN PLACE — the behaviour that satisfies the founder's ruling, and
+ * the one the suite could not see.
+ *
+ * The ruling is that the route Olumi recommends must actually be usable: the
+ * user is told to ask in the chat, and when the answer lands the action must be
+ * there. `READY` above seeds the ready state BEFORE render, so it proves the bar
+ * CAN show an enabled control — never that the control enables WITHOUT the user
+ * leaving the chat. Enable-in-place was verified twice by driving it, and a
+ * behaviour verified only by a reviewer's probe is not protected.
+ *
+ * One variable moves: the PRODUCER's verdict, which supersedes the side-car
+ * (`canRunAnalysis`'s precedence). That is the real journey — the user asks,
+ * Olumi repairs, the next verdict says ready — and it means the flip cannot be
+ * attributed to anything else in the fixture.
+ *
+ * ⚠ IN PLACE IS ASSERTED BY NODE IDENTITY, not by "an enabled button exists".
+ * A remount that produced a fresh enabled button would satisfy the weaker claim
+ * while the user's chat surface flickered or lost its front.
+ */
+describe('ENABLE IN PLACE — the answer lands and the action is already there', () => {
+  it('blocked in the chat → the producer answers → THE SAME button enables, Olumi never loses front', async () => {
+    seedSideCar(SIDE_CAR_OBJECTS)
+    seedCanvasWithModel()
+    useCanvasStore.setState({ analysisStateV1: analysisState(fourBlockers()) } as never)
+
+    render(<Wrapper><OutputsDock /></Wrapper>)
+    await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
+
+    clickOlumiTab()
+    expect(olumiIsFronted()).toBe(true)
+
+    const bar = screen.getByTestId('analysis-readiness-bar')
+    const button = screen.getByTestId('analysis-readiness-bar-analyse')
+    expect(bar).toHaveAttribute('data-blocked', 'true')
+    expect(button).toBeDisabled()
+    expect(button).toHaveAttribute('title', WITNESSED_REASON)
+
+    // The answers land. Nothing else moves — no tab click, no remount, no
+    // second render call.
+    act(() => {
+      useCanvasStore.setState({
+        analysisStateV1: analysisState({ status: 'ready', blockers: [] } as AnalysisStateV1['readiness']),
+      } as never)
+    })
+
+    // ⭐ THE SAME DOM NODE. Not "a button is enabled" — THIS button.
+    expect(screen.getByTestId('analysis-readiness-bar-analyse')).toBe(button)
+    expect(button).toBeEnabled()
+    expect(button).not.toHaveAttribute('title')
+    expect(screen.getByTestId('analysis-readiness-bar')).toBe(bar)
+    expect(bar).toHaveAttribute('data-blocked', 'false')
+
+    // The user is still where the advice sent them, and the reason is gone
+    // because there is no longer one to state.
+    expect(olumiIsFronted()).toBe(true)
+    expect(screen.queryByTestId('analysis-readiness-bar-reason')).toBeNull()
   }, 30_000)
 })

--- a/src/canvas/components/pre-analysis-v3/PreAnalysisPanelV3.tsx
+++ b/src/canvas/components/pre-analysis-v3/PreAnalysisPanelV3.tsx
@@ -170,6 +170,10 @@ function PanelBody({ onAnalyse, isAnalysing, canRun, blockedReason }: PreAnalysi
         // is the surface that used to claim "Analysis available" about a model
         // nothing had assessed. It says so instead. Run authority is unchanged.
         readinessCheck={model.readinessCheck}
+        // The unanswered arm moved out of `model.footer` into the shared
+        // ladder when a second pre-run surface appeared; the flag rides here so
+        // this surface reaches it through the same owner the shell's bar does.
+        nothingHasAnswered={model.nothingHasAnswered}
       />
     </div>
   )

--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -310,6 +310,13 @@ export const FOOTER_COPY = {
   running: 'Analysis running',
   runningSub: 'Hold on while the first pass completes',
   analyse: 'Analyse first pass',
+  /**
+   * The run control's label WHILE a run is in flight. It was a bare literal
+   * at `PanelFooter.tsx:186` while one surface rendered the control; the
+   * shell's `AnalysisReadinessBar` renders the same control on the Olumi
+   * surface, so the string is named here rather than typed a second time.
+   */
+  analysing: 'Analysing…',
 
   // ── ROADMAP 2.332 / 2.339 — the readiness check itself failed ─────
   //

--- a/src/canvas/components/pre-analysis-v3/footer/PanelFooter.tsx
+++ b/src/canvas/components/pre-analysis-v3/footer/PanelFooter.tsx
@@ -6,6 +6,14 @@
  * from the SAME authority first. Only when the gate is open does the line
  * fall back to the readiness-coaching copy from the model. The subline
  * wraps — never truncates.
+ *
+ * ⚠ THE LADDER ITSELF NOW LIVES IN `./readinessDisplay.ts`, AND THIS FILE IS NO
+ * LONGER ITS OWNER. A second pre-run surface (the shell's `AnalysisReadinessBar`
+ * on the Olumi tab) states the same line, and while the two computed it
+ * separately they contradicted each other on a reachable state — this one said
+ * "Readiness not checked yet", the other said "Analysis available", for the
+ * same store. Both now call `deriveReadinessDisplay`. Read that module's header
+ * for the ladder, the measurement, and the one arm the surfaces do NOT share.
  */
 
 import { memo } from 'react'
@@ -13,64 +21,8 @@ import { RefreshCw } from 'lucide-react'
 import { Button } from '../../../../components/ui'
 import { typography, typo } from '../../../../styles/typography'
 import { FOOTER_COPY } from '../constants'
-import { vetBlockedReason } from '../../../utils/vetBlockedReason'
+import { deriveReadinessDisplay, describeReadinessCheck, gateBlockedSubline } from './readinessDisplay'
 import type { PreAnalysisModel } from '../hooks/usePreAnalysisModel'
-
-/**
- * ROADMAP 2.332 — the moment a retained verdict was taken, as a clock time.
- *
- * Deliberately time-of-day and not a "5 minutes ago" elapsed string: elapsed
- * copy goes stale the instant it is rendered unless something re-renders it on
- * a timer, and a wrong elapsed figure is a worse claim than no figure. The
- * locale format is the browser's; the SENTENCE is what the tests bind to.
- */
-function formatTakenAt(ms: number): string {
-  return new Date(ms).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
-}
-
-/**
- * ROADMAP 2.332 / 2.339 — what the footer says when the readiness CHECK
- * failed, as opposed to when the model was graded and found wanting.
- *
- * Three distinct states, because they are three distinct facts:
- *   · nothing timestamped stands behind the panel — either no answer has ever
- *     arrived, or what is on screen is a LOCAL fallback rather than a server
- *     answer (the 429 arm, whose behaviour is unchanged and rowed separately);
- *   · a timestamped server answer, retained, still describing this model;
- *   · a timestamped server answer the model has outgrown.
- *
- * ⚠ The discriminator is `verdictAtMs`, NOT "is there a verdict object". The
- * store stamps `verdictAtMs` only where a real answer landed and explicitly
- * NULLS it on the 429 local-fallback arm, so a surface can never cite a time
- * for a number no server produced. Discriminating on the presence of
- * `readiness` would do exactly that — it is a hand-read of a field that means
- * something else.
- *
- * Every arm names the cause. Returns null when the check completed, which is
- * what keeps this slice invisible on the healthy path.
- */
-function describeReadinessCheck(
-  check: PreAnalysisModel['readinessCheck'],
-): { headline: string; subline: string } | null {
-  if (!check) return null
-
-  // The store's own message names WHICH failure it was (unreachable / missing
-  // / could not answer / rate limited). It is composed in this repo and never
-  // carries the response body, so it is safe to render verbatim.
-  if (check.verdictAtMs == null) {
-    return {
-      headline: check.verdictRetained
-        ? FOOTER_COPY.readinessRecheckFailed
-        : FOOTER_COPY.readinessUnchecked,
-      subline: FOOTER_COPY.readinessSub(check.message),
-    }
-  }
-
-  return {
-    headline: check.stale ? FOOTER_COPY.readinessStale : FOOTER_COPY.readinessRecheckFailed,
-    subline: FOOTER_COPY.readinessRetainedSub(check.message, formatTakenAt(check.verdictAtMs)),
-  }
-}
 
 const DOT_CLASSES: Record<PreAnalysisModel['footer']['dot'], string> = {
   muted: 'bg-text-light',
@@ -91,6 +43,13 @@ interface PanelFooterProps {
    * Never gates the run; it replaces the footer's claim about the check.
    */
   readinessCheck?: PreAnalysisModel['readinessCheck']
+  /**
+   * `readinessNothingHasAnswered(...)` — neither the side-car nor the producer
+   * has spoken. Was an arm INSIDE `usePreAnalysisModel`'s footer memo until the
+   * ladder moved; it is passed explicitly now so the shell's bar, which has no
+   * panel model, reaches the same arm through the same owner.
+   */
+  nothingHasAnswered?: boolean
 }
 
 export const PanelFooter = memo(function PanelFooter({
@@ -100,48 +59,28 @@ export const PanelFooter = memo(function PanelFooter({
   canRun,
   blockedReason,
   readinessCheck = null,
+  nothingHasAnswered = false,
 }: PanelFooterProps) {
   const disabled = isAnalysing || !canRun
 
-  // blockedReason can carry CEE-authored readiness text via OutputsDock's
-  // tooltip. The vetting rule — and the reason composed copy must never meet
-  // the SUBSTITUTING guard — lives in `utils/vetBlockedReason.ts`, which is now
-  // its single owner: the shell's readiness bar renders the same string on the
-  // Olumi surface, and a second copy of this rule here is exactly how two
-  // surfaces come to show two different sentences for one state.
-  const safeBlockedReason = blockedReason
-    ? vetBlockedReason(blockedReason)
-    : undefined
+  // ⭐ ONE LADDER, TWO SURFACES. Everything this used to decide inline — the
+  // outage override, the in-flight arm, the gate arm with its vetted reason, and
+  // the unanswered arm that used to sit inside the model's footer memo — is now
+  // `deriveReadinessDisplay`. `footer` is this surface's RESTING value only: the
+  // one arm a surface with a `PreAnalysisModel` can say more about than a
+  // surface without one.
+  const display = deriveReadinessDisplay({
+    readinessCheck,
+    isAnalysing,
+    canRun,
+    blockedReason,
+    nothingHasAnswered,
+    resting: footer,
+  })
 
-  // Single gate authority: dot, copy and button all derive from canRun.
-  // The tooltip string is advisory while the gate is open (footer diagnosis:
-  // treating it as a gate made an enabled-looking state read as disabled).
-  // While a run is in flight the gate reports blocked ("analysis is
-  // currently running") — say that, not "not ready".
-  //
-  // ROADMAP 2.332 / 2.339 — the outage arm outranks BOTH the gate copy and the
-  // model's own footer, and it has to.
-  //
-  // Below it, `!canRun ? notReady : footer` is a total function over a boolean:
-  // whichever way the gate lands, the footer makes a claim about a readiness
-  // assessment. With `readiness === null` the gate stays OPEN (canRunAnalysis
-  // blocks only on `readiness && !can_run_analysis`), so an unreachable service
-  // rendered as "Analysis available" — the exact invisible outage #564 merged
-  // on record. Deriving this state from `canRun` cannot fix that: `canRun` is a
-  // fact about the run, not about whether anything was checked.
+  // Kept as its own read so the outage TESTID below marks exactly the state the
+  // outage arm fired on, rather than being inferred from the rendered copy.
   const outage = describeReadinessCheck(readinessCheck)
-
-  const display = outage
-    ? { dot: 'warning' as const, headline: outage.headline, subline: outage.subline }
-    : isAnalysing
-      ? { dot: 'success' as const, headline: FOOTER_COPY.running, subline: FOOTER_COPY.runningSub }
-      : !canRun
-        ? {
-            dot: 'muted' as const,
-            headline: FOOTER_COPY.notReady,
-            subline: safeBlockedReason || FOOTER_COPY.notReadySubFallback,
-          }
-        : footer
 
   return (
     <div
@@ -156,7 +95,12 @@ export const PanelFooter = memo(function PanelFooter({
         className="min-w-0 flex-1"
         {...(outage ? { 'data-testid': 'pre-analysis-v3-readiness-outage' } : {})}
       >
-        <p className={typo('panelBody', 'text-text-header')}>{display.headline}</p>
+        <p
+          className={typo('panelBody', 'text-text-header')}
+          data-testid="pre-analysis-v3-footer-headline"
+        >
+          {display.headline}
+        </p>
         <p className={`${typography.panelMeta} text-text-light`}>{display.subline}</p>
       </div>
       {/* The check can be retried without touching the run. Deliberately NOT a
@@ -180,7 +124,7 @@ export const PanelFooter = memo(function PanelFooter({
         className="flex-none"
         onClick={onAnalyse}
         disabled={disabled}
-        title={!isAnalysing && !canRun ? safeBlockedReason || FOOTER_COPY.notReadySubFallback : undefined}
+        title={!isAnalysing && !canRun ? gateBlockedSubline(blockedReason) : undefined}
         data-testid="pre-analysis-v3-analyse"
       >
         {isAnalysing ? FOOTER_COPY.analysing : FOOTER_COPY.analyse}

--- a/src/canvas/components/pre-analysis-v3/footer/PanelFooter.tsx
+++ b/src/canvas/components/pre-analysis-v3/footer/PanelFooter.tsx
@@ -13,8 +13,7 @@ import { RefreshCw } from 'lucide-react'
 import { Button } from '../../../../components/ui'
 import { typography, typo } from '../../../../styles/typography'
 import { FOOTER_COPY } from '../constants'
-import { guardCeeText } from '../signals/ceeTextGuard'
-import { classifyBlockedReason } from '../../../utils/composeBlockedReason'
+import { vetBlockedReason } from '../../../utils/vetBlockedReason'
 import type { PreAnalysisModel } from '../hooks/usePreAnalysisModel'
 
 /**
@@ -73,18 +72,6 @@ function describeReadinessCheck(
   }
 }
 
-/** See the call site for why composed copy never meets the substituting guard. */
-function vetBlockedReason(blockedReason: string): string {
-  switch (classifyBlockedReason(blockedReason)) {
-    case 'composed-safe':
-      return blockedReason
-    case 'composed-unsafe':
-      return FOOTER_COPY.notReadySubFallback
-    default:
-      return guardCeeText(blockedReason, FOOTER_COPY.notReadySubFallback).text
-  }
-}
-
 const DOT_CLASSES: Record<PreAnalysisModel['footer']['dot'], string> = {
   muted: 'bg-text-light',
   warning: 'bg-warning',
@@ -117,22 +104,11 @@ export const PanelFooter = memo(function PanelFooter({
   const disabled = isAnalysing || !canRun
 
   // blockedReason can carry CEE-authored readiness text via OutputsDock's
-  // tooltip — guard it like every other CEE-rendered string in the panel.
-  //
-  // ⚠ …EXCEPT when it is COMPOSED copy (utils/composeBlockedReason.ts), which is
-  // built from vetted parts: a DGAI sentence frame plus the user's OWN option
-  // label. `guardCeeText` prefers IN-PLACE SUBSTITUTION and enforces terms the
-  // label vet does not, so it rewrote a label the user typed — an option named
-  // "Move billing to edge computing" rendered here as "…to connection
-  // computing" while the unguarded ⌘Enter toast and dock tooltip showed the real
-  // one. Two surfaces, two option names, one state: the exact class this
-  // module's copy exists to end, re-created by the guard meant to prevent it.
-  // (Its own header agrees: substitution applies to coaching text, "NEVER to
-  // option/factor/risk labels — those are shared graph data".)
-  //
-  // So composed copy is VETTED, never rewritten; if the vet fails the WHOLE
-  // sentence degrades to the non-committal fallback. Foreign strings (engine
-  // prose, validator messages) keep the guard's contract unchanged.
+  // tooltip. The vetting rule — and the reason composed copy must never meet
+  // the SUBSTITUTING guard — lives in `utils/vetBlockedReason.ts`, which is now
+  // its single owner: the shell's readiness bar renders the same string on the
+  // Olumi surface, and a second copy of this rule here is exactly how two
+  // surfaces come to show two different sentences for one state.
   const safeBlockedReason = blockedReason
     ? vetBlockedReason(blockedReason)
     : undefined
@@ -207,7 +183,7 @@ export const PanelFooter = memo(function PanelFooter({
         title={!isAnalysing && !canRun ? safeBlockedReason || FOOTER_COPY.notReadySubFallback : undefined}
         data-testid="pre-analysis-v3-analyse"
       >
-        {isAnalysing ? 'Analysing…' : FOOTER_COPY.analyse}
+        {isAnalysing ? FOOTER_COPY.analysing : FOOTER_COPY.analyse}
       </Button>
     </div>
   )

--- a/src/canvas/components/pre-analysis-v3/footer/readinessDisplay.ts
+++ b/src/canvas/components/pre-analysis-v3/footer/readinessDisplay.ts
@@ -49,6 +49,32 @@
  * (`FOOTER_COPY.ready`); they differ only in how much detail they add beneath
  * it, and the shell's states LESS rather than something different. A surface
  * without the panel model supplies `RESTING_AVAILABLE` and says no more.
+ *
+ * ⚠ AND BECAUSE IT IS THE UNSHARED ARM, IT IS THE ONE THAT CAN STILL DRIFT — so
+ * it is pinned by the same headline-equality test as the shared arms
+ * (`OutputsDock.readinessSurvivesTabChange.spec.tsx`, "RESTING"), proven to bite
+ * in BOTH directions by the mutant pair R1/R2. It shipped guarded on one side
+ * only: making the SHELL's constant diverge REDed, while making the PANEL's
+ * four-branch memo diverge survived 11/11 green — the guarded half frozen, the
+ * unguarded half the one that actually gets edited. One direction tested and the
+ * other open is trap 22b, and it would have half-closed the very defect class
+ * this module was extracted to close.
+ *
+ * ⚠ RECORDED, SEEN AND JUDGED — NOT CHASED. `usePreAnalysisModel`'s resting memo
+ * has an internal `canRun === false` branch returning `notReady`, where the
+ * shell's `RESTING_AVAILABLE` would say `ready`. It is UNREACHABLE while the run
+ * gate and the readiness authorities agree: the ladder's own gate arm fires
+ * first on `!canRun`, so the panel's branch is reached only if the two ever
+ * disagree — which is what its own comment says. A LATENT contradiction, not a
+ * live one. If the gate and the hook are ever allowed to diverge, this is where
+ * it will surface.
+ *
+ * ⚠ ALSO RECORDED: `describeReadinessCheck`'s RETAINED and STALE branches render
+ * a timestamp through `formatTakenAt`, and the shell's bar now shows that copy on
+ * the Olumi surface. Divergence risk is nil — one shared function, one
+ * expression — but that copy has never been DRIVEN on the bar; the equality test
+ * reaches only the `readinessUnchecked` branch. Presence of a shared function is
+ * not coverage of every branch it can take.
  */
 
 import { FOOTER_COPY } from '../constants'

--- a/src/canvas/components/pre-analysis-v3/footer/readinessDisplay.ts
+++ b/src/canvas/components/pre-analysis-v3/footer/readinessDisplay.ts
@@ -1,0 +1,231 @@
+/**
+ * readinessDisplay — THE ONE OWNER OF WHICH HEADLINE A PRE-RUN SURFACE STATES.
+ *
+ * ── WHY IT EXISTS, AND THE MEASUREMENT THAT FORCED IT ─────────────────────
+ * Two surfaces render a pre-run readiness line: `PanelFooter` on the Analysis
+ * tab, and `AnalysisReadinessBar`, which the shell hosts on the Olumi tab so
+ * that the blocked footer's own advice — *"Ask in the chat what they need"* —
+ * does not destroy its own context.
+ *
+ * The bar shipped with a TWO-ARM expression (`blocked ? notReady : ready`)
+ * beside the footer's FOUR-ARM ladder. Witnessed on the mounted dock, fresh
+ * guest, model on canvas, neither readiness authority having answered
+ * (`readiness == null && analysisReadiness == null`):
+ *
+ *   Analysis footer → "Readiness not checked yet — Olumi has not assessed this
+ *                      model yet. You can still run a first pass."   (warning)
+ *   Olumi bar       → "Analysis available"                           (SUCCESS)
+ *
+ * One state, one tab apart, contradictory claims — and the confident one was on
+ * the surface the advice sends the user to. That is the defect class the bar was
+ * written to end, re-created by the bar.
+ *
+ * ⚠ NOTE THE DATES, BECAUSE THEY ARE THE WHOLE LESSON. The footer's
+ * `nothingHasAnswered` arm landed 19 Aug; the bar landed 20 Aug. Two fixes for
+ * one harm, a day apart, each correct in isolation, neither one's tests able to
+ * see the other. No amount of care inside either diff would have surfaced it —
+ * only a guard that asserts the two surfaces AGREE can, which is why
+ * `OutputsDock.readinessSurvivesTabChange.spec.tsx` asserts headline EQUALITY
+ * rather than asserting each surface's copy separately.
+ *
+ * ── THE LADDER, IN ORDER, AND WHO OWNS WHAT ───────────────────────────────
+ *   1. outage             — the readiness CHECK failed. Outranks everything,
+ *                           including the gate: a surface may not report on a
+ *                           model when it knows the assessment did not happen.
+ *   2. analysing          — a run is in flight; say that, not "not ready".
+ *   3. gate shut          — `canRun === false`, with the gate's own composed
+ *                           and vetted reason.
+ *   4. nothing has answered — neither authority has spoken. Claim NOTHING about
+ *                           the model. (Hoisted here from `usePreAnalysisModel`'s
+ *                           footer memo, which was its only previous home and had
+ *                           exactly one consumer, so this is a MOVE, not a copy.)
+ *   5. resting            — the surface's own healthy-path value.
+ *
+ * ⚠ THE SCOPE LIMIT OF ARM 5, STATED SO NOBODY READS MORE INTO THE EQUALITY.
+ * `resting` is the one arm the surfaces do NOT share, and they cannot: the panel
+ * has a full `PreAnalysisModel` (whether success is defined, whether estimates
+ * are uncalibrated, whether CEE will scaffold options) and the shell does not.
+ * Every resting value on both surfaces states the SAME HEADLINE
+ * (`FOOTER_COPY.ready`); they differ only in how much detail they add beneath
+ * it, and the shell's states LESS rather than something different. A surface
+ * without the panel model supplies `RESTING_AVAILABLE` and says no more.
+ */
+
+import { FOOTER_COPY } from '../constants'
+import { vetBlockedReason } from '../../../utils/vetBlockedReason'
+
+/**
+ * The readiness CHECK's own failure facts.
+ *
+ * ⚠ STRUCTURAL, and deliberately not `PreAnalysisModel['readinessCheck']`. The
+ * shell's conformance guard scopes its rules to the dock's TRANSITIVE IMPORT
+ * CLOSURE, and its crawler follows `import type` exactly as it follows a value
+ * import — so naming that type here would pull `usePreAnalysisModel` and its
+ * whole dependency tree into the closure to buy nothing. The model's slice is
+ * assignable to this; the type test lives in the spec.
+ */
+export interface ReadinessCheckFacts {
+  readonly message: string
+  readonly verdictRetained: boolean
+  readonly stale: boolean
+  readonly verdictAtMs: number | null
+}
+
+export type ReadinessDot = 'muted' | 'warning' | 'success'
+
+export interface ReadinessDisplay {
+  readonly dot: ReadinessDot
+  readonly headline: string
+  readonly subline: string
+}
+
+/** The resting value for a surface that has no `PreAnalysisModel`. See the
+ *  scope-limit note in this module's header: same headline, fewer claims. */
+export const RESTING_AVAILABLE: ReadinessDisplay = {
+  dot: 'success',
+  headline: FOOTER_COPY.ready,
+  subline: '',
+}
+
+/**
+ * ROADMAP 2.332 — the moment a retained verdict was taken, as a clock time.
+ *
+ * Deliberately time-of-day and not a "5 minutes ago" elapsed string: elapsed
+ * copy goes stale the instant it is rendered unless something re-renders it on
+ * a timer, and a wrong elapsed figure is a worse claim than no figure. The
+ * locale format is the browser's; the SENTENCE is what the tests bind to.
+ */
+function formatTakenAt(ms: number): string {
+  return new Date(ms).toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' })
+}
+
+/**
+ * ROADMAP 2.332 / 2.339 — what a surface says when the readiness CHECK failed,
+ * as opposed to when the model was graded and found wanting.
+ *
+ * Three distinct states, because they are three distinct facts:
+ *   · nothing timestamped stands behind the surface — either no answer has ever
+ *     arrived, or what is on screen is a LOCAL fallback rather than a server
+ *     answer (the 429 arm, whose behaviour is unchanged and rowed separately);
+ *   · a timestamped server answer, retained, still describing this model;
+ *   · a timestamped server answer the model has outgrown.
+ *
+ * ⚠ The discriminator is `verdictAtMs`, NOT "is there a verdict object". The
+ * store stamps `verdictAtMs` only where a real answer landed and explicitly
+ * NULLS it on the 429 local-fallback arm, so a surface can never cite a time
+ * for a number no server produced.
+ *
+ * Every arm names the cause. Returns null when the check completed, which is
+ * what keeps this slice invisible on the healthy path.
+ */
+export function describeReadinessCheck(
+  check: ReadinessCheckFacts | null | undefined,
+): { headline: string; subline: string } | null {
+  if (!check) return null
+
+  // The store's own message names WHICH failure it was (unreachable / missing
+  // / could not answer / rate limited). It is composed in this repo and never
+  // carries the response body, so it is safe to render verbatim.
+  if (check.verdictAtMs == null) {
+    return {
+      headline: check.verdictRetained
+        ? FOOTER_COPY.readinessRecheckFailed
+        : FOOTER_COPY.readinessUnchecked,
+      subline: FOOTER_COPY.readinessSub(check.message),
+    }
+  }
+
+  return {
+    headline: check.stale ? FOOTER_COPY.readinessStale : FOOTER_COPY.readinessRecheckFailed,
+    subline: FOOTER_COPY.readinessRetainedSub(check.message, formatTakenAt(check.verdictAtMs)),
+  }
+}
+
+/**
+ * NEITHER AUTHORITY HAS SPOKEN — the state in which no surface may claim
+ * anything about the model.
+ *
+ * ⚠ Deliberately NOT `readiness == null` alone: a producer verdict IS an
+ * answer, so a surface holding one that reported itself as still waiting to
+ * hear would be a false claim of the same family, just in the humble direction.
+ * Exported so the shell and the panel ask ONE question rather than restating
+ * the conjunction (trap 12 — the mirror this estate keeps paying for).
+ */
+export function readinessNothingHasAnswered(
+  sideCarVerdict: unknown,
+  producerVerdict: unknown,
+): boolean {
+  return sideCarVerdict == null && producerVerdict == null
+}
+
+/**
+ * Build the CHECK-failure slice from the readiness store's own fields.
+ *
+ * Both the panel model and the shell derive `readinessCheck` this way; it lives
+ * here so there is one expression rather than two that must be kept identical.
+ */
+export function deriveReadinessCheck<TRetry>(input: {
+  error: string | null | undefined
+  verdictRetained: boolean
+  stale: boolean
+  verdictAtMs: number | null
+  retry: TRetry
+}): (ReadinessCheckFacts & { retry: TRetry }) | null {
+  if (!input.error) return null
+  return {
+    message: input.error,
+    verdictRetained: input.verdictRetained,
+    stale: input.stale,
+    verdictAtMs: input.verdictAtMs,
+    retry: input.retry,
+  }
+}
+
+/**
+ * The sentence a surface shows — and puts in its disabled control's `title` —
+ * when the GATE is shut. One expression, so a surface's tooltip can never
+ * disagree with the line printed beside it.
+ */
+export function gateBlockedSubline(blockedReason?: string): string {
+  return blockedReason ? vetBlockedReason(blockedReason) : FOOTER_COPY.notReadySubFallback
+}
+
+export interface ReadinessDisplayInput {
+  /** Non-null only when the readiness CHECK failed. Never gates the run. */
+  readonly readinessCheck: ReadinessCheckFacts | null | undefined
+  readonly isAnalysing: boolean
+  /** OutputsDock's `canRunAnalysis` — the run gate, not a copy of it. */
+  readonly canRun: boolean
+  /** The gate's own reason. Read only while the gate is shut. */
+  readonly blockedReason?: string
+  /** `readinessNothingHasAnswered(...)`, from the same two authorities the gate reads. */
+  readonly nothingHasAnswered: boolean
+  /** What this surface says when none of the arms above fire. */
+  readonly resting: ReadinessDisplay
+}
+
+/** Pure and total. The ladder in this module's header, in that order. */
+export function deriveReadinessDisplay(input: ReadinessDisplayInput): ReadinessDisplay {
+  const outage = describeReadinessCheck(input.readinessCheck)
+  if (outage) {
+    return { dot: 'warning', headline: outage.headline, subline: outage.subline }
+  }
+  if (input.isAnalysing) {
+    return { dot: 'success', headline: FOOTER_COPY.running, subline: FOOTER_COPY.runningSub }
+  }
+  if (!input.canRun) {
+    return {
+      dot: 'muted',
+      headline: FOOTER_COPY.notReady,
+      subline: gateBlockedSubline(input.blockedReason),
+    }
+  }
+  if (input.nothingHasAnswered) {
+    return {
+      dot: 'warning',
+      headline: FOOTER_COPY.readinessPending,
+      subline: FOOTER_COPY.readinessPendingSub,
+    }
+  }
+  return input.resting
+}

--- a/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
@@ -31,6 +31,10 @@ import { buildEstimateRows, topUncalibrated } from '../selectors/buildEstimateRo
 import { deriveSignalViews } from '../signals/deriveSignalViews'
 import { useSignalSessionStore } from '../signals/signalSessionStore'
 import { CEE_FALLBACK_COPY, FOOTER_COPY, LADDER_COPY } from '../constants'
+import {
+  deriveReadinessCheck,
+  readinessNothingHasAnswered,
+} from '../footer/readinessDisplay'
 import { guardCeeText, guardCeeTextOrNull, categoriseCoaching } from '../signals/ceeTextGuard'
 import type {
   Attribution,
@@ -113,6 +117,13 @@ export interface PreAnalysisModel {
     verdictAtMs: number | null
     retry: () => void
   } | null
+  /**
+   * Neither the side-car nor the producer has answered. Exposed because the
+   * arm that consumes it moved OUT of `footer` and into the shared ladder
+   * (`footer/readinessDisplay.ts`) when a second pre-run surface appeared —
+   * one with no `PreAnalysisModel` to read it from.
+   */
+  nothingHasAnswered: boolean
 }
 
 export function usePreAnalysisModel(): PreAnalysisModel {
@@ -241,7 +252,7 @@ export function usePreAnalysisModel(): PreAnalysisModel {
   // deliberately NOT `readiness == null` alone any more: a producer verdict IS
   // an answer, so a panel that had one would otherwise report itself as still
   // waiting to hear.
-  const nothingHasAnswered = readiness == null && analysisReadiness == null
+  const nothingHasAnswered = readinessNothingHasAnswered(readiness, analysisReadiness)
   const canRun = nothingHasAnswered ? null : !readinessObjectsToRun(readiness, analysisReadiness)
 
   const ladder = useMemo(
@@ -378,45 +389,23 @@ export function usePreAnalysisModel(): PreAnalysisModel {
   const contested = useMemo(() => computeContestedRows(nodes, edges), [nodes, edges])
 
   const footer = useMemo(() => {
-    // ── No verdict: say so, and claim nothing ────────────────────────
+    // ⚠ THE `nothingHasAnswered` ARM USED TO BE FIRST IN THIS MEMO AND IT HAS
+    // MOVED — to `footer/readinessDisplay.ts`, which is now the one owner of
+    // which headline a pre-run surface states. It is a MOVE, not a copy: this
+    // memo had exactly one consumer (`PreAnalysisPanelV3` → `PanelFooter`), and
+    // that consumer now reaches the unanswered arm through the shared ladder
+    // BEFORE this value is read.
     //
-    // FIRST, because with `readiness == null` nothing below this line is
-    // entitled to make a claim about the model. `canRun` is `null` here (not
-    // `false`), so the `canRun === false` arm does not fire and the memo used
-    // to fall through to the availability copy — printing "Analysis available"
-    // about a model nothing had assessed, beside a CTA that `canRunAnalysis`
-    // leaves enabled (it blocks only on `readiness && !can_run_analysis`).
-    // Witnessed on deployed staging 2026-08-13 as the exact triple
-    // "Analysis available / First pass will be provisional until success is
-    // defined / Analyse first pass" while CEE refused the run.
+    // Why it had to move: a SECOND pre-run surface exists (the shell's
+    // `AnalysisReadinessBar`, hosted on the Olumi tab so the blocked footer's
+    // "Ask in the chat" advice does not destroy its own context). It has no
+    // `PreAnalysisModel`, so an arm living in here was unreachable from it —
+    // and it duly claimed "Analysis available" on exactly the state this arm
+    // was added, one day earlier, to stop this surface claiming.
     //
-    // #564 / 2.332 / 2.339 closed the arms where the check FAILS; every one of
-    // them sets `readinessError`, and `readinessCheck` is derived as
-    // `readinessError ? {…} : null`. This is the arm none of them reach: the
-    // check has not answered YET, or never fired at all (the 2.345 starvation
-    // shape, which the readinessStore header records as ZERO graph-readiness
-    // requests in three of four witnessed guest sessions).
-    //
-    // Deliberately NOT keyed on `readinessError == null`. When an error IS
-    // recorded the outage arm in PanelFooter outranks this value anyway, so the
-    // extra conjunct buys nothing — and omitting it means an unanswered verdict
-    // can never produce an availability claim by any route, which is the
-    // fail-safe direction. The run gate is untouched: unknown does not object.
-    //
-    // ⚠ AMENDED 19 Aug 2026. This used to read `readiness == null` ALONE, and
-    // that sentence was written when the side-car was the only thing that could
-    // answer. It is now `nothingHasAnswered` — BOTH authorities silent — because
-    // a producer verdict IS an answer, and a panel holding one that reported
-    // itself as still waiting to hear would be a false claim of the same family
-    // as the one this lane deleted, just in the humble direction.
-    if (nothingHasAnswered) {
-      return {
-        dot: 'warning' as const,
-        headline: FOOTER_COPY.readinessPending,
-        subline: FOOTER_COPY.readinessPendingSub,
-      }
-    }
-
+    // What this value MEANS is therefore narrower than it was: it is the
+    // RESTING display — what to say once the outage, in-flight, gate and
+    // unanswered arms have all declined. Everything below is unchanged.
     // UI-SEM-091: readiness reports not-runnable, but CEE will draft the
     // remaining options — disclose the draft, never the not-ready copy.
     // Scaffold intent is a SIDE-CAR field, so this disclosure belongs to the
@@ -478,7 +467,6 @@ export function usePreAnalysisModel(): PreAnalysisModel {
     }
   }, [
     canRun,
-    nothingHasAnswered,
     // Read directly by two arms now (the scaffold guard and the not-ready
     // subline), so it is a first-class input to this memo, not a value `canRun`
     // can stand in for.
@@ -546,17 +534,17 @@ export function usePreAnalysisModel(): PreAnalysisModel {
   // status (2.339). The 429 arm sets an error too, but it also publishes a
   // labelled local fallback, so it is a verdict-bearing state and reaches the
   // retained arm rather than the never-checked one, which is the truth.
+  // Derived through the shared builder so the shell's bar and this panel cannot
+  // hold different ideas of what "the check failed" means (`readinessDisplay.ts`).
   const readinessCheck = useMemo(
     () =>
-      readinessError
-        ? {
-            message: readinessError,
-            verdictRetained: readiness != null,
-            stale: readinessStale,
-            verdictAtMs: readinessVerdictAtMs,
-            retry: refreshReadiness,
-          }
-        : null,
+      deriveReadinessCheck({
+        error: readinessError,
+        verdictRetained: readiness != null,
+        stale: readinessStale,
+        verdictAtMs: readinessVerdictAtMs,
+        retry: refreshReadiness,
+      }),
     [readinessError, readiness, readinessStale, readinessVerdictAtMs, refreshReadiness],
   )
 
@@ -573,6 +561,7 @@ export function usePreAnalysisModel(): PreAnalysisModel {
       advanced,
       footer,
       readinessCheck,
+      nothingHasAnswered,
     }),
     [
       hero,
@@ -586,6 +575,7 @@ export function usePreAnalysisModel(): PreAnalysisModel {
       advanced,
       footer,
       readinessCheck,
+      nothingHasAnswered,
     ],
   )
 }

--- a/src/canvas/components/workspaceShell/AnalysisReadinessBar.tsx
+++ b/src/canvas/components/workspaceShell/AnalysisReadinessBar.tsx
@@ -1,0 +1,120 @@
+/**
+ * AnalysisReadinessBar — the pre-run readiness statement, on the surface the
+ * product's own advice sends the user to.
+ *
+ * ── THE WITNESSED DEFECT (fresh guest, headful Chrome, 20 Aug 2026) ────────
+ * With the run blocked, the Analysis footer says, verbatim:
+ *
+ *     "4 parts of your model are not ready for analysis yet.
+ *      Ask in the chat what they need."
+ *
+ * Selecting the Olumi tab — doing exactly that — UNMOUNTS the whole
+ * pre-analysis subtree, because `OutputsDock` renders it under
+ * `{effectiveActiveTab === 'results' && …}`. The sentence and the Analyse
+ * control both leave the DOM. The instruction destroyed its own context: the
+ * user arrives in the chat with nothing on screen saying what they came to ask
+ * about, and no control to run once the answer lands.
+ *
+ * ── WHAT THIS BAR IS, AND THE FOUR THINGS IT DELIBERATELY IS NOT ───────────
+ * The shell hosts it in its reserved footer region, declared by the Olumi
+ * surface as `footerBar: 'readiness'` (`shellContract.ts`) — the same mechanism
+ * the Model surface uses to ask for `ReanalyseBar`, and for the same underlying
+ * reason: the control the surface needs is mounted on `results` only.
+ *
+ *  1. NOT A SECOND GATE. `canRun` and `blockedReason` are the shell's own
+ *     `canRunAnalysis` / `runBlockedTooltip` — the SAME two values the Analysis
+ *     footer's button and title are derived from, computed once in
+ *     `OutputsDock` above the tab branch. Nothing is re-derived here. A bar
+ *     that recomputed readiness would be the two-authorities defect this estate
+ *     keeps paying for.
+ *  2. NOT A SECOND RUNNER. `onAnalyse` is `handleRunAnalysis`, the canonical
+ *     runner registered in `canonicalRunRegistry`. The retired
+ *     `StaleAnalysisBadge` is the counter-example: its rerun bypassed it.
+ *  3. NOT A FRESHNESS SURFACE. It renders only PRE-RUN. Staleness after a
+ *     completed analysis belongs to the freshness strip and `ReanalyseBar`, and
+ *     adding a third claimant is what got the last one retired.
+ *  4. NOT A NEW SENTENCE. Every string here is the one the Analysis footer
+ *     already renders for the same state, through the same `vetBlockedReason`.
+ *     Two surfaces, one copy authority.
+ *
+ * ⚠ THE BUTTON'S HONESTY IS THE POINT AND IS NOT NEGOTIABLE. It is `disabled`
+ * on exactly `!canRun`, and carries the same reason as its `title`. It must
+ * never look pressable while the gate is shut — the blocked state on the
+ * Analysis surface was hard-won and this surface inherits it rather than
+ * re-deciding it.
+ */
+
+import { typography } from '../../../styles/typography'
+import { FOOTER_COPY } from '../pre-analysis-v3/constants'
+import { BLOCKED_REASON_FALLBACK, vetBlockedReason } from '../../utils/vetBlockedReason'
+
+export interface AnalysisReadinessBarProps {
+  /**
+   * True while no analysis has completed AND there is a model to analyse —
+   * i.e. exactly when the Analysis surface would be showing its pre-run panel.
+   * The bar makes no claim outside that window.
+   */
+  preRunWithModel: boolean
+  /** OutputsDock's `canRunAnalysis`. The run gate, not a copy of it. */
+  canRun: boolean
+  /** OutputsDock's `runBlockedTooltip`. Only read while `!canRun`. */
+  blockedReason?: string
+  /** OutputsDock's `isRunning`. */
+  isAnalysing: boolean
+  /** OutputsDock's `handleRunAnalysis` — the canonical runner. */
+  onAnalyse: () => void
+}
+
+export function AnalysisReadinessBar({
+  preRunWithModel,
+  canRun,
+  blockedReason,
+  isAnalysing,
+  onAnalyse,
+}: AnalysisReadinessBarProps) {
+  // Outside the pre-run window the Analysis surface itself shows no readiness
+  // panel, so there is nothing to carry and a bar here would be a claim no
+  // other surface is making.
+  if (!preRunWithModel) return null
+
+  const blocked = !canRun && !isAnalysing
+  // While a run is in flight the gate reports blocked for an obvious reason the
+  // label already states, so repeating a gate reason would be noise — and it is
+  // not the reason the control is unpressable.
+  const subline = blocked ? vetBlockedReason(blockedReason || BLOCKED_REASON_FALLBACK) : null
+
+  return (
+    <div
+      className="bg-panel border-t border-panel-border px-3 py-2 flex items-center gap-3"
+      data-testid="analysis-readiness-bar"
+      data-blocked={blocked ? 'true' : 'false'}
+      role="status"
+      aria-live="polite"
+    >
+      <span
+        aria-hidden
+        className={`h-2 w-2 flex-none rounded-full ${blocked ? 'bg-text-light' : 'bg-success'}`}
+      />
+      <div className="min-w-0 flex-1">
+        <p className={`${typography.panelBody} text-text-header`}>
+          {blocked ? FOOTER_COPY.notReady : FOOTER_COPY.ready}
+        </p>
+        {subline && (
+          <p className={`${typography.panelMeta} text-text-light`} data-testid="analysis-readiness-bar-reason">
+            {subline}
+          </p>
+        )}
+      </div>
+      <button
+        type="button"
+        onClick={onAnalyse}
+        disabled={isAnalysing || !canRun}
+        title={blocked ? subline || undefined : undefined}
+        className={`${typography.panelBody} flex-none rounded px-3 py-2 bg-primary text-text-on-color hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed`}
+        data-testid="analysis-readiness-bar-analyse"
+      >
+        {isAnalysing ? FOOTER_COPY.analysing : FOOTER_COPY.analyse}
+      </button>
+    </div>
+  )
+}

--- a/src/canvas/components/workspaceShell/AnalysisReadinessBar.tsx
+++ b/src/canvas/components/workspaceShell/AnalysisReadinessBar.tsx
@@ -44,6 +44,12 @@
  * re-deciding it.
  */
 
+// ⚠ THE MODULE, NOT THE BARREL. `components/ui/index.ts` re-exports the whole
+// brick set, and importing it pulls ~6 unrelated files into the DOCK'S IMPORT
+// CLOSURE — which is the scope of the raw-typography guard, so the barrel
+// silently drags in six files' worth of pre-existing violations and REDs the
+// per-file pin. Measured, not guessed.
+import { Button } from '../../../components/ui/Button'
 import { typography } from '../../../styles/typography'
 import { FOOTER_COPY } from '../pre-analysis-v3/constants'
 import { BLOCKED_REASON_FALLBACK, vetBlockedReason } from '../../utils/vetBlockedReason'
@@ -105,16 +111,25 @@ export function AnalysisReadinessBar({
           </p>
         )}
       </div>
-      <button
-        type="button"
+      {/* ⚠ THE SHARED `Button`, NOT A HAND-ROLLED ONE, AND THAT IS THE POINT.
+          The blocked treatment on the Analysis surface — `opacity 0.4`,
+          `cursor: not-allowed`, an explanatory `title` — was hard-won, and it
+          belongs to this component (`disabled:opacity-40
+          disabled:cursor-not-allowed`, Button.tsx). Re-implementing it here
+          would put a SECOND blocked appearance for the SAME state one tab away
+          from the first: the two would read as different degrees of "no", and
+          would drift the first time either moved. Same component, same props
+          shape, same disabled predicate as `PanelFooter`'s. */}
+      <Button
+        size="sm"
+        className="flex-none"
         onClick={onAnalyse}
         disabled={isAnalysing || !canRun}
         title={blocked ? subline || undefined : undefined}
-        className={`${typography.panelBody} flex-none rounded px-3 py-2 bg-primary text-text-on-color hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-info focus-visible:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed`}
         data-testid="analysis-readiness-bar-analyse"
       >
         {isAnalysing ? FOOTER_COPY.analysing : FOOTER_COPY.analyse}
-      </button>
+      </Button>
     </div>
   )
 }

--- a/src/canvas/components/workspaceShell/AnalysisReadinessBar.tsx
+++ b/src/canvas/components/workspaceShell/AnalysisReadinessBar.tsx
@@ -19,40 +19,60 @@
  * The shell hosts it in its reserved footer region, declared by the Olumi
  * surface as `footerBar: 'readiness'` (`shellContract.ts`) — the same mechanism
  * the Model surface uses to ask for `ReanalyseBar`, and for the same underlying
- * reason: the control the surface needs is mounted on `results` only.
+ * reason: the control that surface needs is mounted on `results` only.
  *
  *  1. NOT A SECOND GATE. `canRun` and `blockedReason` are the shell's own
  *     `canRunAnalysis` / `runBlockedTooltip` — the SAME two values the Analysis
  *     footer's button and title are derived from, computed once in
- *     `OutputsDock` above the tab branch. Nothing is re-derived here. A bar
- *     that recomputed readiness would be the two-authorities defect this estate
- *     keeps paying for.
+ *     `OutputsDock` above the tab branch. Nothing is re-derived here.
  *  2. NOT A SECOND RUNNER. `onAnalyse` is `handleRunAnalysis`, the canonical
  *     runner registered in `canonicalRunRegistry`. The retired
  *     `StaleAnalysisBadge` is the counter-example: its rerun bypassed it.
  *  3. NOT A FRESHNESS SURFACE. It renders only PRE-RUN. Staleness after a
- *     completed analysis belongs to the freshness strip and `ReanalyseBar`, and
- *     adding a third claimant is what got the last one retired.
- *  4. NOT A NEW SENTENCE. Every string here is the one the Analysis footer
- *     already renders for the same state, through the same `vetBlockedReason`.
- *     Two surfaces, one copy authority.
+ *     completed analysis belongs to the freshness strip and `ReanalyseBar`.
+ *  4. ⭐ NOT A SECOND OPINION ABOUT WHAT TO SAY — AND THIS ONE IT GOT WRONG
+ *     THE FIRST TIME. It shipped with a two-arm expression
+ *     (`blocked ? notReady : ready`) beside the footer's four-arm ladder, and
+ *     on a reachable state the two contradicted each other: with neither
+ *     readiness authority having answered, the footer said "Readiness not
+ *     checked yet" (warning) and this bar said "Analysis available" (green) —
+ *     the confident claim, on the surface the advice sends the user to. Both
+ *     surfaces now call `deriveReadinessDisplay`, which is the one owner.
+ *     `readinessDisplay.ts`'s header carries the ladder and the measurement.
  *
  * ⚠ THE BUTTON'S HONESTY IS THE POINT AND IS NOT NEGOTIABLE. It is `disabled`
- * on exactly `!canRun`, and carries the same reason as its `title`. It must
- * never look pressable while the gate is shut — the blocked state on the
- * Analysis surface was hard-won and this surface inherits it rather than
- * re-deciding it.
+ * on exactly `!canRun`, and carries the gate's own sentence as its `title`. It
+ * must never look pressable while the gate is shut.
  */
 
-// ⚠ THE MODULE, NOT THE BARREL. `components/ui/index.ts` re-exports the whole
-// brick set, and importing it pulls ~6 unrelated files into the DOCK'S IMPORT
-// CLOSURE — which is the scope of the raw-typography guard, so the barrel
-// silently drags in six files' worth of pre-existing violations and REDs the
-// per-file pin. Measured, not guessed.
+import { RefreshCw } from 'lucide-react'
+// ⚠ THE MODULE, NOT THE `components/ui` BARREL. Measured: the barrel re-exports
+// the whole brick set, which pulls six unrelated files into the DOCK'S
+// TRANSITIVE IMPORT CLOSURE — the scope of the raw-typography rule — and REDs
+// `tests/ci-guards/shell-conformance.spec.ts` ("no file in the dock closure
+// gains raw typography"): DeltaInterpretation +1, RangeChips +3, RangeLabels
+// +3, ScoreChip +1, VerdictCard +1, FieldLabel +2. It does NOT move
+// `ci:guard:ds:enforce`, which stays EXIT=0 with `panel-typography-scoped` Δ+0
+// — naming that guard here would send the next reader to a check that cannot
+// reproduce the finding.
 import { Button } from '../../../components/ui/Button'
 import { typography } from '../../../styles/typography'
 import { FOOTER_COPY } from '../pre-analysis-v3/constants'
-import { BLOCKED_REASON_FALLBACK, vetBlockedReason } from '../../utils/vetBlockedReason'
+import {
+  deriveReadinessDisplay,
+  gateBlockedSubline,
+  RESTING_AVAILABLE,
+  type ReadinessCheckFacts,
+  type ReadinessDot,
+} from '../pre-analysis-v3/footer/readinessDisplay'
+
+/** The shell's copy of the panel's dot palette, keyed off the shared type so a
+ *  new dot cannot be added in one place and missed here. */
+const DOT_CLASSES: Record<ReadinessDot, string> = {
+  muted: 'bg-text-light',
+  warning: 'bg-warning',
+  success: 'bg-success',
+}
 
 export interface AnalysisReadinessBarProps {
   /**
@@ -63,10 +83,19 @@ export interface AnalysisReadinessBarProps {
   preRunWithModel: boolean
   /** OutputsDock's `canRunAnalysis`. The run gate, not a copy of it. */
   canRun: boolean
-  /** OutputsDock's `runBlockedTooltip`. Only read while `!canRun`. */
+  /** OutputsDock's `runBlockedTooltip`. Only read while the gate is shut. */
   blockedReason?: string
   /** OutputsDock's `isRunning`. */
   isAnalysing: boolean
+  /**
+   * Non-null only when the readiness CHECK failed. Outranks the gate copy —
+   * the gate blocks only on `readiness && !can_run_analysis`, so an unreachable
+   * readiness service leaves `canRun` TRUE, and without this arm the bar would
+   * render a green "Analysis available" straight through an outage.
+   */
+  readinessCheck?: (ReadinessCheckFacts & { retry: () => void }) | null
+  /** `readinessNothingHasAnswered(...)` — neither authority has spoken. */
+  nothingHasAnswered: boolean
   /** OutputsDock's `handleRunAnalysis` — the canonical runner. */
   onAnalyse: () => void
 }
@@ -76,6 +105,8 @@ export function AnalysisReadinessBar({
   canRun,
   blockedReason,
   isAnalysing,
+  readinessCheck = null,
+  nothingHasAnswered,
   onAnalyse,
 }: AnalysisReadinessBarProps) {
   // Outside the pre-run window the Analysis surface itself shows no readiness
@@ -84,10 +115,19 @@ export function AnalysisReadinessBar({
   if (!preRunWithModel) return null
 
   const blocked = !canRun && !isAnalysing
-  // While a run is in flight the gate reports blocked for an obvious reason the
-  // label already states, so repeating a gate reason would be noise — and it is
-  // not the reason the control is unpressable.
-  const subline = blocked ? vetBlockedReason(blockedReason || BLOCKED_REASON_FALLBACK) : null
+  // ⚠ `resting` is the ONLY arm this surface supplies itself, and it says LESS
+  // than the panel's rather than something different: same headline
+  // (`FOOTER_COPY.ready`), no subline. The panel can add whether success is
+  // defined or estimates are uncalibrated; the shell has no `PreAnalysisModel`
+  // and must not invent the difference.
+  const display = deriveReadinessDisplay({
+    readinessCheck,
+    isAnalysing,
+    canRun,
+    blockedReason,
+    nothingHasAnswered,
+    resting: RESTING_AVAILABLE,
+  })
 
   return (
     <div
@@ -99,33 +139,50 @@ export function AnalysisReadinessBar({
     >
       <span
         aria-hidden
-        className={`h-2 w-2 flex-none rounded-full ${blocked ? 'bg-text-light' : 'bg-success'}`}
+        className={`h-2 w-2 flex-none rounded-full ${DOT_CLASSES[display.dot]}`}
       />
-      <div className="min-w-0 flex-1">
-        <p className={`${typography.panelBody} text-text-header`}>
-          {blocked ? FOOTER_COPY.notReady : FOOTER_COPY.ready}
+      <div
+        className="min-w-0 flex-1"
+        {...(readinessCheck ? { 'data-testid': 'analysis-readiness-bar-outage' } : {})}
+      >
+        <p className={`${typography.panelBody} text-text-header`} data-testid="analysis-readiness-bar-headline">
+          {display.headline}
         </p>
-        {subline && (
+        {display.subline && (
           <p className={`${typography.panelMeta} text-text-light`} data-testid="analysis-readiness-bar-reason">
-            {subline}
+            {display.subline}
           </p>
         )}
       </div>
-      {/* ⚠ THE SHARED `Button`, NOT A HAND-ROLLED ONE, AND THAT IS THE POINT.
-          The blocked treatment on the Analysis surface — `opacity 0.4`,
-          `cursor: not-allowed`, an explanatory `title` — was hard-won, and it
-          belongs to this component (`disabled:opacity-40
-          disabled:cursor-not-allowed`, Button.tsx). Re-implementing it here
-          would put a SECOND blocked appearance for the SAME state one tab away
-          from the first: the two would read as different degrees of "no", and
-          would drift the first time either moved. Same component, same props
-          shape, same disabled predicate as `PanelFooter`'s. */}
+      {/* The check can be retried without touching the run. Deliberately NOT a
+          gate: the verdict is the server's, and this asks it again — it never
+          decides in its place. Same affordance the Analysis footer offers, so
+          the route stays usable on whichever surface the user is standing. */}
+      {readinessCheck && (
+        <Button
+          size="sm"
+          variant="secondary"
+          className="flex-none"
+          onClick={readinessCheck.retry}
+          aria-label={FOOTER_COPY.readinessRetry}
+          data-testid="analysis-readiness-bar-retry"
+        >
+          <RefreshCw className="h-3.5 w-3.5" aria-hidden="true" />
+          Retry
+        </Button>
+      )}
+      {/* ⚠ THE SHARED `Button`, NOT A HAND-ROLLED ONE. The blocked treatment on
+          the Analysis surface — `opacity 0.4`, `cursor: not-allowed`, an
+          explanatory `title` — belongs to that component
+          (`disabled:opacity-40 disabled:cursor-not-allowed`). Re-implementing it
+          here would put a SECOND blocked appearance for the SAME state one tab
+          away from the first. */}
       <Button
         size="sm"
         className="flex-none"
         onClick={onAnalyse}
         disabled={isAnalysing || !canRun}
-        title={blocked ? subline || undefined : undefined}
+        title={blocked ? gateBlockedSubline(blockedReason) : undefined}
         data-testid="analysis-readiness-bar-analyse"
       >
         {isAnalysing ? FOOTER_COPY.analysing : FOOTER_COPY.analyse}

--- a/src/canvas/components/workspaceShell/shellContract.ts
+++ b/src/canvas/components/workspaceShell/shellContract.ts
@@ -278,8 +278,35 @@ export interface WorkspaceSurfaceDescriptor {
    * the surface's only re-run control also cannot simply be dropped into the
    * end of a long scrolling list, where it lands several screens below the
    * fold. Declaring it here is how a surface asks the shell to host it.
+   *
+   * ⭐ THIS FIELD IS THE CANONICAL OWNER OF "WHAT DOES THE SHELL PUT UNDER THIS
+   * SURFACE", AND IT IS THE ANSWER TO A RECURRING SHAPE, NOT A ONE-OFF. Both
+   * values exist because a control the user needs lives inside
+   * `OutputsDock`'s `results` render branch — `{effectiveActiveTab ===
+   * 'results' && …}` — and is therefore UNMOUNTED, not merely hidden, on every
+   * other surface:
+   *
+   *   'reanalyse' — the Model surface had no re-run control at all, because
+   *                 `AnalysisFooter` mounts on `results` only.
+   *   'readiness' — the Olumi surface had no statement of WHY the run is
+   *                 blocked, because the pre-analysis footer mounts on
+   *                 `results` only. That mattered more than it sounds: the
+   *                 blocked footer's own copy says *"Ask in the chat what they
+   *                 need"*, and acting on it fronts the Olumi tab, which takes
+   *                 the sentence and the Analyse control off screen. The
+   *                 instruction destroyed its own context.
+   *
+   * ⚠ WHY THE FIX IS A FOOTER DECLARATION AND NOT A MOUNT CHANGE. Making the
+   * `results` subtree survive a tab switch (as Olumi's does) would preserve its
+   * STATE and change nothing a user can see — a CSS-hidden subtree is still
+   * invisible. And Olumi's mount is not the anomaly to copy in the other
+   * direction: it is deliberate and load-bearing (`OutputsDock.tsx`'s wrapper
+   * comment; `OlumiTabBody`'s guidance-store callbacks are registered with no
+   * cleanup precisely because it stays mounted). The asymmetry is fine. What
+   * was missing was a way for the surface the user is SENT TO to carry the fact
+   * they were sent to ask about.
    */
-  readonly footerBar: 'none' | 'reanalyse'
+  readonly footerBar: 'none' | 'reanalyse' | 'readiness'
 }
 
 /**
@@ -301,7 +328,11 @@ export const WORKSPACE_SURFACES: Record<OutputTab, WorkspaceSurfaceDescriptor> =
   olumi: {
     id: 'olumi',
     label: 'Olumi',
-    footerBar: 'none',
+    // `AnalysisReadinessBar` — the pre-run readiness statement, carried to the
+    // surface the blocked footer's own copy sends the user to. Renders null
+    // unless the Analysis surface would be showing its pre-run panel for the
+    // same store state, so it makes no claim Analysis is not already making.
+    footerBar: 'readiness',
     // Bottom-anchored conversation with its own stick-to-bottom threshold.
     scroll: 'self',
     padding: 'self',

--- a/src/canvas/utils/vetBlockedReason.ts
+++ b/src/canvas/utils/vetBlockedReason.ts
@@ -1,0 +1,56 @@
+/**
+ * vetBlockedReason — THE ONE PLACE A BLOCKED-RUN REASON IS MADE SAFE TO RENDER.
+ *
+ * It was a module-private function inside `pre-analysis-v3/footer/PanelFooter.tsx`
+ * while exactly one surface rendered the reason. A second surface now renders the
+ * same string (the readiness bar the shell hosts on the Olumi tab), and a second
+ * COPY of this rule is how two surfaces come to show two different sentences for
+ * one state — the defect class `composeBlockedReason.ts` exists to end, and the
+ * one its own header records happening to an option label.
+ *
+ * So it moved here rather than being duplicated, and `PanelFooter` now imports
+ * it. There is one owner; both consumers read it.
+ *
+ * ── WHAT IT DOES, AND WHY THE THREE ARMS DIFFER ────────────────────────────
+ * `blockedReason` can carry CEE-authored readiness prose (via OutputsDock's run
+ * tooltip), so foreign strings get the same runtime glossary guard every other
+ * CEE-rendered string in the panel gets.
+ *
+ * ⚠ …EXCEPT when it is COMPOSED copy (`composeBlockedReason.ts`), which is built
+ * from vetted parts: a DGAI sentence frame plus the user's OWN option label.
+ * `guardCeeText` prefers IN-PLACE SUBSTITUTION and enforces terms the label vet
+ * does not, so it rewrote a label the user typed — an option named "Move billing
+ * to edge computing" rendered as "…to connection computing" while the unguarded
+ * ⌘Enter toast and dock tooltip showed the real one. Two surfaces, two option
+ * names, one state. (`ceeTextGuard`'s own header agrees: substitution applies to
+ * coaching text, "NEVER to option/factor/risk labels — those are shared graph
+ * data".)
+ *
+ * So composed copy is VETTED, never rewritten; if the vet fails the WHOLE
+ * sentence degrades to the non-committal fallback. Foreign strings keep the
+ * guard's contract unchanged.
+ */
+
+import { guardCeeText } from '../components/pre-analysis-v3/signals/ceeTextGuard'
+import { BLOCKED_REASON_COPY, classifyBlockedReason } from './composeBlockedReason'
+
+/**
+ * The last-resort subline. It must make NO factual claim about the model — it
+ * is reached exactly when we do not know the cause.
+ *
+ * ⚠ REFERENCED, NOT RE-TYPED, and `FOOTER_COPY.notReadySubFallback` references
+ * the same constant for the same reason. Three names, one string.
+ */
+export const BLOCKED_REASON_FALLBACK = BLOCKED_REASON_COPY.unspecified
+
+/** Pure and total. Returns a string that is always safe to render. */
+export function vetBlockedReason(blockedReason: string): string {
+  switch (classifyBlockedReason(blockedReason)) {
+    case 'composed-safe':
+      return blockedReason
+    case 'composed-unsafe':
+      return BLOCKED_REASON_FALLBACK
+    default:
+      return guardCeeText(blockedReason, BLOCKED_REASON_FALLBACK).text
+  }
+}

--- a/tests/ci-guards/shell-conformance.spec.ts
+++ b/tests/ci-guards/shell-conformance.spec.ts
@@ -736,12 +736,47 @@ describe('the shell contract itself holds together', () => {
     expect(WORKSPACE_SURFACES.results.footerBar).toBe('none')
   })
 
+  it('the Olumi surface asks the SHELL to carry the readiness statement', () => {
+    // The blocked Analysis footer says "Ask in the chat what they need"; acting
+    // on it fronts Olumi, and `{effectiveActiveTab === 'results' && …}` unmounts
+    // the sentence and the Analyse control. Declared into the shell's footer
+    // region so the surface the user is SENT TO carries the fact they were sent
+    // to ask about. Bound by identity to `olumi`, so "some surface declares
+    // readiness" cannot satisfy it.
+    expect(WORKSPACE_SURFACES.olumi.footerBar).toBe('readiness')
+    // …and the surface is genuinely presented, so this is not a declaration on
+    // a tab no user can reach (Journey/Compare are the live counter-examples).
+    expect(WORKSPACE_SURFACES.olumi.presentedAsTab).toBe(true)
+  })
+
+  it('every declared footerBar value has a render arm in the shell host', () => {
+    // The declaration is only worth what the host does with it. A value added
+    // to the union and rendered nowhere is the invisible mutant this contract
+    // was built to abolish — declared, type-clean, and dark.
+    const dock = readFileSync(path.join(REPO, SHELL_HOST), 'utf8')
+    const declared = new Set(
+      (Object.keys(WORKSPACE_SURFACES) as Array<keyof typeof WORKSPACE_SURFACES>)
+        .map(id => WORKSPACE_SURFACES[id].footerBar)
+        .filter(v => v !== 'none'),
+    )
+    expect(declared.size).toBeGreaterThan(1)
+    for (const value of declared) {
+      expect(dock, `no render arm for footerBar '${value}'`).toContain(`case '${value}':`)
+    }
+  })
+
   it('the shell renders the footer bar OUTSIDE the flag-gated stack', () => {
     // Hosting it inside the aiPanelV2 block would make the Model tab's only
     // re-run control vanish on rollback — a worse defect than the one fixed.
     const dock = readFileSync(path.join(REPO, SHELL_HOST), 'utf8')
     expect(dock).toContain('data-testid="shell-surface-footer-bar"')
-    expect(dock).toContain("surfaceFor(effectiveActiveTab).footerBar === 'reanalyse'")
+    // ⚠ THE GATE READS THE DESCRIPTOR, NOT A TAB ID — and it is now a lookup
+    // over the whole union rather than an equality against one value, because a
+    // second surface declares a bar. The equality was pinned here verbatim
+    // until 20 Aug 2026; it is SUPERSEDED rather than joined by a second
+    // assertion, so there is exactly one statement of what the gate is.
+    expect(dock).toContain("surfaceFor(effectiveActiveTab).footerBar !== 'none'")
+    expect(dock).not.toContain("effectiveActiveTab === 'olumi' && surfaceFor")
     const barAt = dock.indexOf('data-testid="shell-surface-footer-bar"')
     const stackAt = dock.indexOf('data-testid="ai-panel-footer-stack"')
     expect(barAt).toBeGreaterThan(0)


### PR DESCRIPTION
## The witnessed defect

Fresh guest, headful Chrome, UI `7153fbd7`. With the run blocked, the Analysis footer prints, verbatim:

> **4 parts of your model are not ready for analysis yet. Ask in the chat what they need.**

Selecting the Olumi tab — doing exactly what the product just said — takes both that sentence and the `Analyse first pass` control **out of the DOM**. The user arrives in the chat with nothing on screen saying what they came to ask about, and no control to run once the answer lands. The instruction destroys its own context.

This is not a visibility defect. The button is genuinely visible when mounted and its blocked state is honest. It is a coherence defect between an instruction and a tab switch.

## Deliberate or incidental — this decides the fix

| | verdict | evidence |
|---|---|---|
| Olumi subtree CSS-hidden, kept mounted | **DELIBERATE, load-bearing** | `OutputsDock.tsx:3284-3299` states it ("ChatThread's scroll position and `useSmartScroll` state survive"); `shellContract.ts` corroborates independently (`scroll: 'self'`); `OlumiTabBody.tsx:57-62` registers its guidance-store callbacks **with no cleanup**, explicitly because it survives tab switches |
| `results` subtree unmounted | **INCIDENTAL** | `OutputsDock.tsx:2552` is a bare `{effectiveActiveTab === 'results' && (` — the same default pattern as `diagnostics` (`:3264`) and `journey` (`:3282`). No comment, no code and no spec depends on it, in a file that has systematically lifted every other body-level decision (`scroll`, `padding`, `presentedAsTab`, `footerBar`) into the typed surface registry |

So **no mount predicate moves.** Making the results subtree CSS-hidden would preserve its *state* and change nothing a user can see — a hidden subtree is still invisible — while costing a permanent mount of the largest subtree in the dock. And unmounting Olumi "for consistency" would break the callbacks above.

## The fix

The Olumi surface declares `footerBar: 'readiness'` — **the same mechanism the Model surface already uses to ask the shell for `ReanalyseBar`, for the same underlying reason**: the control that surface needs is mounted on `results` only. (`ReanalyseBar`'s own header states it: *"`AnalysisFooter` … lives in OutputsDock's RESULTS branch … so a Model-tab user loses the control entirely."* The Olumi tab had the identical gap one surface over.)

`AnalysisReadinessBar` renders into the shell's reserved footer region, directly above the composer, fed by the shell's **own** `canRunAnalysis` / `runBlockedTooltip` — the same two values the Analysis footer derives its button and title from, computed once above the tab branch.

- **Not a second gate.** Nothing is re-derived.
- **Not a second runner.** `onAnalyse` is `handleRunAnalysis`, the canonical one.
- **Not a third freshness surface.** Renders only pre-run, with a model on the canvas.
- **Not a new sentence.** Same copy, same `vetBlockedReason`.
- **The button stays honest**: `disabled` on exactly `!canRun`, same reason as its `title`. When the chat repairs the model and the gate opens, it enables *in place*.

### Convergence (Paul's binding rule)

The gate changes from an equality against one value to a lookup over the declared union. Canonical owner: **`WORKSPACE_SURFACES[tab].footerBar` in `shellContract.ts`**. The competitor — the conformance guard's pinned literal `footerBar === 'reanalyse'` — is **superseded, not joined** by a second assertion. A new guard asserts every declared `footerBar` value has a render arm in the host, so a declared-but-dark value REDs.

Two mirrors removed while passing through: `vetBlockedReason` moves out of `PanelFooter` into `canvas/utils/` (one owner, two consumers), and the in-flight button label is named in `FOOTER_COPY` instead of typed twice.

## What else the unmount costs

Beyond the readiness statement and the run control, the `results` unmount also discards `PreAnalysisPanelV3`'s local state: `openGroups` (accordion, resets to `CLOSED_GROUPS`), `expandedEstimate`, `estimateFocus`, any `InlineField` **hint plus the uncommitted text it preserves** after a rejected commit, and the surface's scroll position. Reported, not fixed — none of it is the coherence defect, and fixing it would mean the mount change this PR argues against.

## Evidence

**RED-first** (pristine `7153fbd7` + the new modules present so imports resolve, declaration and wiring untouched — so the RED is behavioural, not a missing file): 8 collected, 3 RED —
- `MOUNT PATH …` → `expected 'none' to be 'readiness'`
- `THE FIX …` → `Unable to find an element by: [data-testid="analysis-readiness-bar"]`
- `READY …` → same

**The test asserts a postcondition ACROSS a tab change**, not presence at one moment — the button is *present* until the tab switches, so a presence assertion would have passed while this shipped. It also asserts the **mount path** itself (`aiPanelV2` at its production default, `preAnalysisV3` on, `olumi.presentedAsTab`, the `footerBar` declaration) so it REDs loudly if a flag moves, and binds every element by `data-testid`.

**Mutants** — throwaway worktree at an absolute path outside the repo root, isolation proven by writing a sentinel (source clone unchanged; distinct inodes), restores from a pristine tar archive, semantic applied-checks, controls exactly zero:

| mutant | expected | result |
|---|---|---|
| control (none) | GREEN | 59/59 green, applied-check **0** |
| M1 `olumi.footerBar: 'readiness'→'none'` | RED | 5 red (both new guards + MOUNT PATH + THE FIX + READY) |
| M2 gate `!== 'none'` → `=== 'reanalyse'` | RED | 3 red incl. the conformance gate string |
| M3 drop the button's `disabled` | RED | THE FIX red — the honesty requirement bites |
| M4 `preRunWithModel` → `true` | RED | POST-RUN red |
| M5 render the fallback, not the vetted reason | RED | THE FIX + the direct twin red |
| M6 `blocked` → always `true` | RED | READY red |
| M7 reason `data-testid` renamed | RED | THE FIX + twin red (identity binding) |
| **M8 CONTRAST — rename `ReanalyseBar`'s testid** | **spec GREEN** | only the conformance test that names `ReanalyseBar` red; **all 8 spec tests green** — the spec discriminates the Olumi bar from the Model bar |
| trailing control | GREEN | 59/59 green, applied-check **0** |

**Collected counts, by spec name** (`VITE_SUPABASE_URL="http://localhost"`, `VITE_SUPABASE_ANON_KEY="test"`, both taken from `ci.yml`):
- `OutputsDock.readinessSurvivesTabChange.spec.tsx` — **8 passed (8)**
- `tests/ci-guards/shell-conformance.spec.ts` — **51 passed (51)** (was 49; +2 new)
- `src/canvas/components/pre-analysis-v3` + `src/canvas/utils/__tests__` + `tests/ci-guards` — 135 files / **2535 passed**
- `src/canvas/components/__tests__` — 161 files / **1752 passed, 15 skipped**

`pnpm run typecheck` (the named gate, `scripts/ci/typecheck-gate.sh`): **PASSED**, coverage + ratchet, baseline unchanged at 2263 — no `--update-baseline`. `eslint` on all changed files: 0 errors. `ci:guard:ds:enforce`: no net-new violations.

## A corrected premise, reported as a deliverable

The brief flagged **UI #790** as colliding with this tab/mount arbitration ("adds `setShowResultsPanel(false)` to ten `openNodeInspector` call sites"). Derived at the bytes (`gh pr diff`, head `9df62b8d`): #790 touches **15 files and none of them is `OutputsDock.tsx`** — zero hunks — and there is **one** production `setShowResultsPanel(false)` call site, `src/canvas/nodes/shared/openNodeInspector.ts:64`, not ten. It touches no tab-selection, tab-render-branch or mount-arbitration code, and none of `shellContract.ts`, `pre-analysis-v3/**`, `composeBlockedReason.ts`, `PersistentInputStrip.tsx` or `revealOlumi.ts`. **File sets are disjoint; no sequencing needed.** (#790 is already `CONFLICTING` against `staging` on its own account, independent of this PR.)

## A cross-test leak worth knowing about

While writing the spec, every test after the first opened on the Olumi tab and failed on a signature unrelated to the defect. Cause: `handleTabClick` syncs the selection into a `?tab=` deep link via `history.replaceState` (`OutputsDock.tsx:2209-2219`), and **jsdom keeps one `window.location` per spec file** — so the first click's `?tab=olumi` was read back by the one-time init effect at `OutputsDock.tsx:1698` on every later mount. Found by instrumenting where the state update was *queued* rather than where it was applied; `sessionStorage` and both stores were provably clean at the time. The spec now resets the URL, with the mechanism recorded in the file. Any dock spec that clicks a tab is exposed to this.

## Not done

- Not merged, per the brief.
- Not driven on deployed staging for a fix witness.
- The advice copy in `composeBlockedReason.ts` is **unchanged** — deliberately. Once the chat surface carries the sentence, the instruction is true as written, and rewording it would move a string that a truthfulness corpus and a classifier pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Founder ruling (20 Aug), and where this lands against it

> *"Make the route Olumi recommends actually usable. Do NOT merely change the wording if the appropriate action can remain available."*

This PR takes the **preferred** option, not the fallbacks:

| ranked option | taken? |
|---|---|
| **Preferred — keep the Run affordance available where the advice sends the user** | ✅ `analysis-readiness-bar-analyse` ("Analyse first pass") is present in the chat tab, above the composer |
| Acceptable — surface the readiness summary and its route in the chat tab | ✅ also done (`analysis-readiness-bar-reason`, the same sentence) |
| **Last resort — reword the advice** | ❌ **not taken.** `composeBlockedReason.ts` is untouched |

The affordance is **present and honestly blocked**, and it now inherits that blocked state from the *same component* the Analysis footer uses rather than re-implementing it: `components/ui/Button` gives it `disabled:opacity-40` + `disabled:cursor-not-allowed` — the `opacity 0.4` / `cursor: not-allowed` the ruling names — plus the explanatory `title`. A second hand-rolled treatment (`opacity-50`) would have put two different degrees of "no" one tab apart for the same state. `M3` proves the honesty bites: drop the `disabled` predicate and the spec REDs.

⚠ Imported from the **module**, not the `components/ui` barrel. Measured: the barrel re-exports the whole brick set and pulls six unrelated files into the dock's import closure — which is the raw-typography guard's scope — and REDs the per-file pin (DeltaInterpretation, RangeChips, RangeLabels, ScoreChip, VerdictCard, FieldLabel). The direct import brings in `Button.tsx` alone.

**The last-resort option was never needed**, and this is the proof the ruling asks for: the action *can* remain available, because `canRunAnalysis` and `runBlockedTooltip` are already computed at shell level, above the tab branch — only their *renderer* was inside the `results` subtree.

## Final state

Head `009210b8`. Checks polled to conclusion in the foreground against that exact SHA:

- **`Staging Gate`: success** (the sole required check)
- `TypeScript + Lint`, `Typecheck Gate Self-Test`, `Production Build`, `Security Audit (pnpm)`, `CEE Contract Validation`, `Flag Deployment Drift`: success
- `Full Test Suite` shards 1–4 + Summary: success
- `Visual Regression (advisory)`: failure — **derived, not inherited**: the same job is `failure` on staging's own head `30db8ac3`. Standing advisory red, not this change.

`mergeable: MERGEABLE`, `mergeStateStatus: UNSTABLE` (the advisory red only).

⚠ **Base note for the integrator:** this branch is based on `7153fbd7`; staging has since moved to `30db8ac3` (one commit, *"Make Resolve Next confirmation truthful (#714)"*). Derived: it touches **none** of this PR's files. No rebase needed for correctness; harmless if you prefer one.

The full mutation battery was re-run at `009210b8` after the Button swap — **identical results**, all 8 mutants biting as tabled, both controls at applied-check 0 and 59/59 green.

---

# Review correction applied — head `d5ed9bd4`

The independent review found that the bar, while correctly **not a second gate**, was a second **authority for which headline to state**: a two-arm expression (`blocked ? notReady : ready`) beside `PanelFooter`'s four-arm ladder. Witnessed on the mounted dock — neither readiness authority having answered — the footer said *"Readiness not checked yet"* (warning) and the bar said **"Analysis available"** (green). Contradictory claims, one tab apart, with the confident one on the surface the advice sends the user to.

**The dates are the lesson, and they are why no care inside either diff could have caught it:** the footer's `nothingHasAnswered` arm landed **19 Aug**; this bar landed **20 Aug**. Two fixes for one harm, a day apart, each correct in isolation, neither one's tests able to see the other.

## The fix — the same convergence rule, one level up

`src/canvas/components/pre-analysis-v3/footer/readinessDisplay.ts` is now the **single owner** of the ladder:

> `outage` → `analysing` → `gate shut` → `nothing has answered` → the surface's `resting` value

Both surfaces call `deriveReadinessDisplay`. The two-arm expression is **superseded, not joined by a third opinion**.

- `describeReadinessCheck` + `formatTakenAt` **moved out of** `PanelFooter`.
- The `nothingHasAnswered` arm **moved out of** `usePreAnalysisModel`'s footer memo — a **move, not a copy**: that memo has exactly one consumer (`PreAnalysisPanelV3` → `PanelFooter`), and the arm was structurally unreachable from a surface with no `PreAnalysisModel`. `model.footer` now means the *resting* display, and its header says so.
- `deriveReadinessCheck` and `readinessNothingHasAnswered` are shared, so the shell does not restate the panel's expressions — the mirror that caused this.
- `gateBlockedSubline` is shared by the ladder **and** the button `title`, so a tooltip cannot disagree with the line beside it.

**Scope limit, stated rather than papered over:** `resting` is the one arm the surfaces do not share, and cannot — the panel has a `PreAnalysisModel` (success defined? estimates uncalibrated? will CEE scaffold?) and the shell does not. Every resting value on both surfaces states the **same headline** (`FOOTER_COPY.ready`); the shell's simply says **less**, never something different. `RESTING_AVAILABLE` is the named minimum.

## Second instance — the outage arm, now handled

Code-derived by the reviewer, not witnessed, and treated as a real reachable state. `canRunAnalysis` blocks only on `readiness && !can_run_analysis`, so an unreachable readiness service leaves the gate **open** — the bar would have rendered a green *"Analysis available"* straight through an outage. It now states the outage and offers the **same Retry** the footer does, so the route stays usable on whichever surface the user is standing.

**I could construct and drive the state the reviewer could not.** A `fetch` that rejects (`TypeError: Failed to fetch`) sets `readinessStore.error` and *keeps* it set — the mount fetch fails again rather than clearing it. That is now a mounted test asserting the store precondition in-test, both headlines equal, and Retry enabled on the bar.

## Pinned by EQUALITY, and both doors watched

The guard asserts the two surfaces' headlines are **equal** across **pending**, **outage** and **gate-shut**, read across a tab change with the store untouched (they can never be on screen together — the results subtree unmounts). Each equality is written against **the other surface**, not a constant: a constant would let both drift together and still pass. Preconditions are pinned in-test so an equality cannot pass because the state never arrived.

Opposite-direction pair, as required:

| mutant | change | result |
|---|---|---|
| **M9** | the **bar** alone drifts — restore its original two-arm expression | **2 RED** (PENDING, OUTAGE) |
| **M10** | the **footer** alone drifts — render `footer.headline`, ignoring the ladder | **2 RED** (PENDING, OUTAGE) |

M9 *is* the reviewer's witnessed defect, reproduced and killed.

## Full battery re-run at `d5ed9bd4` — 10 mutants + both controls

| mutant | expected | result |
|---|---|---|
| control (none) | GREEN | **62/62**, applied-check **0** |
| M1 `olumi.footerBar: 'readiness'→'none'` | RED | 8 red |
| M2 gate `!== 'none'` → `=== 'reanalyse'` | RED | 6 red |
| M3 drop the button's `disabled` | RED | THE FIX red — honesty bites |
| M4 `preRunWithModel` → `true` | RED | POST-RUN red |
| M5 owner's gate subline → fallback | RED | 3 red — **and it REDs the Analysis footer too, which is the proof the sentence is genuinely shared** |
| M6 `blocked` → always `true` | RED | READY red |
| M7 reason `data-testid` renamed | RED | 2 red (identity binding) |
| M8 **contrast** — rename `ReanalyseBar`'s testid | **spec GREEN** | only the guard naming `ReanalyseBar` red |
| M9 **bar drifts alone** | RED | 2 red |
| M10 **footer drifts alone** | RED | 2 red |
| trailing control | GREEN | **62/62**, applied-check **0** |

Worktree at an absolute path outside the repo, isolation re-proved by **writing a sentinel**, restores from a pristine tar archive, semantic applied-checks, controls exactly zero at both ends.

## Counts by name at `d5ed9bd4`

- `OutputsDock.readinessSurvivesTabChange.spec.tsx` — **11 passed (11)** (was 8; +3 equality tests)
- `tests/ci-guards/shell-conformance.spec.ts` — **51 passed (51)**
- `ReanalyseBar.spec.tsx` + `OutputsDock.dom.spec.tsx` — **48 passed (48)**
- `pre-analysis-v3` + `canvas/utils/__tests__` + `tests/ci-guards` — 135 files / **2535 passed**
- `src/canvas/components/__tests__` — 161 files / **1755 passed**, 15 skipped

`pnpm run typecheck` **PASSED**, baseline **unchanged at 2263** (no `--update-baseline`). eslint: **0 errors**; the one `usePreAnalysisModel` warning is **pre-existing** — verified by linting the same file at the previous commit `009210b8`, identical message.

## Barrel comment corrected

The reviewer was right that the measurement was real but the instrument named was wrong. Swapping to the `components/ui` barrel does **not** move `ci:guard:ds:enforce` (EXIT=0, `panel-typography-scoped` Δ+0) — it REDs **1 test in `tests/ci-guards/shell-conformance.spec.ts`** ("no file in the dock closure gains raw typography"): DeltaInterpretation +1, RangeChips +3, RangeLabels +3, ScoreChip +1, VerdictCard +1, FieldLabel +2. The comment now names that check, and says explicitly which one it is *not*.

## Checks at the exact head `d5ed9bd4`

**`Staging Gate`: success.** TypeScript + Lint, Typecheck Gate Self-Test, Production Build, Security Audit, CEE Contract Validation, Flag Deployment Drift, Full Test Suite shards 1–4 + Summary: all success. `Visual Regression (advisory)`: failure — **derived, not inherited**: the same job is `failure` on staging's own head. `mergeable: MERGEABLE`, `mergeStateStatus: UNSTABLE` (the advisory red only).

State-loss finding (accordion, scroll, `InlineField` hint + uncommitted text) remains **reported and unfixed**, per the coordinator, as its own lane. Not merged.

---

# Delta-review pins applied — head `872a3967`

## 1. The resting arm — the door that was open, on the side that gets edited

The review measured the asymmetry: shell resting diverges → **REDs**; panel resting diverges → **SURVIVED, 11/11 green**, with the two surfaces contradicting each other and nothing failing anywhere. The guarded half was a frozen constant; the unguarded half is a four-branch memo that has been edited repeatedly. Nothing referenced `RESTING_AVAILABLE` at all.

`RESTING` now gets the same headline-equality treatment as PENDING / OUTAGE / BLOCKED — written against the other surface, never a constant — with preconditions pinned in-test (no outage, verdict present, control enabled) so it cannot pass by never reaching the state.

| mutant | expected | result |
|---|---|---|
| **R1** shell's `RESTING_AVAILABLE` headline diverges | RED | **2 red** (READY, RESTING) |
| **R2** panel's resting arm headline diverges | RED | **1 red — RESTING.** This is the mutant that survived before |

## 2. Enable-in-place is now protected, not just verified

`READY` seeds ready *before* render, so the suite proved the bar **can** show an enabled control, never that it enables **without the user leaving the chat** — the exact claim that satisfies the founder's ruling.

Now driven end to end: blocked in the chat → the **producer's** verdict lands (one variable; it supersedes the side-car) → assertions on the **same DOM node**: `toBe(button)`, enabled, `title` gone, `data-blocked` flipped to `false`, reason element gone, Olumi still fronted.

Asserted by **node identity**, because "an enabled button exists" would be satisfied by a remount that flickered the user's surface. Proven by **M11**: giving the bar a `key` that changes with the gate forces a remount → **ENABLE IN PLACE REDs alone**, nothing else. A precise discrimination, not a broad one.

## Full battery at `872a3967` — 13 mutants, both controls

Control **64/64 green, applied-check 0**; trailing control **64/64 green, applied-check 0**. Worktree at an absolute path outside the repo, isolation re-proved by writing a sentinel, restores from a pristine tar archive, semantic applied-checks.

M1 → 10 red · M2 → 8 · M3 → 2 · M4 → 1 · M5 → 3 · M6 → 2 · M7 → 2 · **M8 contrast → spec GREEN** (only the guard naming `ReanalyseBar`) · M9 bar-drifts → 2 · M10 footer-drifts → 2 · **R1 → 2** · **R2 → 1** · **M11 → 1**.

## ⭐ A third fix I shipped and failed to claim

The reviewer found it by tracing the arms rather than reading my summary. Verified at the bytes at `009210b8`:

    const blocked = !canRun && !isAnalysing          // :86
    {blocked ? FOOTER_COPY.notReady : FOOTER_COPY.ready}   // :106
    {isAnalysing ? FOOTER_COPY.analysing : ...}            // :131

During a run, `isAnalysing` is true → `blocked` is **false** → the bar printed **"Analysis available"** (`FOOTER_COPY.ready`) beside a **disabled button reading "Analysing…"**. The shared ladder's `isAnalysing` arm now returns `FOOTER_COPY.running` = **"Analysis running"**.

**A third cross-surface contradiction, closed — and an unclaimed fix is one nobody can verify later.** Recording it here so it is protected rather than incidental.

## Correction to my own lint claim

I reported **one** pre-existing warning; there are **five**. Measured at both ends rather than asserted: **5 warnings / 0 errors at the base `7153fbd7`** (4 in `OutputsDock`, 1 in `usePreAnalysisModel`) and **5 warnings / 0 errors at `872a3967`** — identical messages, same files. **Zero new either way.** Nothing changes, but a count that is wrong in the safe direction still teaches the next reader to trust a number that was not measured.

*(The first attempt to lint the changed-file list silently failed because **zsh does not word-split an unquoted expansion** — eslint received all eleven paths as one pattern and errored. It errored loudly rather than linting nothing, but the fix is the standing one: feed the list through `xargs -0` and assert the count.)*

## Recorded in the module header — seen and judged, not chased

- `usePreAnalysisModel`'s resting memo has an internal `canRun === false` branch returning `notReady` where the shell would say `ready`. **Unreachable while the run gate and the readiness authorities agree** — the ladder's gate arm fires first. A latent contradiction, not a live one; the header names where it would surface.
- `describeReadinessCheck`'s **retained** and **stale** branches render a timestamp through `formatTakenAt`, and the bar now shows that copy on the Olumi surface. Divergence risk is nil (one shared expression) but **that copy has never been driven on the bar** — the equality test reaches only `readinessUnchecked`. Presence of a shared function is not coverage of every branch it can take.

## Counts by name at `872a3967`

- `OutputsDock.readinessSurvivesTabChange.spec.tsx` — **13 passed (13)**
- `tests/ci-guards/shell-conformance.spec.ts` — **51 passed (51)**
- `ReanalyseBar.spec.tsx` + `OutputsDock.dom.spec.tsx` — **48 passed (48)**
- `pre-analysis-v3` + `canvas/utils/__tests__` + `tests/ci-guards` — 135 files / **2535 passed**
- `src/canvas/components/__tests__` — 161 files / **1757 passed**, 15 skipped

`pnpm run typecheck` **PASSED**, baseline **unchanged at 2263**.

## Checks at the exact head `872a3967`

**`Staging Gate`: success.** TypeScript + Lint, Typecheck Gate Self-Test, Production Build, Security Audit, CEE Contract Validation, Flag Deployment Drift, Full Test Suite shards 1–4 + Summary — all success. `Visual Regression (advisory)`: failure, **derived not inherited** — the same job fails on staging's own head. `mergeable: MERGEABLE`, `mergeStateStatus: UNSTABLE` (advisory red only).

Not merged.
