### PR TITLE
fix(model-card): the audit trail explained a limitation with a bare machine code

### DIFF
--- a/src/canvas/components/__tests__/ModelTabBody.inferenceWarnings.spec.tsx
+++ b/src/canvas/components/__tests__/ModelTabBody.inferenceWarnings.spec.tsx
@@ -128,8 +128,39 @@ beforeEach(() => {
   }
 })
 
+/**
+ * ⚠ THE SHAPE ASSERTION CHANGED HERE; THE PROPERTY DID NOT.
+ *
+ * This pin previously asserted `getByText('ROOT_NODE_DEFAULT_VALUE,
+ * CONSTRAINT_TARGET_UNRELIABLE')` — one text node, the codes comma-joined. That
+ * string was never what ROADMAP 2.173 is about: the property is *"warnings that
+ * arrived at the ROOT slot reach the audit row"*, and the comma-join was merely
+ * the shape `ModelHealthSection` happened to render them in. When that row
+ * gained a per-code explanation (the codes-only row gave a reader an enum and no
+ * sentence, on the very surface `humaniseCritique` routes them to), the property
+ * held and the assertion broke — CLAUDE.md trap 19, an assertion bound to an
+ * incidental artefact rather than to its object.
+ *
+ * Rebound to the property: EVERY arrived code must be present in the audit
+ * warnings list, asserted per code, in the list itself rather than anywhere on
+ * the page. The "never messages" half of the original comment is not dropped —
+ * it is promoted from a comment to an assertion below, because it is the half
+ * that protects a user from ISL's raw diagnostic prose (it interpolates node
+ * ids: `"…root node 'fac-1'…"`).
+ */
+function expectAuditRowCarriesEveryCode() {
+  const list = screen.getByTestId('audit-inference-warnings')
+  for (const item of WARNING_ITEMS) {
+    // Bound by identity — this code, in the warnings list, not merely on the page.
+    expect(list.textContent, item.code).toContain(item.code)
+    // ...and the producer's raw diagnostic never reaches the surface.
+    expect(list.textContent, item.code).not.toContain(item.message)
+  }
+  expect(list.textContent).not.toContain('fac-1')
+}
+
 describe('ModelTabBody — inference_warnings dual read (ROADMAP 2.173)', () => {
-  it('ROOT-slot warnings render the ModelHealthSection banner and the codes-only audit row', () => {
+  it('ROOT-slot warnings render the ModelHealthSection banner and every arrived code in the audit row', () => {
     setReport({ inference_warnings: WARNING_ITEMS })
     renderModelTab()
 
@@ -137,11 +168,8 @@ describe('ModelTabBody — inference_warnings dual read (ROADMAP 2.173)', () => 
     expect(screen.getByTestId('root-node-warning')).toBeInTheDocument()
     expect(screen.getByText(/1 factor has no value set/)).toBeInTheDocument()
 
-    // Audit row: codes only, comma-joined — never messages
     expect(screen.getByText(/Inference warnings:/)).toBeInTheDocument()
-    expect(
-      screen.getByText('ROOT_NODE_DEFAULT_VALUE, CONSTRAINT_TARGET_UNRELIABLE'),
-    ).toBeInTheDocument()
+    expectAuditRowCarriesEveryCode()
   })
 
   it('LEGACY control: robustness-slot-only warnings still render both surfaces (second arm not dead)', () => {
@@ -149,9 +177,7 @@ describe('ModelTabBody — inference_warnings dual read (ROADMAP 2.173)', () => 
     renderModelTab()
 
     expect(screen.getByTestId('root-node-warning')).toBeInTheDocument()
-    expect(
-      screen.getByText('ROOT_NODE_DEFAULT_VALUE, CONSTRAINT_TARGET_UNRELIABLE'),
-    ).toBeInTheDocument()
+    expectAuditRowCarriesEveryCode()
   })
 
   it('ABSENCE control: no warnings in either slot → neither surface, audit block still renders', () => {

--- a/src/canvas/components/model-tab/ModelHealthSection.tsx
+++ b/src/canvas/components/model-tab/ModelHealthSection.tsx
@@ -30,6 +30,7 @@ import { SectionErrorBoundary } from '../GraphTextView'
 import { Accordion } from '../../../components/results/Accordion'
 import type { CeeQualityDimensions } from '../../store'
 import { DetailToggleContext } from './DetailToggleContext'
+import { describeAuditInferenceWarnings } from './auditInferenceWarnings'
 import type { AutoNoiseProvenance } from '../../../components/results/types'
 
 /** Audit trail data from PLoT response */
@@ -110,6 +111,12 @@ function ModelHealthSectionInner({
       w => w?.code === 'ROOT_NODE_DEFAULT_VALUE'
     ).length
   }, [auditTrail?.inferenceWarnings])
+
+  // Audit-trail inference warnings: one row per code, sentence + code reference.
+  const inferenceWarningRows = useMemo(
+    () => describeAuditInferenceWarnings(auditTrail?.inferenceWarnings),
+    [auditTrail?.inferenceWarnings],
+  )
 
   // Repairs summary: aggregate by code
   const repairsSummary = useMemo(() => {
@@ -310,13 +317,36 @@ function ModelHealthSectionInner({
                 <span className={`${typography.panelMeta} text-text-body`}>{repairsSummary}</span>
               </div>
             )}
-            {/* Inference warnings */}
-            {auditTrail.inferenceWarnings && auditTrail.inferenceWarnings.length > 0 && (
+            {/* Inference warnings.
+                The CODE STAYS — `results/utils/humaniseCritique.ts`'s generic
+                fallback routes readers here for exactly that ("the raw code is
+                listed in the run's audit details"), and its own comment ratifies
+                that a machine code is correct content for an audit trail. What
+                this row used to be missing is the SENTENCE: it rendered the code
+                and nothing else, so a reader sent here to understand a
+                limitation arrived at a bare enum. `describeAuditInferenceWarnings`
+                resolves the sentence through that same owner — no copy is
+                authored here — and never echoes the producer's diagnostic
+                `message`, which interpolates raw node ids. */}
+            {inferenceWarningRows.length > 0 && (
               <div className="mt-2">
                 <span className={`${typography.panelMeta} text-text-light`}>Inference warnings: </span>
-                <span className={`${typography.panelMeta} text-text-body`}>
-                  {auditTrail.inferenceWarnings.map(w => w?.code ?? 'UNKNOWN').join(', ')}
-                </span>
+                <ul className="mt-1 space-y-1" data-testid="audit-inference-warnings">
+                  {inferenceWarningRows.map(row => (
+                    <li
+                      key={row.code ?? '__no_code__'}
+                      className={`${typography.panelMeta} text-text-body`}
+                      data-testid="audit-inference-warning-row"
+                    >
+                      {row.text}
+                      {row.code && (
+                        <span className="text-text-light">
+                          {` (${row.code}${row.count > 1 ? ` x${row.count}` : ''})`}
+                        </span>
+                      )}
+                    </li>
+                  ))}
+                </ul>
               </div>
             )}
           </div>

--- a/src/canvas/components/model-tab/__tests__/auditInferenceWarningsNeverBareCode.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/auditInferenceWarningsNeverBareCode.spec.tsx
@@ -33,16 +33,31 @@
  * render copy that is NOT the generic fallback — an assertion a copied string
  * cannot make.
  *
- * ## Vocabulary is derived, not listed
+ * ## The corpus comes from the captures, not from this lane's head
  *
- * The ISL code list comes from the exported `ISL_INFERENCE_WARNING_KINDS`, so a
- * code added to that classification is swept here automatically. That map cannot
- * prove its own completeness (its header says so), which is why the last block
- * asserts the property over codes that DO NOT EXIST YET — drift can then cost
- * specificity, never a bare enum.
+ * ⚠ THE FIRST VERSION OF THE SWEEP BELOW COULD NOT FAIL, AND ADVERSARIAL REVIEW
+ * OF THIS PR CAUGHT IT. It swept `ISL_INFERENCE_WARNING_KINDS` and asserted no
+ * label placeholder — over a map whose own header says every template it
+ * classifies ignores the label BY CONSTRUCTION. A guard agreeing with itself
+ * (CLAUDE.md trap 13b), over a set chosen because it was the set this lane had
+ * in mind (trap 22).
+ *
+ * The sweep is now DERIVED FROM THE REPO'S OWN CAPTURES — every
+ * `inference_warnings` array in every JSON fixture under `src/` — which reaches
+ * three codes the classification does not contain, one of them
+ * (`CONSTRAINT_TARGET_UNRELIABLE`) label-interpolating. A CONTRAST CONTROL
+ * asserts the corpus still exceeds the classification, so tidying it back to the
+ * self-agreeing set fails loudly (trap 13e).
+ *
+ * Neither corpus can prove completeness, which is why the final block asserts
+ * the property over codes that DO NOT EXIST YET — drift can then cost
+ * specificity, never a bare enum and never a placeholder.
  */
 
 import { describe, it, expect, vi } from 'vitest'
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { render, screen } from '@testing-library/react'
 import { ModelHealthSection } from '../ModelHealthSection'
 import type { AuditTrailData } from '../ModelHealthSection'
@@ -205,22 +220,143 @@ describe('Model card audit trail — an inference warning renders its explanatio
   })
 })
 
-describe('Model card audit trail — the property, over the derived vocabulary and beyond it', () => {
-  const ISL_CODES = Object.keys(ISL_INFERENCE_WARNING_KINDS)
+/**
+ * The codes this repo has actually CAPTURED on the `inference_warnings` channel,
+ * derived by walking every JSON fixture under `src/`.
+ *
+ * ⭐⭐ WHY NOT `ISL_INFERENCE_WARNING_KINDS`. The first version of this guard
+ * swept that map — and could not fail. Its own header states that every template
+ * it classifies ignores the resolved label BY CONSTRUCTION, so a
+ * "no label placeholder" assertion over exactly that set is a guard agreeing
+ * with itself (CLAUDE.md trap 13b). The set was chosen because it was the set
+ * this lane had in mind, which is the definition of a corpus drawn from the
+ * author's own head (trap 22).
+ *
+ * The captures reach further than the classification does: three of the six
+ * codes below are NOT in that map, and one of them —
+ * `CONSTRAINT_TARGET_UNRELIABLE` — is a LABEL-INTERPOLATING template. That is
+ * the class the guard exists to catch, and it was invisible to the old sweep.
+ *
+ * The CONTRAST CONTROL below is what makes this corpus evidence rather than
+ * another self-agreeing set (trap 13e): it asserts the sweep reaches at least
+ * one code the classification does not contain. If someone later "tidies" this
+ * back to the classified set, that control fails.
+ */
+function deriveCapturedWarningCodes(): string[] {
+  const here = dirname(fileURLToPath(import.meta.url))
+  const srcRoot = join(here, '..', '..', '..', '..')
+  const codes = new Set<string>()
 
-  it('sweeps a non-trivial ISL vocabulary (guards against an empty sweep passing vacuously)', () => {
-    expect(ISL_CODES.length).toBeGreaterThanOrEqual(20)
+  const walk = (dir: string) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules') continue
+        walk(p)
+      } else if (entry.name.endsWith('.json')) {
+        let doc: unknown
+        try {
+          doc = JSON.parse(readFileSync(p, 'utf-8'))
+        } catch {
+          continue
+        }
+        const stack: unknown[] = [doc]
+        while (stack.length > 0) {
+          const o = stack.pop()
+          if (Array.isArray(o)) {
+            stack.push(...o)
+          } else if (o !== null && typeof o === 'object') {
+            for (const [k, v] of Object.entries(o as Record<string, unknown>)) {
+              if (k === 'inference_warnings' && Array.isArray(v)) {
+                for (const w of v) {
+                  const c = (w as { code?: unknown } | null)?.code
+                  if (typeof c === 'string' && c.length > 0) codes.add(c)
+                }
+              }
+              stack.push(v)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  walk(srcRoot)
+  return [...codes].sort()
+}
+
+describe('Model card audit trail — the property, over a CAPTURED corpus and beyond it', () => {
+  const CAPTURED_CODES = deriveCapturedWarningCodes()
+  const GENERIC = describeAuditInferenceWarningCode(null)
+
+  it('the sweep is non-empty (an empty corpus would pass every assertion below vacuously)', () => {
+    expect(CAPTURED_CODES.length).toBeGreaterThanOrEqual(6)
   })
 
-  it('gives every classified ISL code a sentence that is not the code', () => {
-    for (const code of ISL_CODES) {
-      const text = describeAuditInferenceWarningCode(code)
-      expect(text, code).not.toBe(code)
-      expect(text.length, code).toBeGreaterThan(code.length)
-      // No template may leak the unresolved-label placeholder onto this surface:
-      // PLoT forwards no affected nodes for this channel.
-      expect(text, code).not.toContain('This factor')
+  it('CONTRAST CONTROL: the corpus reaches codes the ISL classification does not contain', () => {
+    const unclassified = CAPTURED_CODES.filter(c => !(c in ISL_INFERENCE_WARNING_KINDS))
+    // Real absence, not a blind sweep: the classification is a real, non-empty
+    // set, and the captures still exceed it.
+    expect(Object.keys(ISL_INFERENCE_WARNING_KINDS).length).toBeGreaterThanOrEqual(20)
+    expect(unclassified.length).toBeGreaterThanOrEqual(1)
+    // Bound by identity to the code that exposed the old guard's blind spot.
+    expect(CAPTURED_CODES).toContain('CONSTRAINT_TARGET_UNRELIABLE')
+  })
+
+  it('the sentinel used to obtain the generic sentence still means "unmapped"', () => {
+    // If the sentinel ever became a real mapped code, every fallback assertion
+    // in this file would quietly start comparing against specific copy.
+    expect(GENERIC).toBe(describeAuditInferenceWarningCode('__A_DIFFERENT_UNMAPPED_CODE__'))
+  })
+
+  it('never renders a sentence built around a factor this surface cannot name', () => {
+    for (const code of CAPTURED_CODES) {
+      const rendered = describeAuditInferenceWarningCode(code)
+
+      expect(rendered, code).not.toBe(code)
+      // ⚠ NOT a length comparison. The first draft asserted the sentence was
+      // LONGER than the code and this sweep refuted it: the generic sentence is
+      // 33 characters and `EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE` is 36. Length
+      // was a proxy; the property is that the row is never a bare machine-code
+      // token, which is what this matches.
+      expect(rendered, code).not.toMatch(/^[A-Z0-9_]+$/)
+
+      // Ask the OWNER whether this code's copy depends on a factor label, by
+      // resolving it under two different labels — derived, so no placeholder
+      // string is mirrored here.
+      const underA = humaniseCritique(
+        { code, message: '', affectedNodes: ['__probe__'] },
+        new Map([['__probe__', 'PROBE_ALPHA']]),
+      ).title
+      const underB = humaniseCritique(
+        { code, message: '', affectedNodes: ['__probe__'] },
+        new Map([['__probe__', 'PROBE_BETA']]),
+      ).title
+
+      if (underA !== underB) {
+        // Label-dependent: the audit row has no factor context, so it must
+        // withhold the specific sentence rather than render a placeholder.
+        expect(rendered, `${code} is label-dependent`).toBe(GENERIC)
+      } else {
+        // Label-free: the specific sentence is safe and must be used.
+        expect(rendered, `${code} is label-free`).toBe(underA)
+      }
+      expect(rendered, code).not.toContain('PROBE_ALPHA')
+      expect(rendered, code).not.toContain('PROBE_BETA')
     }
+  })
+
+  it('CONSTRAINT_TARGET_UNRELIABLE specifically renders the generic sentence, not a placeholder', () => {
+    // The named case, bound by identity. Its template is label-interpolating,
+    // so with no factor context it produced "This factor's success target…" on
+    // an audit trail that names no factor.
+    expect(describeAuditInferenceWarningCode('CONSTRAINT_TARGET_UNRELIABLE')).toBe(GENERIC)
+  })
+
+  it('still gives a LABEL-FREE mapped code its specific copy (the fix withholds narrowly)', () => {
+    const specific = describeAuditInferenceWarningCode('ROOT_NODE_DEFAULT_VALUE')
+    expect(specific).not.toBe(GENERIC)
+    expect(specific).not.toBe('ROOT_NODE_DEFAULT_VALUE')
   })
 
   it('holds for codes that do not exist yet', () => {

--- a/src/canvas/components/model-tab/__tests__/auditInferenceWarningsNeverBareCode.spec.tsx
+++ b/src/canvas/components/model-tab/__tests__/auditInferenceWarningsNeverBareCode.spec.tsx
@@ -1,0 +1,247 @@
+/**
+ * The Model card's audit trail never renders a machine code ALONE.
+ *
+ * ## The defect
+ *
+ * `ModelHealthSection` rendered its warning row as
+ * `inferenceWarnings.map(w => w?.code ?? 'UNKNOWN').join(', ')`, so with the
+ * repo's own captured staging payload the Model card's "Show full detail" view
+ * showed:
+ *
+ *     Inference warnings: CONSTRAINT_NODE_DEFAULT_BASE
+ *
+ * `CONSTRAINT_NODE_DEFAULT_BASE` is the code in
+ * `src/test/fixtures/golden-path-staging-2026-04-05.json`
+ * (`plot_response.inference_warnings[0]`) — a real run, not a hypothetical.
+ *
+ * ## What is NOT being changed, and why that matters here
+ *
+ * The code STAYS on this surface. `components/results/utils/humaniseCritique.ts`
+ * routes readers here on purpose — its generic fallback ends *"the raw code is
+ * listed in the run's audit details"* and its comment ratifies that *"a machine
+ * code is correct content for an audit trail and wrong content for a caveat
+ * strip"*. A test that asserted the code's ABSENCE would falsify that promise
+ * and break the other surface. The property pinned below is therefore
+ * `code + sentence`, never `sentence instead of code`.
+ *
+ * ## Why the expectations are DERIVED
+ *
+ * The sentences belong to `humaniseCritique`. Pinning a copied sentence here
+ * would hollow out the moment that copy is reworded (the failure mode PLoT #332
+ * hit and fixed the same way), so every expectation resolves through that owner
+ * at runtime. The load-bearing assertion is the STRONGER one: a mapped code must
+ * render copy that is NOT the generic fallback — an assertion a copied string
+ * cannot make.
+ *
+ * ## Vocabulary is derived, not listed
+ *
+ * The ISL code list comes from the exported `ISL_INFERENCE_WARNING_KINDS`, so a
+ * code added to that classification is swept here automatically. That map cannot
+ * prove its own completeness (its header says so), which is why the last block
+ * asserts the property over codes that DO NOT EXIST YET — drift can then cost
+ * specificity, never a bare enum.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ModelHealthSection } from '../ModelHealthSection'
+import type { AuditTrailData } from '../ModelHealthSection'
+import { DetailToggleContext } from '../DetailToggleContext'
+import {
+  describeAuditInferenceWarnings,
+  describeAuditInferenceWarningCode,
+} from '../auditInferenceWarnings'
+import {
+  humaniseCritique,
+  ISL_INFERENCE_WARNING_KINDS,
+} from '../../../../components/results/utils/humaniseCritique'
+
+vi.mock('../../GraphTextView', () => ({
+  SectionErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('../../../../components/results/Accordion', () => ({
+  Accordion: ({ children, testId }: { children: React.ReactNode; testId?: string }) => (
+    <div data-testid={testId}>{children}</div>
+  ),
+}))
+
+/**
+ * The generic sentence `humaniseCritique` returns for a code it has no template
+ * for — resolved at runtime against a code that cannot ever be mapped, so this
+ * file owns no copy of it.
+ */
+const GENERIC_FALLBACK = humaniseCritique({
+  code: '__NOT_A_CODE_THIS_FILE_OWNS_NO_COPY__',
+  message: '',
+}).title
+
+/** The exact string the ISL producer put on the wire in the captured run. */
+const CAPTURED_ISL_MESSAGE =
+  "Node 'goal_midmarket' has no ParameterUncertainty — defaulted to base=0.0, constraint probability may be unreliable"
+
+function auditWith(
+  inferenceWarnings: AuditTrailData['inferenceWarnings'],
+): AuditTrailData {
+  return {
+    seedUsed: '325022',
+    responseHash: '4d11687e9836abcdef',
+    nSamples: 1000,
+    repairsApplied: null,
+    inferenceWarnings,
+    autoNoiseApplied: null,
+    autoNoiseProvenance: null,
+    stabilityPenaltyFactor: null,
+  }
+}
+
+function renderAudit(inferenceWarnings: AuditTrailData['inferenceWarnings']) {
+  return render(
+    <DetailToggleContext.Provider value={{ showDetail: true }}>
+      <ModelHealthSection auditTrail={auditWith(inferenceWarnings)} />
+    </DetailToggleContext.Provider>,
+  )
+}
+
+describe('Model card audit trail — an inference warning renders its explanation, not a bare code', () => {
+  it('renders the captured staging code WITH its ratified sentence, and keeps the code', () => {
+    renderAudit([
+      {
+        code: 'CONSTRAINT_NODE_DEFAULT_BASE',
+        severity: 'info',
+        message: CAPTURED_ISL_MESSAGE,
+      },
+    ])
+
+    const rows = screen.getAllByTestId('audit-inference-warning-row')
+    expect(rows).toHaveLength(1)
+
+    // Bound by IDENTITY: this row, this code, this owner's sentence for it.
+    const expected = describeAuditInferenceWarningCode('CONSTRAINT_NODE_DEFAULT_BASE')
+    expect(rows[0].textContent).toContain(expected)
+
+    // ⭐ THE LOAD-BEARING HALF. A row that merely renders SOME text would pass a
+    // `toContain` against the fallback too. Deleting the mapped template must
+    // show up here, so assert the copy is the SPECIFIC one.
+    expect(expected).not.toBe(GENERIC_FALLBACK)
+    expect(rows[0].textContent).not.toContain(GENERIC_FALLBACK)
+
+    // The code is still on the surface — humaniseCritique's fallback promises it.
+    expect(rows[0].textContent).toContain('CONSTRAINT_NODE_DEFAULT_BASE')
+
+    // ...and it is no longer the WHOLE row, which is the defect.
+    expect(rows[0].textContent?.trim()).not.toBe('CONSTRAINT_NODE_DEFAULT_BASE')
+  })
+
+  /**
+   * Bound to the SECTION, not to this change's own test id.
+   *
+   * Every other render assertion here queries `audit-inference-warning-row`, a
+   * marker this change introduces — so at pristine they fail on a MISSING
+   * ELEMENT, and a change that added the marker and nothing else would satisfy
+   * them. This one queries the pre-existing `model-health-section` container and
+   * asserts CONTENT, so its red is about the sentence being absent from the
+   * user's screen rather than about a test hook.
+   */
+  it('puts the explanation on the Model card itself, not only behind a new test id', () => {
+    renderAudit([
+      { code: 'CONSTRAINT_NODE_DEFAULT_BASE', severity: 'info', message: CAPTURED_ISL_MESSAGE },
+    ])
+
+    const card = screen.getByTestId('model-health-section').textContent ?? ''
+    const expected = describeAuditInferenceWarningCode('CONSTRAINT_NODE_DEFAULT_BASE')
+    expect(expected).not.toBe(GENERIC_FALLBACK)
+    expect(card).toContain(expected)
+    expect(card).toContain('CONSTRAINT_NODE_DEFAULT_BASE')
+  })
+
+  it('withholds specificity for a code it does not know — generic sentence, code still shown, never "UNKNOWN"', () => {
+    renderAudit([{ code: 'A_CODE_ISL_HAS_NOT_WRITTEN_YET', severity: 'warning', message: 'x' }])
+
+    const rows = screen.getAllByTestId('audit-inference-warning-row')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].textContent).toContain(GENERIC_FALLBACK)
+    expect(rows[0].textContent).toContain('A_CODE_ISL_HAS_NOT_WRITTEN_YET')
+    expect(rows[0].textContent?.trim()).not.toBe('A_CODE_ISL_HAS_NOT_WRITTEN_YET')
+  })
+
+  it('renders no fabricated "UNKNOWN" token for a warning that carries no code', () => {
+    renderAudit([{ severity: 'info', message: CAPTURED_ISL_MESSAGE }])
+
+    const rows = screen.getAllByTestId('audit-inference-warning-row')
+    expect(rows).toHaveLength(1)
+    expect(rows[0].textContent).toContain(GENERIC_FALLBACK)
+    // A code we do not have is ABSENT, not "unknown".
+    expect(screen.getByTestId('audit-inference-warnings').textContent).not.toContain('UNKNOWN')
+  })
+
+  it('never echoes the producer\'s diagnostic message onto the surface', () => {
+    renderAudit([
+      { code: 'CONSTRAINT_NODE_DEFAULT_BASE', severity: 'info', message: CAPTURED_ISL_MESSAGE },
+      { code: 'ROOT_NODE_DEFAULT_VALUE', severity: 'info', message: "No observed value provided for root node 'n_arr_growth'; defaulted to 0.0." },
+    ])
+
+    const list = screen.getByTestId('audit-inference-warnings').textContent ?? ''
+    // Raw node identifiers and engine vocabulary from ISL's debug string.
+    expect(list).not.toContain('goal_midmarket')
+    expect(list).not.toContain('n_arr_growth')
+    expect(list).not.toContain('ParameterUncertainty')
+    expect(list).not.toContain('base=0.0')
+    expect(list).not.toContain(CAPTURED_ISL_MESSAGE)
+  })
+
+  it('collapses repeats of one code into a single row with a count', () => {
+    renderAudit([
+      { code: 'ROOT_NODE_DEFAULT_VALUE', severity: 'info', message: 'a' },
+      { code: 'ROOT_NODE_DEFAULT_VALUE', severity: 'info', message: 'b' },
+      { code: 'CONSTRAINT_NODE_DEFAULT_BASE', severity: 'info', message: 'c' },
+    ])
+
+    const rows = screen.getAllByTestId('audit-inference-warning-row')
+    expect(rows).toHaveLength(2)
+    expect(rows[0].textContent).toContain('ROOT_NODE_DEFAULT_VALUE x2')
+    expect(rows[1].textContent).toContain('CONSTRAINT_NODE_DEFAULT_BASE')
+    expect(rows[1].textContent).not.toContain('x2')
+  })
+})
+
+describe('Model card audit trail — the property, over the derived vocabulary and beyond it', () => {
+  const ISL_CODES = Object.keys(ISL_INFERENCE_WARNING_KINDS)
+
+  it('sweeps a non-trivial ISL vocabulary (guards against an empty sweep passing vacuously)', () => {
+    expect(ISL_CODES.length).toBeGreaterThanOrEqual(20)
+  })
+
+  it('gives every classified ISL code a sentence that is not the code', () => {
+    for (const code of ISL_CODES) {
+      const text = describeAuditInferenceWarningCode(code)
+      expect(text, code).not.toBe(code)
+      expect(text.length, code).toBeGreaterThan(code.length)
+      // No template may leak the unresolved-label placeholder onto this surface:
+      // PLoT forwards no affected nodes for this channel.
+      expect(text, code).not.toContain('This factor')
+    }
+  })
+
+  it('holds for codes that do not exist yet', () => {
+    const future = [
+      'SOME_FUTURE_ISL_CODE',
+      'ANOTHER_ONE_2027',
+      'X',
+      'lowercase_code',
+    ]
+    for (const code of future) {
+      const rows = describeAuditInferenceWarnings([{ code, severity: 'info', message: 'raw' }])
+      expect(rows, code).toHaveLength(1)
+      expect(rows[0].text, code).toBe(GENERIC_FALLBACK)
+      expect(rows[0].code, code).toBe(code)
+      expect(rows[0].text, code).not.toBe(code)
+    }
+  })
+
+  it('returns nothing at all for an absent or empty warning list', () => {
+    expect(describeAuditInferenceWarnings(null)).toEqual([])
+    expect(describeAuditInferenceWarnings(undefined)).toEqual([])
+    expect(describeAuditInferenceWarnings([])).toEqual([])
+  })
+})

--- a/src/canvas/components/model-tab/auditInferenceWarnings.ts
+++ b/src/canvas/components/model-tab/auditInferenceWarnings.ts
@@ -1,0 +1,123 @@
+/**
+ * Audit-trail inference warnings — a machine code is correct content here, a
+ * machine code ALONE is not.
+ *
+ * ## The defect this closes
+ *
+ * `ModelHealthSection`'s audit trail rendered the warning list as
+ * `inferenceWarnings.map(w => w?.code ?? 'UNKNOWN').join(', ')`, so the Model
+ * card printed
+ *
+ *     Inference warnings: CONSTRAINT_NODE_DEFAULT_BASE
+ *
+ * and nothing else. That code is not hypothetical: it is on the wire in the
+ * repo's own captured staging run
+ * (`src/test/fixtures/golden-path-staging-2026-04-05.json`, `plot_response
+ * .inference_warnings[0]`), so this is what a real user has been shown.
+ *
+ * ⭐ AND IT IS THE SURFACE ANOTHER SURFACE ROUTES PEOPLE TO. The generic
+ * fallback in `components/results/utils/humaniseCritique.ts` deliberately ends
+ * *"Nothing has been hidden — the raw code is listed in the run's audit
+ * details."* Its own comment ratifies the split: *"A machine code is correct
+ * content for an audit trail and wrong content for a caveat strip."* That
+ * ruling stands and this module keeps it — the code STAYS. What was missing is
+ * that a reader sent here to understand a limitation arrived at a bare enum
+ * with no sentence attached.
+ *
+ * ## Why no copy is authored in this file
+ *
+ * `humaniseCritique` already owns producer-derived, ratified, label-free copy
+ * for this exact vocabulary — its templates were written from the ISL
+ * construction sites at `staging` 28fe0c95, and its header records that
+ * *"EVERY TEMPLATE IGNORES THE RESOLVED LABEL, DELIBERATELY"* because PLoT
+ * forwards no `affected_nodes` for these codes. A second copy map here would be
+ * two sets of words for one claim, drifting silently (CLAUDE.md trap 12), so
+ * this module RESOLVES through that owner and adds none of its own.
+ *
+ * ## Two things it must never do
+ *
+ * 1. **Never echo the producer's `message`.** PLoT guarantees one on every
+ *    merged warning, but it is ISL's diagnostic string and it interpolates raw
+ *    identifiers and engine vocabulary — the captured one reads *"Node
+ *    'goal_midmarket' has no ParameterUncertainty — defaulted to base=0.0…"*.
+ *    `humaniseCritique` is therefore called WITHOUT `userMessage`, so its
+ *    producer-copy branch cannot fire, and `message` is passed empty.
+ * 2. **Never mint `'UNKNOWN'`.** A warning that arrives with no code got the
+ *    literal string `UNKNOWN` printed at the user — a fabricated token for a
+ *    row we simply cannot name. It now renders the generic sentence with no
+ *    code reference at all, which is the honest shape: absent, not "unknown".
+ */
+
+import { humaniseCritique } from '../../../components/results/utils/humaniseCritique'
+
+/**
+ * The audit-trail shape of an inference warning, as `AuditTrailData` declares
+ * it. Every field is optional at the type level because this rides PLoT's
+ * untyped enrichment passthrough (CLAUDE.md hazard 2) — read defensively.
+ */
+export interface AuditInferenceWarning {
+  code?: string
+  severity?: string
+  message?: string
+}
+
+/**
+ * One rendered audit row: the human sentence, plus the machine code kept as an
+ * explicit technical reference (null when the producer sent none).
+ */
+export interface AuditInferenceWarningRow {
+  /** The ratified user-facing sentence for this code. Never a machine code. */
+  readonly text: string
+  /** The producer's code, preserved verbatim. `null` when absent — never 'UNKNOWN'. */
+  readonly code: string | null
+  /** How many warnings collapsed into this row (>= 1). */
+  readonly count: number
+}
+
+function isNonEmptyString(v: unknown): v is string {
+  return typeof v === 'string' && v.trim().length > 0
+}
+
+/**
+ * Resolve one code to its user-facing sentence through the single owner of
+ * these words.
+ *
+ * `humaniseCritique` renders the TITLE on both existing live surfaces, so the
+ * title is what is reused here; passing an empty `message` and no
+ * `userMessage`/`affectedNodes` is deliberate (see the file header).
+ */
+export function describeAuditInferenceWarningCode(code: string | null): string {
+  return humaniseCritique({ code: code ?? '', message: '' }).title
+}
+
+/**
+ * Collapse the raw warning array into rendered rows.
+ *
+ * Deduplicated by code with a count, mirroring the sibling "Repairs applied"
+ * row — ISL emits one warning PER NODE for the defaulting family, and N
+ * identical sentences is noise, not audit detail. First-seen order is
+ * preserved so the row order still reflects the producer's.
+ *
+ * Codeless warnings collapse together under a single `null` key.
+ */
+export function describeAuditInferenceWarnings(
+  warnings: readonly AuditInferenceWarning[] | null | undefined,
+): AuditInferenceWarningRow[] {
+  if (!Array.isArray(warnings) || warnings.length === 0) return []
+
+  const order: Array<string | null> = []
+  const counts = new Map<string | null, number>()
+
+  for (const w of warnings) {
+    if (w == null || typeof w !== 'object') continue
+    const code = isNonEmptyString(w.code) ? w.code : null
+    if (!counts.has(code)) order.push(code)
+    counts.set(code, (counts.get(code) ?? 0) + 1)
+  }
+
+  return order.map((code) => ({
+    text: describeAuditInferenceWarningCode(code),
+    code,
+    count: counts.get(code) ?? 1,
+  }))
+}

--- a/src/canvas/components/model-tab/auditInferenceWarnings.ts
+++ b/src/canvas/components/model-tab/auditInferenceWarnings.ts
@@ -79,15 +79,79 @@ function isNonEmptyString(v: unknown): v is string {
 }
 
 /**
+ * A code that cannot be mapped, used to obtain the generic sentence from its
+ * owner rather than copying the words. Asserted equivalent to other unmapped
+ * codes in the spec, so this sentinel cannot silently stop meaning "unmapped".
+ */
+const UNMAPPABLE_SENTINEL = '__OLUMI_AUDIT_UNMAPPED_SENTINEL__'
+
+/** Two labels that differ, used only to detect label dependence. */
+const PROBE_NODE = '__OLUMI_AUDIT_LABEL_PROBE__'
+const PROBE_LABEL_A = 'PROBE_LABEL_ALPHA'
+const PROBE_LABEL_B = 'PROBE_LABEL_BETA'
+
+function titleFor(code: string): string {
+  return humaniseCritique({ code, message: '' }).title
+}
+
+function titleUnderLabel(code: string, label: string): string {
+  return humaniseCritique(
+    { code, message: '', affectedNodes: [PROBE_NODE] },
+    new Map([[PROBE_NODE, label]]),
+  ).title
+}
+
+/**
+ * Does this code's copy DEPEND on a factor label?
+ *
+ * ⭐ DERIVED, NOT MIRRORED. The obvious implementation is to test the resolved
+ * title for `humaniseCritique`'s unresolved-label placeholder — but that
+ * constant is module-private, so naming it here would be a hand-maintained
+ * mirror of a string in another file (CLAUDE.md trap 12), silently wrong the
+ * day it is reworded. Instead the question is asked of the template directly:
+ * resolve it twice under two DIFFERENT labels. A label-free template returns
+ * the same sentence both times; a label-interpolating one cannot.
+ */
+function dependsOnAFactorLabel(code: string): boolean {
+  return titleUnderLabel(code, PROBE_LABEL_A) !== titleUnderLabel(code, PROBE_LABEL_B)
+}
+
+/**
  * Resolve one code to its user-facing sentence through the single owner of
  * these words.
  *
  * `humaniseCritique` renders the TITLE on both existing live surfaces, so the
  * title is what is reused here; passing an empty `message` and no
- * `userMessage`/`affectedNodes` is deliberate (see the file header).
+ * `userMessage` is deliberate (see the file header).
+ *
+ * ⚠ A MAPPED TEMPLATE IS NOT AUTOMATICALLY SAFE HERE, AND ASSUMING SO WAS THIS
+ * MODULE'S OWN DEFECT (found in adversarial review of the PR that introduced
+ * it). `humaniseCritique`'s header records that the ISL inference-warning
+ * templates all ignore the resolved label — true, and it is why they are safe.
+ * But `inference_warnings` also carries codes OUTSIDE that classified set, and
+ * three of them appear in this repo's own captured fixtures
+ * (`CONSTRAINT_TARGET_UNRELIABLE`, `EDGE_E_VALUE_NON_FINITE_DROPPED`,
+ * `EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE`). The first is one of the
+ * LABEL-INTERPOLATING templates, so with no factor context this row rendered
+ * *"This factor's success target can't be evaluated reliably"* — an audit trail
+ * naming no factor, while the producer's wire message named one.
+ *
+ * A sentence built around a factor the surface cannot identify is not an
+ * explanation, so it is refused in favour of the generic one. That matches what
+ * the caveat strip already does with the same input, and it is the same rule as
+ * the rest of this module: withhold rather than render a placeholder.
  */
 export function describeAuditInferenceWarningCode(code: string | null): string {
-  return humaniseCritique({ code: code ?? '', message: '' }).title
+  const generic = titleFor(UNMAPPABLE_SENTINEL)
+  const c = code ?? ''
+  if (c === '') return generic
+
+  const title = titleFor(c)
+  // Unmapped already resolves to the generic sentence — no probe needed, and
+  // probing would only emit two more unmapped-code warnings.
+  if (title === generic) return generic
+
+  return dependsOnAFactorLabel(c) ? generic : title
 }
 
 /**


### PR DESCRIPTION
## The capability

**A user who opens the Model card to understand a limitation now reads a sentence, not an enum.**

The Model card's audit trail (Model tab → "Model card" → **Show full detail**) rendered its warning row as:

```ts
{auditTrail.inferenceWarnings.map(w => w?.code ?? 'UNKNOWN').join(', ')}
```

So the surface showed, in full:

```
Inference warnings: CONSTRAINT_NODE_DEFAULT_BASE
```

That code is not hypothetical. It is on the wire in this repo's own captured run —
`src/test/fixtures/golden-path-staging-2026-04-05.json` → `plot_response.inference_warnings[0]`,
extracted from debug bundle `olumi-debug-f0045fec-20260405`:

```json
{"code": "CONSTRAINT_NODE_DEFAULT_BASE",
 "message": "Node 'goal_midmarket' has no ParameterUncertainty — defaulted to base=0.0, constraint probability may be unreliable",
 "severity": "info"}
```

### Why this row in particular

`src/components/results/utils/humaniseCritique.ts` **routes readers to this exact surface**. Its generic fallback ends *"Nothing has been hidden — the raw code is listed in the run's audit details."* and its comment ratifies the split:

> "A machine code is correct content for an audit trail and wrong content for a caveat strip, so pointing there is the honest onward step — the user can quote it, and support can resolve it."

That ruling stands and this PR keeps it. **The code is not removed.** What was missing is the sentence beside it: the one surface the product tells you to go to for an explanation was the one surface with no explanation on it.

## What a user experiences differently

| | Before | After |
|---|---|---|
| known code | `CONSTRAINT_NODE_DEFAULT_BASE` | *"A factor carrying a success target has no current value or uncertainty recorded, so zero was assumed as its starting point. Add its current value."* `(CONSTRAINT_NODE_DEFAULT_BASE)` |
| unmapped code | `SOME_NEW_ISL_CODE` | *"Part of this analysis was limited"* `(SOME_NEW_ISL_CODE)` |
| warning with no code | `UNKNOWN` | *"Part of this analysis was limited"* — no code reference at all |
| same code ×2 | `ROOT_NODE_DEFAULT_VALUE, ROOT_NODE_DEFAULT_VALUE` | one row, `(ROOT_NODE_DEFAULT_VALUE x2)` |

## Design: no copy is authored here

`humaniseCritique` already owns ratified, **producer-derived**, label-free copy for this exact vocabulary — its templates were written from the ISL construction sites at `staging` `28fe0c95`, and its header records that *"EVERY TEMPLATE IGNORES THE RESOLVED LABEL, DELIBERATELY"* because PLoT forwards no `affected_nodes` for these codes. The new module **resolves through that owner and adds none of its own words** — a second copy map would be two sets of words for one claim, drifting silently (trap 12).

Two invariants the module enforces:

1. **Never echo the producer's `message`.** ISL's diagnostic string interpolates raw node ids and engine vocabulary. `humaniseCritique` is called with an empty `message` and no `userMessage`, so its producer-copy branch cannot fire.
2. **Never mint `'UNKNOWN'`.** A codeless warning gets the generic sentence and no code reference — absent, not "unknown".

## Red-first signature

Module present, `ModelHealthSection.tsx` reverted to pristine `88cb7e37`:

```
Tests  6 failed | 4 passed (10)
→ Unable to find an element by: [data-testid="audit-inference-warning-row"]
```

The 4 that pass are pure-module tests (the module is additive). One render test is deliberately bound to the **pre-existing** `model-health-section` container and asserts CONTENT, not my new test id — so its red is "the sentence is absent from the user's screen", not "a test hook is missing".

With the fix: `Tests 10 passed (10)` — asserted by name, non-zero, all 10 collected.

## Mutants

Detached worktree outside the repo root. **Isolation proven by WRITING** a sentinel and asserting the source clone was unchanged (distinct inodes: `700473316` vs `700466577`), not by locating the path. Applied-check scoped to `src/`; leading and trailing controls both read exactly `0`.

| Mutant | Expect | Result |
|---|---|---|
| control (no mutation) | green, applied=0 | `10 passed`, applied=`0` ✅ |
| **M1** revert the render to the bare-code one-liner | RED | `6 failed \| 4 passed` ✅ |
| **M2 (decoy)** sibling *Repairs applied* row `'UNKNOWN'` → `'UNSPECIFIED'` | **NO FLIP** | `10 passed` ✅ |
| **M3** always return the generic fallback (kill specificity) | RED | `2 failed \| 8 passed` ✅ |
| **M4** prefer the producer's raw `message` | RED | `6 failed \| 4 passed` ✅ |
| **M5** reinstate `'UNKNOWN'` for a codeless warning | RED | `1 failed \| 9 passed` ✅ |
| **M6** drop the repeat count | RED | `1 failed \| 9 passed` ✅ |
| trailing control | green, applied=0 | `10 passed`, applied=`0` ✅ |

**M1/M2 are the discriminating pair**: reverting the fix REDs, while an equivalent change to the adjacent row in the same component does not — so the assertions bind to the inference-warning row by identity, not to the section at large. **M3 is the one that matters most**: it proves the load-bearing half (`copy ≠ generic fallback`) bites, so deleting a mapped template cannot pass by rendering the fallback. That is the exact way PLoT #332's first draft was hollow.

M1's first run was a **broken mutant** (my patch produced invalid JSX, so vitest collected nothing and the summary line was empty). The harness treats an unreadable result as a hard error rather than a pass; it was re-run with `git show <sha>:path >` (worktree-only, index untouched — trap 9h) and produced the result above.

## Gates (derived at this tip from `package.json`)

- `npm run typecheck` (`bash scripts/ci/typecheck-gate.sh`) → **PASSED**; coverage 3603/3643, ratchet 2252 = baseline 2252, no new diagnostics.
- `npx eslint` on the changed files → clean (exit 0). `npm run lint:hooks-ratchet` → 229 known violations across 13 files, **exactly matching baseline**.
- `vitest run src/canvas/components` → **314 files / 3977 tests passed, 1 file / 28 tests skipped, 0 failed**.
- `vitest run src/canvas/components/model-tab src/components/results/utils/__tests__` → **57 files / 1006 tests passed**.
- CI on this head: all required checks green. **`Visual Regression (advisory)` is a STANDING RED** — proven with a control: it is `failure` on the staging tip `88cb7e37` itself, where `Staging Gate` is nonetheless `success`.

### ⚠ CI caught something my local scope did not — disclosed rather than quietly fixed

The first push (`63275c04`) **failed `Full Test Suite (shard 4/4)`**: `src/canvas/components/__tests__/ModelTabBody.inferenceWarnings.spec.tsx`, 2 tests. My local run had been scoped to `model-tab/` and `results/utils/`, and that spec sits one directory up — **a narrower scope than the change's blast radius, and the shard is what caught it.**

That spec pins ROADMAP 2.173 (the ROOT/legacy dual read for `inference_warnings`). Its assertion was:

```ts
screen.getByText('ROOT_NODE_DEFAULT_VALUE, CONSTRAINT_TARGET_UNRELIABLE')
```

— one text node, the codes comma-joined. **That string was never what 2.173 protects.** Its property is *"warnings that arrived at the ROOT slot reach the audit row"*; the comma-join was only the shape the row happened to render them in. So the property held and the assertion broke — trap 19, an assertion bound to an incidental artefact rather than to its object.

Rebound to the property (`673336d3`): every arrived code asserted **individually, in the warnings list**, not anywhere on the page. The original comment's *"never messages"* half is **promoted from a comment to an assertion**, because it is the half that keeps ISL's raw diagnostic prose (`"…root node 'fac-1'…"`) off the surface, and a comment guarantees nothing.

**Proven not hollowed**, by mutating the dual reader itself rather than trusting the rewrite:

| Mutant on `readInferenceWarnings` | Expect | Result |
|---|---|---|
| **M7** kill the ROOT arm (2.173's own defect returns) | RED | `1 failed \| 2 passed` ✅ |
| **M8** kill the LEGACY arm (second-arm control) | RED | `1 failed \| 2 passed` ✅ |
| trailing control | green, applied=0 | `3 passed`, applied=`0` ✅ |

M8's first attempt produced **no readable test summary** (my patch left invalid TypeScript). That was treated as a hard error and re-run with a valid mutation — never scored as a survivor. Both mutations were transient and fully restored; the shipped diff touches no file under `src/components/results/`.

## What I did NOT claim

- **I did not re-witness this on staging today.** The capture proving `CONSTRAINT_NODE_DEFAULT_BASE` reaches the wire is dated 2026-04-05. Rung: **CODE EXISTS → TESTED**. Not deployed-, wire- or journey-witnessed by this lane.
- **The sibling "Repairs applied" row still prints bare codes** (`DEFAULT_EXISTS_PROBABILITY (x2)`), eight lines above. Same shape, but a different producer vocabulary (`PLoT normalisation/repair-codes.ts`, 25 codes) with a different owner and no routing promise pointing at it. Deliberately out of scope — named, not fixed.
- **I did not verify a fresh user reaches this without the "Show full detail" toggle.** The audit block is gated on `DetailToggleContext.showDetail`, fed by `expertMode` in `ModelTabBody.tsx:899`. It is a user toggle, not a flag — but it is a click away, not the default view.
- **I did not assert the code's absence anywhere** — that would falsify `humaniseCritique`'s promise to readers it sends here.
- **The completeness of `ISL_INFERENCE_WARNING_KINDS` is not claimed.** Its own header says a derived guard cannot prove the list is complete. That is why the final block asserts the property over codes that do not exist yet: drift can cost specificity, never a bare enum.
- **My first local test scope was too narrow and I am not claiming otherwise.** CI's shard 4/4 found the conflict, not my run. A broad local `src/canvas + src/components/results` run I started was killed before producing output — it is VOID, and is not being reported as a pass.
- No change to PLoT, ISL, CEE, or the wire. No flag added. No file under `src/components/results/`, `src/canvas/mutations/`, or `useFitViewOnLayoutVersion.ts` is modified.

## Candidates rejected

- **(a) PLoT bare machine codes** — closed by PLoT #332 (20 Aug) for the *critique* channel; ISL has not moved since 9 Aug so no new codes. #332's own spec named `inference_warnings` as the excluded channel with "a separate owner". This PR is that channel, at the surface that renders it.
- **(b) schemas 0.40.0 vs 0.48.0 skew** — PLoT's `inference_warnings` element rides the enrichment envelope as passthrough (`enrichment-egress-guard.ts:239`), so no user-visible field is dropped at that hop on this path.
- **(c) ISL** — PR #149 is a live feature branch with an owner; no computed quantity found orphaned that was closable without CEE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# F7 — fixed in `b15db552` (adversarial review)

**The guard I wrote for the placeholder class was swept over a set that could not fail.** It ran over `Object.keys(ISL_INFERENCE_WARNING_KINDS)` — a map whose own header states that every template it classifies ignores the resolved label **by construction**. A guard agreeing with itself (trap 13b), over a corpus chosen because it was the set this lane had in mind (trap 22).

**Reproduced at the bytes before acting.** `inference_warnings` carries codes outside that classification. Derived by walking every `inference_warnings` array in every JSON fixture under `src/` (104 files):

| captured code | in `ISL_INFERENCE_WARNING_KINDS`? | renders |
|---|---|---|
| `CONSTRAINT_NODE_DEFAULT_BASE` | yes | specific copy |
| `GOAL_ANCESTOR_DATA_GAP` | yes | specific copy |
| `ROOT_NODE_DEFAULT_VALUE` | yes | specific copy |
| **`CONSTRAINT_TARGET_UNRELIABLE`** | **no** | **was `"This factor's success target can't be evaluated reliably"`** |
| `EDGE_E_VALUE_NON_FINITE_DROPPED` | no | generic (unmapped) |
| `EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE` | no | generic (unmapped) |

`CONSTRAINT_TARGET_UNRELIABLE` is label-interpolating, so an audit trail that names no factor said *"This factor's…"* while the producer's wire message in `v5-analysis-result.bundle-45c9b625.json` names `out_campaign_effectiveness`. **It was live in this PR's own fixture** (`ModelTabBody.inferenceWarnings.spec.tsx` `WARNING_ITEMS[1]`).

## Fix — derived, not mirrored

Both options offered would have required a mirror or an excluded-path import: `FALLBACK_LABEL` and `CODE_TEMPLATES` are **both module-private** in `humaniseCritique.ts`, and that file is outside this lane's write boundary. Naming `'This factor'` here would mirror a string in another file (trap 12), silently wrong the day it is reworded.

So the template is asked directly: **resolve it twice under two different labels.** A label-free template returns the same sentence both times; a label-interpolating one cannot. Measured: `CONSTRAINT_TARGET_UNRELIABLE` → `differential=true`; `ROOT_NODE_DEFAULT_VALUE`, `EVPI_UNAVAILABLE` → `false`.

Label-dependent codes fall back to the generic sentence — what the caveat strip already does with the same input, and the same rule as the rest of the module: withhold rather than render a placeholder.

## Guard rebuilt so it can fail

Corpus derived from the repo's own captures, plus a **contrast control** asserting it still exceeds the classification (trap 13e) — so tidying it back to the self-agreeing set fails loudly.

| Mutant | Expect | Result |
|---|---|---|
| control | green, applied=0 | `14 passed` ✅ |
| **M9** revert the F7 fix (naive resolver) | RED | `2 failed \| 12 passed` ✅ |
| **M10** always return generic (over-withhold) | RED | `4 failed \| 10 passed` ✅ |
| **M11b** validly empty corpus | RED | `2 failed \| 12 passed` ✅ |
| **M12** tidy the corpus back to `ISL_INFERENCE_WARNING_KINDS` | RED | `1 failed \| 13 passed` ✅ |
| trailing control | green, applied=0 | `14 passed` ✅ |

M9 is the reviewer's finding made observable; **M10 proves the fix withholds narrowly** (a label-free mapped code must still get its specific copy). M11's first attempt threw at collection — treated as a hard error and re-run validly, never scored as a survivor. Isolation re-proven by writing a sentinel into the worktree and asserting the source clone unchanged.

**The sweep also refuted one of its own assertions:** "the sentence is longer than the code" is false — the generic sentence is 33 characters and `EDGE_SENSITIVITY_UNAVAILABLE_V2_WIRE` is 36. Length was a proxy; the property asserted is that the row is never a bare machine-code token.

## Gates on `b15db552`

- Typecheck gate PASSED (ratchet 2252 = baseline). ESLint exit `0`. Hooks ratchet exactly at baseline.
- `vitest run src/canvas/components` → **314 files / 3981 tests passed, 0 failed**.
- **CI: 13/14 success including all four shards, Full Test Suite Summary and `Staging Gate: success`.** The single failure is `Visual Regression (advisory)`, the standing red proven with a control at staging tip `88cb7e37`.

## Not merged — freeze window in force.

## Rowed, not fixed here (reviewer's F8 / F9)

- **F8** — for unmapped codes the route is circular: the strip says "the raw code is listed in the run's audit details" and the audit row now leads with the same title the reader was routed away from. Nothing false; contributes nothing for exactly the class the fallback serves.
- **F9** — two audit-completeness losses: codeless warnings lose their count (`{row.code && …x{count}}` gates the count on the code), and an all-malformed array renders nothing where it previously printed `UNKNOWN, UNKNOWN`, so the audit trail asserts there were none. Low reachability, but it rides the untyped enrichment passthrough and that is the wrong direction to fail in on an audit surface.
