### PR TITLE
feat(constraints): show the user the hard limit they stated (chain step 6)

### DIFF
--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -33,7 +33,7 @@ import { computeSuccessState } from '../../../canvas/components/pre-analysis-v3/
 import { computeGraphFacts } from '../../../canvas/components/pre-analysis-v3/selectors/graphFacts'
 import { ActionsMenu } from './ActionsMenu'
 import { REVIEW_BRIEF_ASK } from './actionsCatalogue'
-import { parseStatedLimitsKey, selectStatedLimitsKey } from './statedLimits'
+import { formatStatedLimitsNote, parseStatedLimitsKey, selectStatedLimitsKey } from './statedLimits'
 
 export type BriefStateOverride = 'thin' | 'contradictory' | 'unverified'
 
@@ -395,6 +395,30 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
         ? { line: OVERVIEW_COPY.thin, note: OVERVIEW_COPY.thinLiveNote }
         : STATE_COPY[state]
 
+  // ⭐ THE CLOSURE CONDITION, ON THE COLLAPSED CARD.
+  //
+  // Post-analysis `hasResult` is structurally true, so `autoExpand` reduces to
+  // `state === 'blocked'` — on the ordinary success path this card is
+  // COLLAPSED. The limits list below lives inside `{expanded && …}`, so
+  // rendering ONLY there meant a user who said "the budget cannot exceed
+  // £50,000" and got a successful analysis saw the word "constraints" and no
+  // £50,000. (That is the same criterion this lane used to disqualify
+  // `SuccessTarget` for sitting in a default-collapsed accordion.)
+  //
+  // The limit is therefore named in the note that already renders collapsed,
+  // on the one line it already occupies — NOT by lifting the list out of
+  // `expanded`, which would push the verdict down and regress ANSWER-FIRST.
+  //
+  // ⚠ `ready` ONLY, and that is a deliberate honesty boundary, not an
+  // oversight. Every other state's note is doing more urgent work than an
+  // orientation line: `blocked`/`contradictory` say "Resolve it before relying
+  // on the read", `needs_input` points at the questions, `thin` reports the
+  // missing success measure. A limit must never displace a warning about
+  // whether the result can be trusted. `blocked` auto-expands anyway, so the
+  // full list is visible there; on `thin`/`needs_input` the limit stays one
+  // click away, which is disclosed rather than hidden.
+  const collapsedLimitsNote = state === 'ready' ? formatStatedLimitsNote(statedLimits) : null
+
   // UI-SEM-077 (+ V7 L2, values-not-labels): decision-classification pill
   // inference. No producer classification contract exists; the only honest
   // client-side input today is the decision node's brief timeframe
@@ -570,7 +594,13 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
         />
         <span className="min-w-0 flex-1">
           <span className={`${typography.panelHeader} block text-text-header`}>{copy.line}</span>
-          <span className={`${typography.panelMeta} block text-text-light`}>{copy.note}</span>
+          <span
+            className={`${typography.panelMeta} block text-text-light${collapsedLimitsNote ? ' truncate' : ''}`}
+            data-testid={collapsedLimitsNote ? 'brief-bar-stated-limits' : undefined}
+            title={collapsedLimitsNote ? statedLimits.map((l) => l.text).join(' · ') : undefined}
+          >
+            {collapsedLimitsNote ?? copy.note}
+          </span>
         </span>
         <ChevronDown
           size={16}

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -20,7 +20,7 @@
  * DS v4/5: bg-panel card, panel typography tokens only, Lucide, sentence
  * case, en-GB, no em dashes in prose.
  */
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { ChevronDown } from 'lucide-react'
 
 import { useCanvasStore } from '../../../canvas/store'
@@ -33,6 +33,7 @@ import { computeSuccessState } from '../../../canvas/components/pre-analysis-v3/
 import { computeGraphFacts } from '../../../canvas/components/pre-analysis-v3/selectors/graphFacts'
 import { ActionsMenu } from './ActionsMenu'
 import { REVIEW_BRIEF_ASK } from './actionsCatalogue'
+import { parseStatedLimitsKey, selectStatedLimitsKey } from './statedLimits'
 
 export type BriefStateOverride = 'thin' | 'contradictory' | 'unverified'
 
@@ -83,6 +84,11 @@ export const OVERVIEW_COPY = {
   // risks (L3-BROWSER-TRUTH §9 C7). The sentence must be unambiguously about
   // what the MODEL has set, which is the only thing `constraintCount` knows.
   constraintsNoteEmpty: 'Nothing set as a hard limit',
+  // ⭐ STEP 6. The possessive is load-bearing and earned: every limit under
+  // this heading is one the USER stated and CEE recorded verbatim, never a
+  // value Olumi derived. The heading makes NO claim about whether a limit is
+  // met — that verdict does not reach this surface (see the render site).
+  statedLimitsHeading: 'Your stated limits',
   optionsNoteEmpty: 'No options mapped yet',
   // V6-RESPEC §4: empty classification fields fold into ONE muted aggregate
   // chip ("+N to set") — collapsed shows what IS, never a per-field inventory
@@ -271,6 +277,21 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
   const currentScenarioId = useCanvasStore((s) => s.currentScenarioId)
   const optionCount = useCanvasStore((s) => s.nodes.filter((n) => n.type === 'option').length)
   const constraintCount = useCanvasStore((s) => s.goalConstraints?.length ?? 0)
+  // ⭐ STEP 6 of the hard-constraint chain — the user sees the limit they
+  // stated, not merely a count of how many were captured.
+  //
+  // This reads the SAME store slice `constraintCount` already counts, so there
+  // is no second constraint vocabulary and no second producer. What it shows is
+  // strictly the TRUSTWORTHY half of a constraint — label, operator, value,
+  // unit, all of them things the user said and CEE recorded. The DISTRUSTED
+  // half (`probability`, and PLoT's per-option `constraint_analysis`, still
+  // gated by `PLOT_PER_OPTION_CONSTRAINTS_SUSPECT`) is never read here.
+  // Selected as a PRIMITIVE string, never the array identity: this card is
+  // under a primitive-selector contract (primitiveSelectors.spec) so that a
+  // store write which rebuilds an equal-content constraints array — a node
+  // drag, a producer re-sync — does not re-commit the whole card.
+  const statedLimitsKey = useCanvasStore((s) => selectStatedLimitsKey(s.goalConstraints))
+  const statedLimits = useMemo(() => parseStatedLimitsKey(statedLimitsKey), [statedLimitsKey])
   const briefPresent = useCanvasStore((s) => Boolean(s.currentBriefText?.trim()))
   // Mirrors ResultsBody's UI-SEM-065 blocker read (graphHealth is the
   // engine-critique carrier; blocker severity never reaches uncertainties).
@@ -585,6 +606,39 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
               </button>
             ))}
           </div>
+
+          {/* ⭐ The limits the user actually stated.
+              Renders NOTHING when there are none, so a model with no hard
+              limit is byte-identical to before this shipped.
+
+              Deliberately silent about COMPLIANCE. Whether an option breaches
+              a limit is not derivable here: the browser holds no per-option
+              value on the constrained node, and PLoT's run-level
+              `constraints_status` is stripped on the CEE→UI hop (absent from
+              CEE compose.ts `P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP`). Saying
+              "not evaluated" would be just as false as saying "met" —
+              evaluation DOES happen upstream, its verdict simply does not
+              reach this surface. So this states the limit and claims nothing
+              else. See the lane report's CEE dependency. */}
+          {statedLimits.length > 0 && (
+            <div className="mt-2" data-testid="stated-limits">
+              <p className={`${typography.panelMeta} text-text-light`}>
+                {OVERVIEW_COPY.statedLimitsHeading}
+              </p>
+              <ul className="mt-1 space-y-0.5">
+                {statedLimits.map((limit) => (
+                  <li
+                    key={limit.id}
+                    data-testid={`stated-limit-${limit.id}`}
+                    className={`${typography.panelBody} truncate text-text-body`}
+                    title={limit.text}
+                  >
+                    {limit.text}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
 
           {state === 'needs_input' && questions.length > 0 && (
             <ul className="mt-2 space-y-1" data-testid="brief-questions">

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.statedLimits.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.statedLimits.spec.tsx
@@ -78,6 +78,13 @@ const MARGIN_FLOOR = {
   value: 78,
   unit: '%',
 }
+const REDUNDANCY_CAP = {
+  constraint_id: 'constraint_redundancy_max',
+  node_id: 'n_red',
+  label: 'Compulsory redundancy rounds',
+  operator: '<=' as const,
+  value: 1,
+}
 
 function seed(goalConstraints: unknown) {
   localStorage.clear()
@@ -104,6 +111,18 @@ function seed(goalConstraints: unknown) {
 
 function openBrief() {
   fireEvent.click(screen.getByTestId('brief-bar'))
+}
+
+/**
+ * Put the card in the POST-ANALYSIS state the mount gate guarantees
+ * (`OutputsDock.tsx:3155` only mounts it once there is a report). This is what
+ * makes `hasResult` true and therefore `autoExpand` false — i.e. the ordinary
+ * success path, collapsed.
+ */
+function withCompletedAnalysis() {
+  useCanvasStore.setState({
+    results: { status: 'complete', report: { summary: 'A leads on the modelled outcome.' } },
+  } as never)
 }
 
 describe('step 6 — the model shows the user the hard limit they stated', () => {
@@ -210,5 +229,99 @@ describe('step 6 — the model shows the user the hard limit they stated', () =>
       expect(row).toHaveTextContent('≤ 3')
       expect(row).not.toHaveTextContent('count')
     })
+  })
+})
+
+/**
+ * ⭐ THE CLOSURE CONDITION ITSELF — WITHOUT A CLICK.
+ *
+ * ── WHY THIS BLOCK EXISTS (the review finding, recorded) ────────────────────
+ * The first cut of this lane rendered the limits ONLY inside
+ * `{expanded && (…)}`. Post-analysis `hasResult` is structurally true, so
+ * `autoExpand` collapses to `state === 'blocked'` — meaning on the ORDINARY
+ * SUCCESS PATH (`state === 'ready'`) the card is COLLAPSED and the limit did
+ * not render at all. Every test above passed because each one calls
+ * `openBrief()` first.
+ *
+ * That is the exact criterion this lane used to disqualify `SuccessTarget`
+ * ("only inside the default-collapsed T3 Advanced accordion") applied to the
+ * rival and not to itself. A user who said "the budget cannot exceed £50,000"
+ * and got a successful analysis saw the word "constraints" and no £50,000.
+ *
+ * ── WHY NOT SIMPLY MOVE THE BLOCK OUT OF `expanded` ─────────────────────────
+ * Because that regresses the ratified ANSWER-FIRST gate: this card sits ABOVE
+ * the results region, and on deployed `4d1e650b` the verdict sentence already
+ * sat 573px down a 515px-tall region when this card auto-expanded. Adding the
+ * limits list to the collapsed card would push the verdict down again.
+ *
+ * The limit is therefore named in the collapsed `brief-bar` NOTE, which
+ * already renders and already occupies exactly one line.
+ */
+describe('the closure condition: a successful analysis shows the limit with NO click', () => {
+  beforeEach(() => {
+    seed(null)
+  })
+
+  it('names the stated limit on the COLLAPSED card, post-analysis, no interaction', () => {
+    seed([BUDGET_CAP])
+    withCompletedAnalysis()
+    render(<DecisionOverviewCard title="Take £4m out of opex" />)
+
+    // Deliberately NO openBrief() — this is the whole point.
+    expect(screen.queryByTestId('stated-limits')).toBeNull()
+    expect(screen.getByTestId('brief-bar')).toHaveTextContent('Budget ≤ £50,000')
+  })
+
+  it('names the first limit and discloses the count of the rest', () => {
+    seed([BUDGET_CAP, MARGIN_FLOOR, REDUNDANCY_CAP])
+    withCompletedAnalysis()
+    render(<DecisionOverviewCard title="Take £4m out of opex" />)
+
+    const bar = screen.getByTestId('brief-bar')
+    // One complete limit is always visible; the rest are counted, never
+    // truncated mid-value, so the bar stays exactly one line.
+    expect(bar).toHaveTextContent('Budget ≤ £50,000')
+    expect(bar).toHaveTextContent('+2 more')
+  })
+
+  it('POSITIVE CONTROL on the precondition: the card really is COLLAPSED here', () => {
+    // Pins `autoExpand === false` post-analysis as a DELIBERATE recorded fact.
+    // Without this, a future change to the default expansion would leave every
+    // other test in this file green while the user saw nothing.
+    seed([BUDGET_CAP])
+    withCompletedAnalysis()
+    render(<DecisionOverviewCard title="Take £4m out of opex" />)
+
+    expect(screen.getByTestId('brief-bar')).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('brief-dim-constraints')).toBeNull()
+  })
+
+  it('still shows nothing extra when there is no stated limit', () => {
+    seed(null)
+    withCompletedAnalysis()
+    render(<DecisionOverviewCard title="Take £4m out of opex" />)
+
+    expect(screen.getByTestId('brief-bar')).toHaveTextContent(
+      'Goal, context, constraints and options',
+    )
+    expect(screen.queryByTestId('brief-bar-stated-limits')).toBeNull()
+  })
+
+  it('does NOT displace an urgent state note with a limit', () => {
+    // `blocked` says "Resolve it before relying on the read" — a safety
+    // instruction about trusting the result. A limit must never push that off
+    // the collapsed bar. (`blocked` also auto-expands, so the full list is
+    // visible there anyway.)
+    seed([BUDGET_CAP])
+    withCompletedAnalysis()
+    useCanvasStore.setState({
+      graphHealth: { issues: [{ severity: 'blocker' }] },
+    } as never)
+    render(<DecisionOverviewCard title="Take £4m out of opex" />)
+
+    expect(screen.getByTestId('brief-bar')).toHaveTextContent(
+      'Resolve it before relying on the read',
+    )
+    expect(screen.getByTestId('brief-bar')).not.toHaveTextContent('+1 more')
   })
 })

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.statedLimits.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.statedLimits.spec.tsx
@@ -1,0 +1,214 @@
+/**
+ * STEP 6 OF THE HARD-CONSTRAINT CHAIN — THE USER SEES THE LIMIT THEY STATED.
+ *
+ * ── THE GAP THIS PINS ───────────────────────────────────────────────────────
+ * Steps 1-5 are closed: CEE mints `goal_constraints[]` from a stated limit,
+ * transport preserves it, PLoT returns an honest verdict, and eligibility
+ * consumes it (the leader claim is withheld and the limit named in chat).
+ *
+ * On the RESULTS surface, though, the limit itself was never shown. This card
+ * rendered a COUNT — "1 limit captured" — and nothing else. A user who told
+ * Olumi "the budget cannot exceed £50,000" could read the whole framing panel
+ * and never see £50,000 on it.
+ *
+ * Derived at this tip, the complete set of live constraint renders was:
+ *   · this card                     — the COUNT only
+ *   · GoalNode (canvas badge)       — "{operator} {label}", no value
+ *   · GoalPanel (inspector-v2)      — label + operator + value, but only after
+ *                                     selecting the Goal node, inside a
+ *                                     `<fieldset disabled>`
+ *   · FactorNode                    — an aria/title string only
+ * and the three components that DID render "{label} {operator} {value}" as
+ * body copy (`SuccessTarget`, `DraftNotes`, `PreAnalysisPanel`) have ZERO
+ * mount sites — dead code. Hence: on the surface where the recommendation is
+ * read, the stated limit was absent.
+ *
+ * ── THE SEPARATION THIS SUITE ENFORCES ──────────────────────────────────────
+ * The user's stated limit and the producer's computed probability are
+ * different facts with different trust levels. The limit is trustworthy (the
+ * user said it, CEE recorded it). The probabilities are gated OFF for cause.
+ * This card shows the FIRST and must never state or imply the SECOND — see
+ * `probability is never rendered` below, which seeds a constraint carrying a
+ * probability and proves it does not reach the surface.
+ *
+ * ── BINDING ─────────────────────────────────────────────────────────────────
+ * Every assertion binds to a limit BY ITS CONSTRAINT ID, never by a value
+ * predicate another limit could satisfy. The fixture deliberately carries TWO
+ * limits so that a render broken for one is distinguishable from a render
+ * broken for all (the discriminating mutant pair recorded in the lane report).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { DecisionOverviewCard } from '../DecisionOverviewCard'
+import { useCanvasStore } from '../../../../canvas/store'
+import { useGuidanceStore } from '../../../../canvas/stores/guidanceStore'
+import { useAskOlumiStore } from '../../coaching/askOlumiStore'
+
+/** The card is flag-gated; the chips only exist once it renders. */
+const READY = { status: 'ready', options: [{ id: 'o1' }], goal_node_id: 'g1' }
+const GOAL_NODE_WITH_MEASURE = {
+  id: 'g1',
+  type: 'goal',
+  position: { x: 0, y: 0 },
+  data: { label: 'G', threshold_source: 'user', success_threshold: 20 },
+}
+
+/**
+ * Two limits, distinct on EVERY axis a lazy assertion might key on: different
+ * ids, labels, operators, values and units. `probability` is present on the
+ * first deliberately — it is the distrusted field, and it must not surface.
+ */
+const BUDGET_CAP = {
+  constraint_id: 'constraint_cost_max',
+  node_id: 'n_cost',
+  label: 'Budget',
+  operator: '<=' as const,
+  value: 50000,
+  unit: '£',
+  probability: 0.92,
+  source_quote: 'the budget cannot exceed £50,000',
+  provenance: 'explicit' as const,
+}
+const MARGIN_FLOOR = {
+  constraint_id: 'constraint_margin_min',
+  node_id: 'n_margin',
+  label: 'Gross margin',
+  operator: '>=' as const,
+  value: 78,
+  unit: '%',
+}
+
+function seed(goalConstraints: unknown) {
+  localStorage.clear()
+  localStorage.setItem('feature.decisionOverview', '1')
+  useGuidanceStore.setState({ guidanceItems: [], _sendMessage: null } as never)
+  useAskOlumiStore.setState({
+    isOpen: false,
+    context: '',
+    draft: '',
+    label: '',
+    targetId: null,
+    parameters: undefined,
+    source: 'chip',
+  })
+  useCanvasStore.setState({
+    ceeAnalysisReady: READY,
+    goalThreshold: 20,
+    nodes: [GOAL_NODE_WITH_MEASURE],
+    goalConstraints,
+    currentBriefText: null,
+    graphHealth: null,
+  } as never)
+}
+
+function openBrief() {
+  fireEvent.click(screen.getByTestId('brief-bar'))
+}
+
+describe('step 6 — the model shows the user the hard limit they stated', () => {
+  beforeEach(() => {
+    seed(null)
+  })
+
+  // ── TWIN A: no stated limit ⇒ nothing new renders ─────────────────────────
+  describe('a model with NO stated limit is unchanged', () => {
+    it('renders no stated-limits region at all', () => {
+      seed(null)
+      render(<DecisionOverviewCard title="Take £4m out of opex" />)
+      openBrief()
+
+      expect(screen.queryByTestId('stated-limits')).toBeNull()
+    })
+
+    it('renders no stated-limits region for an EMPTY constraint array', () => {
+      seed([])
+      render(<DecisionOverviewCard title="Take £4m out of opex" />)
+      openBrief()
+
+      expect(screen.queryByTestId('stated-limits')).toBeNull()
+    })
+
+    it('still reports the zero exactly as before, in the same words', () => {
+      seed(null)
+      render(<DecisionOverviewCard title="Take £4m out of opex" />)
+      openBrief()
+
+      // The pre-existing honesty fix (LINK-R1 C7) is untouched by this lane.
+      expect(screen.getByTestId('brief-dim-constraints')).toHaveTextContent(
+        'Nothing set as a hard limit',
+      )
+    })
+  })
+
+  // ── TWIN B: a stated limit ⇒ the user sees it ─────────────────────────────
+  describe('a model WITH a stated limit shows it', () => {
+    it('shows the £50,000 budget cap, bound by its constraint id', () => {
+      seed([BUDGET_CAP, MARGIN_FLOOR])
+      render(<DecisionOverviewCard title="Take £4m out of opex" />)
+      openBrief()
+
+      const row = screen.getByTestId('stated-limit-constraint_cost_max')
+      expect(row).toHaveTextContent('Budget ≤ £50,000')
+    })
+
+    it('shows the 78% margin floor, bound by its OWN constraint id', () => {
+      seed([BUDGET_CAP, MARGIN_FLOOR])
+      render(<DecisionOverviewCard title="Take £4m out of opex" />)
+      openBrief()
+
+      const row = screen.getByTestId('stated-limit-constraint_margin_min')
+      expect(row).toHaveTextContent('Gross margin ≥ 78%')
+    })
+
+    it('renders the region once both limits are present', () => {
+      seed([BUDGET_CAP, MARGIN_FLOOR])
+      render(<DecisionOverviewCard title="Take £4m out of opex" />)
+      openBrief()
+
+      expect(screen.getByTestId('stated-limits')).toBeInTheDocument()
+    })
+  })
+
+  // ── CLAUSE 4: never state or imply a probability ──────────────────────────
+  describe('the distrusted probability never reaches the surface', () => {
+    it('does not render the constraint probability that rode in on the fixture', () => {
+      // BUDGET_CAP carries `probability: 0.92`. Every rendering of it a reader
+      // could mistake for a likelihood is pinned absent here.
+      seed([BUDGET_CAP, MARGIN_FLOOR])
+      render(<DecisionOverviewCard title="Take £4m out of opex" />)
+      openBrief()
+
+      const region = screen.getByTestId('stated-limits')
+      expect(region).not.toHaveTextContent('92%')
+      expect(region).not.toHaveTextContent('0.92')
+      // The margin floor legitimately renders "78%" as the USER'S OWN UNIT, so
+      // a blanket "no % anywhere" assertion would be wrong. Bind to the budget
+      // row instead: it has no percentage of any kind to show.
+      expect(screen.getByTestId('stated-limit-constraint_cost_max')).not.toHaveTextContent('%')
+    })
+  })
+
+  // ── DEFENSIVE READS AT AN UNTYPED BOUNDARY ────────────────────────────────
+  describe('a constraint that is not a statable limit is omitted, not guessed at', () => {
+    it('omits a constraint whose value is missing', () => {
+      seed([{ constraint_id: 'constraint_no_value', label: 'Headcount', operator: '<=' }])
+      render(<DecisionOverviewCard title="Take £4m out of opex" />)
+      openBrief()
+
+      expect(screen.queryByTestId('stated-limit-constraint_no_value')).toBeNull()
+      expect(screen.queryByTestId('stated-limits')).toBeNull()
+    })
+
+    it('shows the boundary alone when the producer sent no label', () => {
+      seed([{ constraint_id: 'constraint_unlabelled', operator: '<=', value: 3, unit: 'count' }])
+      render(<DecisionOverviewCard title="Take £4m out of opex" />)
+      openBrief()
+
+      const row = screen.getByTestId('stated-limit-constraint_unlabelled')
+      // No invented name, no trailing unknown unit — just the limit.
+      expect(row).toHaveTextContent('≤ 3')
+      expect(row).not.toHaveTextContent('count')
+    })
+  })
+})

--- a/src/components/results/decision-overview/statedLimits.ts
+++ b/src/components/results/decision-overview/statedLimits.ts
@@ -1,0 +1,143 @@
+/**
+ * statedLimits — the user's own hard limits, formatted for display.
+ *
+ * ── WHAT THIS IS, AND THE ONE THING IT MUST NEVER DO ────────────────────────
+ * The hard-constraint chain carries TWO different facts about a limit, with
+ * two different trust levels, and this module handles exactly one of them:
+ *
+ *   TRUSTWORTHY — the limit ITSELF: label, operator, value, unit. The user
+ *     stated it; CEE recorded it into `goal_constraints[]`; the store holds it
+ *     at `goalConstraints`. Nothing here is computed. That is what this module
+ *     formats.
+ *
+ *   DISTRUSTED — `prob_satisfied` / `joint_probability` /
+ *     `constraint_probabilities` / the per-constraint `probability` field.
+ *     These are producer-computed and currently gated OFF for cause
+ *     (`PLOT_PER_OPTION_CONSTRAINTS_SUSPECT`, `adapters/plot/constraintTrust.ts`).
+ *
+ * This module therefore reads `label`, `operator`, `value` and `unit` and
+ * NOTHING ELSE. It deliberately does not accept, thread or format
+ * `probability` — a limit is displayed as the user's own statement of a
+ * boundary, never as a likelihood of meeting it. Reviving the suspect
+ * probabilities here would ship exactly the confident wrongness the constraint
+ * chain exists to prevent.
+ *
+ * ── WHY A CONSTRAINT CAN BE SKIPPED ─────────────────────────────────────────
+ * `CEEGoalConstraint` types `value` and `operator` as required, but the value
+ * arrives across a wire boundary from two independent producers (CEE's
+ * `draft_graph.goal_constraints` and `add_constraint` graph patches) and the
+ * persisted JSONB column is untyped. A row whose value is absent or non-finite
+ * is not a limit we can state, so it is omitted rather than rendered as
+ * "undefined" or coerced to a number the user never said.
+ */
+import type { CEEGoalConstraint } from '../../../adapters/cee/types'
+import { formatTargetValue } from '../utils/formatTargetValue'
+
+/**
+ * ASCII → unicode for display. The wire operator is ASCII by contract
+ * (@talchain/schemas `DraftGoalConstraintSchema`: `z.enum(['>=', '<='])`);
+ * an unrecognised operator is passed through verbatim rather than guessed at.
+ */
+export function renderLimitOperator(operator: string): string {
+  if (operator === '>=') return '≥'
+  if (operator === '<=') return '≤'
+  return operator
+}
+
+/**
+ * Currency units arrive as the SYMBOL itself ('£', '$'), not as the
+ * `'currency'` union member `formatTargetValue` expects, so the symbol is
+ * mapped onto that formatter rather than a second number-formatting
+ * vocabulary being minted here.
+ */
+const CURRENCY_SYMBOLS = new Set(['£', '$', '€', '¥'])
+
+/**
+ * Format the limit's value in the user's units.
+ *
+ * An unrecognised unit (e.g. 'fraction', 'headcount') formats the bare number
+ * — appending an unknown unit string would be inventing a display the producer
+ * did not specify.
+ */
+export function formatStatedLimitValue(value: number, unit?: string): string {
+  if (unit != null && CURRENCY_SYMBOLS.has(unit)) return formatTargetValue(value, 'currency', unit)
+  if (unit === '%') return formatTargetValue(value, 'percent')
+  return formatTargetValue(value)
+}
+
+export interface StatedLimit {
+  /**
+   * Stable identity for this limit, `constraint_id ?? id ?? index`.
+   * Consumers bind to a limit BY THIS ID — never by its text or its value,
+   * either of which another limit could satisfy.
+   */
+  id: string
+  /** The limit as the user stated it, e.g. "Budget ≤ £50,000". */
+  text: string
+}
+
+/**
+ * Project the store's `goalConstraints` slice into displayable limits.
+ *
+ * Returns an EMPTY ARRAY for every shape that is not a usable constraint, so a
+ * model with no stated limit renders exactly as it did before this existed.
+ */
+export function selectStatedLimits(
+  constraints: readonly CEEGoalConstraint[] | null | undefined,
+): StatedLimit[] {
+  if (!Array.isArray(constraints)) return []
+
+  const limits: StatedLimit[] = []
+
+  constraints.forEach((constraint, index) => {
+    if (constraint == null || typeof constraint !== 'object') return
+
+    const { value, operator } = constraint
+    if (typeof value !== 'number' || !Number.isFinite(value)) return
+    if (typeof operator !== 'string' || operator.length === 0) return
+
+    const id = String(constraint.constraint_id ?? constraint.id ?? index)
+    const measure = `${renderLimitOperator(operator)} ${formatStatedLimitValue(value, constraint.unit)}`
+    // Guard the read: CEE's own producer schema declares `label` optional and
+    // it is genuinely absent in practice. A limit with no label shows its
+    // boundary alone rather than a fabricated name like "Constraint 1".
+    const label = typeof constraint.label === 'string' ? constraint.label.trim() : ''
+
+    limits.push({ id, text: label.length > 0 ? `${label} ${measure}` : measure })
+  })
+
+  return limits
+}
+
+/**
+ * A PRIMITIVE, content-addressed key for the stated limits.
+ *
+ * ── WHY THIS EXISTS ─────────────────────────────────────────────────────────
+ * `DecisionOverviewCard` is under a standing primitive-selector contract
+ * (`DecisionOverviewCard.primitiveSelectors.spec.tsx`, React 185 / the
+ * `ci:guard:zustand` guard): the card must re-commit only when a value it
+ * RENDERS changes. Selecting `s.goalConstraints` directly hands back the array
+ * IDENTITY, so every store write that rebuilds an equal-content array — a node
+ * drag, a producer re-sync — would re-commit the whole card. That regression
+ * was caught by the existing suite, not theorised.
+ *
+ * Selecting this string instead means the card re-commits when, and only when,
+ * the limits it displays actually change. JSON is used rather than a delimiter
+ * so no label content can corrupt the encoding; the list is at most a handful
+ * of entries.
+ */
+export function selectStatedLimitsKey(
+  constraints: readonly CEEGoalConstraint[] | null | undefined,
+): string {
+  return JSON.stringify(selectStatedLimits(constraints))
+}
+
+/** Inverse of {@link selectStatedLimitsKey}. */
+export function parseStatedLimitsKey(key: string): StatedLimit[] {
+  try {
+    const parsed: unknown = JSON.parse(key)
+    return Array.isArray(parsed) ? (parsed as StatedLimit[]) : []
+  } catch {
+    return []
+  }
+}

--- a/src/components/results/decision-overview/statedLimits.ts
+++ b/src/components/results/decision-overview/statedLimits.ts
@@ -141,3 +141,32 @@ export function parseStatedLimitsKey(key: string): StatedLimit[] {
     return []
   }
 }
+
+/**
+ * The one-line form of the stated limits, for the COLLAPSED brief bar.
+ *
+ * ── WHY A SEPARATE, SHORTER FORM ────────────────────────────────────────────
+ * The expanded region can list every limit. The collapsed bar cannot: this
+ * card sits ABOVE the results region, and the ratified ANSWER-FIRST gate was
+ * won by getting the verdict back onto the first screenful (on deployed
+ * `4d1e650b` it sat 573px down a 515px-tall region). Anything added to the
+ * collapsed card pushes the verdict down again, so this must occupy exactly
+ * the ONE line the note already occupies.
+ *
+ * ── WHY FIRST-PLUS-COUNT RATHER THAN A TRUNCATED JOIN ───────────────────────
+ * Joining every limit and letting CSS truncate would cut a value mid-number —
+ * "Programme cost ≤ £50,0…" is worse than useless on a surface whose whole
+ * job is showing the user the figure they stated. Showing the first limit in
+ * FULL guarantees at least one complete, correct limit is always visible, and
+ * "+N more" discloses that there are others without ranking them: the order is
+ * the producer's extraction order and carries no claim about which limit
+ * matters most or which is binding.
+ *
+ * Returns null when there is nothing to say, so the caller keeps its existing
+ * note untouched.
+ */
+export function formatStatedLimitsNote(limits: readonly StatedLimit[]): string | null {
+  if (limits.length === 0) return null
+  const [first, ...rest] = limits
+  return rest.length === 0 ? first.text : `${first.text} · +${rest.length} more`
+}


### PR DESCRIPTION
**Component:** 1 + 6, the ratified hard-constraint chain. **Rung reached:** step 6 built, tested, mounted-witnessed locally at three widths. Not deployed.

Steps 1-5 are closed. Step 6 — the user seeing their own limit on the results surface — was absent. This closes the **first half** of the closure condition. The second half (seeing a breach) is a **CEE dependency**, stated exactly below, not guessed at client-side.

---

## The three bounded answers

**1. Does `goal_constraints[]` reach the browser, and by what route?**
**Yes — this is a render change, no transport change.** Two live ingress routes write the store's `goalConstraints` slice: `applyDraftResult` (CEE `draft_graph.goal_constraints`) and `applyV5State` (`add_constraint` graph patches, upserted by id). It also persists to `scenarios.graph.goal_constraints`. The brief's "zero `goal_constraints` egress in 13 captured bodies" is about **egress**, which this lane does not need — and `applyV5State.ts:1210` records that the response-**root** read is deliberately absent because `responseParser` demotes unknown top-level keys to `__additive__`.

**2. Which surface is the right home?**
**`DecisionOverviewCard`** — mounted at `OutputsDock.tsx:3156`, already reads the same slice, already showed the count. Not the node inspector: every node panel ships inside a literal unconditional `<fieldset disabled>` (`InspectorRouter.tsx:221,334`), confirming the brief.

**3. Is the breach magnitude computable from data the browser already holds?**
**No — out of scope, returned as a dependency.** Swept for any per-option value keyed by the constrained node (`node_values|per_node|nodeValues|factor_values|node_outcomes`): **zero**, with two contrast controls firing non-zero in the same run. Options carry only `p10/expected/p50/p90` on the **goal** axis, normalised then `* scale`. The brief's example assumes the browser holds the £90,000; it holds the £50,000 cap and not the £90,000. This repo has already measured that subtracting a threshold from those numbers is a frame error — `SuccessTargetRow`'s L62 note records "£200,678 short" as a fabricated distance, removed for exactly this reason.

---

## What was built

| file | role |
|---|---|
| `src/components/results/decision-overview/statedLimits.ts` | pure projection: `selectStatedLimits`, `selectStatedLimitsKey`, `parseStatedLimitsKey` |
| `src/components/results/decision-overview/DecisionOverviewCard.tsx` | renders the limits in the expanded region |
| `__tests__/DecisionOverviewCard.statedLimits.spec.tsx` | 9 tests |

Reads **only** `label`, `operator`, `value`, `unit`. It does not accept or thread `probability` at all — the distrusted producer numbers stay gated.

---

## Evidence

**RED-first**, 9 collected by name, 5 failed at pristine:
- `shows the £50,000 budget cap, bound by its constraint id`
- `shows the 78% margin floor, bound by its OWN constraint id`
- `renders the region once both limits are present`
- `does not render the constraint probability that rode in on the fixture`
- `shows the boundary alone when the producer sent no label`

**Twins**

| direction | result |
|---|---|
| no stated limit | **byte-identical to pristine `4984ea4c`** — same sha256 `4276d6e8…`, 5,066 bytes; positive control confirms a real card, not an empty dump |
| a stated limit | `Programme cost ≤ £50,000` etc., bound by `constraint_id` |
| live browser twin | region present with limits → **absent** after clearing; chip reverts to "Nothing set as a hard limit"; `92%` appears nowhere in the document |

**Discriminating mutant pair** (worktree outside the repo root, isolation proven by **writing a sentinel** — source sha unchanged, inodes differ; restores HEAD-relative; applied-check scoped to `src/`, control exactly 0; clean tree before and after; trailing control 9/9):

| mutant | budget test | margin test |
|---|---|---|
| break render for **all** constraints | **RED** | — |
| break render for a **different row only** | **GREEN** | **RED** |

**Gate** — derived the required check's step sequence rather than assuming: `Staging Gate` needs `tsc` + `typecheck-selftest` + `vitest` + `vitest-summary` + `build`. All 8 `tsc` steps pass locally in order (**`lint` runs first**), `typecheck:selftest` 18/18, `build` passes, decision-overview suite 89/89.

**Mounted evidence** at **1280×800, 1440×900, 1512×982** — real app, fresh disposable guest, never the user's account. The `Visual Regression (advisory)` job is not cited in either direction, per the brief.

---

## CEE dependency — exact contract

To close the second half (a breach), CEE must forward on the CEE→UI hop:

1. **`constraints_status`** (`'computed' | 'unavailable' | 'skipped' | 'error'`) — already produced by PLoT #333 and already read defensively at `mapV5AnalysisToReport.ts:1329`, which is a **no-op today** because the key is absent from CEE `compose.ts` `P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP`. *(The brief said an 18-key allowlist; the repo says **11**.)* Adding it needs **no UI change** to arrive.
2. **A per-option compliance verdict** — the eligibility decision, not a probability: constraint id + breach/comply/unevaluable, and where breaching, the option's value on the constrained node **in the constraint's own units and frame**. Without the frame attestation this is the L62 fabrication again.

Clause 3 ("say so and name what is missing") is **not** rendered, deliberately: saying "not evaluated" would be as false as "met" — evaluation happens upstream, its verdict just does not reach this surface.

---

## Corrected premises

1. **`SuccessTargetRow` cannot be reused — it has zero product call sites.** The brief says it "already exists and is switched OFF"; it is not merely starved by `PLOT_PER_OPTION_CONSTRAINTS_SUSPECT`, it is **unmounted**. Flipping that constant would still render nothing. Hosting step 6 there would have shipped it dark.
2. **My own mount probe produced a false absence, self-caught.** `<Component[ />]` cannot match a component whose props open on the next line. Re-derived: `SuccessTargetRow` 0 and `DraftNotes` 0 (both genuine), but `PreAnalysisPanel` 1 and `SuccessTarget` 1. `SuccessTarget` **does** render `{label} {operator} {value}` and is reachable — but only pre-run, only on the legacy panel (V3 supersedes it on `preAnalysisV3`), and only inside the **default-collapsed T3 Advanced accordion**. So the limit was reachable for a power-user *before* running and absent from the surface where the recommendation is read. The gap is real and narrower than "rendered nowhere".
3. **CEE's keep-list is 11 keys, not 18.**

## Observation, out of scope — not a verdict

`GoalPanel.tsx:405-424` renders `probability` as a percentage **and a `DataBar`** for each constraint, sourced from `results.report.goal_constraints[]` via `useGoalConstraints()`. That is a **different seam** from the per-option `constraint_analysis` block gated by `PLOT_PER_OPTION_CONSTRAINTS_SUSPECT`. I did **not** derive whether that seam is trustworthy, and did not touch it. Flagging it because if it is the same distrusted quantity, it is a live confident-wrongness surface in the chain this work belongs to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)