### PR TITLE
feat(panel): surface causal-structure absence on opening a model

### DIFF
--- a/src/canvas/components/pre-analysis-v3/__tests__/PreAnalysisPanelV3.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/__tests__/PreAnalysisPanelV3.spec.tsx
@@ -182,6 +182,36 @@ describe('setup state', () => {
     expect(screen.getByTestId('pre-analysis-v3-sharpen-reveal')).toHaveTextContent('Show fewer')
   })
 
+  it('keeps a structural gap visible on first paint when count signals also fire', () => {
+    // This is the exact cap collision from the #829 review: two options and two
+    // risks make both count signals live, while both options act on the same
+    // immediate target. The structural finding must not sit third behind them.
+    useCanvasStore.setState({
+      edges: [edge('o1', 'f1'), edge('o2', 'f1'), edge('f1', 'r1'), edge('f1', 'g1')],
+    })
+
+    renderPanel()
+
+    const sharpen = screen.getByTestId('pre-analysis-v3-sharpen')
+    expect(sharpen).toHaveTextContent(
+      'All two options act through exactly the same parts of the model.',
+    )
+    expect(screen.getAllByTestId(/pre-analysis-v3-signal-/)).toHaveLength(2)
+    expect(screen.getByTestId('pre-analysis-v3-signal-sig_structural_absence')).toBeVisible()
+    expect(screen.getByTestId('pre-analysis-v3-signal-sig_option_breadth')).toBeVisible()
+    expect(screen.queryByTestId('pre-analysis-v3-signal-sig_risk_count')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('pre-analysis-v3-sharpen-reveal'))
+    expect(
+      screen.getAllByTestId(/pre-analysis-v3-signal-/).map(el => el.getAttribute('data-testid')),
+    ).toEqual([
+      'pre-analysis-v3-signal-sig_structural_absence',
+      'pre-analysis-v3-signal-sig_option_breadth',
+      'pre-analysis-v3-signal-sig_risk_count',
+      'pre-analysis-v3-signal-sig_estimates',
+    ])
+  })
+
   it('a live CEE row counts within the cap and never pushes the visible set beyond it', () => {
     useCanvasStore.setState({
       ceeAnalysisReady: {

--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -193,8 +193,8 @@ export const SIGNAL_COPY = {
     emphasis: 'Connect the downside to the options it threatens, so the analysis can weigh it.',
   }),
   structuralSharedMechanism: (optionCount: number) => ({
-    lead: `All ${optionCount === 2 ? 'two' : String(optionCount)} options act through exactly the same factors.`,
-    emphasis: 'Options that differ only in degree give the analysis little to separate.',
+    lead: `All ${optionCount === 2 ? 'two' : String(optionCount)} options act through exactly the same parts of the model.`,
+    emphasis: 'These may be variations on one route rather than genuinely different approaches.',
   }),
   structuralNoExternalFactor: {
     lead: 'Nothing outside your control is modelled.',
@@ -203,7 +203,7 @@ export const SIGNAL_COPY = {
   structuralNoDownsideRationale:
     'Downside paths: an option connected only to benefits cannot lose. Linking each option to the harms it risks lets the analysis trade one against the other instead of ranking upside alone.',
   structuralSharedMechanismRationale:
-    'Mechanism diversity: when every option drives the same factors, they are settings of one lever rather than alternatives. A route that works through a different mechanism is what widens the decision.',
+    'Mechanism diversity: when every option acts on the same immediate parts of the model, they may be settings of one lever rather than alternatives. A route that works through a different mechanism is what widens the decision.',
   structuralNoExternalFactorRationale:
     'Controllability (Howard): separating what you decide from what you merely endure shows where choice actually operates, and stops a model that quietly assumes the world holds still.',
 } as const

--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -179,6 +179,33 @@ export const SIGNAL_COPY = {
     'Checking estimates: replacing the highest-influence estimates with your judgement usually helps the analysis. Influence comes from a quick structural pass of your model.',
   ceeBiasRationale:
     'A reflective check from Olumi, based on the structure of your model. Worth a thought, not a verdict.',
+  /**
+   * Structural absence — what the model's SHAPE does not contain.
+   *
+   * These three read the causal structure, not counts, so they say something
+   * the presence signals above cannot. Each one only ever fires when its
+   * precondition holds (see `selectors/computeStructuralAbsence.ts`), so every
+   * lead below is a statement about the user's model, never about a field we
+   * failed to populate.
+   */
+  structuralNoDownside: (optionCount: number) => ({
+    lead: `Nothing bad happens on any of your ${optionCount === 2 ? 'two' : String(optionCount)} options.`,
+    emphasis: 'Connect the downside to the options it threatens, so the analysis can weigh it.',
+  }),
+  structuralSharedMechanism: (optionCount: number) => ({
+    lead: `All ${optionCount === 2 ? 'two' : String(optionCount)} options act through exactly the same factors.`,
+    emphasis: 'Options that differ only in degree give the analysis little to separate.',
+  }),
+  structuralNoExternalFactor: {
+    lead: 'Nothing outside your control is modelled.',
+    emphasis: 'Naming what you do not control shows which outcomes you can actually move.',
+  },
+  structuralNoDownsideRationale:
+    'Downside paths: an option connected only to benefits cannot lose. Linking each option to the harms it risks lets the analysis trade one against the other instead of ranking upside alone.',
+  structuralSharedMechanismRationale:
+    'Mechanism diversity: when every option drives the same factors, they are settings of one lever rather than alternatives. A route that works through a different mechanism is what widens the decision.',
+  structuralNoExternalFactorRationale:
+    'Controllability (Howard): separating what you decide from what you merely endure shows where choice actually operates, and stops a model that quietly assumes the world holds still.',
 } as const
 
 /**

--- a/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
@@ -26,6 +26,7 @@ import { computeEstimateRanking } from '../selectors/computeEstimateRanking'
 import { computeGraphFacts, computeProvenanceCounts } from '../selectors/graphFacts'
 import { computeInfluenceCoverage } from '../selectors/computeInfluenceCoverage'
 import { computeLadder } from '../selectors/computeLadder'
+import { computeStructuralAbsence } from '../selectors/computeStructuralAbsence'
 import { computeSuccessState, type SuccessState } from '../selectors/computeSuccessState'
 import { buildEstimateRows, topUncalibrated } from '../selectors/buildEstimateRows'
 import { deriveSignalViews } from '../signals/deriveSignalViews'
@@ -299,6 +300,18 @@ export function usePreAnalysisModel(): PreAnalysisModel {
    */
   const isSavedExample = useMemo(() => resolveStarterId(nodes) != null, [nodes])
 
+  /**
+   * Causal-structure absence — the one thing the model's SHAPE does not contain.
+   *
+   * Keyed on the store's own nodes/edges, the same slices every other v3
+   * selector reads, so the panel and the canvas can never disagree about the
+   * structure being described.
+   */
+  const structuralAbsence = useMemo(
+    () => computeStructuralAbsence(nodes, edges),
+    [nodes, edges],
+  )
+
   const derived = useMemo(
     () =>
       deriveSignalViews(
@@ -313,10 +326,11 @@ export function usePreAnalysisModel(): PreAnalysisModel {
           isSavedExample,
           narrowFramingDetail,
           biasFindingExplanation,
+          structuralAbsence,
         },
         seen,
       ),
-    [facts, success.isSet, provenance.aiEstimatedCount, top, isSavedExample, narrowFramingDetail, biasFindingExplanation, seen],
+    [facts, success.isSet, provenance.aiEstimatedCount, top, isSavedExample, narrowFramingDetail, biasFindingExplanation, structuralAbsence, seen],
   )
 
   useEffect(() => {

--- a/src/canvas/components/pre-analysis-v3/selectors/__tests__/computeStructuralAbsence.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/selectors/__tests__/computeStructuralAbsence.spec.ts
@@ -122,17 +122,17 @@ describe('computeStructuralAbsence — no_downside', () => {
 })
 
 describe('computeStructuralAbsence — shared_mechanism', () => {
-  it('fires when every option targets the identical factor set', () => {
+  it('fires when every option targets the identical set, regardless of target kind', () => {
     const nodes = [
       node('o1', 'option'),
       node('o2', 'option'),
-      node('f1', 'factor', { category: 'external' }),
+      node('x1', 'outcome'),
       node('r1', 'risk'),
     ]
     const edges = [
-      edge('e1', 'o1', 'f1'),
-      edge('e2', 'o2', 'f1'),
-      edge('e3', 'f1', 'r1'),
+      edge('e1', 'o1', 'x1'),
+      edge('e2', 'o2', 'x1'),
+      edge('e3', 'x1', 'r1'),
     ]
     expect(computeStructuralAbsence(nodes, edges)).toEqual({
       kind: 'shared_mechanism',
@@ -228,6 +228,38 @@ describe('computeStructuralAbsence — no_external_factor', () => {
       node('o2', 'option'),
       node('f1', 'factor'),
       node('f2', 'factor'),
+      node('r1', 'risk'),
+    ]
+    const edges = [
+      edge('e1', 'o1', 'f1'),
+      edge('e2', 'o2', 'f2'),
+      edge('e3', 'f1', 'r1'),
+    ]
+    expect(computeStructuralAbsence(nodes, edges)).toBeNull()
+  })
+
+  it("PRECONDITION: treats controllability 'unknown' as unknown, not as non-external", () => {
+    const nodes = [
+      node('o1', 'option'),
+      node('o2', 'option'),
+      node('f1', 'factor', { controllability: 'unknown' }),
+      node('f2', 'factor', { controllability: 'unknown' }),
+      node('r1', 'risk'),
+    ]
+    const edges = [
+      edge('e1', 'o1', 'f1'),
+      edge('e2', 'o2', 'f2'),
+      edge('e3', 'f1', 'r1'),
+    ]
+    expect(computeStructuralAbsence(nodes, edges)).toBeNull()
+  })
+
+  it('PRECONDITION: one unknown factor holds the whole absence claim closed', () => {
+    const nodes = [
+      node('o1', 'option'),
+      node('o2', 'option'),
+      node('f1', 'factor', { category: 'controllable' }),
+      node('f2', 'factor', { controllability: 'unknown' }),
       node('r1', 'risk'),
     ]
     const edges = [

--- a/src/canvas/components/pre-analysis-v3/selectors/__tests__/computeStructuralAbsence.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/selectors/__tests__/computeStructuralAbsence.spec.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect } from 'vitest'
+import type { Edge, Node } from '@xyflow/react'
+import {
+  computeStructuralAbsence,
+  type StructuralAbsenceKind,
+} from '../computeStructuralAbsence'
+
+function node(id: string, kind: string, data: Record<string, unknown> = {}): Node {
+  return { id, type: kind, position: { x: 0, y: 0 }, data: { kind, label: id, ...data } } as Node
+}
+
+function edge(id: string, source: string, target: string, data: Record<string, unknown> = {}): Edge {
+  return { id, source, target, data } as Edge
+}
+
+/** A producer-stated negative edge — `directionSource` is what makes it readable. */
+function negativeEdge(id: string, source: string, target: string): Edge {
+  return edge(id, source, target, { direction: 'negative', directionSource: 'cee' })
+}
+
+/**
+ * Two options acting through DIFFERENT factors, each reaching a modelled risk.
+ * This is the "healthy" baseline: every check's precondition holds and none of
+ * them fires. Each test below perturbs exactly one thing away from it, so a
+ * finding can only be attributed to that perturbation.
+ */
+function healthyGraph(): { nodes: Node[]; edges: Edge[] } {
+  return {
+    nodes: [
+      node('o1', 'option'),
+      node('o2', 'option'),
+      node('f1', 'factor', { category: 'controllable' }),
+      node('f2', 'factor', { category: 'external' }),
+      node('r1', 'risk'),
+    ],
+    edges: [
+      edge('e1', 'o1', 'f1'),
+      edge('e2', 'o2', 'f2'),
+      edge('e3', 'f1', 'r1'),
+    ],
+  }
+}
+
+describe('computeStructuralAbsence — gates', () => {
+  it('returns null when there are no edges', () => {
+    expect(computeStructuralAbsence([node('o1', 'option'), node('o2', 'option')], [])).toBeNull()
+  })
+
+  it('returns null below two options — sig_option_breadth owns that advice', () => {
+    const { nodes, edges } = healthyGraph()
+    const oneOption = nodes.filter(n => n.id !== 'o2')
+    expect(computeStructuralAbsence(oneOption, edges)).toBeNull()
+  })
+
+  it('returns null on the healthy baseline (no check fires)', () => {
+    const { nodes, edges } = healthyGraph()
+    expect(computeStructuralAbsence(nodes, edges)).toBeNull()
+  })
+
+  it('GLOBAL PRECONDITION: says nothing when an option acts on nothing', () => {
+    // The panel's own fixture shape: options wired to nothing, risks floating.
+    // The downside check would fire here by its own logic, and it would be the
+    // wrong thing to say — the model is not wired yet, which the ladder owns.
+    const nodes = [
+      node('o1', 'option'),
+      node('o2', 'option'),
+      node('r1', 'risk'),
+      node('r2', 'risk'),
+      node('f1', 'factor', { category: 'controllable' }),
+      node('g1', 'goal'),
+    ]
+    const edges = [edge('e1', 'f1', 'g1')]
+    expect(computeStructuralAbsence(nodes, edges)).toBeNull()
+  })
+})
+
+describe('computeStructuralAbsence — no_downside', () => {
+  it('fires when risks are modelled but no option reaches one', () => {
+    const { nodes } = healthyGraph()
+    // Drop the f1 → r1 link: the risk is now stranded.
+    const edges = [edge('e1', 'o1', 'f1'), edge('e2', 'o2', 'f2')]
+    const result = computeStructuralAbsence(nodes, edges)
+    expect(result).toEqual({ kind: 'no_downside', optionCount: 2 })
+  })
+
+  it('fires when a negative edge exists but no option reaches it', () => {
+    const nodes = [
+      node('o1', 'option'),
+      node('o2', 'option'),
+      node('f1', 'factor', { category: 'external' }),
+      node('f2', 'factor', { category: 'controllable' }),
+      node('x1', 'outcome'),
+      node('x2', 'outcome'),
+    ]
+    const edges = [
+      edge('e1', 'o1', 'f1'),
+      edge('e2', 'o2', 'f2'),
+      // Negative edge sits in a component no option can reach.
+      negativeEdge('e3', 'x1', 'x2'),
+    ]
+    expect(computeStructuralAbsence(nodes, edges)?.kind).toBe('no_downside')
+  })
+
+  it('does NOT fire when an option reaches a risk transitively', () => {
+    const { nodes, edges } = healthyGraph()
+    expect(computeStructuralAbsence(nodes, edges)).toBeNull()
+  })
+
+  it('PRECONDITION: says nothing when no downside is modelled at all', () => {
+    // No risk node, no negative edge → we cannot distinguish "options miss the
+    // downside" from "no downside exists". sig_risk_count owns this case.
+    const nodes = [
+      node('o1', 'option'),
+      node('o2', 'option'),
+      node('f1', 'factor', { category: 'external' }),
+      node('f2', 'factor', { category: 'controllable' }),
+    ]
+    const edges = [edge('e1', 'o1', 'f1'), edge('e2', 'o2', 'f2')]
+    const result = computeStructuralAbsence(nodes, edges)
+    expect(result?.kind).not.toBe('no_downside')
+  })
+})
+
+describe('computeStructuralAbsence — shared_mechanism', () => {
+  it('fires when every option targets the identical factor set', () => {
+    const nodes = [
+      node('o1', 'option'),
+      node('o2', 'option'),
+      node('f1', 'factor', { category: 'external' }),
+      node('r1', 'risk'),
+    ]
+    const edges = [
+      edge('e1', 'o1', 'f1'),
+      edge('e2', 'o2', 'f1'),
+      edge('e3', 'f1', 'r1'),
+    ]
+    expect(computeStructuralAbsence(nodes, edges)).toEqual({
+      kind: 'shared_mechanism',
+      optionCount: 2,
+    })
+  })
+
+  it('does NOT fire when option target sets differ', () => {
+    const { nodes, edges } = healthyGraph()
+    expect(computeStructuralAbsence(nodes, edges)).toBeNull()
+  })
+
+  it('PRECONDITION: says nothing when an option has no outgoing edge', () => {
+    const nodes = [
+      node('o1', 'option'),
+      node('o2', 'option'),
+      node('f1', 'factor', { category: 'external' }),
+      node('r1', 'risk'),
+    ]
+    // o2 is unconnected — a different defect. Claiming its mechanism "overlaps"
+    // would be a statement about an empty set.
+    const edges = [edge('e1', 'o1', 'f1'), edge('e3', 'f1', 'r1')]
+    expect(computeStructuralAbsence(nodes, edges)?.kind).not.toBe('shared_mechanism')
+  })
+})
+
+describe('computeStructuralAbsence — no_external_factor', () => {
+  it('fires when factors carry a category but none is external', () => {
+    const nodes = [
+      node('o1', 'option'),
+      node('o2', 'option'),
+      node('f1', 'factor', { category: 'controllable' }),
+      node('f2', 'factor', { category: 'observable' }),
+      node('r1', 'risk'),
+    ]
+    const edges = [
+      edge('e1', 'o1', 'f1'),
+      edge('e2', 'o2', 'f2'),
+      edge('e3', 'f1', 'r1'),
+    ]
+    expect(computeStructuralAbsence(nodes, edges)).toEqual({
+      kind: 'no_external_factor',
+      optionCount: 2,
+    })
+  })
+
+  it('does NOT fire when an external factor exists', () => {
+    const { nodes, edges } = healthyGraph()
+    expect(computeStructuralAbsence(nodes, edges)).toBeNull()
+  })
+
+  it('reads `controllability` when `category` is absent', () => {
+    const nodes = [
+      node('o1', 'option'),
+      node('o2', 'option'),
+      node('f1', 'factor', { controllability: 'external' }),
+      node('f2', 'factor', { controllability: 'controllable' }),
+      node('r1', 'risk'),
+    ]
+    const edges = [
+      edge('e1', 'o1', 'f1'),
+      edge('e2', 'o2', 'f2'),
+      edge('e3', 'f1', 'r1'),
+    ]
+    // An external factor IS present via controllability → must not fire.
+    expect(computeStructuralAbsence(nodes, edges)).toBeNull()
+  })
+
+  it('`category` takes precedence over `controllability`', () => {
+    const nodes = [
+      node('o1', 'option'),
+      node('o2', 'option'),
+      // category says controllable; the stale controllability says external.
+      node('f1', 'factor', { category: 'controllable', controllability: 'external' }),
+      node('f2', 'factor', { category: 'observable' }),
+      node('r1', 'risk'),
+    ]
+    const edges = [
+      edge('e1', 'o1', 'f1'),
+      edge('e2', 'o2', 'f2'),
+      edge('e3', 'f1', 'r1'),
+    ]
+    expect(computeStructuralAbsence(nodes, edges)?.kind).toBe('no_external_factor')
+  })
+
+  it('PRECONDITION: NEVER INVENTS — says nothing when no factor carries controllability metadata', () => {
+    // This is the fabrication guard. Without it, every graph whose factors CEE
+    // has not categorised would be told "nothing outside your control is
+    // modelled" — a claim about our own missing metadata dressed as a claim
+    // about the user's thinking.
+    const nodes = [
+      node('o1', 'option'),
+      node('o2', 'option'),
+      node('f1', 'factor'),
+      node('f2', 'factor'),
+      node('r1', 'risk'),
+    ]
+    const edges = [
+      edge('e1', 'o1', 'f1'),
+      edge('e2', 'o2', 'f2'),
+      edge('e3', 'f1', 'r1'),
+    ]
+    expect(computeStructuralAbsence(nodes, edges)).toBeNull()
+  })
+})
+
+describe('computeStructuralAbsence — one finding, fixed priority', () => {
+  it('no_downside outranks shared_mechanism when both hold', () => {
+    const nodes = [
+      node('o1', 'option'),
+      node('o2', 'option'),
+      node('f1', 'factor', { category: 'external' }),
+      node('r1', 'risk'),
+    ]
+    // Both options target only f1 (shared mechanism) AND the risk is stranded.
+    const edges = [edge('e1', 'o1', 'f1'), edge('e2', 'o2', 'f1')]
+    expect(computeStructuralAbsence(nodes, edges)?.kind).toBe('no_downside')
+  })
+
+  it('shared_mechanism outranks no_external_factor when both hold', () => {
+    const nodes = [
+      node('o1', 'option'),
+      node('o2', 'option'),
+      node('f1', 'factor', { category: 'controllable' }),
+      node('r1', 'risk'),
+    ]
+    const edges = [
+      edge('e1', 'o1', 'f1'),
+      edge('e2', 'o2', 'f1'),
+      edge('e3', 'f1', 'r1'),
+    ]
+    expect(computeStructuralAbsence(nodes, edges)?.kind).toBe('shared_mechanism')
+  })
+
+  it('returns at most one finding — the type admits exactly three kinds', () => {
+    const kinds: StructuralAbsenceKind[] = ['no_downside', 'shared_mechanism', 'no_external_factor']
+    expect(kinds).toHaveLength(3)
+  })
+})
+
+/**
+ * ⚠ PINNED DELIBERATE OMISSION — do not "complete the set".
+ *
+ * A fourth structural check, "no feedback anywhere", was named in the original
+ * brief. It is NOT implemented and must not be: the UI blocks cycle creation
+ * (`validation/graphGuardrails.wouldCreateCycle`) and CEE rejects cycles as a
+ * structural violation (`CYCLE_DETECTED`), so every graph is acyclic by
+ * construction. The check would fire on 100% of models and its advice would
+ * name an edit the product refuses.
+ *
+ * This test REDs if someone adds a feedback/cycle kind, forcing them to read
+ * the reasoning first. It is the KNOWN-DROPPED set, asserted exactly.
+ */
+describe('computeStructuralAbsence — the fourth check is deliberately absent', () => {
+  it('a graph the product could never produce (a cycle) yields no feedback finding', () => {
+    const nodes = [
+      node('o1', 'option'),
+      node('o2', 'option'),
+      node('f1', 'factor', { category: 'external' }),
+      node('f2', 'factor', { category: 'controllable' }),
+      node('r1', 'risk'),
+    ]
+    const edges = [
+      edge('e1', 'o1', 'f1'),
+      edge('e2', 'o2', 'f2'),
+      edge('e3', 'f1', 'r1'),
+      // deliberate cycle — impossible via the UI, constructed here on purpose
+      edge('e4', 'f1', 'f2'),
+      edge('e5', 'f2', 'f1'),
+    ]
+    const result = computeStructuralAbsence(nodes, edges)
+    // Whatever it returns — including nothing — it is never a feedback verdict.
+    expect(result === null || !/feedback|cycle|loop/.test(result.kind)).toBe(true)
+  })
+
+  it('the kind union admits no feedback member', () => {
+    // A compile-time truth asserted at runtime: if someone widens
+    // StructuralAbsenceKind with a feedback member, they must delete this test
+    // and read the reasoning above it.
+    const admitted: string[] = ['no_downside', 'shared_mechanism', 'no_external_factor']
+    expect(admitted.some(k => /feedback|cycle|loop/.test(k))).toBe(false)
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/selectors/computeStructuralAbsence.ts
+++ b/src/canvas/components/pre-analysis-v3/selectors/computeStructuralAbsence.ts
@@ -1,0 +1,208 @@
+/**
+ * computeStructuralAbsence — what the model does not contain, diagnosed from
+ * causal STRUCTURE alone (Paul, 2026-08-24: "Strategy fails on what is MISSING,
+ * and nothing in the default surfaces absence").
+ *
+ * The existing registry signals answer PRESENCE/COUNT questions — is there a
+ * goal, how many options, how many risks. Those are already live. This module
+ * answers the different question the panel could not previously ask: given the
+ * nodes and edges that ARE here, what SHAPE of reasoning is absent?
+ *
+ * ⚠ THREE CHECKS, NOT FOUR. The fourth structural check originally named —
+ * "no feedback anywhere" — IS NOT IMPLEMENTED AND MUST NOT BE. This product
+ * forbids feedback loops end to end: the UI blocks their creation
+ * (`validation/graphGuardrails.wouldCreateCycle`, wired into `ReactFlowGraph`
+ * and the edge-reversal context action) and CEE rejects them as a structural
+ * violation (`orchestrator/graph-structure-validator.ts`, `CYCLE_DETECTED`).
+ * Every graph reaching this selector is therefore acyclic BY CONSTRUCTION, so
+ * the check would fire on 100% of models — and its advice would name an edit
+ * the canvas physically refuses and the analyser rejects. A signal that is
+ * always true and never actionable is noise with a science badge on it.
+ *
+ * ⚠ NEVER INVENT AN ABSENCE. Each check carries a PRECONDITION naming the data
+ * it needs. When that data is not present the check does not run and this
+ * module returns `null` — it never reports "missing" about a field the model
+ * simply does not populate. This is the difference between "there is no
+ * external factor" and "nobody has told us which factors are external", and
+ * reporting the second as the first is the fabrication class this panel exists
+ * to avoid.
+ *
+ * ⚠ ONE FINDING, NOT A LIST. Checks run in a fixed priority order and the
+ * FIRST match wins ("three excellent suggestions beat twenty AI observations",
+ * Paul). The ranking is by how badly the absence distorts a decision:
+ *   1. no_downside        — the model can only say yes
+ *   2. shared_mechanism   — the options are not really alternatives
+ *   3. no_external_factor — the model assumes total control
+ *
+ * REUSE, NOT RE-SPELLING (trap 12). Edge direction comes from
+ * `resolveEdgeDirectionDisplay`, the read-side gate that already decides when a
+ * direction is knowable; node kind comes from `kindOf`. Neither predicate is
+ * restated here.
+ */
+
+import type { Edge, Node } from '@xyflow/react'
+import { resolveEdgeDirectionDisplay } from '../../../domain/edgeValueProvenance'
+import { kindOf } from './graphFacts'
+
+export type StructuralAbsenceKind = 'no_downside' | 'shared_mechanism' | 'no_external_factor'
+
+export interface StructuralAbsence {
+  kind: StructuralAbsenceKind
+  /** Options in the model when the finding fired — copy names the quantity. */
+  optionCount: number
+}
+
+/**
+ * Minimum shape before structural critique is meaningful.
+ *
+ * Below two options the foundational signals (`sig_goal_missing`,
+ * `sig_success_missing`, `sig_option_breadth`) are the right advice and already
+ * fire; adding "your options all act through the same factors" to a one-option
+ * sketch is noise, and it would double-report what `sig_option_breadth` owns.
+ */
+const MIN_OPTIONS_FOR_STRUCTURAL_CRITIQUE = 2
+
+function isExternalFactor(data: Record<string, unknown> | undefined): boolean {
+  // `category` takes precedence over `controllability` — the precedence is
+  // declared at `domain/nodes.ts` (`FactorNodeDataSchema.category`: "Explicit
+  // category from CEE analysis (takes precedence over derived controllability)").
+  const resolved = data?.category ?? data?.controllability
+  return resolved === 'external'
+}
+
+function hasControllabilitySignal(data: Record<string, unknown> | undefined): boolean {
+  return data?.category != null || data?.controllability != null
+}
+
+/** Forward-reachable node ids from `start`, following edge direction. */
+function forwardReachable(start: string, adjacency: Map<string, string[]>): Set<string> {
+  const seen = new Set<string>()
+  const stack = [start]
+  while (stack.length > 0) {
+    const current = stack.pop()!
+    for (const next of adjacency.get(current) ?? []) {
+      if (seen.has(next)) continue
+      seen.add(next)
+      stack.push(next)
+    }
+  }
+  return seen
+}
+
+export function computeStructuralAbsence(
+  nodes: ReadonlyArray<Node>,
+  edges: ReadonlyArray<Edge>,
+): StructuralAbsence | null {
+  if (edges.length === 0) return null
+
+  const optionIds: string[] = []
+  const riskIds = new Set<string>()
+  const factorNodes: Node[] = []
+
+  for (const node of nodes) {
+    switch (kindOf(node)) {
+      case 'option':
+        optionIds.push(node.id)
+        break
+      case 'risk':
+        riskIds.add(node.id)
+        break
+      case 'factor':
+        factorNodes.push(node)
+        break
+      default:
+        break
+    }
+  }
+
+  if (optionIds.length < MIN_OPTIONS_FOR_STRUCTURAL_CRITIQUE) return null
+
+  const adjacency = new Map<string, string[]>()
+  for (const edge of edges) {
+    const list = adjacency.get(edge.source)
+    if (list) list.push(edge.target)
+    else adjacency.set(edge.source, [edge.target])
+  }
+
+  /**
+   * ⚠ GLOBAL PRECONDITION: CAUSAL CRITIQUE PRESUPPOSES A CAUSAL STRUCTURE.
+   *
+   * Every option must have at least one outgoing edge. Where an option is
+   * connected to nothing, "nothing bad happens on any of your options" is
+   * TRUE and USELESS — nothing at all happens on them, and the honest finding
+   * is that the model is not wired yet, which the ladder and the foundational
+   * signals already say. Saying it in the language of downside blindness would
+   * dress an unwired sketch up as a reasoning flaw.
+   *
+   * Measured against the panel's own fixture (`PreAnalysisPanelV3.spec.tsx`):
+   * two options with no edges and two floating risks. Without this gate the
+   * downside check fires there, correctly by its own logic and wrongly as
+   * advice.
+   */
+  const everyOptionActs = optionIds.every(id => (adjacency.get(id)?.length ?? 0) > 0)
+  if (!everyOptionActs) return null
+
+  // ── 1. no_downside ────────────────────────────────────────────────────────
+  // PRECONDITION: the model must CONTAIN a downside to be blind to. Downside
+  // elements are risk nodes and edges the producer states are negative. With
+  // none of either, "no option reaches a downside" is indistinguishable from
+  // "no downside is modelled at all" — which `sig_risk_count` already owns, and
+  // reporting it here would be a second answer to one question.
+  const negativeEdges = edges.filter(e => {
+    const display = resolveEdgeDirectionDisplay(e.data as Record<string, unknown> | undefined)
+    return display.show && display.direction === 'negative'
+  })
+  const hasDownsideElement = riskIds.size > 0 || negativeEdges.length > 0
+  if (hasDownsideElement) {
+    const negativeEdgeSources = new Set(negativeEdges.map(e => e.source))
+    const anyOptionReachesDownside = optionIds.some(optionId => {
+      const reachable = forwardReachable(optionId, adjacency)
+      for (const id of reachable) {
+        if (riskIds.has(id)) return true
+        // A negative edge is traversed when its source is reachable (or is the
+        // option itself) — the option's causal path runs through a stated harm.
+        if (negativeEdgeSources.has(id)) return true
+      }
+      return negativeEdgeSources.has(optionId)
+    })
+    if (!anyOptionReachesDownside) {
+      return { kind: 'no_downside', optionCount: optionIds.length }
+    }
+  }
+
+  // ── 2. shared_mechanism ───────────────────────────────────────────────────
+  // PRECONDITION: every option must have at least one outgoing edge. An option
+  // with none is unconnected — a different defect, and claiming its mechanism
+  // "overlaps" would be a statement about an empty set.
+  const targetSets = optionIds.map(id => new Set(adjacency.get(id) ?? []))
+  if (targetSets.every(s => s.size > 0)) {
+    const [first, ...rest] = targetSets
+    const allIdentical = rest.every(
+      s => s.size === first.size && [...s].every(t => first.has(t)),
+    )
+    if (allIdentical) {
+      return { kind: 'shared_mechanism', optionCount: optionIds.length }
+    }
+  }
+
+  // ── 3. no_external_factor ─────────────────────────────────────────────────
+  // PRECONDITION: at least one factor must carry a controllability signal. When
+  // no factor does, the field is simply unpopulated and absence is unknowable —
+  // "nothing outside your control is modelled" would be a claim about our own
+  // missing metadata, dressed as a claim about the user's thinking.
+  if (factorNodes.length > 0) {
+    const anySignal = factorNodes.some(n =>
+      hasControllabilitySignal(n.data as Record<string, unknown> | undefined),
+    )
+    if (anySignal) {
+      const anyExternal = factorNodes.some(n =>
+        isExternalFactor(n.data as Record<string, unknown> | undefined),
+      )
+      if (!anyExternal) {
+        return { kind: 'no_external_factor', optionCount: optionIds.length }
+      }
+    }
+  }
+
+  return null
+}

--- a/src/canvas/components/pre-analysis-v3/selectors/computeStructuralAbsence.ts
+++ b/src/canvas/components/pre-analysis-v3/selectors/computeStructuralAbsence.ts
@@ -57,21 +57,35 @@ export interface StructuralAbsence {
  *
  * Below two options the foundational signals (`sig_goal_missing`,
  * `sig_success_missing`, `sig_option_breadth`) are the right advice and already
- * fire; adding "your options all act through the same factors" to a one-option
+ * fire; adding "your options all act through the same parts" to a one-option
  * sketch is noise, and it would double-report what `sig_option_breadth` owns.
  */
 const MIN_OPTIONS_FOR_STRUCTURAL_CRITIQUE = 2
 
-function isExternalFactor(data: Record<string, unknown> | undefined): boolean {
+type KnownControllability = 'controllable' | 'observable' | 'external' | 'partial'
+
+function isKnownControllability(value: unknown): value is KnownControllability {
+  return (
+    value === 'controllable' ||
+    value === 'observable' ||
+    value === 'external' ||
+    value === 'partial'
+  )
+}
+
+function resolveKnownControllability(
+  data: Record<string, unknown> | undefined,
+): KnownControllability | null {
   // `category` takes precedence over `controllability` — the precedence is
   // declared at `domain/nodes.ts` (`FactorNodeDataSchema.category`: "Explicit
   // category from CEE analysis (takes precedence over derived controllability)").
-  const resolved = data?.category ?? data?.controllability
-  return resolved === 'external'
-}
-
-function hasControllabilitySignal(data: Record<string, unknown> | undefined): boolean {
-  return data?.category != null || data?.controllability != null
+  // Presence is not knowledge: `controllability: 'unknown'` must hold the
+  // finding closed, and an invalid explicit category must not silently fall
+  // back to a weaker derived field.
+  if (data?.category != null) {
+    return isKnownControllability(data.category) ? data.category : null
+  }
+  return isKnownControllability(data?.controllability) ? data.controllability : null
 }
 
 /** Forward-reachable node ids from `start`, following edge direction. */
@@ -186,21 +200,18 @@ export function computeStructuralAbsence(
   }
 
   // ── 3. no_external_factor ─────────────────────────────────────────────────
-  // PRECONDITION: at least one factor must carry a controllability signal. When
-  // no factor does, the field is simply unpopulated and absence is unknowable —
-  // "nothing outside your control is modelled" would be a claim about our own
-  // missing metadata, dressed as a claim about the user's thinking.
+  // PRECONDITION: every factor must carry a known controllability value. One
+  // unknown factor is enough to make the absence unknowable — it could be the
+  // external factor — so "nothing outside your control is modelled" would be
+  // a claim about our own missing metadata, dressed as a claim about the
+  // user's thinking.
   if (factorNodes.length > 0) {
-    const anySignal = factorNodes.some(n =>
-      hasControllabilitySignal(n.data as Record<string, unknown> | undefined),
+    const resolved = factorNodes.map(n =>
+      resolveKnownControllability(n.data as Record<string, unknown> | undefined),
     )
-    if (anySignal) {
-      const anyExternal = factorNodes.some(n =>
-        isExternalFactor(n.data as Record<string, unknown> | undefined),
-      )
-      if (!anyExternal) {
-        return { kind: 'no_external_factor', optionCount: optionIds.length }
-      }
+    const everyFactorKnown = resolved.every(value => value !== null)
+    if (everyFactorKnown && !resolved.includes('external')) {
+      return { kind: 'no_external_factor', optionCount: optionIds.length }
     }
   }
 

--- a/src/canvas/components/pre-analysis-v3/signals/__tests__/estimatesAttribution.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/__tests__/estimatesAttribution.spec.ts
@@ -40,6 +40,7 @@ function input(overrides: Partial<SignalDetectionInput> = {}): SignalDetectionIn
     topUncalibrated: { id: 'f_snowflake', label: 'Snowflake-Native Build Adoption' },
     narrowFramingDetail: null,
     biasFindingExplanation: null,
+    structuralAbsence: null,
     isSavedExample: false,
     ...overrides,
   }

--- a/src/canvas/components/pre-analysis-v3/signals/__tests__/registry.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/__tests__/registry.spec.ts
@@ -40,18 +40,24 @@ function input(overrides: Partial<SignalDetectionInput> = {}): SignalDetectionIn
     isSavedExample: false,
     narrowFramingDetail: null,
     biasFindingExplanation: null,
+    structuralAbsence: null,
     ...overrides,
   }
 }
 
 describe('signal registry — exact id set (banned signals cannot exist)', () => {
-  it('contains exactly the six audited signals', () => {
+  it('contains exactly the seven audited signals', () => {
     expect(SIGNAL_REGISTRY.map(d => d.signal_id).sort()).toEqual([
       'sig_cee_bias',
       'sig_estimates',
       'sig_goal_missing',
       'sig_option_breadth',
       'sig_risk_count',
+      // Causal-structure absence — what the model's SHAPE does not contain.
+      // Added 2026-08-24; its own guards live in
+      // `signals/__tests__/structuralAbsenceSignal.spec.ts` and
+      // `selectors/__tests__/computeStructuralAbsence.spec.ts`.
+      'sig_structural_absence',
       'sig_success_missing',
     ])
   })

--- a/src/canvas/components/pre-analysis-v3/signals/__tests__/signalSession.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/__tests__/signalSession.spec.ts
@@ -66,6 +66,19 @@ describe('deriveSignalViews — lifecycle', () => {
     ])
   })
 
+  it('puts a live structural gap ahead of lower-value count signals', () => {
+    const derived = deriveSignalViews(
+      input({ structuralAbsence: { kind: 'shared_mechanism', optionCount: 2 } }),
+      {},
+    )
+    expect(derived.sharpen.map(v => v.detection.signal_id)).toEqual([
+      'sig_structural_absence',
+      'sig_option_breadth',
+      'sig_risk_count',
+      'sig_estimates',
+    ])
+  })
+
   it('ordering is stable when a deterministic signal clears', () => {
     const derived = deriveSignalViews(
       input({ optionCount: 3, biasFindingExplanation: 'A reflective check.' }),

--- a/src/canvas/components/pre-analysis-v3/signals/__tests__/signalSession.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/__tests__/signalSession.spec.ts
@@ -15,6 +15,7 @@ function input(overrides: Partial<SignalDetectionInput> = {}): SignalDetectionIn
     isSavedExample: false,
     narrowFramingDetail: null,
     biasFindingExplanation: null,
+    structuralAbsence: null,
     ...overrides,
   }
 }

--- a/src/canvas/components/pre-analysis-v3/signals/__tests__/structuralAbsenceSignal.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/__tests__/structuralAbsenceSignal.spec.ts
@@ -97,6 +97,14 @@ describe('sig_structural_absence — detection', () => {
     expect(detection!.copy.lead).toContain('4')
   })
 
+  it('describes shared targets without claiming they are factors', () => {
+    const detection = def().detect(
+      baseInput({ structuralAbsence: { kind: 'shared_mechanism', optionCount: 2 } }),
+    )
+    expect(`${detection!.copy.lead} ${detection!.rationale}`).not.toMatch(/\bfactors?\b/i)
+    expect(detection!.copy.lead).toContain('parts of the model')
+  })
+
   it('attaches a live spark action — no dead-end intents', () => {
     const detection = def().detect(
       baseInput({ structuralAbsence: { kind: 'no_downside', optionCount: 2 } }),
@@ -133,9 +141,10 @@ describe('sig_structural_absence — reaches the rendered row list', () => {
     expect(derived.sharpen.find(v => v.detection.signal_id === SIGNAL_ID)).toBeUndefined()
   })
 
-  it('holds a deterministic priority slot ahead of estimates', () => {
+  it('holds the first sharpen priority slot so it survives the default cap', () => {
     const ids = SIGNAL_REGISTRY.map(d => d.signal_id)
+    expect(ids.indexOf(SIGNAL_ID)).toBeLessThan(ids.indexOf('sig_option_breadth'))
+    expect(ids.indexOf(SIGNAL_ID)).toBeLessThan(ids.indexOf('sig_risk_count'))
     expect(ids.indexOf(SIGNAL_ID)).toBeLessThan(ids.indexOf('sig_estimates'))
-    expect(ids.indexOf(SIGNAL_ID)).toBeGreaterThan(ids.indexOf('sig_risk_count'))
   })
 })

--- a/src/canvas/components/pre-analysis-v3/signals/__tests__/structuralAbsenceSignal.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/__tests__/structuralAbsenceSignal.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * The structural-absence signal, bound BY IDENTITY.
+ *
+ * Every lookup here finds its row via `signal_id === 'sig_structural_absence'`,
+ * never via a value predicate another row could satisfy (trap 19: a spec that
+ * finds its object by value can pass on the wrong object while the real one is
+ * deleted).
+ */
+
+import { describe, it, expect } from 'vitest'
+import { SIGNAL_REGISTRY, type SignalDetectionInput } from '../registry'
+import { deriveSignalViews } from '../deriveSignalViews'
+import { SIGNAL_COPY } from '../../constants'
+import type { StructuralAbsence } from '../../selectors/computeStructuralAbsence'
+
+const SIGNAL_ID = 'sig_structural_absence' as const
+
+function baseInput(overrides: Partial<SignalDetectionInput> = {}): SignalDetectionInput {
+  return {
+    // A fully healthy model, so no OTHER signal fires and any row we observe is
+    // unambiguously ours.
+    goalPresent: true,
+    successSet: true,
+    optionCount: 3,
+    riskCount: 3,
+    risksAllOlumi: false,
+    aiEstimatedCount: 0,
+    topUncalibrated: null,
+    isSavedExample: false,
+    narrowFramingDetail: null,
+    biasFindingExplanation: null,
+    structuralAbsence: null,
+    ...overrides,
+  }
+}
+
+function def() {
+  const found = SIGNAL_REGISTRY.find(d => d.signal_id === SIGNAL_ID)
+  if (!found) throw new Error(`${SIGNAL_ID} is not in SIGNAL_REGISTRY`)
+  return found
+}
+
+describe('sig_structural_absence — registration', () => {
+  it('is registered exactly once, by identity', () => {
+    const matches = SIGNAL_REGISTRY.filter(d => d.signal_id === SIGNAL_ID)
+    expect(matches).toHaveLength(1)
+  })
+
+  it('renders on the sharpen surface (structural findings queue)', () => {
+    expect(def().surface).toBe('sharpen')
+  })
+
+  it('carries NO resolved confirmation — null return is ambiguous by design', () => {
+    // `computeStructuralAbsence` returns null both for "no absence found" and
+    // for "no check could run". A quiet confirmation cannot tell those apart,
+    // so asserting one would fabricate a resolution that never happened.
+    expect(def().resolvedCopy).toBeNull()
+  })
+})
+
+describe('sig_structural_absence — detection', () => {
+  it('does not detect when no structural absence is supplied', () => {
+    expect(def().detect(baseInput({ structuralAbsence: null }))).toBeNull()
+  })
+
+  it.each([
+    ['no_downside', 'risk', SIGNAL_COPY.structuralNoDownsideRationale],
+    ['shared_mechanism', 'option', SIGNAL_COPY.structuralSharedMechanismRationale],
+    ['no_external_factor', 'factor', SIGNAL_COPY.structuralNoExternalFactorRationale],
+  ] as const)(
+    'maps %s to its own entity channel and rationale',
+    (kind, entityKind, rationale) => {
+      const absence = { kind, optionCount: 2 } as StructuralAbsence
+      const detection = def().detect(baseInput({ structuralAbsence: absence }))
+      expect(detection).not.toBeNull()
+      expect(detection!.signal_id).toBe(SIGNAL_ID)
+      expect(detection!.entityKind).toBe(entityKind)
+      expect(detection!.rationale).toBe(rationale)
+    },
+  )
+
+  it('every kind produces non-empty lead AND emphasis copy', () => {
+    const kinds = ['no_downside', 'shared_mechanism', 'no_external_factor'] as const
+    for (const kind of kinds) {
+      const detection = def().detect(
+        baseInput({ structuralAbsence: { kind, optionCount: 2 } as StructuralAbsence }),
+      )
+      expect(detection!.copy.lead.length, `${kind} lead`).toBeGreaterThan(0)
+      expect(detection!.copy.emphasis.length, `${kind} emphasis`).toBeGreaterThan(0)
+    }
+  })
+
+  it('names the real option count in the copy — never a fabricated quantity', () => {
+    const detection = def().detect(
+      baseInput({ structuralAbsence: { kind: 'shared_mechanism', optionCount: 4 } }),
+    )
+    expect(detection!.copy.lead).toContain('4')
+  })
+
+  it('attaches a live spark action — no dead-end intents', () => {
+    const detection = def().detect(
+      baseInput({ structuralAbsence: { kind: 'no_downside', optionCount: 2 } }),
+    )
+    expect(detection!.action).toBeDefined()
+    expect(detection!.action!.type).toBe('send_prompt')
+    expect(detection!.spark).toBeDefined()
+    expect(detection!.spark!.id.length).toBeGreaterThan(0)
+  })
+})
+
+describe('sig_structural_absence — reaches the rendered row list', () => {
+  it('appears as a LIVE sharpen row when an absence is detected', () => {
+    const derived = deriveSignalViews(
+      baseInput({ structuralAbsence: { kind: 'no_downside', optionCount: 2 } }),
+      {},
+    )
+    const row = derived.sharpen.find(v => v.detection.signal_id === SIGNAL_ID)
+    expect(row).toBeDefined()
+    expect(row!.status).toBe('live')
+  })
+
+  it('is absent from the row list when nothing is detected', () => {
+    const derived = deriveSignalViews(baseInput({ structuralAbsence: null }), {})
+    expect(derived.sharpen.find(v => v.detection.signal_id === SIGNAL_ID)).toBeUndefined()
+  })
+
+  it('never produces a resolved confirmation, even once seen', () => {
+    // Seen previously, now not detecting → the other signals would emit a quiet
+    // confirmation here. This one must stay silent.
+    const derived = deriveSignalViews(baseInput({ structuralAbsence: null }), {
+      [SIGNAL_ID]: { firstSeenAt: 1 },
+    })
+    expect(derived.sharpen.find(v => v.detection.signal_id === SIGNAL_ID)).toBeUndefined()
+  })
+
+  it('holds a deterministic priority slot ahead of estimates', () => {
+    const ids = SIGNAL_REGISTRY.map(d => d.signal_id)
+    expect(ids.indexOf(SIGNAL_ID)).toBeLessThan(ids.indexOf('sig_estimates'))
+    expect(ids.indexOf(SIGNAL_ID)).toBeGreaterThan(ids.indexOf('sig_risk_count'))
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/signals/registry.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/registry.ts
@@ -66,7 +66,7 @@ export interface SignalDef {
   detect: (input: SignalDetectionInput) => SignalDetection | null
 }
 
-/** Priority order is the array order: foundational, options, risks, estimates, reflective. */
+/** Priority order is the array order: foundational, structural, counts, estimates, reflective. */
 export const SIGNAL_REGISTRY: ReadonlyArray<SignalDef> = [
   {
     signal_id: 'sig_goal_missing',
@@ -106,55 +106,13 @@ export const SIGNAL_REGISTRY: ReadonlyArray<SignalDef> = [
           },
   },
   {
-    signal_id: 'sig_option_breadth',
-    surface: 'sharpen',
-    entityKind: 'option',
-    resolvedCopy: 'Options widened.',
-    detect: input => {
-      if (input.optionCount >= 3) return null
-      const copy =
-        input.optionCount <= 1
-          ? SIGNAL_COPY.optionBreadthOne
-          : SIGNAL_COPY.optionBreadth(input.optionCount)
-      return {
-        signal_id: 'sig_option_breadth',
-        copy: { lead: copy.lead, emphasis: copy.emphasis },
-        // CEE narrow-framing swap-in-place: same row, same signal slot,
-        // CEE's own text verbatim with attribution.
-        ceeOverride: input.narrowFramingDetail
-          ? { text: input.narrowFramingDetail, attribution: { kind: 'olumi' } }
-          : undefined,
-        rationale: SIGNAL_COPY.optionRationale,
-        entityKind: 'option',
-        action: { type: 'send_prompt', spark: SPARK_PROMPTS.widenOptions },
-        spark: SPARK_PROMPTS.widenOptions,
-      }
-    },
-  },
-  {
-    signal_id: 'sig_risk_count',
-    surface: 'sharpen',
-    entityKind: 'risk',
-    resolvedCopy: 'Risks captured.',
-    detect: input => {
-      if (input.riskCount >= 3) return null
-      const copy =
-        input.riskCount === 0
-          ? SIGNAL_COPY.riskNone
-          : SIGNAL_COPY.riskCount(input.riskCount, input.risksAllOlumi)
-      return {
-        signal_id: 'sig_risk_count',
-        copy: { lead: copy.lead, emphasis: copy.emphasis },
-        rationale: SIGNAL_COPY.riskRationale,
-        entityKind: 'risk',
-        action: { type: 'send_prompt', spark: SPARK_PROMPTS.preMortem },
-        spark: SPARK_PROMPTS.preMortem,
-      }
-    },
-  },
-  {
     signal_id: 'sig_structural_absence',
     surface: 'sharpen',
+    // The structural finding is the highest-value sharpen prompt: unlike the
+    // count-based rows below, it describes a gap in the model's reasoning.
+    // Registry order is render priority, so keeping it here guarantees that a
+    // live finding is visible within the default two-row cap.
+    //
     // Stable channel for the def. The DETECTION carries the entity kind of the
     // finding that actually fired (risk / option / factor), which is what the
     // row renders — this value only shapes a resolved row, and there is none.
@@ -204,6 +162,53 @@ export const SIGNAL_REGISTRY: ReadonlyArray<SignalDef> = [
             action: { type: 'send_prompt', spark: SPARK_PROMPTS.pressureTestFrame },
             spark: SPARK_PROMPTS.pressureTestFrame,
           }
+      }
+    },
+  },
+  {
+    signal_id: 'sig_option_breadth',
+    surface: 'sharpen',
+    entityKind: 'option',
+    resolvedCopy: 'Options widened.',
+    detect: input => {
+      if (input.optionCount >= 3) return null
+      const copy =
+        input.optionCount <= 1
+          ? SIGNAL_COPY.optionBreadthOne
+          : SIGNAL_COPY.optionBreadth(input.optionCount)
+      return {
+        signal_id: 'sig_option_breadth',
+        copy: { lead: copy.lead, emphasis: copy.emphasis },
+        // CEE narrow-framing swap-in-place: same row, same signal slot,
+        // CEE's own text verbatim with attribution.
+        ceeOverride: input.narrowFramingDetail
+          ? { text: input.narrowFramingDetail, attribution: { kind: 'olumi' } }
+          : undefined,
+        rationale: SIGNAL_COPY.optionRationale,
+        entityKind: 'option',
+        action: { type: 'send_prompt', spark: SPARK_PROMPTS.widenOptions },
+        spark: SPARK_PROMPTS.widenOptions,
+      }
+    },
+  },
+  {
+    signal_id: 'sig_risk_count',
+    surface: 'sharpen',
+    entityKind: 'risk',
+    resolvedCopy: 'Risks captured.',
+    detect: input => {
+      if (input.riskCount >= 3) return null
+      const copy =
+        input.riskCount === 0
+          ? SIGNAL_COPY.riskNone
+          : SIGNAL_COPY.riskCount(input.riskCount, input.risksAllOlumi)
+      return {
+        signal_id: 'sig_risk_count',
+        copy: { lead: copy.lead, emphasis: copy.emphasis },
+        rationale: SIGNAL_COPY.riskRationale,
+        entityKind: 'risk',
+        action: { type: 'send_prompt', spark: SPARK_PROMPTS.preMortem },
+        spark: SPARK_PROMPTS.preMortem,
       }
     },
   },

--- a/src/canvas/components/pre-analysis-v3/signals/registry.ts
+++ b/src/canvas/components/pre-analysis-v3/signals/registry.ts
@@ -12,6 +12,7 @@
  */
 
 import { SIGNAL_COPY, SPARK_PROMPTS } from '../constants'
+import type { StructuralAbsence } from '../selectors/computeStructuralAbsence'
 import type { PanelSignalId, SignalDetection } from '../types'
 
 export interface SignalDetectionInput {
@@ -36,6 +37,16 @@ export interface SignalDetectionInput {
   narrowFramingDetail: string | null
   /** First analysis_ready bias finding explanation, verbatim — null when not live. */
   biasFindingExplanation: string | null
+  /**
+   * Highest-priority causal-structure absence, or null when none is detected
+   * OR no check could honestly run. Computed by
+   * `selectors/computeStructuralAbsence.ts` from nodes + edges only.
+   *
+   * Required, not optional: this signal claims something about the SHAPE of the
+   * user's model, and an omitted field defaulting to `null` would silently turn
+   * "we did not look" into "we looked and found nothing" at the next call site.
+   */
+  structuralAbsence: StructuralAbsence | null
 }
 
 export type SignalSurface = 'hero' | 'sharpen'
@@ -138,6 +149,61 @@ export const SIGNAL_REGISTRY: ReadonlyArray<SignalDef> = [
         entityKind: 'risk',
         action: { type: 'send_prompt', spark: SPARK_PROMPTS.preMortem },
         spark: SPARK_PROMPTS.preMortem,
+      }
+    },
+  },
+  {
+    signal_id: 'sig_structural_absence',
+    surface: 'sharpen',
+    // Stable channel for the def. The DETECTION carries the entity kind of the
+    // finding that actually fired (risk / option / factor), which is what the
+    // row renders — this value only shapes a resolved row, and there is none.
+    entityKind: 'option',
+    // ⚠ DELIBERATELY NULL — no quiet confirmation, by the registry's own rule.
+    // `computeStructuralAbsence` returns null BOTH when no absence is found AND
+    // when no check could honestly run (too few options, no downside modelled,
+    // no controllability metadata). A confirmation line cannot tell those apart,
+    // so "Model structure checked." would assert a pass that was never measured
+    // every time a precondition simply stopped holding.
+    resolvedCopy: null,
+    detect: input => {
+      const absence = input.structuralAbsence
+      if (!absence) return null
+      switch (absence.kind) {
+        case 'no_downside': {
+          const copy = SIGNAL_COPY.structuralNoDownside(absence.optionCount)
+          return {
+            signal_id: 'sig_structural_absence',
+            copy: { lead: copy.lead, emphasis: copy.emphasis },
+            rationale: SIGNAL_COPY.structuralNoDownsideRationale,
+            entityKind: 'risk',
+            action: { type: 'send_prompt', spark: SPARK_PROMPTS.findRisks },
+            spark: SPARK_PROMPTS.findRisks,
+          }
+        }
+        case 'shared_mechanism': {
+          const copy = SIGNAL_COPY.structuralSharedMechanism(absence.optionCount)
+          return {
+            signal_id: 'sig_structural_absence',
+            copy: { lead: copy.lead, emphasis: copy.emphasis },
+            rationale: SIGNAL_COPY.structuralSharedMechanismRationale,
+            entityKind: 'option',
+            action: { type: 'send_prompt', spark: SPARK_PROMPTS.widenOptions },
+            spark: SPARK_PROMPTS.widenOptions,
+          }
+        }
+        case 'no_external_factor':
+          return {
+            signal_id: 'sig_structural_absence',
+            copy: {
+              lead: SIGNAL_COPY.structuralNoExternalFactor.lead,
+              emphasis: SIGNAL_COPY.structuralNoExternalFactor.emphasis,
+            },
+            rationale: SIGNAL_COPY.structuralNoExternalFactorRationale,
+            entityKind: 'factor',
+            action: { type: 'send_prompt', spark: SPARK_PROMPTS.pressureTestFrame },
+            spark: SPARK_PROMPTS.pressureTestFrame,
+          }
       }
     },
   },

--- a/src/canvas/components/pre-analysis-v3/types.ts
+++ b/src/canvas/components/pre-analysis-v3/types.ts
@@ -67,6 +67,8 @@ export type PanelSignalId =
   | 'sig_risk_count'
   | 'sig_estimates'
   | 'sig_cee_bias'
+  /** Causal-structure absence — see `selectors/computeStructuralAbsence.ts`. */
+  | 'sig_structural_absence'
 
 export type BarKey = 'frame' | 'options' | 'risks' | 'estimates'
 


### PR DESCRIPTION
## What a user now sees

**On opening a model, the panel names one thing the model's SHAPE is missing** — "Nothing bad happens on any of your three options.", "All two options act through exactly the same parts of the model.", or "Nothing outside your control is modelled." — with a rationale behind the info icon and one spark that acts on it. No click required, no new tab, no flag.

This closes Paul's failing test 2: *"Everything we specified renders what is IN the model. Strategy fails on what is MISSING, and nothing in the default surfaces absence."*

## What I derived, and what I refuted

The brief's premises were checked at the deployed tips (CEE `77e2e7d9`, UI `f5794541`) before any code. **Three of four were wrong**, and the correction changed the whole shape of the work:

| Premise | Verdict |
|---|---|
| CEE `detectCriticalGap` exists with four structural checks | **TRUE**, but its four are `narrow_options` / no-risk / `uncalibrated_driver` / `no_cost_factor` — **not** the four Paul named |
| `buildCoachingContext` is uncalled with **zero tests** | **HALF FALSE** — zero production callers (1 `src/` occurrence, its own definition), but a ~500-line test file with ~40 call sites. It is **V4-legacy**; the live path is `orchestrator-v5` |
| `missing_factors` is discarded **by the UI** one hop before the screen | **REFUTED** — discarded in **CEE's own route**, `routes/assist.v1.graph-readiness.ts`, whose hand-built `response` literal drops `domain_completeness`, `key_assumptions` and `goal_conflicts`. It never reaches the wire. Also `checkDomainCompleteness` is **template-driven**, not structural |
| Is there already a UI consumer? | **YES — and this is the big one.** A live, deployed, deterministic signal registry already ships the equivalent of **three of `detectCriticalGap`'s four checks** (`sig_option_breadth`, `sig_risk_count`, `sig_estimates`). Wiring the V4 code would have **duplicated live behaviour** |

Confirmed at the deployed bundle (83 chunks, controls green both directions, two same-family contrast controls non-zero, fabricated controls zero): all six `sig_*` ids ship; `critical_gap` / `narrow_options` / `missing_factor` / `no_cost_factor` / `missing_factors` are **0**, string-literal class.

**So the genuinely missing capability was never `detectCriticalGap` — it was Paul's own four causal-structure checks, none of which exist anywhere in the estate.**

## Three checks, not four

**"No feedback anywhere" is deliberately not implemented, and is pinned by test.** The UI blocks cycle creation (`validation/graphGuardrails.wouldCreateCycle`, wired into `ReactFlowGraph` and the edge-reversal action) and CEE rejects cycles as a structural violation (`CYCLE_DETECTED`). Every graph is **acyclic by construction**, so the check would fire on 100% of models and its advice would name an edit the product refuses.

## The seam

`src/canvas/components/pre-analysis-v3/` — the live pre-run panel, whose registry contract is already *"a pure detection function (presence/count/structure only)"*. No CEE change, no contract change, no new flag, no new component. None of the forbidden paths is touched.

- **new** `selectors/computeStructuralAbsence.ts` — pure `(nodes, edges)` selector, first-match-wins so the panel gains **one** row
- `signals/registry.ts` — `sig_structural_absence`, ordered **above** `sig_option_breadth` and `sig_risk_count`. Both of those are `surface: 'hero'`, and `deriveSignalViews` partitions hero out of the sharpen list, so structural absence is **index 0 of sharpen** and a `slice(0, 2)` cannot displace it. Fixed structurally, not case-by-case.
- `constants.ts` — copy added to the ratified `SIGNAL_COPY` owner, not a rival vocabulary

Reuses the ratified owners rather than re-spelling them (trap 12): `resolveEdgeDirectionDisplay` for edge polarity, `kindOf` for node kind, existing `SPARK_PROMPTS` (**no new wire intents**).

## Never invents an absence

Every check carries a precondition naming the data it needs, and returns `null` rather than report "missing" about a field that is merely unpopulated:

- **no_downside** needs a modelled downside to be blind to (a risk node or a producer-stated negative edge) — otherwise `sig_risk_count` owns the case
- **no_external_factor** needs **every** factor to carry *known* controllability — `resolveKnownControllability` tests information content, not mere presence, so **one unknown factor holds the whole claim closed**, and an invalid explicit `category` no longer falls back to the weaker derived field. Otherwise the claim would be about *our* missing metadata, dressed as the user's thinking
- **global**: every option must have an outgoing edge — on an unwired model "nothing bad happens on your options" is true and useless. *Caught by the panel's own fixture, where the check fired correctly by its logic and wrongly as advice.*

`resolvedCopy` is deliberately `null`: the selector returns `null` both for "no absence" and "could not run", and a quiet confirmation cannot tell those apart.

## Evidence

- **Gate**: `lint` **0 errors**, hooks ratchet exactly at baseline · `typecheck` **PASSED**, 3606/3646 files, ratchet **2252 = baseline** (no new diagnostics)
- **Suite**: `pre-analysis-v3` **631 passed / 38 files**; own specs asserted **by name**: 23 + 15
- **Discriminating mutant pair (trap 19)**: break **my** detection → **RED** (7/14); break an **adjacent** surface (`sig_risk_count` threshold) → **GREEN** (35/35)
- **Anti-fabrication mutants**: delete the never-invents guard → **RED on that exact named test**; delete the global precondition → **RED on that exact named test**
- Isolation proven by **write-sentinel** + distinct inodes; restores `git checkout HEAD --`; applied-check scoped to `src/`, control exactly **0**; leading and trailing controls identical

## Rung claimed

**TESTED** (2026-08-24). Not deployed, not journey-witnessed. Bundle evidence establishes the sibling signals ship; it is silent on runtime flag posture for a given user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## ⚠ Body corrected at integration — 2026-08-25

This body described the **first** commit (`d191eaac`), not the head (`6b3c0cc3`). Four passages were
materially false about the implementation being merged: the old *"the same factors"* copy, the
priority-slot description, the `no_external_factor` precondition, and the evidence figures. Corrected
above, because **the merge body becomes the permanent record** and a stale one is the
hand-maintained-mirror defect this estate keeps paying for.

### Cross-review — independent falsification, not a rerun of the author's kit

- **F2 was LIVE on shipped data, not hypothetical.** The previous review called it *"reachable in
  principle… not observed in the 18-model corpus."* It was firing: `routes/templates/data/feature-v1.json`
  and `hiring-v1.json` — **two of the twelve shipped templates**, each with **zero factor nodes** —
  emitted *"All two options act through exactly the same factors."* This PR fixes a falsehood that
  was in production copy.
- **Detection is unchanged; only the copy moved.** Same harness at both heads via the product's own
  `insertBlueprint`: **3 of 18 fire, the same three**, differing *only* in the copy string — the
  opposite-direction control. All three firings verified structurally true by hand.
- **Discriminating mutant pair.** Own-object (kill `shared_mechanism`) → **RED** on two named tests;
  adjacent-object (`sig_risk_count` 3→4) → **GREEN 38/38**. Leading and trailing controls identical;
  applied-check non-zero for every mutant and **exactly 0** for both controls; clean tree asserted
  before *and* after each. Isolation proven **by writing a sentinel** with a positive control on the
  write, inodes compared, worktree outside the repo root.
- **CI at the exact head SHA:** 14 checks, `total_count > 0`, **zero running**, `Staging Gate`
  success. `Visual Regression (advisory)` is the standing estate-wide non-discriminating red.
- **No collisions** — clean into `374c157c`, and clean in either order against
  `codex/c11-strategic-workspace-entry`.

### Rowed, not blocking — two residuals on the author's seam

1. **The anti-"factors" guard omits `emphasis`** — it asserts over `lead` + `rationale` only.
   `emphasis` is clean today, so the gap is **latent**. One-word fix.
2. **`isKnownControllability` is a hand-maintained mirror of `ControllabilityEnum`** — not derived,
   not pinned by any test. Drift fails **closed** (suppresses the finding), so it degrades quietly
   rather than fabricating. Deriving it from `ControllabilityEnum.options` closes it.

### Reachability, to its exact scope
The panel is gated on `VITE_FEATURE_PRE_ANALYSIS_V3`, which `netlify.toml` sets to `"1"` under
`[context.staging.environment]`. That is **build-config-derived only** — not wire-witnessed, and
silent on any dashboard override. **Rung claimed: TESTED**, 2026-08-25.
