### PR TITLE
fix(v5): the change receipt names the FIELD that moved, not just the entity

### DIFF
--- a/src/v5/__tests__/journey-3-and-6-wire-to-dom.test.tsx
+++ b/src/v5/__tests__/journey-3-and-6-wire-to-dom.test.tsx
@@ -315,7 +315,7 @@ describe('Workstream 1 — Journey 6 wire-to-DOM (set_factor_value)', () => {
 
     render(<V5GraphPatchBlock block={block} />)
 
-    expect(screen.getByTestId('v5-change-action').textContent).toBe('Updated factor')
+    expect(screen.getByTestId('v5-change-action').textContent).toBe('Updated factor value')
     expect(screen.getByTestId('v5-change-entity').textContent).toBe('team morale')
     // Renders user-facing raw_value + unit, NOT the normalised
     // 0.5 → 0.7 the wire envelope also carries.

--- a/src/v5/blocks/__tests__/V5GraphPatchBlock.test.tsx
+++ b/src/v5/blocks/__tests__/V5GraphPatchBlock.test.tsx
@@ -83,7 +83,7 @@ beforeEach(() => {
 })
 
 describe('V5GraphPatchBlock — clean receipt rendering', () => {
-  it('renders set_factor_value as "Updated factor" + entity + numeric diff', () => {
+  it('renders set_factor_value as "Updated factor value" + entity + numeric diff', () => {
     const block: V5GraphPatchBlockType = {
       type: 'v5_graph_patch',
       status: 'applied',
@@ -93,7 +93,7 @@ describe('V5GraphPatchBlock — clean receipt rendering', () => {
       after: { value: 0.7 },
     }
     render(<V5GraphPatchBlock block={block} />)
-    expect(screen.getByTestId('v5-change-action').textContent).toBe('Updated factor')
+    expect(screen.getByTestId('v5-change-action').textContent).toBe('Updated factor value')
     expect(screen.getByTestId('v5-change-entity').textContent).toBe('team morale')
     expect(screen.getByTestId('v5-change-summary').textContent).toBe('0.5 → 0.7')
     expect(screen.getByTestId('v5-change-status').textContent).toBe('Applied')
@@ -116,7 +116,7 @@ describe('V5GraphPatchBlock — clean receipt rendering', () => {
     expectNoLeakInDOM()
   })
 
-  it('renders adjust_edge_strength as "Adjusted connection" + endpoints + numeric diff', () => {
+  it('renders adjust_edge_strength as "Adjusted connection strength" + endpoints + numeric diff', () => {
     const block: V5GraphPatchBlockType = {
       type: 'v5_graph_patch',
       status: 'applied',
@@ -126,7 +126,7 @@ describe('V5GraphPatchBlock — clean receipt rendering', () => {
       after: { strength: 0.6 },
     }
     render(<V5GraphPatchBlock block={block} />)
-    expect(screen.getByTestId('v5-change-action').textContent).toBe('Adjusted connection')
+    expect(screen.getByTestId('v5-change-action').textContent).toBe('Adjusted connection strength')
     expect(screen.getByTestId('v5-change-entity').textContent).toBe('team morale → overall outcome')
     expect(screen.getByTestId('v5-change-summary').textContent).toBe('0.3 → 0.6')
     expectNoLeakInDOM()
@@ -276,7 +276,7 @@ describe('V5GraphPatchBlock — code-review regression bar (P1.1 / P1.2 / P1.3)'
       after: { value: 0.7, raw_value: 70, unit: '%', cap: 100 },
     }
     render(<V5GraphPatchBlock block={block} />)
-    expect(screen.getByTestId('v5-change-action').textContent).toBe('Updated factor')
+    expect(screen.getByTestId('v5-change-action').textContent).toBe('Updated factor value')
     expect(screen.getByTestId('v5-change-entity').textContent).toBe('team morale')
     expect(screen.getByTestId('v5-change-summary').textContent).toBe('50% → 70%')
     // Critical: never the normalised decimals in the visible text.
@@ -314,7 +314,7 @@ describe('V5GraphPatchBlock — code-review regression bar (P1.1 / P1.2 / P1.3)'
       },
     }
     render(<V5GraphPatchBlock block={block} />)
-    expect(screen.getByTestId('v5-change-action').textContent).toBe('Adjusted connection')
+    expect(screen.getByTestId('v5-change-action').textContent).toBe('Adjusted connection strength')
     expect(screen.getByTestId('v5-change-entity').textContent).toBe(
       'Marketing budget → Revenue',
     )
@@ -477,7 +477,7 @@ describe('V5GraphPatchBlock — G3 adjust_edge_strength graceful fallback', () =
       after: null,
     }
     render(<V5GraphPatchBlock block={block} />)
-    expect(screen.getByTestId('v5-change-action').textContent).toBe('Adjusted connection')
+    expect(screen.getByTestId('v5-change-action').textContent).toBe('Adjusted connection strength')
     // Endpoints resolve via the canvas store fallback (edge id is in EDGES).
     expect(screen.getByTestId('v5-change-entity').textContent).toBe(
       'team morale → overall outcome',
@@ -505,7 +505,7 @@ describe('V5GraphPatchBlock — G3 adjust_edge_strength graceful fallback', () =
     }
     render(<V5GraphPatchBlock block={block} />)
     const card = screen.getByTestId('v5-change-receipt')
-    expect(screen.getByTestId('v5-change-action').textContent).toBe('Adjusted connection')
+    expect(screen.getByTestId('v5-change-action').textContent).toBe('Adjusted connection strength')
     expect(screen.queryByTestId('v5-change-entity')).toBeNull()
     expect(screen.queryByTestId('v5-change-summary')).toBeNull()
     expect(card.outerHTML).not.toContain('edge_unknown_unmapped')
@@ -528,7 +528,7 @@ describe('V5GraphPatchBlock — G3 adjust_edge_strength graceful fallback', () =
       after: 'oops' as unknown as null,
     }
     render(<V5GraphPatchBlock block={block} />)
-    expect(screen.getByTestId('v5-change-action').textContent).toBe('Adjusted connection')
+    expect(screen.getByTestId('v5-change-action').textContent).toBe('Adjusted connection strength')
     expect(screen.queryByTestId('v5-change-summary')).toBeNull()
     expectNoLeakInDOM()
   })

--- a/src/v5/blocks/__tests__/v5GraphPatchDescription.spec.ts
+++ b/src/v5/blocks/__tests__/v5GraphPatchDescription.spec.ts
@@ -15,6 +15,7 @@ import {
   buildV5PatchReceipt,
   buildV5PatchDeps,
   formatConstraintValue,
+  V5_OPERATION_LABELS,
 } from '../v5GraphPatchDescription'
 
 const FORBIDDEN_TERMS = [
@@ -106,7 +107,7 @@ describe('buildV5PatchReceipt — set_factor_value', () => {
   it('uses canvas-store label when present and shows numeric diff', () => {
     const deps = makeDeps([{ id: 'fac_team_morale', label: 'team morale' }])
     const r = buildV5PatchReceipt(block(), deps)
-    expect(r.actionLabel).toBe('Updated factor')
+    expect(r.actionLabel).toBe('Updated factor value')
     expect(r.entityLabel).toBe('team morale')
     expect(r.changeSummary).toBe('0.5 → 0.7')
     expectNoLeak(`${r.actionLabel} ${r.entityLabel} ${r.changeSummary}`)
@@ -349,7 +350,7 @@ describe('buildV5PatchReceipt — adjust_edge_strength', () => {
       ],
     )
     const r = buildV5PatchReceipt(block(), deps)
-    expect(r.actionLabel).toBe('Adjusted connection')
+    expect(r.actionLabel).toBe('Adjusted connection strength')
     expect(r.entityLabel).toBe('team morale → outcome')
     expect(r.changeSummary).toBe('0.3 → 0.6')
     expectNoLeak(`${r.actionLabel} ${r.entityLabel} ${r.changeSummary}`)
@@ -383,5 +384,38 @@ describe('buildV5PatchReceipt — invariants', () => {
       )
       expectNoLeak(`${r.actionLabel} ${r.entityLabel} ${r.changeSummary}`)
     }
+  })
+})
+
+/**
+ * ⭐⭐ THE RECEIPT NAMES THE FIELD — pinned for its REASON, not for its wording.
+ *
+ * Fresh-guest browser witness, 20 Aug 2026 (UI `7153fbd7` / CEE `65445df`).
+ * Three different numbers hang off one option → factor pair: the link's
+ * STRENGTH, the factor's OWN VALUE, and the option's EFFECT VALUE. Two writes
+ * landed on the first two while the product's blocker was asking for the third,
+ * and the card's action label said only "Adjusted connection" / "Updated
+ * factor" — true of the entity, silent about which number moved.
+ *
+ * These assert the FIELD WORD is present rather than the exact phrase, so a
+ * later copy edit is free to reword the verb and is NOT free to drop the field.
+ */
+describe('the action label names the field that moved', () => {
+  it('every applied operation label names its field', () => {
+    expect(V5_OPERATION_LABELS.set_factor_value).toMatch(/\bvalue\b/i)
+    expect(V5_OPERATION_LABELS.adjust_edge_strength).toMatch(/\bstrength\b/i)
+    expect(V5_OPERATION_LABELS.add_constraint).toMatch(/\bconstraint\b/i)
+  })
+
+  it('the two numeric fields on one option → factor pair are DISTINGUISHABLE from each other', () => {
+    // The discriminating assertion: a reader must be able to tell a link
+    // strength change from a factor value change. Equal labels — or labels that
+    // differ only in the entity word — would fail the user in exactly the way
+    // the witness recorded.
+    expect(V5_OPERATION_LABELS.set_factor_value).not.toBe(
+      V5_OPERATION_LABELS.adjust_edge_strength,
+    )
+    expect(V5_OPERATION_LABELS.set_factor_value).not.toMatch(/\bstrength\b/i)
+    expect(V5_OPERATION_LABELS.adjust_edge_strength).not.toMatch(/\bfactor value\b/i)
   })
 })

--- a/src/v5/blocks/v5GraphPatchDescription.ts
+++ b/src/v5/blocks/v5GraphPatchDescription.ts
@@ -30,10 +30,31 @@ import type { V5GraphPatchBlock } from '../../canvas/conversation/types'
 // for V5 ops so the block component does not duplicate the table).
 // ---------------------------------------------------------------------------
 
+/**
+ * ⭐⭐ THE ACTION LABEL NAMES THE FIELD, NOT JUST THE ENTITY.
+ *
+ * Fresh-guest browser witness, 20 Aug 2026 (UI `7153fbd7` / CEE `65445df`). Two
+ * writes landed under the "Applied" badge that answered a question the user had
+ * not asked: an edge STRENGTH moved 1 → 0.6, and a factor's OWN VALUE moved
+ * 0.5 → 0.7, both while the product's blocker was asking for that option ×
+ * factor pair's EFFECT VALUE — a third number, on the same two entities.
+ *
+ * The card already named the entity and the before → after. What it could not
+ * do was let the reader tell WHICH NUMBER had moved: "Adjusted connection" and
+ * "Updated factor" both describe a change to an entity, not to a field. On a
+ * surface where three different numbers hang off the same option → factor pair,
+ * that is the difference between a receipt a user can check and one they cannot.
+ *
+ * ⚠ THE BADGE BESIDE THIS IS STILL THE BARE WORD "Applied"
+ * (`V5GraphPatchBlock.tsx:115`), gated on `block.status` alone. It stays: the
+ * badge answers *did it land?* and this label answers *what moved?* — two
+ * questions, named apart. What is fixed here is that the second question now
+ * has an answer.
+ */
 export const V5_OPERATION_LABELS: Record<V5GraphPatchBlock['operation'], string> = {
-  set_factor_value: 'Updated factor',
+  set_factor_value: 'Updated factor value',
   add_constraint: 'Added constraint',
-  adjust_edge_strength: 'Adjusted connection',
+  adjust_edge_strength: 'Adjusted connection strength',
 }
 
 const V5_NOOP_LABELS: Record<V5GraphPatchBlock['operation'], string> = {
@@ -221,8 +242,9 @@ export interface V5PatchDeps {
 
 export interface V5PatchReceipt {
   /**
-   * Action label — the title-case verb phrase, e.g. "Updated factor",
-   * "Added constraint", "Adjusted connection". Safe to show as a heading.
+   * Action label — the title-case verb phrase naming the FIELD that moved,
+   * e.g. "Updated factor value", "Added constraint", "Adjusted connection
+   * strength". Safe to show as a heading.
    */
   readonly actionLabel: string
   /**


### PR DESCRIPTION
## The witness

Fresh-guest browser witness, 20 Aug 2026 — deployed UI `7153fbd7` / CEE `65445df`.
Artefacts: `olumi-docs/PHASE0-EVIDENCE-2026-07-28/golden-journey-runs/2026-08-20-fresh-guest-browser-witness/`.

Two writes landed under the **Applied** badge that answered a question the user had not asked:

- an edge **strength** moved 1 → 0.6 (`shots/07-adjust-this-link-chip.png`), and
- a factor's **own value** moved 0.5 → 0.7,

both while the product's blocker was asking that option × factor pair for its **effect value** — a *third* number hanging off the same two entities. Readiness did not move either time.

## What the card actually said, measured

Contrary to the "Applied with no object" framing, the V5 receipt (`V5GraphPatchBlock.tsx:101-139`) already rendered three rows: the badge, an action label, the entity, and a before → after. For defect A that reads:

> **[Applied]  Adjusted connection**
> double down on mid-market with a lower-priced self-serve tier → Self-serve product investment
> 1 → 0.6

So the entity **was** named. What the card could not do was let the reader tell **which number moved**: *"Adjusted connection"* and *"Updated factor"* describe a change to an **entity**, not to a **field**. On a surface where three different numbers hang off one option → factor pair, that is the difference between a receipt a user can check against what they asked and one they cannot.

## The change

`src/v5/blocks/v5GraphPatchDescription.ts` — `V5_OPERATION_LABELS`:

| operation | before | after |
|---|---|---|
| `set_factor_value` | `Updated factor` | **`Updated factor value`** |
| `adjust_edge_strength` | `Adjusted connection` | **`Adjusted connection strength`** |
| `add_constraint` | `Added constraint` | unchanged — already names the thing |

**The "Applied" badge is deliberately unchanged.** It answers *did it land?*; the action label answers *what moved?*. Two questions, named apart — what is fixed here is that the second now has an answer. Suppressing the badge would be a silent success, which is worse.

## Why this is only half the fix

The wire block cannot carry this itself. `GraphEditResultBase` (`@talchain/schemas` 0.48.0, `handler-results.js:236-241`) is `.strict()` and carries `target_id` / `status` / `before` / `after` — **no entity label and no field name**; the deferral is documented at `CEE compose.ts:548-567`. The friendly receipt is therefore computed UI-side from the canvas store, and this change is made where the labels live.

The producer-side half — refusing to *make* those writes at all when they collide with the pair the product is asking about — is **Talchain/olumi-assistants-service#1067**, which also replaces the offered chip with a refusal that names the entity **and** the field.

## Evidence

- Pinned **by field word**, not by exact phrase, so a later copy edit is free to reword the verb and is **not** free to drop the field.
- A **discriminating pair**: the two numeric fields on one option × factor pair must not render indistinguishably — `set_factor_value` must not match `/strength/i`, `adjust_edge_strength` must not match `/factor value/i`, and the two labels must differ. Equal-or-near-equal labels fail the user in exactly the way the witness recorded.
- Suites run with `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set, and collection asserted **by name**: `V5GraphPatchBlock.test.tsx` 23, `v5GraphPatchDescription.spec.ts` 30, `journey-3-and-6-wire-to-dom.test.tsx` 6 — 59 passed.
- `pnpm run lint` clean (hooks ratchet: 229 known violations, exactly matching baseline). `pnpm run typecheck` **PASSED** — coverage 3587/3627 tracked files, ratchet 557 files / 2263 errors against a 2263 baseline.
- Residual-label sweep with a contrast control: the only remaining `'Adjusted connection'` / `'Updated factor'` hits are (a) prose in the two comments explaining this change and (b) two unrelated V4 fixtures — a `summary` field value in `GraphPatchBlock.spec.tsx:726` and a node **label** in `autoApplyPatch.spec.ts:501,510`. Contrast control: the new labels appear in 4 files.

## Not merged. Not deployed.
