### PR TITLE
feat(explain-diff): mount "Why these changes?" on the applied-edit receipt [PR 2 of 2 — LAND SECOND]

### DIFF
--- a/netlify/edge-functions/cee-proxy.ts
+++ b/netlify/edge-functions/cee-proxy.ts
@@ -158,6 +158,17 @@ const ALLOWED_TARGETS: readonly RegExp[] = [
   /^\/assist\/v1\/scenarios\/[^/]+\/versions\/restore$/,
   /^\/assist\/v1\/decision-records\/commit$/,
   /^\/assist\/v1\/decision-records\/[^/]+\/outcome$/,
+  // Explain-diff (CEE #1082). Backs the "Why these changes?" affordance on the
+  // applied-edit receipt card. REQUIRES CEE #1082 to be serving — that PR adds
+  // /assist/v1/explain-diff; the handler previously existed ONLY on the legacy
+  // /assist/* surface, which this rewrite can never reach.
+  //
+  // Its ON-LIST and exact-match cases are in
+  // tests/ci-guards/bffProxyPathAllowlist.spec.ts, in this same PR — a missing
+  // entry here is precisely how this capability was dark: the component shipped
+  // calling /bff/assist/explain-diff, a seam that exists only in vite.config.ts
+  // for dev and has never existed in production.
+  /^\/assist\/v1\/explain-diff$/,
 ]
 
 function isAllowedTarget(pathname: string): boolean {

--- a/src/components/assistants/ExplainDiffButton.tsx
+++ b/src/components/assistants/ExplainDiffButton.tsx
@@ -1,77 +1,153 @@
 /**
- * N4: Explain Diff Button
- * Calls BFF /assist/explain-diff with patch context
- * Renders ≤280-char rationales inline
+ * ExplainDiffButton — "Why these changes?" on the applied-edit receipt.
+ *
+ * The user has just watched the assistant modify their model. This asks CEE why,
+ * and renders the SERVER'S answer.
+ *
+ * ── WHAT THIS COMPONENT USED TO DO, AND WHY THAT MATTERED ───────────────────
+ * The previous version was written against a contract that has never existed on
+ * any deployed surface, and it had never been imported by anything:
+ *
+ *   1. it POSTed to `/bff/assist/explain-diff` — a seam that exists only in
+ *      vite.config.ts for dev. In production a live probe returned the Netlify
+ *      SPA catch-all, byte-identical (3449 B) to a deliberately fabricated path;
+ *   2. it sent `{ patch: string, context: string }` where the route requires a
+ *      structured patch and rejects unknown keys (`.strict()`);
+ *   3. it read `data.explanation`, a key the route has never returned, and on
+ *      `undefined` rendered "No explanation available" — telling the user the
+ *      server had nothing to say at the precise moment it answered in full.
+ *
+ * (3) is the one worth keeping in mind while editing this file. A false failure
+ * report is not a cosmetic bug; it teaches users the feature is broken when it
+ * works, and it is the same class of harm as inventing an explanation.
+ *
+ * ── THE RULES THIS COMPONENT FOLLOWS ────────────────────────────────────────
+ * · What is displayed is ALWAYS the server's text. Never synthesised here.
+ * · If the server cannot answer, say so plainly and leave a route — the chat
+ *   composer is directly below this card, so "ask in the chat" is a real one.
+ * · Never claim an edit was explained when it was not. No placeholder copy that
+ *   could be mistaken for an explanation.
  */
-
 import { useState } from 'react'
-import { Lightbulb, Loader2 } from 'lucide-react'
+import { HelpCircle, Loader2 } from 'lucide-react'
+import { typography } from '../../styles/typography'
+import type { V5GraphPatchBlock } from '../../canvas/conversation/types'
+import {
+  buildExplainDiffRequest,
+  parseExplainDiffResponse,
+  type ExplainDiffRationale,
+} from './explainDiffRequest'
 
-interface ExplainDiffButtonProps {
-  patch: string
-  context?: string
-  onExplanation?: (text: string) => void
+/**
+ * The browser-reachable seam. `/bff/cee/*` is a Netlify EDGE FUNCTION that
+ * rewrites to CEE `/assist/v1/*` and injects the caller-auth key server-side.
+ *
+ * ⚠ Requires TWO things to be live, both shipped alongside this component:
+ *   · CEE registers `/assist/v1/explain-diff` (CEE #1082) — the handler
+ *     previously existed ONLY on the legacy `/assist/*` surface, which this
+ *     rewrite cannot reach;
+ *   · `/^\/assist\/v1\/explain-diff$/` is on `ALLOWED_TARGETS` in
+ *     netlify/edge-functions/cee-proxy.ts, or the proxy 404s before forwarding.
+ */
+const EXPLAIN_DIFF_ENDPOINT = '/bff/cee/explain-diff'
+
+export interface ExplainDiffButtonProps {
+  /** The applied-edit receipt being explained. */
+  block: V5GraphPatchBlock
+  /** Current model size, for context. Omitted rather than guessed if unknown. */
+  graphSummary?: { node_count: number; edge_count: number }
 }
 
-export function ExplainDiffButton({ patch, context, onExplanation }: ExplainDiffButtonProps) {
-  const [loading, setLoading] = useState(false)
-  const [explanation, setExplanation] = useState<string>('')
-  const [error, setError] = useState<string>('')
+type Status = 'idle' | 'loading' | 'answered' | 'unavailable'
+
+export function ExplainDiffButton({ block, graphSummary }: ExplainDiffButtonProps) {
+  const [status, setStatus] = useState<Status>('idle')
+  const [rationales, setRationales] = useState<ExplainDiffRationale[]>([])
 
   const handleExplain = async () => {
-    setLoading(true)
-    setError('')
-
+    setStatus('loading')
     try {
-      const response = await fetch('/bff/assist/explain-diff', {
+      const response = await fetch(EXPLAIN_DIFF_ENDPOINT, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ patch, context })
+        body: JSON.stringify(buildExplainDiffRequest(block, graphSummary)),
       })
 
       if (!response.ok) {
-        throw new Error(`Failed to explain diff: ${response.statusText}`)
+        setStatus('unavailable')
+        return
       }
 
-      const data = await response.json()
-      const text = data.explanation?.slice(0, 280) || 'No explanation available'
-      setExplanation(text)
-      onExplanation?.(text)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch explanation')
-    } finally {
-      setLoading(false)
+      // A non-JSON body is the signature of the SPA catch-all answering instead
+      // of the service — the exact failure that kept this capability dark. It
+      // must read as unavailable, never as an empty explanation.
+      const data = await response.json().catch(() => null)
+      const parsed = parseExplainDiffResponse(data)
+
+      if (!parsed) {
+        setStatus('unavailable')
+        return
+      }
+
+      setRationales(parsed)
+      setStatus('answered')
+    } catch {
+      setStatus('unavailable')
     }
   }
 
+  const isLoading = status === 'loading'
+
   return (
-    <div className="space-y-2">
+    <div className="space-y-2" data-testid="explain-diff">
       <button
         onClick={handleExplain}
-        disabled={loading}
-        className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-info bg-panel border border-info/30 rounded-lg hover:opacity-80 transition-colors disabled:opacity-50"
+        disabled={isLoading}
+        className="inline-flex items-center gap-1.5 rounded-lg border border-panel-border bg-transparent px-2.5 py-1 text-text-body transition-opacity hover:opacity-80 disabled:opacity-50"
         type="button"
-        aria-label="Explain this diff"
+        data-testid="explain-diff-trigger"
       >
-        {loading ? (
-          <Loader2 className="w-4 h-4 animate-spin" />
+        {isLoading ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
         ) : (
-          <Lightbulb className="w-4 h-4" />
+          <HelpCircle className="h-3.5 w-3.5" aria-hidden="true" />
         )}
-        {loading ? 'Explaining...' : 'Explain Diff'}
+        <span className={typography.panelMeta}>
+          {isLoading ? 'Asking…' : 'Why these changes?'}
+        </span>
       </button>
 
-      {explanation && (
-        <div className="px-3 py-2 bg-panel border border-info/30 rounded-lg text-sm text-info">
-          {explanation}
-        </div>
+      {status === 'answered' && (
+        <ul className="space-y-1.5" data-testid="explain-diff-rationales">
+          {rationales.map((r, i) => (
+            <li
+              key={`${r.target}-${i}`}
+              className={`${typography.panelMeta} text-text-body`}
+              data-testid="explain-diff-rationale"
+            >
+              {r.why}
+            </li>
+          ))}
+        </ul>
       )}
 
-      {error && (
-        <div className="px-3 py-2 bg-panel border border-danger/30 rounded-lg text-sm text-danger">
-          {error}
-        </div>
+      {/*
+        The honest-failure surface. It states what happened, does not dress it up
+        as an explanation, and points at the composer immediately below this card.
+        Deliberately NOT a retry-only dead end and NOT a spinner that never
+        resolves — every path out of `loading` lands on a terminal state.
+      */}
+      {status === 'unavailable' && (
+        <p
+          className={`${typography.panelMeta} text-text-light`}
+          data-testid="explain-diff-unavailable"
+        >
+          Couldn&rsquo;t get an explanation for this change just now. Ask in the chat
+          below and the assistant can talk it through.
+        </p>
       )}
     </div>
   )
 }
+
+export default ExplainDiffButton

--- a/src/components/assistants/__tests__/assist.all.spec.tsx
+++ b/src/components/assistants/__tests__/assist.all.spec.tsx
@@ -1,60 +1,25 @@
 /**
  * N4: Assistants Integration Tests
+ *
+ * ⚠ The four "Explain Diff" cases that lived here were REMOVED, not ported, and
+ * that is deliberate.
+ *
+ * They asserted a contract that never existed on any deployed surface: a `patch`
+ * string, a `context` key the input schema rejects (`.strict()`), a
+ * `data.explanation` response key this route has never returned, and a
+ * `/bff/assist/explain-diff` seam absent from production Netlify config. Every
+ * one of them passed — against a hand-written mock of an imaginary server. They
+ * are the reason the component sat with zero importers and a fabricated failure
+ * message for its entire life, with a green suite the whole time.
+ *
+ * Porting them would have carried the fiction forward. The real coverage now
+ * lives where the claims can be checked against the actual contract:
+ *   · explainDiffRequest.spec.ts       — the request mapping and refusal semantics
+ *   · V5GraphPatchBlock.explainDiffMount.spec.tsx — the mount path and behaviour
  */
-
-import { describe, it, expect, vi } from 'vitest'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { ExplainDiffButton } from '../ExplainDiffButton'
+import { describe, it, expect } from 'vitest'
 
 describe('N4: Assistants Integration', () => {
-  describe('Explain Diff', () => {
-    it('renders button', () => {
-      render(<ExplainDiffButton patch="test patch" />)
-      expect(screen.getByLabelText('Explain this diff')).toBeInTheDocument()
-    })
-
-    it('shows concise rationales on success', async () => {
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ explanation: 'This change improves performance' })
-      })
-
-      render(<ExplainDiffButton patch="test patch" />)
-      fireEvent.click(screen.getByLabelText('Explain this diff'))
-
-      await waitFor(() => {
-        expect(screen.getByText(/improves performance/)).toBeInTheDocument()
-      })
-    })
-
-    it('shows error fallback on failure', async () => {
-      global.fetch = vi.fn().mockRejectedValue(new Error('Network error'))
-
-      render(<ExplainDiffButton patch="test patch" />)
-      fireEvent.click(screen.getByLabelText('Explain this diff'))
-
-      await waitFor(() => {
-        expect(screen.getByText(/Network error/)).toBeInTheDocument()
-      })
-    })
-
-    it('truncates rationales to 280 chars', async () => {
-      const longText = 'x'.repeat(500)
-      global.fetch = vi.fn().mockResolvedValue({
-        ok: true,
-        json: () => Promise.resolve({ explanation: longText })
-      })
-
-      render(<ExplainDiffButton patch="test" />)
-      fireEvent.click(screen.getByText('Explain Diff'))
-
-      await waitFor(() => {
-        const explanation = screen.getByText(/xxx/)
-        expect(explanation.textContent?.length).toBeLessThanOrEqual(280)
-      })
-    })
-  })
-
   describe('Options Tiles', () => {
     it('append-only behavior - passes', () => {
       expect(true).toBe(true) // Stub for append-only verification

--- a/src/components/assistants/__tests__/explainDiffRequest.spec.ts
+++ b/src/components/assistants/__tests__/explainDiffRequest.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * Pins the receipt -> explain-diff request mapping, and the REFUSAL semantics of
+ * the response parser.
+ *
+ * WHY THIS FILE EXISTS. CEE types `patch.updates` as `z.array(z.any())`. A wrong
+ * mapping is therefore accepted silently — no schema error, no red anywhere —
+ * and surfaces only as a vague explanation that reads like a bad model day. The
+ * permissive schema is exactly where this drifts, so the shape is asserted here
+ * rather than left implicit inside a component.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  buildExplainDiffRequest,
+  parseExplainDiffResponse,
+} from '../explainDiffRequest'
+import type { V5GraphPatchBlock } from '../../../canvas/conversation/types'
+
+const receipt = (over: Partial<V5GraphPatchBlock> = {}): V5GraphPatchBlock => ({
+  type: 'v5_graph_patch',
+  status: 'applied',
+  operation: 'set_factor_value',
+  target_id: 'factor_7',
+  before: { value: 0.2 },
+  after: { value: 0.45 },
+  ...over,
+})
+
+describe('buildExplainDiffRequest', () => {
+  it('maps the receipt into updates[], never adds[]', () => {
+    const req = buildExplainDiffRequest(receipt())
+
+    // The load-bearing claim: every V5 operation modifies something that already
+    // exists, so it is an UPDATE. If this ever lands in `adds`, CEE's change gate
+    // still counts it and the explanation silently describes the wrong kind of
+    // change.
+    expect(req.patch.updates).toHaveLength(1)
+    expect(req.patch.adds.nodes).toEqual([])
+    expect(req.patch.adds.edges).toEqual([])
+    expect(req.patch.removes).toEqual([])
+  })
+
+  it('carries the identity and the before/after the card is showing', () => {
+    const req = buildExplainDiffRequest(receipt())
+
+    // Bound by IDENTITY (target_id), not by a value predicate another entry
+    // could satisfy — this is the field CEE hands the model as the thing to
+    // explain, and the field it sorts rationales by.
+    expect(req.patch.updates[0]).toEqual({
+      target_id: 'factor_7',
+      operation: 'set_factor_value',
+      before: { value: 0.2 },
+      after: { value: 0.45 },
+    })
+  })
+
+  it.each([
+    'set_factor_value',
+    'add_constraint',
+    'adjust_edge_strength',
+  ] as const)('maps operation %s into updates (whole operation domain)', (operation) => {
+    // The complete operation union from types.ts — not a sample. A new operation
+    // added upstream fails to typecheck here rather than silently mis-mapping.
+    const req = buildExplainDiffRequest(receipt({ operation }))
+    expect(req.patch.updates[0].operation).toBe(operation)
+    expect(req.patch.adds.nodes).toEqual([])
+  })
+
+  it('includes graph_summary when known and OMITS the key entirely when not', () => {
+    const withSummary = buildExplainDiffRequest(receipt(), { node_count: 6, edge_count: 5 })
+    expect(withSummary.graph_summary).toEqual({ node_count: 6, edge_count: 5 })
+
+    // Omitted, not sent as undefined/zeros: the input schema is `.strict()` and
+    // zeros would be a fabricated fact about the user's model.
+    const without = buildExplainDiffRequest(receipt())
+    expect('graph_summary' in without).toBe(false)
+  })
+
+  it('never sends a brief (optional upstream, but minimum-length gated)', () => {
+    expect('brief' in buildExplainDiffRequest(receipt())).toBe(false)
+  })
+
+  it('tolerates null before/after without inventing values', () => {
+    const req = buildExplainDiffRequest(receipt({ before: null, after: null }))
+    expect(req.patch.updates[0].before).toBeNull()
+    expect(req.patch.updates[0].after).toBeNull()
+  })
+})
+
+describe('parseExplainDiffResponse — refuses rather than repairs', () => {
+  it('returns the server rationales when genuinely present', () => {
+    const out = parseExplainDiffResponse({
+      rationales: [{ target: 'factor_7', why: 'Raised to match the stated Q3 uplift.' }],
+    })
+    expect(out).toHaveLength(1)
+    expect(out?.[0].why).toBe('Raised to match the stated Q3 uplift.')
+  })
+
+  it('preserves provenance_source when the server supplies it', () => {
+    const out = parseExplainDiffResponse({
+      rationales: [{ target: 'f1', why: 'because', provenance_source: 'user_brief' }],
+    })
+    expect(out?.[0].provenance_source).toBe('user_brief')
+  })
+
+  /**
+   * ⚠ THE REGRESSION THIS FILE EXISTS FOR.
+   *
+   * The shipped-dark version read `data.explanation` — a key this route has never
+   * returned — and rendered "No explanation available" on undefined. That is a
+   * FALSE FAILURE REPORT at the exact moment the server answered in full.
+   *
+   * The fix is not a better fallback string. It is that an unrecognised body
+   * yields null, and null means the caller must SAY it could not get an answer —
+   * with no placeholder that could be mistaken for one.
+   */
+  it.each([
+    ['the legacy shape that was never real', { explanation: 'a plausible sentence' }],
+    ['rationales absent', {}],
+    ['rationales not an array', { rationales: 'nope' }],
+    ['empty rationales', { rationales: [] }],
+    ['entries missing why', { rationales: [{ target: 'f1' }] }],
+    ['entries missing target', { rationales: [{ why: 'because' }] }],
+    ['blank why', { rationales: [{ target: 'f1', why: '   ' }] }],
+    ['null body', null],
+    ['a string body (the SPA catch-all signature)', '<!DOCTYPE html>'],
+  ])('returns null for %s', (_label, body) => {
+    expect(parseExplainDiffResponse(body)).toBeNull()
+  })
+
+  it('keeps only usable entries when a response is partly malformed', () => {
+    const out = parseExplainDiffResponse({
+      rationales: [
+        { target: 'f1', why: 'a real reason' },
+        { target: 'f2' },
+        'garbage',
+      ],
+    })
+    // Server text is preserved; junk is dropped. Nothing is invented to fill it.
+    expect(out).toHaveLength(1)
+    expect(out?.[0].target).toBe('f1')
+  })
+})

--- a/src/components/assistants/explainDiffRequest.ts
+++ b/src/components/assistants/explainDiffRequest.ts
@@ -1,0 +1,105 @@
+/**
+ * Maps a V5 applied-edit receipt into the request CEE's explain-diff route expects.
+ *
+ * ── WHY A MAPPER EXISTS AT ALL ──────────────────────────────────────────────
+ * The two ends speak different vocabularies and neither can be changed cheaply:
+ *
+ *   the receipt card  { operation, target_id, before, after }
+ *   the explain route { patch: { adds: {nodes, edges}, updates, removes } }
+ *
+ * Every V5 operation — `set_factor_value`, `add_constraint`, `adjust_edge_strength`
+ * — modifies something that already exists. NONE of them is a node or edge ADD.
+ * So every receipt maps into `updates[]`, and `adds`/`removes` are always empty.
+ *
+ * ── WHY THIS IS A SEPARATE, TESTED MODULE ───────────────────────────────────
+ * CEE types `updates` as `z.array(z.any())`. A wrong mapping is therefore
+ * ACCEPTED SILENTLY — no schema error, no red anywhere — and would surface only
+ * as a vague or wrong explanation that reads like a bad model day. A permissive
+ * schema is exactly where a mapping drifts unnoticed, so the shape is pinned in
+ * explainDiffRequest.spec.ts rather than left implicit inside a component.
+ *
+ * ── WHAT IS DELIBERATELY NOT SENT ───────────────────────────────────────────
+ * `brief` is omitted. It is optional upstream but carries a MINIMUM LENGTH, so
+ * passing a short or synthesised string would earn a 400 rather than better
+ * context. Only facts the card actually holds are sent.
+ */
+import type { V5GraphPatchBlock } from '../../canvas/conversation/types'
+
+/** One entry in the route's `updates[]`. Mirrors the receipt, renamed to nothing. */
+export interface ExplainDiffUpdate {
+  target_id: string
+  operation: V5GraphPatchBlock['operation']
+  before: Record<string, unknown> | null
+  after: Record<string, unknown> | null
+}
+
+export interface ExplainDiffRequest {
+  patch: {
+    adds: { nodes: never[]; edges: never[] }
+    updates: ExplainDiffUpdate[]
+    removes: never[]
+  }
+  graph_summary?: { node_count: number; edge_count: number }
+}
+
+/** A single rationale as the server returns it. */
+export interface ExplainDiffRationale {
+  target: string
+  why: string
+  provenance_source?: string
+}
+
+export function buildExplainDiffRequest(
+  block: V5GraphPatchBlock,
+  graphSummary?: { node_count: number; edge_count: number },
+): ExplainDiffRequest {
+  return {
+    patch: {
+      adds: { nodes: [], edges: [] },
+      updates: [
+        {
+          target_id: block.target_id,
+          operation: block.operation,
+          before: block.before,
+          after: block.after,
+        },
+      ],
+      removes: [],
+    },
+    ...(graphSummary ? { graph_summary: graphSummary } : {}),
+  }
+}
+
+/**
+ * Narrow an unknown server response to the rationales we will render.
+ *
+ * ⚠ THE POINT OF THIS FUNCTION IS TO REFUSE, NOT TO REPAIR.
+ *
+ * The version of this feature that shipped dark read `data.explanation` — a key
+ * this route has never returned — and on `undefined` rendered the literal string
+ * "No explanation available". That is a FALSE FAILURE REPORT: it tells the user
+ * the server had nothing to say at the exact moment the server answered fully.
+ * It is the mirror of the fabrication risk and just as damaging to trust.
+ *
+ * So: return the rationales when they are genuinely there and usable, and return
+ * `null` otherwise. `null` means "we could not get an answer" and the caller must
+ * say so plainly. There is deliberately no partial-credit path, no placeholder
+ * text, and no client-side narrative — an invented explanation of a real edit to
+ * the user's own model is worse than no explanation.
+ */
+export function parseExplainDiffResponse(data: unknown): ExplainDiffRationale[] | null {
+  if (typeof data !== 'object' || data === null) return null
+  const rationales = (data as { rationales?: unknown }).rationales
+  if (!Array.isArray(rationales)) return null
+
+  const usable = rationales.filter(
+    (r): r is ExplainDiffRationale =>
+      typeof r === 'object' &&
+      r !== null &&
+      typeof (r as ExplainDiffRationale).target === 'string' &&
+      typeof (r as ExplainDiffRationale).why === 'string' &&
+      (r as ExplainDiffRationale).why.trim().length > 0,
+  )
+
+  return usable.length > 0 ? usable : null
+}

--- a/src/v5/blocks/V5GraphPatchBlock.tsx
+++ b/src/v5/blocks/V5GraphPatchBlock.tsx
@@ -26,6 +26,7 @@ import { useAnalysisTrust } from '../../canvas/hooks/useAnalysisTrust'
 import { claimStalenessVoice } from '../../canvas/conversation/stalenessVoice'
 import type { V5GraphPatchBlock as V5GraphPatchBlockType } from '../../canvas/conversation/types'
 import { buildV5PatchReceipt, buildV5PatchDeps } from './v5GraphPatchDescription'
+import { ExplainDiffButton } from '../../components/assistants/ExplainDiffButton'
 
 export interface V5GraphPatchBlockProps {
   block: V5GraphPatchBlockType
@@ -144,6 +145,26 @@ export function V5GraphPatchBlock({
         >
           Latest analysis is now out of date.
         </p>
+      )}
+
+      {/*
+        "Why these changes?" — the receipt is where the question actually arises.
+        The user has just watched their model change; this is the moment they ask
+        why, and it is the only surface in the product that knows WHICH change is
+        being asked about.
+
+        RENDERED ONLY FOR 'applied'. A 'noop' receipt means CEE looked and nothing
+        needed changing, so there is no diff to explain — and the route would
+        rightly answer 400 "patch has no changes to explain". Offering the button
+        there would advertise an action that terminates in refusal.
+
+        The answer shown is always CEE's; see ExplainDiffButton for the rules.
+      */}
+      {isApplied && (
+        <ExplainDiffButton
+          block={block}
+          graphSummary={{ node_count: nodes.length, edge_count: edges.length }}
+        />
       )}
     </div>
   )

--- a/src/v5/blocks/__tests__/V5GraphPatchBlock.explainDiffMount.spec.tsx
+++ b/src/v5/blocks/__tests__/V5GraphPatchBlock.explainDiffMount.spec.tsx
@@ -1,0 +1,229 @@
+/**
+ * Explain-diff MOUNT + behaviour on the applied-edit receipt.
+ *
+ * ── WHY THE MOUNT PATH IS ASSERTED AND NOT ASSUMED ──────────────────────────
+ * This estate has twice shipped a feature onto a component the deployed flags
+ * switch off, with a fully green suite each time, because every test pointed at
+ * the wrong component. A render test alone would repeat that: it proves the
+ * button appears when THIS component is rendered, and says nothing about whether
+ * anything renders this component.
+ *
+ * So the mount path itself is asserted below, derived from the dispatcher source,
+ * and it fails loud if the `v5_graph_patch` case is re-routed or gains a flag.
+ *
+ * Host verified at the DEPLOYED bytes, not from flag prose: a full 83-chunk crawl
+ * of the staging bundle finds `v5-change-receipt`, `v5-change-status` and
+ * `v5-change-summary` present (positive controls `key-question-card`, `No change`
+ * non-zero; fabricated negatives zero). The card a user sees after an assistant
+ * edit is this one.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+import type { V5GraphPatchBlock as V5GraphPatchBlockType } from '../../../canvas/conversation/types'
+
+const NODES = [
+  { id: 'fac_team_morale', data: { label: 'team morale' } },
+  { id: 'goal_outcome', data: { label: 'overall outcome' } },
+]
+const EDGES = [{ id: 'edge_a', source: 'fac_team_morale', target: 'goal_outcome' }]
+
+vi.mock('../../../canvas/store', () => ({
+  useCanvasStore: (
+    selector: (s: {
+      nodes: unknown
+      edges: unknown
+      analysisFreshness: { freshness: string } | null
+      analysisFreshnessDirty: boolean
+    }) => unknown,
+  ) =>
+    selector({
+      nodes: NODES,
+      edges: EDGES,
+      analysisFreshness: { freshness: 'unknown' },
+      analysisFreshnessDirty: false,
+    }),
+}))
+
+import { V5GraphPatchBlock } from '../V5GraphPatchBlock'
+
+const applied: V5GraphPatchBlockType = {
+  type: 'v5_graph_patch',
+  status: 'applied',
+  operation: 'set_factor_value',
+  target_id: 'fac_team_morale',
+  before: { value: 0.5 },
+  after: { value: 0.7 },
+}
+
+const jsonResponse = (body: unknown, ok = true) =>
+  ({ ok, json: () => Promise.resolve(body) }) as unknown as Response
+
+beforeEach(() => cleanup())
+afterEach(() => vi.restoreAllMocks())
+
+/* ── THE MOUNT PATH ─────────────────────────────────────────────────────────── */
+describe('mount path: the dispatcher actually renders this card', () => {
+  const dispatcherSource = readFileSync(
+    resolve(__dirname, '../../../canvas/conversation/InlineBlocks.tsx'),
+    'utf8',
+  )
+
+  it('routes the v5_graph_patch block type to V5GraphPatchBlock', () => {
+    expect(dispatcherSource).toContain("case 'v5_graph_patch':")
+    expect(dispatcherSource).toMatch(/case 'v5_graph_patch':[\s\S]{0,200}<V5GraphPatchBlock/)
+  })
+
+  it('renders that case with NO block-level flag gate', () => {
+    // Neighbouring V4 cases DO gate (`if (!isDeterministicCeeEnabled()) return null`).
+    // If a gate is ever added to this case, this REDs — which is the whole point:
+    // a flag moving must not silently dark this capability again.
+    const caseBody = dispatcherSource
+      .split("case 'v5_graph_patch':")[1]
+      .split('case ')[0]
+    expect(caseBody).not.toContain('isDeterministicCeeEnabled')
+    expect(caseBody).not.toMatch(/return null/)
+  })
+
+  // Positive control: the gating pattern this file claims to detect is genuinely
+  // present in the same source. Without it, both assertions above could pass
+  // because the pattern never appears anywhere — an absence probe with nothing
+  // proving it can see a presence.
+  it('CONTROL: the flag-gate pattern does exist in this dispatcher', () => {
+    expect(dispatcherSource).toContain('isDeterministicCeeEnabled')
+  })
+})
+
+/* ── THE AFFORDANCE ─────────────────────────────────────────────────────────── */
+describe('V5GraphPatchBlock — "Why these changes?"', () => {
+  it('offers the question on an applied receipt', () => {
+    render(<V5GraphPatchBlock block={applied} />)
+    expect(screen.getByTestId('explain-diff-trigger')).toBeInTheDocument()
+    expect(screen.getByTestId('explain-diff-trigger').textContent).toContain(
+      'Why these changes?',
+    )
+  })
+
+  it('does NOT offer it on a noop receipt (nothing changed to explain)', () => {
+    // The route answers 400 "patch has no changes to explain" for an empty patch,
+    // so offering the button here would advertise an action that ends in refusal.
+    render(<V5GraphPatchBlock block={{ ...applied, status: 'noop' }} />)
+    expect(screen.queryByTestId('explain-diff-trigger')).not.toBeInTheDocument()
+  })
+
+  it('asks CEE through the browser-reachable seam, with the receipt mapped into updates[]', async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(jsonResponse({ rationales: [{ target: 'fac_team_morale', why: 'ok' }] }))
+
+    render(<V5GraphPatchBlock block={applied} />)
+    fireEvent.click(screen.getByTestId('explain-diff-trigger'))
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled())
+
+    const [url, init] = fetchSpy.mock.calls[0]
+    // The seam. `/bff/assist/*` — what the dark version called — does not exist
+    // in production and returns the SPA catch-all.
+    expect(url).toBe('/bff/cee/explain-diff')
+
+    const body = JSON.parse((init as RequestInit).body as string)
+    // Bound by IDENTITY to the receipt on screen, not by a value predicate.
+    expect(body.patch.updates).toEqual([
+      {
+        target_id: 'fac_team_morale',
+        operation: 'set_factor_value',
+        before: { value: 0.5 },
+        after: { value: 0.7 },
+      },
+    ])
+    expect(body.patch.adds.nodes).toEqual([])
+    // Real counts from the store, not fabricated.
+    expect(body.graph_summary).toEqual({ node_count: 2, edge_count: 1 })
+  })
+
+  it("renders the SERVER'S words, verbatim", async () => {
+    const serverText = 'Raised because the brief states Q3 headcount is already committed.'
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ rationales: [{ target: 'fac_team_morale', why: serverText }] }),
+    )
+
+    render(<V5GraphPatchBlock block={applied} />)
+    fireEvent.click(screen.getByTestId('explain-diff-trigger'))
+
+    await waitFor(() =>
+      expect(screen.getByTestId('explain-diff-rationale').textContent).toBe(serverText),
+    )
+  })
+
+  it('renders every rationale the server returns', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({
+        rationales: [
+          { target: 'a', why: 'first reason' },
+          { target: 'b', why: 'second reason' },
+        ],
+      }),
+    )
+    render(<V5GraphPatchBlock block={applied} />)
+    fireEvent.click(screen.getByTestId('explain-diff-trigger'))
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId('explain-diff-rationale')).toHaveLength(2),
+    )
+  })
+
+  /* ── HONESTY UNDER FAILURE ────────────────────────────────────────────────── */
+
+  it.each([
+    ['a network error', () => vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('boom'))],
+    ['a non-ok status', () => vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({}, false))],
+    ['the legacy shape that was never real', () =>
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ explanation: 'plausible' }))],
+    ['an empty rationale list', () =>
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue(jsonResponse({ rationales: [] }))],
+  ])('says plainly that it could not answer, given %s', async (_label, arrange) => {
+    arrange()
+    render(<V5GraphPatchBlock block={applied} />)
+    fireEvent.click(screen.getByTestId('explain-diff-trigger'))
+
+    const notice = await screen.findByTestId('explain-diff-unavailable')
+    expect(notice.textContent).toMatch(/couldn.t get an explanation/i)
+    // And it leaves a route the user can actually take — the composer is directly
+    // below this card.
+    expect(notice.textContent).toMatch(/ask in the chat/i)
+
+    // No explanation is claimed.
+    expect(screen.queryByTestId('explain-diff-rationale')).not.toBeInTheDocument()
+  })
+
+  /**
+   * ⚠ THE FABRICATION REGRESSION, PINNED.
+   *
+   * The dark version rendered the literal "No explanation available" whenever
+   * `data.explanation` was undefined — which was ALWAYS, because this route
+   * returns `rationales`. It reported failure at the moment the server answered
+   * in full, and it did so in words a user reads as the server's verdict.
+   */
+  it('never renders the old fabricated placeholder, even when the server answers well', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      jsonResponse({ rationales: [{ target: 'fac_team_morale', why: 'a genuine reason' }] }),
+    )
+    render(<V5GraphPatchBlock block={applied} />)
+    fireEvent.click(screen.getByTestId('explain-diff-trigger'))
+
+    await waitFor(() => expect(screen.getByTestId('explain-diff-rationale')).toBeInTheDocument())
+    expect(screen.queryByText(/no explanation available/i)).not.toBeInTheDocument()
+  })
+
+  it('always leaves a terminal state — never a spinner that never resolves', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('boom'))
+    render(<V5GraphPatchBlock block={applied} />)
+    fireEvent.click(screen.getByTestId('explain-diff-trigger'))
+
+    await screen.findByTestId('explain-diff-unavailable')
+    expect(screen.getByTestId('explain-diff-trigger').textContent).toContain('Why these changes?')
+    expect(screen.getByTestId('explain-diff-trigger')).not.toBeDisabled()
+  })
+})

--- a/src/v5/blocks/__tests__/V5GraphPatchBlock.explainDiffMount.spec.tsx
+++ b/src/v5/blocks/__tests__/V5GraphPatchBlock.explainDiffMount.spec.tsx
@@ -61,8 +61,12 @@ const applied: V5GraphPatchBlockType = {
 const jsonResponse = (body: unknown, ok = true) =>
   ({ ok, json: () => Promise.resolve(body) }) as unknown as Response
 
-beforeEach(() => cleanup())
-afterEach(() => vi.restoreAllMocks())
+beforeEach(() => {
+  cleanup()
+})
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 /* ── THE MOUNT PATH ─────────────────────────────────────────────────────────── */
 describe('mount path: the dispatcher actually renders this card', () => {

--- a/tests/ci-guards/bffProxyPathAllowlist.spec.ts
+++ b/tests/ci-guards/bffProxyPathAllowlist.spec.ts
@@ -135,6 +135,35 @@ describe('cee-proxy path allowlist (/bff/cee/* → /assist/v1/*)', () => {
     )
   })
 
+  /**
+   * Explain-diff (CEE #1082 / this PR). The applied-edit receipt card asks the
+   * server "why did you make these changes?" through this seam.
+   *
+   * This case exists because the capability's FIRST failure was exactly a
+   * missing entry here: the component shipped calling `/bff/assist/explain-diff`,
+   * a seam that exists only in vite.config.ts for dev and has never existed in
+   * production. A live probe returned the SPA catch-all, byte-identical (3449 B)
+   * to a deliberately fabricated path, while `/bff/cee/graph-readiness` returned
+   * live CEE JSON in the same run. Keep the route and its case in one PR.
+   */
+  it('ON-LIST /bff/cee/explain-diff forwards to /assist/v1/explain-diff WITH the injected key', async () => {
+    const r = await invoke(ceeHandler as Handler, { path: '/bff/cee/explain-diff' })
+    expect(r.fetchCalled).toBe(true)
+    expect(r.calledUrl).toBe('https://cee-staging.onrender.com/assist/v1/explain-diff')
+    expect(r.requestHeaders?.get('X-Olumi-Assist-Key')).toBe(FAKE_KEY)
+    expect(r.status).toBe(200)
+  })
+
+  /**
+   * The entry is EXACT — a prefix match would re-open the blast radius the
+   * allowlist exists to bound.
+   */
+  it('OFF-LIST /bff/cee/explain-diff/extra is 404 with NO key sent (entry is exact)', async () => {
+    const r = await invoke(ceeHandler as Handler, { path: '/bff/cee/explain-diff/extra' })
+    expect(r.status).toBe(404)
+    expect(r.fetchCalled).toBe(false)
+  })
+
   it('OFF-LIST /bff/cee/decision-review (a real LLM route the UI never calls) is 404 with NO key sent', async () => {
     const r = await invoke(ceeHandler as Handler, { path: '/bff/cee/decision-review' })
     expect(r.status).toBe(404)


### PR DESCRIPTION
## ⚠ LAND ORDER — THIS IS PR 2 OF 2, AND IT MUST LAND SECOND

| | repo | what it does | order |
|---|---|---|---|
| **PR 1** | CEE [#1082](https://github.com/Talchain/olumi-assistants-service/pull/1082) | registers the handler at `/assist/v1/explain-diff` | **merge + deploy FIRST** |
| **PR 2 — this one** | UI | proxy allowlist + client + host | merge only once #1082 is **serving** |

**Merging this first ships a button that 404s on every assistant edit** — the exact "advertises an action that terminates in refusal" defect this lane exists to remove. CEE #1082 is user-invisible on its own and safe to land alone.

⚠ A freeze window is in force; neither PR is expected to land same-day.

---

## What a user gets

**After the assistant edits their model, the receipt card now offers "Why these changes?", and answers it with CEE's explanation of that specific change.**

## Why it was dark

Not one missing wire — **four independent breaks**, in a component with zero production importers:

1. **No transport.** It POSTed to `/bff/assist/explain-diff`. That seam exists only in `vite.config.ts` for dev; production Netlify has no redirect and no edge function for `/bff/assist/*`.
2. **No reachable path even if it had one.** `/bff/cee/*` rewrites to `/assist/v1/*`, and the handler lived only at `/assist/explain-diff` (legacy). No `<x>` produces it. → fixed by CEE #1082.
3. **Wrong request.** It sent `{patch: string, context}`; the route needs a structured patch and is `.strict()`, so `context` is rejected outright.
4. **Wrong response — and it fabricated.** It read `data.explanation`, a key this route has never returned, and on `undefined` rendered **"No explanation available"** — a false failure report at the exact moment the server answered in full.

### Live probe, with controls in the same run

| path | status | content-type | size |
|---|---|---|---|
| `/bff/assist/explain-diff` (target) | 404 | `text/html` | **3449 B** |
| `/bff/assist/totally-fabricated-xyzzy` (neg control) | 404 | `text/html` | **3449 B** |
| `/bff/nonexistentfamily/foo` (neg control) | 404 | `text/html` | **3449 B** |
| `/bff/cee/graph-readiness` (contrast control) | **400** | **`application/json`** | live CEE JSON |
| `/bff/orchestrate/v5/turn` (contrast control) | **403** | `application/json` | edge fn alive |

The target is **byte-identical to a fabricated route**, while two contrast controls return two different live answers — a discriminating probe, not a blind one.

Confirmed at the deployed bytes: an **83-chunk crawl** of the staging bundle finds `Explain Diff`, `Explain this diff` and `/bff/assist/` in **zero** chunks (positive controls `key-question-card`, `No change` non-zero; fabricated negatives zero). The component was not merely unmounted — it was absent from the shipped build. It is one of **8 of 9** components in `src/components/assistants/` with no production importer.

## Why this host

`V5GraphPatchBlock` — the applied-edit receipt. It is where the user is at the moment the question arises, and **the only surface that knows which change is being asked about**. `useConversation.ts:4057` already calls it "the graph_patch card".

- Rendered for **`applied` only**. A `noop` has no diff to explain and would earn a 400 "patch has no changes to explain".
- Host presence verified at the deployed bytes (`v5-change-receipt`, `v5-change-status`, `v5-change-summary` all in the bundle), **not** from flag prose.
- The `v5_graph_patch` case in `InlineBlocks.tsx` carries **no block-level flag gate**, unlike its V4 neighbours.
- **The mount path is asserted, with a positive control**, so a flag appearing on that case REDs instead of silently darking this again.

## Honesty rules the client now follows

- What is shown is **always the server's text**. Never synthesised.
- `parseExplainDiffResponse` **refuses rather than repairs**: an unrecognised body yields `null`, and `null` means the UI says plainly it could not answer. No placeholder that could be mistaken for an explanation, no partial-credit path.
- A non-JSON body — the SPA-catch-all signature — reads as unavailable, never as an empty explanation.
- The failure notice leaves a **real route**: the chat composer sits directly below the card.
- Every path out of `loading` reaches a terminal state; no spinner that never resolves.

## ⚠ A BLOCKER THE REVIEWER MUST WEIGH BEFORE THE DEPLOY STEP

**Only one of three providers can serve this route**, and I could not derive staging's posture from this seam:

| `LLM_PROVIDER` | outcome |
|---|---|
| `anthropic` | ✅ works |
| `fixtures` | ❌ **500 on every real payload from this UI** |
| `openai` | ❌ 400 `not_supported` — `openai.ts` explicitly does not implement `explainDiff` |

Every V5 receipt operation is an **update**, never an add; `FixturesAdapter.explainDiff` builds rationales from `patch.adds` only, so an updates-only patch yields zero rationales and `.min(1)` 500s. Pinned as an exact test in CEE #1082.

**Posture must be derived from the Render API or a live witness, never YAML.** If staging is not on `anthropic`, hold this PR: the client will degrade honestly (the "couldn't get an explanation" notice), but every user would see that notice every time — a working affordance that never works.

## Verification

**RED-first**, allowlist guard at pristine edge function: `ON-LIST /bff/cee/explain-diff forwards…` → `expected false to be true` (proxy 404s, never forwards). Signature `1 failed | 53 passed (54)`.

**Discriminating mutant pair**, throwaway worktree at an absolute path **outside** the repo root. Isolation proven by **writing a sentinel** and asserting the source sha did not move, plus distinct inodes (`701631827` vs `701638139`), with an **existence precondition** — an earlier attempt in this lane "passed" all three isolation proofs against a worktree that had never been created. Restores are `git checkout HEAD -- <path>`.

| mutant | applied-check | result |
|---|---|---|
| control (pristine) | **0** | 88/88 green |
| **A — delete the `<ExplainDiffButton/>` render from the host** (0 renders remaining, verified) | 1 | **RED — 10 failed / 78 passed** |
| **B — unrelated surface, same card** (freshness copy + status label; **2 hits verified applied**, so not a false survivor) | 1 | **GREEN 88/88** |
| trailing control | 0 | 88/88 — matches pristine |

A alone proves sensitivity to *something*; the pair proves sensitivity to **this host binding**.

**Gate (`Staging Gate`), derived at this tip and run as its step sequence:**

- `pnpm run lint` → **exit 0** (hooks ratchet: 229 known violations across 13 files, exactly matching baseline)
- `pnpm run typecheck` → **exit 0** — `3604 / 3644` tracked files loaded; **`within baseline — 556 file(s) / 2252 error(s)`, zero drift**
- `ci:guard:zustand`, `ci:guard:starters`, `check:vendor` → **all PASS**
- Full unit suite → reported in a comment below once it concludes; **not claimed here, because it had not returned when this body was written.**

**The typecheck ratchet caught a real defect the green tests could not see:** `afterEach(() => vi.restoreAllMocks())` returns `VitestUtils`, not `Awaitable<void>` (TS2322, +1 over baseline). Fixed at the source — **the baseline was NOT regenerated**.

**Own-spec collection asserted by name**, never inferred from a total: `explainDiffRequest.spec.ts` (20) + `V5GraphPatchBlock.explainDiffMount.spec.tsx` (14) = **34**, each listed individually; plus `bffProxyPathAllowlist.spec.ts` 54. Pre-existing host specs re-run clean: `V5GraphPatchBlock.test.tsx` 23, `v5GraphPatchDescription.spec.ts` 30 — the receipt-leak guard still passes with the button inside the card.

## On the deleted tests
The four legacy `Explain Diff` cases were **removed, not ported**. Each passed against a hand-written mock of an imaginary server — a `patch` string, a `context` key the schema rejects, a `data.explanation` key that never existed. That is why this component sat unreachable with a fabricated failure message under a permanently green suite. Porting them would have carried the fiction forward. Real coverage now sits in the two specs above.

## Still owed after merge
A deployed-edge probe of `/bff/cee/explain-diff`, in the same discriminating form as the table above (fabricated-path negative + live-service contrast, one run). **A registration correct in source and unreachable in production is exactly the defect that created this cohort**, so the rung stays below MOUNTED until that probe returns.