### PR TITLE
Step 6b: show whether the crowned option met the user's stated limits

### DIFF
--- a/src/adapters/plot/v2/responseMapper.ts
+++ b/src/adapters/plot/v2/responseMapper.ts
@@ -571,6 +571,13 @@ export function mapV2ResponseToReportV1(
         // and falls back to this mapped slot, then normalises fail-closed.
         ...(typeof robustnessRaw?.display_verdict === 'string' ? { display_verdict: robustnessRaw.display_verdict } : {}),
         ...(typeof robustnessRaw?.display_verdict_reason === 'string' ? { display_verdict_reason: robustnessRaw.display_verdict_reason } : {}),
+        // Hard-constraint chain step 5 (producer PLoT #338): crown compliance
+        // verdict + producer reason pass through VERBATIM so saved/hydrated
+        // reports keep them — the render seam prefers the raw response and
+        // falls back to this mapped slot, then normalises fail-closed. Same
+        // treatment as `display_verdict` directly above.
+        ...(typeof robustnessRaw?.recommended_option_compliance === 'string' ? { recommended_option_compliance: robustnessRaw.recommended_option_compliance } : {}),
+        ...(typeof robustnessRaw?.recommended_option_compliance_reason === 'string' ? { recommended_option_compliance_reason: robustnessRaw.recommended_option_compliance_reason } : {}),
       }
     })() : undefined,
     // P0 Fix: Pass through robustness_status for gating logic

--- a/src/adapters/plot/v2/types.ts
+++ b/src/adapters/plot/v2/types.ts
@@ -338,6 +338,29 @@ export interface V2RobustnessActual {
    */
   display_verdict?: string
   display_verdict_reason?: string
+  /**
+   * CROWN COMPLIANCE (hard-constraint chain step 5; producer PLoT #338,
+   * staging `e19ac506`) — may the crowned option be badged as leading, given
+   * the limits the user actually stated? Emitted UNCONDITIONALLY on every
+   * /v2/run (`routes/v2/run.ts:3608-3609`), so ABSENCE here means an older
+   * producer build, never "no limits".
+   *
+   * Producer enum (`routes/v2/crown-eligibility.ts`):
+   *   not_applicable | compliant | uncertain | unverified | not_assessed |
+   *   no_eligible_option
+   * Typed `string` (not the union) at the trust boundary — same tagged
+   * passthrough convention as `display_verdict` / `level` / `label` above,
+   * and for the same reason: the vendored @talchain/schemas pin (0.48.0) does
+   * not know these members, and a future producer value must not crash an old
+   * UI build. `normaliseCrownCompliance` narrows FAIL-CLOSED at the render
+   * seam.
+   *
+   * The reason is the producer's own claim-safe phrase and is rendered
+   * VERBATIM — never re-authored here
+   * (`contracts/isl-to-ui.contract.ts:281`).
+   */
+  recommended_option_compliance?: string
+  recommended_option_compliance_reason?: string
   /** Tipping-point analysis: how much each factor must change to flip the recommendation */
   flip_thresholds?: Array<{
     node_id?: string

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -34,6 +34,12 @@ import { computeGraphFacts } from '../../../canvas/components/pre-analysis-v3/se
 import { ActionsMenu } from './ActionsMenu'
 import { REVIEW_BRIEF_ASK } from './actionsCatalogue'
 import { formatStatedLimitsNote, parseStatedLimitsKey, selectStatedLimitsKey } from './statedLimits'
+import {
+  CROWN_COMPLIANCE_DOT_TONE,
+  selectCrownComplianceReason,
+  selectCrownComplianceVerdict,
+  selectCrownComplianceDisclosure,
+} from './crownCompliance'
 
 export type BriefStateOverride = 'thin' | 'contradictory' | 'unverified'
 
@@ -292,6 +298,17 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
   // drag, a producer re-sync — does not re-commit the whole card.
   const statedLimitsKey = useCanvasStore((s) => selectStatedLimitsKey(s.goalConstraints))
   const statedLimits = useMemo(() => parseStatedLimitsKey(statedLimitsKey), [statedLimitsKey])
+  // Step 6, second half — the PRODUCER's compliance verdict on the crown, read
+  // as two PRIMITIVES to keep the card's primitive-selector contract (U1), then
+  // composed. Fresh raw response wins over the saved/hydrated report; the
+  // narrowing is fail-closed, so an older producer or an unknown future token
+  // leaves the surface silent rather than guessing.
+  const crownComplianceVerdict = useCanvasStore(selectCrownComplianceVerdict)
+  const crownComplianceReason = useCanvasStore(selectCrownComplianceReason)
+  const crownCompliance = useMemo(
+    () => selectCrownComplianceDisclosure(crownComplianceVerdict, crownComplianceReason),
+    [crownComplianceVerdict, crownComplianceReason],
+  )
   const briefPresent = useCanvasStore((s) => Boolean(s.currentBriefText?.trim()))
   // Mirrors ResultsBody's UI-SEM-065 blocker read (graphHealth is the
   // engine-critique carrier; blocker severity never reaches uncertainties).
@@ -637,19 +654,25 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
             ))}
           </div>
 
-          {/* ⭐ The limits the user actually stated.
-              Renders NOTHING when there are none, so a model with no hard
+          {/* ⭐ The limits the user actually stated, and — since PLoT #338 —
+              the producer's verdict on whether the crowned option met them.
+
+              Renders NOTHING when there are no limits, so a model with no hard
               limit is byte-identical to before this shipped.
 
-              Deliberately silent about COMPLIANCE. Whether an option breaches
-              a limit is not derivable here: the browser holds no per-option
-              value on the constrained node, and PLoT's run-level
+              ⚠ THE "DELIBERATELY SILENT ABOUT COMPLIANCE" NOTE THAT STOOD HERE
+              IS WITHDRAWN, and precisely because its reasoning was sound. It
+              said compliance "is not derivable here" because PLoT's run-level
               `constraints_status` is stripped on the CEE→UI hop (absent from
-              CEE compose.ts `P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP`). Saying
-              "not evaluated" would be just as false as saying "met" —
-              evaluation DOES happen upstream, its verdict simply does not
-              reach this surface. So this states the limit and claims nothing
-              else. See the lane report's CEE dependency. */}
+              CEE compose.ts `P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP`). That is
+              still true OF `constraints_status`. It is NOT true of
+              `robustness.recommended_option_compliance`, which PLoT #338 emits
+              unconditionally and which CEE forwards because `robustness` is
+              itself a keep-list member carried WHOLE — verified at the CEE
+              bytes and at the deployed bundle. Nothing is derived on this
+              surface: the verdict and its sentence are both the producer's,
+              rendered verbatim. See `crownCompliance.ts` for the four things
+              this render must never do. */}
           {statedLimits.length > 0 && (
             <div className="mt-2" data-testid="stated-limits">
               <p className={`${typography.panelMeta} text-text-light`}>
@@ -667,6 +690,28 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
                   </li>
                 ))}
               </ul>
+              {/* The producer's sentence, VERBATIM. `data-verdict` carries the
+                  exact enum so a test — and a support engineer reading the DOM
+                  — binds to the state by identity rather than by the prose or
+                  the colour, either of which another state could share. */}
+              {crownCompliance !== null && (
+                <div
+                  className="mt-1.5 flex items-start gap-1.5"
+                  data-testid="crown-compliance"
+                  data-verdict={crownCompliance.verdict}
+                  data-tone={crownCompliance.tone}
+                >
+                  <span
+                    aria-hidden="true"
+                    className={`mt-1 h-[7px] w-[7px] flex-none rounded-full ${
+                      CROWN_COMPLIANCE_DOT_TONE[crownCompliance.tone]
+                    }`}
+                  />
+                  <span className={`${typography.panelMeta} min-w-0 text-text-light`}>
+                    {crownCompliance.reason}
+                  </span>
+                </div>
+              )}
             </div>
           )}
 

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -39,6 +39,7 @@ import {
   selectCrownComplianceReason,
   selectCrownComplianceVerdict,
   selectCrownComplianceDisclosure,
+  selectGoalConstraintCount,
 } from './crownCompliance'
 
 export type BriefStateOverride = 'thin' | 'contradictory' | 'unverified'
@@ -305,9 +306,17 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
   // leaves the surface silent rather than guessing.
   const crownComplianceVerdict = useCanvasStore(selectCrownComplianceVerdict)
   const crownComplianceReason = useCanvasStore(selectCrownComplianceReason)
+  // ⭐ Gated on the constraints the USER SET, never on whether those constraints
+  // happened to be FORMATTABLE — see `selectGoalConstraintCount` for why those
+  // are two different questions and why the gap bites hardest on the one state
+  // (`not_assessed`) a malformed limit is most likely to produce.
+  const goalConstraintCount = useCanvasStore(selectGoalConstraintCount)
   const crownCompliance = useMemo(
-    () => selectCrownComplianceDisclosure(crownComplianceVerdict, crownComplianceReason),
-    [crownComplianceVerdict, crownComplianceReason],
+    () =>
+      goalConstraintCount > 0
+        ? selectCrownComplianceDisclosure(crownComplianceVerdict, crownComplianceReason)
+        : null,
+    [goalConstraintCount, crownComplianceVerdict, crownComplianceReason],
   )
   const briefPresent = useCanvasStore((s) => Boolean(s.currentBriefText?.trim()))
   // Mirrors ResultsBody's UI-SEM-065 blocker read (graphHealth is the
@@ -690,28 +699,38 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
                   </li>
                 ))}
               </ul>
-              {/* The producer's sentence, VERBATIM. `data-verdict` carries the
-                  exact enum so a test — and a support engineer reading the DOM
-                  — binds to the state by identity rather than by the prose or
-                  the colour, either of which another state could share. */}
-              {crownCompliance !== null && (
-                <div
-                  className="mt-1.5 flex items-start gap-1.5"
-                  data-testid="crown-compliance"
-                  data-verdict={crownCompliance.verdict}
-                  data-tone={crownCompliance.tone}
-                >
-                  <span
-                    aria-hidden="true"
-                    className={`mt-1 h-[7px] w-[7px] flex-none rounded-full ${
-                      CROWN_COMPLIANCE_DOT_TONE[crownCompliance.tone]
-                    }`}
-                  />
-                  <span className={`${typography.panelMeta} min-w-0 text-text-light`}>
-                    {crownCompliance.reason}
-                  </span>
-                </div>
-              )}
+            </div>
+          )}
+
+          {/* The producer's sentence, VERBATIM. `data-verdict` carries the exact
+              enum so a test — and a support engineer reading the DOM — binds to
+              the state by identity rather than by the prose or the colour,
+              either of which another state could share.
+
+              ⭐ A SIBLING OF THE LIMITS LIST, NOT A CHILD OF IT. Nesting it
+              inside `stated-limits` gated it on the limits being FORMATTABLE,
+              which silently suppressed the disclosure in exactly the case that
+              needs it most: a limit whose value is non-finite or whose operator
+              is empty is skipped by `selectStatedLimits`, and that is precisely
+              what produces `not_assessed` ("we could not check every limit you
+              set on this run"). Its own gate is `goalConstraintCount > 0`,
+              applied where the disclosure is built. */}
+          {crownCompliance !== null && (
+            <div
+              className="mt-1.5 flex items-start gap-1.5"
+              data-testid="crown-compliance"
+              data-verdict={crownCompliance.verdict}
+              data-tone={crownCompliance.tone}
+            >
+              <span
+                aria-hidden="true"
+                className={`mt-1 h-[7px] w-[7px] flex-none rounded-full ${
+                  CROWN_COMPLIANCE_DOT_TONE[crownCompliance.tone]
+                }`}
+              />
+              <span className={`${typography.panelMeta} min-w-0 text-text-light`}>
+                {crownCompliance.reason}
+              </span>
             </div>
           )}
 

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.crownCompliance.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.crownCompliance.spec.tsx
@@ -1,0 +1,296 @@
+/**
+ * STEP 6, SECOND HALF — THE USER SEES WHETHER THEIR STATED LIMIT WAS MET.
+ *
+ * ── WHAT THIS CLOSES ────────────────────────────────────────────────────────
+ * `DecisionOverviewCard.statedLimits.spec.tsx` beside this file closed step 6's
+ * FIRST half: the limit the user stated is visible on the results surface. The
+ * card was then "deliberately silent about COMPLIANCE", on the recorded grounds
+ * that PLoT's `constraints_status` is stripped on the CEE→UI hop.
+ *
+ * That reasoning was right about `constraints_status` and does NOT hold for the
+ * field this suite exercises. PLoT #338 (staging `e19ac506`) emits
+ * `robustness.recommended_option_compliance` + `_reason` UNCONDITIONALLY, and
+ * CEE keep-lists `robustness` WHOLE (`compose.ts:723`) with a shallow keep plus
+ * a deep DENY-strip (`compose.ts:1079`), so the members ride through — verified
+ * at the CEE bytes, and at the deployed bundle, in the lane report. They were
+ * dropped inside THIS repo, at the two mapper keep-lists, and read by nothing.
+ *
+ * ── WHAT THE PRODUCER OWNS ──────────────────────────────────────────────────
+ * The reason strings below are PLoT's, verbatim
+ * (`src/routes/v2/crown-eligibility.ts`, `CROWN_COMPLIANCE_REASONS`). The UI
+ * authors no copy for a verdict, so every assertion on screen text is an
+ * assertion that the producer's sentence survived unedited.
+ *
+ * ── BINDING ─────────────────────────────────────────────────────────────────
+ * Assertions bind by EXACT testid and EXACT enum value carried on a
+ * `data-verdict` attribute — never by a tone or a truthiness predicate another
+ * state could satisfy. The suite deliberately drives BOTH a rendered state and
+ * a silent one so a render broken for all states is distinguishable from a
+ * render broken for one (the discriminating mutant pair in the lane report).
+ *
+ * ⚠ PRECONDITION PINNING. Every case asserts the STATED LIMIT is on screen
+ * BEFORE asserting anything about compliance. Without that, a suite could reach
+ * the right verdict through a card that failed to render the limits region at
+ * all, and pass with zero coverage of the pairing this step is about.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import { DecisionOverviewCard } from '../DecisionOverviewCard'
+import { useCanvasStore } from '../../../../canvas/store'
+import { useGuidanceStore } from '../../../../canvas/stores/guidanceStore'
+import { useAskOlumiStore } from '../../coaching/askOlumiStore'
+
+const READY = { status: 'ready', options: [{ id: 'o1' }], goal_node_id: 'g1' }
+const GOAL_NODE_WITH_MEASURE = {
+  id: 'g1',
+  type: 'goal',
+  position: { x: 0, y: 0 },
+  data: { label: 'G', threshold_source: 'user', success_threshold: 20 },
+}
+
+/** The same £50,000 cap the first-half suite uses — one chain, one fixture. */
+const BUDGET_CAP = {
+  constraint_id: 'constraint_cost_max',
+  node_id: 'n_cost',
+  label: 'Budget',
+  operator: '<=' as const,
+  value: 50000,
+  unit: '£',
+  source_quote: 'the budget cannot exceed £50,000',
+  provenance: 'explicit' as const,
+}
+
+/** PLoT's own table, quoted — never authored here. */
+const REASON = {
+  not_applicable: 'no limits were set for this decision',
+  compliant: 'this option met every limit you set, in all the scenarios we tested',
+  uncertain: 'this option met your limits in some scenarios but not others',
+  unverified: 'we could not check this option against your limits on a reliable scale',
+  not_assessed: 'we could not check every limit you set on this run',
+  no_eligible_option: 'no option met the limits you set, so none is being recommended',
+} as const
+
+/**
+ * Seed the card AND the raw analysis response.
+ *
+ * `rawV2Response` is the FRESH-RUN seam — permissive, carries the producer's
+ * robustness object verbatim (`analysisEnrichmentShape.ts` casts it whole). The
+ * mapped `results.report.robustness` is the saved/hydrated fallback, exercised
+ * separately below.
+ */
+function seed(opts: {
+  goalConstraints: unknown
+  rawRobustness?: Record<string, unknown> | null
+  reportRobustness?: Record<string, unknown> | null
+}) {
+  localStorage.clear()
+  localStorage.setItem('feature.decisionOverview', '1')
+  useGuidanceStore.setState({ guidanceItems: [], _sendMessage: null } as never)
+  useAskOlumiStore.setState({
+    isOpen: false,
+    context: '',
+    draft: '',
+    label: '',
+    targetId: null,
+    parameters: undefined,
+    source: 'chip',
+  })
+  useCanvasStore.setState({
+    ceeAnalysisReady: READY,
+    goalThreshold: 20,
+    nodes: [GOAL_NODE_WITH_MEASURE],
+    goalConstraints: opts.goalConstraints,
+    currentBriefText: null,
+    graphHealth: null,
+    rawV2Response: opts.rawRobustness ? { robustness: opts.rawRobustness } : null,
+    results: {
+      status: 'complete',
+      report: {
+        summary: 'A leads on the modelled outcome.',
+        ...(opts.reportRobustness ? { robustness: opts.reportRobustness } : {}),
+      },
+    },
+  } as never)
+}
+
+function openBrief() {
+  fireEvent.click(screen.getByTestId('brief-bar'))
+}
+
+/**
+ * PRECONDITION. Assert we are in the state the case claims to be in — the
+ * stated limit is on screen — before reading anything about compliance.
+ */
+function expectStatedLimitVisible() {
+  expect(screen.getByTestId('stated-limits')).toBeInTheDocument()
+  expect(screen.getByTestId('stated-limit-constraint_cost_max')).toHaveTextContent(
+    'Budget ≤ £50,000',
+  )
+}
+
+function renderWith(rawRobustness: Record<string, unknown> | null) {
+  seed({ goalConstraints: [BUDGET_CAP], rawRobustness })
+  render(<DecisionOverviewCard title="Take £4m out of opex" />)
+  openBrief()
+  expectStatedLimitVisible()
+}
+
+describe('step 6 — the stated limit is paired with the producer’s compliance verdict', () => {
+  beforeEach(() => {
+    seed({ goalConstraints: null })
+  })
+
+  it('⭐ no_eligible_option — the withheld crown is EXPLAINED, never an empty slot', () => {
+    renderWith({
+      // No recommended_option_id — the producer omits it in this state, and
+      // that absence is exactly why the reason must carry the message.
+      recommended_option_compliance: 'no_eligible_option',
+      recommended_option_compliance_reason: REASON.no_eligible_option,
+    })
+
+    const row = screen.getByTestId('crown-compliance')
+    expect(row).toHaveAttribute('data-verdict', 'no_eligible_option')
+    expect(row).toHaveTextContent(REASON.no_eligible_option)
+  })
+
+  it('OPPOSITE-DIRECTION TWIN — a compliant run still reads as compliant', () => {
+    renderWith({
+      recommended_option_id: 'opt_a',
+      recommended_option_compliance: 'compliant',
+      recommended_option_compliance_reason: REASON.compliant,
+    })
+
+    const row = screen.getByTestId('crown-compliance')
+    expect(row).toHaveAttribute('data-verdict', 'compliant')
+    expect(row).toHaveTextContent(REASON.compliant)
+  })
+
+  it('⭐ uncertain renders as UNKNOWN and never as a breach', () => {
+    renderWith({
+      recommended_option_id: 'opt_a',
+      recommended_option_compliance: 'uncertain',
+      recommended_option_compliance_reason: REASON.uncertain,
+    })
+
+    const row = screen.getByTestId('crown-compliance')
+    expect(row).toHaveAttribute('data-verdict', 'uncertain')
+    expect(row).toHaveAttribute('data-tone', 'unknown')
+    // Bound in BOTH directions: "not negative" alone would also pass for a
+    // positive render, which would be the opposite falsehood.
+    expect(row).not.toHaveAttribute('data-tone', 'negative')
+    expect(row).not.toHaveAttribute('data-tone', 'positive')
+    expect(row).toHaveTextContent(REASON.uncertain)
+  })
+
+  it('⭐ unverified renders as UNKNOWN — no claim in EITHER direction', () => {
+    renderWith({
+      recommended_option_id: 'opt_a',
+      recommended_option_compliance: 'unverified',
+      recommended_option_compliance_reason: REASON.unverified,
+    })
+
+    const row = screen.getByTestId('crown-compliance')
+    expect(row).toHaveAttribute('data-verdict', 'unverified')
+    expect(row).toHaveAttribute('data-tone', 'unknown')
+    expect(row).toHaveTextContent(REASON.unverified)
+  })
+
+  it('⭐ not_assessed renders, and does NOT say "no limits were set"', () => {
+    renderWith({
+      recommended_option_id: 'opt_a',
+      recommended_option_compliance: 'not_assessed',
+      recommended_option_compliance_reason: REASON.not_assessed,
+    })
+
+    const row = screen.getByTestId('crown-compliance')
+    expect(row).toHaveAttribute('data-verdict', 'not_assessed')
+    expect(row).toHaveTextContent(REASON.not_assessed)
+    // The falsehood PLoT #338 fixed one layer up must not be recreated here.
+    expect(row).not.toHaveTextContent(REASON.not_applicable)
+  })
+})
+
+describe('step 6 — the surface stays silent where the producer makes no claim', () => {
+  beforeEach(() => {
+    seed({ goalConstraints: null })
+  })
+
+  it('not_applicable renders NO compliance row — the limits still render', () => {
+    renderWith({
+      recommended_option_compliance: 'not_applicable',
+      recommended_option_compliance_reason: REASON.not_applicable,
+    })
+
+    // The precondition above already proved the limits region is present, so
+    // this null is about the compliance row and not about a card that failed
+    // to render.
+    expect(screen.queryByTestId('crown-compliance')).toBeNull()
+  })
+
+  it('an OLDER producer (field absent) renders no compliance row', () => {
+    renderWith({ recommended_option_id: 'opt_a', level: 'high' })
+    expect(screen.queryByTestId('crown-compliance')).toBeNull()
+  })
+
+  it('an UNRECOGNISED future token renders no compliance row', () => {
+    renderWith({
+      recommended_option_compliance: 'partially_compliant',
+      recommended_option_compliance_reason: 'something this build has never heard of',
+    })
+    expect(screen.queryByTestId('crown-compliance')).toBeNull()
+  })
+
+  it('a verdict with NO producer reason renders no compliance row', () => {
+    renderWith({ recommended_option_compliance: 'no_eligible_option' })
+    expect(screen.queryByTestId('crown-compliance')).toBeNull()
+  })
+})
+
+describe('step 6 — the saved/hydrated report is the fallback seam', () => {
+  beforeEach(() => {
+    seed({ goalConstraints: null })
+  })
+
+  it('reads the mapped report slot when the raw response is absent', () => {
+    // The hydrated path: no fresh rawV2Response, but a persisted report that
+    // travelled through the mapper keep-list this lane extended.
+    seed({
+      goalConstraints: [BUDGET_CAP],
+      rawRobustness: null,
+      reportRobustness: {
+        recommended_option_compliance: 'no_eligible_option',
+        recommended_option_compliance_reason: REASON.no_eligible_option,
+      },
+    })
+    render(<DecisionOverviewCard title="Take £4m out of opex" />)
+    openBrief()
+    expectStatedLimitVisible()
+
+    const row = screen.getByTestId('crown-compliance')
+    expect(row).toHaveAttribute('data-verdict', 'no_eligible_option')
+    expect(row).toHaveTextContent(REASON.no_eligible_option)
+  })
+
+  it('the FRESH raw response wins over a stale mapped report', () => {
+    // Precedence must match `display_verdict`'s (`raw ?? mapped`), or a
+    // hydrated verdict from a previous run would outrank the current one.
+    seed({
+      goalConstraints: [BUDGET_CAP],
+      rawRobustness: {
+        recommended_option_compliance: 'compliant',
+        recommended_option_compliance_reason: REASON.compliant,
+      },
+      reportRobustness: {
+        recommended_option_compliance: 'no_eligible_option',
+        recommended_option_compliance_reason: REASON.no_eligible_option,
+      },
+    })
+    render(<DecisionOverviewCard title="Take £4m out of opex" />)
+    openBrief()
+    expectStatedLimitVisible()
+
+    const row = screen.getByTestId('crown-compliance')
+    expect(row).toHaveAttribute('data-verdict', 'compliant')
+  })
+})

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.crownCompliance.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.crownCompliance.spec.tsx
@@ -294,3 +294,149 @@ describe('step 6 — the saved/hydrated report is the fallback seam', () => {
     expect(row).toHaveAttribute('data-verdict', 'compliant')
   })
 })
+
+/**
+ * ⭐ THE GATE IS "DID THE USER SET LIMITS", NOT "CAN WE FORMAT THEM".
+ *
+ * Review finding on this PR. The row was first gated on `statedLimits.length > 0`.
+ * `selectStatedLimits` (statedLimits.ts:96-98) SKIPS any constraint whose
+ * `value` is non-finite or whose `operator` is empty, so that gate silently
+ * suppressed the disclosure whenever the user's limit was unformattable — and
+ * `not_assessed` ("we could not check every limit you set on this run") is
+ * EXACTLY the state a malformed or withheld constraint produces. The gate was
+ * quietest precisely where the producer was speaking loudest.
+ *
+ * Both directions are pinned here, because widening naively would reopen the
+ * opposite falsehood.
+ */
+const MALFORMED_NON_FINITE = {
+  constraint_id: 'constraint_broken_value',
+  node_id: 'n_cost',
+  label: 'Programme cost',
+  operator: '<=' as const,
+  value: Number.NaN, // skipped by selectStatedLimits — unformattable
+  unit: '£',
+}
+const MALFORMED_EMPTY_OPERATOR = {
+  constraint_id: 'constraint_broken_operator',
+  node_id: 'n_margin',
+  label: 'Gross margin',
+  operator: '' as const, // skipped by selectStatedLimits
+  value: 78,
+  unit: '%',
+}
+
+describe('step 6 — a limit we cannot FORMAT is still a limit the user SET', () => {
+  beforeEach(() => {
+    seed({ goalConstraints: null })
+  })
+
+  it('⭐ non-finite value + not_assessed — the disclosure RENDERS, though no limit can be listed', () => {
+    seed({
+      goalConstraints: [MALFORMED_NON_FINITE],
+      rawRobustness: {
+        recommended_option_compliance: 'not_assessed',
+        recommended_option_compliance_reason: REASON.not_assessed,
+      },
+    })
+    render(<DecisionOverviewCard title="Take £4m out of opex" />)
+    openBrief()
+
+    // PRECONDITION, pinned: this is genuinely the unformattable case — the
+    // limits region is ABSENT, so the assertion below is about the compliance
+    // gate and not about a card that happened to render limits anyway.
+    expect(screen.queryByTestId('stated-limits')).toBeNull()
+
+    const row = screen.getByTestId('crown-compliance')
+    expect(row).toHaveAttribute('data-verdict', 'not_assessed')
+    expect(row).toHaveTextContent(REASON.not_assessed)
+  })
+
+  it('⭐ empty operator + no_eligible_option — the withheld crown is still explained', () => {
+    seed({
+      goalConstraints: [MALFORMED_EMPTY_OPERATOR],
+      rawRobustness: {
+        recommended_option_compliance: 'no_eligible_option',
+        recommended_option_compliance_reason: REASON.no_eligible_option,
+      },
+    })
+    render(<DecisionOverviewCard title="Take £4m out of opex" />)
+    openBrief()
+
+    expect(screen.queryByTestId('stated-limits')).toBeNull()
+    const row = screen.getByTestId('crown-compliance')
+    expect(row).toHaveAttribute('data-verdict', 'no_eligible_option')
+    expect(row).toHaveTextContent(REASON.no_eligible_option)
+  })
+
+  it('OPPOSITE-DIRECTION TWIN — a well-formed limit still renders BOTH the limit and the verdict', () => {
+    // Proves the widening did not trade the pairing away: where the limit CAN
+    // be shown, it is still shown beside the verdict. That pairing is the whole
+    // point of step 6.
+    renderWith({
+      recommended_option_compliance: 'not_assessed',
+      recommended_option_compliance_reason: REASON.not_assessed,
+    })
+    expect(screen.getByTestId('stated-limit-constraint_cost_max')).toHaveTextContent(
+      'Budget ≤ £50,000',
+    )
+    expect(screen.getByTestId('crown-compliance')).toHaveAttribute('data-verdict', 'not_assessed')
+  })
+})
+
+describe('step 6 — the auto-synthesised-constraint falsehood stays suppressed', () => {
+  beforeEach(() => {
+    seed({ goalConstraints: null })
+  })
+
+  /**
+   * ⚠ THE REASON THE GATE IS NOT SIMPLY "ALWAYS RENDER".
+   *
+   * PLoT synthesises a `'Goal target'` constraint (`auto_goal_threshold`,
+   * run.ts:6035-6042) from the goal node's threshold when the user set NO
+   * limits, and can then return `compliant` carrying "this option met every
+   * limit YOU SET" — about limits nobody set. That synthesis happens inside
+   * PLoT's run handler and never reaches this store, so `goalConstraints` is
+   * genuinely empty in that case and this gate keeps the sentence off screen.
+   *
+   * A PLoT-side fix for the wording is commissioned separately. Until it lands,
+   * THIS TEST IS LOAD-BEARING — deleting it reopens a producer falsehood.
+   */
+  it('⭐ NO user-set limits + compliant — renders NOTHING, even though a verdict arrived', () => {
+    seed({
+      goalConstraints: [],
+      rawRobustness: {
+        recommended_option_compliance: 'compliant',
+        recommended_option_compliance_reason: REASON.compliant,
+      },
+    })
+    render(<DecisionOverviewCard title="Take £4m out of opex" />)
+    openBrief()
+
+    expect(screen.queryByTestId('crown-compliance')).toBeNull()
+  })
+
+  it('null goalConstraints + compliant — renders NOTHING', () => {
+    seed({
+      goalConstraints: null,
+      rawRobustness: {
+        recommended_option_compliance: 'compliant',
+        recommended_option_compliance_reason: REASON.compliant,
+      },
+    })
+    render(<DecisionOverviewCard title="Take £4m out of opex" />)
+    openBrief()
+
+    expect(screen.queryByTestId('crown-compliance')).toBeNull()
+  })
+
+  it('DISCRIMINATING CONTROL — the SAME verdict WITH a user-set limit does render', () => {
+    // Without this, the two nulls above could pass because the verdict is
+    // unrenderable for some unrelated reason rather than because of the gate.
+    renderWith({
+      recommended_option_compliance: 'compliant',
+      recommended_option_compliance_reason: REASON.compliant,
+    })
+    expect(screen.getByTestId('crown-compliance')).toHaveAttribute('data-verdict', 'compliant')
+  })
+})

--- a/src/components/results/decision-overview/__tests__/crownCompliance.spec.ts
+++ b/src/components/results/decision-overview/__tests__/crownCompliance.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Crown compliance render seam — the six producer states, plus absence.
+ *
+ * PROVENANCE. Every enum value and every reason string below is quoted from the
+ * PRODUCER (`plot-lite-service` @ staging `e19ac506`,
+ * `src/routes/v2/crown-eligibility.ts`: `CrownCompliance` and
+ * `CROWN_COMPLIANCE_REASONS`). None is authored here — that is the point of the
+ * verbatim rule, and a reason invented in this spec would be testing the wrong
+ * oracle (doctrine trap 13c).
+ *
+ * ⚠ HONEST NOTE ON ORDER: this spec was written AFTER `crownCompliance.ts`, not
+ * RED-first — the module is new, so there was no defect to reproduce. Its
+ * discrimination is therefore established by the mutant pair recorded in the
+ * lane report, not by a pristine RED.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  CROWN_COMPLIANCE_DOT_TONE,
+  CROWN_COMPLIANCE_VALUES,
+  normaliseCrownCompliance,
+  selectCrownComplianceDisclosure,
+} from '../crownCompliance'
+
+/** The producer's own table, quoted. */
+const PRODUCER_REASONS = {
+  not_applicable: 'no limits were set for this decision',
+  compliant: 'this option met every limit you set, in all the scenarios we tested',
+  uncertain: 'this option met your limits in some scenarios but not others',
+  unverified: 'we could not check this option against your limits on a reliable scale',
+  not_assessed: 'we could not check every limit you set on this run',
+  no_eligible_option: 'no option met the limits you set, so none is being recommended',
+} as const
+
+describe('normaliseCrownCompliance — fail-closed narrowing', () => {
+  it('accepts every producer enum value, bound by EXACT token', () => {
+    // Iterates the exported constant rather than a hand-copied list, so a
+    // producer value added to the module without a test cannot pass unnoticed
+    // (doctrine trap 12 — derive, do not mirror).
+    expect(CROWN_COMPLIANCE_VALUES).toHaveLength(6)
+    for (const value of CROWN_COMPLIANCE_VALUES) {
+      expect(normaliseCrownCompliance(value), `enum ${value}`).toBe(value)
+    }
+  })
+
+  it('rejects an unrecognised token, absence, and non-strings', () => {
+    // A future producer value must not crash or be guessed at.
+    expect(normaliseCrownCompliance('partially_compliant')).toBeUndefined()
+    expect(normaliseCrownCompliance('COMPLIANT')).toBeUndefined()
+    expect(normaliseCrownCompliance(undefined)).toBeUndefined()
+    expect(normaliseCrownCompliance(null)).toBeUndefined()
+    expect(normaliseCrownCompliance(true)).toBeUndefined()
+    expect(normaliseCrownCompliance(1)).toBeUndefined()
+    expect(normaliseCrownCompliance({ verdict: 'compliant' })).toBeUndefined()
+  })
+})
+
+describe('selectCrownComplianceDisclosure — the six-state rendering table', () => {
+  it('not_applicable renders NOTHING — the only value meaning "no limits were set"', () => {
+    // Its reason would directly contradict the user's stated-limits list above
+    // it. Silence here is not a dead end: the limits themselves still render.
+    expect(
+      selectCrownComplianceDisclosure('not_applicable', PRODUCER_REASONS.not_applicable),
+    ).toBeNull()
+  })
+
+  it('compliant renders POSITIVE, with the producer reason verbatim', () => {
+    const d = selectCrownComplianceDisclosure('compliant', PRODUCER_REASONS.compliant)
+    expect(d?.verdict).toBe('compliant')
+    expect(d?.tone).toBe('positive')
+    expect(d?.reason).toBe(PRODUCER_REASONS.compliant)
+  })
+
+  it('no_eligible_option renders NEGATIVE — a definite producer claim, never an absence', () => {
+    const d = selectCrownComplianceDisclosure(
+      'no_eligible_option',
+      PRODUCER_REASONS.no_eligible_option,
+    )
+    expect(d?.verdict).toBe('no_eligible_option')
+    expect(d?.tone).toBe('negative')
+    // The obligation from the wire contract: on this state there is NO
+    // recommended_option_id, so the reason is the ONLY thing standing between
+    // the user and an unexplained empty leader slot.
+    expect(d?.reason).toBe(PRODUCER_REASONS.no_eligible_option)
+  })
+
+  it('⭐ uncertain is UNKNOWN and is NEVER binarised into a breach', () => {
+    const d = selectCrownComplianceDisclosure('uncertain', PRODUCER_REASONS.uncertain)
+    expect(d?.verdict).toBe('uncertain')
+    expect(d?.tone).toBe('unknown')
+    // Bound by exact tone identity in BOTH directions — asserting "not negative"
+    // alone would also pass for 'positive'.
+    expect(d?.tone).not.toBe('negative')
+    expect(d?.tone).not.toBe('positive')
+  })
+
+  it('⭐ unverified is UNKNOWN — the scale was untrusted, so no claim EITHER way', () => {
+    const d = selectCrownComplianceDisclosure('unverified', PRODUCER_REASONS.unverified)
+    expect(d?.verdict).toBe('unverified')
+    expect(d?.tone).toBe('unknown')
+    expect(d?.tone).not.toBe('negative')
+    expect(d?.tone).not.toBe('positive')
+  })
+
+  it('⭐ not_assessed is UNKNOWN and is DISTINCT from not_applicable', () => {
+    const d = selectCrownComplianceDisclosure('not_assessed', PRODUCER_REASONS.not_assessed)
+    // Renders — where not_applicable does not. The two states are byte-similar
+    // in English and opposite in meaning: "we did not check your limits" vs
+    // "you set none". Collapsing them is the falsehood PLoT #338 fixed upstream.
+    expect(d).not.toBeNull()
+    expect(d?.verdict).toBe('not_assessed')
+    expect(d?.tone).toBe('unknown')
+    expect(d?.reason).toBe(PRODUCER_REASONS.not_assessed)
+    // And it must never borrow the "no limits" sentence.
+    expect(d?.reason).not.toBe(PRODUCER_REASONS.not_applicable)
+  })
+
+  it('every rendered state carries a NON-EMPTY producer reason', () => {
+    // The counter-invariant: safety must not reduce this surface to a silent
+    // dead end. Wherever we speak at all, the user gets a sentence.
+    for (const value of CROWN_COMPLIANCE_VALUES) {
+      const d = selectCrownComplianceDisclosure(value, PRODUCER_REASONS[value])
+      if (value === 'not_applicable') {
+        expect(d, 'not_applicable stays silent').toBeNull()
+        continue
+      }
+      expect(d, `${value} renders`).not.toBeNull()
+      expect(d?.reason.length, `${value} reason non-empty`).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('selectCrownComplianceDisclosure — the verdict is never shown without its reason', () => {
+  it('drops the disclosure when the producer reason is missing or blank', () => {
+    // The UI authors no copy for the verdict, so a token with no sentence is
+    // unrenderable rather than rendered raw.
+    expect(selectCrownComplianceDisclosure('no_eligible_option', undefined)).toBeNull()
+    expect(selectCrownComplianceDisclosure('no_eligible_option', '')).toBeNull()
+    expect(selectCrownComplianceDisclosure('no_eligible_option', '   ')).toBeNull()
+    expect(selectCrownComplianceDisclosure('compliant', 42)).toBeNull()
+  })
+
+  it('OPPOSITE-DIRECTION TWIN — a present reason on the same verdict DOES render', () => {
+    // Proves the null above is caused by the missing reason and not by the
+    // verdict being unrenderable for some other cause.
+    const d = selectCrownComplianceDisclosure(
+      'no_eligible_option',
+      PRODUCER_REASONS.no_eligible_option,
+    )
+    expect(d).not.toBeNull()
+  })
+})
+
+describe('CROWN_COMPLIANCE_DOT_TONE — reuses the card’s own tone classes', () => {
+  it('maps the three tones to the card’s existing STATE_DOT_TONE classes', () => {
+    // Not a new palette: these are the classes DecisionOverviewCard already
+    // uses, so a compliance dot cannot drift from the card around it.
+    expect(CROWN_COMPLIANCE_DOT_TONE.positive).toBe('bg-success')
+    expect(CROWN_COMPLIANCE_DOT_TONE.negative).toBe('bg-danger')
+    expect(CROWN_COMPLIANCE_DOT_TONE.unknown).toBe('bg-text-light')
+  })
+})

--- a/src/components/results/decision-overview/crownCompliance.ts
+++ b/src/components/results/decision-overview/crownCompliance.ts
@@ -1,0 +1,214 @@
+/**
+ * CROWN COMPLIANCE — the render seam for hard-constraint chain step 6.
+ *
+ * WHAT THIS CLOSES. `DecisionOverviewCard` has stated the user's limits since
+ * UI #832 while being "deliberately silent about COMPLIANCE", on the recorded
+ * grounds that PLoT's run-level `constraints_status` is stripped on the CEE→UI
+ * hop. That reasoning was correct about `constraints_status` and it is NOT
+ * correct about the field this module reads: PLoT #338 emits
+ * `robustness.recommended_option_compliance`, and CEE keep-lists `robustness`
+ * WHOLE (`compose.ts:723`), projecting it with a shallow top-level keep plus a
+ * deep DENY-strip of internal carriers only (`compose.ts:1079`) — so additive
+ * members ride through. They also survive the withheld-crown projection,
+ * because `keyDesignatesLeadingOption`'s pattern is anchored with a closed
+ * suffix group (`id|label|name`) these names do not match. The verdict reaches
+ * the browser; before this module nothing read it.
+ *
+ * ⛔ THE UI AUTHORS NO COPY FOR THE VERDICT. The reason string is the
+ * producer's own claim-safe phrase and is rendered VERBATIM
+ * (`contracts/isl-to-ui.contract.ts:281` — "emit verbatim, never re-derive").
+ * A consumer that reworded it would be the second opinion this whole chain
+ * exists to remove.
+ *
+ * ⚠ THE FOUR THINGS THIS MODULE MUST NOT DO, each a defect the chain already
+ * paid for upstream:
+ *   1. NEVER BINARISE `uncertain`. ISL publishes no satisfied/breached
+ *      threshold, so any cut invented here is a claim the producer declined to
+ *      make. It renders as unknown.
+ *   2. `unverified` means the SCALE could not be trusted — no claim in either
+ *      direction. Not compliant, not breaching. Unknown.
+ *   3. `not_assessed` does NOT mean "no limits were set". It means the limits
+ *      were not fully checked (including a limit PLoT withheld before it
+ *      reached the engine). Rendering it as "no limits" would recreate exactly
+ *      the falsehood PLoT #338 fixed one layer up. `not_applicable` is the
+ *      only value that means no limits were set.
+ *   4. On `no_eligible_option` there is NO `recommended_option_id`. The reason
+ *      MUST be rendered rather than an empty leader slot — a blank badge is
+ *      indistinguishable from "we did not compute one", a different and much
+ *      weaker statement than the one the producer is making.
+ */
+
+/**
+ * The producer's enum, verbatim (`plot-lite-service`
+ * `src/routes/v2/crown-eligibility.ts`). Ordered as the producer's own ladder
+ * documents it, not alphabetically.
+ */
+export const CROWN_COMPLIANCE_VALUES = [
+  'not_applicable',
+  'compliant',
+  'uncertain',
+  'unverified',
+  'not_assessed',
+  'no_eligible_option',
+] as const
+
+export type CrownCompliance = (typeof CROWN_COMPLIANCE_VALUES)[number]
+
+/**
+ * Screen tone. Reuses `DecisionOverviewCard`'s OWN established vocabulary
+ * (`STATE_DOT_TONE`) rather than minting a second one — `bg-text-light` is
+ * already this card's "unassessed" tone.
+ */
+export type CrownComplianceTone = 'positive' | 'unknown' | 'negative'
+
+/**
+ * Verdict → tone. THREE tones for six states, and the collapsing is the whole
+ * point: only two of the six are claims the producer is entitled to make in a
+ * direction. The other four are disclosures, and a disclosure that borrowed a
+ * directional tone would be the binarisation this chain forbids.
+ */
+const CROWN_COMPLIANCE_TONE: Record<CrownCompliance, CrownComplianceTone> = {
+  // The producer checked every limit on a trusted scale and every draw satisfied.
+  compliant: 'positive',
+  // A definite producer statement: no option qualified. Not an absence.
+  no_eligible_option: 'negative',
+  // Partial satisfaction. Genuinely unknown — never a breach.
+  uncertain: 'unknown',
+  // Untrusted scale. No claim in either direction.
+  unverified: 'unknown',
+  // Limits stated, not fully evaluated. NOT "no limits".
+  not_assessed: 'unknown',
+  // No limits were stated. Never rendered — see `selectCrownComplianceDisclosure`.
+  not_applicable: 'unknown',
+}
+
+/**
+ * Verdicts this surface renders. `not_applicable` is DELIBERATELY ABSENT.
+ *
+ * WHY. Its producer reason is "no limits were set for this decision", and this
+ * surface only exists to speak about limits. Printing that sentence would at
+ * best be redundant and at worst directly contradict the list of the user's own
+ * stated limits sitting immediately above it. Silence is the honest state — and
+ * it is not a dead end, because the limits themselves still render.
+ *
+ * Every OTHER state renders, including all three unknowns: a limit the product
+ * could not check is precisely the thing a user needs told.
+ */
+const RENDERED_CROWN_COMPLIANCE: ReadonlySet<CrownCompliance> = new Set<CrownCompliance>([
+  'compliant',
+  'uncertain',
+  'unverified',
+  'not_assessed',
+  'no_eligible_option',
+])
+
+/**
+ * Narrow an untrusted wire value to the producer enum. FAIL-CLOSED: anything
+ * unrecognised — an older producer's absence, a future value this build has
+ * never heard of, a non-string — yields `undefined` and the surface stays
+ * silent. The same rule `display_verdict` already follows
+ * (`useResultsSectionData.ts`), for the same reason: a UI that guessed at an
+ * unknown token would be inventing a verdict.
+ */
+export function normaliseCrownCompliance(raw: unknown): CrownCompliance | undefined {
+  return typeof raw === 'string' &&
+    (CROWN_COMPLIANCE_VALUES as readonly string[]).includes(raw)
+    ? (raw as CrownCompliance)
+    : undefined
+}
+
+/** What the surface renders, or `null` for "say nothing". */
+export interface CrownComplianceDisclosure {
+  readonly verdict: CrownCompliance
+  /** The PRODUCER's phrase, verbatim. Never authored in this repo. */
+  readonly reason: string
+  readonly tone: CrownComplianceTone
+}
+
+/**
+ * Build the disclosure, or `null`.
+ *
+ * ⚠ THE REASON IS REQUIRED, AND THAT IS NOT DEFENSIVE PADDING. The verdict
+ * token alone is not user-facing English, and this module is forbidden from
+ * authoring a substitute. A verdict whose producer reason did not arrive is
+ * therefore unrenderable — exposing the token would either show a raw enum or
+ * force this consumer to invent the sentence. `display_verdict` already binds
+ * the two together the same way ("never exposed without its verdict").
+ */
+export function selectCrownComplianceDisclosure(
+  rawVerdict: unknown,
+  rawReason: unknown,
+): CrownComplianceDisclosure | null {
+  const verdict = normaliseCrownCompliance(rawVerdict)
+  if (verdict === undefined) return null
+  if (!RENDERED_CROWN_COMPLIANCE.has(verdict)) return null
+
+  const reason = typeof rawReason === 'string' ? rawReason.trim() : ''
+  if (reason === '') return null
+
+  return { verdict, reason, tone: CROWN_COMPLIANCE_TONE[verdict] }
+}
+
+/**
+ * Tone → the card's own dot class. Kept beside the tone table so a reader sees
+ * both halves at once; the classes are `STATE_DOT_TONE`'s, not new ones.
+ */
+export const CROWN_COMPLIANCE_DOT_TONE: Record<CrownComplianceTone, string> = {
+  positive: 'bg-success',
+  negative: 'bg-danger',
+  unknown: 'bg-text-light',
+}
+
+// ---------------------------------------------------------------------------
+// Store selectors
+// ---------------------------------------------------------------------------
+
+/**
+ * The two slots, in precedence order — the SAME chain `display_verdict` already
+ * uses (`useResultsSectionData`: `raw ?? mapped`).
+ *
+ *   1. `rawV2Response.robustness` — the FRESH-RUN seam. Permissive: the whole
+ *      producer object is cast through verbatim (`analysisEnrichmentShape.ts`
+ *      `readRobustnessSlot`), so additive members are present without any
+ *      keep-list entry.
+ *   2. `results.report.robustness` — the SAVED/HYDRATED fallback, which travels
+ *      through `mapV5AnalysisToReport`'s explicit keep-list.
+ *
+ * ⚠ ORDER IS LOAD-BEARING. Raw must win: the mapped report can outlive the run
+ * that produced it, and a hydrated verdict outranking the current one would
+ * show the user last run's compliance beside this run's limits.
+ */
+interface CrownComplianceStoreSlice {
+  readonly rawV2Response?: unknown
+  readonly results?: unknown
+}
+
+function robustnessOf(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+}
+
+function readMember(s: CrownComplianceStoreSlice, member: string): string | null {
+  const raw = robustnessOf(robustnessOf(s.rawV2Response)?.robustness)
+  const report = robustnessOf(robustnessOf(robustnessOf(s.results)?.report)?.robustness)
+  const value = raw?.[member] ?? report?.[member]
+  return typeof value === 'string' ? value : null
+}
+
+/**
+ * PRIMITIVE selectors — `string | null`, never an object.
+ *
+ * The card is under a primitive-selector contract
+ * (`DecisionOverviewCard.primitiveSelectors.spec.tsx`): an object-returning
+ * selector re-commits the whole card subtree on every store write that rebuilds
+ * an equal-content object, which on the live path means every frame of every
+ * node drag. Two primitives, composed in a `useMemo`, keep that contract.
+ */
+export function selectCrownComplianceVerdict(s: CrownComplianceStoreSlice): string | null {
+  return readMember(s, 'recommended_option_compliance')
+}
+
+export function selectCrownComplianceReason(s: CrownComplianceStoreSlice): string | null {
+  return readMember(s, 'recommended_option_compliance_reason')
+}

--- a/src/components/results/decision-overview/crownCompliance.ts
+++ b/src/components/results/decision-overview/crownCompliance.ts
@@ -212,3 +212,39 @@ export function selectCrownComplianceVerdict(s: CrownComplianceStoreSlice): stri
 export function selectCrownComplianceReason(s: CrownComplianceStoreSlice): string | null {
   return readMember(s, 'recommended_option_compliance_reason')
 }
+
+/**
+ * How many constraints the user actually set — a PRIMITIVE count.
+ *
+ * ⭐ WHY THIS EXISTS RATHER THAN REUSING `statedLimits.length` (trap 21 — ONE
+ * PREDICATE ANSWERING TWO QUESTIONS). The compliance row was originally gated
+ * on `statedLimits.length > 0`. Those are different questions:
+ *
+ *   `statedLimits.length > 0`  answers "can we FORMAT and display the limits?"
+ *   this selector              answers "did the user set limits the producer
+ *                              could make a claim about?"
+ *
+ * They diverge in BOTH directions, and the gap is not hypothetical:
+ * `selectStatedLimits` (statedLimits.ts:96-98) SKIPS any constraint whose
+ * `value` is non-finite or whose `operator` is empty. So `statedLimits` can be
+ * EMPTY while `goalConstraints` is populated.
+ *
+ * ⚠ AND THE CORRELATION IS THE SHARP EDGE. `not_assessed` means "we could not
+ * check every limit you set on this run" — precisely the state a malformed or
+ * withheld constraint produces. Gating on `statedLimits` therefore suppressed
+ * the disclosure in exactly the case most likely to need it: the user's limit
+ * was unformattable, the producer said so, and the surface stayed silent.
+ *
+ * ⚠⚠ THE OTHER DIRECTION MUST BE PRESERVED, AND IT IS WHY THIS IS NOT SIMPLY
+ * "ALWAYS RENDER". PLoT auto-synthesises a `'Goal target'` constraint
+ * (`constraint_id: 'auto_goal_threshold'`, run.ts:6035-6042) from the goal
+ * node's threshold when the user set no limits, which can yield `compliant`
+ * carrying the reason "this option met every limit YOU SET" — about limits
+ * nobody set. That synthesis happens INSIDE PLoT's run handler and never
+ * reaches this store, so `goalConstraints` is genuinely empty in that case and
+ * this gate keeps the falsehood suppressed. A PLoT-side fix for the reason
+ * wording is commissioned separately; until it lands, this gate is load-bearing.
+ */
+export function selectGoalConstraintCount(s: { readonly goalConstraints?: unknown }): number {
+  return Array.isArray(s.goalConstraints) ? s.goalConstraints.length : 0
+}

--- a/src/v5/__tests__/mapV5AnalysisToReport.crown-compliance.spec.ts
+++ b/src/v5/__tests__/mapV5AnalysisToReport.crown-compliance.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * Step 6 (UI leg) — the CROWN COMPLIANCE verdict reaches `report.robustness`.
+ *
+ * THE DEFECT. PLoT #338 (staging `e19ac506`) emits two additive members on
+ * `robustness`, UNCONDITIONALLY, on every /v2/run:
+ *   - `recommended_option_compliance`        (enum, six values)
+ *   - `recommended_option_compliance_reason` (producer-owned prose, verbatim)
+ * CEE forwards them intact — `robustness` is a member of
+ * `P0B_SAFE_TRANSPORT_ENRICHMENT_KEEP` (compose.ts:723) and the projection
+ * (compose.ts:1079) is a SHALLOW top-level keep plus a deep DENY-strip of
+ * internal carriers only, so additive nested members ride through. They also
+ * survive the withheld-crown projection, because
+ * `keyDesignatesLeadingOption`'s pattern is anchored with a CLOSED suffix group
+ * (`/^recommend(?:ed|ation)_option(?:_(?:id|label|name))?$/i`) that these two
+ * names do not match.
+ *
+ * They then died HERE. `mapV5AnalysisToReport`'s `report.robustness` is an
+ * explicit KEEP-LIST (see this function's own header) and neither member was on
+ * it — the identical failure this file already records for `display_verdict`:
+ * "ON-WIRE on Seam A ... but previously dropped here".
+ *
+ * PRODUCER PROVENANCE — derived at the PLoT bytes, never invented
+ * (plot-lite-service @ staging `e19ac506`):
+ *   - `src/routes/v2/run.ts:3608-3609` — the two assignments, unconditional.
+ *   - `src/routes/v2/crown-eligibility.ts` — `CrownCompliance` is exactly
+ *     `not_applicable | compliant | uncertain | unverified | not_assessed |
+ *     no_eligible_option`, and `CROWN_COMPLIANCE_REASONS` is the single source
+ *     of the prose the route emits verbatim.
+ *   - `src/contracts/isl-to-ui.contract.ts:280-281` — the wire contract, whose
+ *     consumer obligation is quoted in `crownCompliance.ts`.
+ *
+ * SCOPE, STATED HONESTLY:
+ *   - The checked-in staging capture `v5-analysis-result.bundle-45c9b625.json`
+ *     PREDATES PLoT #338 and carries NEITHER member (asserted below as the
+ *     scope pin). Values are therefore SYNTHESISED from the producer's own
+ *     enum + reason table above and OVERLAID on the real captured envelope —
+ *     the same device the `conditional_winners` spec beside this one uses.
+ *   - These are MAPPER tests. They prove the data reaches the report slot.
+ *     They are NOT a render witness and NOT a wire witness.
+ */
+import { describe, expect, it } from 'vitest'
+
+import type { AnalysisResultBlock } from '@talchain/schemas/boundary'
+
+import { mapV5AnalysisToReport } from '../mapV5AnalysisToReport'
+
+import bundleFixture from './fixtures/v5-analysis-result.bundle-45c9b625.json'
+
+type WidenedReport = ReturnType<typeof mapV5AnalysisToReport> & Record<string, unknown>
+
+/** Overlay onto the REAL captured envelope's `robustness`; never rebuild it. */
+function blockWithRobustness(overlay: Record<string, unknown>): AnalysisResultBlock {
+  const base = bundleFixture.block as unknown as Record<string, unknown>
+  const baseEnrichment = base.enrichment as Record<string, unknown>
+  const baseRobustness = baseEnrichment.robustness as Record<string, unknown>
+  return {
+    ...base,
+    enrichment: {
+      ...baseEnrichment,
+      robustness: { ...baseRobustness, ...overlay },
+    },
+  } as unknown as AnalysisResultBlock
+}
+
+function mappedRobustness(overlay: Record<string, unknown>): Record<string, unknown> {
+  const report = mapV5AnalysisToReport(blockWithRobustness(overlay)) as WidenedReport
+  return (report.robustness ?? {}) as Record<string, unknown>
+}
+
+describe('mapV5AnalysisToReport — crown compliance fixture provenance', () => {
+  it('POSITIVE CONTROL — the mapper genuinely reads this capture’s robustness slot', () => {
+    // `recommended_option_id` is present in the capture and IS on the keep-list.
+    // If this ever fails, the absence assertions below prove nothing about the
+    // compliance members and only that the mapper ignored the fixture entirely
+    // (doctrine trap 13 — an absence probe needs a positive control).
+    const robustness = mappedRobustness({})
+    expect(robustness.recommended_option_id, 'capture’s crown id reaches the report').toBe(
+      'opt_hire',
+    )
+  })
+
+  it('SCOPE PIN — the capture predates PLoT #338 and carries neither member', () => {
+    const enrichment = (bundleFixture.block as unknown as Record<string, unknown>)
+      .enrichment as Record<string, unknown>
+    const robustness = enrichment.robustness as Record<string, unknown>
+    expect('recommended_option_compliance' in robustness).toBe(false)
+    expect('recommended_option_compliance_reason' in robustness).toBe(false)
+  })
+})
+
+describe('mapV5AnalysisToReport — crown compliance reaches report.robustness', () => {
+  it('carries the verdict and its producer reason VERBATIM', () => {
+    const robustness = mappedRobustness({
+      recommended_option_compliance: 'no_eligible_option',
+      recommended_option_compliance_reason:
+        'no option met the limits you set, so none is being recommended',
+    })
+
+    // Bound by EXACT enum value, never by a truthiness predicate another state
+    // could satisfy.
+    expect(robustness.recommended_option_compliance).toBe('no_eligible_option')
+    expect(robustness.recommended_option_compliance_reason).toBe(
+      'no option met the limits you set, so none is being recommended',
+    )
+  })
+
+  it('OPPOSITE-DIRECTION TWIN — a compliant run still arrives as compliant', () => {
+    const robustness = mappedRobustness({
+      recommended_option_compliance: 'compliant',
+      recommended_option_compliance_reason:
+        'this option met every limit you set, in all the scenarios we tested',
+    })
+
+    expect(robustness.recommended_option_compliance).toBe('compliant')
+    expect(robustness.recommended_option_compliance_reason).toBe(
+      'this option met every limit you set, in all the scenarios we tested',
+    )
+  })
+
+  it('carries EVERY producer enum value — no state is silently filtered', () => {
+    // The mapper transports; it does not judge. A mapper that passed only the
+    // states this lane happened to think interesting would hide a producer fact,
+    // and the filtering that DOES happen belongs in the renderer.
+    for (const value of [
+      'not_applicable',
+      'compliant',
+      'uncertain',
+      'unverified',
+      'not_assessed',
+      'no_eligible_option',
+    ] as const) {
+      const robustness = mappedRobustness({ recommended_option_compliance: value })
+      expect(robustness.recommended_option_compliance, `enum ${value} transported`).toBe(value)
+    }
+  })
+
+  it('ABSENCE IS PRESERVED — an older producer yields no key, never a default', () => {
+    const robustness = mappedRobustness({})
+    expect('recommended_option_compliance' in robustness).toBe(false)
+    expect('recommended_option_compliance_reason' in robustness).toBe(false)
+  })
+
+  it('a non-string verdict is DROPPED rather than coerced', () => {
+    const robustness = mappedRobustness({
+      recommended_option_compliance: 42,
+      recommended_option_compliance_reason: { text: 'nope' },
+    })
+    expect('recommended_option_compliance' in robustness).toBe(false)
+    expect('recommended_option_compliance_reason' in robustness).toBe(false)
+  })
+})

--- a/src/v5/mapV5AnalysisToReport.ts
+++ b/src/v5/mapV5AnalysisToReport.ts
@@ -1221,6 +1221,35 @@ export function mapV5AnalysisToReport(
               ),
             }
           : {}),
+        // Hard-constraint chain step 5 (producer PLoT #338, staging
+        // `e19ac506`): the crown's compliance verdict + its producer-owned
+        // reason, both carried VERBATIM. This is the `display_verdict` story
+        // immediately above, one field over and one month later — ON-WIRE
+        // (CEE keep-lists `robustness` WHOLE at compose.ts:723, and the
+        // projection at :1079 is a shallow keep plus a deep DENY-strip, so
+        // additive members ride through) and dropped HERE, one hop before any
+        // renderer could read it.
+        //
+        // Transport only: every producer state is carried, including
+        // `not_applicable`. Deciding which states are worth showing is the
+        // RENDERER's job (`crownCompliance.ts`) — a mapper that filtered here
+        // would hide a producer fact and make absence indistinguishable from a
+        // state this lane happened to find uninteresting.
+        ...(safeString(robustnessRaw.recommended_option_compliance) !== undefined
+          ? {
+              recommended_option_compliance: safeString(
+                robustnessRaw.recommended_option_compliance,
+              ),
+            }
+          : {}),
+        ...(safeString(robustnessRaw.recommended_option_compliance_reason) !==
+        undefined
+          ? {
+              recommended_option_compliance_reason: safeString(
+                robustnessRaw.recommended_option_compliance_reason,
+              ),
+            }
+          : {}),
       }
     : undefined
 


### PR DESCRIPTION
## What a user sees differently

Where a user stated a hard limit, the results card now says **whether the recommended option met it — in the producer's own words** — instead of listing the limit and saying nothing.

---

## Phase 1 first: this began as a reachability question, and the prior was wrong

The lane was dispatched on the prior that **CEE drops** `robustness.recommended_option_compliance`. **Refuted.** CEE forwards it intact. The fields died *inside this repo*.

| Hop | Verdict | Evidence |
|---|---|---|
| PLoT emits | ✅ passes | `routes/v2/run.ts:3608-3609`, unconditional — no flag gate in the 200 preceding lines |
| CEE keep-list | ✅ passes | `robustness` is a member (`compose.ts:723`); projection `:1079` is `out[key]=stripInternalKeysDeep(src[key])` — shallow top-level **keep** + deep **deny**-strip of internal carriers only, so additive nested members ride through |
| CEE withheld-crown projection | ✅ passes | `projectLeaderDesignatingMembers` is a **deny**-list; `keyDesignatesLeadingOption`'s pattern `/^recommend(?:ed\|ation)_option(?:_(?:id\|label\|name))?$/i` is anchored with a **closed** suffix group these names do not match. Executed, with positive controls (`recommended_option_id`/`_label`/`leading_option`/`top_option_id` all `true`) and contrast controls (`display_verdict`/`score` `false`) |
| schemas pin skew (0.40.0 → 0.48.0) | ✅ **not** the breaking hop | `EnrichmentRobustnessSchema` is `.passthrough()` at the **shipped 0.48.0 vendored tarball bytes**. 0.48.0 does not *know* the fields (0 files; contrast `recommended_option_id` 6 files) but passthrough tolerates unknown keys |
| **UI mappers** | ❌ **BREAKING HOP** | `mapV5AnalysisToReport.ts` and `responseMapper.ts` both rebuild `robustness` as **key-by-key allow-lists**; neither listed them |
| **UI consumer** | ❌ **absent** | zero references |

**Absence evidence, contrast-controlled on both instruments:**
- Source sweep (repo HEAD == deployed `/version.json` commit `39162243`): target **0** files in CEE/UI/schemas; contrast `recommended_option_id` **12 / 70 / 11**.
- **Deployed-bundle sweep** (83 chunks, 5,950,662 bytes, BFS from `/assets/index-CUPZ6R6f.js`): both targets **0 chunks**; six same-family contrast symbols (`display_verdict`, `display_verdict_reason`, `recommended_option_id`, `conditional_winners`, `flip_thresholds`, `near_tie`) at **3–4 chunks each**; negative control **0**.

Settled by **derivation + deployed-artefact sweep**. **No live wire capture was taken** — that bound is not upgraded anywhere in this PR.

The V5 mapper's own comment already recorded this exact failure for `display_verdict`: *"ON-WIRE on Seam A … but previously dropped here."* This is that story one field on.

---

## The six-state rendering table

| enum | renders? | tone | treatment |
|---|---|---|---|
| `not_applicable` | **no** | — | Its sentence is "no limits were set for this decision" — it would contradict the user's own stated-limits list above it. Silence, and not a dead end: the limits still render |
| `compliant` | yes | positive | producer reason, verbatim |
| `uncertain` | yes | **unknown** | ⚠ never binarised — ISL publishes no breach threshold |
| `unverified` | yes | **unknown** | the scale was untrusted → no claim in *either* direction |
| `not_assessed` | yes | **unknown** | ⚠ **not** "no limits were set" — that would recreate the falsehood PLoT #338 fixed one layer up |
| `no_eligible_option` | yes | negative | ⚠ no `recommended_option_id` in this state, so the **reason** carries the message rather than an empty leader slot |
| field absent / unknown token | **no** | — | fail-closed; an older or future producer leaves the surface silent |

The UI **authors no copy for a verdict**. Every sentence is PLoT's, verbatim (`isl-to-ui.contract.ts:281`).

---

## Reuse, not a second vocabulary

- Tone classes are `DecisionOverviewCard`'s **own** `STATE_DOT_TONE` (`bg-success` / `bg-danger` / `bg-text-light` — already this card's "unassessed" tone), not a new palette.
- The renderer extends **UI #832's** live `stated-limits` region rather than minting a surface.
- `SuccessTargetRow.tsx` was **avoided deliberately** — confirmed zero product call sites (all four importers are specs; contrast control `TargetProbabilityBars` *does* return a product importer).
- Selectors return **primitives**, honouring the card's primitive-selector contract (`primitiveSelectors.spec`).
- The card's "deliberately silent about COMPLIANCE" note is **withdrawn in place, with its reason**: it was correct about `constraints_status` (which CEE genuinely strips) and does not hold for this field.

---

## Tests

**RED-first**, at pristine, by name:
- `mapV5AnalysisToReport.crown-compliance.spec.ts` — 7 collected, **3 RED**. ⚠ **Correction:** the first run printed 4 failures, but one was the positive control failing on a fixture id I had *guessed wrong* — my own spec defect, not the defect under test. The honest RED-first signature is **3/7**. (The control earned its place by catching it.)
- `DecisionOverviewCard.crownCompliance.spec.tsx` — 11 collected, **7 RED**.
- `crownCompliance.spec.ts` — written *after* its module (new code, no defect to reproduce). Disclosed in-file; its discrimination rests on the mutant pair, not a pristine RED.

**Discriminating mutant pair** (throwaway worktree at an absolute path outside the repo root; isolation proven by **writing** a sentinel with a positive control on the write, inodes differing; restores `git checkout HEAD --`):
- **Mutant A** — break rendering for **all** states → **14/30 RED**.
- **Mutant B** — break rendering for **`compliant` only** → the `no_eligible_option` assertion stays **GREEN** (binds by identity), while its own `compliant` twin **REDs** (proving the mutant applied and bites).
- Applied-check scoped to `src/`: leading control **0**, mutants **1**, trailing control **0**, markers remaining **0**, source clone dirty **0**.

**Opposite-direction twins** throughout: a compliant run still reads compliant; an unknown never becomes a breach (asserted in *both* directions — `not_negative` alone would also pass for a positive render).

**Precondition pinning**: every render case asserts the stated limit is on screen *before* asserting anything about compliance, so a case cannot reach the right verdict through a card that failed to render the limits region.

**Mount path, asserted against the DEPLOYED BUNDLE** (post-resolution inlined value, superseding `netlify.toml` and the dashboard):
- `VITE_FEATURE_DECISION_OVERVIEW:"1"` is inlined, and the resolver is `return"1"===t||"true"===t` → **TRUE**.
- The surface itself ships: `stated-limits`, `stated-limit-`, `Your stated limits`, `brief-bar-stated-limits` all present in the deployed bundle.
- Negative control: `crown-compliance` (this PR's new testid) **0 chunks** pre-deploy.

⚠ **Bound on that claim, stated rather than implied.** This establishes **"deployed, flag-gate proven open"** — *not* MOUNTED in the status-ladder sense. Mounting also requires the runtime data conditions `!W && mt && Me` (a completed analysis carrying a recommendation), which no bundle grep can settle. A MOUNTED rung would need a DOM witness, and this PR does not have one.

**Gate**, run in the required order (lint gates the rest):
- `npm run lint` — **0 errors**; hooks ratchet *"229 known violation(s) … exactly matching the baseline. No new conditional hooks."*
- `npm run typecheck` — **PASSED**, ratchet **2252 = 2252 baseline**, 3635/3675 files covered.
- Regression: **1801 passed / 0 failed** across 116 files (decision-overview, v5, adapters/plot).

---

## Review round 2 — the named change is in

**Gate corrected: `goalConstraintCount > 0`, not `statedLimits.length > 0`.** The review found my disclosed gap was narrower and worse than I framed it. `selectStatedLimits` (`statedLimits.ts:96-98`) **skips any constraint whose `value` is non-finite or whose `operator` is empty**, so `statedLimits` can be empty while `goalConstraints` is populated — and `not_assessed` (*"we could not check every limit you set on this run"*) is **exactly the state a malformed or withheld constraint produces**. The gate was quietest precisely where the producer was speaking loudest. One predicate answering two questions (trap 21): *"can we format the limits?"* vs *"did the user set limits the producer could speak to?"*

The row is now a **sibling** of the limits list rather than a child of it.

⚠ **The other direction is preserved deliberately.** PLoT auto-synthesises a `'Goal target'` constraint (`auto_goal_threshold`, `run.ts:6035-6042`) when the user set no limits, which can return `compliant` carrying *"this option met every limit **you set**"* — about limits nobody set. That synthesis happens inside PLoT's run handler and never reaches this store, so `goalConstraints` is genuinely empty there and the gate keeps it off screen. **Derived at PLoT staging `e19ac506` — the PLoT-side wording fix has NOT landed** (staging unchanged since this lane began), so the suppression test is load-bearing and says so in-file.

**Two-directional discriminating pair** — each way of breaking the predicate reds a *disjoint* set:
- revert the gate to pre-fix → **exactly 2 RED**, the two malformed-limit cases; all three suppression tests + control **GREEN**
- **Mutant C**, remove the gate entirely (the naive widening) → **exactly 2 RED**, the two suppression tests; both widening tests **GREEN** and the **discriminating control GREEN**, proving the reds are the gate and not the card breaking wholesale

Isolation re-proven by writing a sentinel with a positive control on the write; inodes differed; applied-check leading 0 / mutant 1 / trailing 0; markers remaining 0; source clone dirty 0. Regression **1807 passed / 0 failed** across 116 files, including #832's stated-limits suite and the primitive-selector contract. Lint 0 errors, hooks ratchet at baseline; typecheck ratchet **2252 = 2252**.

Three of the review's own findings strengthened the record and are adopted: PLoT's emission is more unconditional than I stated (no top-level returns, no try/catch, no flag in the span) and `CROWN_COMPLIANCE_REASONS` is **total over the union**, so a verdict cannot arrive without a reason; the withheld-crown projection survives because `projectLeaderDesignatingMembers` is a **keep-by-default deny-filter, not an allow-list rebuild** — the load-bearing fact, which I under-cited by crediting only the regex's closed suffix group; and the pin skew is safer than I said because **validation is not applied on the transport path at all** (`enrichment` is `z.record(z.unknown())`).

---

## ⚠ Routed, not fixed here — a CEE residual

`compose.ts:1017` drops any string leaf containing `[REDACTED]` **under any key**. `recommended_option_compliance_reason` is free prose: **if PLoT ever redacts into it, the key vanishes silently with no alarm**, and this card renders nothing where a verdict genuinely exists. Out of scope for a UI lane; flagged for the CEE owner.

---

## Not merging

This is for review. Please do not merge without an independent adversarial review — the seam it touches is a trust surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
