### PR TITLE
fix(results): no surface may state an influence number as a share of the outcome

### DIFF
--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -37,7 +37,8 @@ import { openNodeInspector } from '@/canvas/nodes/shared/openNodeInspector'
 import type { ScientificEditorProps } from '@/components/shared/ScientificEditor'
 import { TargetProbabilityBars } from './TargetProbabilityBars'
 import { stripEncodingNotation, cleanFactorLabel } from './utils/cleanFactorLabel'
-import { INFLUENCE_TIE_EPSILON } from './driverDisplayModel'
+import { INFLUENCE_TIE_EPSILON, resolveDriverClaimBasis } from './driverDisplayModel'
+import { influenceMagnitudePredicate } from './influenceScaleCopy'
 // Canonical glossary check shared with the v17 hero row builders. Used in
 // v17 mode (`useV17Copy === true`) to sanitise user-supplied labels before
 // they are interpolated into GENERATED prose, aria-labels, or titles. The
@@ -390,26 +391,22 @@ function T1DominantNudge({
   const rankedDrivers = (drivers.topDrivers?.length ? drivers.topDrivers : drivers.drivers) ?? []
   const topDriver = rankedDrivers[0]
   const runnerUp = rankedDrivers[1]
-  // Lane 2 (policy): gate and phrase the nudge on the SAME display influence
-  // the panel/hero/graph/tornado show (driverDisplayModel via the stamped
-  // displayInfluence) — a raw-score read here claimed dominance the panel's
-  // own bars contradicted under partial producer coverage (Codex R3-B1 class).
-  const topInfluence = topDriver
-    ? (topDriver.displayInfluence ?? topDriver.influenceScore ?? topDriver.normalisedInfluence ?? 0)
-    : 0
-  // Review fold: "drives NN% of the outcome" is an ABSOLUTE causal claim —
-  // honest only on the producer influence_score basis. Under partial
-  // coverage the display value is set-relative (top driver ≡ 1.0 by
-  // construction), so the nudge would fire on EVERY such run claiming
-  // "100% of the outcome", contradicting the V17 dominance gate
-  // (UI-SEM-040, deliberately absolute) on the same screen. No provenance
-  // marker (legacy fixture) falls back to "a finite raw producer score
-  // exists" — the pre-fold absolute semantic.
-  const absoluteBasis = topDriver
-    ? (topDriver.displayProvenance
-        ? topDriver.displayProvenance === 'influence_score'
-        : typeof topDriver.influenceScore === 'number')
-    : false
+  // ⭐ ONE READ FOR THE VALUE AND ITS BASIS (2026-08-23, trap 21). This used
+  // to be TWO reads answering DIFFERENT questions: the value came from
+  // `displayInfluence ?? influenceScore ?? normalisedInfluence` while the gate
+  // separately asked "does an absolute producer score exist?". On an unstamped
+  // payload the gate passed on `influenceScore` while the sentence printed the
+  // SET-RELATIVE `displayInfluence` (top ≡ 1.0 by construction) — the
+  // witnessed "drives 100% of the outcome". `resolveDriverClaimBasis` is now
+  // the canonical owner of that question and returns value + basis together,
+  // so the two cannot disagree. Both former reads are DELETED, not wrapped.
+  const topBasis = resolveDriverClaimBasis(topDriver)
+  const topInfluence = topBasis?.value ?? 0
+  // Unchanged semantics: the dominance warning is licensed only on the
+  // producer's absolute basis. Under partial coverage the display value is
+  // set-relative and the top is 1.0 on EVERY such run, so a relative basis
+  // may not support a dominance claim at all.
+  const absoluteBasis = topBasis?.provenance === 'influence_score'
   // ⚠ DOMINANCE REQUIRES A RUNNER-UP TO BE DOMINANT OVER (2026-08-19). The
   // gate tested only the top's own magnitude, so on a run where three factors
   // tied at 100% it printed "Dominant factor: Cloud migration progress drives
@@ -417,20 +414,25 @@ function T1DominantNudge({
   // 100%. "Dominant" is a COMPARATIVE claim; a tie cannot support one. Same
   // `INFLUENCE_TIE_EPSILON` the panel's badges and its equal-influence note
   // use, so all three surfaces agree on what counts as a tie.
-  const runnerUpInfluence = runnerUp
-    ? (runnerUp.displayInfluence ?? runnerUp.influenceScore ?? runnerUp.normalisedInfluence ?? 0)
-    : 0
+  const runnerUpInfluence = resolveDriverClaimBasis(runnerUp)?.value ?? 0
   const topIsClearOfRunnerUp = !runnerUp || topInfluence - runnerUpInfluence > INFLUENCE_TIE_EPSILON
   const showNudge = absoluteBasis && topInfluence >= 0.8 && topIsClearOfRunnerUp
   const rawLabel = drivers.dominantFactorLabel ?? topDriver?.factorLabel ?? ''
   const dominantLabel = cleanFactorLabel(rawLabel).label
   if (!showNudge || !dominantLabel) return null
   const dominantPct = Math.round(Math.min(1, topInfluence) * 100)
+  // ⭐ THE CLAIM COMES FROM ITS ONE OWNER (influenceScaleCopy). The literal
+  // `drives ${pct}% of the outcome` that stood here was an absolute SHARE
+  // claim, and NO number this product holds is a share: the producer's
+  // influence_score is an absolute causal-influence SCORE, not a partition —
+  // the golden staging capture's seven scores sum to 450%. Fixing the number
+  // or the gate could not make that sentence true, so the CLAIM is what
+  // changed. The number survives, on its disclosed basis.
   const dominantFocusId = drivers.dominantFactorId
     ?? topDriver?.matchedNodeId
     ?? topDriver?.factorKey
     ?? null
-  const explanation = `drives ${dominantPct}% of the outcome.`
+  const explanation = `${influenceMagnitudePredicate(dominantPct, topBasis?.provenance)}.`
   // (Round-5 P1.2, P0 follow-up) Both v17 and legacy modes use glossary-
   // safe copy. The legacy branch previously contained "the recommendation
   // could change"; the P0 surface-copy cleanup retired that. The two

--- a/src/components/results/__tests__/influenceScaleCopy.copyHygiene.spec.ts
+++ b/src/components/results/__tests__/influenceScaleCopy.copyHygiene.spec.ts
@@ -21,6 +21,8 @@ import {
   influenceExplanation,
   influencePillAriaLabel,
   influenceBarAriaLabel,
+  influenceMagnitudePredicate,
+  influenceMagnitudeTitle,
 } from '../influenceScaleCopy'
 
 const BANNED_TERMS = /\b(node|edge|coefficient|elasticity|normalised value|graph hash|winner|validate)\b/i
@@ -42,6 +44,9 @@ function allStrings(): string[] {
       influenceExplanation(p),
       influencePillAriaLabel(62, p),
       influenceBarAriaLabel(p),
+      // The absolute-share claim's two grammatical slots — same policing.
+      influenceMagnitudePredicate(62, p),
+      influenceMagnitudeTitle(62, p),
     ]),
   ]
 }
@@ -56,6 +61,14 @@ describe('influence-scale disclosure copy hygiene (C4 fix 3)', () => {
       const shouting = s.match(/\b[A-Z]{2,}\b/g) ?? []
       expect(shouting, s).toEqual([])
     }
+  })
+
+  it('never states an influence number as a share of the outcome', () => {
+    // The 21 Aug fresh-guest witness: "drives 100% of the outcome" beside
+    // rows reading 75% and 68%. No basis this product resolves partitions
+    // (the golden staging capture's seven influence_scores sum to 450%), so
+    // no string here may imply one.
+    for (const s of allStrings()) expect(s, s).not.toMatch(/\d+\s*%\s*of the outcome/i)
   })
 
   it('avoids internal analytical vocabulary and American spellings', () => {

--- a/src/components/results/__tests__/noAbsoluteOutcomeShareClaim.spec.tsx
+++ b/src/components/results/__tests__/noAbsoluteOutcomeShareClaim.spec.tsx
@@ -1,0 +1,397 @@
+/**
+ * SENDABLE trust defect — the product printed an arithmetically impossible
+ * causal SHARE.
+ *
+ * WITNESSED (fresh-guest journey, 2026-08-21): the T1 dominance nudge read
+ *
+ *     "Dominant factor: <label> drives 100% of the outcome."
+ *
+ * BESIDE two other factors on the SAME screen reading Influence 75% and 68%.
+ * Three shares of one outcome summing to 243%.
+ *
+ * ROOT CAUSE — TWO DEFECTS, ONE SENTENCE.
+ *
+ * (1) THE CLAIM IS FALSE ON EVERY BASIS THIS PRODUCT HOLDS. "drives NN% of
+ *     the outcome" is a SHARE claim: it asserts the factor accounts for NN%
+ *     of the outcome, which implies the factors' shares partition 100%.
+ *     Neither basis `driverDisplayModel` can resolve is a share:
+ *       • 'normalised_elasticity' is |elasticity| / max|elasticity| — the top
+ *         factor is 1.0 BY CONSTRUCTION, per-set, not a share of anything;
+ *       • 'influence_score' is the producer's absolute causal influence SCORE
+ *         (this repo's own canonical wording: INFLUENCE_EXPLANATION_ABSOLUTE,
+ *         "an absolute causal influence score from the analysis"). Absolute
+ *         SCALE is not PARTITION. Measured at this tip, the repo's golden
+ *         staging capture `src/test/fixtures/golden-path-staging-2026-04-05.json`
+ *         carries seven `influence_score` values —
+ *         1.0 / 0.8494 / 0.7304 / 0.6694 / 0.6562 / 0.3730 / 0.2238 —
+ *         SUMMING TO 4.5022, i.e. 450%. On the very basis the old gate called
+ *         "honest", the shares are impossible.
+ *     So no adjustment to the NUMBER or to the GATE can make this sentence
+ *     true. THE CLAIM IS WHAT IS WRONG, and the claim is what this lane fixes.
+ *
+ * (2) TRAP 21 — THE GATE CERTIFIED ONE FIELD AND THE SENTENCE PRINTED ANOTHER.
+ *     `absoluteBasis` asked "does an ABSOLUTE producer score exist?" (reading
+ *     `displayProvenance` / `influenceScore`) while `topInfluence` — the value
+ *     actually rendered — was read `displayInfluence ?? influenceScore ?? …`
+ *     FIRST. On an unstamped payload carrying BOTH a set-relative
+ *     `displayInfluence` (top ≡ 1.0) and a modest `influenceScore`, the gate
+ *     passed on the producer score and the sentence printed the set-relative
+ *     1.0 as "100%". Two authorities, one sentence, different questions.
+ *
+ * CONVERGENCE (Paul's binding rule).
+ *   • Canonical owner of WHAT NUMBER MAY BACK A BASIS-STAMPED INFLUENCE CLAIM:
+ *     `driverDisplayModel.resolveDriverClaimBasis` — returns the value AND the
+ *     basis THAT PRODUCED IT, so a surface cannot certify one field and print
+ *     another. The competing inline `displayInfluence ?? influenceScore ?? …`
+ *     / `displayProvenance ? … : typeof influenceScore` pair in
+ *     `TriageActionCardsBody` is REMOVED, not wrapped.
+ *   • Canonical owner of HOW AN INFLUENCE NUMBER MAY BE DESCRIBED IN WORDS:
+ *     `influenceScaleCopy` (already "the ONE home for influence-scale
+ *     disclosure wording"). Both share-claiming surfaces — the T1 nudge and
+ *     `TriageCard`'s influence-bar tooltip — now render from
+ *     `influenceMagnitudePredicate` / `influenceMagnitudeTitle`. The literal
+ *     "of the outcome" template in `TriageCard.tsx` is REMOVED, not wrapped.
+ *
+ * WHAT IS DELIBERATELY UNCHANGED: the nudge's firing condition (absolute
+ * producer basis AND >= 0.8 AND clear of the runner-up). A genuinely dominant
+ * factor still gets its warning — see the OPPOSITE-DIRECTION TWINS below.
+ * Silencing the honest case would be the inverse defect (trap 22b).
+ *
+ * Trap-19 identity binding: every driver assertion names its object by
+ * `factorKey`/`factorLabel`, never by a value predicate a sibling row shares.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { resolveDriverClaimBasis } from '../driverDisplayModel'
+import {
+  influenceMagnitudePredicate,
+  influenceMagnitudeTitle,
+} from '../influenceScaleCopy'
+import { TriageActionCardsBody } from '../TriageActionCardsBody'
+import { TriageCard } from '../../shared/TriageCard'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type { DriversSectionData, DriverItem } from '../types'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+}))
+
+/**
+ * The forbidden sentence shape. Deliberately matches the CLAIM ("<n>% of the
+ * outcome"), not the specific number, so it stays sensitive to a re-worded
+ * regression that keeps the share framing.
+ */
+const OUTCOME_SHARE_CLAIM = /\d+\s*%\s*of the outcome/i
+
+function makeDriver(overrides: Partial<DriverItem> & { factorKey: string }): DriverItem {
+  return {
+    factorLabel: overrides.factorKey,
+    rawElasticity: 0.5,
+    normalisedInfluence: 0.8,
+    influenceScore: 0.8,
+    rank: 1,
+    semanticLabel: 'biggest',
+    canFocus: false,
+    direction: 'positive',
+    ...overrides,
+  }
+}
+
+function makeData(drivers: DriverItem[]): DriversSectionData {
+  return {
+    drivers,
+    topDrivers: drivers.slice(0, 3),
+    driversStatus: 'computed',
+    totalCount: drivers.length,
+    hasMagnitudeData: true,
+  }
+}
+
+function triageData(drivers: DriverItem[]) {
+  return {
+    drivers: {
+      ...makeData(drivers),
+      dominantFactorId: drivers[0]?.factorKey,
+      dominantFactorLabel: drivers[0]?.factorLabel,
+    },
+    recommendation: { recommendedOption: null },
+    confidence: { recommendedOptionId: undefined },
+    assumptions: { items: [] },
+    gaps: { items: [] },
+    risks: { items: [] },
+  } as unknown as ResultsSectionDataReturn
+}
+
+/** The witnessed set: a real producer-basis run whose scores do not partition. */
+const WITNESSED_NON_PARTITIONING_SET = [
+  makeDriver({
+    factorKey: 'cloud_migration_progress',
+    factorLabel: 'Cloud migration progress',
+    influenceScore: 1,
+    normalisedInfluence: 1,
+    displayInfluence: 1,
+    displayProvenance: 'influence_score',
+  }),
+  makeDriver({
+    factorKey: 'licence_cost',
+    factorLabel: 'Licence cost',
+    influenceScore: 0.75,
+    normalisedInfluence: 0.75,
+    displayInfluence: 0.75,
+    displayProvenance: 'influence_score',
+  }),
+  makeDriver({
+    factorKey: 'team_capacity',
+    factorLabel: 'Team capacity',
+    influenceScore: 0.68,
+    normalisedInfluence: 0.68,
+    displayInfluence: 0.68,
+    displayProvenance: 'influence_score',
+  }),
+]
+
+// =============================================================================
+// 1. THE WITNESSED SENTENCE — no surface states an influence number as a share
+// =============================================================================
+
+describe('no surface states an influence number as a share of the outcome', () => {
+  it('THE WITNESSED CLAIM: the dominance nudge does not say "100% of the outcome"', () => {
+    render(
+      <TriageActionCardsBody data={triageData(WITNESSED_NON_PARTITIONING_SET)} suppressTriageQueue />,
+    )
+    const nudge = screen.getByTestId('t1-dominant-nudge')
+    expect(nudge.textContent ?? '').not.toMatch(OUTCOME_SHARE_CLAIM)
+    // The title/aria copy carries the same sentence; the claim must be gone
+    // from the generated text too, not merely hidden from the visible span.
+    expect(nudge.getAttribute('title') ?? '').not.toMatch(OUTCOME_SHARE_CLAIM)
+    expect(nudge.getAttribute('aria-label') ?? '').not.toMatch(OUTCOME_SHARE_CLAIM)
+  })
+
+  it("THE SECOND SURFACE: TriageCard's influence tooltip does not claim a share", () => {
+    render(
+      <TriageCard
+        cardKey="licence_cost"
+        ordinal={1}
+        title="Licence cost"
+        detail="Detail"
+        category="verify"
+        influence={0.68}
+      />,
+    )
+    const titled = document.querySelectorAll('[title]')
+    const titles = Array.from(titled).map((el) => el.getAttribute('title') ?? '')
+    // Positive control: the influence bar DOES carry a tooltip, so a clean
+    // "no share claim" result cannot come from there being no tooltip at all.
+    expect(titles.some((t) => /influence/i.test(t))).toBe(true)
+    for (const t of titles) expect(t).not.toMatch(OUTCOME_SHARE_CLAIM)
+  })
+})
+
+// =============================================================================
+// 2. THE CANONICAL OWNER — value and basis come from ONE read (trap 21)
+// =============================================================================
+
+describe('resolveDriverClaimBasis — the certified basis and the printed value are one read', () => {
+  it('stamped payload: returns the stamped value on the stamped basis', () => {
+    expect(
+      resolveDriverClaimBasis({
+        displayInfluence: 0.9,
+        displayProvenance: 'influence_score',
+        influenceScore: 0.9,
+        normalisedInfluence: 1,
+      }),
+    ).toEqual({ value: 0.9, provenance: 'influence_score' })
+  })
+
+  it('stamped set-relative payload: never reports the absolute basis', () => {
+    expect(
+      resolveDriverClaimBasis({
+        displayInfluence: 1,
+        displayProvenance: 'normalised_elasticity',
+        influenceScore: 0.42,
+        normalisedInfluence: 1,
+      }),
+    ).toEqual({ value: 1, provenance: 'normalised_elasticity' })
+  })
+
+  it('THE TRAP-21 CASE: unstamped payload takes the value FROM the field that certifies the basis', () => {
+    // displayInfluence is set-relative (top === 1 by construction); the only
+    // absolute number on this row is influenceScore. Reading displayInfluence
+    // while certifying influenceScore is exactly what printed "100%".
+    expect(
+      resolveDriverClaimBasis({
+        displayInfluence: 1,
+        influenceScore: 0.6,
+        normalisedInfluence: 1,
+      }),
+    ).toEqual({ value: 0.6, provenance: 'influence_score' })
+  })
+
+  it('no absolute number at all: falls back to the set-relative basis, never claims absolute', () => {
+    expect(resolveDriverClaimBasis({ normalisedInfluence: 0.7 })).toEqual({
+      value: 0.7,
+      provenance: 'normalised_elasticity',
+    })
+  })
+
+  it('no usable number: returns null rather than defaulting to zero on a claimed basis', () => {
+    expect(resolveDriverClaimBasis({})).toBeNull()
+  })
+})
+
+describe('the nudge reads its number through the canonical owner', () => {
+  it('THE TRAP-21 REGRESSION: an unstamped row with a modest producer score does not fire a 100% nudge', () => {
+    const legacyMixedBasis = [
+      makeDriver({
+        factorKey: 'cloud_migration_progress',
+        factorLabel: 'Cloud migration progress',
+        influenceScore: 0.6, // absolute, below the 0.8 dominance floor
+        normalisedInfluence: 1,
+        displayInfluence: 1, // set-relative: top === 1 by construction
+        displayProvenance: undefined, // legacy fixture / cached payload
+      }),
+      makeDriver({
+        factorKey: 'licence_cost',
+        factorLabel: 'Licence cost',
+        influenceScore: 0.1,
+        normalisedInfluence: 0.17,
+        displayInfluence: 0.17,
+        displayProvenance: undefined,
+      }),
+    ]
+    render(<TriageActionCardsBody data={triageData(legacyMixedBasis)} suppressTriageQueue />)
+    expect(screen.queryByTestId('t1-dominant-nudge')).not.toBeInTheDocument()
+  })
+
+  // ── OPPOSITE-DIRECTION TWIN ──────────────────────────────────────────────
+  it('TWIN — an unstamped row whose PRODUCER score is genuinely dominant still fires, at the producer number', () => {
+    const legacyGenuinelyDominant = [
+      makeDriver({
+        factorKey: 'cloud_migration_progress',
+        factorLabel: 'Cloud migration progress',
+        influenceScore: 0.93,
+        normalisedInfluence: 1,
+        displayInfluence: 1,
+        displayProvenance: undefined,
+      }),
+      makeDriver({
+        factorKey: 'licence_cost',
+        factorLabel: 'Licence cost',
+        influenceScore: 0.1,
+        normalisedInfluence: 0.11,
+        displayInfluence: 0.11,
+        displayProvenance: undefined,
+      }),
+    ]
+    render(<TriageActionCardsBody data={triageData(legacyGenuinelyDominant)} suppressTriageQueue />)
+    const nudge = screen.getByTestId('t1-dominant-nudge')
+    // Identity binding: the nudge names THIS factor, and quotes the PRODUCER
+    // number (93%), not the set-relative 100% that sits on the same row.
+    expect(nudge.textContent).toContain('Cloud migration progress')
+    expect(nudge.textContent).toContain('93%')
+    expect(nudge.textContent).not.toContain('100%')
+  })
+})
+
+// =============================================================================
+// 3. OPPOSITE-DIRECTION TWINS — the honest warning survives
+// =============================================================================
+
+describe('the honest dominance warning still fires', () => {
+  it('TWIN — a genuinely dominant factor on the producer basis is still named', () => {
+    const clearlyDominant = [
+      makeDriver({
+        factorKey: 'cloud_migration_progress',
+        factorLabel: 'Cloud migration progress',
+        influenceScore: 0.95,
+        normalisedInfluence: 1,
+        displayInfluence: 0.95,
+        displayProvenance: 'influence_score',
+      }),
+      makeDriver({
+        factorKey: 'licence_cost',
+        factorLabel: 'Licence cost',
+        influenceScore: 0.15,
+        normalisedInfluence: 0.16,
+        displayInfluence: 0.15,
+        displayProvenance: 'influence_score',
+      }),
+    ]
+    render(<TriageActionCardsBody data={triageData(clearlyDominant)} suppressTriageQueue />)
+    const nudge = screen.getByTestId('t1-dominant-nudge')
+    expect(nudge).toBeInTheDocument()
+    expect(nudge.textContent).toContain('Cloud migration progress')
+    expect(nudge.textContent).toContain('95%')
+    // The number survives; only the SHARE framing is gone.
+    expect(nudge.textContent ?? '').not.toMatch(OUTCOME_SHARE_CLAIM)
+  })
+
+  it('TWIN — the set-relative basis still gets no dominance claim at all', () => {
+    const setRelative = [
+      makeDriver({
+        factorKey: 'cloud_migration_progress',
+        factorLabel: 'Cloud migration progress',
+        influenceScore: undefined,
+        normalisedInfluence: 1,
+        displayInfluence: 1,
+        displayProvenance: 'normalised_elasticity',
+      }),
+      makeDriver({
+        factorKey: 'licence_cost',
+        factorLabel: 'Licence cost',
+        influenceScore: undefined,
+        normalisedInfluence: 0.2,
+        displayInfluence: 0.2,
+        displayProvenance: 'normalised_elasticity',
+      }),
+    ]
+    render(<TriageActionCardsBody data={triageData(setRelative)} suppressTriageQueue />)
+    expect(screen.queryByTestId('t1-dominant-nudge')).not.toBeInTheDocument()
+  })
+})
+
+// =============================================================================
+// 4. THE COPY OWNER — basis-aware, share-free, in both grammatical slots
+// =============================================================================
+
+describe('influenceScaleCopy owns the wording, on every basis', () => {
+  const BASES = ['influence_score', 'normalised_elasticity', null, undefined] as const
+
+  it('no basis produces a share claim, in either slot', () => {
+    for (const basis of BASES) {
+      expect(influenceMagnitudePredicate(100, basis)).not.toMatch(OUTCOME_SHARE_CLAIM)
+      expect(influenceMagnitudeTitle(100, basis)).not.toMatch(OUTCOME_SHARE_CLAIM)
+    }
+  })
+
+  it('every basis still carries the number', () => {
+    for (const basis of BASES) {
+      expect(influenceMagnitudePredicate(68, basis)).toContain('68%')
+      expect(influenceMagnitudeTitle(68, basis)).toContain('68%')
+    }
+  })
+
+  it('the set-relative basis discloses that it is set-relative; the absolute one does not', () => {
+    expect(influenceMagnitudePredicate(100, 'normalised_elasticity')).toMatch(
+      /relative to the strongest factor/i,
+    )
+    expect(influenceMagnitudePredicate(100, 'influence_score')).not.toMatch(
+      /relative to the strongest factor/i,
+    )
+  })
+
+  it('an unstamped basis fails closed: no basis is claimed either way', () => {
+    const unstamped = influenceMagnitudePredicate(68, undefined)
+    expect(unstamped).not.toMatch(/relative to the strongest factor/i)
+    expect(unstamped).not.toMatch(/absolute/i)
+  })
+
+  it('the title slot is sentence case and the predicate slot is not', () => {
+    expect(influenceMagnitudeTitle(68, null)[0]).toBe(
+      influenceMagnitudeTitle(68, null)[0].toUpperCase(),
+    )
+    expect(influenceMagnitudePredicate(68, null).startsWith('has ')).toBe(true)
+  })
+})

--- a/src/components/results/driverDisplayModel.ts
+++ b/src/components/results/driverDisplayModel.ts
@@ -135,6 +135,60 @@ export function selectDriverDisplayModel(
 }
 
 /**
+ * ⭐⭐ THE ONE OWNER OF "WHICH NUMBER MAY BACK A BASIS-STAMPED INFLUENCE CLAIM,
+ * AND ON WHICH BASIS" (2026-08-23).
+ *
+ * ⚠ TRAP 21 — TWO AUTHORITIES ANSWERING DIFFERENT QUESTIONS UNDER ONE
+ * SENTENCE. The T1 dominance nudge used to read its VALUE as
+ * `displayInfluence ?? influenceScore ?? normalisedInfluence` and separately
+ * certify its BASIS as `displayProvenance === 'influence_score'` or, when
+ * unstamped, `typeof influenceScore === 'number'`. Those are different
+ * questions: "what do we show?" and "does an absolute producer score exist?".
+ * On an unstamped payload carrying BOTH a set-relative `displayInfluence`
+ * (top ≡ 1.0 by construction) and a modest `influenceScore`, the gate passed
+ * on the producer score while the sentence printed the set-relative 1.0 — the
+ * witnessed "drives 100% of the outcome".
+ *
+ * The fix is structural, not a bigger gate: the value and the basis come from
+ * ONE read, so a surface CANNOT certify one field and print another. When the
+ * pipeline has stamped a basis, that stamp and its value are taken together
+ * (`selectDriverDisplayModel` writes both, so they cannot disagree). When it
+ * has not (legacy fixtures, cached payloads), the value is taken FROM THE
+ * FIELD THAT CERTIFIES THE BASIS — never from `displayInfluence`, whose basis
+ * is then unknown. Absence is returned as `null`, never defaulted to 0 on a
+ * claimed basis (a 0 on a claimed basis is still a claim).
+ *
+ * Deliberately NOT a share. See `influenceScaleCopy.influenceMagnitudeClaim`
+ * for why no value here may back a "NN% of the outcome" sentence.
+ */
+export function resolveDriverClaimBasis(
+  driver: {
+    displayInfluence?: number | null
+    displayProvenance?: DriverDisplayProvenance | null
+    influenceScore?: number | null
+    normalisedInfluence?: number | null
+  } | null | undefined,
+): DriverDisplayEntry | null {
+  if (!driver) return null
+  const finite = (v: unknown): v is number => typeof v === 'number' && Number.isFinite(v)
+
+  if (driver.displayProvenance === 'influence_score' || driver.displayProvenance === 'normalised_elasticity') {
+    // Stamped: the stamper wrote value and basis together. Take both.
+    return finite(driver.displayInfluence)
+      ? { value: driver.displayInfluence, provenance: driver.displayProvenance }
+      : null
+  }
+  // Unstamped: read the value from whichever field certifies the basis.
+  if (finite(driver.influenceScore)) {
+    return { value: driver.influenceScore, provenance: 'influence_score' }
+  }
+  if (finite(driver.normalisedInfluence)) {
+    return { value: driver.normalisedInfluence, provenance: 'normalised_elasticity' }
+  }
+  return null
+}
+
+/**
  * Rank comparator on a resolved display model: value descending, then
  * elasticity as the tie-break, then key alphabetically for determinism.
  * The graph badge ranks with this so its order matches the panel's, both keyed

--- a/src/components/results/influenceScaleCopy.ts
+++ b/src/components/results/influenceScaleCopy.ts
@@ -85,3 +85,70 @@ export function influenceBarAriaLabel(
       ? 'Influence, an absolute causal influence score from the analysis'
       : 'Influence'
 }
+
+// ── The absolute-share claim ────────────────────────────────────────────────
+
+/**
+ * ⭐⭐ THE ONE OWNER OF "WHAT NUMBER MAY BACK AN ABSOLUTE CAUSAL SHARE CLAIM"
+ * (2026-08-23). The answer is NONE OF THEM, and that is why this returns a
+ * MAGNITUDE claim rather than a SHARE claim.
+ *
+ * ⚠ WHY. "drives NN% of the outcome" is a SHARE claim: it asserts the factor
+ * accounts for NN% of the outcome, which implies the factors' shares
+ * partition 100%. Neither basis `driverDisplayModel` can resolve partitions:
+ *
+ *   • 'normalised_elasticity' is |elasticity| / max|elasticity|. The top
+ *     factor is 1.0 BY CONSTRUCTION and the values are per-set. Never a share.
+ *   • 'influence_score' is the producer's ABSOLUTE CAUSAL INFLUENCE SCORE —
+ *     this module's own INFLUENCE_EXPLANATION_ABSOLUTE says exactly that.
+ *     An absolute SCALE is not a PARTITION: every factor may score high at
+ *     once. Measured at the bytes on the repo's golden staging capture
+ *     (`src/test/fixtures/golden-path-staging-2026-04-05.json`), seven
+ *     `influence_score` values read 1.0 / 0.8494 / 0.7304 / 0.6694 / 0.6562 /
+ *     0.3730 / 0.2238 and SUM TO 4.5022 — 450% of one outcome.
+ *
+ * So the witnessed defect (a nudge reading "drives 100% of the outcome"
+ * beside rows reading 75% and 68%, summing to 243%) cannot be repaired by
+ * adjusting the number or by tightening the gate. THE CLAIM IS WHAT IS
+ * WRONG. Both surfaces that made it — the T1 dominance nudge
+ * (`TriageActionCardsBody`) and the `TriageCard` influence-bar tooltip —
+ * render from here, and their local "of the outcome" templates are gone.
+ *
+ * The number itself is retained and is honest: it is the influence value on
+ * a disclosed basis. Only the partition framing is removed.
+ *
+ * Fail-closed on an unstamped basis: state the number, claim no basis.
+ */
+function influenceMagnitudeCore(
+  pct: number,
+  provenance: DriverDisplayProvenance | null | undefined,
+): string {
+  return provenance === 'influence_score'
+    ? `influence score of ${pct}%`
+    : provenance === 'normalised_elasticity'
+      ? `influence of ${pct}%, relative to the strongest factor`
+      : `influence of ${pct}%`
+}
+
+/**
+ * Predicate slot: reads after a subject, e.g. "{factor} has an influence
+ * score of 95%." Used by the T1 dominance nudge.
+ */
+export function influenceMagnitudePredicate(
+  pct: number,
+  provenance: DriverDisplayProvenance | null | undefined,
+): string {
+  return `has an ${influenceMagnitudeCore(pct, provenance)}`
+}
+
+/**
+ * Standalone slot: a native `title` / tooltip on its own. Same claim, same
+ * decision, sentence case. Used by the TriageCard influence bar.
+ */
+export function influenceMagnitudeTitle(
+  pct: number,
+  provenance: DriverDisplayProvenance | null | undefined,
+): string {
+  const core = influenceMagnitudeCore(pct, provenance)
+  return core.charAt(0).toUpperCase() + core.slice(1)
+}

--- a/src/components/shared/TriageCard.tsx
+++ b/src/components/shared/TriageCard.tsx
@@ -16,6 +16,7 @@ import { evaluativeVar } from '@/styles/evaluative'
 import type { ScientificEditorProps } from './ScientificEditor'
 import { ExpandableCoachingText } from './ExpandableCoachingText'
 import Tooltip from '@/components/Tooltip'
+import { influenceMagnitudeTitle } from '@/components/results/influenceScaleCopy'
 import { classifyUnit } from '@/utils/unitClassifier'
 
 // ── Types ───────────────────────────────────────────────────────────────────
@@ -480,7 +481,14 @@ export function TriageCard(props: TriageCardProps) {
         {influencePct != null && (
           <div
             className="flex items-center gap-1 flex-shrink-0"
-            title={`Drives ${influencePct}% of the outcome`}
+            /* ⭐ ONE OWNER (influenceScaleCopy.influenceMagnitudeTitle). The
+               literal `Drives ${influencePct}% of the outcome` that stood
+               here was an absolute SHARE claim on a number that is not a
+               share, made with NO basis at all — this card receives a bare
+               `influence` prop and never learns its provenance, so it fails
+               closed to the number without a basis. The competing local
+               template is DELETED, not wrapped. */
+            title={influenceMagnitudeTitle(influencePct, undefined)}
           >
             <div className="w-[28px] h-[3px] rounded-sm overflow-hidden" style={{ backgroundColor: 'var(--border-default, #EEE6D8)' }}>
               <div


### PR DESCRIPTION
## The measured failure

21 Aug fresh-guest journey witness: the T1 dominance nudge read

> **Dominant factor: <label> drives 100% of the outcome.**

**beside two other factors on the same screen reading Influence 75% and 68%.** Three shares of one outcome summing to **243%**.

Reproduced at pristine `54cc9cbb`, RED-first, verbatim:

```
AssertionError: expected 'Dominant factor:Cloud migration progr…' not to match /\d+\s*%\s*of the outcome/i
+ Received: "Dominant factor:Cloud migration progressdrives 100% of the outcome."
```

## What I am fixing: the CLAIM. Not the number, not the gate.

**No number this product holds is a share of the outcome**, so no adjustment to the number and no tightening of the gate can make that sentence true.

- `'normalised_elasticity'` is `|elasticity| / max|elasticity|`. The top factor is **1.0 by construction**, per set. Never a share.
- `'influence_score'` is the producer's **absolute causal influence SCORE** — this repo's own canonical wording (`INFLUENCE_EXPLANATION_ABSOLUTE`: *"an absolute causal influence score from the analysis"*). **An absolute SCALE is not a PARTITION.** Measured at the bytes on the repo's own golden staging capture `src/test/fixtures/golden-path-staging-2026-04-05.json`, the seven `influence_score` values read

  `1.0 / 0.8494 / 0.7304 / 0.6694 / 0.6562 / 0.3730 / 0.2238` → **sum 4.5022, i.e. 450% of one outcome.**

So on the very basis the old gate called *"honest only on the producer influence_score basis"*, the shares are impossible. The number survives and is honest; only the partition framing is removed.

## Second, real defect: trap 21 — two authorities, one sentence

The brief's derivation is **confirmed at `54cc9cbb`**:

```ts
const topInfluence = topDriver
  ? (topDriver.displayInfluence ?? topDriver.influenceScore ?? topDriver.normalisedInfluence ?? 0) : 0
const absoluteBasis = topDriver
  ? (topDriver.displayProvenance ? topDriver.displayProvenance === 'influence_score'
     : typeof topDriver.influenceScore === 'number') : false
```

`absoluteBasis` asks *"does an absolute producer score exist?"*; `topInfluence` — the number **printed** — reads `displayInfluence` **first**, which is set-relative by construction. On an unstamped payload (legacy fixture / cached payload) carrying both a set-relative `displayInfluence` of 1.0 and a modest `influenceScore`, **the gate passes on one field and the sentence prints the other.**

## Convergence — owners named, competitors REMOVED not wrapped

| Question | Canonical owner | Competitor removed |
|---|---|---|
| **Which number may back a basis-stamped influence claim, and on which basis** | `driverDisplayModel.resolveDriverClaimBasis` — returns value **and** the basis that produced it, from **one read** | the inline `displayInfluence ?? influenceScore ?? normalisedInfluence` / `displayProvenance ? … : typeof influenceScore` pair in `TriageActionCardsBody` (both deleted) |
| **How an influence number may be described in words** | `influenceScaleCopy.influenceMagnitude{Predicate,Title}` — already *"the ONE home for influence-scale disclosure wording"* | both `of the outcome` literals: `TriageActionCardsBody.tsx:433` and `TriageCard.tsx:483` (both deleted) |

Net: **26 deletions against 567 insertions**, of which 397 are the new spec and ~120 are the derivation written into the two owners' headers. The production logic in `TriageActionCardsBody` **shrank**.

`TriageCard` receives a bare `influence` prop and **never learns its provenance**, so it fails closed: the number, no basis claimed.

## Both directions

- **The honest case still fires.** Gate semantics are deliberately **unchanged**: absolute producer basis AND `>= 0.8` AND clear of the runner-up. A genuinely dominant factor still gets its warning, now reading:
  > *Dominant factor: Cloud migration progress has an influence score of 95%. If your assumptions about this factor are wrong, the result could change.*
- **The set-relative basis still gets no dominance claim at all** (it would fire on every such run).
- **The trap-21 case now fires at the producer number**, not the set-relative 1.0: an unstamped row with `influenceScore 0.93` / `displayInfluence 1` prints **93%**, and one with `influenceScore 0.6` prints **nothing**.

## Evidence

- **RED-first:** 16 collected by name, 15 failing at pristine; signature quoted above.
- **Mutants** (throwaway worktree at an absolute path outside the repo root, mutating committed state only; **isolation proven by WRITING a sentinel** — distinct inodes `694236266` vs `694651240`, source sha unchanged, sentinel absent from source; restored from a **pristine tar archive**, never `git checkout -- <path>`; applied-check scoped to `src/`, leading and trailing controls both **exactly 0**):

  | Mutant | Expect | Result |
  |---|---|---|
  | M1 revert the T1 share literal | RED | RED (2 failed) |
  | M2 revert the TriageCard share literal | RED | RED (1 failed) |
  | M3 reinstate the trap-21 value/basis split | RED | RED (3 failed) |
  | **M4a loosen for ALL objects** (nudge reads a different driver every run) | RED | **RED (3 failed)** |
  | **M4b loosen for a DIFFERENT object only** (runner-up clearance read) | GREEN | **GREEN (16 passed)** |
  | M5 drop the set-relative disclosure | RED | RED (1 failed) |
  | M6 widen the gate to any basis | RED | RED (1 failed) |

  **M4a/M4b is the discriminating pair (trap 19):** the assertions bind to the **top driver by identity**, not to whichever driver happens to satisfy a value predicate.
- **Gate:** `npx eslint` on all six changed files exit 0 · `bash scripts/ci/typecheck-gate.sh` **PASSED** (3596/3636 files, ratchet 2263 = baseline 2263).
- **Neighbours:** all 30 specs referencing `t1-dominant-nudge` / `driverDisplayModel` / `influenceScaleCopy` / `TriageCard` / `TriageActionCardsBody`, run in 3 shards — **1,475 passed, 0 failed** (includes `no-raw-influence-read.spec.ts`, 1,005 tests).
- Copy hygiene extended: the new builders are exercised across every basis, plus a new share-claim ban on the whole module.

## Sweep (with contrast control)

`rg -a "of the outcome" src/` — **target sites carrying a number: exactly two**, both fixed. Contrast control `"the outcome"`: **68 files**, so the sweep can see the family.

## Out of scope — reported, not touched (rule 13)

1. `src/canvas/components/pre-analysis/PreAnalysisPanel.tsx:1513` — *"`{label}` drives most of the outcome…"*. A **qualitative** claim carrying no number, in a file this lane does not own.
2. **`TriageActionCardsBody:169` feeds `influence={gap.voi}`** — value-of-information into a prop named `influence`. The tooltip is now honest about *an influence number*, but the **value** is not an influence at all. That is a different defect (wrong value into a correctly-named prop) and needs its own lane.
