### PR TITLE
fix(inspector): the Inspector says who chose each intervention target (B1-b)

### DIFF
--- a/src/canvas/domain/valueProvenance.ts
+++ b/src/canvas/domain/valueProvenance.ts
@@ -181,6 +181,96 @@ export function classifyValueProvenance(
 }
 
 /**
+ * ─────────────────────────────────────────────────────────────────────────────
+ * ⭐⭐ THE INTERVENTION VOCABULARY — A DIFFERENT FIELD WEARING THE SAME NAME
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * An option's `interventions[factorId].source` answers **HOW THIS TARGET WAS
+ * DETERMINED**. A node's `observed_state.source` answers **WHO PUT THIS VALUE
+ * HERE**. Two questions, two closed vocabularies, one field name — and the
+ * shared contract says so itself, at `edit-tool-ops.js:229-238` in the vendored
+ * 0.48.0 package:
+ *
+ *   *"`source` IS ONE OF ITS FIELDS (`cee-v3.ts:284` — an enum of
+ *   `brief_extraction | cee_hypothesis | user_specified`, meaning HOW THE
+ *   INTERVENTION WAS DETERMINED). That is a different field from node
+ *   `observed_state.source` wearing the same name, and CEE exempts it for
+ *   exactly this reason."*
+ *
+ * ⚠⚠ THIS IS WHY `cee_hypothesis` IS **NOT** IN `SOURCE_CLASSES`, AND ADDING IT
+ * WAS THE FIRST THING THIS LANE TRIED (B1-a, 2026-08-24). It typechecks, it
+ * makes the surface render the right words, and `sourceClassesCompleteness`
+ * REDs on it — correctly, because the guard's complement assertion exists to
+ * catch exactly this: a literal classified here that the contract's
+ * `OBSERVED_STATE_SOURCE_LITERALS` does not declare. Merging the two maps would
+ * have made `classifyValueProvenance('cee_hypothesis')` answer a question about
+ * a factor's observed value that no producer ever asks, and would have made the
+ * one guard that can see contract drift permanently unable to.
+ *
+ * The two vocabularies OVERLAP on `brief_extraction` and are otherwise
+ * disjoint, which is what makes the merge look harmless and is why it is not.
+ *
+ * ⚠ WHAT IS SHARED IS THE **KIND**, DELIBERATELY. Both classifiers return the
+ * same `ValueProvenanceKind`, so every surface keeps ONE taxonomy and ONE
+ * `Record<ValueProvenanceKind, …>` register. The concepts are named apart at the
+ * literal layer and joined at the kind layer — which is the shape CLAUDE.md
+ * trap 21 prescribes for two authorities answering different questions.
+ *
+ * ⚠ THE CONTRACT DOES NOT EXPORT THESE LITERALS. The vendored package "does not
+ * carry InterventionV3" (same comment, same file), so unlike `SOURCE_CLASSES`
+ * this map has NO canonical list to be checked against and no derivation is
+ * available. Stated rather than discovered later: the guard for this map is a
+ * HAND-WRITTEN CORPUS pinned to the contract's own quoted enum, which is the
+ * other half of trap 12d — where you cannot derive, a corpus is what notices the
+ * list is short. If a future schemas minor exports the intervention literals,
+ * replace the corpus with a derived guard and delete this paragraph.
+ */
+const INTERVENTION_SOURCE_CLASSES: Readonly<Record<string, ValueProvenanceKind>> = Object.freeze({
+  /** The target is the user's own figure, lifted from their brief. */
+  brief_extraction: 'brief',
+  /**
+   * ⭐ THE MODEL CHOSE THIS NUMBER. Witnessed on the deployed build (UI
+   * `88cb7e37` · CEE `d1da670`, fresh guest, 2026-08-24): every
+   * `cee_hypothesis` entry on that draw carried `value_confidence: 'low'` and
+   * the producer's own reasoning — *"Model-chosen intervention level; this
+   * amount is not stated in the brief"* — against `brief_extraction` siblings
+   * carrying `value_confidence: 'high'` and a reasoning quoting the user's own
+   * sentence verbatim. The class is the one the PRODUCER declares, not one
+   * inferred from the symptom (trap 13c).
+   */
+  cee_hypothesis: 'ai',
+  /** The human supplied the target. `'edited'`, and therefore user-owned. */
+  user_specified: 'edited',
+})
+
+/** Every intervention-source literal this map classifies — the corpus checks it. */
+export const INTERVENTION_PROVENANCE_SOURCES: readonly string[] = Object.freeze(
+  Object.keys(INTERVENTION_SOURCE_CLASSES),
+)
+
+/**
+ * Classify an `interventions[factorId].source` literal.
+ *
+ * Returns `null` — never a guessed class — for an unknown literal, for the same
+ * reason `classifyValueProvenance` does: a surface that renders `null` must fall
+ * back to its own honest silence. Guessing here would put "AI estimate" over a
+ * number the user typed, or the reverse, which is the defect this pair of
+ * classifiers exists to end.
+ *
+ * ⚠ DO NOT ROUTE AN `observed_state.source` THROUGH THIS FUNCTION, or an
+ * intervention source through its sibling. They overlap on one literal and
+ * would agree on it, which is precisely how a wrong call survives review.
+ */
+export function classifyInterventionProvenance(
+  source: string | null | undefined,
+): ValueProvenanceClass | null {
+  if (typeof source !== 'string') return null
+  const kind = INTERVENTION_SOURCE_CLASSES[source]
+  if (kind === undefined) return null
+  return { kind, userOwned: USER_OWNED_KINDS.has(kind) }
+}
+
+/**
  * Classify the NODE-LEVEL `data.provenance` value, whose vocabulary is a
  * different, smaller one (`CEEProvenance`).
  *

--- a/src/canvas/model-tab-v2/ModelDetailRegion.tsx
+++ b/src/canvas/model-tab-v2/ModelDetailRegion.tsx
@@ -28,8 +28,70 @@
 
 import { typography } from '../../styles/typography'
 import { SourceProvenancePill } from '../components/model-tab/SourceProvenancePill'
+import {
+  classifyInterventionProvenance,
+  type ValueProvenanceKind,
+} from '../domain/valueProvenance'
 import { KIND_LABEL } from './rowPresentation'
 import type { DetailField, DetailTier, ModelRow, ModelRowDetail } from './types'
+
+/**
+ * ⭐ WHO CHOSE THIS TARGET — this surface's register, TOTAL over the kind.
+ *
+ * ⚠ A SECOND REGISTER, AND THAT IS THE RATIFIED SHAPE, NOT A TRAP-12 MIRROR.
+ * `valueProvenance` owns the KIND and says so in its own header: *"This module
+ * owns the kind. Each surface keeps its own register (the Model tab is terse,
+ * the inspector writes sentences) but must be TOTAL over `ValueProvenanceKind`
+ * — a `Record<ValueProvenanceKind, …>` makes a missing kind a type error rather
+ * than a silent fallback."* A new kind cannot land here unlabelled.
+ *
+ * ⚠ WHY NOT `SourceProvenancePill`, WHICH SITS TEN LINES BELOW. That component
+ * takes a raw LITERAL and classifies it with `classifyValueProvenance` — the
+ * NODE `observed_state.source` vocabulary. An intervention's `source` is a
+ * different, three-member vocabulary wearing the same field name (see
+ * `valueProvenance`), so handing it `'cee_hypothesis'` renders **"Not set"** —
+ * a claim about the value, over a value that is set. The wording is kept
+ * identical to the pill's on purpose: same tab, same register, one voice.
+ */
+const INTERVENTION_PROVENANCE_LABEL: Record<ValueProvenanceKind, string> = {
+  brief: 'From brief',
+  ai: 'AI estimate',
+  confirmed: 'Confirmed by you',
+  edited: 'User edited',
+  assumption: 'Your assumption',
+  human: 'Set by you',
+  panel: 'From your panel',
+}
+
+const INTERVENTION_PROVENANCE_BORDER: Record<ValueProvenanceKind, string> = {
+  brief: 'border-info/30',
+  ai: 'border-warning/30',
+  confirmed: 'border-success/30',
+  edited: 'border-success/30',
+  assumption: 'border-success/30',
+  human: 'border-success/30',
+  panel: 'border-info/30',
+}
+
+/**
+ * The mark that sits beside an intervention's number.
+ *
+ * ⚠ RENDERS **NOTHING** WHEN THE RECORD DOES NOT SAY. Not "Not set", not a
+ * neutral pill, not a dash. An unrecorded provenance is unknown, and unknown
+ * stays unknown — a default in any direction is an invented provenance, which
+ * is the defect one level up from the one this component closes.
+ */
+function InterventionProvenanceMark({ source }: { source: string | undefined }) {
+  const cls = classifyInterventionProvenance(source)
+  if (cls === null) return null
+  return (
+    <span
+      className={`inline-flex items-center px-2 py-0.5 rounded-full bg-transparent border ${INTERVENTION_PROVENANCE_BORDER[cls.kind]} text-text-body ${typography.panelMeta}`}
+    >
+      {INTERVENTION_PROVENANCE_LABEL[cls.kind]}
+    </span>
+  )
+}
 
 export interface ModelDetailRegionProps {
   row: ModelRow
@@ -51,6 +113,22 @@ export interface ModelDetailRegionProps {
   /** Commit the draft through the write authority. */
   onCommitIntervention?: (factorId: string) => void
   onDiscardInterventionEdit?: () => void
+}
+
+/**
+ * Would "Where it came from" have anything under its heading?
+ *
+ * ⚠ ONE PREDICATE, MIRRORING THE THREE CHILDREN EXACTLY. Written as a separate
+ * function so the mirror is visible: if a fourth child is ever added to that
+ * section and not added here, the section can render empty again — which is the
+ * defect this predicate closes, wearing a fourth condition.
+ */
+function hasProvenanceContent(
+  provenanceSource: string | undefined,
+  detail: ModelRowDetail,
+): boolean {
+  const pillWouldRender = typeof provenanceSource === 'string' && provenanceSource !== ''
+  return pillWouldRender || detail.basis !== null || detail.adjustments.length > 0
 }
 
 /** Absence is rendered as absence — never as a zero, never as a blank cell. */
@@ -240,6 +318,37 @@ export function ModelDetailRegion({
                       {iv.value ?? 'Not set'}
                     </span>
                   )}
+
+                  {/*
+                    ⭐ WHO CHOSE THIS NUMBER — ON THE SAME LINE AS THE NUMBER.
+
+                    ⚠⚠ THE DEFECT THIS CLOSES (B1-a, deployed witness UI
+                    `88cb7e37` · CEE `d1da670`, 2026-08-24). A target CEE had
+                    invented — raw 22,500, no unit, `value_confidence: low`, its
+                    own reasoning saying *"this amount is not stated in the
+                    brief"* — rendered here as a bare `0.45`, in the same
+                    control, the same typography and with no badge, tooltip,
+                    icon or unit, directly comparable with the user's own
+                    £45,000 rendered as a bare `0.9`. **The only difference
+                    between a number Olumi invented and one the user wrote was
+                    the digits.**
+
+                    ⚠ INLINE, NOT IN "Where it came from" AND NOT BEHIND A
+                    HOVER. A disclosure a user has to go and look for is a
+                    disclosure that arrives after they have already believed the
+                    number. It costs no extra interaction: it is in the same
+                    glance as the figure it qualifies.
+
+                    ⚠ IT CLASSIFIES THROUGH THE **INTERVENTION** VOCABULARY, not
+                    the node one the pill below uses. `cee_hypothesis` is not an
+                    `observed_state.source` literal and never was — see
+                    `InterventionProvenanceMark`.
+
+                    ⚠ NO STAMP ⇒ NOTHING RENDERS. Unknown stays unknown.
+                  */}
+                  <span data-testid={`model-detail-v2-intervention-${iv.factorId}-provenance`}>
+                    <InterventionProvenanceMark source={iv.provenanceSource} />
+                  </span>
                 </li>
               )
             })}
@@ -247,7 +356,25 @@ export function ModelDetailRegion({
         </section>
       )}
 
-      {/* 3 — Where it came from */}
+      {/*
+        3 — Where it came from.
+
+        ⚠ THE HEADING IS NOT RENDERED WHEN NOTHING WOULD SIT UNDER IT. On the
+        deployed build (UI `88cb7e37`) this section rendered on an OPTION as a
+        heading with an empty body: an option node carries no `observedState`,
+        so `row.provenanceSource` is absent and `basis` is `null`, and the pane
+        announced that provenance had been looked for and none exists — on the
+        one element whose provenance is the finding. That is the same rule
+        `FieldList` above already applies and the same rule this file states in
+        its own words: absence is rendered as absence, never as a blank cell.
+
+        ⚠ THE PREDICATE IS DERIVED FROM WHAT EACH CHILD ACTUALLY RENDERS, not
+        from "is the field present". `SourceProvenancePill` with
+        `showWhenAbsent={false}` renders nothing for an empty string, so a
+        `provenanceSource: ''` would satisfy `!== undefined` and reproduce the
+        empty heading this gate exists to remove.
+      */}
+      {(hasProvenanceContent(row.provenanceSource, detail)) && (
       <section data-testid="model-detail-v2-provenance">
         <h4 className={`${typography.label} text-text-header`}>Where it came from</h4>
         {row.provenanceSource !== undefined && (
@@ -271,6 +398,7 @@ export function ModelDetailRegion({
           </ul>
         )}
       </section>
+      )}
 
       {/* 4 — What it affects */}
       <section data-testid="model-detail-v2-affects">

--- a/src/canvas/model-tab-v2/__tests__/interventionProvenanceIsDisclosed.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/interventionProvenanceIsDisclosed.spec.tsx
@@ -1,0 +1,513 @@
+/**
+ * ⭐ AN INVENTED TARGET MUST NOT LOOK LIKE A NUMBER THE USER WROTE (B1-a).
+ *
+ * ## The defect this file pins, witnessed on the deployed build
+ *
+ * UI `88cb7e37` · CEE `d1da670`, fresh guest, 2026-08-24. On ONE draw, on ONE
+ * factor, the product produced the discriminating pair:
+ *
+ *   · `cee_hypothesis`   raw 22,500, no unit, `value_confidence: low`,
+ *     CEE's own reasoning "this amount is not stated in the brief" → 0.45
+ *   · `brief_extraction` raw 45,000, unit `£`, `value_confidence: high`,
+ *     reasoning naming `stated_items[3]` verbatim → 0.9
+ *
+ * Both rendered in the same control, same typography, no unit on either, no
+ * badge, icon, colour or tooltip on either. **The only difference between a
+ * number Olumi invented and one the user wrote was the digits.**
+ *
+ * The data was never the problem — every field above is correct on the wire.
+ * `unwrapInterventionValue` returned `{value, displayValue}` and threw `source`
+ * away at the ONE point every render surface reads an intervention through, so
+ * nothing downstream still had the fact to show.
+ *
+ * ## Why the fixtures are the wire's, verbatim
+ *
+ * Trap 22: a corpus drawn from the author's head cannot see the class the author
+ * did not imagine. Every intervention object below is copied byte-for-byte from
+ * `drawA-11-autosave-raw.json` — the canonical client-side model captured from
+ * the deployed build — including the two that a fixture written from the defect
+ * report would NOT have contained:
+ *
+ *   1. `raw_value: 0` invented targets. Half the invented interventions on that
+ *      draw are ZERO. A guard keyed on "22,500 is missing" sees nothing here.
+ *   2. `682a7e2d` — an option whose own `provenance` is `from_brief` and which
+ *      nevertheless carries an INVENTED intervention. **Option-level provenance
+ *      does not predict intervention-level provenance**, so a disclosure bound
+ *      to the option node would be wrong on this row and right on the other two
+ *      — the shape of test that passes on the wrong object (trap 19).
+ *
+ * ## Binding
+ *
+ * Every value assertion resolves its row BY `factorId` through `within(...)`,
+ * never by the digits. `0.45` is a value predicate a different intervention
+ * could satisfy, and reading it off the whole pane is precisely how this estate
+ * shipped a spec that passed against a factor it was not written for.
+ *
+ * Every "invented is marked" case has its OPPOSITE-DIRECTION TWIN asserting the
+ * user-stated row is NOT marked as invented (trap 22b). The inversion is the
+ * live defect on the deployed build — the twin is the load-bearing half.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { ModelDetailRegion } from '../ModelDetailRegion'
+import { toRowDetail, type ModelProjectionInput } from '../adapters'
+import type { ModelRow } from '../types'
+import { unwrapInterventionValue } from '../../utils/labelUtils'
+import {
+  INTERVENTION_PROVENANCE_SOURCES,
+  classifyInterventionProvenance,
+  classifyValueProvenance,
+} from '../../domain/valueProvenance'
+
+// ── The deployed draw, verbatim ──────────────────────────────────────────────
+
+const FACTOR_LICENSING = '440d2e30'
+const FACTOR_MIGRATION = 'fd255d32'
+const OPTION_PHASED = '6f2c97b3' // option provenance: ai_inferred
+const OPTION_STAYING = 'f259d659' // option provenance: from_brief
+const OPTION_FULL = '682a7e2d' // option provenance: from_brief — AND carries an invented target
+
+/** `f259d659[440d2e30]` — the user's own £45,000, bound to `stated_items[3]`. */
+const IV_STATED_45K = {
+  value: 0.9,
+  raw_value: 45000,
+  unit: '£',
+  source: 'brief_extraction',
+  target_match: { node_id: FACTOR_LICENSING, match_type: 'exact_id', confidence: 'high' },
+  value_confidence: 'high',
+  reasoning:
+    'Direct causal value bound by edge 3d61e986 to stated_items[3]: our annual Salesforce licensing is £45,000',
+}
+
+/** `6f2c97b3[440d2e30]` — the invented 22,500, exactly half the user's figure. */
+const IV_INVENTED_22K5 = {
+  value: 0.45,
+  raw_value: 22500,
+  source: 'cee_hypothesis',
+  target_match: { node_id: FACTOR_LICENSING, match_type: 'exact_id', confidence: 'high' },
+  value_confidence: 'low',
+  reasoning: 'Model-chosen intervention level; this amount is not stated in the brief',
+}
+
+/** `682a7e2d[440d2e30]` — INVENTED, and sitting on a `from_brief` option. */
+const IV_INVENTED_ZERO = {
+  value: 0,
+  raw_value: 0,
+  source: 'cee_hypothesis',
+  target_match: { node_id: FACTOR_LICENSING, match_type: 'exact_id', confidence: 'high' },
+  value_confidence: 'low',
+  reasoning: 'Model-chosen intervention level; this amount is not stated in the brief',
+}
+
+/** `682a7e2d[fd255d32]` — the user's own £20,000. */
+const IV_STATED_20K = {
+  value: 0.4,
+  raw_value: 20000,
+  unit: '£',
+  source: 'brief_extraction',
+  target_match: { node_id: FACTOR_MIGRATION, match_type: 'exact_id', confidence: 'high' },
+  value_confidence: 'high',
+  reasoning:
+    'Direct causal value bound by edge 36e4730e to stated_items[2]: A full switch costs £20,000 in migration and training',
+}
+
+/**
+ * A bare number. The Model tab's own intervention editor commits one of these,
+ * and CEE stamps nothing on it — so the honest answer for this row is that the
+ * record does not say, and the surface must say nothing rather than guess.
+ */
+const IV_UNSTAMPED = 0.6
+
+function factorNode(id: string, label: string): Node {
+  return {
+    id,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { label, type: 'factor', observedState: { value: 0.9, raw_value: 45000, source: 'cee_inference' } },
+  } as unknown as Node
+}
+
+/**
+ * ⚠ `provenance` IS ON THE FIXTURE AND IT IS LOAD-BEARING, NOT DECORATION.
+ *
+ * The option node carries its OWN `provenance` on the wire, and a plausible
+ * wrong implementation reads the mark off it. Omitting it from the fixture
+ * would make that implementation render NOTHING — so the suite would red for
+ * the wrong reason and would go green again the moment someone "fixed" the
+ * mapping. With it present, the wrong implementation renders CONFIDENTLY and
+ * is right on two of the three options, and only the discriminating case can
+ * tell the two apart. A fixture that cannot express the wrong answer cannot
+ * refute it (trap 19).
+ */
+function optionNode(
+  id: string,
+  label: string,
+  interventions: Record<string, unknown>,
+  provenance?: string,
+): Node {
+  return {
+    id,
+    type: 'option',
+    position: { x: 0, y: 0 },
+    data: { label, type: 'option', interventions, ...(provenance ? { provenance } : {}) },
+  } as unknown as Node
+}
+
+function projection(): ModelProjectionInput {
+  return {
+    nodes: [
+      factorNode(FACTOR_LICENSING, 'Annual CRM Licensing Cost'),
+      factorNode(FACTOR_MIGRATION, 'Migration and Training Cost'),
+      optionNode(
+        OPTION_PHASED,
+        'Phased HubSpot Migration (pilot team first)',
+        { [FACTOR_LICENSING]: IV_INVENTED_22K5 },
+        'ai_inferred',
+      ),
+      optionNode(
+        OPTION_STAYING,
+        'Staying on Salesforce',
+        { [FACTOR_LICENSING]: IV_STATED_45K },
+        'from_brief',
+      ),
+      // ⭐ THE DISCRIMINATING OPTION: `from_brief` at the option level, and an
+      // INVENTED target inside it. An implementation reading the option node is
+      // right on the two above and wrong here.
+      optionNode(
+        OPTION_FULL,
+        'move our whole sales team off Salesforce onto HubSpot this year',
+        { [FACTOR_LICENSING]: IV_INVENTED_ZERO, [FACTOR_MIGRATION]: IV_STATED_20K },
+        'from_brief',
+      ),
+    ],
+    edges: [],
+    goalThreshold: null,
+  }
+}
+
+function optionRow(id: string, label: string): ModelRow {
+  return { id, kind: 'option', group: 'options', label, primaryValue: '1 change', attention: [], editable: true }
+}
+
+/** The pill's own copy, keyed off the ONE classifier — never re-spelled here. */
+const AI_LABEL = 'AI estimate'
+const BRIEF_LABEL = 'From brief'
+const ABSENT_LABEL = 'Not set'
+
+function provenanceOf(factorId: string): HTMLElement | null {
+  return screen.queryByTestId(`model-detail-v2-intervention-${factorId}-provenance`)
+}
+
+// ── 1. The drop point ────────────────────────────────────────────────────────
+
+describe('⭐ unwrapInterventionValue carries the producer’s own source stamp', () => {
+  it('keeps `cee_hypothesis` on the invented target', () => {
+    expect(unwrapInterventionValue(IV_INVENTED_22K5).source).toBe('cee_hypothesis')
+  })
+
+  it('TWIN: keeps `brief_extraction` on the user-stated target', () => {
+    expect(unwrapInterventionValue(IV_STATED_45K).source).toBe('brief_extraction')
+  })
+
+  it('carries the stamp on a ZERO invented target — the value is not the signal', () => {
+    // Half the invented interventions on the witnessed draw are `raw_value: 0`.
+    // A carrier keyed on truthiness of the value drops every one of them.
+    expect(unwrapInterventionValue(IV_INVENTED_ZERO).source).toBe('cee_hypothesis')
+    expect(unwrapInterventionValue(IV_INVENTED_ZERO).value).toBe(0)
+  })
+
+  it('reports UNKNOWN as null — never a guessed stamp in either direction', () => {
+    expect(unwrapInterventionValue(IV_UNSTAMPED).source).toBeNull()
+    expect(unwrapInterventionValue({ value: 0.5 }).source).toBeNull()
+    expect(unwrapInterventionValue({ value: 0.5, source: '   ' }).source).toBeNull()
+    expect(unwrapInterventionValue({ value: 0.5, source: 42 }).source).toBeNull()
+    expect(unwrapInterventionValue(undefined).source).toBeNull()
+  })
+
+  it('does not disturb the numeric or display halves it already answered', () => {
+    // CONTRAST CONTROL: the additive field must not move the two answers every
+    // caller in the tree already depends on.
+    expect(unwrapInterventionValue(IV_INVENTED_22K5).value).toBe(0.45)
+    expect(unwrapInterventionValue(IV_STATED_45K).value).toBe(0.9)
+    expect(unwrapInterventionValue({ value: 0.3, display_value: '  High  ' }).displayValue).toBe('High')
+  })
+})
+
+// ── 2. The classifier — ONE authority, extended, not duplicated ──────────────
+
+describe('⭐ cee_hypothesis is classified by the ratified authority', () => {
+  it('classifies `cee_hypothesis` as the model’s own estimate', () => {
+    expect(classifyInterventionProvenance('cee_hypothesis')).toEqual({ kind: 'ai', userOwned: false })
+  })
+
+  it('TWIN: `brief_extraction` still classifies to the user’s brief, not to AI', () => {
+    expect(classifyInterventionProvenance('brief_extraction')).toEqual({
+      kind: 'brief',
+      userOwned: false,
+    })
+  })
+
+  it('classifies `user_specified` as the human’s own, and USER-OWNED', () => {
+    expect(classifyInterventionProvenance('user_specified')).toEqual({
+      kind: 'edited',
+      userOwned: true,
+    })
+  })
+
+  it('CONTRAST CONTROL: an unknown literal is still refused, not guessed', () => {
+    // Without this the three above are satisfiable by a classifier that returns
+    // a class for everything — which is the failure mode the module was
+    // written to end ("Estimated by Olumi" over a confirmed value).
+    expect(classifyInterventionProvenance('cee_hypothesis_v2')).toBeNull()
+    expect(classifyInterventionProvenance(undefined)).toBeNull()
+  })
+
+  /**
+   * ⭐⭐ THE HAND-WRITTEN CORPUS, because no derivation is available here.
+   *
+   * The vendored contract does not export the intervention literals — it says
+   * so itself: *"This package does not carry InterventionV3, so it does not
+   * carry that contract's screen either."* So the completeness check that
+   * `SOURCE_CLASSES` gets against `OBSERVED_STATE_SOURCE_LITERALS` cannot exist
+   * for this map, and a corpus pinned to the contract's own QUOTED enum is what
+   * notices the list going short (trap 12d).
+   */
+  it('⭐ CORPUS: classifies exactly the three literals the contract declares', () => {
+    // Quoted verbatim from the vendored 0.48.0 package,
+    // `dist/orchestrator/edit-tool-ops.js:235`, citing `cee-v3.ts:284`:
+    //   "an enum of `brief_extraction | cee_hypothesis | user_specified`"
+    // Asserted as a SET EQUALITY so this REDs if the map GROWS as well as if it
+    // shrinks — a corpus that only checks membership cannot see an invention.
+    expect([...INTERVENTION_PROVENANCE_SOURCES].sort()).toEqual([
+      'brief_extraction',
+      'cee_hypothesis',
+      'user_specified',
+    ])
+  })
+})
+
+/**
+ * ⭐⭐ THE TWO `source` FIELDS ARE DIFFERENT QUESTIONS WEARING ONE NAME.
+ *
+ * `observed_state.source` asks WHO PUT THIS VALUE HERE. `interventions[f].source`
+ * asks HOW THIS TARGET WAS DETERMINED. The vendored contract states the
+ * distinction outright and CEE exempts the interventions subtree from its
+ * observed-state screen because of it.
+ *
+ * They OVERLAP on `brief_extraction` and are otherwise disjoint — which is what
+ * makes merging them look harmless. This lane tried the merge first: adding
+ * `cee_hypothesis` to `SOURCE_CLASSES` typechecks, renders the right words, and
+ * REDs `sourceClassesCompleteness` — the one guard that can see contract drift.
+ * These cases pin the separation so a future tidy-up cannot quietly re-merge it.
+ */
+describe('⭐⭐ the two source vocabularies stay apart', () => {
+  it('the node classifier REFUSES an intervention-only literal', () => {
+    expect(classifyValueProvenance('cee_hypothesis')).toBeNull()
+    expect(classifyValueProvenance('user_specified')).toBeNull()
+  })
+
+  it('the intervention classifier REFUSES a node-only literal', () => {
+    expect(classifyInterventionProvenance('cee_inference')).toBeNull()
+    expect(classifyInterventionProvenance('user_confirmed')).toBeNull()
+    expect(classifyInterventionProvenance('panel_elicited')).toBeNull()
+  })
+
+  it('CONTRAST CONTROL: they agree on the ONE literal both vocabularies declare', () => {
+    // Without this the two refusals above are satisfiable by two classifiers
+    // that refuse everything — an absence probe with no proof it sees a
+    // presence (trap 13).
+    expect(classifyValueProvenance('brief_extraction')?.kind).toBe('brief')
+    expect(classifyInterventionProvenance('brief_extraction')?.kind).toBe('brief')
+  })
+})
+
+// ── 3. The projection ────────────────────────────────────────────────────────
+
+describe('⭐ the option projection carries each intervention’s OWN provenance', () => {
+  it('stamps the invented target `cee_hypothesis`, bound by factor id', () => {
+    const detail = toRowDetail(projection(), OPTION_PHASED)
+    const iv = detail?.interventions.find(i => i.factorId === FACTOR_LICENSING)
+    expect(iv?.provenanceSource).toBe('cee_hypothesis')
+  })
+
+  it('TWIN: stamps the user-stated target `brief_extraction`, bound by factor id', () => {
+    const detail = toRowDetail(projection(), OPTION_STAYING)
+    const iv = detail?.interventions.find(i => i.factorId === FACTOR_LICENSING)
+    expect(iv?.provenanceSource).toBe('brief_extraction')
+  })
+
+  it('⭐ reads the INTERVENTION, never the option — one option carries both', () => {
+    // `682a7e2d`'s own provenance is `from_brief`, and it carries an invented
+    // target anyway. A disclosure bound to the option node reads "from brief"
+    // for both rows here and is right twice on the other two options — the
+    // exact shape of a guard that passes on the wrong object.
+    const detail = toRowDetail(projection(), OPTION_FULL)
+    const invented = detail?.interventions.find(i => i.factorId === FACTOR_LICENSING)
+    const stated = detail?.interventions.find(i => i.factorId === FACTOR_MIGRATION)
+    expect(invented?.provenanceSource).toBe('cee_hypothesis')
+    expect(stated?.provenanceSource).toBe('brief_extraction')
+  })
+
+  it('leaves an unstamped target UNSTAMPED', () => {
+    const input = projection()
+    const nodes = input.nodes.map(n =>
+      n.id === OPTION_PHASED
+        ? optionNode(
+            OPTION_PHASED,
+            'Phased HubSpot Migration (pilot team first)',
+            { [FACTOR_LICENSING]: IV_UNSTAMPED },
+            'ai_inferred',
+          )
+        : n,
+    )
+    const detail = toRowDetail({ ...input, nodes }, OPTION_PHASED)
+    const iv = detail?.interventions.find(i => i.factorId === FACTOR_LICENSING)
+    // CONTRAST CONTROL in the same assertion: the row still projects, with its
+    // value — so the absence below is a missing STAMP, not a missing row.
+    expect(iv).toBeDefined()
+    expect(iv?.numericValue).toBe(0.6)
+    expect(iv?.provenanceSource).toBeUndefined()
+  })
+})
+
+// ── 4. The surface — what the user actually reads ────────────────────────────
+
+describe('⭐ the detail region marks an invented target where the number is read', () => {
+  it('shows "AI estimate" on the invented row', () => {
+    const detail = toRowDetail(projection(), OPTION_PHASED)!
+    render(
+      <ModelDetailRegion
+        row={optionRow(OPTION_PHASED, 'Phased HubSpot Migration (pilot team first)')}
+        detail={detail}
+        tier="plain"
+      />,
+    )
+    expect(within(provenanceOf(FACTOR_LICENSING)!).getByText(AI_LABEL)).toBeInTheDocument()
+  })
+
+  it('⭐ TWIN: the user-stated row says "From brief" and is NOT marked as invented', () => {
+    // The load-bearing half. On the deployed build the product does the exact
+    // inverse elsewhere — it labels the user's own £45,000 "AI estimate" and
+    // tells them to check it first. Marking invention without this twin would
+    // leave that failure mode wide open on this surface too.
+    const detail = toRowDetail(projection(), OPTION_STAYING)!
+    render(
+      <ModelDetailRegion
+        row={optionRow(OPTION_STAYING, 'Staying on Salesforce')}
+        detail={detail}
+        tier="plain"
+      />,
+    )
+    const cell = provenanceOf(FACTOR_LICENSING)!
+    expect(within(cell).getByText(BRIEF_LABEL)).toBeInTheDocument()
+    expect(within(cell).queryByText(AI_LABEL)).toBeNull()
+  })
+
+  it('⭐ marks BOTH rows correctly on the same pane, each by its own stamp', () => {
+    // The discriminating case, rendered: one option, two rows, opposite marks.
+    // A surface reading the option node would render the same word twice.
+    const detail = toRowDetail(projection(), OPTION_FULL)!
+    render(
+      <ModelDetailRegion
+        row={optionRow(OPTION_FULL, 'move our whole sales team off Salesforce onto HubSpot this year')}
+        detail={detail}
+        tier="plain"
+      />,
+    )
+    expect(within(provenanceOf(FACTOR_LICENSING)!).getByText(AI_LABEL)).toBeInTheDocument()
+    expect(within(provenanceOf(FACTOR_MIGRATION)!).getByText(BRIEF_LABEL)).toBeInTheDocument()
+    expect(within(provenanceOf(FACTOR_LICENSING)!).queryByText(BRIEF_LABEL)).toBeNull()
+    expect(within(provenanceOf(FACTOR_MIGRATION)!).queryByText(AI_LABEL)).toBeNull()
+  })
+
+  it('marks the ZERO invented target too — the mark tracks the stamp, not the digits', () => {
+    const detail = toRowDetail(projection(), OPTION_FULL)!
+    render(
+      <ModelDetailRegion
+        row={optionRow(OPTION_FULL, 'full switch')}
+        detail={detail}
+        tier="plain"
+      />,
+    )
+    // CONTRAST CONTROL: the value itself renders, and it is the falsy one.
+    expect(
+      screen.getByTestId(`model-detail-v2-intervention-${FACTOR_LICENSING}-value`),
+    ).toHaveTextContent('0')
+    expect(within(provenanceOf(FACTOR_LICENSING)!).getByText(AI_LABEL)).toBeInTheDocument()
+  })
+
+  it('⭐ says NOTHING for an unstamped target — unknown stays unknown', () => {
+    const input = projection()
+    const nodes = input.nodes.map(n =>
+      n.id === OPTION_PHASED
+        ? optionNode(OPTION_PHASED, 'Phased', { [FACTOR_LICENSING]: IV_UNSTAMPED }, 'ai_inferred')
+        : n,
+    )
+    const detail = toRowDetail({ ...input, nodes }, OPTION_PHASED)!
+    render(<ModelDetailRegion row={optionRow(OPTION_PHASED, 'Phased')} detail={detail} tier="plain" />)
+    // Neither claim, and not the pill's "Not set" fallback either: "Not set"
+    // is a statement about the VALUE, and the value is set — it is the
+    // provenance that is unrecorded. Asserting it in all three directions is
+    // what stops "no source" quietly becoming "AI estimate" or "From brief".
+    const row = screen.getByTestId(`model-detail-v2-intervention-${FACTOR_LICENSING}`)
+    expect(within(row).queryByText(AI_LABEL)).toBeNull()
+    expect(within(row).queryByText(BRIEF_LABEL)).toBeNull()
+    expect(within(row).queryByText(ABSENT_LABEL)).toBeNull()
+    // CONTRAST CONTROL: the row is there and shows its value, so the three
+    // absences above are not the absence of the whole row (trap 13).
+    expect(
+      screen.getByTestId(`model-detail-v2-intervention-${FACTOR_LICENSING}-value`),
+    ).toHaveTextContent('0.6')
+  })
+
+  it('the mark is TEXT, not colour alone', () => {
+    const detail = toRowDetail(projection(), OPTION_PHASED)!
+    render(<ModelDetailRegion row={optionRow(OPTION_PHASED, 'Phased')} detail={detail} tier="plain" />)
+    // A border-colour-only distinction is invisible to a monochrome reader and
+    // to anyone who cannot compare two rows side by side.
+    expect(provenanceOf(FACTOR_LICENSING)!.textContent?.trim()).toBe(AI_LABEL)
+  })
+
+  it('the mark is visible in PLAIN — it is not an Advanced parameter', () => {
+    // Trap 3b at tier grain: a disclosure that only exists behind the Advanced
+    // toggle is a disclosure most users never load.
+    const detail = toRowDetail(projection(), OPTION_PHASED)!
+    const { rerender } = render(
+      <ModelDetailRegion row={optionRow(OPTION_PHASED, 'Phased')} detail={detail} tier="plain" />,
+    )
+    expect(provenanceOf(FACTOR_LICENSING)).not.toBeNull()
+    rerender(<ModelDetailRegion row={optionRow(OPTION_PHASED, 'Phased')} detail={detail} tier="advanced" />)
+    expect(provenanceOf(FACTOR_LICENSING)).not.toBeNull()
+  })
+})
+
+// ── 5. "Where it came from" stops promising an answer it does not have ───────
+
+describe('an empty "Where it came from" is an absence, and renders as one', () => {
+  it('does not render the heading when there is nothing under it', () => {
+    // The witnessed defect: on an option the heading rendered with NOTHING
+    // beneath it — a section announcing that provenance was looked for and
+    // none exists, on the exact element whose provenance is the finding.
+    const detail = toRowDetail(projection(), OPTION_PHASED)!
+    expect(detail.basis).toBeNull()
+    expect(detail.adjustments).toHaveLength(0)
+    render(<ModelDetailRegion row={optionRow(OPTION_PHASED, 'Phased')} detail={detail} tier="plain" />)
+    expect(screen.queryByTestId('model-detail-v2-provenance')).toBeNull()
+    expect(screen.queryByText('Where it came from')).toBeNull()
+  })
+
+  it('POSITIVE CONTROL: it still renders when it HAS something to say', () => {
+    const detail = toRowDetail(projection(), OPTION_PHASED)!
+    render(
+      <ModelDetailRegion
+        row={{ ...optionRow(OPTION_PHASED, 'Phased'), provenanceSource: 'brief_extraction' }}
+        detail={detail}
+        tier="plain"
+      />,
+    )
+    expect(screen.getByTestId('model-detail-v2-provenance')).toBeInTheDocument()
+    expect(screen.getByText('Where it came from')).toBeInTheDocument()
+  })
+})

--- a/src/canvas/model-tab-v2/adapters.ts
+++ b/src/canvas/model-tab-v2/adapters.ts
@@ -778,7 +778,7 @@ function buildOptionInterventions(
     const factorLabel = resolveCanvasLabel(factorId, labels)
     if (factorLabel === null) return []
     const numeric = interventionTargetValue(rawValue)
-    const { displayValue } = unwrapInterventionValue(rawValue)
+    const { displayValue, source } = unwrapInterventionValue(rawValue)
     // A CEE-authored `display_value` wins the DISPLAY (the F.6 passthrough the
     // v1 rows already honoured); the numeric half is independent of it.
     const value = displayValue ?? (numeric === undefined ? null : formatSmartNumber(numeric))
@@ -788,6 +788,15 @@ function buildOptionInterventions(
         factorLabel,
         value,
         numericValue: numeric === undefined ? null : numeric,
+        /*
+         * ⭐ THE TARGET'S OWN STAMP, READ PER INTERVENTION (B1-a).
+         *
+         * ⚠ THE KEY IS OMITTED, NOT SET TO A PLACEHOLDER, when the record
+         * states no source. `provenanceSource: 'unknown'` or `: null` would
+         * both be a value the surface then has to special-case, and the surface
+         * that forgets to is the one that renders a guess. Absent is the fact.
+         */
+        ...(source === null ? {} : { provenanceSource: source }),
       },
     ]
   })

--- a/src/canvas/model-tab-v2/types.ts
+++ b/src/canvas/model-tab-v2/types.ts
@@ -246,6 +246,25 @@ export interface OptionInterventionField {
   factorLabel: string
   value: string | null
   numericValue: number | null
+  /**
+   * ⭐ WHO PUT **THIS TARGET** THERE — the RAW stamp the producer wrote
+   * (`'cee_hypothesis'`, `'brief_extraction'`, …), classified at the surface by
+   * the one authority, exactly as `ModelRow.provenanceSource` is.
+   *
+   * ⚠⚠ THIS IS THE INTERVENTION'S STAMP AND NOT THE OPTION'S, AND THE TWO
+   * GENUINELY DISAGREE. On the deployed witness draw (UI `88cb7e37`) option
+   * `682a7e2d` is `provenance: 'from_brief'` and carries an INVENTED target
+   * alongside a brief-extracted one. Sourcing this from the option node would
+   * be right on two of that draw's three options and wrong on the third, while
+   * looking correct in every screenshot anyone happened to take.
+   *
+   * ⚠ ABSENT MEANS THE RECORD DOES NOT SAY, and the surface must then say
+   * NOTHING. Not "AI estimate", not "From brief", and not the pill's "Not set"
+   * either — "Not set" is a claim about the VALUE, and the value is set. A
+   * default in any of those three directions is an invented provenance, which
+   * is the defect one level up from the one this field closes.
+   */
+  provenanceSource?: string
 }
 
 /**

--- a/src/canvas/ui/inspector-v2/__tests__/OptionPanel.interventionProvenanceMark.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/OptionPanel.interventionProvenanceMark.spec.tsx
@@ -1,0 +1,570 @@
+/**
+ * ⭐ AN INVENTED TARGET MUST NOT LOOK LIKE A NUMBER THE USER WROTE — **ON THE
+ * INSPECTOR** (B1-b).
+ *
+ * ── WHY THIS FILE EXISTS WHEN #827 ALREADY CLOSED THIS ────────────────────
+ * UI #827 closes the defect on the **Model tab**. An independent review of it
+ * put the residual in one sentence:
+ *
+ *     "On the Model tab, yes. On the Inspector — the surface the defect was
+ *      witnessed on — no."
+ *
+ * The Inspector is reached by DOUBLE-CLICKING A NODE ON THE CANVAS, arguably
+ * before anyone opens the Model tab at all. Its live path is
+ * `ReactFlowGraph.tsx:2334` → `InspectorModal` (`USE_INSPECTOR_V2 = true`,
+ * hardcoded at `InspectorModal.tsx:16`) → the v2 branch at `:159` →
+ * `InspectorRouter` (`NODE_PANELS.option`) → `OptionPanel`. And at
+ * `OptionPanel.tsx:118` it read:
+ *
+ *     const { value, displayValue } = unwrapInterventionValue(rawValue)
+ *
+ * **`source` was dropped at the destructure.** #827 had already made
+ * `unwrapInterventionValue` carry it; this surface simply did not take it, so
+ * `InterventionRow` received no provenance and rendered the number bare — an
+ * invented `0.45` and the user's own `0.9` in identical controls, no badge, no
+ * tooltip, no unit on either. The only difference between them was the digits.
+ *
+ * ── ⚠⚠ WHY NOT `getExtractionLabel`, WHICH THIS SURFACE ALREADY OWNS ──────
+ * DERIVED, not assumed, at `valueProvenance.ts` and `inspectorStrings.ts` on
+ * this tip. `getExtractionLabel` classifies through `classifyValueProvenance` —
+ * the **node** `observed_state.source` vocabulary. Two of the three intervention
+ * literals are not members of it:
+ *
+ *   · `cee_hypothesis`  → unclassified → default arm → "Estimated by Olumi"
+ *     (accidentally right, for the wrong reason)
+ *   · `user_specified`  → unclassified → default arm → **"Estimated by Olumi"**
+ *     — ⭐ THE MACHINE CLAIMING AUTHORSHIP OF A NUMBER THE USER TYPED. That is
+ *     the exact inversion this lane is forbidden to ship, and reusing the
+ *     surface's existing helper is how it would have arrived.
+ *
+ * The two vocabularies overlap on `brief_extraction` ONLY, which is what makes
+ * the reuse look harmless and is why it is not (CLAUDE.md trap 21 — two
+ * authorities answering different questions under one field name). T-VOCAB below
+ * pins that inversion so nobody "simplifies" this back.
+ *
+ * ── HOW THIS FILE BINDS ──────────────────────────────────────────────────
+ * · ⭐ MOUNTS `InspectorModal`, THE DEPLOYED PATH, never `OptionPanel` directly.
+ *   #827's reviewer noted that its own spec renders its component directly and
+ *   so does not pin its mount — a future default change could dark-ship the mark
+ *   under a green suite (trap 3b). T-MOUNT asserts the chain itself.
+ * · Every row is resolved BY `factorId` through `within(...)`. `0.45` is a value
+ *   predicate a different intervention could satisfy, and reading a number off
+ *   the whole pane is precisely how this estate shipped a spec that passed
+ *   against a factor it was not written for (trap 19).
+ * · Every "invented is marked" case has its OPPOSITE-DIRECTION TWIN: the
+ *   user-stated row must NOT carry the invented mark, and the unstamped row must
+ *   carry NOTHING AT ALL — not "Not set", which is a claim about the value, and
+ *   the value is set (trap 22b).
+ * · Expected user-facing strings are written LITERALLY here. The separate
+ *   agreement guard (T-VOICE) compares the register against `getExtractionLabel`
+ *   — a different module, driven by a different vocabulary — so it is a
+ *   derivation, not a constant agreeing with itself, and it PINS ITS OWN
+ *   PRECONDITION before comparing (trap 13b).
+ *
+ * ── WHY THE FIXTURES ARE THE WIRE'S, VERBATIM ────────────────────────────
+ * Trap 22: a corpus from the author's head cannot see the class the author did
+ * not imagine. The intervention objects are #827's, which are the deployed
+ * draw's (UI `88cb7e37` · CEE `d1da670`, fresh guest, 2026-08-24) — including
+ * the two a fixture written from the defect report would not have contained:
+ * `raw_value: 0` invented targets, and an option whose OWN `provenance` is
+ * `from_brief` while carrying an invented intervention.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, within } from '@testing-library/react'
+import { InspectorModal } from '../../../components/InspectorModal'
+import { useCanvasStore } from '../../../store'
+import {
+  INSPECTOR_INTERVENTION_PROVENANCE_LABEL,
+  InterventionRow,
+} from '../shared/InterventionRow'
+import { getExtractionLabel } from '../inspectorStrings'
+import {
+  INTERVENTION_PROVENANCE_SOURCES,
+  classifyInterventionProvenance,
+  classifyValueProvenance,
+  type ValueProvenanceKind,
+} from '../../../domain/valueProvenance'
+
+// importOriginal-spread, NOT a hand-listed factory: `vi.mock` REPLACES the
+// module, so a bare `{ useViewport }` factory silently removes every other
+// @xyflow/react export the subtree imports (CLAUDE.md trap 12).
+vi.mock('@xyflow/react', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  useViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+}))
+
+// ── Identity anchors — the deployed v2 mount path ────────────────────────────
+const NODE_INSPECTOR = 'div[role="dialog"][aria-label="Node inspector"]'
+const INSPECTOR_SHELL = '[role="region"][aria-label="Inspector panel"]'
+
+// ── The deployed draw's ids, verbatim from #827's fixtures ───────────────────
+const OPTION_ID = '6f2c97b3'
+const OPTION_LABEL = 'Phased migration'
+/** `682a7e2d` — `provenance: 'from_brief'` AND carries an invented target. */
+const OPTION_FROM_BRIEF_ID = '682a7e2d'
+const OPTION_FROM_BRIEF_LABEL = 'Full switch'
+
+const FACTOR_LICENSING = '440d2e30'
+const FACTOR_LICENSING_LABEL = 'Annual licensing spend'
+const FACTOR_MIGRATION = 'fd255d32'
+const FACTOR_MIGRATION_LABEL = 'Migration and training cost'
+const FACTOR_UNSTAMPED = 'aa11bb22'
+const FACTOR_UNSTAMPED_LABEL = 'Support headcount'
+
+// ── The wire's intervention objects, verbatim ────────────────────────────────
+
+/** The invented 22,500 — exactly half the user's figure, no unit. */
+const IV_INVENTED_22K5 = {
+  value: 0.45,
+  raw_value: 22500,
+  source: 'cee_hypothesis',
+  target_match: { node_id: FACTOR_LICENSING, match_type: 'exact_id', confidence: 'high' },
+  value_confidence: 'low',
+  reasoning: 'Model-chosen intervention level; this amount is not stated in the brief',
+}
+
+/** INVENTED, and `raw_value: 0` — half the invented targets on that draw are zero. */
+const IV_INVENTED_ZERO = {
+  value: 0,
+  raw_value: 0,
+  source: 'cee_hypothesis',
+  target_match: { node_id: FACTOR_LICENSING, match_type: 'exact_id', confidence: 'high' },
+  value_confidence: 'low',
+  reasoning: 'Model-chosen intervention level; this amount is not stated in the brief',
+}
+
+/** The user's own £45,000, bound to `stated_items[3]`. */
+const IV_STATED_45K = {
+  value: 0.9,
+  raw_value: 45000,
+  unit: '£',
+  source: 'brief_extraction',
+  target_match: { node_id: FACTOR_LICENSING, match_type: 'exact_id', confidence: 'high' },
+  value_confidence: 'high',
+  reasoning:
+    'Direct causal value bound by edge 3d61e986 to stated_items[3]: our annual Salesforce licensing is £45,000',
+}
+
+/** The user's own £20,000. */
+const IV_STATED_20K = {
+  value: 0.4,
+  raw_value: 20000,
+  unit: '£',
+  source: 'brief_extraction',
+  target_match: { node_id: FACTOR_MIGRATION, match_type: 'exact_id', confidence: 'high' },
+  value_confidence: 'high',
+  reasoning:
+    'Direct causal value bound by edge 36e4730e to stated_items[2]: A full switch costs £20,000 in migration and training',
+}
+
+/** The human supplied this target directly. */
+const IV_USER_SPECIFIED = {
+  value: 0.75,
+  raw_value: 37500,
+  unit: '£',
+  source: 'user_specified',
+  target_match: { node_id: FACTOR_MIGRATION, match_type: 'exact_id', confidence: 'high' },
+  value_confidence: 'high',
+}
+
+/**
+ * A bare number. The Inspector's OWN intervention editor commits one of these
+ * (`mutations.setIntervention(factorId, v)`), and nothing stamps it — so the
+ * honest answer for this row is that the record does not say.
+ */
+const IV_UNSTAMPED = 0.6
+
+// ── The exact sentences a user reads. Written literally, never imported. ─────
+const MARK_AI = 'Estimated by Olumi'
+const MARK_BRIEF = 'From your brief'
+const MARK_EDITED = 'Set by you'
+
+// ── Store harness ────────────────────────────────────────────────────────────
+
+function factorNode(id: string, label: string, observed?: Record<string, unknown>) {
+  return {
+    id,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: {
+      kind: 'factor',
+      category: 'controllable',
+      label,
+      ...(observed === undefined ? {} : { observedState: observed }),
+    },
+  }
+}
+
+function optionNode(
+  id: string,
+  label: string,
+  interventions: Record<string, unknown>,
+  provenance = 'ai_inferred',
+) {
+  return {
+    id,
+    type: 'option',
+    position: { x: 0, y: 0 },
+    data: { kind: 'option', label, provenance, interventions },
+  }
+}
+
+function seedStore(nodes: unknown[]) {
+  useCanvasStore.setState({
+    nodes: nodes as never[],
+    edges: [],
+    results: { status: 'idle' },
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: { x: 0, y: 0 } },
+    goalThreshold: null,
+    confirmedNodeIds: new Set(),
+    _internal: {},
+  } as never)
+}
+
+/** Mounts the DEPLOYED inspector chain and PROVES IT OPENED before returning. */
+function openInspector(nodeId: string) {
+  const utils = render(<InspectorModal nodeId={nodeId} edgeId={null} onClose={vi.fn()} />)
+
+  const dialog = utils.container.querySelector(NODE_INSPECTOR)
+  expect(dialog, 'PRECONDITION: the node inspector dialog must be mounted').not.toBeNull()
+  expect(
+    utils.container.querySelector(INSPECTOR_SHELL),
+    'PRECONDITION: the InspectorShell must have rendered inside it',
+  ).not.toBeNull()
+
+  return { ...utils, dialog: dialog as HTMLElement }
+}
+
+/**
+ * The one intervention row for `factorId` — bound by IDENTITY.
+ *
+ * ⚠ Never `getByText('0.45')`. A second intervention on the same option can
+ * carry the same digits, and then the assertion is about whichever the query
+ * reached first (trap 19).
+ */
+function row(dialog: HTMLElement, factorId: string): HTMLElement {
+  return within(dialog).getByTestId(`inspector-intervention-${factorId}`)
+}
+
+/** The provenance mark inside that row, or null when the surface says nothing. */
+function mark(dialog: HTMLElement, factorId: string): HTMLElement | null {
+  return within(row(dialog, factorId)).queryByTestId(
+    `inspector-intervention-${factorId}-provenance`,
+  )
+}
+
+/** The complete visible text of one row — what a user actually reads. */
+function rowText(dialog: HTMLElement, factorId: string): string {
+  return row(dialog, factorId).textContent ?? ''
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  seedStore([])
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('B1-b — the Inspector says who chose each target', () => {
+  // ── The mount path itself ──────────────────────────────────────────────────
+
+  it('⭐⭐ T-MOUNT the DEPLOYED chain renders OptionPanel, and the mark is on it', () => {
+    // Trap 3b: a spec that renders `OptionPanel` directly is green whatever the
+    // router or the `USE_INSPECTOR_V2` default does. This one drives
+    // `InspectorModal` — the component `ReactFlowGraph.tsx:2334` mounts — so a
+    // flag flip, a router arm change, or a panel swap RED s here rather than
+    // dark-shipping the mark under a green suite.
+    seedStore([
+      factorNode(FACTOR_LICENSING, FACTOR_LICENSING_LABEL),
+      optionNode(OPTION_ID, OPTION_LABEL, { [FACTOR_LICENSING]: IV_INVENTED_22K5 }),
+    ])
+    const { dialog } = openInspector(OPTION_ID)
+
+    // The panel that actually mounted is the OPTION panel, identified by its own
+    // group heading, not by anything this test rendered.
+    expect(
+      within(dialog).getByText(OPTION_LABEL),
+      'PRECONDITION: the OPTION inspector is what opened',
+    ).toBeTruthy()
+    expect(
+      within(dialog).getByText('What this option changes'),
+      "PRECONDITION: OptionPanel's own Input group must be on screen",
+    ).toBeTruthy()
+
+    expect(mark(dialog, FACTOR_LICENSING)?.textContent).toBe(MARK_AI)
+  })
+
+  // ── The defect, and both of its twins ─────────────────────────────────────
+
+  it('⭐⭐ T1 an INVENTED target is marked as the model’s own estimate', () => {
+    seedStore([
+      factorNode(FACTOR_LICENSING, FACTOR_LICENSING_LABEL),
+      optionNode(OPTION_ID, OPTION_LABEL, { [FACTOR_LICENSING]: IV_INVENTED_22K5 }),
+    ])
+    const { dialog } = openInspector(OPTION_ID)
+
+    expect(mark(dialog, FACTOR_LICENSING)?.textContent).toBe(MARK_AI)
+    // Mark by TEXT, not colour alone — the sentence is in the row's own text.
+    expect(rowText(dialog, FACTOR_LICENSING)).toContain(MARK_AI)
+  })
+
+  it('⭐⭐ T2 TWIN — the user’s OWN stated figure is NOT marked as invented', () => {
+    // The load-bearing half. Marking everything would satisfy T1 and reproduce
+    // the defect in the opposite direction, which is the worse one: the product
+    // disowning a number its user wrote.
+    seedStore([
+      factorNode(FACTOR_LICENSING, FACTOR_LICENSING_LABEL),
+      optionNode(OPTION_ID, OPTION_LABEL, { [FACTOR_LICENSING]: IV_STATED_45K }),
+    ])
+    const { dialog } = openInspector(OPTION_ID)
+
+    expect(mark(dialog, FACTOR_LICENSING)?.textContent).toBe(MARK_BRIEF)
+    expect(rowText(dialog, FACTOR_LICENSING)).not.toContain(MARK_AI)
+  })
+
+  it('⭐⭐ T3 TWIN — an UNSTAMPED target renders NOTHING, not a fallback', () => {
+    // Not "AI estimate". Not "From brief". And not "Not set" — that is a claim
+    // about the VALUE, and the value is set. Unknown stays unknown.
+    seedStore([
+      factorNode(FACTOR_UNSTAMPED, FACTOR_UNSTAMPED_LABEL),
+      optionNode(OPTION_ID, OPTION_LABEL, { [FACTOR_UNSTAMPED]: IV_UNSTAMPED }),
+    ])
+    const { dialog } = openInspector(OPTION_ID)
+
+    // PRECONDITION: the row itself is on screen, so the absence below is about
+    // the mark and not about an empty panel (trap 13 — an absence assertion
+    // needs to prove it could have seen a presence).
+    expect(within(row(dialog, FACTOR_UNSTAMPED)).getByText(FACTOR_UNSTAMPED_LABEL)).toBeTruthy()
+
+    expect(mark(dialog, FACTOR_UNSTAMPED)).toBeNull()
+    const text = rowText(dialog, FACTOR_UNSTAMPED)
+    expect(text).not.toContain(MARK_AI)
+    expect(text).not.toContain(MARK_BRIEF)
+    expect(text).not.toContain(MARK_EDITED)
+    expect(text).not.toContain('Not set')
+  })
+
+  it('⭐⭐ T4 the two are DISCRIMINATED SIDE BY SIDE on one option', () => {
+    // The witnessed defect in one frame: an invented target and a user-stated
+    // one, on the same option, in the same control. Each resolved by factorId.
+    seedStore([
+      factorNode(FACTOR_LICENSING, FACTOR_LICENSING_LABEL),
+      factorNode(FACTOR_MIGRATION, FACTOR_MIGRATION_LABEL),
+      factorNode(FACTOR_UNSTAMPED, FACTOR_UNSTAMPED_LABEL),
+      optionNode(OPTION_ID, OPTION_LABEL, {
+        [FACTOR_LICENSING]: IV_INVENTED_22K5,
+        [FACTOR_MIGRATION]: IV_STATED_20K,
+        [FACTOR_UNSTAMPED]: IV_UNSTAMPED,
+      }),
+    ])
+    const { dialog } = openInspector(OPTION_ID)
+
+    expect(mark(dialog, FACTOR_LICENSING)?.textContent).toBe(MARK_AI)
+    expect(mark(dialog, FACTOR_MIGRATION)?.textContent).toBe(MARK_BRIEF)
+    expect(mark(dialog, FACTOR_UNSTAMPED)).toBeNull()
+
+    // …and no row borrows another row's answer.
+    expect(rowText(dialog, FACTOR_MIGRATION)).not.toContain(MARK_AI)
+    expect(rowText(dialog, FACTOR_LICENSING)).not.toContain(MARK_BRIEF)
+  })
+
+  it('⭐⭐ T5 a `raw_value: 0` invented target is marked too', () => {
+    // Half the invented targets on the witnessed draw are ZERO. A guard keyed on
+    // the value being truthy — or on "22,500 is missing" — sees nothing here.
+    seedStore([
+      factorNode(FACTOR_LICENSING, FACTOR_LICENSING_LABEL),
+      optionNode(OPTION_ID, OPTION_LABEL, { [FACTOR_LICENSING]: IV_INVENTED_ZERO }),
+    ])
+    const { dialog } = openInspector(OPTION_ID)
+
+    expect(mark(dialog, FACTOR_LICENSING)?.textContent).toBe(MARK_AI)
+  })
+
+  it('⭐⭐ T6 provenance is the INTERVENTION’s, never the OPTION’s', () => {
+    // Option `682a7e2d` is `provenance: 'from_brief'` and carries an INVENTED
+    // target beside a brief-extracted one. A disclosure sourced from the option
+    // node is right on two of that draw's three options and wrong on this one —
+    // a claim that passes on the wrong object (trap 19).
+    seedStore([
+      factorNode(FACTOR_LICENSING, FACTOR_LICENSING_LABEL),
+      factorNode(FACTOR_MIGRATION, FACTOR_MIGRATION_LABEL),
+      optionNode(
+        OPTION_FROM_BRIEF_ID,
+        OPTION_FROM_BRIEF_LABEL,
+        { [FACTOR_LICENSING]: IV_INVENTED_ZERO, [FACTOR_MIGRATION]: IV_STATED_20K },
+        'from_brief',
+      ),
+    ])
+    const { dialog } = openInspector(OPTION_FROM_BRIEF_ID)
+
+    expect(mark(dialog, FACTOR_LICENSING)?.textContent).toBe(MARK_AI)
+    expect(mark(dialog, FACTOR_MIGRATION)?.textContent).toBe(MARK_BRIEF)
+  })
+
+  it('⭐⭐ T-VOCAB `user_specified` reads as the USER’s, and the surface’s own helper would have inverted it', () => {
+    // ⭐ THE REASON THIS LANE DOES NOT REUSE `getExtractionLabel`, asserted
+    // rather than argued. Both halves run: the inversion is REAL on this tip,
+    // and the shipped mark does not commit it.
+    expect(
+      classifyValueProvenance('user_specified'),
+      'PRECONDITION: `user_specified` is NOT a node observed_state.source literal',
+    ).toBeNull()
+    expect(
+      getExtractionLabel('user_specified'),
+      "the surface's node-vocabulary helper credits the machine for the user's own number",
+    ).toBe(MARK_AI)
+
+    seedStore([
+      factorNode(FACTOR_MIGRATION, FACTOR_MIGRATION_LABEL),
+      optionNode(OPTION_ID, OPTION_LABEL, { [FACTOR_MIGRATION]: IV_USER_SPECIFIED }),
+    ])
+    const { dialog } = openInspector(OPTION_ID)
+
+    expect(mark(dialog, FACTOR_MIGRATION)?.textContent).toBe(MARK_EDITED)
+    expect(rowText(dialog, FACTOR_MIGRATION)).not.toContain(MARK_AI)
+  })
+
+  it('⭐ T7 the mark survives a CEE-authored `display_value`, which hides the numeric control', () => {
+    // `InterventionRow` swaps its whole numeric surface out when CEE supplies a
+    // `display_value` (the F.6 passthrough). A mark hung off the numeric branch
+    // would vanish on exactly the rows CEE has written prose for. Enumerating
+    // EVERY path that reaches the marking is the review-doctrine rule.
+    seedStore([
+      factorNode(FACTOR_LICENSING, FACTOR_LICENSING_LABEL),
+      optionNode(OPTION_ID, OPTION_LABEL, {
+        [FACTOR_LICENSING]: { ...IV_INVENTED_22K5, display_value: 'halve licensing spend' },
+      }),
+    ])
+    const { dialog } = openInspector(OPTION_ID)
+
+    expect(
+      within(row(dialog, FACTOR_LICENSING)).getByText('halve licensing spend'),
+      'PRECONDITION: the display_value branch is the one that rendered',
+    ).toBeTruthy()
+    expect(mark(dialog, FACTOR_LICENSING)?.textContent).toBe(MARK_AI)
+  })
+
+  it('⭐ T8 SCOPING — a factor node with the same observedState source gets no intervention mark', () => {
+    // Positive control on the negative: the mark is an OPTION-panel affordance
+    // about interventions, not a general provenance badge that follows a
+    // literal around the Inspector.
+    seedStore([
+      factorNode(FACTOR_LICENSING, FACTOR_LICENSING_LABEL, {
+        value: 0.45,
+        source: 'brief_extraction',
+      }),
+    ])
+    const { dialog } = openInspector(FACTOR_LICENSING)
+
+    expect(
+      within(dialog).getByText(FACTOR_LICENSING_LABEL),
+      'PRECONDITION: the factor inspector really did open',
+    ).toBeTruthy()
+    expect(
+      within(dialog).queryByTestId(`inspector-intervention-${FACTOR_LICENSING}-provenance`),
+    ).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('B1-b — the register is this surface’s existing voice, derived', () => {
+  it('⭐⭐ T-VOICE every reachable arm equals what this surface already says', () => {
+    // ⚠ NOT a constant agreeing with itself. `getExtractionLabel` lives in a
+    // different module and is driven by the NODE vocabulary; this asserts the
+    // intervention mark speaks the Inspector's existing words rather than
+    // inventing a fourth register for the same concept (trap 12). Every pair
+    // PINS ITS OWN PRECONDITION first, so an arm cannot pass by both sides
+    // falling through to the same default (trap 13b).
+    const pairs: ReadonlyArray<readonly [ValueProvenanceKind, string]> = [
+      ['brief', 'brief_extraction'],
+      ['ai', 'cee_inference'],
+      ['edited', 'user_override'],
+      ['confirmed', 'user_confirmed'],
+      ['assumption', 'user_assumption'],
+      ['panel', 'panel_elicited'],
+    ]
+
+    for (const [kind, nodeLiteral] of pairs) {
+      expect(
+        classifyValueProvenance(nodeLiteral)?.kind,
+        `PRECONDITION: '${nodeLiteral}' must really classify to '${kind}', or the comparison below is two defaults agreeing`,
+      ).toBe(kind)
+      expect(
+        INSPECTOR_INTERVENTION_PROVENANCE_LABEL[kind],
+        `the intervention mark for '${kind}' must speak this surface's existing words`,
+      ).toBe(getExtractionLabel(nodeLiteral))
+    }
+
+    // `human` has NO `observed_state.source` literal on this tip, so it cannot
+    // be derived the same way. Stated rather than quietly skipped: it shares
+    // `edited`'s copy, exactly as `inspectorStrings`' own register does.
+    expect(
+      INTERVENTION_PROVENANCE_SOURCES.every(s => classifyInterventionProvenance(s)?.kind !== 'human'),
+      "PRECONDITION: no intervention literal reaches 'human' on this tip",
+    ).toBe(true)
+    expect(INSPECTOR_INTERVENTION_PROVENANCE_LABEL.human).toBe(
+      INSPECTOR_INTERVENTION_PROVENANCE_LABEL.edited,
+    )
+  })
+
+  it('⭐⭐ T-REACH the reachable kinds are exactly {brief, ai, edited}', () => {
+    // A DERIVED guard, not a mirror: it reads the classifier's own literal list.
+    // If a schemas minor adds an intervention source — or remaps one — this REDs
+    // and somebody has to look at the copy, instead of a new kind arriving
+    // silently on an arm nobody has read since it was typed.
+    const reachable = new Set(
+      INTERVENTION_PROVENANCE_SOURCES.map(s => classifyInterventionProvenance(s)?.kind),
+    )
+    expect([...reachable].sort()).toEqual(['ai', 'brief', 'edited'])
+
+    // …and the contract's own three literals are all of them (trap 12d — where
+    // you cannot derive, a hand-written corpus is what notices the list is
+    // short; the enum is `cee-v3.ts:284`, quoted in `valueProvenance.ts`).
+    expect([...INTERVENTION_PROVENANCE_SOURCES].sort()).toEqual([
+      'brief_extraction',
+      'cee_hypothesis',
+      'user_specified',
+    ])
+  })
+
+  it('⭐ T-NULL an unknown literal classifies to nothing and renders nothing', () => {
+    expect(classifyInterventionProvenance('cee_repair')).toBeNull()
+    expect(classifyInterventionProvenance('')).toBeNull()
+    expect(classifyInterventionProvenance(undefined)).toBeNull()
+
+    // …and the row proves the component honours that rather than guessing.
+    // `InterventionRow` is rendered directly HERE, and only here, because this
+    // is a claim about the COMPONENT's contract; the user-facing claims above
+    // all go through the deployed mount.
+    const { container } = render(
+      <InterventionRow
+        factorId={FACTOR_LICENSING}
+        factorLabel={FACTOR_LICENSING_LABEL}
+        currentValue={0.45}
+        provenanceSource="cee_repair"
+        onChange={vi.fn()}
+      />,
+    )
+    expect(
+      container.querySelector(`[data-testid="inspector-intervention-${FACTOR_LICENSING}"]`),
+      'PRECONDITION: the row rendered',
+    ).not.toBeNull()
+    expect(
+      container.querySelector(
+        `[data-testid="inspector-intervention-${FACTOR_LICENSING}-provenance"]`,
+      ),
+    ).toBeNull()
+    expect(container.textContent).not.toContain(MARK_AI)
+    expect(container.textContent).not.toContain('cee_repair')
+  })
+})
+
+// A cheap guard against the failure mode that makes every number above a lie:
+// a spec that collected zero tests still exits 0 (CLAUDE.md standing brief).
+describe('B1-b — instrument', () => {
+  it('screen is real (the harness collected and ran)', () => {
+    expect(typeof screen.queryByTestId).toBe('function')
+  })
+})

--- a/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/OptionPanel.tsx
@@ -115,7 +115,17 @@ export const OptionPanel = memo(function OptionPanel({
     const raw = (node?.data as Record<string, unknown>)?.interventions as Record<string, unknown> | undefined
     if (!raw) return []
     return Object.entries(raw).flatMap(([factorId, rawValue]) => {
-      const { value, displayValue } = unwrapInterventionValue(rawValue)
+      /*
+       * ⭐⭐ `source` IS THE THIRD NAME HERE, AND ITS ABSENCE WAS THE WHOLE
+       * DEFECT (B1-b). #827 made `unwrapInterventionValue` carry the producer's
+       * stamp; this surface did not take it, so `InterventionRow` had no
+       * provenance to show and rendered an invented target identically to a
+       * number the user wrote — on the Inspector, which is where the defect was
+       * witnessed. One destructure is the entire carry: the classification and
+       * the copy live at the row, per surface, as `valueProvenance`'s own header
+       * prescribes.
+       */
+      const { value, displayValue, source } = unwrapInterventionValue(rawValue)
       if (value == null) return []
       const factorNode = nodes.find(n => n.id === factorId)
       const obs = (factorNode?.data as Record<string, unknown>)?.observedState as Record<string, unknown> | undefined
@@ -132,6 +142,19 @@ export const OptionPanel = memo(function OptionPanel({
         unit: obs?.unit as string | undefined,
         value,
         displayValue: displayValue ?? undefined,
+        /*
+         * ⚠ THE INTERVENTION'S OWN STAMP, NOT THE OPTION NODE'S, and the two
+         * genuinely disagree: on the witnessed draw option `682a7e2d` is
+         * `provenance: 'from_brief'` and carries an INVENTED target beside a
+         * brief-extracted one. Reading it off the option would be right on two
+         * of that draw's three options and wrong on the third, while looking
+         * correct in every screenshot anyone happened to take (trap 19).
+         *
+         * ⚠ `undefined`, NEVER a placeholder string. "unknown" or "" would be a
+         * value the row then has to special-case, and the row that forgets to is
+         * the one that renders a guess. Absent is the fact.
+         */
+        provenanceSource: source ?? undefined,
       }]
     })
   }, [node?.data, nodes])
@@ -317,6 +340,7 @@ export const OptionPanel = memo(function OptionPanel({
                 currentValue={iv.value}
                 displayValue={iv.displayValue}
                 unit={iv.unit}
+                provenanceSource={iv.provenanceSource}
                 onChange={v => mutations.setIntervention(iv.factorId, v)}
                 onNavigate={() => onNavigate(iv.factorId)}
                 disabled={false}

--- a/src/canvas/ui/inspector-v2/shared/InterventionRow.tsx
+++ b/src/canvas/ui/inspector-v2/shared/InterventionRow.tsx
@@ -7,6 +7,75 @@ import { useState, useCallback, useRef, type KeyboardEvent } from 'react'
 import { ArrowRight } from 'lucide-react'
 import { NodeShapeIndicator } from '../../../nodes/NodeShapeIndicator'
 import { typography } from '../../../../styles/typography'
+import {
+  classifyInterventionProvenance,
+  type ValueProvenanceKind,
+} from '../../../domain/valueProvenance'
+
+/**
+ * ─────────────────────────────────────────────────────────────────────────────
+ * ⭐⭐ WHO CHOSE THIS TARGET — THE INSPECTOR'S REGISTER (B1-b)
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * `valueProvenance` owns the KIND and says so in its own header: *"Each surface
+ * keeps its own register (the Model tab is terse, the inspector writes
+ * sentences) but must be TOTAL over `ValueProvenanceKind` — a
+ * `Record<ValueProvenanceKind, …>` makes a missing kind a type error rather than
+ * a silent fallback."* This is the Inspector's.
+ *
+ * ⚠⚠ NOT ONE NEW WORD. Every string below is one this surface ALREADY says
+ * through `inspectorStrings`: `getExtractionLabel('brief_extraction')` is "From
+ * your brief", `getExtractionLabel('cee_inference')` is "Estimated by Olumi",
+ * and `ATTRIBUTED_LABEL` supplies the other four. The spec's T-VOICE asserts
+ * that agreement pair by pair against `getExtractionLabel` itself, so this is a
+ * DERIVED register rather than a fourth hand-maintained copy of the same concept
+ * (CLAUDE.md trap 12). If the Inspector changes its voice, this REDs.
+ *
+ * ⚠⚠ AND THE REASON IT IS NOT SIMPLY `getExtractionLabel(source)`, WHICH WAS THE
+ * FIRST THING THIS LANE TRIED. That function classifies through
+ * `classifyValueProvenance` — the NODE `observed_state.source` vocabulary. Two
+ * of the three intervention literals are not members of it, so both fall through
+ * to its default arm:
+ *
+ *   · `cee_hypothesis` → "Estimated by Olumi" — right, by accident
+ *   · `user_specified` → **"Estimated by Olumi"** — the machine claiming
+ *     authorship of a number the user typed, which is the exact inversion this
+ *     component exists to prevent
+ *
+ * The vocabularies overlap on `brief_extraction` ONLY, which is what makes the
+ * reuse look harmless (trap 21 — two authorities answering different questions
+ * under one field name). `T-VOCAB` pins the inversion so nobody "simplifies"
+ * this back to the helper.
+ *
+ * ⚠ FOUR ARMS ARE UNREACHABLE ON THIS TIP, stated rather than discovered later:
+ * `classifyInterventionProvenance` maps the contract's three literals onto
+ * `brief`, `ai` and `edited` only. `confirmed`, `assumption`, `human` and
+ * `panel` exist here so a future kind lands with COPY instead of a type hole —
+ * they are not covered by any render test and must not be claimed as such.
+ * `T-REACH` pins the reachable set, so a schemas minor that adds a literal REDs
+ * rather than arriving silently on an arm nobody has read since it was typed.
+ */
+export const INSPECTOR_INTERVENTION_PROVENANCE_LABEL: Record<ValueProvenanceKind, string> = {
+  brief: 'From your brief',
+  ai: 'Estimated by Olumi',
+  edited: 'Set by you',
+  confirmed: 'Confirmed by you',
+  assumption: 'Your assumption',
+  /** No intervention literal reaches this kind today — see T-VOICE. */
+  human: 'Set by you',
+  panel: 'From your panel',
+}
+
+/** Border tint per kind. TEXT is the mark; this only reinforces it. */
+const INSPECTOR_INTERVENTION_PROVENANCE_BORDER: Record<ValueProvenanceKind, string> = {
+  brief: 'border-info/30',
+  ai: 'border-warning/30',
+  edited: 'border-success/30',
+  confirmed: 'border-success/30',
+  assumption: 'border-success/30',
+  human: 'border-success/30',
+  panel: 'border-info/30',
+}
 
 interface InterventionRowProps {
   factorId: string
@@ -19,6 +88,20 @@ interface InterventionRowProps {
    * present, replacing the "Currently: X → editable" numeric formatter. */
   displayValue?: string
   unit?: string
+  /**
+   * ⭐ THE PRODUCER'S OWN `source` STAMP FOR **THIS INTERVENTION** — the RAW
+   * literal (`'cee_hypothesis'`, `'brief_extraction'`, `'user_specified'`),
+   * classified HERE by the one authority. Never a pre-classified kind: several
+   * literals map to one kind, and an inverse map at the caller would be a second
+   * mirror of the classifier.
+   *
+   * ⚠ UNDEFINED MEANS THE RECORD DOES NOT SAY, and this component then renders
+   * NOTHING. Not "Estimated by Olumi", not "From your brief", and not a "Not
+   * set" fallback — "Not set" is a claim about the VALUE, and the value is set.
+   * A default in any direction is an invented provenance, which is the defect
+   * one level up from the one this prop closes.
+   */
+  provenanceSource?: string
   onChange: (newValue: number) => void
   onNavigate?: () => void
   disabled?: boolean
@@ -28,11 +111,13 @@ interface InterventionRowProps {
 }
 
 export function InterventionRow({
+  factorId,
   factorLabel,
   baseline,
   currentValue,
   displayValue,
   unit = '',
+  provenanceSource,
   onChange,
   onNavigate,
   disabled = false,
@@ -84,8 +169,20 @@ export function InterventionRow({
   const hasDisplayValue = !!displayValue
   const showNumericSurface = !hasDisplayValue || techMode
 
+  /**
+   * ⚠ CLASSIFIED ONCE, OUTSIDE BOTH VALUE BRANCHES. The mark must not hang off
+   * `showNumericSurface` or off `hasDisplayValue`: CEE writes a `display_value`
+   * for some interventions and not others, and a mark on either branch alone
+   * would vanish on exactly the rows the producer had written prose for. `null`
+   * is the honest answer for an unknown or absent stamp and renders nothing.
+   */
+  const provenance = classifyInterventionProvenance(provenanceSource)
+
   return (
-    <div className="bg-panel border border-panel-border rounded-lg p-2.5 mb-1.5">
+    <div
+      data-testid={`inspector-intervention-${factorId}`}
+      className="bg-panel border border-panel-border rounded-lg p-2.5 mb-1.5"
+    >
       {/* Factor label + change indicator (delta hidden when displayValue is primary) */}
       <div className="flex justify-between items-center">
         <div className="flex items-center gap-1.5">
@@ -138,6 +235,41 @@ export function InterventionRow({
               disabled ? 'border-panel-border text-text-light' : 'border-info'
             }`}
           />
+        </div>
+      )}
+
+      {/*
+        ⭐ WHO CHOSE THIS NUMBER — IN THE SAME GLANCE AS THE NUMBER.
+
+        ⚠⚠ THE DEFECT THIS CLOSES, ON THE SURFACE IT WAS WITNESSED ON (B1-b).
+        UI #827 closed it on the Model tab; the Inspector — reached by
+        double-clicking a node on the canvas, arguably before anyone opens the
+        Model tab — still dropped `source` at `OptionPanel`'s destructure, so
+        this row received no provenance and rendered the number bare. On the
+        witnessed draw that meant a target CEE had invented (raw 22,500, no
+        unit, `value_confidence: low`, CEE's own reasoning saying *"this amount
+        is not stated in the brief"*) sitting in the same control, the same
+        typography and with no badge, tooltip or unit beside the user's own
+        £45,000. **The only difference between them was the digits.**
+
+        ⚠ INLINE, NOT BEHIND A HOVER AND NOT IN A DISCLOSURE. A mark a user has
+        to go and look for arrives after they have already believed the number.
+        This costs no extra interaction — it is beneath the figure it qualifies,
+        on both value branches.
+
+        ⚠ TEXT, NOT COLOUR ALONE. The border tint reinforces a sentence that is
+        already readable; it never carries the meaning by itself.
+
+        ⚠ NO STAMP ⇒ NOTHING RENDERS. Unknown stays unknown.
+      */}
+      {provenance !== null && (
+        <div className="mt-1.5">
+          <span
+            data-testid={`inspector-intervention-${factorId}-provenance`}
+            className={`inline-flex items-center px-2 py-0.5 rounded-full bg-transparent border ${INSPECTOR_INTERVENTION_PROVENANCE_BORDER[provenance.kind]} text-text-body ${typography.panelMeta}`}
+          >
+            {INSPECTOR_INTERVENTION_PROVENANCE_LABEL[provenance.kind]}
+          </span>
         </div>
       )}
 

--- a/src/canvas/utils/__tests__/labelUtils.spec.ts
+++ b/src/canvas/utils/__tests__/labelUtils.spec.ts
@@ -380,19 +380,19 @@ describe('denormaliseInterventionValue', () => {
 describe('unwrapInterventionValue', () => {
   describe('null and undefined', () => {
     it('returns { value: null, displayValue: null } for undefined', () => {
-      expect(unwrapInterventionValue(undefined)).toEqual({ value: null, displayValue: null })
+      expect(unwrapInterventionValue(undefined)).toEqual({ value: null, displayValue: null, source: null })
     })
     it('returns { value: null, displayValue: null } for null', () => {
-      expect(unwrapInterventionValue(null)).toEqual({ value: null, displayValue: null })
+      expect(unwrapInterventionValue(null)).toEqual({ value: null, displayValue: null, source: null })
     })
   })
 
   describe('primitive number', () => {
     it('returns finite numbers with null displayValue', () => {
-      expect(unwrapInterventionValue(0.1)).toEqual({ value: 0.1, displayValue: null })
-      expect(unwrapInterventionValue(0)).toEqual({ value: 0, displayValue: null })
-      expect(unwrapInterventionValue(-7)).toEqual({ value: -7, displayValue: null })
-      expect(unwrapInterventionValue(1_000_000)).toEqual({ value: 1_000_000, displayValue: null })
+      expect(unwrapInterventionValue(0.1)).toEqual({ value: 0.1, displayValue: null, source: null })
+      expect(unwrapInterventionValue(0)).toEqual({ value: 0, displayValue: null, source: null })
+      expect(unwrapInterventionValue(-7)).toEqual({ value: -7, displayValue: null, source: null })
+      expect(unwrapInterventionValue(1_000_000)).toEqual({ value: 1_000_000, displayValue: null, source: null })
     })
     it('returns value:null for NaN', () => {
       expect(unwrapInterventionValue(NaN).value).toBeNull()
@@ -405,7 +405,7 @@ describe('unwrapInterventionValue', () => {
 
   describe('CEEInterventionV3 / UIInterventionValue object', () => {
     it('extracts .value when raw is a {value} object', () => {
-      expect(unwrapInterventionValue({ value: 0.1 })).toEqual({ value: 0.1, displayValue: null })
+      expect(unwrapInterventionValue({ value: 0.1 })).toEqual({ value: 0.1, displayValue: null, source: null })
     })
     it('extracts .value from a full CEEInterventionV3 shape', () => {
       const intervention = {
@@ -415,7 +415,12 @@ describe('unwrapInterventionValue', () => {
         value_confidence: 'high',
         reasoning: 'Extracted from "£25k marketing budget"',
       }
-      expect(unwrapInterventionValue(intervention)).toEqual({ value: 25000, displayValue: null })
+      // The `source` half is now CARRIED, not dropped. This case is the exact
+      // shape B1-a was written for: a CEE intervention whose `source` says where
+      // the number came from, read through the ONE unwrap every render surface
+      // uses. Before 2026-08-24 it arrived here and was discarded.
+      expect(unwrapInterventionValue(intervention))
+        .toEqual({ value: 25000, displayValue: null, source: 'brief_extraction' })
     })
     it('returns value:null when .value is missing', () => {
       expect(unwrapInterventionValue({ source: 'brief_extraction' }).value).toBeNull()
@@ -448,16 +453,16 @@ describe('unwrapInterventionValue', () => {
   describe('display_value extraction (CEE-authored labels)', () => {
     it('returns value and displayValue together from V3 object', () => {
       expect(unwrapInterventionValue({ value: 0.85, display_value: 'High', source: 'cee' }))
-        .toEqual({ value: 0.85, displayValue: 'High' })
+        .toEqual({ value: 0.85, displayValue: 'High', source: 'cee' })
     })
     it('returns displayValue:null when display_value absent', () => {
-      expect(unwrapInterventionValue({ value: 0.5 })).toEqual({ value: 0.5, displayValue: null })
+      expect(unwrapInterventionValue({ value: 0.5 })).toEqual({ value: 0.5, displayValue: null, source: null })
     })
     it('preserves displayValue even when .value is null', () => {
       // Renderers that tolerate null value (e.g. FactorNode comparison rows)
       // can still show the CEE string. Computation sites drop on value==null.
       expect(unwrapInterventionValue({ value: null, display_value: 'no change' }))
-        .toEqual({ value: null, displayValue: 'no change' })
+        .toEqual({ value: null, displayValue: 'no change', source: null })
     })
     it('returns displayValue:null for empty string display_value', () => {
       expect(unwrapInterventionValue({ value: 0.3, display_value: '' }).displayValue).toBeNull()
@@ -468,7 +473,7 @@ describe('unwrapInterventionValue', () => {
     })
     it('trims surrounding whitespace on display_value', () => {
       expect(unwrapInterventionValue({ value: 0.3, display_value: '  High  ' }))
-        .toEqual({ value: 0.3, displayValue: 'High' })
+        .toEqual({ value: 0.3, displayValue: 'High', source: null })
     })
     it('returns displayValue:null for non-string display_value', () => {
       expect(unwrapInterventionValue({ value: 0.3, display_value: 42 }).displayValue).toBeNull()

--- a/src/canvas/utils/labelUtils.ts
+++ b/src/canvas/utils/labelUtils.ts
@@ -628,6 +628,40 @@ export interface UnwrappedIntervention {
   value: number | null
   /** CEE-authored human-readable label (trimmed), or null when absent. */
   displayValue: string | null
+  /**
+   * ⭐ THE PRODUCER'S OWN `source` STAMP FOR **THIS INTERVENTION** — the RAW
+   * literal (`'cee_hypothesis'`, `'brief_extraction'`, …), never a classified
+   * kind. `null` when the record does not state one.
+   *
+   * ⚠⚠ ADDED BECAUSE ITS ABSENCE HERE WAS THE WHOLE DEFECT (B1-a, deployed
+   * witness UI `88cb7e37` · CEE `d1da670`, 2026-08-24). Every render surface in
+   * the tree reads an intervention through this one function, so a field
+   * dropped here is a field no surface downstream can ever show. On the
+   * witnessed draw that meant a value CEE had invented — raw 22,500, no unit,
+   * `value_confidence: low`, and CEE's own reasoning saying *"this amount is
+   * not stated in the brief"* — rendered in the same control, the same
+   * typography and with no marker at all beside the user's own £45,000. **The
+   * only difference between a number Olumi invented and one the user wrote was
+   * the digits.**
+   *
+   * ⚠ THE LITERAL, NOT A KIND — the same rule `ModelRow.provenanceSource`
+   * states and for the same reason: `classifyValueProvenance` is the one
+   * authority, several literals classify to one kind, and an inverse map here
+   * would be a second hand-maintained mirror of the classifier (trap 12).
+   *
+   * ⚠ IT IS THE **INTERVENTION'S** STAMP, NOT THE OPTION'S. On the witnessed
+   * draw option `682a7e2d` carries `provenance: 'from_brief'` and an INVENTED
+   * target anyway, while its sibling target on the same option is the user's
+   * own £20,000. Reading provenance off the option node is right on two of that
+   * draw's three options and wrong on the third — a claim that passes on the
+   * wrong object (trap 19).
+   *
+   * ⚠ ONLY `source`. `reasoning` and `value_confidence` are deliberately NOT
+   * carried: `reasoning` is raw engine prose that this estate's surfaces put
+   * through `sanitiseDetail` before showing, and carrying a field no surface
+   * renders is dead weight that the next reader mistakes for a promise.
+   */
+  source: string | null
 }
 
 export function unwrapInterventionValue(raw: unknown): UnwrappedIntervention {
@@ -650,7 +684,20 @@ export function unwrapInterventionValue(raw: unknown): UnwrappedIntervention {
     }
   }
 
-  return { value, displayValue }
+  // The provenance stamp is independent of BOTH halves above — it may be
+  // present on an intervention whose value is null, and (as on the witnessed
+  // draw, where half the invented targets are `raw_value: 0`) on one whose
+  // value is falsy. Keyed on the string being non-blank, never on the value.
+  let source: string | null = null
+  if (raw != null && typeof raw === 'object' && 'source' in raw) {
+    const s = (raw as { source: unknown }).source
+    if (typeof s === 'string') {
+      const trimmed = s.trim()
+      if (trimmed.length > 0) source = trimmed
+    }
+  }
+
+  return { value, displayValue, source }
 }
 
 /**


### PR DESCRIPTION
## ⚠⚠ STACKED ON #827 — DO NOT MERGE THIS BEFORE #827 IS REVIEWED AND MERGED

This branch is cut from `b1a-invented-value-provenance-disclosed` (#827 head `b672ee04`), because
its `classifyInterventionProvenance` and `unwrapInterventionValue`'s `source` field are what this
change reuses — deriving them was the alternative and would have minted a second classifier for one
concept (CLAUDE.md trap 12).

The base is `staging` **only because `Staging Gate` is triggered by
`pull_request: branches: [staging]` and by nothing else** (`.github/workflows/staging-full-tests.yml:28-32`),
so a stacked base would have produced a PR with no required check at all. The consequence is that
this PR's diff **contains #827's seven files**. Merging it merges #827 with it. Once #827 lands,
GitHub collapses this diff to the three files below.

**My own change is exactly three files, none of them in #827's seam:**

| file | change |
|---|---|
| `src/canvas/ui/inspector-v2/panels/OptionPanel.tsx` | one destructure + carry the stamp per intervention |
| `src/canvas/ui/inspector-v2/shared/InterventionRow.tsx` | classify + render the mark |
| `src/canvas/ui/inspector-v2/__tests__/OptionPanel.interventionProvenanceMark.spec.tsx` | new, 14 tests |

---

## The defect

#827 closes this **on the Model tab**. It was witnessed **on the Inspector**, and the review of #827
said so plainly: *"On the Model tab, yes. On the Inspector — the surface the defect was witnessed
on — no."*

The Inspector is reached by **double-clicking a node on the canvas**, arguably before anyone opens
the Model tab. Its live path is `ReactFlowGraph.tsx:2334` → `InspectorModal`
(`USE_INSPECTOR_V2 = true`, hardcoded at `:16`) → the v2 branch at `:159` → `InspectorRouter`
(`NODE_PANELS.option`) → `OptionPanel`. And `OptionPanel.tsx:118` read:

```ts
const { value, displayValue } = unwrapInterventionValue(rawValue)
```

**`source` was dropped at the destructure.** #827 had already made the unwrapper carry it; this
surface did not take it, so `InterventionRow` had no provenance and rendered the number bare.

On the witnessed draw (UI `88cb7e37` · CEE `d1da670`) that meant a target CEE had **invented** —
raw 22,500, no unit, `value_confidence: low`, its own reasoning saying *"this amount is not stated
in the brief"* — in the same control, the same typography, no badge, no tooltip, no unit, directly
beside the user's own **£45,000**. The only difference between them was the digits.

## What a user now sees

| the row | before | after |
|---|---|---|
| CEE's invented target | `0.45`, bare | `0.45` · **Estimated by Olumi** |
| the user's own £45,000 | `0.9`, bare | `0.9` · **From your brief** |
| a target the user typed in the Inspector | bare | **Set by you** |
| an unstamped bare number | bare | **nothing** — unknown stays unknown |

Beneath the figure, in the same glance, on **both** value branches (a CEE `display_value` replaces
the whole numeric control, and a mark hung off the numeric branch would have vanished on exactly the
rows the producer had written prose for — T7). **Interaction cost: zero.** Text, not colour alone;
the border tint only reinforces a sentence that is already readable.

## ⚠⚠ Why NOT `getExtractionLabel`, which this surface already owns

Derived at the bytes on this tip, and it is the finding worth reading. `getExtractionLabel`
classifies through `classifyValueProvenance` — the **node** `observed_state.source` vocabulary. Two
of the three intervention literals are not members of it, so both reach its default arm:

* `cee_hypothesis` → `"Estimated by Olumi"` — right, **by accident**
* `user_specified` → **`"Estimated by Olumi"`** — ⭐ the machine claiming authorship of a number the
  user typed

That is the exact inversion this lane is forbidden to ship, and reusing the surface's own helper is
how it would have arrived. The vocabularies overlap on `brief_extraction` **only**, which is what
makes the reuse look harmless (trap 21). **T-VOCAB asserts both halves**: the inversion is real on
this tip, and the shipped mark does not commit it.

## The register is derived, not a fourth mirror

`valueProvenance`'s own header ratifies a per-surface register that is TOTAL over
`ValueProvenanceKind`. This one contains **not one new word** — every string is one the Inspector
already says. **T-VOICE proves it rather than asserting it**: each arm is compared against
`getExtractionLabel(<node literal of that kind>)` — a different module, driven by a different
vocabulary — with `classifyValueProvenance(literal)?.kind` pinned first so an arm cannot pass by both
sides falling through to the same default (trap 13b). If the Inspector changes its voice, this REDs.

`T-REACH` pins the reachable kinds as exactly `{brief, ai, edited}` by reading the classifier's own
literal list, so a schemas minor that adds a source REDs instead of landing silently on an arm nobody
has read since it was typed. The four unreachable arms are documented as unreachable and are **not**
claimed as covered.

## Evidence

* **RED-first at pristine (`b672ee04`, unmodified):** 14 collected · **11 failed** · 3 passed.
  The three that passed are accounted for: `T8` is a scoping guard (vacuous until the mark exists —
  covered by mutant M5), `T-REACH` guards #827's inherited classifier, and the instrument test is
  trivially green by design. Named signatures in the lane report.
* **After:** 14/14 green — **asserted by name, not inferred from a suite total** (a spec that
  collects zero still exits 0).
* **Typecheck gate** (`scripts/ci/typecheck-gate.sh`, the repo's own named gate at this tip):
  ✅ PASSED — 3602/3642 files, ratchet 2252/2252, no drift.
* **Mutation kit:** discriminating pair — see the lane report.

No new flags. No dark launch. No wire change. Nothing crosses a service boundary.
