### PR TITLE
fix(canvas): an invented target renders identically to a number the user wrote (B1-a)

### DIFF
--- a/src/canvas/domain/valueProvenance.ts
+++ b/src/canvas/domain/valueProvenance.ts
@@ -181,6 +181,96 @@ export function classifyValueProvenance(
 }
 
 /**
+ * ─────────────────────────────────────────────────────────────────────────────
+ * ⭐⭐ THE INTERVENTION VOCABULARY — A DIFFERENT FIELD WEARING THE SAME NAME
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * An option's `interventions[factorId].source` answers **HOW THIS TARGET WAS
+ * DETERMINED**. A node's `observed_state.source` answers **WHO PUT THIS VALUE
+ * HERE**. Two questions, two closed vocabularies, one field name — and the
+ * shared contract says so itself, at `edit-tool-ops.js:229-238` in the vendored
+ * 0.48.0 package:
+ *
+ *   *"`source` IS ONE OF ITS FIELDS (`cee-v3.ts:284` — an enum of
+ *   `brief_extraction | cee_hypothesis | user_specified`, meaning HOW THE
+ *   INTERVENTION WAS DETERMINED). That is a different field from node
+ *   `observed_state.source` wearing the same name, and CEE exempts it for
+ *   exactly this reason."*
+ *
+ * ⚠⚠ THIS IS WHY `cee_hypothesis` IS **NOT** IN `SOURCE_CLASSES`, AND ADDING IT
+ * WAS THE FIRST THING THIS LANE TRIED (B1-a, 2026-08-24). It typechecks, it
+ * makes the surface render the right words, and `sourceClassesCompleteness`
+ * REDs on it — correctly, because the guard's complement assertion exists to
+ * catch exactly this: a literal classified here that the contract's
+ * `OBSERVED_STATE_SOURCE_LITERALS` does not declare. Merging the two maps would
+ * have made `classifyValueProvenance('cee_hypothesis')` answer a question about
+ * a factor's observed value that no producer ever asks, and would have made the
+ * one guard that can see contract drift permanently unable to.
+ *
+ * The two vocabularies OVERLAP on `brief_extraction` and are otherwise
+ * disjoint, which is what makes the merge look harmless and is why it is not.
+ *
+ * ⚠ WHAT IS SHARED IS THE **KIND**, DELIBERATELY. Both classifiers return the
+ * same `ValueProvenanceKind`, so every surface keeps ONE taxonomy and ONE
+ * `Record<ValueProvenanceKind, …>` register. The concepts are named apart at the
+ * literal layer and joined at the kind layer — which is the shape CLAUDE.md
+ * trap 21 prescribes for two authorities answering different questions.
+ *
+ * ⚠ THE CONTRACT DOES NOT EXPORT THESE LITERALS. The vendored package "does not
+ * carry InterventionV3" (same comment, same file), so unlike `SOURCE_CLASSES`
+ * this map has NO canonical list to be checked against and no derivation is
+ * available. Stated rather than discovered later: the guard for this map is a
+ * HAND-WRITTEN CORPUS pinned to the contract's own quoted enum, which is the
+ * other half of trap 12d — where you cannot derive, a corpus is what notices the
+ * list is short. If a future schemas minor exports the intervention literals,
+ * replace the corpus with a derived guard and delete this paragraph.
+ */
+const INTERVENTION_SOURCE_CLASSES: Readonly<Record<string, ValueProvenanceKind>> = Object.freeze({
+  /** The target is the user's own figure, lifted from their brief. */
+  brief_extraction: 'brief',
+  /**
+   * ⭐ THE MODEL CHOSE THIS NUMBER. Witnessed on the deployed build (UI
+   * `88cb7e37` · CEE `d1da670`, fresh guest, 2026-08-24): every
+   * `cee_hypothesis` entry on that draw carried `value_confidence: 'low'` and
+   * the producer's own reasoning — *"Model-chosen intervention level; this
+   * amount is not stated in the brief"* — against `brief_extraction` siblings
+   * carrying `value_confidence: 'high'` and a reasoning quoting the user's own
+   * sentence verbatim. The class is the one the PRODUCER declares, not one
+   * inferred from the symptom (trap 13c).
+   */
+  cee_hypothesis: 'ai',
+  /** The human supplied the target. `'edited'`, and therefore user-owned. */
+  user_specified: 'edited',
+})
+
+/** Every intervention-source literal this map classifies — the corpus checks it. */
+export const INTERVENTION_PROVENANCE_SOURCES: readonly string[] = Object.freeze(
+  Object.keys(INTERVENTION_SOURCE_CLASSES),
+)
+
+/**
+ * Classify an `interventions[factorId].source` literal.
+ *
+ * Returns `null` — never a guessed class — for an unknown literal, for the same
+ * reason `classifyValueProvenance` does: a surface that renders `null` must fall
+ * back to its own honest silence. Guessing here would put "AI estimate" over a
+ * number the user typed, or the reverse, which is the defect this pair of
+ * classifiers exists to end.
+ *
+ * ⚠ DO NOT ROUTE AN `observed_state.source` THROUGH THIS FUNCTION, or an
+ * intervention source through its sibling. They overlap on one literal and
+ * would agree on it, which is precisely how a wrong call survives review.
+ */
+export function classifyInterventionProvenance(
+  source: string | null | undefined,
+): ValueProvenanceClass | null {
+  if (typeof source !== 'string') return null
+  const kind = INTERVENTION_SOURCE_CLASSES[source]
+  if (kind === undefined) return null
+  return { kind, userOwned: USER_OWNED_KINDS.has(kind) }
+}
+
+/**
  * Classify the NODE-LEVEL `data.provenance` value, whose vocabulary is a
  * different, smaller one (`CEEProvenance`).
  *

--- a/src/canvas/model-tab-v2/ModelDetailRegion.tsx
+++ b/src/canvas/model-tab-v2/ModelDetailRegion.tsx
@@ -28,8 +28,70 @@
 
 import { typography } from '../../styles/typography'
 import { SourceProvenancePill } from '../components/model-tab/SourceProvenancePill'
+import {
+  classifyInterventionProvenance,
+  type ValueProvenanceKind,
+} from '../domain/valueProvenance'
 import { KIND_LABEL } from './rowPresentation'
 import type { DetailField, DetailTier, ModelRow, ModelRowDetail } from './types'
+
+/**
+ * ⭐ WHO CHOSE THIS TARGET — this surface's register, TOTAL over the kind.
+ *
+ * ⚠ A SECOND REGISTER, AND THAT IS THE RATIFIED SHAPE, NOT A TRAP-12 MIRROR.
+ * `valueProvenance` owns the KIND and says so in its own header: *"This module
+ * owns the kind. Each surface keeps its own register (the Model tab is terse,
+ * the inspector writes sentences) but must be TOTAL over `ValueProvenanceKind`
+ * — a `Record<ValueProvenanceKind, …>` makes a missing kind a type error rather
+ * than a silent fallback."* A new kind cannot land here unlabelled.
+ *
+ * ⚠ WHY NOT `SourceProvenancePill`, WHICH SITS TEN LINES BELOW. That component
+ * takes a raw LITERAL and classifies it with `classifyValueProvenance` — the
+ * NODE `observed_state.source` vocabulary. An intervention's `source` is a
+ * different, three-member vocabulary wearing the same field name (see
+ * `valueProvenance`), so handing it `'cee_hypothesis'` renders **"Not set"** —
+ * a claim about the value, over a value that is set. The wording is kept
+ * identical to the pill's on purpose: same tab, same register, one voice.
+ */
+const INTERVENTION_PROVENANCE_LABEL: Record<ValueProvenanceKind, string> = {
+  brief: 'From brief',
+  ai: 'AI estimate',
+  confirmed: 'Confirmed by you',
+  edited: 'User edited',
+  assumption: 'Your assumption',
+  human: 'Set by you',
+  panel: 'From your panel',
+}
+
+const INTERVENTION_PROVENANCE_BORDER: Record<ValueProvenanceKind, string> = {
+  brief: 'border-info/30',
+  ai: 'border-warning/30',
+  confirmed: 'border-success/30',
+  edited: 'border-success/30',
+  assumption: 'border-success/30',
+  human: 'border-success/30',
+  panel: 'border-info/30',
+}
+
+/**
+ * The mark that sits beside an intervention's number.
+ *
+ * ⚠ RENDERS **NOTHING** WHEN THE RECORD DOES NOT SAY. Not "Not set", not a
+ * neutral pill, not a dash. An unrecorded provenance is unknown, and unknown
+ * stays unknown — a default in any direction is an invented provenance, which
+ * is the defect one level up from the one this component closes.
+ */
+function InterventionProvenanceMark({ source }: { source: string | undefined }) {
+  const cls = classifyInterventionProvenance(source)
+  if (cls === null) return null
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-full bg-transparent border ${INTERVENTION_PROVENANCE_BORDER[cls.kind]} text-text-body ${typography.panelMeta}`}
+    >
+      {INTERVENTION_PROVENANCE_LABEL[cls.kind]}
+    </span>
+  )
+}
 
 export interface ModelDetailRegionProps {
   row: ModelRow
@@ -51,6 +113,22 @@ export interface ModelDetailRegionProps {
   /** Commit the draft through the write authority. */
   onCommitIntervention?: (factorId: string) => void
   onDiscardInterventionEdit?: () => void
+}
+
+/**
+ * Would "Where it came from" have anything under its heading?
+ *
+ * ⚠ ONE PREDICATE, MIRRORING THE THREE CHILDREN EXACTLY. Written as a separate
+ * function so the mirror is visible: if a fourth child is ever added to that
+ * section and not added here, the section can render empty again — which is the
+ * defect this predicate closes, wearing a fourth condition.
+ */
+function hasProvenanceContent(
+  provenanceSource: string | undefined,
+  detail: ModelRowDetail,
+): boolean {
+  const pillWouldRender = typeof provenanceSource === 'string' && provenanceSource !== ''
+  return pillWouldRender || detail.basis !== null || detail.adjustments.length > 0
 }
 
 /** Absence is rendered as absence — never as a zero, never as a blank cell. */
@@ -240,6 +318,37 @@ export function ModelDetailRegion({
                       {iv.value ?? 'Not set'}
                     </span>
                   )}
+
+                  {/*
+                    ⭐ WHO CHOSE THIS NUMBER — ON THE SAME LINE AS THE NUMBER.
+
+                    ⚠⚠ THE DEFECT THIS CLOSES (B1-a, deployed witness UI
+                    `88cb7e37` · CEE `d1da670`, 2026-08-24). A target CEE had
+                    invented — raw 22,500, no unit, `value_confidence: low`, its
+                    own reasoning saying *"this amount is not stated in the
+                    brief"* — rendered here as a bare `0.45`, in the same
+                    control, the same typography and with no badge, tooltip,
+                    icon or unit, directly comparable with the user's own
+                    £45,000 rendered as a bare `0.9`. **The only difference
+                    between a number Olumi invented and one the user wrote was
+                    the digits.**
+
+                    ⚠ INLINE, NOT IN "Where it came from" AND NOT BEHIND A
+                    HOVER. A disclosure a user has to go and look for is a
+                    disclosure that arrives after they have already believed the
+                    number. It costs no extra interaction: it is in the same
+                    glance as the figure it qualifies.
+
+                    ⚠ IT CLASSIFIES THROUGH THE **INTERVENTION** VOCABULARY, not
+                    the node one the pill below uses. `cee_hypothesis` is not an
+                    `observed_state.source` literal and never was — see
+                    `InterventionProvenanceMark`.
+
+                    ⚠ NO STAMP ⇒ NOTHING RENDERS. Unknown stays unknown.
+                  */}
+                  <span data-testid={`model-detail-v2-intervention-${iv.factorId}-provenance`}>
+                    <InterventionProvenanceMark source={iv.provenanceSource} />
+                  </span>
                 </li>
               )
             })}
@@ -247,7 +356,25 @@ export function ModelDetailRegion({
         </section>
       )}
 
-      {/* 3 — Where it came from */}
+      {/*
+        3 — Where it came from.
+
+        ⚠ THE HEADING IS NOT RENDERED WHEN NOTHING WOULD SIT UNDER IT. On the
+        deployed build (UI `88cb7e37`) this section rendered on an OPTION as a
+        heading with an empty body: an option node carries no `observedState`,
+        so `row.provenanceSource` is absent and `basis` is `null`, and the pane
+        announced that provenance had been looked for and none exists — on the
+        one element whose provenance is the finding. That is the same rule
+        `FieldList` above already applies and the same rule this file states in
+        its own words: absence is rendered as absence, never as a blank cell.
+
+        ⚠ THE PREDICATE IS DERIVED FROM WHAT EACH CHILD ACTUALLY RENDERS, not
+        from "is the field present". `SourceProvenancePill` with
+        `showWhenAbsent={false}` renders nothing for an empty string, so a
+        `provenanceSource: ''` would satisfy `!== undefined` and reproduce the
+        empty heading this gate exists to remove.
+      */}
+      {(hasProvenanceContent(row.provenanceSource, detail)) && (
       <section data-testid="model-detail-v2-provenance">
         <h4 className={`${typography.label} text-text-header`}>Where it came from</h4>
         {row.provenanceSource !== undefined && (
@@ -271,6 +398,7 @@ export function ModelDetailRegion({
           </ul>
         )}
       </section>
+      )}
 
       {/* 4 — What it affects */}
       <section data-testid="model-detail-v2-affects">

--- a/src/canvas/model-tab-v2/__tests__/interventionProvenanceIsDisclosed.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/interventionProvenanceIsDisclosed.spec.tsx
@@ -1,0 +1,513 @@
+/**
+ * ⭐ AN INVENTED TARGET MUST NOT LOOK LIKE A NUMBER THE USER WROTE (B1-a).
+ *
+ * ## The defect this file pins, witnessed on the deployed build
+ *
+ * UI `88cb7e37` · CEE `d1da670`, fresh guest, 2026-08-24. On ONE draw, on ONE
+ * factor, the product produced the discriminating pair:
+ *
+ *   · `cee_hypothesis`   raw 22,500, no unit, `value_confidence: low`,
+ *     CEE's own reasoning "this amount is not stated in the brief" → 0.45
+ *   · `brief_extraction` raw 45,000, unit `£`, `value_confidence: high`,
+ *     reasoning naming `stated_items[3]` verbatim → 0.9
+ *
+ * Both rendered in the same control, same typography, no unit on either, no
+ * badge, icon, colour or tooltip on either. **The only difference between a
+ * number Olumi invented and one the user wrote was the digits.**
+ *
+ * The data was never the problem — every field above is correct on the wire.
+ * `unwrapInterventionValue` returned `{value, displayValue}` and threw `source`
+ * away at the ONE point every render surface reads an intervention through, so
+ * nothing downstream still had the fact to show.
+ *
+ * ## Why the fixtures are the wire's, verbatim
+ *
+ * Trap 22: a corpus drawn from the author's head cannot see the class the author
+ * did not imagine. Every intervention object below is copied byte-for-byte from
+ * `drawA-11-autosave-raw.json` — the canonical client-side model captured from
+ * the deployed build — including the two that a fixture written from the defect
+ * report would NOT have contained:
+ *
+ *   1. `raw_value: 0` invented targets. Half the invented interventions on that
+ *      draw are ZERO. A guard keyed on "22,500 is missing" sees nothing here.
+ *   2. `682a7e2d` — an option whose own `provenance` is `from_brief` and which
+ *      nevertheless carries an INVENTED intervention. **Option-level provenance
+ *      does not predict intervention-level provenance**, so a disclosure bound
+ *      to the option node would be wrong on this row and right on the other two
+ *      — the shape of test that passes on the wrong object (trap 19).
+ *
+ * ## Binding
+ *
+ * Every value assertion resolves its row BY `factorId` through `within(...)`,
+ * never by the digits. `0.45` is a value predicate a different intervention
+ * could satisfy, and reading it off the whole pane is precisely how this estate
+ * shipped a spec that passed against a factor it was not written for.
+ *
+ * Every "invented is marked" case has its OPPOSITE-DIRECTION TWIN asserting the
+ * user-stated row is NOT marked as invented (trap 22b). The inversion is the
+ * live defect on the deployed build — the twin is the load-bearing half.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { ModelDetailRegion } from '../ModelDetailRegion'
+import { toRowDetail, type ModelProjectionInput } from '../adapters'
+import type { ModelRow } from '../types'
+import { unwrapInterventionValue } from '../../utils/labelUtils'
+import {
+  INTERVENTION_PROVENANCE_SOURCES,
+  classifyInterventionProvenance,
+  classifyValueProvenance,
+} from '../../domain/valueProvenance'
+
+// ── The deployed draw, verbatim ──────────────────────────────────────────────
+
+const FACTOR_LICENSING = '440d2e30'
+const FACTOR_MIGRATION = 'fd255d32'
+const OPTION_PHASED = '6f2c97b3' // option provenance: ai_inferred
+const OPTION_STAYING = 'f259d659' // option provenance: from_brief
+const OPTION_FULL = '682a7e2d' // option provenance: from_brief — AND carries an invented target
+
+/** `f259d659[440d2e30]` — the user's own £45,000, bound to `stated_items[3]`. */
+const IV_STATED_45K = {
+  value: 0.9,
+  raw_value: 45000,
+  unit: '£',
+  source: 'brief_extraction',
+  target_match: { node_id: FACTOR_LICENSING, match_type: 'exact_id', confidence: 'high' },
+  value_confidence: 'high',
+  reasoning:
+    'Direct causal value bound by edge 3d61e986 to stated_items[3]: our annual Salesforce licensing is £45,000',
+}
+
+/** `6f2c97b3[440d2e30]` — the invented 22,500, exactly half the user's figure. */
+const IV_INVENTED_22K5 = {
+  value: 0.45,
+  raw_value: 22500,
+  source: 'cee_hypothesis',
+  target_match: { node_id: FACTOR_LICENSING, match_type: 'exact_id', confidence: 'high' },
+  value_confidence: 'low',
+  reasoning: 'Model-chosen intervention level; this amount is not stated in the brief',
+}
+
+/** `682a7e2d[440d2e30]` — INVENTED, and sitting on a `from_brief` option. */
+const IV_INVENTED_ZERO = {
+  value: 0,
+  raw_value: 0,
+  source: 'cee_hypothesis',
+  target_match: { node_id: FACTOR_LICENSING, match_type: 'exact_id', confidence: 'high' },
+  value_confidence: 'low',
+  reasoning: 'Model-chosen intervention level; this amount is not stated in the brief',
+}
+
+/** `682a7e2d[fd255d32]` — the user's own £20,000. */
+const IV_STATED_20K = {
+  value: 0.4,
+  raw_value: 20000,
+  unit: '£',
+  source: 'brief_extraction',
+  target_match: { node_id: FACTOR_MIGRATION, match_type: 'exact_id', confidence: 'high' },
+  value_confidence: 'high',
+  reasoning:
+    'Direct causal value bound by edge 36e4730e to stated_items[2]: A full switch costs £20,000 in migration and training',
+}
+
+/**
+ * A bare number. The Model tab's own intervention editor commits one of these,
+ * and CEE stamps nothing on it — so the honest answer for this row is that the
+ * record does not say, and the surface must say nothing rather than guess.
+ */
+const IV_UNSTAMPED = 0.6
+
+function factorNode(id: string, label: string): Node {
+  return {
+    id,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { label, type: 'factor', observedState: { value: 0.9, raw_value: 45000, source: 'cee_inference' } },
+  } as unknown as Node
+}
+
+/**
+ * ⚠ `provenance` IS ON THE FIXTURE AND IT IS LOAD-BEARING, NOT DECORATION.
+ *
+ * The option node carries its OWN `provenance` on the wire, and a plausible
+ * wrong implementation reads the mark off it. Omitting it from the fixture
+ * would make that implementation render NOTHING — so the suite would red for
+ * the wrong reason and would go green again the moment someone "fixed" the
+ * mapping. With it present, the wrong implementation renders CONFIDENTLY and
+ * is right on two of the three options, and only the discriminating case can
+ * tell the two apart. A fixture that cannot express the wrong answer cannot
+ * refute it (trap 19).
+ */
+function optionNode(
+  id: string,
+  label: string,
+  interventions: Record<string, unknown>,
+  provenance?: string,
+): Node {
+  return {
+    id,
+    type: 'option',
+    position: { x: 0, y: 0 },
+    data: { label, type: 'option', interventions, ...(provenance ? { provenance } : {}) },
+  } as unknown as Node
+}
+
+function projection(): ModelProjectionInput {
+  return {
+    nodes: [
+      factorNode(FACTOR_LICENSING, 'Annual CRM Licensing Cost'),
+      factorNode(FACTOR_MIGRATION, 'Migration and Training Cost'),
+      optionNode(
+        OPTION_PHASED,
+        'Phased HubSpot Migration (pilot team first)',
+        { [FACTOR_LICENSING]: IV_INVENTED_22K5 },
+        'ai_inferred',
+      ),
+      optionNode(
+        OPTION_STAYING,
+        'Staying on Salesforce',
+        { [FACTOR_LICENSING]: IV_STATED_45K },
+        'from_brief',
+      ),
+      // ⭐ THE DISCRIMINATING OPTION: `from_brief` at the option level, and an
+      // INVENTED target inside it. An implementation reading the option node is
+      // right on the two above and wrong here.
+      optionNode(
+        OPTION_FULL,
+        'move our whole sales team off Salesforce onto HubSpot this year',
+        { [FACTOR_LICENSING]: IV_INVENTED_ZERO, [FACTOR_MIGRATION]: IV_STATED_20K },
+        'from_brief',
+      ),
+    ],
+    edges: [],
+    goalThreshold: null,
+  }
+}
+
+function optionRow(id: string, label: string): ModelRow {
+  return { id, kind: 'option', group: 'options', label, primaryValue: '1 change', attention: [], editable: true }
+}
+
+/** The pill's own copy, keyed off the ONE classifier — never re-spelled here. */
+const AI_LABEL = 'AI estimate'
+const BRIEF_LABEL = 'From brief'
+const ABSENT_LABEL = 'Not set'
+
+function provenanceOf(factorId: string): HTMLElement | null {
+  return screen.queryByTestId(`model-detail-v2-intervention-${factorId}-provenance`)
+}
+
+// ── 1. The drop point ────────────────────────────────────────────────────────
+
+describe('⭐ unwrapInterventionValue carries the producer’s own source stamp', () => {
+  it('keeps `cee_hypothesis` on the invented target', () => {
+    expect(unwrapInterventionValue(IV_INVENTED_22K5).source).toBe('cee_hypothesis')
+  })
+
+  it('TWIN: keeps `brief_extraction` on the user-stated target', () => {
+    expect(unwrapInterventionValue(IV_STATED_45K).source).toBe('brief_extraction')
+  })
+
+  it('carries the stamp on a ZERO invented target — the value is not the signal', () => {
+    // Half the invented interventions on the witnessed draw are `raw_value: 0`.
+    // A carrier keyed on truthiness of the value drops every one of them.
+    expect(unwrapInterventionValue(IV_INVENTED_ZERO).source).toBe('cee_hypothesis')
+    expect(unwrapInterventionValue(IV_INVENTED_ZERO).value).toBe(0)
+  })
+
+  it('reports UNKNOWN as null — never a guessed stamp in either direction', () => {
+    expect(unwrapInterventionValue(IV_UNSTAMPED).source).toBeNull()
+    expect(unwrapInterventionValue({ value: 0.5 }).source).toBeNull()
+    expect(unwrapInterventionValue({ value: 0.5, source: '   ' }).source).toBeNull()
+    expect(unwrapInterventionValue({ value: 0.5, source: 42 }).source).toBeNull()
+    expect(unwrapInterventionValue(undefined).source).toBeNull()
+  })
+
+  it('does not disturb the numeric or display halves it already answered', () => {
+    // CONTRAST CONTROL: the additive field must not move the two answers every
+    // caller in the tree already depends on.
+    expect(unwrapInterventionValue(IV_INVENTED_22K5).value).toBe(0.45)
+    expect(unwrapInterventionValue(IV_STATED_45K).value).toBe(0.9)
+    expect(unwrapInterventionValue({ value: 0.3, display_value: '  High  ' }).displayValue).toBe('High')
+  })
+})
+
+// ── 2. The classifier — ONE authority, extended, not duplicated ──────────────
+
+describe('⭐ cee_hypothesis is classified by the ratified authority', () => {
+  it('classifies `cee_hypothesis` as the model’s own estimate', () => {
+    expect(classifyInterventionProvenance('cee_hypothesis')).toEqual({ kind: 'ai', userOwned: false })
+  })
+
+  it('TWIN: `brief_extraction` still classifies to the user’s brief, not to AI', () => {
+    expect(classifyInterventionProvenance('brief_extraction')).toEqual({
+      kind: 'brief',
+      userOwned: false,
+    })
+  })
+
+  it('classifies `user_specified` as the human’s own, and USER-OWNED', () => {
+    expect(classifyInterventionProvenance('user_specified')).toEqual({
+      kind: 'edited',
+      userOwned: true,
+    })
+  })
+
+  it('CONTRAST CONTROL: an unknown literal is still refused, not guessed', () => {
+    // Without this the three above are satisfiable by a classifier that returns
+    // a class for everything — which is the failure mode the module was
+    // written to end ("Estimated by Olumi" over a confirmed value).
+    expect(classifyInterventionProvenance('cee_hypothesis_v2')).toBeNull()
+    expect(classifyInterventionProvenance(undefined)).toBeNull()
+  })
+
+  /**
+   * ⭐⭐ THE HAND-WRITTEN CORPUS, because no derivation is available here.
+   *
+   * The vendored contract does not export the intervention literals — it says
+   * so itself: *"This package does not carry InterventionV3, so it does not
+   * carry that contract's screen either."* So the completeness check that
+   * `SOURCE_CLASSES` gets against `OBSERVED_STATE_SOURCE_LITERALS` cannot exist
+   * for this map, and a corpus pinned to the contract's own QUOTED enum is what
+   * notices the list going short (trap 12d).
+   */
+  it('⭐ CORPUS: classifies exactly the three literals the contract declares', () => {
+    // Quoted verbatim from the vendored 0.48.0 package,
+    // `dist/orchestrator/edit-tool-ops.js:235`, citing `cee-v3.ts:284`:
+    //   "an enum of `brief_extraction | cee_hypothesis | user_specified`"
+    // Asserted as a SET EQUALITY so this REDs if the map GROWS as well as if it
+    // shrinks — a corpus that only checks membership cannot see an invention.
+    expect([...INTERVENTION_PROVENANCE_SOURCES].sort()).toEqual([
+      'brief_extraction',
+      'cee_hypothesis',
+      'user_specified',
+    ])
+  })
+})
+
+/**
+ * ⭐⭐ THE TWO `source` FIELDS ARE DIFFERENT QUESTIONS WEARING ONE NAME.
+ *
+ * `observed_state.source` asks WHO PUT THIS VALUE HERE. `interventions[f].source`
+ * asks HOW THIS TARGET WAS DETERMINED. The vendored contract states the
+ * distinction outright and CEE exempts the interventions subtree from its
+ * observed-state screen because of it.
+ *
+ * They OVERLAP on `brief_extraction` and are otherwise disjoint — which is what
+ * makes merging them look harmless. This lane tried the merge first: adding
+ * `cee_hypothesis` to `SOURCE_CLASSES` typechecks, renders the right words, and
+ * REDs `sourceClassesCompleteness` — the one guard that can see contract drift.
+ * These cases pin the separation so a future tidy-up cannot quietly re-merge it.
+ */
+describe('⭐⭐ the two source vocabularies stay apart', () => {
+  it('the node classifier REFUSES an intervention-only literal', () => {
+    expect(classifyValueProvenance('cee_hypothesis')).toBeNull()
+    expect(classifyValueProvenance('user_specified')).toBeNull()
+  })
+
+  it('the intervention classifier REFUSES a node-only literal', () => {
+    expect(classifyInterventionProvenance('cee_inference')).toBeNull()
+    expect(classifyInterventionProvenance('user_confirmed')).toBeNull()
+    expect(classifyInterventionProvenance('panel_elicited')).toBeNull()
+  })
+
+  it('CONTRAST CONTROL: they agree on the ONE literal both vocabularies declare', () => {
+    // Without this the two refusals above are satisfiable by two classifiers
+    // that refuse everything — an absence probe with no proof it sees a
+    // presence (trap 13).
+    expect(classifyValueProvenance('brief_extraction')?.kind).toBe('brief')
+    expect(classifyInterventionProvenance('brief_extraction')?.kind).toBe('brief')
+  })
+})
+
+// ── 3. The projection ────────────────────────────────────────────────────────
+
+describe('⭐ the option projection carries each intervention’s OWN provenance', () => {
+  it('stamps the invented target `cee_hypothesis`, bound by factor id', () => {
+    const detail = toRowDetail(projection(), OPTION_PHASED)
+    const iv = detail?.interventions.find(i => i.factorId === FACTOR_LICENSING)
+    expect(iv?.provenanceSource).toBe('cee_hypothesis')
+  })
+
+  it('TWIN: stamps the user-stated target `brief_extraction`, bound by factor id', () => {
+    const detail = toRowDetail(projection(), OPTION_STAYING)
+    const iv = detail?.interventions.find(i => i.factorId === FACTOR_LICENSING)
+    expect(iv?.provenanceSource).toBe('brief_extraction')
+  })
+
+  it('⭐ reads the INTERVENTION, never the option — one option carries both', () => {
+    // `682a7e2d`'s own provenance is `from_brief`, and it carries an invented
+    // target anyway. A disclosure bound to the option node reads "from brief"
+    // for both rows here and is right twice on the other two options — the
+    // exact shape of a guard that passes on the wrong object.
+    const detail = toRowDetail(projection(), OPTION_FULL)
+    const invented = detail?.interventions.find(i => i.factorId === FACTOR_LICENSING)
+    const stated = detail?.interventions.find(i => i.factorId === FACTOR_MIGRATION)
+    expect(invented?.provenanceSource).toBe('cee_hypothesis')
+    expect(stated?.provenanceSource).toBe('brief_extraction')
+  })
+
+  it('leaves an unstamped target UNSTAMPED', () => {
+    const input = projection()
+    const nodes = input.nodes.map(n =>
+      n.id === OPTION_PHASED
+        ? optionNode(
+            OPTION_PHASED,
+            'Phased HubSpot Migration (pilot team first)',
+            { [FACTOR_LICENSING]: IV_UNSTAMPED },
+            'ai_inferred',
+          )
+        : n,
+    )
+    const detail = toRowDetail({ ...input, nodes }, OPTION_PHASED)
+    const iv = detail?.interventions.find(i => i.factorId === FACTOR_LICENSING)
+    // CONTRAST CONTROL in the same assertion: the row still projects, with its
+    // value — so the absence below is a missing STAMP, not a missing row.
+    expect(iv).toBeDefined()
+    expect(iv?.numericValue).toBe(0.6)
+    expect(iv?.provenanceSource).toBeUndefined()
+  })
+})
+
+// ── 4. The surface — what the user actually reads ────────────────────────────
+
+describe('⭐ the detail region marks an invented target where the number is read', () => {
+  it('shows "AI estimate" on the invented row', () => {
+    const detail = toRowDetail(projection(), OPTION_PHASED)!
+    render(
+      <ModelDetailRegion
+        row={optionRow(OPTION_PHASED, 'Phased HubSpot Migration (pilot team first)')}
+        detail={detail}
+        tier="plain"
+      />,
+    )
+    expect(within(provenanceOf(FACTOR_LICENSING)!).getByText(AI_LABEL)).toBeInTheDocument()
+  })
+
+  it('⭐ TWIN: the user-stated row says "From brief" and is NOT marked as invented', () => {
+    // The load-bearing half. On the deployed build the product does the exact
+    // inverse elsewhere — it labels the user's own £45,000 "AI estimate" and
+    // tells them to check it first. Marking invention without this twin would
+    // leave that failure mode wide open on this surface too.
+    const detail = toRowDetail(projection(), OPTION_STAYING)!
+    render(
+      <ModelDetailRegion
+        row={optionRow(OPTION_STAYING, 'Staying on Salesforce')}
+        detail={detail}
+        tier="plain"
+      />,
+    )
+    const cell = provenanceOf(FACTOR_LICENSING)!
+    expect(within(cell).getByText(BRIEF_LABEL)).toBeInTheDocument()
+    expect(within(cell).queryByText(AI_LABEL)).toBeNull()
+  })
+
+  it('⭐ marks BOTH rows correctly on the same pane, each by its own stamp', () => {
+    // The discriminating case, rendered: one option, two rows, opposite marks.
+    // A surface reading the option node would render the same word twice.
+    const detail = toRowDetail(projection(), OPTION_FULL)!
+    render(
+      <ModelDetailRegion
+        row={optionRow(OPTION_FULL, 'move our whole sales team off Salesforce onto HubSpot this year')}
+        detail={detail}
+        tier="plain"
+      />,
+    )
+    expect(within(provenanceOf(FACTOR_LICENSING)!).getByText(AI_LABEL)).toBeInTheDocument()
+    expect(within(provenanceOf(FACTOR_MIGRATION)!).getByText(BRIEF_LABEL)).toBeInTheDocument()
+    expect(within(provenanceOf(FACTOR_LICENSING)!).queryByText(BRIEF_LABEL)).toBeNull()
+    expect(within(provenanceOf(FACTOR_MIGRATION)!).queryByText(AI_LABEL)).toBeNull()
+  })
+
+  it('marks the ZERO invented target too — the mark tracks the stamp, not the digits', () => {
+    const detail = toRowDetail(projection(), OPTION_FULL)!
+    render(
+      <ModelDetailRegion
+        row={optionRow(OPTION_FULL, 'full switch')}
+        detail={detail}
+        tier="plain"
+      />,
+    )
+    // CONTRAST CONTROL: the value itself renders, and it is the falsy one.
+    expect(
+      screen.getByTestId(`model-detail-v2-intervention-${FACTOR_LICENSING}-value`),
+    ).toHaveTextContent('0')
+    expect(within(provenanceOf(FACTOR_LICENSING)!).getByText(AI_LABEL)).toBeInTheDocument()
+  })
+
+  it('⭐ says NOTHING for an unstamped target — unknown stays unknown', () => {
+    const input = projection()
+    const nodes = input.nodes.map(n =>
+      n.id === OPTION_PHASED
+        ? optionNode(OPTION_PHASED, 'Phased', { [FACTOR_LICENSING]: IV_UNSTAMPED }, 'ai_inferred')
+        : n,
+    )
+    const detail = toRowDetail({ ...input, nodes }, OPTION_PHASED)!
+    render(<ModelDetailRegion row={optionRow(OPTION_PHASED, 'Phased')} detail={detail} tier="plain" />)
+    // Neither claim, and not the pill's "Not set" fallback either: "Not set"
+    // is a statement about the VALUE, and the value is set — it is the
+    // provenance that is unrecorded. Asserting it in all three directions is
+    // what stops "no source" quietly becoming "AI estimate" or "From brief".
+    const row = screen.getByTestId(`model-detail-v2-intervention-${FACTOR_LICENSING}`)
+    expect(within(row).queryByText(AI_LABEL)).toBeNull()
+    expect(within(row).queryByText(BRIEF_LABEL)).toBeNull()
+    expect(within(row).queryByText(ABSENT_LABEL)).toBeNull()
+    // CONTRAST CONTROL: the row is there and shows its value, so the three
+    // absences above are not the absence of the whole row (trap 13).
+    expect(
+      screen.getByTestId(`model-detail-v2-intervention-${FACTOR_LICENSING}-value`),
+    ).toHaveTextContent('0.6')
+  })
+
+  it('the mark is TEXT, not colour alone', () => {
+    const detail = toRowDetail(projection(), OPTION_PHASED)!
+    render(<ModelDetailRegion row={optionRow(OPTION_PHASED, 'Phased')} detail={detail} tier="plain" />)
+    // A border-colour-only distinction is invisible to a monochrome reader and
+    // to anyone who cannot compare two rows side by side.
+    expect(provenanceOf(FACTOR_LICENSING)!.textContent?.trim()).toBe(AI_LABEL)
+  })
+
+  it('the mark is visible in PLAIN — it is not an Advanced parameter', () => {
+    // Trap 3b at tier grain: a disclosure that only exists behind the Advanced
+    // toggle is a disclosure most users never load.
+    const detail = toRowDetail(projection(), OPTION_PHASED)!
+    const { rerender } = render(
+      <ModelDetailRegion row={optionRow(OPTION_PHASED, 'Phased')} detail={detail} tier="plain" />,
+    )
+    expect(provenanceOf(FACTOR_LICENSING)).not.toBeNull()
+    rerender(<ModelDetailRegion row={optionRow(OPTION_PHASED, 'Phased')} detail={detail} tier="advanced" />)
+    expect(provenanceOf(FACTOR_LICENSING)).not.toBeNull()
+  })
+})
+
+// ── 5. "Where it came from" stops promising an answer it does not have ───────
+
+describe('an empty "Where it came from" is an absence, and renders as one', () => {
+  it('does not render the heading when there is nothing under it', () => {
+    // The witnessed defect: on an option the heading rendered with NOTHING
+    // beneath it — a section announcing that provenance was looked for and
+    // none exists, on the exact element whose provenance is the finding.
+    const detail = toRowDetail(projection(), OPTION_PHASED)!
+    expect(detail.basis).toBeNull()
+    expect(detail.adjustments).toHaveLength(0)
+    render(<ModelDetailRegion row={optionRow(OPTION_PHASED, 'Phased')} detail={detail} tier="plain" />)
+    expect(screen.queryByTestId('model-detail-v2-provenance')).toBeNull()
+    expect(screen.queryByText('Where it came from')).toBeNull()
+  })
+
+  it('POSITIVE CONTROL: it still renders when it HAS something to say', () => {
+    const detail = toRowDetail(projection(), OPTION_PHASED)!
+    render(
+      <ModelDetailRegion
+        row={{ ...optionRow(OPTION_PHASED, 'Phased'), provenanceSource: 'brief_extraction' }}
+        detail={detail}
+        tier="plain"
+      />,
+    )
+    expect(screen.getByTestId('model-detail-v2-provenance')).toBeInTheDocument()
+    expect(screen.getByText('Where it came from')).toBeInTheDocument()
+  })
+})

--- a/src/canvas/model-tab-v2/adapters.ts
+++ b/src/canvas/model-tab-v2/adapters.ts
@@ -778,7 +778,7 @@ function buildOptionInterventions(
     const factorLabel = resolveCanvasLabel(factorId, labels)
     if (factorLabel === null) return []
     const numeric = interventionTargetValue(rawValue)
-    const { displayValue } = unwrapInterventionValue(rawValue)
+    const { displayValue, source } = unwrapInterventionValue(rawValue)
     // A CEE-authored `display_value` wins the DISPLAY (the F.6 passthrough the
     // v1 rows already honoured); the numeric half is independent of it.
     const value = displayValue ?? (numeric === undefined ? null : formatSmartNumber(numeric))
@@ -788,6 +788,15 @@ function buildOptionInterventions(
         factorLabel,
         value,
         numericValue: numeric === undefined ? null : numeric,
+        /*
+         * ⭐ THE TARGET'S OWN STAMP, READ PER INTERVENTION (B1-a).
+         *
+         * ⚠ THE KEY IS OMITTED, NOT SET TO A PLACEHOLDER, when the record
+         * states no source. `provenanceSource: 'unknown'` or `: null` would
+         * both be a value the surface then has to special-case, and the surface
+         * that forgets to is the one that renders a guess. Absent is the fact.
+         */
+        ...(source === null ? {} : { provenanceSource: source }),
       },
     ]
   })

--- a/src/canvas/model-tab-v2/types.ts
+++ b/src/canvas/model-tab-v2/types.ts
@@ -246,6 +246,25 @@ export interface OptionInterventionField {
   factorLabel: string
   value: string | null
   numericValue: number | null
+  /**
+   * ⭐ WHO PUT **THIS TARGET** THERE — the RAW stamp the producer wrote
+   * (`'cee_hypothesis'`, `'brief_extraction'`, …), classified at the surface by
+   * the one authority, exactly as `ModelRow.provenanceSource` is.
+   *
+   * ⚠⚠ THIS IS THE INTERVENTION'S STAMP AND NOT THE OPTION'S, AND THE TWO
+   * GENUINELY DISAGREE. On the deployed witness draw (UI `88cb7e37`) option
+   * `682a7e2d` is `provenance: 'from_brief'` and carries an INVENTED target
+   * alongside a brief-extracted one. Sourcing this from the option node would
+   * be right on two of that draw's three options and wrong on the third, while
+   * looking correct in every screenshot anyone happened to take.
+   *
+   * ⚠ ABSENT MEANS THE RECORD DOES NOT SAY, and the surface must then say
+   * NOTHING. Not "AI estimate", not "From brief", and not the pill's "Not set"
+   * either — "Not set" is a claim about the VALUE, and the value is set. A
+   * default in any of those three directions is an invented provenance, which
+   * is the defect one level up from the one this field closes.
+   */
+  provenanceSource?: string
 }
 
 /**

--- a/src/canvas/utils/__tests__/labelUtils.spec.ts
+++ b/src/canvas/utils/__tests__/labelUtils.spec.ts
@@ -380,19 +380,19 @@ describe('denormaliseInterventionValue', () => {
 describe('unwrapInterventionValue', () => {
   describe('null and undefined', () => {
     it('returns { value: null, displayValue: null } for undefined', () => {
-      expect(unwrapInterventionValue(undefined)).toEqual({ value: null, displayValue: null })
+      expect(unwrapInterventionValue(undefined)).toEqual({ value: null, displayValue: null, source: null })
     })
     it('returns { value: null, displayValue: null } for null', () => {
-      expect(unwrapInterventionValue(null)).toEqual({ value: null, displayValue: null })
+      expect(unwrapInterventionValue(null)).toEqual({ value: null, displayValue: null, source: null })
     })
   })
 
   describe('primitive number', () => {
     it('returns finite numbers with null displayValue', () => {
-      expect(unwrapInterventionValue(0.1)).toEqual({ value: 0.1, displayValue: null })
-      expect(unwrapInterventionValue(0)).toEqual({ value: 0, displayValue: null })
-      expect(unwrapInterventionValue(-7)).toEqual({ value: -7, displayValue: null })
-      expect(unwrapInterventionValue(1_000_000)).toEqual({ value: 1_000_000, displayValue: null })
+      expect(unwrapInterventionValue(0.1)).toEqual({ value: 0.1, displayValue: null, source: null })
+      expect(unwrapInterventionValue(0)).toEqual({ value: 0, displayValue: null, source: null })
+      expect(unwrapInterventionValue(-7)).toEqual({ value: -7, displayValue: null, source: null })
+      expect(unwrapInterventionValue(1_000_000)).toEqual({ value: 1_000_000, displayValue: null, source: null })
     })
     it('returns value:null for NaN', () => {
       expect(unwrapInterventionValue(NaN).value).toBeNull()
@@ -405,7 +405,7 @@ describe('unwrapInterventionValue', () => {
 
   describe('CEEInterventionV3 / UIInterventionValue object', () => {
     it('extracts .value when raw is a {value} object', () => {
-      expect(unwrapInterventionValue({ value: 0.1 })).toEqual({ value: 0.1, displayValue: null })
+      expect(unwrapInterventionValue({ value: 0.1 })).toEqual({ value: 0.1, displayValue: null, source: null })
     })
     it('extracts .value from a full CEEInterventionV3 shape', () => {
       const intervention = {
@@ -415,7 +415,12 @@ describe('unwrapInterventionValue', () => {
         value_confidence: 'high',
         reasoning: 'Extracted from "£25k marketing budget"',
       }
-      expect(unwrapInterventionValue(intervention)).toEqual({ value: 25000, displayValue: null })
+      // The `source` half is now CARRIED, not dropped. This case is the exact
+      // shape B1-a was written for: a CEE intervention whose `source` says where
+      // the number came from, read through the ONE unwrap every render surface
+      // uses. Before 2026-08-24 it arrived here and was discarded.
+      expect(unwrapInterventionValue(intervention))
+        .toEqual({ value: 25000, displayValue: null, source: 'brief_extraction' })
     })
     it('returns value:null when .value is missing', () => {
       expect(unwrapInterventionValue({ source: 'brief_extraction' }).value).toBeNull()
@@ -448,16 +453,16 @@ describe('unwrapInterventionValue', () => {
   describe('display_value extraction (CEE-authored labels)', () => {
     it('returns value and displayValue together from V3 object', () => {
       expect(unwrapInterventionValue({ value: 0.85, display_value: 'High', source: 'cee' }))
-        .toEqual({ value: 0.85, displayValue: 'High' })
+        .toEqual({ value: 0.85, displayValue: 'High', source: 'cee' })
     })
     it('returns displayValue:null when display_value absent', () => {
-      expect(unwrapInterventionValue({ value: 0.5 })).toEqual({ value: 0.5, displayValue: null })
+      expect(unwrapInterventionValue({ value: 0.5 })).toEqual({ value: 0.5, displayValue: null, source: null })
     })
     it('preserves displayValue even when .value is null', () => {
       // Renderers that tolerate null value (e.g. FactorNode comparison rows)
       // can still show the CEE string. Computation sites drop on value==null.
       expect(unwrapInterventionValue({ value: null, display_value: 'no change' }))
-        .toEqual({ value: null, displayValue: 'no change' })
+        .toEqual({ value: null, displayValue: 'no change', source: null })
     })
     it('returns displayValue:null for empty string display_value', () => {
       expect(unwrapInterventionValue({ value: 0.3, display_value: '' }).displayValue).toBeNull()
@@ -468,7 +473,7 @@ describe('unwrapInterventionValue', () => {
     })
     it('trims surrounding whitespace on display_value', () => {
       expect(unwrapInterventionValue({ value: 0.3, display_value: '  High  ' }))
-        .toEqual({ value: 0.3, displayValue: 'High' })
+        .toEqual({ value: 0.3, displayValue: 'High', source: null })
     })
     it('returns displayValue:null for non-string display_value', () => {
       expect(unwrapInterventionValue({ value: 0.3, display_value: 42 }).displayValue).toBeNull()

--- a/src/canvas/utils/labelUtils.ts
+++ b/src/canvas/utils/labelUtils.ts
@@ -628,6 +628,40 @@ export interface UnwrappedIntervention {
   value: number | null
   /** CEE-authored human-readable label (trimmed), or null when absent. */
   displayValue: string | null
+  /**
+   * ⭐ THE PRODUCER'S OWN `source` STAMP FOR **THIS INTERVENTION** — the RAW
+   * literal (`'cee_hypothesis'`, `'brief_extraction'`, …), never a classified
+   * kind. `null` when the record does not state one.
+   *
+   * ⚠⚠ ADDED BECAUSE ITS ABSENCE HERE WAS THE WHOLE DEFECT (B1-a, deployed
+   * witness UI `88cb7e37` · CEE `d1da670`, 2026-08-24). Every render surface in
+   * the tree reads an intervention through this one function, so a field
+   * dropped here is a field no surface downstream can ever show. On the
+   * witnessed draw that meant a value CEE had invented — raw 22,500, no unit,
+   * `value_confidence: low`, and CEE's own reasoning saying *"this amount is
+   * not stated in the brief"* — rendered in the same control, the same
+   * typography and with no marker at all beside the user's own £45,000. **The
+   * only difference between a number Olumi invented and one the user wrote was
+   * the digits.**
+   *
+   * ⚠ THE LITERAL, NOT A KIND — the same rule `ModelRow.provenanceSource`
+   * states and for the same reason: `classifyValueProvenance` is the one
+   * authority, several literals classify to one kind, and an inverse map here
+   * would be a second hand-maintained mirror of the classifier (trap 12).
+   *
+   * ⚠ IT IS THE **INTERVENTION'S** STAMP, NOT THE OPTION'S. On the witnessed
+   * draw option `682a7e2d` carries `provenance: 'from_brief'` and an INVENTED
+   * target anyway, while its sibling target on the same option is the user's
+   * own £20,000. Reading provenance off the option node is right on two of that
+   * draw's three options and wrong on the third — a claim that passes on the
+   * wrong object (trap 19).
+   *
+   * ⚠ ONLY `source`. `reasoning` and `value_confidence` are deliberately NOT
+   * carried: `reasoning` is raw engine prose that this estate's surfaces put
+   * through `sanitiseDetail` before showing, and carrying a field no surface
+   * renders is dead weight that the next reader mistakes for a promise.
+   */
+  source: string | null
 }
 
 export function unwrapInterventionValue(raw: unknown): UnwrappedIntervention {
@@ -650,7 +684,20 @@ export function unwrapInterventionValue(raw: unknown): UnwrappedIntervention {
     }
   }
 
-  return { value, displayValue }
+  // The provenance stamp is independent of BOTH halves above — it may be
+  // present on an intervention whose value is null, and (as on the witnessed
+  // draw, where half the invented targets are `raw_value: 0`) on one whose
+  // value is falsy. Keyed on the string being non-blank, never on the value.
+  let source: string | null = null
+  if (raw != null && typeof raw === 'object' && 'source' in raw) {
+    const s = (raw as { source: unknown }).source
+    if (typeof s === 'string') {
+      const trimmed = s.trim()
+      if (trimmed.length > 0) source = trimmed
+    }
+  }
+
+  return { value, displayValue, source }
 }
 
 /**


### PR DESCRIPTION
## The defect, witnessed on the deployed build

UI `88cb7e37` · CEE `d1da670`, fresh disposable guest, 1280×800, 2026-08-24. On **one draw, on one factor** (`440d2e30` *Annual CRM Licensing Cost*) the product produced the discriminating pair, so nothing here is confounded:

| | invented | user-stated |
|---|---|---|
| `raw_value` | **22,500** | 45,000 |
| `unit` | — | `£` |
| `source` | **`cee_hypothesis`** | `brief_extraction` |
| `value_confidence` | `low` | `high` |
| `reasoning` | *"Model-chosen intervention level; **this amount is not stated in the brief**"* | *"…bound by edge `3d61e986` to `stated_items[3]`: our annual Salesforce licensing is £45,000"* |
| rendered | `Currently: 0.9 → [ 0.45 ]` | `Currently: 0.9 → [ 0.9 ]` |

Identical control, identical typography, no unit on either, no badge, tooltip, icon, colour or reasoning on either. **The only difference between a number Olumi invented and one the user wrote was the digits.**

Census over 41 rendered-text dumps and 16 mounted surfaces: `22,500` → 0 · `cee_hypothesis` → 0 · `not stated in the brief` → 0, against nine non-zero contrast controls in the same runs.

**The data was never wrong.** Every field above is correct on the wire. `unwrapInterventionValue` (`labelUtils.ts:633`) returned `{value, displayValue}` and discarded `source` at **the one point every render surface in the tree reads an intervention through**, so nothing downstream still had the fact to show.

## What changed

- **`labelUtils.ts`** — carry the producer's own `source` literal through the unwrap. Additive; the numeric and display halves are untouched.
- **`valueProvenance.ts`** — a **second** classifier, `classifyInterventionProvenance`, for the intervention vocabulary.
- **`model-tab-v2/{types,adapters}.ts`** — project each intervention's **own** stamp.
- **`model-tab-v2/ModelDetailRegion.tsx`** — mark it **inline, beside the number, in Plain**. And *"Where it came from"* no longer renders a heading with nothing under it (on an option it always did — the one element whose provenance is the finding).

**No stamp renders no mark** — not `"Not set"`, which is a claim about the *value*, and the value is set. Unknown stays unknown.

## ⚠ The thing worth reviewing: the two `source` fields are different questions wearing one name

Adding `cee_hypothesis` to `SOURCE_CLASSES` was tried **first**. It typechecks, it renders the right words, and it REDs `sourceClassesCompleteness` — **correctly**. The vendored contract says so itself (`@talchain/schemas@0.48.0`, `dist/orchestrator/edit-tool-ops.js:229-238`):

> *"`source` IS ONE OF ITS FIELDS (`cee-v3.ts:284` — an enum of `brief_extraction | cee_hypothesis | user_specified`, meaning HOW THE INTERVENTION WAS DETERMINED). **That is a different field from node `observed_state.source` wearing the same name**, and CEE exempts it for exactly this reason."*

- `OBSERVED_STATE_SOURCE_LITERALS` — 12 literals, "who put this value here". No `cee_hypothesis`.
- `InterventionV3.source` — 3 literals, "how this target was determined". Not exported by the package.

They **overlap on `brief_extraction`** and are otherwise disjoint, which is exactly what makes the merge look harmless. Merging them would have answered a question about a factor's observed value that no producer asks, and would have permanently blinded the one guard able to see contract drift. **The kind taxonomy is shared; the literal vocabularies are not** — CLAUDE.md trap 21.

Because the contract does not export the intervention literals, no derivation is available: the guard is a **hand-written corpus pinned to the contract's own quoted enum**, asserted as a set equality so it REDs if the map grows *or* shrinks (trap 12d).

## Evidence

**RED-first at pristine** — 21 collected, **15 RED**, 6 green (contrast controls + the unknown-stays-unknown twins, vacuous at pristine and proven non-vacuous by M3).
**Now** — `interventionProvenanceIsDisclosed.spec.tsx` **26/26**, asserted by name and count.

Every fixture is copied byte-for-byte from `drawA-11-autosave-raw.json`, the deployed capture — including two things a fixture written from the defect report would not contain: `raw_value: 0` invented targets (half the invented ones on that draw), and option `682a7e2d`, which is `provenance: from_brief` **and carries an invented target anyway**.

### Mutant kit (throwaway worktree outside the repo root; isolation proven by writing a sentinel and asserting the source unchanged — trap 9g; restores HEAD-relative — trap 9h; applied-check scoped to `src/`, control exactly 0)

| mutant | want | got |
|---|---|---|
| **M1** carrier severed at the drop point (the pristine defect restored) | RED | RED 11/26 |
| **M2** provenance read off the **option node** — plausible, confident, right on 2 of 3 options | RED | **RED 5/26 — exactly the discriminating cases** |
| **M3** unknown defaults to `'ai'` instead of rendering nothing | RED | RED 1/26 |
| **M4** carrier keyed on the value, so `raw_value: 0` loses its stamp | RED | RED 4/26 |
| **M5** labels inverted (the live deployed inversion, reproduced) | RED | RED 5/26 |
| **M6** the two vocabularies re-merged | RED | RED 1/26 **+ contract guard RED 1/4** |
| **M7** empty-heading gate removed | RED | RED 1/26 |
| **PAIR-B** a *different* value's rendering changed on the *same* panel | GREEN | **GREEN 26/26** |
| pristine + trailing control | GREEN | 30/30 both; applied-check 0 |

M2 ∧ PAIR-B is the discriminating pair: neither alone shows binding.

⚠ M2's first form produced invalid TS and collected **zero** tests — an unapplied mutation is indistinguishable from an equivalent one. Rebuilt as valid TypeScript and re-run; the table shows the rebuilt result.

Local: `pnpm typecheck` PASSED, ratchet **2252 / baseline 2252** · `pnpm lint` 0 errors, hooks ratchet exactly at baseline.

## Scope — what this PR does NOT do

**Defect 2 (the inversion) is not fixable in the UI and is deliberately untouched.** On the witnessed draw factor `440d2e30` carries `observedState.source: 'cee_inference'`, `provenance: 'ai_inferred'`, `extractionType: 'inferred'` — with `raw_value: 45000`, the user's own figure. Every provenance-bearing field on the factor says AI. The UI badges read it faithfully; correcting it client-side would be a second authority over a server fact (trap 21). The seam is CEE `src/cee/transforms/schema-v3.ts:329-330`, upstream of it the `extractionType` the model emits. Routed separately.

**The Inspector v2 Option panel** — the surface in the original finding — is outside this lane's seam and still shows `0.45` bare. `OptionPanel.tsx:118` already destructures `unwrapInterventionValue`, so the `source` this PR carries is one field away for whoever owns that directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
