### PR TITLE
fix(conversation): a truncated narrative card no longer deletes the paragraph's tail — plus a corrected premise on UX gate 4b

### DIFF
--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -353,8 +353,16 @@ export const InlineBlocks = memo(function InlineBlocks({
   /**
    * SECOND-CHANNEL ROUTING (UX gate 2026-08-18 point 4b). Computed ONCE per
    * turn, because the analysis-result card cannot see its siblings and must
-   * not guess. Structural — block presence, never a string comparison. See
-   * `turnDeliversNarrativeAsTypedCard`.
+   * not guess. See `turnDeliversNarrativeAsTypedCard`.
+   *
+   * Block presence decides the CHANNEL; the card's body is then read to
+   * confirm it carries the narrative in full. This line used to read
+   * "never a string comparison" — it now is one, deliberately. Not
+   * de-duplication: a repeated sentence is never suppressed for repeating.
+   * The question is only whether the card DELIVERS the paragraph, because a
+   * card whose body the contract caps at 300 chars can carry a prefix of an
+   * uncapped `narrative_summary`, and withholding the complete copy in
+   * favour of that prefix deletes the tail.
    *
    * ⚠⚠ COMPUTED OVER `topLevel`, NOT OVER `blocks`, AND THE DIFFERENCE IS A
    * DELETED PARAGRAPH. The first version of this passed the whole `blocks`

--- a/src/canvas/conversation/__tests__/InlineBlocks.narrativeChannel.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.narrativeChannel.spec.tsx
@@ -405,6 +405,158 @@ describe('Olumi copy assembly — the narrative channel renders once', () => {
   )
 
   /**
+   * ══ THE COMPLETENESS TWINS (UX gate 4b, second order) ══════════════════
+   *
+   * The routing above is STRUCTURAL: it withholds the untyped copy whenever a
+   * narrative card is present. That is right only while the card carries the
+   * WHOLE narrative. It does not always.
+   *
+   * CEE builds the card body as `truncate(narrative_summary, BODY_MAX)` with
+   * `BODY_MAX = 300` (`olumi-assistants-service`
+   * `src/orchestrator-v5/compose/phase3-blocks.ts:2529`, constant at `:214`
+   * via `COACHING_BLOCK_BODY_MAX`), appending an ellipsis when it cuts.
+   * `narrative_summary` itself is free LLM prose specified as "2-4 sentences"
+   * with NO cap at any hop — the shared contract's enrichment record is
+   * documented "deliberately open ... passes through verbatim", so nothing
+   * upstream bounds it.
+   *
+   * So a long-but-ordinary narrative yields a card carrying a PREFIX, while
+   * the only complete copy is the one the routing withholds — and the tail is
+   * then rendered NOWHERE. That inverts this file's own governing rule, stated
+   * on the twin below: absence of the card may only ever cost a DUPLICATE,
+   * never a paragraph. Here it costs the end of one.
+   *
+   * REACHABILITY, bounded by the producer rather than by imagination
+   * (trap 16-inverse): the corpus does not reach the cap — 176-264 chars
+   * across 8/8, a margin as thin as 36 characters — so no capture can pin
+   * this. But CEE's own prompt ships a canonical `narrative_summary` exemplar
+   * of 368 characters (`src/prompts/Versions /decision_review_prompt_v4_1.txt`
+   * :246), 68 over the cap. The producer's documented model of this field
+   * already exceeds what the card can carry.
+   *
+   * These tests are deliberately CAP-AGNOSTIC. They assert the UI's rule —
+   * "a card that carries only part of the narrative has not delivered it" —
+   * which is correct wherever the producer chooses to cut. Mirroring CEE's
+   * 300 here would be a hand-maintained copy of another repo's constant, the
+   * defect class this file already refuses elsewhere.
+   *
+   * Every string remains PRODUCER PROSE: the long narrative is two real
+   * capture narratives concatenated, never a sentence composed by this spec.
+   */
+  describe('completeness — a truncated card has not delivered the narrative', () => {
+    /** Two real producer narratives joined: long enough to be cut, all producer prose. */
+    function longNarrative(): string {
+      const a = liftCapture(CAPTURES[0]).narrativeSummary
+      const b = liftCapture(CAPTURES[1]).narrativeSummary
+      const joined = `${a} ${b}`
+      expect(joined.length).toBeGreaterThan(300)
+      return joined
+    }
+
+    /**
+     * The turn as the producer would send it when the narrative overruns the
+     * card: `narrative_summary` complete, card body cut to a prefix + ellipsis.
+     * The cut point is expressed as a FRACTION, not CEE's constant.
+     */
+    function truncatedCardTurn(): { blocks: ConversationBlock[]; full: string; shown: string } {
+      const { blocks } = liftCapture(CAPTURES[0])
+      const full = longNarrative()
+      const shown = `${full.slice(0, Math.floor(full.length * 0.6)).trimEnd()}\u2026`
+      expect(shown.length).toBeLessThan(full.length)
+
+      const next = blocks.map((b) => {
+        if (b.type === 'v5_analysis_result') {
+          const enrichment = b.enrichment as Record<string, unknown>
+          const review = enrichment.decision_review as Record<string, unknown>
+          return {
+            ...b,
+            enrichment: {
+              ...enrichment,
+              decision_review: { ...review, narrative_summary: full },
+            },
+          } as ConversationBlock
+        }
+        if (b.type === 'v5_review_card' && b.card_kind === NARRATIVE_REVIEW_CARD_KIND) {
+          return { ...b, body: shown } as ConversationBlock
+        }
+        return b
+      })
+      return { blocks: next, full, shown }
+    }
+
+    /**
+     * THE DEFECT. RED before the fix: the complete narrative appears zero
+     * times, because the card shows a prefix and the routing withheld the
+     * only complete copy.
+     */
+    it('a card carrying only a PREFIX does not suppress the complete copy', () => {
+      const { blocks, full } = truncatedCardTurn()
+      const { container } = render(<InlineBlocks blocks={blocks} turnId="t-trunc" />)
+      expect(countOccurrences(container.textContent ?? '', full)).toBe(1)
+    })
+
+    /** The tail is the part that vanished; name it directly, not just the whole. */
+    it('the TAIL past the producer\u2019s cut still reaches the user', () => {
+      const { blocks, full, shown } = truncatedCardTurn()
+      const tail = full.slice(shown.length - 1).trim()
+      expect(tail.length).toBeGreaterThan(20)
+      const { container } = render(<InlineBlocks blocks={blocks} turnId="t-tail" />)
+      expect(container.textContent ?? '').toContain(tail)
+    })
+
+    /** Nothing is deleted in exchange: the titled card still renders. */
+    it('the titled card still renders alongside the complete copy', () => {
+      const { blocks } = truncatedCardTurn()
+      const { container } = render(<InlineBlocks blocks={blocks} turnId="t-both" />)
+      expect(container.textContent).toContain('How the analysis reads')
+    })
+
+    /**
+     * OPPOSITE-DIRECTION TWIN (trap 22b). The fix must not re-open the
+     * duplicate: when the card carries the narrative IN FULL, the untyped
+     * copy stays withheld. Same construction, uncut body.
+     */
+    it('TWIN: a card carrying the narrative IN FULL still suppresses the copy', () => {
+      const { blocks } = liftCapture(CAPTURES[0])
+      const full = longNarrative()
+      const next = blocks.map((b) => {
+        if (b.type === 'v5_analysis_result') {
+          const enrichment = b.enrichment as Record<string, unknown>
+          const review = enrichment.decision_review as Record<string, unknown>
+          return {
+            ...b,
+            enrichment: {
+              ...enrichment,
+              decision_review: { ...review, narrative_summary: full },
+            },
+          } as ConversationBlock
+        }
+        if (b.type === 'v5_review_card' && b.card_kind === NARRATIVE_REVIEW_CARD_KIND) {
+          return { ...b, body: full } as ConversationBlock
+        }
+        return b
+      })
+      const { container } = render(<InlineBlocks blocks={next} turnId="t-full" />)
+      expect(countOccurrences(container.textContent ?? '', full)).toBe(1)
+      expect(
+        container.querySelector('[data-testid="v5-analysis-result-narrative-summary"]'),
+      ).toBeNull()
+    })
+
+    /**
+     * THE PRECONDITION PIN (trap 13b). These twins are only discriminating
+     * while the two bodies genuinely differ; if the construction ever stopped
+     * cutting, every assertion above would pass by testing nothing.
+     */
+    it('the probe really does cut the body (the twins discriminate)', () => {
+      const { full, shown } = truncatedCardTurn()
+      expect(shown).not.toEqual(full)
+      expect(full.startsWith(shown.slice(0, -1))).toBe(true)
+      expect(full.includes(shown)).toBe(false)
+    })
+  })
+
+  /**
    * THE NARROWNESS TWIN. Only the narrative channel is routed. The other
    * `decision_review` prose fields are NOT duplicated by any card (measured
    * 0/8) and must keep rendering in the analysis-result card exactly as

--- a/src/canvas/conversation/__tests__/InlineBlocks.narrativeChannel.spec.tsx
+++ b/src/canvas/conversation/__tests__/InlineBlocks.narrativeChannel.spec.tsx
@@ -29,8 +29,11 @@
  * sentence later, and it would hide the composer defect instead of resolving
  * it. `messageComposition.ts` already refuses to de-duplicate a text against
  * itself for exactly this reason. What is resolved here is the CHANNEL: when
- * the turn delivers the narrative as a typed, titled card, the untyped copy
- * inside the analysis-result card does not render. One content, one surface.
+ * the turn delivers the narrative as a typed, titled card IN FULL, the untyped
+ * copy inside the analysis-result card does not render. One content, one
+ * surface. (The card's body is read to confirm that "in full" — see the
+ * completeness twins below. That is a delivery test, not a de-duplication:
+ * nothing is ever suppressed for merely repeating.)
  *
  * This also REPAIRS A STALE PREMISE rather than overriding a live rule.
  * `V5AnalysisResultBlock`'s docblock justified rendering these fields as "the

--- a/src/canvas/conversation/__tests__/narrativeChannelContract.spec.ts
+++ b/src/canvas/conversation/__tests__/narrativeChannelContract.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * THE ANTI-RECURRENCE GUARD for the narrative channel (UX gate 4b).
+ *
+ * ## What went wrong, and why a guard belongs here
+ *
+ * UI #785 routes the analysis narrative onto one channel by asking whether the
+ * turn delivers it as a typed card. That predicate keys on the block type
+ * `v5_review_card`, while CEE emits `review_card` — and a reader comparing
+ * those two literals concludes, reasonably and WRONGLY, that the predicate is
+ * dead on every real turn. It is not: `adaptTypedReviewCardBlock`
+ * (`src/v5/phase3TypedBlocks.ts`) sits between them, accepting the wire type
+ * and re-emitting the UI type with `card_kind` carried through verbatim.
+ *
+ * The two names are separated by a TRANSLATION BOUNDARY, not by drift. But
+ * nothing executable said so, so the question had to be re-derived by hand —
+ * and the honest reading of the source in isolation is the wrong one. That is
+ * what this file fixes: it makes the boundary assert itself.
+ *
+ * ## Why this is DERIVED and not a hand-listed mirror
+ *
+ * The UI cannot read CEE's source at test time. What it CAN read is the thing
+ * BOTH services are bound to: the shared contract. CEE does not merely happen
+ * to send `review_card` — it VALIDATES every narrative card it emits against
+ * `ReviewCardBlockSchema` before sending it
+ * (`olumi-assistants-service` `src/orchestrator-v5/compose/phase3-blocks.ts`
+ * :2555, `validateProseAndSchemaOrDrop(ReviewCardBlockSchema, candidate, …)`).
+ * Both repos pin `file:./vendor/talchain-schemas-0.48.0.tgz`, and the two
+ * vendored tarballs are byte-identical (SHA-256
+ * `02f78afc8e554fc498c00e26ae555524da36516ebe632a253f8147bb8055805a`,
+ * compared 2026-08-20).
+ *
+ * So the contract is a genuine shared derivation point, not a copy: every
+ * literal below is READ OUT of the schema at run time. If CEE renames the
+ * block type or the narrative kind, it must change the contract to keep
+ * emitting — and this file REDs. If the UI's constant drifts, this file REDs.
+ * Nothing here is a list a human must remember to update (trap 12).
+ *
+ * What derivation CANNOT prove is that the contract is RIGHT — only that both
+ * ends still agree with it (trap 12d). The corpus in
+ * `InlineBlocks.narrativeChannel.spec.tsx` is the other half: it measures real
+ * captured payloads. Neither guard supersedes the other; both ship.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { ReviewCardBlockSchema } from '@talchain/schemas/boundary'
+import { maximalReviewCardBlock } from '@talchain/schemas/fixtures'
+import { adaptTypedReviewCardBlock } from '../../../v5/phase3TypedBlocks'
+import {
+  NARRATIVE_REVIEW_CARD_KIND,
+  turnDeliversNarrativeAsTypedCard,
+} from '../messageComposition'
+import type { ConversationBlock } from '../types'
+
+/** The wire type CEE must send, read out of the contract it validates against. */
+const CONTRACT_WIRE_TYPE = ReviewCardBlockSchema.shape.type.value
+
+/** The kind vocabulary the contract admits, read out of the contract. */
+const CONTRACT_CARD_KINDS: readonly string[] = ReviewCardBlockSchema.shape.card_kind.options
+
+describe('narrative channel — the producer/consumer boundary asserts itself', () => {
+  it('the contract still admits the narrative kind the UI gates on', () => {
+    // If CEE renamed the kind, it would have to change the contract to keep
+    // validating — and this is the assertion that notices.
+    expect(CONTRACT_CARD_KINDS).toContain(NARRATIVE_REVIEW_CARD_KIND)
+  })
+
+  it('the UI adapter accepts exactly the wire type the contract defines', () => {
+    // Positive: the contract's own type is accepted.
+    const accepted = adaptTypedReviewCardBlock({
+      ...maximalReviewCardBlock,
+      type: CONTRACT_WIRE_TYPE,
+      card_kind: NARRATIVE_REVIEW_CARD_KIND,
+    })
+    expect(accepted).not.toBeNull()
+
+    // Contrast control (trap 13e): the probe discriminates rather than
+    // accepting anything at all. A neighbouring type is refused.
+    const refused = adaptTypedReviewCardBlock({
+      ...maximalReviewCardBlock,
+      type: 'coaching',
+      card_kind: NARRATIVE_REVIEW_CARD_KIND,
+    })
+    expect(refused).toBeNull()
+  })
+
+  /**
+   * THE LOAD-BEARING ONE. A card that is legal for CEE to emit — proven legal
+   * by the contract's own validator, not by assertion — must survive the
+   * adapter and be RECOGNISED by the gate. This is the whole producer →
+   * translation → consumer chain, executed.
+   *
+   * Break any link (CEE's type, the contract's kind, the adapter's accepted
+   * type, the adapter's `card_kind` passthrough, the gate's constant) and this
+   * goes RED.
+   */
+  it('a contract-valid narrative card survives the adapter and satisfies the gate', () => {
+    const wireCard = {
+      ...maximalReviewCardBlock,
+      card_kind: NARRATIVE_REVIEW_CARD_KIND,
+      body: 'The producer narrative, carried whole.',
+    }
+
+    // The producer's own gate: this is emittable by CEE.
+    const parsed = ReviewCardBlockSchema.safeParse(wireCard)
+    expect(parsed.success).toBe(true)
+
+    // The translation the two names are separated by.
+    const adapted = adaptTypedReviewCardBlock(wireCard)
+    expect(adapted).not.toBeNull()
+    expect(adapted?.card_kind).toBe(NARRATIVE_REVIEW_CARD_KIND)
+
+    // The consumer recognises it.
+    expect(turnDeliversNarrativeAsTypedCard([adapted as ConversationBlock])).toBe(true)
+  })
+
+  /**
+   * The negative half of the same chain (trap 22b). The gate must not fire on
+   * a review card of a DIFFERENT contract kind — otherwise it would suppress
+   * the narrative paragraph in turns that never carried a narrative card, and
+   * the paragraph would be deleted rather than de-duplicated.
+   */
+  it('a contract-valid card of another kind does NOT satisfy the gate', () => {
+    const otherKind = CONTRACT_CARD_KINDS.find((k) => k !== NARRATIVE_REVIEW_CARD_KIND)
+    expect(otherKind).toBeDefined()
+
+    const wireCard = { ...maximalReviewCardBlock, card_kind: otherKind }
+    expect(ReviewCardBlockSchema.safeParse(wireCard).success).toBe(true)
+
+    const adapted = adaptTypedReviewCardBlock(wireCard)
+    expect(adapted).not.toBeNull()
+    expect(turnDeliversNarrativeAsTypedCard([adapted as ConversationBlock])).toBe(false)
+  })
+})

--- a/src/canvas/conversation/messageComposition.ts
+++ b/src/canvas/conversation/messageComposition.ts
@@ -94,6 +94,7 @@
  *    silently absorbed.
  */
 import type { ConversationBlock, GraphPatchBlock } from './types'
+import { readDecisionReviewWireState } from '../../v5/decisionReviewAdapter'
 import { isLensCompanionBlock } from './phase3Pacing'
 import {
   isGraphPatchApplied,
@@ -763,18 +764,76 @@ export function turnDeliversNarrativeAsTypedCard(
   blocks: readonly ConversationBlock[] | undefined,
 ): boolean {
   if (!blocks || blocks.length === 0) return false
-  return blocks.some((block) => {
-    // `v5_review_card` ONLY. The legacy `review_card` was in this condition
-    // and was UNREACHABLE: `ReviewCardBlock` (types.ts) carries
-    // title/body/variant/tone/priority and has NO `card_kind` at all, so the
-    // kind test below could never pass for it. A dead branch in a predicate
-    // reads as coverage of a case that cannot occur — removed rather than
-    // left to imply the legacy shape was considered and handled.
-    if (block.type !== 'v5_review_card') return false
-    if (block.card_kind !== NARRATIVE_REVIEW_CARD_KIND) return false
+
+  let cardBody: string | null = null
+  for (const block of blocks) {
+    // `v5_review_card` ONLY — and that is the POST-ADAPTER type, not the wire
+    // type. CEE sends `type: "review_card"` with `card_kind: "narrative"`
+    // (`phase3-blocks.ts:2544-2545`); `adaptTypedReviewCardBlock`
+    // (`src/v5/phase3TypedBlocks.ts:104-131`) accepts that wire type and
+    // re-emits it as `v5_review_card`, carrying `card_kind` through verbatim.
+    // Comparing this constant against CEE's wire literal therefore compares
+    // across a translation boundary and reads as a mismatch that is not one.
+    // `narrativeChannelContract.spec.ts` pins both ends against the shared
+    // contract so a real divergence REDs.
+    //
+    // The legacy `review_card` was in this condition and was UNREACHABLE:
+    // the UI's own `ReviewCardBlock` (types.ts) carries
+    // title/body/variant/tone/priority and has NO `card_kind` at all.
+    if (block.type !== 'v5_review_card') continue
+    if (block.card_kind !== NARRATIVE_REVIEW_CARD_KIND) continue
     const body: unknown = block.body
-    return typeof body === 'string' && body.trim().length > 0
-  })
+    if (typeof body === 'string' && body.trim().length > 0) {
+      cardBody = body
+      break
+    }
+  }
+  if (cardBody === null) return false
+
+  // ── COMPLETENESS ────────────────────────────────────────────────────────
+  // Presence of the card is not delivery of the narrative. CEE builds the
+  // body as `truncate(narrative_summary, 300)`
+  // (`phase3-blocks.ts:2529`, cap at `:214`), while `narrative_summary`
+  // is uncapped free prose at every hop. When the narrative overruns, the
+  // card carries a PREFIX — and withholding the untyped copy in favour of it
+  // renders the tail NOWHERE.
+  //
+  // The rule this file already states, on the no-card twin, is that absence
+  // of the card may only ever cost a DUPLICATE, never a paragraph. The same
+  // rule decides this: a card that carries only part of the narrative has
+  // not delivered it, so the complete copy stands. The cost is a
+  // near-duplicate on long narratives; the alternative is deleting the end
+  // of the producer's own paragraph.
+  //
+  // Deliberately CONTAINMENT, not equality: a future producer that frames the
+  // narrative inside a longer body still delivers it in full. And the check
+  // only ever flips the answer to false on POSITIVE evidence of a short body
+  // — when the turn carries no readable narrative to compare against, the
+  // structural verdict stands unchanged.
+  const narrative = turnNarrativeSummary(blocks)
+  if (narrative === null) return true
+  return cardBody.trim().includes(narrative.trim())
+}
+
+/**
+ * The turn's `narrative_summary`, read through the SAME canonical adapter the
+ * analysis-result card renders from (`readDecisionReviewWireState`), so the
+ * two can never disagree about what the untyped copy would say. A second
+ * hand-rolled path-walk into `enrichment.decision_review` would be exactly the
+ * parallel reader this platform keeps paying for.
+ *
+ * `null` when the turn carries no analysis-result block, no decision review,
+ * or no narrative prose — all of which mean there is nothing to lose.
+ */
+function turnNarrativeSummary(blocks: readonly ConversationBlock[]): string | null {
+  for (const block of blocks) {
+    if (block.type !== 'v5_analysis_result') continue
+    const state = readDecisionReviewWireState(block.enrichment)
+    if (state.kind !== 'v0_30') continue
+    const summary = state.review.narrative_summary
+    if (typeof summary === 'string' && summary.trim().length > 0) return summary
+  }
+  return null
 }
 
 /**

--- a/src/canvas/conversation/messageComposition.ts
+++ b/src/canvas/conversation/messageComposition.ts
@@ -755,10 +755,30 @@ export const NARRATIVE_REVIEW_CARD_KIND = 'narrative'
 /**
  * Does this turn deliver the analysis narrative as a TYPED, TITLED card?
  *
- * True iff the turn carries a review card of the narrative kind with a
- * non-empty body. Body content is never compared to anything — only its
- * existence, because an empty card delivers nothing and must not cause the
- * untyped copy to be withheld.
+ * True iff the turn carries a review card of the narrative kind whose body
+ * carries the narrative IN FULL. An empty card delivers nothing; so does a
+ * card carrying only part of the paragraph.
+ *
+ * ⚠ THE BODY *IS* COMPARED, and this docstring used to say it never was.
+ * The check is DELIVERY-COMPLETENESS, not de-duplication: the two channels
+ * are never reconciled by matching prose, and a repeated sentence is never
+ * suppressed for being repeated. What is asked is only whether the card
+ * carries the whole of what the untyped copy would otherwise say — because
+ * withholding a complete copy in favour of a truncated one deletes the tail.
+ *
+ * Do not "simplify" this back to presence-only. That is precisely the shape
+ * that deleted the end of the paragraph: the card body is bounded BY THE
+ * CONTRACT (`ReviewCardBlockSchema.body` is `.max(300)`), while
+ * `narrative_summary` is not a declared field of
+ * `EnrichmentDecisionReviewSchema` at all — that object is `.passthrough()`
+ * and documented "deliberately open ... passes through verbatim". One channel
+ * is capped by the spec and the other is uncapped by the spec, so the
+ * overrun is ADMITTED BY THE CONTRACT, not merely observed.
+ *
+ * THE DELTA IS MONOTONE, which is why this is safe: no card still returns
+ * false, and a card present returns true UNLESS there is positive evidence
+ * of a short body. Every input that kept the untyped copy before still keeps
+ * it — the change can only ever ADD kept copies, never remove one.
  */
 export function turnDeliversNarrativeAsTypedCard(
   blocks: readonly ConversationBlock[] | undefined,

--- a/src/v5/blocks/V5AnalysisResultBlock.tsx
+++ b/src/v5/blocks/V5AnalysisResultBlock.tsx
@@ -425,10 +425,19 @@ function V5AnalysisResultBlockImpl({
         >
           {/*
             UX gate 2026-08-18 point 4b — the narrative is withheld HERE only
-            when the turn delivers it as its own titled card. Not a string
-            comparison and not a de-duplication: a channel choice, made on
-            block presence, so it cannot depend on the prose staying
-            byte-identical. See `turnDeliversNarrativeAsTypedCard`.
+            when the turn delivers it as its own titled card, IN FULL. A
+            channel choice, not a de-duplication: a repeated sentence is
+            never suppressed for being repeated. See
+            `turnDeliversNarrativeAsTypedCard`.
+
+            This comment used to say "not a string comparison ... so it
+            cannot depend on the prose staying byte-identical". The card's
+            body IS now read, to confirm it carries the whole paragraph —
+            because the contract caps that body at 300 chars while
+            `narrative_summary` is uncapped, so a presence-only test withheld
+            the complete copy in favour of a truncated one and the tail
+            rendered nowhere. Withholding still requires a card; it now also
+            requires that the card actually delivers the paragraph.
           */}
           {review030.narrative_summary !== null && !narrativeDeliveredByTypedCard && (
             <p


### PR DESCRIPTION
## The briefed premise is refuted — and a different, live defect is fixed

I was dispatched to make UI #785 fire, on the premise that it is *"merged, deployed, and dead code on the live wire"* — that `turnDeliversNarrativeAsTypedCard` is **always false on every real turn** because it gates on `v5_review_card` while CEE emits `review_card`.

**That premise is false, and it is worth being precise about why, because the reasoning behind it is the correct reasoning applied across the wrong boundary.**

The two literals are separated by a **translation boundary**, not by drift:

| hop | location | type |
|---|---|---|
| CEE emits | `phase3-blocks.ts:2544-2545` | `review_card` + `card_kind: 'narrative'` |
| UI adapts | `src/v5/phase3TypedBlocks.ts:104-131` | accepts `review_card` → re-emits `v5_review_card`, **carrying `card_kind` through verbatim** |
| UI gates | `messageComposition.ts:773` | matches `v5_review_card` + `card_kind: 'narrative'` ✅ |

`adaptTypedReviewCardBlock` (and `mapV5Blocks.ts:106`) do the translation. The gate matches the **post-adapter** type. Comparing CEE's wire literal directly against the UI's gate literal skips the adapter and reads as a mismatch that is not one.

Three independent lines confirm the gate fires:

1. **At the bytes** — both adapters copy `card_kind` verbatim (`card_kind: cardKind` / `card_kind: block.card_kind`).
2. **By execution** — `InlineBlocks.narrativeChannel.spec.tsx` runs 8 real captures (2026-07-31 → 2026-08-17) through the real render path: 69/69 green at pristine `30db8ac3`.
3. **By live witness, from another lane** — #810's commit records driving *deployed staging* on 19 + 20 Aug: **"0 duplicate paragraphs in the default collapsed view"**, 3 pairs only once the disclosure is opened. Those 3 are what #810 fixed at 04:55 today.

The 18 Aug gate failure is also explained by build ordering: `4d1e650b` was committed **2026-08-18T21:41:14Z** and #785 merged **2026-08-19T00:24:05Z** — the build the gate measured **predates the merge by 2h43m**. A FAIL against a build that does not contain the predicate is not evidence about the predicate. (Independently re-derived in review rather than accepted.)

Deployed staging is `30db8ac3` (`version.json`, built 07:05:58Z today) — the exact tip this branch is cut from, containing both #785 and #810.

---

## The real defect: a truncated card silently deletes the end of the paragraph

Hunting for a residual gap rather than stopping at the refutation, I found one — in the **opposite direction** from a duplicate.

The routing is **structural**: it withholds the untyped copy whenever a narrative card is present. That is correct only while the card carries the **whole** narrative. It does not always.

- CEE builds the body as `truncate(narrative_summary, BODY_MAX)` — `phase3-blocks.ts:2529`, `BODY_MAX = 300` at `:214` via `COACHING_BLOCK_BODY_MAX` — appending `…` when it cuts.
- `narrative_summary` is **uncapped free LLM prose** at every hop, specified as "2-4 sentences". The shared contract's enrichment record is documented *"deliberately open … passes through verbatim"*; there is no `.max()` anywhere.

So when the narrative overruns, the card carries a **prefix**, the routing withholds the only complete copy, and **the tail renders nowhere**.

That inverts the rule this spec already states on its own no-card twin: *absence of the card may only ever cost a **duplicate**, never a paragraph.* Here it cost the end of one.

### Why the overrun is real: **the contract admits it**

The decisive evidence is contractual — one channel is bounded **by the spec**, the other is unbounded **by the spec**:

```
ReviewCardBlockSchema.body        z.string().min(1).max(PHASE3_BODY_MAX)   // 300
EnrichmentDecisionReviewSchema    z.object({ produced_at: z.string() }).passthrough()
```

`narrative_summary` is **not a declared field at all** — it survives only through `.passthrough()`, and the contract's own comment says the shape is *"deliberately open … passes through verbatim"*. Verified at runtime, not read off the types: `body._def.checks` → `[{min:1},{max:300}]`.

So the card can carry at most 300 characters of a field nothing anywhere caps. **The overrun is admitted by the specification**, which is the right basis — write the invariant against the spec, never against the failure mode you came in through. The live prompt (`DECISION_REVIEW_PROMPT_VERSION = 'v11.1'`, `defaults.ts:1223`) independently mandates *"narrative_summary (string, 2-4 sentences)"*.

### Severity, stated precisely: **real by contract, latent in every capture measured**

The corpus **cannot** pin this, and saying so is the point: all 8 captures measure **176–264 chars** against the 300 cap — a margin as thin as **36 characters**. A corpus that never reaches the cap cannot observe what happens past it (trap 22: check what your corpus *excludes*). Measured across all of CEE: **31 `narrative_summary` literals over 40 chars, exactly 2 over 300 — and both are prompt text**; every real capture or fixture is **≤ 264**.

**A correction to my own first framing.** I originally led with *"CEE's own prompt ships a 368-character exemplar"* (`decision_review_prompt_v4_1.txt:246`, losing the clause *" (35%), which limits how much weight to place on this recommendation."*). The number is exact — but **that is a RETIRED prompt**. The live v11.1 prompt ships **no exemplar**; its skeleton reads `"narrative_summary": "string"`. So the claim is true of the repo and **not of the live prompt**.

The general rule I am adopting from it: a prompt exemplar is legitimate evidence about the **input domain** — the producer's own statement of the shape it asks for — but it establishes **admissibility, never frequency**, and an exemplar in a retired prompt is weaker still. **On its own it would not carry the claim.** The contract does.

### RED-first, on producer prose

Failing at pristine, named:

- `InlineBlocks.narrativeChannel.spec.tsx:495` — `countOccurrences(full)` expected `1`, received **`0`**
- `:504` — the tail is absent from the DOM

Every string is **producer prose**: the long narrative is two real capture narratives concatenated, never a sentence composed by the spec. The tests are deliberately **cap-agnostic** — they assert the UI's rule ("a card carrying only part of the narrative has not delivered it"), correct wherever the producer cuts. Mirroring CEE's `300` here would be a hand-maintained copy of another repo's constant.

### The fix

One predicate, extended — **no parallel predicate added**. `turnDeliversNarrativeAsTypedCard` remains the canonical owner of *"is the narrative already delivered as a typed card"*. It now asks whether the card carries the narrative **in full**, reading the summary through the **same canonical adapter** (`readDecisionReviewWireState`) the analysis-result card renders from, so the two can never disagree.

Containment, not equality, so a future producer that frames the narrative inside a longer body still counts as delivering it.

**The delta is MONOTONE, which is the structural reason this is safe** — stronger than "safe at each branch". No card → `false` (unchanged). Card present → `true` unless there is *positive evidence* of a short body. **Every input that kept the untyped copy before still keeps it; the change can only ever ADD kept copies, never remove one.** It cannot delete a paragraph that renders today, whatever the producer sends.

### The design fork, stated deliberately (obligation 6)

Two options for the truncated case:

- **(X) shipped** — the card keeps its truncated body and the complete copy also renders. Cost: a **near-duplicate on long narratives**.
- **(Y) rejected** — the UI substitutes the full `narrative_summary` into the card body. One complete copy, but the UI would be overriding producer card content with another field, coupling the card renderer to a sibling block's enrichment, and defeating whatever layout intent the cap encodes.

**(X), because a near-duplicate is recoverable and a deleted clause is not** — which is this file's own stated preference, not a new rule. This is a **known, recorded** cost, not an invisible one: it is pinned by tests, so it REDs if it changes.

---

## The anti-recurrence guard — `narrativeChannelContract.spec.ts`

The most valuable thing here. `v5_review_card` and `review_card` are separated by a translation boundary, but **nothing executable said so** — which is why the question had to be re-derived by hand, and why the honest reading of either side in isolation is the wrong one.

It is **derived, not hand-listed**. The UI cannot read CEE's source at test time; what it *can* read is what both services are bound to. CEE does not merely happen to send `review_card` — it **validates every narrative card against `ReviewCardBlockSchema` before sending** (`phase3-blocks.ts:2555`). Both repos pin `file:./vendor/talchain-schemas-0.48.0.tgz`, and I verified the two vendored tarballs are **byte-identical** (SHA-256 `02f78afc…5805a`) rather than assuming parity.

So every literal is read out of the contract at run time, and the load-bearing test runs a **contract-valid** card (proven valid by the contract's own validator, using the contract's own `maximalReviewCardBlock` fixture) through the **real adapter** into the **real gate**.

Break any link and it REDs — proven by mutation, not asserted.

## Mutation results — 8/8, leading and trailing controls green

Throwaway worktree **outside** the repo root; isolation proven by **writing a sentinel and asserting the source was unchanged** (not by inspecting paths — trap 9g); restored from a **pristine tar archive**, never `git checkout --` (trap 9h); semantic applied-check per mutation (exact-match count must be 1 **and** the hash must change), an unapplied mutation aborting loud.

| # | mutation | expect | got |
|---|---|---|---|
| M1 | gate rejects the narrative card's own type | RED | RED (18) |
| M2 | gate additionally rejects an **unrelated** type | **GREEN** | **GREEN** |
| M3 | completeness reverted (pre-fix behaviour) | RED | RED (2) |
| M4 | completeness inverted (over-fires) | RED | RED (19) |
| M5 | completeness reads the wrong field | RED | RED (17) |
| M6 | narrative kind drifts off the contract vocabulary | RED | RED (27) |
| M7 | adapter stops carrying `card_kind` through | RED | RED (1) |
| M8 | adapter stops accepting CEE's wire type | RED | RED (3) |

**M1/M2 are the discriminating pair** (obligation 4): loosening for the narrative card's own type REDs, while an edit touching an unrelated type stays GREEN — so the tests bind by **identity**, not to arbitrary edits. **M6/M7/M8 prove the cross-repo guard can fail from either side independently** — the acceptance constant, the `card_kind` passthrough, and the accepted wire type each RED on drift.

Controls: leading GREEN 78/78, trailing GREEN 78/78 at an identical collected count (no silent shrink).

## Opposite-direction twins (trap 22b)

Every case has its twin, and they were green *before* the fix so it cannot buy one direction with the other:

- card carries the narrative **in full** → untyped copy still suppressed ✅
- **no** narrative card at all → analysis-result copy still renders (8/8 captures) ✅
- card of a **different** contract kind → gate does not fire ✅
- `readiness_rationale` untouched by the routing (8/8) — the contrast control proving the measurement discriminates ✅
- precondition pin: the probe really does cut the body, so the twins cannot pass by testing nothing (trap 13b) ✅

## Gate

Run as the required check's **step sequence**, not by habit (trap 22e) — `Staging Gate` needs `tsc` → `typecheck-selftest` → `vitest` → `vitest-summary` → `build`, and `tsc` runs **lint first**:

- `pnpm run lint` → **0 errors**, hooks ratchet exactly at baseline
- `pnpm run typecheck` → **PASS**, 3588/3628 files, ratchet **2263 = baseline** (no new errors)
- `ci:guard:zustand` · `ci:guard:starters` · `check:vendor` · `ci:guard:schemas-version` · `ci:guard:ds:enforce` → all PASS
- `typecheck:selftest` → PASS · `build` → PASS
- Target specs: **78/78** (74 narrative channel + 4 contract), each asserted **non-zero by name**, with `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported

**Required check polled to conclusion, in the foreground:** `Staging Gate` = **completed / success**, re-polled on the corrected head `49bd9823` (first green on `ef3add29`). All 14 check-runs completed, `running=0` (filtered on `.status == "completed"` before reading `.conclusion` — trap 24b), queried against the exact head SHA with `total_count > 0`. All four `Full Test Suite` shards green. The one failure is `Visual Regression (advisory)`, which the workflow itself declares *"advisory — does not block merges"* and which `Staging Gate` does not depend on.

### A local-only guard failure — and a correction to my own first reading

`ci:guard:bundle-credentials` failed on my **local** build (a 37-char high-entropy literal in `ProfileSettingsPage`). I built **pristine `origin/staging`** in a separate worktree: it fails **identically**, same literal `sha256:60f1f38c` — so it is not caused by this change.

I first wrote that up as *"a standing red on `staging`"*. **That was wrong, and CI refuted it:** `Production Build` is **green** on this PR. The guard's failure is an artefact of building locally without the real Supabase environment, not a condition on `staging`. Recording the correction rather than quietly dropping it — a claim about our own verification is still a claim, and this one survived about twenty minutes.

Full local suite for completeness: **25,584 passed / 52 skipped, exit 0**.

## Review correction (second commit, `49bd9823`)

Review found three comments asserting the **opposite** of what the predicate now does — none touched by the first commit, because the docstring hunk started one line below and the other two files were unchanged:

- `messageComposition.ts` — the function's own docstring, directly above the change: *"Body content is never compared to anything — only its existence"*
- `InlineBlocks.tsx` — *"Structural — block presence, never a string comparison."*
- `V5AnalysisResultBlock.tsx` — *"Not a string comparison and not a de-duplication: a channel choice, made on block presence"*

Not cosmetic. **"Never a string comparison" sitting above a string comparison is the sentence that licenses the next lane to simplify the predicate back to presence-only and re-delete the paragraph** — a false comment beside correct code, addressed to someone who will believe it. In a codebase whose doctrine names the hand-maintained mirror as its dominant defect class, that is the defect.

All three now say the body IS read, say why (delivery-completeness, never de-duplication — nothing is suppressed for merely repeating), carry the contract argument, and **disclose the retraction rather than erasing it**. I also swept every file referencing the predicate (4 total) for residual claims: the only remaining hits are those disclosures. One further clause in the spec header (*"delivers it as a typed, titled card"* → *"IN FULL"*) was refined for the same reason.

**Comments only, proven not asserted:** compiled output is **byte-identical** across all four files (esbuild, `loader=ts/tsx`, `jsx=automatic`). My first check used `jsx: 'preserve'`, which keeps JSX comments verbatim and so reported a false difference — the instrument, not the code.

## What this does NOT claim

Component witnesses do not compose into a journey claim. This is **TESTED** on real captures at the deployed tip; it is **not** journey-witnessed. The truncation case is latent — real today only because CEE's own exemplar exceeds the cap, and one long narrative away from being user-visible.

**Recommended next:** a live fresh-session journey on deployed staging with a narrative over 300 characters, which is the only thing that can move this to WIRE/JOURNEY-WITNESSED.

**For CEE (reported, not actioned — scope boundary):** `BODY_MAX = 300` on a field the prompt itself models at 368 characters is an upstream mismatch worth its own row. This change makes it *harmless* rather than *lossy*; it does not remove it.
