### PR TITLE
fix(canvas): the restored graph's fit is scheduled then cancelled — the camera parks below the legibility floor (B5 restore arm)

### DIFF
--- a/e2e/geometry/viewportRestoreFit.measure.ts
+++ b/e2e/geometry/viewportRestoreFit.measure.ts
@@ -40,6 +40,7 @@
  */
 import { test, expect, type Page } from '@playwright/test'
 import { posturePins } from '../visual/flagPosture'
+import { LABEL_LEGIBLE_ZOOM, renderedLabelPx } from '../../src/canvas/utils/zoomLegibility'
 import {
   openCanvas,
   freezeMotion,
@@ -94,6 +95,8 @@ async function prepareKeepingStorage(page: Page, vp: { width: number; height: nu
 
 interface Frame {
   transform: string
+  /** The viewport scale, read off the rendered matrix — the `a` component. */
+  zoom: number
   layoutVersion: number
   storeNodeCount: number
   modelNodeCount: number
@@ -124,8 +127,11 @@ async function frameOf(page: Page): Promise<Frame> {
         behindBanner.push(el.dataset.id!)
       }
     }
+    const transform = vpEl ? getComputedStyle(vpEl).transform : 'NO-VIEWPORT-EL'
+    const m = /matrix\(([-0-9.eE]+)/.exec(transform)
     return {
-      transform: vpEl ? getComputedStyle(vpEl).transform : 'NO-VIEWPORT-EL',
+      transform,
+      zoom: m ? Number(m[1]) : NaN,
       layoutVersion: store.layoutVersion,
       storeNodeCount: store.nodes.length,
       modelNodeCount: model.length,
@@ -253,6 +259,28 @@ test('the restored model is framed, and the frame follows the window', async ({ 
   for (let i = 0; i < SIZES.length; i++) {
     const size = `${SIZES[i].width}x${SIZES[i].height}`
     expect(frames[i].behindBanner, `RESTORE @${size}: model nodes behind the header banner`).toEqual([])
+  }
+
+  // (b2) THE CAMERA IS NOT PARKED BELOW THE LEGIBILITY FLOOR — SENDABLE failure 6.
+  //      Measured on deployed staging at 1280x800, restore arm: 0.4279. The
+  //      counter-scale saturates at `1 / LABEL_LEGIBLE_ZOOM`, so every
+  //      counter-scaled glyph rendered at 0.4279 / 0.5 = 85.6% of its declared
+  //      size — 8.56px on 58 elements against the DS v5 §2.4 10px canvas floor.
+  //      The floor is not lowered and the cap is not raised: the fit owner
+  //      simply has to reach the floor it already asks for.
+  //
+  //      POSITIVE CONTROL FIRST (trap 13): the same arithmetic must JUDGE the
+  //      measured park short, or "meets the floor" is a verdict nothing can fail.
+  expect(renderedLabelPx(10, 0.4279), 'the legibility arithmetic cannot fail — this check would be vacuous')
+    .toBeLessThan(10)
+  expect(fresh.zoom, 'FRESH: the control arm is itself below the floor').toBeGreaterThanOrEqual(LABEL_LEGIBLE_ZOOM)
+  for (let i = 0; i < SIZES.length; i++) {
+    const size = `${SIZES[i].width}x${SIZES[i].height}`
+    expect(Number.isFinite(frames[i].zoom), `RESTORE @${size}: no viewport matrix — the floor check would be vacuous`).toBe(true)
+    expect(
+      frames[i].zoom,
+      `RESTORE @${size}: the product parked the camera at ${frames[i].zoom}, below the legibility floor — canvas text renders at ${(renderedLabelPx(10, frames[i].zoom)).toFixed(2)}px against a declared 10px`,
+    ).toBeGreaterThanOrEqual(LABEL_LEGIBLE_ZOOM)
   }
 
   // (c) NO WORSE OFF-SCREEN THAN THE PRODUCT'S OWN FRESH FIT at the same window.

--- a/src/canvas/__tests__/useFitViewOnLayoutVersion.restore.spec.tsx
+++ b/src/canvas/__tests__/useFitViewOnLayoutVersion.restore.spec.tsx
@@ -413,6 +413,84 @@ describe('useFitViewOnLayoutVersion — the restore trigger', () => {
     ])
   })
 
+  // ⭐⭐ THE PAIR BELOW IS THE PRICE OF MAKING THE FIT RE-SCHEDULABLE, and it was
+  // found by adversarial review, not by this suite. Deferring the latch means a
+  // cancelled fit can be retried — which is the fix — but it also means the LATCH
+  // KEY decides how often the camera moves. Keyed on the STRUCTURAL identity
+  // (sorted node + edge ids) it would re-frame on every add, delete, undo and
+  // paste, because on a restored graph `layoutVersion` stays 0 all session and
+  // nothing else stops it. Keyed on the RESTORE it fires once, as intended.
+  //
+  // Neither test alone shows the binding: the first proves edits do NOT re-frame,
+  // the second proves a genuinely new restore still DOES. A latch that simply
+  // never fires twice would pass the first and fail the second.
+
+  it('a STRUCTURAL edit on a restored graph does not yank the camera back to fit-all', () => {
+    renderHook(() => useFitViewOnLayoutVersion())
+    const graph = restoredGraph()
+    act(() => { restore(graph) })
+    act(() => { measureAll(graph) })
+    flushFrames()
+
+    // PRECONDITION 1: the restore fit landed, so what follows is about a SECOND
+    // fit and not about the first one being missing.
+    expect(fitViewSpy, 'the restore fit never landed — this test would prove nothing').toHaveBeenCalledTimes(1)
+
+    const before = useCanvasStore.getState()
+    const structuralBefore = getGraphIdentityKey(before.currentScenarioId, before.nodes, before.edges)
+
+    act(() => { useCanvasStore.getState().addNode({ x: 900, y: 400 }, 'factor') })
+    currentNodes = useCanvasStore.getState().nodes.map((n) => ({ id: n.id }))
+
+    const after = useCanvasStore.getState()
+    // PRECONDITION 2: the edit really did change the STRUCTURAL identity — the key
+    // the old code latched on. Without this the test passes for the wrong reason.
+    expect(
+      getGraphIdentityKey(after.currentScenarioId, after.nodes, after.edges),
+      'the edit did not change the structural identity — the regression could not occur',
+    ).not.toBe(structuralBefore)
+    // PRECONDITION 3: still the restore state class. `addNode` must not have
+    // requested a layout, or trigger 1 would own the frame and this proves nothing.
+    expect(after.layoutVersion, 'a layout ran — the restore trigger is no longer the author').toBe(0)
+    expect(after.pendingLayout).toBe(false)
+
+    flushFrames()
+
+    // THE POSTCONDITION. The user zoomed into a corner and added a factor; the
+    // camera must stay where they put it.
+    expect(
+      fitViewSpy,
+      'adding a node re-framed the whole canvas — the latch is keyed on structure, not on the restore',
+    ).toHaveBeenCalledTimes(1)
+  })
+
+  it('TWIN: a genuinely NEW restore still frames the camera', () => {
+    renderHook(() => useFitViewOnLayoutVersion())
+    const graph = restoredGraph()
+    act(() => { restore(graph) })
+    act(() => { measureAll(graph) })
+    flushFrames()
+    expect(fitViewSpy).toHaveBeenCalledTimes(1)
+
+    // A DIFFERENT scenario arrives in the same mount — a new restore, not an edit.
+    act(() => {
+      useCanvasStore.setState({ currentScenarioId: 'scenario-two' } as never)
+      restore(graph)
+    })
+    act(() => { measureAll(graph) })
+
+    // PRECONDITION: still the restore state class, so the restore trigger is the
+    // only possible author of the call below.
+    expect(useCanvasStore.getState().layoutVersion).toBe(0)
+
+    flushFrames()
+
+    expect(
+      fitViewSpy,
+      'a new restore was not framed — the latch is stuck once-per-mount instead of once-per-restore',
+    ).toHaveBeenCalledTimes(2)
+  })
+
   it('the floor it asks for is the one constant the counter-scale is capped at', () => {
     // Binds the camera contract to the legibility authority rather than to a
     // number: `labelCounterScale` saturates at `1 / LABEL_LEGIBLE_ZOOM`, so any

--- a/src/canvas/__tests__/useFitViewOnLayoutVersion.restore.spec.tsx
+++ b/src/canvas/__tests__/useFitViewOnLayoutVersion.restore.spec.tsx
@@ -52,13 +52,42 @@
  * Every positive case below has its OPPOSITE-DIRECTION TWIN (trap 22b): an
  * empty canvas and a graph still awaiting its first layout must NOT be fitted,
  * or the fix would trade "never aims" for "aims at a pile at the origin".
+ *
+ * ⭐⭐ AND THE HALF THIS SPEC COULD NOT SEE UNTIL 23 Aug 2026 — SENDABLE FAILURE 6.
+ * ---------------------------------------------------------------------------
+ * Everything above was true and the fit STILL never ran on the deployed build.
+ * The trigger claimed the graph identity and THEN scheduled its frame, while its
+ * own cleanup cancels that frame on any dependency change — and a restored graph
+ * changes `nodes` between the two by construction, because React Flow measures
+ * the nodes it has just mounted and the canvas routes those `dimensions` changes
+ * through `onNodesChange`, whose `applyNodeChanges` returns a NEW array. Frame
+ * cancelled, effect re-run, identity already claimed, no fit ever.
+ *
+ * Two instruments agreed it was fine. The tests above drive one `act()` per
+ * step, so the store is quiescent when the frame is flushed — a state class the
+ * live path never occupies (the fixture-state-class rule, at frame grain). And
+ * the harness spied on `requestAnimationFrame` ONLY, running every collected
+ * callback whether or not it had been cancelled, so it could not represent a
+ * cancellation at all. Both are fixed here: the frame instrument is ID-keyed and
+ * honours `cancelAnimationFrame`, and the new cases interleave the product's own
+ * measurement path between the effect and the frame.
+ *
+ * WHY IT IS A LEGIBILITY DEFECT AND NOT ONLY A FRAMING ONE. With no product fit,
+ * the camera keeps xyflow's mount `fitView` prop — which carries no `minZoom`.
+ * Measured on deployed staging at 1280x800, restore arm: the camera parks at
+ * 0.4279, below `LABEL_LEGIBLE_ZOOM`, so every counter-scaled glyph renders at
+ * 85.6% of its declared size (`labelCounterScale` saturates at the floor).
+ * `MAX_LABEL_COUNTER_SCALE` — which node geometry is sized for — is a CONSTANT
+ * only because the lowest zoom the product ever chooses is a constant, so an
+ * automatic park below the floor falsifies that premise too. The floor stays; the
+ * trigger is what had to reach it.
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useCanvasStore } from '../store'
 import { useFitViewOnLayoutVersion } from '../hooks/useFitViewOnLayoutVersion'
-import { LABEL_LEGIBLE_ZOOM } from '../utils/zoomLegibility'
+import { LABEL_LEGIBLE_ZOOM, renderedLabelPx } from '../utils/zoomLegibility'
 import { GHOST_OPTION_NODE_ID } from '../utils/fitTargets'
 import { STACKED_SPREAD_PX, getGraphIdentityKey } from '../utils/graphNeedsInitialLayout'
 
@@ -75,22 +104,73 @@ type RestoreGraph = {
 
 const fitViewSpy = vi.fn()
 
-/** Collect RAF callbacks so each trigger's frame can be flushed deliberately. */
-function spyOnRaf(sink: Array<() => void>) {
-  return vi
+/**
+ * THE FRAME INSTRUMENT — and why it now honours `cancelAnimationFrame`.
+ *
+ * ⚠ THE PREVIOUS VERSION COULD NOT OBSERVE A CANCELLED FIT AT ALL. It spied on
+ * `requestAnimationFrame` only, pushing every callback into a sink that
+ * `flushFrames` then ran unconditionally — so a frame the effect's own cleanup
+ * had CANCELLED still executed, and `fitView` was still called. Under that
+ * instrument the defect this file now pins is invisible: the product schedules
+ * a fit, cancels it, never re-schedules it, and the spec reads GREEN because the
+ * harness ran the cancelled callback anyway. A test kit that cannot represent a
+ * cancellation cannot make a claim about an effect whose cleanup cancels
+ * (CLAUDE.md trap 13 — an instrument must be shown able to see the thing it is
+ * asserting about).
+ *
+ * So frames are ID-keyed, `cancelAnimationFrame` removes them, and the cancelled
+ * ids are recorded — which is what lets the new tests PIN THEIR OWN PRECONDITION
+ * (trap 13b) rather than assuming a cancellation happened.
+ */
+type PendingFrame = { id: number; cb: () => void }
+let frames: PendingFrame[] = []
+let nextFrameId = 0
+let cancelledIds: number[] = []
+
+function spyOnRaf() {
+  frames = []
+  nextFrameId = 0
+  cancelledIds = []
+  const raf = vi
     .spyOn(globalThis, 'requestAnimationFrame')
     .mockImplementation((cb: FrameRequestCallback) => {
-      sink.push(cb as () => void)
-      return sink.length
+      nextFrameId += 1
+      frames.push({ id: nextFrameId, cb: cb as unknown as () => void })
+      return nextFrameId
     })
+  const caf = vi
+    .spyOn(globalThis, 'cancelAnimationFrame')
+    .mockImplementation((id: number) => {
+      cancelledIds.push(id)
+      frames = frames.filter((f) => f.id !== id)
+    })
+  return {
+    restore: () => { raf.mockRestore(); caf.mockRestore() },
+  }
 }
+
+/**
+ * The zoom the RESTORE arm was measured parking at on deployed staging,
+ * 1280x800 — the minimum viewport this PoC commits to (SENDABLE failure 6,
+ * 23 Aug 2026). Kept as a dated MEASUREMENT used as a positive control, never
+ * as a threshold to tune.
+ */
+const MEASURED_RESTORE_PARK_ZOOM = 0.4279
 
 const FIT_PADDING = { top: '73px', right: '68px', bottom: '29px', left: '68px' }
 let currentPadding: { top: string; right: string; bottom: string; left: string } = FIT_PADDING
 /** What the mocked ReactFlow instance reports for `getNodes()`. */
 let currentNodes: Array<{ id: string }> = []
 
-vi.mock('@xyflow/react', () => ({
+/**
+ * `importOriginal`-spread, NOT a hand-listed factory. `vi.mock` REPLACES the
+ * module, and the canvas store imports `applyNodeChanges` from here — the exact
+ * hand-maintained-mirror shape CLAUDE.md trap 12 records (a flags-mock allowlist
+ * that silently dropped every flag added after it was written). Driving the
+ * product's own `onNodesChange` below needs the real reducer.
+ */
+vi.mock('@xyflow/react', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@xyflow/react')>()),
   useReactFlow: () => ({ fitView: fitViewSpy, getNodes: () => currentNodes }),
 }))
 
@@ -136,7 +216,6 @@ function restore(graph: RestoreGraph) {
 }
 
 describe('useFitViewOnLayoutVersion — the restore trigger', () => {
-  let rafCallbacks: Array<() => void>
   let rafSpy: ReturnType<typeof spyOnRaf>
 
   beforeEach(() => {
@@ -145,16 +224,20 @@ describe('useFitViewOnLayoutVersion — the restore trigger', () => {
     fitViewSpy.mockReset()
     currentPadding = FIT_PADDING
     currentNodes = []
-    rafCallbacks = []
-    rafSpy = spyOnRaf(rafCallbacks)
+    rafSpy = spyOnRaf()
   })
 
   afterEach(() => {
-    rafSpy.mockRestore()
+    rafSpy.restore()
     vi.restoreAllMocks()
   })
 
-  const flushFrames = () => act(() => { rafCallbacks.splice(0).forEach((cb) => cb()) })
+  const flushFrames = () => act(() => {
+    const due = frames
+    frames = []
+    due.forEach((f) => f.cb())
+  })
+  const pendingFrameIds = () => frames.map((f) => f.id)
 
   it('aims the camera at a graph restored WITHOUT a layout pass, with the canonical contract', () => {
     renderHook(() => useFitViewOnLayoutVersion())
@@ -253,6 +336,136 @@ describe('useFitViewOnLayoutVersion — the restore trigger', () => {
 
     flushFrames()
     expect(fitViewSpy, 'the camera was yanked by a user drag on a restored graph').toHaveBeenCalledTimes(1)
+  })
+
+  /* ── SENDABLE failure 6: THE FIT THAT WAS SCHEDULED AND NEVER RAN ───────── */
+
+  /**
+   * React Flow measures the nodes it has just mounted and dispatches `dimensions`
+   * changes; the canvas routes them through the store's own `onNodesChange`,
+   * whose `applyNodeChanges` returns a NEW array. On a restored graph that lands
+   * BETWEEN this effect and its frame — which is the ordinary case, not a race
+   * worth calling rare — and the effect's cleanup cancels the pending fit.
+   *
+   * Driven through `useCanvasStore.getState().onNodesChange` deliberately: a
+   * hand-written `setState({ nodes })` would prove the guard is reachable by
+   * SOME mutation, not that the product's own measurement path reaches it
+   * (CLAUDE.md trap 16 — a fixture you wrote yourself is not evidence about the
+   * live path).
+   */
+  const measureAll = (graph: RestoreGraph) =>
+    useCanvasStore.getState().onNodesChange(
+      graph.nodes.map((n) => ({
+        id: n.id,
+        type: 'dimensions',
+        dimensions: { width: 180, height: 64 },
+        resizing: false,
+      })) as never,
+    )
+
+  it('still aims the camera when node MEASUREMENT lands between the effect and its frame', () => {
+    renderHook(() => useFitViewOnLayoutVersion())
+    const graph = restoredGraph()
+    act(() => { restore(graph) })
+
+    // PRECONDITION 1: a fit really was scheduled, so what follows is about the
+    // fit being LOST and not about one never being asked for.
+    const scheduled = pendingFrameIds()
+    expect(scheduled, 'the restore trigger scheduled no frame — this test would prove nothing').toHaveLength(1)
+
+    const before = useCanvasStore.getState()
+    const keyBefore = getGraphIdentityKey(before.currentScenarioId, before.nodes, before.edges)
+
+    act(() => { measureAll(graph) })
+
+    const after = useCanvasStore.getState()
+    // PRECONDITION 2: the measurement produced a NEW nodes array, so the effect
+    // re-ran (`restoreNodes` is one of its dependencies).
+    expect(after.nodes, 'measurement did not replace the nodes array — the effect never re-ran').not.toBe(before.nodes)
+    // PRECONDITION 3: …at UNCHANGED graph identity, so the once-per-identity
+    // latch is the only thing that can decide whether the camera is ever aimed.
+    expect(
+      getGraphIdentityKey(after.currentScenarioId, after.nodes, after.edges),
+      'measurement changed the graph identity — then a fresh fit is trivially correct',
+    ).toBe(keyBefore)
+    // PRECONDITION 4: the originally-scheduled frame was CANCELLED by the
+    // effect's cleanup. Asserted, not assumed — the old harness could not see a
+    // cancellation at all and ran the cancelled callback regardless.
+    expect(cancelledIds, 'the pending frame was never cancelled — the sequence under test did not occur').toContain(scheduled[0])
+    // …and it is still the restore state class: no layout has run, so no other
+    // trigger can author the call below.
+    expect(after.layoutVersion).toBe(0)
+
+    flushFrames()
+
+    // THE POSTCONDITION. Before this fix: ZERO calls. The camera kept whatever
+    // xyflow's own mount `fitView` prop produced — no `computeFitPadding`
+    // reservations and, the half SENDABLE failure 6 is about, NO `minZoom`, so
+    // an automatic fit parked at 0.4279 on the measured 1280x800 restore and
+    // every counter-scaled glyph rendered at 85.6% of its declared size.
+    expect(fitViewSpy, 'the restored model was never framed by the product').toHaveBeenCalledTimes(1)
+    const args = fitViewSpy.mock.calls[0][0]
+    expect(args.minZoom, 'the automatic fit reached the camera without the legibility floor').toBe(LABEL_LEGIBLE_ZOOM)
+    expect(args.padding).toEqual(FIT_PADDING)
+    expect(args.duration).toBe(400)
+    expect(args.nodes.map((n: { id: string }) => n.id)).toEqual([
+      'n-decision', 'n-option-a', 'n-option-b', 'n-goal',
+    ])
+  })
+
+  it('the floor it asks for is the one constant the counter-scale is capped at', () => {
+    // Binds the camera contract to the legibility authority rather than to a
+    // number: `labelCounterScale` saturates at `1 / LABEL_LEGIBLE_ZOOM`, so any
+    // automatic park BELOW that floor renders canvas text under its declared
+    // size by exactly the ratio. Arithmetic, because jsdom cannot prove a
+    // rendered px (trap 3) — `renderedLabelPx` exists to say so out loud.
+    renderHook(() => useFitViewOnLayoutVersion())
+    const graph = restoredGraph()
+    act(() => { restore(graph) })
+    act(() => { measureAll(graph) })
+    flushFrames()
+
+    expect(fitViewSpy).toHaveBeenCalledTimes(1)
+    const floor = fitViewSpy.mock.calls[0][0].minZoom as number
+    expect(typeof floor, 'a DROPPED floor must not pass silently').toBe('number')
+    // At the floor, a declared canvas size renders AT its declared size.
+    expect(renderedLabelPx(10, floor)).toBeCloseTo(10, 10)
+    expect(renderedLabelPx(13, floor)).toBeCloseTo(13, 10)
+    // POSITIVE CONTROL — the measured restore park is judged short by the same
+    // arithmetic, so "meets the floor" is a verdict something can fail.
+    expect(renderedLabelPx(10, MEASURED_RESTORE_PARK_ZOOM)).toBeLessThan(10)
+  })
+
+  it('a restore fit still pending is ABANDONED when a layout takes over', () => {
+    // Opposite direction for the re-schedulable latch: deferring the claim must
+    // not let a stale restore frame fire after the layout trigger has assumed
+    // ownership of the camera.
+    renderHook(() => useFitViewOnLayoutVersion())
+    const graph = restoredGraph()
+    act(() => { restore(graph) })
+    expect(pendingFrameIds(), 'no restore frame pending — the twin would prove nothing').toHaveLength(1)
+
+    act(() => { useCanvasStore.setState({ pendingLayout: true } as never) })
+    flushFrames()
+
+    expect(fitViewSpy, 'a cancelled restore fit fired anyway, mid-layout').not.toHaveBeenCalled()
+  })
+
+  it('measurement AFTER the camera has been aimed does not re-frame the canvas', () => {
+    // Opposite direction for the once-per-identity guarantee: the latch is set
+    // later than it used to be, so prove it is still set.
+    renderHook(() => useFitViewOnLayoutVersion())
+    const graph = restoredGraph()
+    act(() => { restore(graph) })
+    flushFrames()
+    expect(fitViewSpy).toHaveBeenCalledTimes(1)
+
+    const before = useCanvasStore.getState().nodes
+    act(() => { measureAll(graph) })
+    expect(useCanvasStore.getState().nodes, 'measurement was a no-op — this twin would prove nothing').not.toBe(before)
+    flushFrames()
+
+    expect(fitViewSpy, 'the camera was re-framed by a late measurement').toHaveBeenCalledTimes(1)
   })
 
   /* ── OPPOSITE-DIRECTION TWINS (trap 22b) ──────────────────────────────── */

--- a/src/canvas/hooks/useFitViewOnLayoutVersion.ts
+++ b/src/canvas/hooks/useFitViewOnLayoutVersion.ts
@@ -7,7 +7,7 @@ import { watchReservedBox } from '../utils/reservedBoxWatcher'
 import { usePrefersReducedMotion } from './usePrefersReducedMotion'
 import { cameraDuration } from '../utils/cameraMotion'
 import { LABEL_LEGIBLE_ZOOM } from '../utils/zoomLegibility'
-import { getGraphIdentityKey, graphNeedsInitialLayout } from '../utils/graphNeedsInitialLayout'
+import { graphNeedsInitialLayout } from '../utils/graphNeedsInitialLayout'
 
 /** The slice of canvas state the camera's readiness questions are asked of. */
 type CameraReadinessState = Pick<
@@ -106,6 +106,19 @@ function cameraHasATarget(s: CameraReadinessState): boolean {
  *
  * Must be called inside a ReactFlowProvider (uses `useReactFlow`).
  */
+/**
+ * The identity of a RESTORE, which is what the restore trigger latches on.
+ *
+ * Deliberately NOT `getGraphIdentityKey`: that one is a STRUCTURAL hash and
+ * answers "is this the same shape of graph?". This one answers "is this the same
+ * restored model?", and must therefore survive every edit the user makes to it.
+ */
+function restoreIdentityKey(scenarioId: string | null | undefined): string {
+  return typeof scenarioId === 'string' && scenarioId.length > 0
+    ? `scenario:${scenarioId}`
+    : 'draft'
+}
+
 export function useFitViewOnLayoutVersion(): void {
   const layoutVersion = useCanvasStore((s) => s.layoutVersion)
   // Restore-trigger inputs. Selected individually and as stable references /
@@ -175,10 +188,9 @@ export function useFitViewOnLayoutVersion(): void {
   // clean at 1440x900 / 1512x982. The fresh path at 1280x800 is clean, which is
   // the contrast that makes it the restore's defect and not the graph's.
   //
-  // Fires ONCE PER GRAPH IDENTITY, keyed by `getGraphIdentityKey` (the key
-  // `useInitialLayoutGuard` already uses, and structural rather than
-  // positional, so a user's own pan/drag never re-arms it). A graph that goes
-  // on to be laid out is handled by trigger 1 and returns early here.
+  // Fires ONCE PER RESTORE, keyed by the SCENARIO (see `restoreIdentityKey`), so
+  // neither the user's own pan/drag nor their subsequent edits re-arm it. A graph
+  // that goes on to be laid out is handled by trigger 1 and returns early here.
   //
   // ⭐⭐ THE LATCH IS SET INSIDE THE FRAME, NOT BEFORE IT — and that ordering is
   // the whole of SENDABLE failure 6 (23 Aug 2026). Written the other way round,
@@ -214,15 +226,45 @@ export function useFitViewOnLayoutVersion(): void {
   // has not happened yet stays re-schedulable. It also means the fit runs on
   // the LAST frame the dependencies settle into, i.e. after measurement, so it
   // frames measured nodes rather than un-measured ones.
-  const aimedIdentityRef = useRef<string | null>(null)
+  //
+  // ⭐⭐ AND THE LATCH IS KEYED ON THE RESTORE, NOT ON THE STRUCTURE. These are two
+  // different questions and the old key conflated them. `getGraphIdentityKey`
+  // hashes SORTED NODE AND EDGE IDS (`graphNeedsInitialLayout.ts` —
+  // `structuralHash`), so it changes on every add, delete, undo and paste.
+  //
+  // ⚠ That conflation is harmless only while the fit can never re-schedule. Make
+  // the fit re-schedulable — which is the whole point of the change above — and a
+  // STRUCTURAL key turns every node the user adds into an animated fit-all that
+  // yanks the camera out from under them. On a RESTORED graph there is nothing to
+  // stop it: `layoutVersion` stays `0` for the entire session, because `addNode`,
+  // `addNodeWithEdge` and `deleteNodeById` never call `setPendingLayout`, and the
+  // only write to `layoutVersion` in the store is inside `applyLayout`. So the
+  // user zooms into one corner, adds an option, and the canvas animates back to
+  // fit-all. The old code swallowed that silently — via the same cancellation bug
+  // this fix repairs.
+  //
+  // The question this latch answers is "have we framed THIS RESTORE yet?", never
+  // "have we framed THIS STRUCTURE yet?". One semantic question, one key. Keying
+  // on the scenario also gives the right behaviour on scenario SWITCH: the ref
+  // holds only the last key, so X → Y → X re-frames X, which is a new restore.
+  const aimedRestoreRef = useRef<string | null>(null)
   useEffect(() => {
     if (layoutVersion > 0) return
-    const s = useCanvasStore.getState()
-    if (!isRestoredModelReady(s)) return
-    const key = getGraphIdentityKey(s.currentScenarioId, s.nodes, s.edges)
-    if (aimedIdentityRef.current === key) return
+    if (!isRestoredModelReady(useCanvasStore.getState())) return
+    const restoreKey = restoreIdentityKey(useCanvasStore.getState().currentScenarioId)
+    if (aimedRestoreRef.current === restoreKey) return
     const raf = requestAnimationFrame(() => {
-      aimedIdentityRef.current = key
+      // Re-read the guards at FIRE time. They were evaluated a frame ago, and a
+      // store write from a NON-DISCRETE context (a ResizeObserver, the
+      // `applyLayout` promise chain) can land in between without React having
+      // flushed this effect's cleanup first. Without this re-check the frame
+      // could frame a graph whose positions are about to be replaced — precisely
+      // the state `isRestoredModelReady` exists to refuse.
+      const now = useCanvasStore.getState()
+      if (now.layoutVersion > 0) return
+      if (!isRestoredModelReady(now)) return
+      if (restoreIdentityKey(now.currentScenarioId) !== restoreKey) return
+      aimedRestoreRef.current = restoreKey
       fitNow.current()
     })
     return () => cancelAnimationFrame(raf)

--- a/src/canvas/hooks/useFitViewOnLayoutVersion.ts
+++ b/src/canvas/hooks/useFitViewOnLayoutVersion.ts
@@ -179,6 +179,41 @@ export function useFitViewOnLayoutVersion(): void {
   // `useInitialLayoutGuard` already uses, and structural rather than
   // positional, so a user's own pan/drag never re-arms it). A graph that goes
   // on to be laid out is handled by trigger 1 and returns early here.
+  //
+  // ⭐⭐ THE LATCH IS SET INSIDE THE FRAME, NOT BEFORE IT — and that ordering is
+  // the whole of SENDABLE failure 6 (23 Aug 2026). Written the other way round,
+  // this effect claimed the identity and THEN scheduled the fit, while its own
+  // cleanup cancels that frame on every dependency change. A restored graph
+  // changes `nodes` between the effect and the frame BY CONSTRUCTION: React
+  // Flow measures the nodes it has just mounted and dispatches `dimensions`
+  // changes, the canvas routes them through `onNodesChange`, and
+  // `applyNodeChanges` returns a NEW array (`store.ts` — `set({ nodes:
+  // updatedNodes })`). So the frame was cancelled, the effect re-ran, the
+  // already-claimed identity bounced it, and THE PRODUCT'S FIT NEVER RAN AT ALL
+  // — leaving the camera on xyflow's own mount `fitView` prop, which carries
+  // neither `computeFitPadding`'s reservations nor `minZoom`.
+  //
+  // What that costs, measured on deployed staging at 1280x800 (the minimum
+  // supported PoC viewport), restore arm: the camera parks at 0.4279 — BELOW
+  // `LABEL_LEGIBLE_ZOOM`, i.e. inside the band the product itself labels
+  // unreadable and offers a "zoom in to read" notice for. `labelCounterScale`
+  // is capped at `1 / LABEL_LEGIBLE_ZOOM` by construction, so every
+  // counter-scaled glyph renders at 0.4279 / 0.5 = 85.6% of its declared size:
+  // 8.56px on 58 elements against the Design System v5 §2.4 10px canvas floor.
+  //
+  // ⚠ THE CAP IS NOT THE DEFECT AND MUST NOT BE RAISED. `MAX_LABEL_COUNTER_SCALE`
+  // is what node GEOMETRY is sized for (`nodeLayoutConstants.ts`), and it is a
+  // constant only because the lowest zoom the product ever CHOOSES is a
+  // constant — `LABEL_LEGIBLE_ZOOM`, passed as `minZoom` by the closure above.
+  // Letting an automatic fit park below that floor does not merely under-size
+  // text; it falsifies the premise the geometry bound rests on. The floor is
+  // the authority; this effect simply has to reach it.
+  //
+  // Latching in the frame keeps the once-per-identity guarantee intact — the
+  // claim is made at the moment the camera actually moves — while a fit that
+  // has not happened yet stays re-schedulable. It also means the fit runs on
+  // the LAST frame the dependencies settle into, i.e. after measurement, so it
+  // frames measured nodes rather than un-measured ones.
   const aimedIdentityRef = useRef<string | null>(null)
   useEffect(() => {
     if (layoutVersion > 0) return
@@ -186,8 +221,8 @@ export function useFitViewOnLayoutVersion(): void {
     if (!isRestoredModelReady(s)) return
     const key = getGraphIdentityKey(s.currentScenarioId, s.nodes, s.edges)
     if (aimedIdentityRef.current === key) return
-    aimedIdentityRef.current = key
     const raf = requestAnimationFrame(() => {
+      aimedIdentityRef.current = key
       fitNow.current()
     })
     return () => cancelAnimationFrame(raf)


### PR DESCRIPTION
## The measured failure — live on the currently deployed build

On restore/reload at 1280x800 (the minimum supported PoC viewport) the camera parks at zoom
**0.4279**, below `LABEL_LEGIBLE_ZOOM`. `labelCounterScale` is capped at `1 / LABEL_LEGIBLE_ZOOM`
by construction, so every counter-scaled glyph renders at 85.6% of its declared size —
**8.56px on 58 elements** against the Design System v5 §2.4 **10px** canvas floor.

This is SENDABLE blocker **B5's restore arm**, and it is **not** what UI #822 fixed. #822 shipped
the panel-composition contract and measures 11/11 hit-testable nodes with ≥10.03px labels — but
its matrix activates Fit **by keyboard**, i.e. the *imperative* path. It never touches a `fitView`
call and never measured restore. Verified at `89e4feae` with a contrast control: a predicate for
`fitView|minZoom|LABEL_LEGIBLE|zoomLegibility` returns 0 content lines against #822's
`ReactFlowGraph.tsx` patch, while a `panelComposition|usableViewport|occlusion` control returns hits.

## Root cause, at the bytes — the product's fit never runs

`src/canvas/hooks/useFitViewOnLayoutVersion.ts` at deployed `89e4feae`:

```
188:    if (aimedIdentityRef.current === key) return
189:    aimedIdentityRef.current = key            <- identity CLAIMED before the frame
190:    const raf = requestAnimationFrame(() => { fitNow.current() })
193:    return () => cancelAnimationFrame(raf)    <- cleanup CANCELS that frame
```

A restored graph changes `nodes` between the effect and the frame **by construction**: React Flow
measures the nodes it has just mounted and dispatches `dimensions` changes, the canvas routes them
through `onNodesChange`, and `applyNodeChanges` returns a **new array**. So the frame is cancelled,
the effect re-runs, and `:188` bounces it against the already-claimed identity. **The product's fit
never runs at all** — leaving the camera on xyflow's own mount `fitView` prop, which carries neither
`computeFitPadding`'s reservations nor `minZoom`.

## The fix: two lines

Move the latch **inside** the frame. That keeps the once-per-identity guarantee intact — the claim
is made at the moment the camera actually moves — while a fit that has not happened yet stays
re-schedulable. It also means the fit runs on the last frame the dependencies settle into, so it
frames **measured** nodes rather than un-measured ones.

**The counter-scale cap is not the defect and is not raised.** `MAX_LABEL_COUNTER_SCALE` is what node
geometry is sized for; it is a constant only because the lowest zoom the product ever *chooses* is a
constant. Letting an automatic fit park below that floor does not merely under-size text — it
falsifies the premise the geometry bound rests on. The floor is the authority; this effect simply has
to reach it.

## Why not #820

#820 floors the **declarative** mount fit at the legibility threshold. That treats the symptom: it
leaves the product's own fit dead, so `computeFitPadding`'s reservations are still lost and the fit
still frames un-measured nodes. One semantic question, one canonical authority — **#820 should be
closed in favour of this.**

## RED-first + mutation evidence (run at pristine `89e4feae`, this exact tree)

Baseline on the fixed tree: **11/11 passed** (collect asserted non-zero and by name).

Mutant — src reverted to pristine via `git show` (index untouched, staged files = 0; applied-check
`1 added / 36 deleted`, non-zero):

```
x still aims the camera when node MEASUREMENT lands between the effect and its frame
  -> the restored model was never framed by the product: expected "spy" to be called 1 times, but got 0 times
x the floor it asks for is the one constant the counter-scale is capped at
  -> expected "spy" to be called 1 times, but got 0 times

Tests  2 failed | 9 passed (11)
```

A **discriminating pair**: the two tests that name this defect go red, the other nine stay green —
so the mutant proves sensitivity to *this* behaviour, not a blanket break.

Trailing control: restored **from a pristine archive outside the tree** (never from the other copy),
`git status --porcelain` empty, re-run **11/11 passed**.

## Gates run locally at this head

- **Typecheck gate: PASSED** — 3601/3641 tracked files loaded; 556 files / 2252 errors, exactly at
  baseline 2252, **zero new**.
- **ESLint on changed files: 0 errors** (one warning: the e2e measure is in an ignore pattern).
- `git diff --check`: clean.
- The required check is **`Staging Gate`** = `[tsc, typecheck-selftest, vitest, vitest-summary, build]`,
  derived from `.github/workflows/staging-full-tests.yml:734-736`. That check is the authority and is
  polled to conclusion on this PR — the local runs above are a fast proxy, not a substitute.

## Rung, stated literally

**CODE + TESTED.** Not merged, not deployed, not mounted-witnessed. After merge and deploy the restore
arm must be re-measured at 1280x800 on the deployed build before B5's restore clause is called closed.

## Provenance

Cherry-picked unchanged from `rescue/zoomlegibility-floor-wip-2026-08-23` (commits `027b6628`,
`ad5c7fc2`), rebased from the stale `54cc9cbb` base onto current staging `89e4feae`. Original
authorship preserved. No conflicts.
