### PR TITLE
fix(analysis-summary): an unevaluated constraint must not read as a breach

### DIFF
--- a/src/__contracts__/__tests__/bilContract.spec.ts
+++ b/src/__contracts__/__tests__/bilContract.spec.ts
@@ -15,8 +15,8 @@ describe('BIL Contract', () => {
     expect(BIL_CONTRACT_VERSION).toBe('1.1.0')
   })
 
-  it('ANALYSIS_INPUTS_CONTRACT_VERSION is 1.0.0', () => {
-    expect(ANALYSIS_INPUTS_CONTRACT_VERSION).toBe('1.0.0')
+  it('ANALYSIS_INPUTS_CONTRACT_VERSION is 1.1.0', () => {
+    expect(ANALYSIS_INPUTS_CONTRACT_VERSION).toBe('1.1.0')
   })
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -118,7 +118,7 @@ describe('BIL Contract', () => {
     const typed = fixture as unknown as AnalysisInputsSummary
 
     // contract_version
-    expect(typed.contract_version).toBe('1.0.0')
+    expect(typed.contract_version).toBe('1.1.0')
 
     // recommendation
     expect(typed.recommendation).toHaveProperty('option_id')
@@ -173,12 +173,21 @@ describe('BIL Contract', () => {
     expect(typed.constraints_status.length).toBeLessThanOrEqual(5)
     for (const c of typed.constraints_status) {
       expect(c).toHaveProperty('label')
-      expect(c).toHaveProperty('satisfied')
+      expect(c).toHaveProperty('status')
       expect(typeof c.label).toBe('string')
-      expect(typeof c.satisfied).toBe('boolean')
-      // probability is optional
+      expect(['likely_met', 'uncertain', 'likely_missed', 'unevaluated']).toContain(c.status)
+      // No fabricated boolean. `satisfied` was `prob_satisfied >= 0.5`, which
+      // reported an unevaluated constraint as breached; it had zero readers in
+      // any repo and was removed at 1.1.0.
+      expect(c).not.toHaveProperty('satisfied')
+      // probability is optional, and present ONLY when actually evaluated —
+      // an unevaluated constraint must carry no number at all.
       if ('probability' in c) {
         expect(typeof c.probability).toBe('number')
+        expect(Number.isFinite(c.probability)).toBe(true)
+        expect(c.status).not.toBe('unevaluated')
+      } else {
+        expect(c.status).toBe('unevaluated')
       }
     }
 

--- a/src/__contracts__/analysis-inputs-summary.fixture.json
+++ b/src/__contracts__/analysis-inputs-summary.fixture.json
@@ -1,18 +1,38 @@
 {
-  "contract_version": "1.0.0",
+  "contract_version": "1.1.0",
   "recommendation": {
     "option_id": "opt_senior_hire",
     "option_label": "Hire senior engineer",
     "win_probability": 0.72
   },
   "options": [
-    { "id": "opt_senior_hire", "label": "Hire senior engineer", "win_probability": 0.72 },
-    { "id": "opt_promote", "label": "Promote from within", "win_probability": 0.28 }
+    {
+      "id": "opt_senior_hire",
+      "label": "Hire senior engineer",
+      "win_probability": 0.72
+    },
+    {
+      "id": "opt_promote",
+      "label": "Promote from within",
+      "win_probability": 0.28
+    }
   ],
   "top_drivers": [
-    { "factor_id": "f_team_velocity", "factor_label": "Team velocity", "elasticity": 0.42 },
-    { "factor_id": "f_retention", "factor_label": "Employee retention", "elasticity": 0.28 },
-    { "factor_id": "f_ramp_time", "factor_label": "Ramp-up time", "elasticity": 0.18 }
+    {
+      "factor_id": "f_team_velocity",
+      "factor_label": "Team velocity",
+      "elasticity": 0.42
+    },
+    {
+      "factor_id": "f_retention",
+      "factor_label": "Employee retention",
+      "elasticity": 0.28
+    },
+    {
+      "factor_id": "f_ramp_time",
+      "factor_label": "Ramp-up time",
+      "elasticity": 0.18
+    }
   ],
   "sensitivity_concentration": 0.477,
   "confidence_band": "medium",
@@ -21,8 +41,16 @@
     "recommendation_stability": 0.61
   },
   "constraints_status": [
-    { "label": "Headcount budget", "satisfied": true, "probability": 0.88 },
-    { "label": "Time to productivity", "satisfied": true, "probability": 0.65 }
+    {
+      "label": "Headcount budget",
+      "status": "likely_met",
+      "probability": 0.88
+    },
+    {
+      "label": "Time to productivity",
+      "status": "uncertain",
+      "probability": 0.65
+    }
   ],
   "run_metadata": {
     "seed": "42",

--- a/src/canvas/analysis/__tests__/assembleAnalysisInputsSummary.constraintHonesty.spec.ts
+++ b/src/canvas/analysis/__tests__/assembleAnalysisInputsSummary.constraintHonesty.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * Constraint satisfaction honesty — the `satisfied` fabrication.
+ *
+ * At 4984ea4 `buildConstraintsStatus` emitted:
+ *
+ *   satisfied: c.prob_satisfied >= 0.5,
+ *   ...(c.prob_satisfied != null ? { probability: c.prob_satisfied } : {}),
+ *
+ * Two defects in adjacent lines:
+ *
+ *  (1) UNKNOWN RENDERED AS A DEFINITE BREACH. `null >= 0.5` and
+ *      `undefined >= 0.5` are both `false`, so a constraint the science never
+ *      evaluated was reported to the model as NOT SATISFIED. The second line
+ *      guards `probability` against null; the first is unguarded — so the
+ *      unevaluated case shipped as a BARER, more absolute breach claim than a
+ *      real one (`{satisfied:false}` with no probability at all, versus
+ *      `{satisfied:false, probability:0.02}` for a genuine miss). The guard did
+ *      not mitigate the fabrication, it concealed it.
+ *
+ *  (2) A PROBABILITY COLLAPSED TO A BINARY AT A THRESHOLD THIS ESTATE DOES NOT
+ *      USE ANYWHERE ELSE. 0.49 and 0.51 are near-identical coin flips that
+ *      received opposite confident verdicts. Meanwhile `src/types/constraints.ts`
+ *      already bands this exact field (`prob_satisfied`) at 0.40/0.70 —
+ *      CONSTRAINT_CONFIDENCE_THRESHOLDS, UI-SEM-010 — and the results panel
+ *      renders the middle band as "uncertain". So the model was told
+ *      `satisfied: false` for a constraint the user's own screen showed as
+ *      uncertain-blue. Producer and screen disagreed inside one product.
+ *
+ * This payload is not display-only: it is `compact_summary` inside
+ * `analysis_state` on every CEE turn request (useConversation.ts:3371), so it
+ * reaches the model as context and can produce coaching about a breach that
+ * was never computed.
+ *
+ * Fix: reuse the existing banding rather than mint a fourth threshold, and let
+ * "not evaluated" be its own state instead of collapsing into `false`.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { assembleAnalysisInputsSummary } from '../assembleAnalysisInputsSummary'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+import type { ConstraintItem } from '../../../types/constraints'
+
+/**
+ * A complete ConstraintItem. `prob` is deliberately widened: the V2 wire admits
+ * null/absent `prob_satisfied` (which is precisely why the shipped code guarded
+ * `probability` against it) even though the local interface declares `number`.
+ */
+function constraint(node_id: string, label: string, prob: number): ConstraintItem {
+  return {
+    node_id,
+    operator: '>=',
+    threshold: 100,
+    label,
+    prob_satisfied: prob,
+    failure_margin_median: 0,
+    near_miss_fraction: 0,
+    binding: false,
+  }
+}
+
+/** A constraint whose `prob_satisfied` KEY IS ABSENT, as an uncomputed wire row is. */
+function constraintWithNoProbKey(node_id: string, label: string): ConstraintItem {
+  const c = constraint(node_id, label, 0)
+  delete (c as Partial<ConstraintItem>).prob_satisfied
+  return c
+}
+
+function reportWith(constraints: ConstraintItem[]): V2RunResponse {
+  return {
+    option_comparison_status: 'computed',
+    robustness_status: 'not_computed',
+    option_comparison: [
+      {
+        option_id: 'opt-a',
+        option_label: 'Option A',
+        win_probability: 0.7,
+        constraint_analysis: { constraints, joint_probability: 0.5 },
+      },
+    ],
+  } as unknown as V2RunResponse
+}
+
+/** Bind by IDENTITY — exact label — never by a value predicate another row could satisfy. */
+function byLabel(result: ReturnType<typeof assembleAnalysisInputsSummary>, label: string) {
+  const row = result?.constraints_status.find(c => c.label === label)
+  if (!row) throw new Error(`no constraint row with label "${label}"`)
+  return row as Record<string, unknown>
+}
+
+describe('buildConstraintsStatus — unknown must stay unknown', () => {
+  it('a constraint with prob_satisfied null is NOT reported as a breach', () => {
+    const row = byLabel(
+      assembleAnalysisInputsSummary(
+        reportWith([constraint('c-null', 'Never evaluated null', null as unknown as number)]),
+      ),
+      'Never evaluated null',
+    )
+    expect(row.satisfied).toBeUndefined()
+    expect(row.status).toBe('unevaluated')
+  })
+
+  it('a constraint whose prob_satisfied key is absent is NOT reported as a breach', () => {
+    const row = byLabel(
+      assembleAnalysisInputsSummary(reportWith([constraintWithNoProbKey('c-abs', 'Never evaluated absent')])),
+      'Never evaluated absent',
+    )
+    expect(row.satisfied).toBeUndefined()
+    expect(row.status).toBe('unevaluated')
+  })
+
+  it('a non-finite prob_satisfied is NOT reported as a breach and emits no NaN probability', () => {
+    const row = byLabel(
+      assembleAnalysisInputsSummary(reportWith([constraint('c-nan', 'Not a number', Number.NaN)])),
+      'Not a number',
+    )
+    expect(row.satisfied).toBeUndefined()
+    expect(row.status).toBe('unevaluated')
+    expect(row).not.toHaveProperty('probability')
+  })
+
+  it('an unevaluated constraint is distinguishable from a genuine breach in the emitted payload', () => {
+    const result = assembleAnalysisInputsSummary(
+      reportWith([
+        constraint('c-null', 'Unevaluated', null as unknown as number),
+        constraint('c-miss', 'Genuine breach', 0.02),
+      ]),
+    )
+    const unevaluated = byLabel(result, 'Unevaluated')
+    const breach = byLabel(result, 'Genuine breach')
+    // At 4984ea4 BOTH serialised to satisfied:false — indistinguishable to the model.
+    expect(unevaluated.status).not.toBe(breach.status)
+  })
+})
+
+describe('buildConstraintsStatus — near-threshold must not read as a confident verdict', () => {
+  it('0.49 and 0.51 both read uncertain rather than opposite confident verdicts', () => {
+    const result = assembleAnalysisInputsSummary(
+      reportWith([
+        constraint('c-lo', 'Coin flip low', 0.49),
+        constraint('c-hi', 'Coin flip high', 0.51),
+      ]),
+    )
+    const lo = byLabel(result, 'Coin flip low')
+    const hi = byLabel(result, 'Coin flip high')
+    expect(lo.status).toBe('uncertain')
+    expect(hi.status).toBe('uncertain')
+    expect(lo.satisfied).toBeUndefined()
+    expect(hi.satisfied).toBeUndefined()
+    // The pair must not receive opposite verdicts across a 0.02 gap.
+    expect(lo.status).toBe(hi.status)
+  })
+
+  it('0.65 reads uncertain, matching the band the results panel already shows the user', () => {
+    // The shipped contract fixture carries exactly this case asserted as
+    // satisfied:true, while SuccessTargetRow renders 0.65 as uncertain-blue.
+    const row = byLabel(
+      assembleAnalysisInputsSummary(reportWith([constraint('c-65', 'Time to productivity', 0.65)])),
+      'Time to productivity',
+    )
+    expect(row.status).toBe('uncertain')
+  })
+})
+
+describe('OPPOSITE-DIRECTION TWINS — the fix must not soften a real breach or a real pass', () => {
+  it('a genuinely satisfied constraint still reads met', () => {
+    const row = byLabel(
+      assembleAnalysisInputsSummary(reportWith([constraint('c-ok', 'Comfortably met', 0.95)])),
+      'Comfortably met',
+    )
+    expect(row.status).toBe('likely_met')
+    expect(row.probability).toBe(0.95)
+  })
+
+  it('a genuinely breaching constraint still reads missed', () => {
+    const row = byLabel(
+      assembleAnalysisInputsSummary(reportWith([constraint('c-bad', 'Clearly breached', 0.02)])),
+      'Clearly breached',
+    )
+    expect(row.status).toBe('likely_missed')
+    expect(row.probability).toBe(0.02)
+  })
+
+  it('an exact 0 probability is a measured breach, NOT an absence', () => {
+    const row = byLabel(
+      assembleAnalysisInputsSummary(reportWith([constraint('c-zero', 'Zero probability', 0)])),
+      'Zero probability',
+    )
+    expect(row.status).toBe('likely_missed')
+    expect(row.probability).toBe(0)
+  })
+
+  it('band boundaries are the estate thresholds (0.70 met, 0.40 uncertain), not a minted 0.5', () => {
+    const result = assembleAnalysisInputsSummary(
+      reportWith([
+        constraint('c-70', 'Exactly seventy', 0.70),
+        constraint('c-40', 'Exactly forty', 0.40),
+        constraint('c-39', 'Just under forty', 0.39),
+      ]),
+    )
+    expect(byLabel(result, 'Exactly seventy').status).toBe('likely_met')
+    expect(byLabel(result, 'Exactly forty').status).toBe('uncertain')
+    expect(byLabel(result, 'Just under forty').status).toBe('likely_missed')
+  })
+
+  it('a mixed set keeps every row bound to its own identity', () => {
+    const result = assembleAnalysisInputsSummary(
+      reportWith([
+        constraint('c-a', 'Alpha met', 0.9),
+        constraint('c-b', 'Bravo unevaluated', null as unknown as number),
+        constraint('c-c', 'Charlie missed', 0.1),
+        constraint('c-d', 'Delta uncertain', 0.5),
+      ]),
+    )
+    expect(byLabel(result, 'Alpha met').status).toBe('likely_met')
+    expect(byLabel(result, 'Bravo unevaluated').status).toBe('unevaluated')
+    expect(byLabel(result, 'Charlie missed').status).toBe('likely_missed')
+    expect(byLabel(result, 'Delta uncertain').status).toBe('uncertain')
+  })
+})

--- a/src/canvas/analysis/__tests__/assembleAnalysisInputsSummary.spec.ts
+++ b/src/canvas/analysis/__tests__/assembleAnalysisInputsSummary.spec.ts
@@ -65,7 +65,7 @@ describe('assembleAnalysisInputsSummary', () => {
 
     expect(result).not.toBeNull()
     expect(result!.contract_version).toBe(ANALYSIS_INPUTS_CONTRACT_VERSION)
-    expect(result!.contract_version).toBe('1.0.0')
+    expect(result!.contract_version).toBe('1.1.0')
     expect(result!.recommendation.option_id).toBe('opt_a')
     expect(result!.recommendation.win_probability).toBe(0.65)
     expect(result!.options).toHaveLength(2)

--- a/src/canvas/analysis/assembleAnalysisInputsSummary.ts
+++ b/src/canvas/analysis/assembleAnalysisInputsSummary.ts
@@ -12,6 +12,7 @@ import type { V2RunResponse, V2OptionComparison, V2FactorSensitivity, V2Robustne
 import type { AnalysisInputsSummary } from '../../types/analysis-inputs-summary'
 import { ANALYSIS_INPUTS_CONTRACT_VERSION } from '../../types/analysis-inputs-summary'
 import { normaliseFactorFields } from '../../lib/mappers/mapFactorSensitivity'
+import { getConstraintSatisfactionBand } from '../../types/constraints'
 
 const MAX_SERIALISED_BYTES = 2048
 const MAX_TOP_DRIVERS = 3
@@ -210,11 +211,24 @@ function buildConstraintsStatus(
   return constraints
     .filter(c => c.label != null && c.label !== '')
     .slice(0, max)
-    .map(c => ({
-      label: c.label,
-      satisfied: c.prob_satisfied >= 0.5,
-      ...(c.prob_satisfied != null ? { probability: c.prob_satisfied } : {}),
-    }))
+    .map(c => {
+      // `satisfied: c.prob_satisfied >= 0.5` used to sit here. It reported a
+      // constraint the science never evaluated as NOT SATISFIED (`null >= 0.5`
+      // and `undefined >= 0.5` are both false), and collapsed a probability
+      // into a binary at a threshold no other surface in this estate uses.
+      // The band reuses CONSTRAINT_CONFIDENCE_THRESHOLDS — the same 0.40/0.70
+      // the results panel shows the user — and keeps "not evaluated" as its own
+      // answer rather than folding it into "breached".
+      const band = getConstraintSatisfactionBand(c.prob_satisfied)
+      return {
+        label: c.label,
+        status: band,
+        // Omit the number whenever there is no evaluated number to report.
+        // Bound to the BAND, not to a second null-test, so the two can never
+        // disagree about whether this constraint was evaluated.
+        ...(band !== 'unevaluated' ? { probability: c.prob_satisfied } : {}),
+      }
+    })
 }
 
 function enforceByteLimit(result: AnalysisInputsSummary): AnalysisInputsSummary | null {

--- a/src/types/analysis-inputs-summary.ts
+++ b/src/types/analysis-inputs-summary.ts
@@ -6,17 +6,41 @@
  * has structured context about the latest analysis without re-parsing the full response.
  */
 
-export const ANALYSIS_INPUTS_CONTRACT_VERSION = '1.0.0'
+/**
+ * 1.1.0 — `constraints_status[]` carries a four-state `status` band instead of a
+ * fabricated `satisfied` boolean. See `ConstraintSatisfactionBand`.
+ *
+ * The removed boolean had ZERO readers estate-wide. Derived 2026-08-24 with
+ * contrast controls in every sweep: UI `.satisfied` on a constraint object — 0
+ * (contrast `.probability`, 32 files); CEE @ `77e2e7d9` `compact_summary` — 0
+ * files (contrasts `constraints_status` 15, `analysis_state` 126, `satisfied`
+ * 203, `analysis_status` 238); `olumi-schemas` @ `81493081` `compact_summary` —
+ * 0 (contrasts 10 / 13). CEE's ingress schema for this carrier is
+ * `z.object({ analysis_status: z.string() }).passthrough()`, so the reshape is
+ * admitted unchanged and no consumer breaks. Minor, not major, on that evidence.
+ */
+import type { ConstraintSatisfactionBand } from './constraints'
+
+export const ANALYSIS_INPUTS_CONTRACT_VERSION = '1.1.0'
 
 export interface AnalysisInputsSummary {
-  contract_version: '1.0.0'
+  contract_version: '1.1.0'
   recommendation: { option_id: string; option_label: string; win_probability: number }
   options: Array<{ id: string; label: string; win_probability: number }>
   top_drivers: Array<{ factor_id: string; factor_label: string; elasticity: number }> // max 3
   sensitivity_concentration: number
   confidence_band: 'low' | 'medium' | 'high'
   robustness?: { level: 'robust' | 'moderate' | 'fragile'; recommendation_stability: number } | null
-  constraints_status: Array<{ label: string; satisfied: boolean; probability?: number }> // max 5
+  /**
+   * Max 5. `status` is the honest verdict; `probability` is present only when
+   * the constraint was actually evaluated (`status !== 'unevaluated'`), so an
+   * uncomputed constraint asserts neither outcome.
+   */
+  constraints_status: Array<{
+    label: string
+    status: ConstraintSatisfactionBand
+    probability?: number
+  }>
   run_metadata: {
     seed: string | number | null
     quality_mode: string | null

--- a/src/types/analysis-inputs-summary.ts
+++ b/src/types/analysis-inputs-summary.ts
@@ -1,10 +1,29 @@
 /**
  * AnalysisInputsSummary — enriched analysis summary assembled from V2RunResponse.
  *
- * The UI is the sole production assembler. CEE owns the schema and validation rules.
- * Sent as `analysis_state.analysis_summary` on turn requests so the orchestrator
- * has structured context about the latest analysis without re-parsing the full response.
+ * The UI is the sole production assembler.
+ *
+ * ⚠ CARRIER AND REACHABILITY — derived 2026-08-24 at `4984ea4`, because the two
+ * sentences that used to sit here were both wrong:
+ *
+ *  · The key on the wire is **`compact_summary`**, not `analysis_summary`
+ *    (`useConversation.ts:3371`). Nothing anywhere sends `analysis_summary`.
+ *  · "CEE owns the schema and validation rules" overstates it. CEE re-parses
+ *    this carrier as `z.object({ analysis_status: z.string() }).passthrough()`
+ *    — only `analysis_status` is required, everything else rides through
+ *    undeclared and unvalidated. There is no schema for this object anywhere.
+ *  · It is built ONLY on the V4/legacy path. `useConversation.ts:4445-5785` is
+ *    the V5 block ("V4 path below — reachable ONLY when
+ *    VITE_ENABLE_V5_ORCHESTRATOR !== 'true'"), and the sole builder of
+ *    `analysis_state` is called at :5906, OUTSIDE it. `v5/buildPayload.ts`
+ *    carries no `analysis_state`, and `buildV5Payload({...})` takes no
+ *    analysis-state argument. With the V5 flag baked on, this payload does not
+ *    reach CEE — it is live on the rollback path only.
+ *
+ * Re-derive before relying on any of this; do not inherit it.
  */
+
+import type { ConstraintSatisfactionBand } from './constraints'
 
 /**
  * 1.1.0 — `constraints_status[]` carries a four-state `status` band instead of a
@@ -19,7 +38,6 @@
  * `z.object({ analysis_status: z.string() }).passthrough()`, so the reshape is
  * admitted unchanged and no consumer breaks. Minor, not major, on that evidence.
  */
-import type { ConstraintSatisfactionBand } from './constraints'
 
 export const ANALYSIS_INPUTS_CONTRACT_VERSION = '1.1.0'
 

--- a/src/types/constraints.ts
+++ b/src/types/constraints.ts
@@ -78,3 +78,68 @@ export function jointProbabilityLabel(probability: number): string {
   if (probability >= CONSTRAINT_CONFIDENCE_THRESHOLDS.LOW) return 'Meets all targets'
   return 'May miss targets'
 }
+
+/**
+ * UI-SEM-010b: constraint satisfaction BAND — the honest classification of
+ * `prob_satisfied` for machine consumers.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `assembleAnalysisInputsSummary` used to emit `satisfied: c.prob_satisfied >= 0.5`
+ * into the analysis summary. Two things were wrong with that line:
+ *
+ *  1. `null >= 0.5` and `undefined >= 0.5` are both `false`, so a constraint the
+ *     science never evaluated was asserted to be BREACHED. The adjacent line
+ *     already guarded `probability` against null — which made it worse, not
+ *     better: the unevaluated row shipped as a bare `{satisfied:false}` with no
+ *     probability at all, a MORE absolute claim than a genuine miss.
+ *
+ *  2. It minted a 0.5 threshold that exists nowhere else in this estate. The
+ *     bands immediately above (CONSTRAINT_CONFIDENCE_THRESHOLDS, 0.40/0.70) are
+ *     what `SuccessTargetRow` and `TargetProbabilityBars` already show the user.
+ *     So a constraint at 0.45 was rendered "uncertain" blue on screen while the
+ *     summary asserted a flat breach. Producer and screen disagreed inside one
+ *     product.
+ *
+ * This banding therefore REUSES CONSTRAINT_CONFIDENCE_THRESHOLDS rather than
+ * introducing a fourth threshold: the number a consumer is told and the colour
+ * the user sees now come from one source.
+ *
+ * ⚠ NAMING — deliberately `'unevaluated'`, NOT `'not_evaluated'`.
+ * `olumi-schemas` already owns this concept's word in
+ * `ConstraintVerdictStateSchema` (`src/orchestrator/handler-results.ts`), whose
+ * own docstring states the principle this type implements: *there is no correct
+ * BOOLEAN here — "we could not tell" is a third answer, and collapsing it either
+ * way states something false.* That state set is BLOCK-level (the whole
+ * constraint set) and this one is PER-CONSTRAINT, so they are not the same type
+ * — but they must not be differently-spelled twins of one idea either. Swept
+ * 2026-08-24: `'not_evaluated'` appears in neither repo; `'unevaluated'` is the
+ * estate's existing spelling.
+ */
+export type ConstraintSatisfactionBand =
+  | 'likely_met'
+  | 'uncertain'
+  | 'likely_missed'
+  | 'unevaluated'
+
+/**
+ * Classify a constraint's satisfaction probability into a band.
+ *
+ * Returns `'unevaluated'` for anything that is not a finite number — null,
+ * undefined, NaN, or a non-numeric wire value. The V2 wire admits all of these
+ * even though `ConstraintItem.prob_satisfied` is declared `number`, which is
+ * precisely why the shipped code guarded `probability` against null.
+ *
+ * ⚠ An exact `0` is a MEASURED breach, not an absence, and bands as
+ * `'likely_missed'`. Guarding with a truthiness test instead of
+ * `Number.isFinite` would silently reclassify it as unknown — the mirror of the
+ * defect this function exists to fix.
+ */
+export function getConstraintSatisfactionBand(
+  probability: number | null | undefined,
+): ConstraintSatisfactionBand {
+  if (typeof probability !== 'number' || !Number.isFinite(probability)) return 'unevaluated'
+  if (probability >= CONSTRAINT_CONFIDENCE_THRESHOLDS.HIGH) return 'likely_met'
+  if (probability >= CONSTRAINT_CONFIDENCE_THRESHOLDS.LOW) return 'uncertain'
+  return 'likely_missed'
+}


### PR DESCRIPTION
## The defect

`src/canvas/analysis/assembleAnalysisInputsSummary.ts:215-216` at `4984ea4`:

```ts
satisfied: c.prob_satisfied >= 0.5,
...(c.prob_satisfied != null ? { probability: c.prob_satisfied } : {}),
```

**1. Unknown was rendered as a definite breach.** `null >= 0.5` and `undefined >= 0.5` are both `false`, so a constraint the science never evaluated was reported as **not satisfied**.

Measured at pristine, this is worse than it reads. The adjacent line guards `probability` against null — which does not mitigate the fabrication, it **conceals** it:

```
{ "label": "Never evaluated (null)", "satisfied": false }                    ← no probability at all
{ "label": "Real breach",            "satisfied": false, "probability": 0.02 }
```

The unevaluated constraint ships as a **barer, more absolute** breach claim than a genuine one. The only field that could have signalled absence is the one that gets stripped.

**2. A probability collapsed to a binary at a threshold used nowhere else.** `src/types/constraints.ts` already bands this exact field at **0.40/0.70** (`CONSTRAINT_CONFIDENCE_THRESHOLDS`, UI-SEM-010), and `SuccessTargetRow`/`TargetProbabilityBars` render the middle band as *uncertain*. So a constraint at 0.45 showed the user uncertain-blue while the summary asserted a flat breach — producer and screen disagreeing inside one product. The shipped contract fixture carried the same defect: `{"label": "Time to productivity", "satisfied": true, "probability": 0.65}`, asserted as satisfied while 0.65 is mid-band.

## The shape, and why

Reuses the existing banding instead of minting a fourth threshold:

```ts
constraints_status: Array<{
  label: string
  status: 'likely_met' | 'uncertain' | 'likely_missed' | 'unevaluated'
  probability?: number   // present only when actually evaluated
}>
```

- **`'unevaluated'`, not `'not_evaluated'`** — `olumi-schemas`' `ConstraintVerdictStateSchema` already owns this word, and its docstring states the principle: *there is no correct BOOLEAN here — "we could not tell" is a third answer, and collapsing it either way states something false.* Swept both repos: `'not_evaluated'` appears in neither.
- **`satisfied` removed.** It had zero readers estate-wide, derived with a contrast control in every sweep — UI `.satisfied` on a constraint object 0 (contrast `.probability` 32 files); CEE @ `77e2e7d9` `compact_summary` 0 files (contrasts 15/126/203/238); schemas @ `81493081` 0 (contrasts 10/13). It never reaches a prompt: both CEE prompt builders are fixed-key projections and the V5 builder explicitly discards `analysis_state`.
- `probability` omission is bound to the **band**, not to a second null-test, so the two cannot disagree about whether a constraint was evaluated.
- An exact `0` bands as `likely_missed` — a measured breach, not an absence.

Contract version `1.0.0 → 1.1.0`. CEE's ingress schema is `z.object({ analysis_status: z.string() }).passthrough()`, so the reshape is admitted unchanged; minor rather than major on that evidence.

## Evidence

- **RED-first**: 11/11 failing at pristine; the unknown cases failed as `expected false to be undefined` — the fabrication itself.
- **Twins**: 0.95 still `likely_met`, 0.02 still `likely_missed`, exact 0 still `likely_missed`, boundaries 0.70/0.40/0.39 pinned. Fixing unknown softens no real breach.
- **Discriminating mutant pair**: degrade the band for *all* constraints → RED (8 failures); degrade it for a label no test binds to → GREEN. Sensitivity **to the named object**, not to anything.
- 6 further mutants bite (guard removed, 0.5 restored, both boundaries strictened, probability always emitted, `satisfied` restored). Leading and trailing controls GREEN at applied-count exactly 0.
- Mutants ran in a worktree outside the repo root, isolation proven by **writing a sentinel** with a positive control that the write landed, distinct inodes asserted, restores HEAD-relative, applied-check scoped to `src/`, clean tree before and after each.

## Corrected premise (deliverable, not a failure)

The brief stated this payload reaches the model on every CEE turn. **Refuted at this tip.** `compact_summary` is built only on the **V4/legacy path**:

- `useConversation.ts:4445-5785` is the V5 block; line 5786 reads *"V4 path below — reachable ONLY when `VITE_ENABLE_V5_ORCHESTRATOR !== 'true'`."*
- `buildRequest(...)` — the only builder of `analysis_state`/`compact_summary` — is called at **line 5906, outside that block**.
- `src/v5/buildPayload.ts` contains **zero** `compact_summary`/`analysis_state` (contrast `graph_state|scenario_id` = 4), and the `buildV5Payload({...})` call site passes **no analysis-state argument at all**.

Three independent lines of evidence agree, and CEE's own byte-checked header comment says the same. `VITE_ENABLE_V5_ORCHESTRATOR` is baked `"true"` on staging, so **the fabricated boolean is not on the live wire today** — it is live on the rollback path, i.e. the path taken during an incident, when trustworthiness matters most. Fixed on that basis; not claimed as a live user-facing defect.

## Not fixed here (scope fence)

`constraints_status` names **two unrelated things**: this array, and a PLoT→CEE **string enum** (`'computed' | 'unavailable' | 'skipped' | 'error'`) read at `constraint-feasibility.ts:654` and typed at `enrichment.ts:1075`. A name-grep reads them as one seam. Reported, not touched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
