### PR TITLE
fix(model-tab): collapse the stacked v1 editor by default — mounted, expandable, no capability lost

### DIFF
--- a/src/canvas/components/ModelTabBody.tsx
+++ b/src/canvas/components/ModelTabBody.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react'
 import type { Node, Edge } from '@xyflow/react'
 import { useCanvasStore } from '../store'
+import { typography } from '../../styles/typography'
 import { useAnalysisTrust } from '../hooks/useAnalysisTrust'
 import { AnalysisRunStateCover } from './AnalysisRunStateCover'
 import { useUIStore } from '../../stores/uiStore'
@@ -102,6 +103,14 @@ interface ModelTabBodyProps {
 // the one classification authority now serves both (trap 12: derive, do not
 // mirror).
 
+/**
+ * The id `model-tab-v1-disclosure` points `aria-controls` at. A module constant
+ * rather than a literal at both use sites: the button and the region it labels
+ * must agree, and two hand-copied literals are the mirror this estate keeps
+ * paying for.
+ */
+const V1_STACK_CONTENT_ID = 'model-tab-v1-stack-content'
+
 const KIND_ORDER = ['goal', 'decision', 'option', 'factor', 'risk', 'outcome'] as const
 const EMPTY_NODE_IDS = new Set<string>()
 const EMPTY_EDGE_IDS = new Set<string>()
@@ -134,6 +143,22 @@ export const ModelTabBody = memo(function ModelTabBody({
   // Single-open accordion: in default mode, only one section open at a time.
   // In expert mode (showDetail), sections manage their own state independently.
   const [openSection, setOpenSection] = useState<string | null>('factors')
+
+  // ── The v1 stack's disclosure (2026-08-20) ──────────────────────────────────
+  //
+  // The Model tab renders TWO complete editors of the SAME model, stacked: the
+  // v2 outline and, below it, the v1 sections. Measured on the deployed build
+  // `d4b9f981` by a fresh guest with their own drafted brief: 2,967px of
+  // content in a 669px dock body — 4.47 screens — at both 1280×800 and
+  // 1440×900, before and after analysis. The lower block addressed NO entity
+  // the outline did not already address.
+  //
+  // COLLAPSED BY DEFAULT, NOT DELETED AND NOT GATED AWAY. Six capabilities have
+  // no v2 equivalent and must stay reachable: contested-edge adjudication, CEE
+  // structural repairs, the model card / audit trail, goal-target editing, edge
+  // strength/direction/likelihood editing, and factor prior-range + baseline
+  // editing. This is a default, not a removal.
+  const [v1Expanded, setV1Expanded] = useState(false)
   const isExpert = expertMode ?? false
   const makeSectionProps = useCallback((sectionId: string) => {
     if (isExpert) return {} // expert mode: uncontrolled (multi-open)
@@ -171,10 +196,32 @@ export const ModelTabBody = memo(function ModelTabBody({
   // triggers a re-render that fires the previous run's cleanup before the RAF
   // callback gets a chance to execute, killing the scroll. The mountedRef
   // guard above handles the unmount-during-RAF case without that race.
+  //
+  // ⚠⚠ THE DISCLOSURE ABOVE HAD TO BE BUILT AROUND THIS EFFECT, NOT PAST IT.
+  // The scroll target is found with `document.querySelector`, so it exists only
+  // while the v1 sections are MOUNTED. Two consequences, both load-bearing:
+  //
+  //   1. The collapsed v1 stack stays MOUNTED and is hidden with the `hidden`
+  //      ATTRIBUTE — never unmounted, never conditionally rendered. Unmounting
+  //      it would make this `querySelector` return null and the deep link would
+  //      fail SILENTLY: `el?.scrollIntoView` no-ops on null, nothing throws, and
+  //      no test that does not assert the scroll would notice.
+  //   2. Mounted is necessary but NOT sufficient — `scrollIntoView` on a
+  //      `display:none` element does nothing either. So the request also
+  //      EXPANDS the stack, in the same commit as `setOpenSection`, before the
+  //      frame that scrolls. This is the pattern the existing `setOpenSection`
+  //      call already relies on: a passive-effect state update is processed
+  //      before the browser paints, so the RAF callback sees the expanded DOM.
+  //
+  // Reachable callers of this deep link, all live: the assistant's `open_section`
+  // UI directive (`v5/applyV5State.ts`), PreAnalysisPanel's "See all
+  // relationships", and ContestedSection. Pinned in
+  // `__tests__/ModelTabBody.v1StackCollapsed.spec.tsx`.
   const pendingSection = useUIStore(s => s.pendingModelTabSection)
   useEffect(() => {
     if (!pendingSection) return
     setOpenSection(pendingSection)
+    setV1Expanded(true)
     requestAnimationFrame(() => {
       if (!mountedRef.current) return
       const el = document.querySelector<HTMLElement>(`[data-testid="model-${pendingSection}-section"]`)
@@ -826,6 +873,31 @@ export const ModelTabBody = memo(function ModelTabBody({
         onHandOffToOlumi={olumiHandOff ? handOffToOlumi : undefined}
       />
 
+      {/* ── The v1 stack, COLLAPSED BY DEFAULT ────────────────────────────── */}
+      {/* Present and expandable, never removed. See the `v1Expanded` note. */}
+      <section data-testid="model-tab-v1-stack" className="border-t border-panel-border pt-3">
+        <button
+          type="button"
+          data-testid="model-tab-v1-disclosure"
+          aria-expanded={v1Expanded}
+          aria-controls={V1_STACK_CONTENT_ID}
+          onClick={() => setV1Expanded(v => !v)}
+          className="w-full flex items-baseline gap-2 text-left py-1"
+        >
+          <span aria-hidden="true" className="text-text-light">{v1Expanded ? '▾' : '▸'}</span>
+          <span className={`${typography.panelHeader} text-text-header`}>Detailed editing</span>
+          <span className={`${typography.panelMeta} text-text-light`}>
+            Goal target, option interventions, relationship strengths, risks and the model card
+          </span>
+        </button>
+
+        {/* ⚠ MOUNTED WHEN COLLAPSED. `hidden` is an attribute, not a branch:
+            the sections stay in the DOM so the `model-{section}-section`
+            deep-link `querySelector` above keeps resolving. Do not convert this
+            to `{v1Expanded && (...)}` — that silently breaks assistant-driven
+            section navigation with no error anywhere. */}
+        <div id={V1_STACK_CONTENT_ID} data-testid={V1_STACK_CONTENT_ID} hidden={!v1Expanded}>
+
       {/* ── Header: factor/edge counts + "Show full detail" toggle ─────────── */}
       {/* No sort label post-analysis. The list is ordered by influence, and we
           do not assert that its order encodes value — the previous
@@ -922,6 +994,8 @@ export const ModelTabBody = memo(function ModelTabBody({
           />
         </div>
       </ModelTabHeader>
+        </div>
+      </section>
 
       {/* ── Streaming diagnostics (Shift+D) ───────────────────────────────── */}
       <StreamingDiagnostics

--- a/src/canvas/components/__tests__/ModelTabBody.v1StackCollapsed.spec.tsx
+++ b/src/canvas/components/__tests__/ModelTabBody.v1StackCollapsed.spec.tsx
@@ -1,0 +1,311 @@
+/**
+ * The Model tab opens showing the v2 outline, with the v1 stack COLLAPSED —
+ * present, mounted and expandable.
+ *
+ * ── WHAT THIS PINS, AND WHERE IT CAME FROM ──────────────────────────────────
+ *
+ * NOT a fixture. A fresh guest on a brand-new browser profile, entering as a
+ * guest and drafting their own substantive brief, on deployed build
+ * `d4b9f981`, was observed to receive TWO complete editors of the SAME model,
+ * stacked:
+ *
+ *   1280×800, no analysis   dock body 669px, content 2991px  — 4.47 screens
+ *   1440×900, no analysis   dock body 769px, content 3012px  — 3.92 screens
+ *   1280×800, post-analysis dock body 669px, content 2882px  — 4.31 screens
+ *
+ * `model-tab` 2967px = `model-tab-v2-panel` 1947 + 15 + the v1 block 844 +
+ * `model-footer` 43. The lower block addressed NO entity the outline did not
+ * already address (8 shared ids, 0 v1-only).
+ *
+ * ── WHY COLLAPSE AND NOT DELETE ─────────────────────────────────────────────
+ *
+ * The stacked block is NOT dead. Six capabilities have no v2 equivalent —
+ * contested-edge adjudication, CEE structural repairs, the model card / audit
+ * trail, goal-target editing, edge strength/direction/likelihood editing, and
+ * factor prior-range + baseline editing. The same fresh observation measured
+ * the v2 outline as 15-controls-disabled on exactly those rows, each saying so
+ * in its own `aria-label` ("Editing is not connected yet"). Removing the lower
+ * block would remove the ONLY working editor for them.
+ *
+ * So this is a DEFAULT, not a removal, and half these tests point the OPPOSITE
+ * WAY: they exist to fail if the collapse ever costs a capability. A fix that
+ * makes the tab tidier by making capability unreachable is a worse defect than
+ * the one it closes.
+ *
+ * ── BOUND TO THE MOUNT PATH (trap 3b) ───────────────────────────────────────
+ *
+ * Every assertion renders `ModelTabBody` — the container `OutputsDock` renders
+ * for the Model tab — never a child in isolation, and asserts containment
+ * within `model-tab`. This estate has twice shipped a component whose entire
+ * suite pointed at a surface the deployment does not mount: RED-first, a full
+ * mutant kit and a positive control all passed while the user saw nothing.
+ *
+ * ── THE DEEP LINK IS THE DANGEROUS PART ─────────────────────────────────────
+ *
+ * `ModelTabBody`'s cross-panel handoff resolves its scroll target with
+ * `document.querySelector('[data-testid="model-{section}-section"]')`. If the
+ * collapsed stack were UNMOUNTED, that returns null and `el?.scrollIntoView`
+ * no-ops — the assistant's `open_section` directive, PreAnalysisPanel's "See
+ * all relationships" and ContestedSection would all fail SILENTLY, with no
+ * throw and no red anywhere. `it('keeps the v1 sections MOUNTED…')` and the
+ * deep-link tests below are the guard on that, and they bind the scroll to its
+ * receiver BY IDENTITY: a scroll that lands on some other element does not
+ * satisfy them.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { Node, Edge } from '@xyflow/react'
+
+vi.mock('../../utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusEdgeById: vi.fn(),
+}))
+
+vi.mock('../../../telemetry/guidanceEvents', () => ({ trackGuidance: vi.fn() }))
+
+const mockGraph: { nodes: unknown[]; edges: unknown[] } = { nodes: [], edges: [] }
+
+function getMockState() {
+  return {
+    nodes: mockGraph.nodes,
+    edges: mockGraph.edges,
+    updateNode: vi.fn(),
+    updateEdge: vi.fn(),
+    ceePipelineTrace: null,
+    highlightedNodes: new Set<string>(),
+    highlightedEdges: new Set<string>(),
+    setHighlightedNodes: vi.fn(),
+    setHighlightedEdges: vi.fn(),
+    currentScenarioId: null,
+    currentStage: null,
+    graphEditedSinceLastRun: false,
+    goalThreshold: null,
+    goalThresholdRepresentation: null,
+  }
+}
+
+vi.mock('../../store', () => ({
+  useCanvasStore: Object.assign(
+    vi.fn((selector: (s: unknown) => unknown) => selector(getMockState())),
+    { getState: getMockState },
+  ),
+}))
+
+vi.mock('../GraphTextView', () => ({
+  SectionErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+import { ModelTabBody } from '../ModelTabBody'
+import { useUIStore } from '../../../stores/uiStore'
+
+const FACTOR_ID = 'fac_budget'
+const GOAL_ID = 'goal_margin'
+
+function factorNode(): Node {
+  return {
+    id: FACTOR_ID,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: {
+      label: 'Budget',
+      category: 'observable',
+      observedState: { value: 0.5, source: 'cee_inference' },
+    },
+  } as unknown as Node
+}
+
+function goalNode(): Node {
+  return {
+    id: GOAL_ID,
+    type: 'goal',
+    position: { x: 0, y: 0 },
+    data: { label: 'Protect gross margin' },
+  } as unknown as Node
+}
+
+const NODES: Node[] = [goalNode(), factorNode()]
+const EDGES: Edge[] = []
+
+const DEFAULT_PROPS = {
+  showDebug: false,
+  hasDiagnostics: false,
+  diagnostics: null,
+  hasTrim: false,
+  effectiveCorrelationId: null,
+  correlationMismatch: false,
+  correlationIdHeader: null,
+  robustness: null,
+}
+
+function renderTab() {
+  return render(<ModelTabBody {...DEFAULT_PROPS} nodes={NODES} edges={EDGES} />)
+}
+
+/**
+ * `scrollIntoView` does not exist in jsdom at all, so installing this IS the
+ * instrument — and it records the RECEIVER, not just the fact of a call. An
+ * assertion that merely counts calls would pass on a scroll to any element;
+ * `contexts` is what lets the deep-link tests bind by identity.
+ */
+const scrollContexts: Element[] = []
+let originalScrollIntoView: unknown
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGraph.nodes = NODES
+  mockGraph.edges = EDGES
+  scrollContexts.length = 0
+  originalScrollIntoView = (Element.prototype as unknown as Record<string, unknown>).scrollIntoView
+  ;(Element.prototype as unknown as Record<string, unknown>).scrollIntoView =
+    function (this: Element) { scrollContexts.push(this) }
+  useUIStore.setState({ pendingModelTabSection: null })
+})
+
+afterEach(() => {
+  if (originalScrollIntoView === undefined) {
+    delete (Element.prototype as unknown as Record<string, unknown>).scrollIntoView
+  } else {
+    ;(Element.prototype as unknown as Record<string, unknown>).scrollIntoView = originalScrollIntoView
+  }
+  useUIStore.setState({ pendingModelTabSection: null })
+})
+
+// ── The instrument itself ────────────────────────────────────────────────────
+
+describe('instrument health', () => {
+  it('the scroll spy can SEE a scroll (positive control)', () => {
+    renderTab()
+    expect(scrollContexts).toHaveLength(0)
+    const el = screen.getByTestId('model-tab')
+    el.scrollIntoView()
+    expect(scrollContexts).toEqual([el])
+  })
+})
+
+// ── (c) The stacked duplicate ────────────────────────────────────────────────
+
+describe('the Model tab opens with the v1 stack collapsed', () => {
+  it('mounts BOTH surfaces inside the Model tab (the mount path)', () => {
+    renderTab()
+    const tab = screen.getByTestId('model-tab')
+    expect(tab.contains(screen.getByTestId('model-tab-v2-panel'))).toBe(true)
+    expect(tab.contains(screen.getByTestId('model-tab-v1-stack'))).toBe(true)
+  })
+
+  it('shows the v2 outline and HIDES the v1 stack by default', () => {
+    renderTab()
+    // The outline is what a fresh guest reads first.
+    expect(screen.getByTestId('model-tab-v2-panel')).toBeVisible()
+    // The stacked second editor is not stacked on it any more.
+    expect(screen.getByTestId('model-tab-v1-stack-content')).not.toBeVisible()
+  })
+
+  it('the disclosure declares its collapsed state to assistive tech', () => {
+    renderTab()
+    const disclosure = screen.getByTestId('model-tab-v1-disclosure')
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false')
+    expect(disclosure).toHaveAttribute('aria-controls', 'model-tab-v1-stack-content')
+    // aria-controls must resolve — a dangling reference is worse than none.
+    expect(document.getElementById('model-tab-v1-stack-content')).toBe(
+      screen.getByTestId('model-tab-v1-stack-content'),
+    )
+  })
+
+  it('⚠ keeps the v1 sections MOUNTED while collapsed', () => {
+    renderTab()
+    // Hidden, but IN THE DOCUMENT. This is the precondition the deep-link
+    // `document.querySelector` depends on; unmounting breaks it silently.
+    for (const testId of [
+      'model-goal-section',
+      'model-factors-section',
+      'model-relationships-section',
+      'model-risks-section',
+    ]) {
+      const el = screen.getByTestId(testId)
+      expect(el).toBeInTheDocument()
+      expect(document.querySelector(`[data-testid="${testId}"]`)).toBe(el)
+    }
+  })
+})
+
+// ── The opposite direction: collapse must cost NO capability ─────────────────
+
+describe('the collapsed v1 stack stays reachable and functional', () => {
+  it('expands on click and reveals the stack', async () => {
+    const user = userEvent.setup()
+    renderTab()
+    await user.click(screen.getByTestId('model-tab-v1-disclosure'))
+
+    expect(screen.getByTestId('model-tab-v1-disclosure')).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByTestId('model-tab-v1-stack-content')).toBeVisible()
+  })
+
+  it('once expanded, a v1-ONLY capability is present and enabled', async () => {
+    const user = userEvent.setup()
+    renderTab()
+    await user.click(screen.getByTestId('model-tab-v1-disclosure'))
+
+    // Goal-target editing is one of the six with no v2 equivalent: the v2
+    // outline renders the goal row DISABLED. If collapsing ever cost this,
+    // the product would have no way to set a success target at all.
+    const goalTarget = screen.getByTestId('goal-threshold-not-set-display')
+    expect(goalTarget).toBeVisible()
+    expect(goalTarget).not.toBeDisabled()
+  })
+
+  it('collapses again — the disclosure is a toggle, not a one-way door', async () => {
+    const user = userEvent.setup()
+    renderTab()
+    const disclosure = screen.getByTestId('model-tab-v1-disclosure')
+    await user.click(disclosure)
+    expect(screen.getByTestId('model-tab-v1-stack-content')).toBeVisible()
+    await user.click(disclosure)
+    expect(screen.getByTestId('model-tab-v1-stack-content')).not.toBeVisible()
+    expect(disclosure).toHaveAttribute('aria-expanded', 'false')
+  })
+})
+
+// ── The deep link, bound to its receiver by identity ─────────────────────────
+
+describe('deep-link navigation to a section still works', () => {
+  it('a section request EXPANDS the stack and scrolls to THAT section', async () => {
+    renderTab()
+
+    act(() => { useUIStore.getState().requestModelTabSection('relationships') })
+
+    // (1) The stack must be open, or the scroll lands on a display:none box.
+    await waitFor(() => {
+      expect(screen.getByTestId('model-tab-v1-stack-content')).toBeVisible()
+    })
+
+    // (2) The scroll must land on the requested section — BY IDENTITY. A count
+    //     assertion would be satisfied by a scroll to any element.
+    const target = screen.getByTestId('model-relationships-section')
+    await waitFor(() => {
+      expect(scrollContexts).toContain(target)
+    })
+  })
+
+  it('a request for a DIFFERENT section scrolls to THAT one, not the first', async () => {
+    renderTab()
+
+    act(() => { useUIStore.getState().requestModelTabSection('risks') })
+
+    const risks = screen.getByTestId('model-risks-section')
+    await waitFor(() => {
+      expect(scrollContexts).toContain(risks)
+    })
+    // Discrimination: the effect is reading the requested id, not scrolling to
+    // a hardcoded section. Without this the test above passes on a constant.
+    expect(scrollContexts).not.toContain(screen.getByTestId('model-relationships-section'))
+  })
+
+  it('does nothing at all when no section is requested', async () => {
+    renderTab()
+    await Promise.resolve()
+    expect(scrollContexts).toHaveLength(0)
+    expect(screen.getByTestId('model-tab-v1-stack-content')).not.toBeVisible()
+  })
+})

--- a/src/canvas/components/__tests__/ModelTabBody.v1StackCollapsed.spec.tsx
+++ b/src/canvas/components/__tests__/ModelTabBody.v1StackCollapsed.spec.tsx
@@ -293,6 +293,16 @@ describe('deep-link navigation to a section still works', () => {
 
     act(() => { useUIStore.getState().requestModelTabSection('risks') })
 
+    // (1) The SAME load-bearing assertion the sibling test carries. Without it
+    //     this test stays GREEN under the mutant that deletes
+    //     `setV1Expanded(true)`, because jsdom fires the scroll spy even on a
+    //     `display:none` element — so the scroll assertions below prove
+    //     INTENT, never EFFECT. A test that survives the very mutant that
+    //     breaks the thing it is named for does not pin its property.
+    await waitFor(() => {
+      expect(screen.getByTestId('model-tab-v1-stack-content')).toBeVisible()
+    })
+
     const risks = screen.getByTestId('model-risks-section')
     await waitFor(() => {
       expect(scrollContexts).toContain(risks)


### PR DESCRIPTION
## What a fresh guest actually got

A brand-new browser profile, guest entry, own substantive brief drafted from scratch, deployed build `d4b9f981` — **two complete editors of the same model, stacked**:

| viewport | state | dock body | content | screens |
|---|---|---|---|---|
| 1280×800 | no analysis | 669px | 2991px | **4.47** |
| 1440×900 | no analysis | 769px | 3012px | **3.92** |
| 1280×800 | post-analysis | 669px | 2882px | **4.31** |

`model-tab` 2967px = `model-tab-v2-panel` **1947** + 15 + the v1 block **844** + `model-footer` 43.
Entity identity, not eye: **8 shared ids, 0 v1-only** — the lower block addressed no entity the outline did not already address.

## What this does

The Model tab opens on the **v2 outline**, with the v1 stack **collapsed** behind a `Detailed editing` disclosure. **Not deleted. Not gated away.**

## Why collapse and not remove

The lower block is not dead. **Six capabilities have no v2 equivalent** — contested-edge adjudication, CEE structural repairs, model card / audit trail, goal-target editing, edge strength/direction/likelihood editing, factor prior-range + baseline editing. The same observation measured the v2 outline as **15 controls disabled** on exactly those rows, each saying so in its own `aria-label` ("Editing is not connected yet"). This is a **default, not a removal**.

## ⚠ The deep link — the part that could have broken silently

`ModelTabBody` resolves its cross-panel scroll target with
`document.querySelector('[data-testid="model-${pendingSection}-section"]')` (line ~180).

**If the collapsed stack were unmounted, that returns `null`, `el?.scrollIntoView` no-ops, and nothing throws.** The assistant's `open_section` UI directive (`v5/applyV5State.ts`), PreAnalysisPanel's "See all relationships" and ContestedSection would all fail with no error and no red anywhere.

Two things were done about it, and both are pinned:
1. The collapsed stack stays **MOUNTED**, hidden with the `hidden` **attribute** — never `{v1Expanded && (...)}`.
2. Mounted is necessary but not sufficient (`scrollIntoView` no-ops on `display:none`), so a section request also **expands** the stack in the same commit, before the frame that scrolls.

## Proof

**RED-first, from the fresh observation — not a fixture.** New spec run against pristine `d4b9f981` in an isolated worktree: **8 of 11 RED**. The 3 that passed at pristine are exactly the *preservation* guards (positive control, sections-mounted, deep-link-works) — they must be green in both states, and are.

**Bound to the mount path.** Every assertion renders `ModelTabBody` — the container `OutputsDock` renders — and asserts containment within `model-tab`. Never a child in isolation.

**Mutants** (throwaway worktree outside the repo root; isolation proven by *writing* a sentinel and asserting the source hash was unchanged, distinct inodes `691180415` vs `691186409`; restores from a pristine **tar archive**, never `git checkout -- <path>`; semantic applied-check per mutation; leading and trailing controls both 11/11):

| mutant | applied-check | result |
|---|---|---|
| M1 unmount while collapsed | ✅ | **5 RED** — incl. `keeps the v1 sections MOUNTED` |
| M2 drop `setV1Expanded(true)` from the effect | ✅ | **1 RED** — the expand-on-deep-link |
| M2b unmount **and** no expand (the exact silent failure) | ✅ | **7 RED** — both deep-link tests |
| M3 default expanded | ✅ | **6 RED** |
| **4a** loosen for **ALL** objects (constant scroll target) | ✅ | **both** deep-link identity tests RED |
| **4b** loosen for a **DIFFERENT** object only (`risks` misrouted) | ✅ | `risks` RED, `relationships` **GREEN** |

4a/4b are the discriminating pair: each test binds to its **named** object, not to a shared predicate.

> An earlier 4a/4b attempt scored **11 passed** — a **false survivor**: perl mangled the backtick/`${}` anchor and the mutation never applied. The applied-check caught it and the result was voided. Recorded because an unapplied mutation is indistinguishable from an equivalent one without one.

**Suites** (`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported; each spec's collected count asserted by name and non-zero — the new spec collects **11**, never inferred from a total):

- new spec — **11/11**
- `ModelTabBody*` — 9 files, **77/77**
- `model-tab` + `model-tab-v2` — 42 files, **696/696**
- `OutputsDock` + `applyV5State` + `contestedSection` (mount path + deep-link callers) — 39 files, **403/403**
- `pnpm typecheck` — **PASSED** (3595/3635 coverage, ratchet 2263 = baseline)
- `eslint` on changed files — **0 errors**; the 3 warnings are pre-existing and byte-identical at `HEAD` (verified by linting the pristine file)
- `vite build` — ✓

## Scope — only what the fresh observation recorded

- **No raw-machine-vocabulary change.** Every candidate token (`EDGE_E_VALUE_NON_FINITE_DROPPED`, `NON_FINITE`, "Node ID", "Edge ID", "Strength mean", "Exists probability", "Normalised targets", `node_id`, `edge_id`…) read **FALSE** in text *and* attributes, in Plain *and* Advanced, before *and* after analysis, with working contrast controls. Three of them exist in source on **conditional surfaces the fresh guest never reached** — fixing those would be fixing something no observed user saw.
  - ⚠ **Location corrected (independent review, 20 Aug — verified at the bytes on this branch).** `Strength mean` (`model-tab/ContestedEdgeCard.tsx:518,521`) and `Normalised targets` (`model-tab/OptionsSection.tsx:349`) are **v1-only**, so they do now sit inside the newly collapsed stack. **`Exists probability` does not.** Besides its two v1 sites (`ContestedEdgeCard.tsx:529`, `RelationshipsSection.tsx:478`) it also lives at `model-tab-v2/adapters.ts:830` — in the **never-collapsed v2 panel**. That instance is Advanced-tier-gated, so it stays closed by default and the verdict is unchanged, but the honest statement is: **this PR reduces default exposure of the other two and does not touch the v2 instance.**
- **No id-gate change.** v2's tier state is `useState<DetailTier>('plain')` — the gate already exists and already defaults closed. Minting a second expert-mode authority was not needed and was not done.
- **No v1 removal.** Classified separately as a MEDIUM job requiring seven shared-library files to be extracted first; v2 imports from `model-tab/`, so it is not a legacy directory.

## Reviewer notes

- The wrapped block is **deliberately not re-indented** — that would have added ~120 lines of pure whitespace and buried the change.
- `ModelFooter`'s dead `model-search` box (`disabled` + `readOnly`, "Search is not connected yet") sits **outside** the collapsed region and is untouched. The fresh guest did see it, but it is honest copy, not raw vocabulary, and it is not in this brief's (a)/(b)/(c). Flagged, not fixed.

## Status rung

**CODE EXISTS → TESTED.** Not deployed, not journey-witnessed — the Model tab needs a CEE-drafted model, so a journey witness is only possible after this deploys to staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## CI, polled to conclusion in the foreground

Head `3695bd44bdaae541328befa1e502ca5f2366ed40` · `mergeable=MERGEABLE` (not DIRTY) · `total_count=14`, `running=0`.

**Required check `Staging Gate` (derived from branch protection, not assumed) — ✅ success.**

13 of 14 green. The one red is **`Visual Regression (advisory)`**, and it is **pre-existing, not caused by this PR** — proven rather than assumed by label:

- The same job is **already failing on the base commit `d4b9f981`**.
- Base **13 failed / 21 passed**; this PR **13 failed / 21 passed**.
- Failing-test **identities diffed** (timings stripped): **34 vs 34, byte-identical — empty delta.**
- Contrast control in the same comparison: the set is not trivially "everything" — 2 `Model tab` entries against 11 `nodeLabelFit` entries this change cannot touch.

⚠ **The honest limit that follows:** the visual harness is red at base *including its own self-test* (`selftest.visual.spec.ts` — "proves the instrument can fail" — fails on both commits), and `Model tab [1280x800]` / `[1440x900]` were **already failing before this change**. So the visual job **cannot certify this Model tab change in either direction**. It is not evidence that the change is safe, only that the change did not move it.

