### PR TITLE
fix(autosave): flush the graph on close, and stop the timer persisting a preview

### DIFF
--- a/src/canvas/hooks/__tests__/useAutosave.closeWindowFlush.spec.ts
+++ b/src/canvas/hooks/__tests__/useAutosave.closeWindowFlush.spec.ts
@@ -1,0 +1,327 @@
+/**
+ * The autosave's TWO store-scoped write paths must both ask the same question:
+ * "are this scenario's draft values settled right now?"
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY THIS SPEC EXISTS — a guard that was only ever wired on ONE side
+ * ─────────────────────────────────────────────────────────────────────────────
+ * `applyDraftResult` skips its immediate localStorage write for a streamed
+ * GRAPH_READY preview (`opts.skipAutosave`, applyDraftResult.ts:318, passed at
+ * useConversation.ts:729-731). Its own comment states the resulting guarantee:
+ *
+ *   "before then there is deliberately nothing on disk to restore, which is the
+ *    honest state"
+ *
+ * That sentence was FALSE, in the one direction nobody checked. The skip covers
+ * only the payload-scoped write. `useAutosave`'s periodic timer is a SECOND,
+ * store-scoped writer to the very same slot, it re-reads the store at fire time,
+ * and it had ZERO phase awareness — so a 30 s tick landing inside the settling
+ * window persisted the preview anyway. On reload `draftStreamPhase` is in-memory
+ * and therefore gone, so the preview came back UNMARKED with the run gate OPEN:
+ * exactly the fabrication state the skip exists to prevent, reached through the
+ * other door. The server-row path was already guarded at its own choke point
+ * (`persistGraphNow` → `shouldPersistGraphForScenario`, useScenario.ts:219); the
+ * localStorage path never was.
+ *
+ * And the mirror-image hole on the same seam: nothing flushed the graph to
+ * localStorage when the page went away. `flushWorkToAutosave` exists and is
+ * synchronous, but its only importer was `ErrorBoundary.tsx:4` — a React CRASH,
+ * not a close. The two `beforeunload` handlers in the tree are a navigation
+ * WARNING (useScenario.ts:653 — `preventDefault` only, it writes nothing) and
+ * the chat transcript (useThreadPersistence.ts:342). So once a draft settled,
+ * every subsequent edit lived only in memory for up to
+ * AUTOSAVE_INTERVAL_MS + DEBOUNCE_MS, and a close inside that window lost it
+ * silently.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * BOTH DIRECTIONS, OR THE GUARD IS ONE-SIDED
+ * ─────────────────────────────────────────────────────────────────────────────
+ * A fix that just wrote on close would pass direction A while re-opening the
+ * preview hole; a fix that just blocked writes would pass direction B by
+ * persisting nothing at all. Every case below is paired:
+ *
+ *   A. SETTLED work reaches localStorage on close, WITHOUT the timer advancing.
+ *      The timing property is the point — a test that advances 30 s and finds
+ *      the data proves nothing about the window this closes, so these cases
+ *      assert the write has ALREADY landed with the fake clock untouched.
+ *   B. An UNSETTLED preview still reaches localStorage from NEITHER path — not
+ *      the close flush, not the periodic tick.
+ *
+ * B3 is the discrimination control: an unsettled draft owned by a DIFFERENT
+ * scenario must NOT block this one. Without it, every direction-B case would
+ * also pass under a blanket "never write" mutant.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useAutosave } from '../useAutosave'
+import { useCanvasStore } from '../../store'
+import { useDraftStore } from '../../stores/draftStore'
+
+// ---------------------------------------------------------------------------
+// Mocks — intercept the localStorage persistence boundary only, the same
+// `importOriginal`-spread pattern as useAutosave.analysisFieldPersist.spec.ts
+// (a bare factory would REPLACE the module and silently drop every other
+// export — CLAUDE.md trap 12).
+//
+// `saveAutosave` is the single write primitive BOTH paths under test reach:
+// the periodic timer calls it directly, and `flushWorkToAutosave`
+// (persist/crashFlush.ts) imports it from this same module specifier, so one
+// spy observes both.
+// ---------------------------------------------------------------------------
+
+const mockSaveAutosave = vi.fn()
+const mockLoadAutosave = vi.fn()
+
+vi.mock('../../store/scenarios', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../store/scenarios')>()
+  return {
+    ...actual,
+    saveAutosave: (...args: unknown[]) => mockSaveAutosave(...args),
+    loadAutosave: (...args: unknown[]) => mockLoadAutosave(...args),
+  }
+})
+
+const SCENARIO_ID = 'd4d4d4d4-e5e5-4f6f-8a7a-b8b8b8b8b8b8'
+const OTHER_SCENARIO_ID = 'e9e9e9e9-f0f0-4a1a-8b2b-c3c3c3c3c3c3'
+const TURN_ID = 'turn-close-window-1'
+
+const AUTOSAVE_INTERVAL_MS = 30 * 1000
+const DEBOUNCE_MS = 500
+
+const GOAL_ID = 'goal-1'
+const OPTION_ID = 'option-1'
+
+/**
+ * A settled, plausible graph. Node shape matters: `flushWorkToAutosave` drops
+ * anything without a string `id` and finite `position.x/y` (its crash-time
+ * plausibility gates), so a sloppy fixture would make direction A pass or fail
+ * for a reason that has nothing to do with the guard.
+ */
+function seedCanvas() {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_ID,
+    nodes: [
+      {
+        id: GOAL_ID,
+        type: 'goal',
+        position: { x: 400, y: 40 },
+        data: { kind: 'goal', label: 'Grow recurring revenue' },
+      },
+      {
+        id: OPTION_ID,
+        type: 'option',
+        position: { x: 120, y: 260 },
+        data: { kind: 'option', label: 'Enter the German market' },
+      },
+    ] as never,
+    edges: [
+      {
+        id: 'edge-1',
+        source: OPTION_ID,
+        target: GOAL_ID,
+        data: { confidence: 0.7 },
+      },
+    ] as never,
+  })
+}
+
+/** The user closes the tab / navigates away. */
+function fireCloseEvent(type: 'pagehide' | 'beforeunload') {
+  act(() => {
+    window.dispatchEvent(new Event(type))
+  })
+}
+
+/** One full periodic autosave cycle: interval tick, then the debounce flush. */
+function advanceOneAutosaveCycle() {
+  act(() => {
+    vi.advanceTimersByTime(AUTOSAVE_INTERVAL_MS)
+  })
+  act(() => {
+    vi.advanceTimersByTime(DEBOUNCE_MS)
+  })
+}
+
+/** The node ids in whatever payload `saveAutosave` was last handed. */
+function persistedNodeIds(): string[] {
+  const last = mockSaveAutosave.mock.calls.at(-1)?.[0] as
+    | { nodes?: Array<{ id?: string }> }
+    | undefined
+  return (last?.nodes ?? []).map((n) => String(n?.id))
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockSaveAutosave.mockReset()
+  mockLoadAutosave.mockReset()
+  // No competing tab — the multi-tab staleness guard must not be what decides
+  // any of these outcomes.
+  mockLoadAutosave.mockReturnValue(null)
+  useDraftStore.getState().resetDraft()
+  seedCanvas()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  useDraftStore.getState().resetDraft()
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// DIRECTION A — settled work survives a close, with the clock UNTOUCHED
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('A. the close window — settled work is flushed before the page goes away', () => {
+  it('A1: `pagehide` persists the settled graph WITHOUT any timer advancing', () => {
+    renderHook(() => useAutosave())
+
+    // The premise of the whole defect: nothing is on disk yet. If this fires,
+    // the case below would be measuring a timer write, not a close flush.
+    expect(mockSaveAutosave).not.toHaveBeenCalled()
+
+    fireCloseEvent('pagehide')
+
+    // No vi.advanceTimersByTime anywhere above. THIS is the timing property —
+    // the graph is persisted at the moment of close, not 30 s later.
+    expect(mockSaveAutosave).toHaveBeenCalled()
+    expect(persistedNodeIds()).toEqual(expect.arrayContaining([GOAL_ID, OPTION_ID]))
+  })
+
+  it('A2: `beforeunload` persists the settled graph, and the write is SYNCHRONOUS', () => {
+    renderHook(() => useAutosave())
+    expect(mockSaveAutosave).not.toHaveBeenCalled()
+
+    fireCloseEvent('beforeunload')
+
+    // `beforeunload` offers no async guarantee, so the write must have landed by
+    // the time dispatchEvent returns — no timers, no awaited microtask, nothing
+    // that a real unload would never wait for. localStorage.setItem is
+    // synchronous, which is exactly why this path can be trusted at all.
+    expect(mockSaveAutosave).toHaveBeenCalled()
+    expect(persistedNodeIds()).toEqual(expect.arrayContaining([GOAL_ID, OPTION_ID]))
+  })
+
+  it('A3: an edit made after settle is in the flushed payload (the lost-edit window)', () => {
+    renderHook(() => useAutosave())
+
+    act(() => {
+      useCanvasStore.getState().updateNode(OPTION_ID, {
+        data: { label: 'Enter the German market (phased)' },
+      } as never)
+    })
+
+    fireCloseEvent('pagehide')
+
+    const last = mockSaveAutosave.mock.calls.at(-1)?.[0] as
+      | { nodes?: Array<{ id?: string; data?: { label?: string } }> }
+      | undefined
+    const option = (last?.nodes ?? []).find((n) => n?.id === OPTION_ID)
+    expect(option?.data?.label).toBe('Enter the German market (phased)')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// DIRECTION B — the deliberate preview skip still holds, on BOTH paths
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('B. the preview skip — an unsettled draft reaches localStorage from neither path', () => {
+  it('B1: `settling` — the close flush declines', () => {
+    renderHook(() => useAutosave())
+    act(() => {
+      useDraftStore.getState().setDraftStreamPhase('settling', TURN_ID, SCENARIO_ID)
+    })
+
+    fireCloseEvent('pagehide')
+
+    // Persisting here would restore an unmarked preview with an OPEN run gate,
+    // because the phase that marks it does not survive a reload.
+    expect(mockSaveAutosave).not.toHaveBeenCalled()
+  })
+
+  it('B2: `settling` — the PERIODIC timer declines (the hole the skip never covered)', () => {
+    renderHook(() => useAutosave())
+    act(() => {
+      useDraftStore.getState().setDraftStreamPhase('settling', TURN_ID, SCENARIO_ID)
+    })
+
+    advanceOneAutosaveCycle()
+
+    expect(mockSaveAutosave).not.toHaveBeenCalled()
+  })
+
+  it('B3: an unsettled draft on ANOTHER scenario does NOT block this one (discrimination control)', () => {
+    // Without this, every case in this block would also pass under a blanket
+    // "never write" mutant — and under the F2 defect the ownership boundary was
+    // introduced to fix, where one scenario's phase froze every other one.
+    renderHook(() => useAutosave())
+    act(() => {
+      useDraftStore.getState().setDraftStreamPhase('settling', TURN_ID, OTHER_SCENARIO_ID)
+    })
+
+    fireCloseEvent('pagehide')
+
+    expect(mockSaveAutosave).toHaveBeenCalled()
+    expect(persistedNodeIds()).toEqual(expect.arrayContaining([GOAL_ID, OPTION_ID]))
+  })
+
+  it('B4: `unsettled` — neither path writes', () => {
+    renderHook(() => useAutosave())
+    act(() => {
+      useDraftStore.getState().setDraftStreamPhase('unsettled', TURN_ID, SCENARIO_ID)
+    })
+
+    advanceOneAutosaveCycle()
+    fireCloseEvent('pagehide')
+
+    expect(mockSaveAutosave).not.toHaveBeenCalled()
+  })
+
+  it('B5: `drafting` is NOT unsettled — nothing is on the canvas yet to be wrong about', () => {
+    // Pins the classification this guard inherits from `draftValuesAreUnsettled`
+    // rather than re-deriving it here: before GRAPH_READY there is no preview to
+    // misrepresent, so persistence must continue normally.
+    renderHook(() => useAutosave())
+    act(() => {
+      useDraftStore.getState().setDraftStreamPhase('drafting', TURN_ID, SCENARIO_ID)
+    })
+
+    fireCloseEvent('pagehide')
+
+    expect(mockSaveAutosave).toHaveBeenCalled()
+  })
+
+  it('B6: once the draft settles to `idle`, the periodic timer writes again', () => {
+    // The regression twin for B2: the guard must gate on the phase, not disable
+    // the timer. A settled graph still autosaves on its normal cycle.
+    renderHook(() => useAutosave())
+    act(() => {
+      useDraftStore.getState().setDraftStreamPhase('settling', TURN_ID, SCENARIO_ID)
+    })
+    advanceOneAutosaveCycle()
+    expect(mockSaveAutosave).not.toHaveBeenCalled()
+
+    act(() => {
+      useDraftStore.getState().setDraftStreamPhase('idle', null, null)
+    })
+    advanceOneAutosaveCycle()
+
+    expect(mockSaveAutosave).toHaveBeenCalled()
+    expect(persistedNodeIds()).toEqual(expect.arrayContaining([GOAL_ID, OPTION_ID]))
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Listener hygiene — a close flush that outlives its canvas is a stray writer
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('C. teardown', () => {
+  it('C1: the close listeners are removed on unmount', () => {
+    const { unmount } = renderHook(() => useAutosave())
+    unmount()
+
+    fireCloseEvent('pagehide')
+    fireCloseEvent('beforeunload')
+
+    expect(mockSaveAutosave).not.toHaveBeenCalled()
+  })
+})

--- a/src/canvas/hooks/useAutosave.ts
+++ b/src/canvas/hooks/useAutosave.ts
@@ -23,6 +23,8 @@ import { projectAutosaveData, analysisSnapshotFromStore } from '../store/autosav
 import type { AutosaveProjectionSource } from '../store/autosaveProjection'
 import { EPHEMERAL_NODE_FIELDS, EPHEMERAL_EDGE_FIELDS } from '../domain/analyticalNodeFields'
 import { isCanvasShapedNode } from '../utils/normalisePersistedGraph'
+import { shouldPersistGraphForScenario } from '../stores/draftStore'
+import { flushWorkToAutosave } from '../persist/crashFlush'
 
 // The autosave hash now covers node/edge `data.*` BY DEFAULT (Codex P1-1) and
 // EXCLUDES only the small ephemeral denylist below (transient UI/session state +
@@ -65,6 +67,40 @@ function serializableData(
 
 const AUTOSAVE_INTERVAL_MS = 30 * 1000 // 30 seconds
 const DEBOUNCE_MS = 500 // Debounce writes to reduce localStorage contention
+
+/**
+ * May this hook's STORE-SCOPED writers persist the graph right now?
+ *
+ * ⚠ THE PREVIEW SKIP WAS ONLY EVER WIRED ON ONE SIDE. `applyDraftResult` skips
+ * its own immediate localStorage write for a streamed GRAPH_READY preview
+ * (`opts.skipAutosave`, applyDraftResult.ts:318) and its comment claims that
+ * "before then there is deliberately nothing on disk to restore, which is the
+ * honest state". That was false in this direction: the skip covers only the
+ * PAYLOAD-scoped write, while both writers in this file are STORE-scoped — they
+ * re-read the store at fire time — and neither knew the phase existed. A 30 s
+ * tick landing inside the settling window therefore persisted the preview
+ * anyway. `draftStreamPhase` is in-memory and does not survive a reload, so it
+ * came back UNMARKED with the run gate OPEN: exactly the fabrication state the
+ * skip exists to prevent, reached through the other door.
+ *
+ * ONE AUTHORITY, NOT A SECOND COPY. This delegates to
+ * `shouldPersistGraphForScenario` — the same derived read the SERVER-row choke
+ * point already consults (`persistGraphNow`, hooks/useScenario.ts:219). Adding a
+ * phase test of our own here would be the two-`generateGraphHash`-twins defect:
+ * two spellings of one rule, drifting apart in silence. A new phase is
+ * classified once, in `draftValuesAreUnsettled`'s compiler-checked switch.
+ *
+ * Read at FIRE time, never at registration/setup — the whole point is the phase
+ * as it is at the instant of the write.
+ *
+ * NOT applied to `applyDraftResult`'s payload-scoped write: that path makes an
+ * explicit per-call-site decision (`skipAutosave`) about a graph it was handed,
+ * and the TERMINAL apply must autosave the settled values immediately even
+ * while this scenario's phase is still being released.
+ */
+function mayPersistGraphNow(scenarioId: string | null): boolean {
+  return shouldPersistGraphForScenario(scenarioId)
+}
 
 /**
  * Compute a canonical hash of graph state for autosave dirty-detection.
@@ -218,6 +254,18 @@ export function useAutosave() {
     }
 
     writeTimerRef.current = setTimeout(() => {
+      // The streamed draft's values are still in progress — see
+      // `mayPersistGraphNow`. Checked HERE, inside the fired callback, rather
+      // than at the interval tick: the phase can settle during the debounce, and
+      // the only phase that matters is the one at the instant of the write.
+      //
+      // `lastSavedHashRef` is deliberately NOT advanced on this path, so the
+      // skipped content stays dirty and the first tick after the draft settles
+      // writes it. Declining is a deferral, not a drop.
+      if (!mayPersistGraphNow(currentScenarioId)) {
+        return
+      }
+
       // P1 Fix: Skip save if content hasn't changed
       if (currentHash === lastSavedHashRef.current) {
         return
@@ -297,4 +345,50 @@ export function useAutosave() {
       }
     }
   }, [currentHash, nodes.length, edges.length, debouncedSave])
+
+  // -----------------------------------------------------------------------
+  // THE CLOSE WINDOW — flush the graph before the page goes away
+  // -----------------------------------------------------------------------
+  // Between two ticks of the interval above, the newest work exists ONLY in the
+  // in-memory store: up to AUTOSAVE_INTERVAL_MS + DEBOUNCE_MS of edits that a
+  // reload or a tab close silently destroyed. `flushWorkToAutosave` was written
+  // for precisely this and is fully synchronous, but its only importer was
+  // `ErrorBoundary.tsx` — a React CRASH, not a close. Neither `beforeunload`
+  // handler in the tree closed it either: `useScenario.ts`'s is a navigation
+  // WARNING (`preventDefault` only, it writes nothing) and
+  // `useThreadPersistence.ts`'s carries the chat transcript, not the graph.
+  //
+  // ⚠ SYNCHRONOUS OR IT IS THEATRE. `beforeunload`/`pagehide` give no async
+  // guarantee — a promise, a `setTimeout` or an `await` here would simply not
+  // land. `flushWorkToAutosave` → `saveAutosave` → `localStorage.setItem` is
+  // synchronous end to end and completes inside the handler, which is the only
+  // reason this path can be trusted at all. Do not make it async.
+  //
+  // BOTH EVENTS, on purpose. `pagehide` is the reliable one (it fires on
+  // bfcache entry and on mobile teardown, where `beforeunload` often does not);
+  // `beforeunload` covers the desktop close/reload path. A double fire is free —
+  // `saveAutosave` early-returns on a byte-identical payload.
+  //
+  // Reusing the crash primitive rather than re-projecting here is deliberate:
+  // it already owns the shared `projectAutosaveData` projection, the structural
+  // plausibility gates, and the "never clobber a good autosave with an empty
+  // graph" rule. A second projection would be a hand-maintained mirror of the
+  // one above (CLAUDE.md trap 12). Its provider is registered at store MODULE
+  // INIT (store.ts:6146), not by the boundary, so it is safe outside one.
+  useEffect(() => {
+    const flushOnClose = () => {
+      // Registered once and read at FIRE time, so the listener stays correct
+      // across scenario switches without re-registering — and so the phase it
+      // tests is the phase at the moment of the close.
+      if (!mayPersistGraphNow(useCanvasStore.getState().currentScenarioId)) return
+      flushWorkToAutosave()
+    }
+
+    window.addEventListener('pagehide', flushOnClose)
+    window.addEventListener('beforeunload', flushOnClose)
+    return () => {
+      window.removeEventListener('pagehide', flushOnClose)
+      window.removeEventListener('beforeunload', flushOnClose)
+    }
+  }, [])
 }

--- a/src/canvas/utils/applyDraftResult.ts
+++ b/src/canvas/utils/applyDraftResult.ts
@@ -315,6 +315,17 @@ export function applyDraftResult(
   // no Stop click needed. The terminal apply autosaves normally, so nothing is
   // lost once the values settle; before then there is deliberately nothing on
   // disk to restore, which is the honest state.
+  //
+  // ⚠ THAT LAST SENTENCE ONLY BECAME TRUE ON 2026-08-25, AND ONLY BECAUSE OF A
+  // GUARD THAT IS NOT IN THIS FILE. Skipping HERE covers just the
+  // PAYLOAD-scoped write. `hooks/useAutosave.ts` holds two STORE-scoped writers
+  // to the SAME localStorage slot — they re-read the store at fire time — and
+  // neither knew the phase existed, so a 30 s tick landing inside the settling
+  // window persisted the preview regardless of this skip. Both now consult
+  // `shouldPersistGraphForScenario` (see `mayPersistGraphNow` there), which is
+  // also what makes the close flush added alongside them safe. If you change
+  // the rule here, change it there: one skip alone has already proved it does
+  // not hold the line.
   if (!opts.skipAutosave) try {
     // Shared projection — previously this literal omitted ceeAnalysisReady and
     // selectedGoalNode. NOTE: this runs BEFORE setCeeAnalysisReady below, so


### PR DESCRIPTION
## ⚠ The brief's premise is corrected — read this first

The lane was dispatched to **write the graph as soon as the draft SETTLES**, on the measurement that
the first disk write lands at **t+25.0s** after the model appears.

**That write already exists and is already immediate.** The terminal ingest calls `applyDraftResult`
**without** `skipAutosave` (`useConversation.ts:5177`, `:5263`), so the settled graph reaches
`localStorage` synchronously the moment the terminal payload lands. The measured t+25.0s **is** that
settle write.

The ~25 s is **the settling window itself** — the gap between the streamed `GRAPH_READY` preview and
the terminal payload. `applyDraftResult.ts:311-317` documents it with the *same* ~25 s figure. So the
measured window is the deliberate preview skip, and closing it as specified would **persist a
preview** — the exact defect the constraint exists to prevent. Per the brief's own instruction, this
PR stops at that boundary rather than inventing a durable-phase state machine.

**What it does close** are two real, adjacent, user-facing defects in the same seam — one in each
direction.

## A. Nothing flushed the graph on close

Between two ticks of the 30 s interval the newest work existed **only in the in-memory store** — up
to `AUTOSAVE_INTERVAL_MS + DEBOUNCE_MS` of edits that a reload or a tab close destroyed silently.

`flushWorkToAutosave` was written for exactly this and is fully synchronous, but its only importer
was `ErrorBoundary.tsx:4` — **a React crash, not a close**. Neither `beforeunload` handler in the
tree closed it either: `useScenario.ts:653` is a navigation **warning** (`preventDefault` only, it
writes nothing) and `useThreadPersistence.ts:342` carries the chat transcript, not the graph.

`useAutosave` now registers `pagehide` + `beforeunload` and flushes synchronously
(`saveAutosave` → `localStorage.setItem`, no async step an unload would not wait for).

## B. The preview skip was one-sided — the timer persisted previews anyway

`applyDraftResult` skips its immediate write for a streamed preview and claims *"before then there is
deliberately nothing on disk to restore, which is the honest state"*. **That was false.**

The skip covers only the **payload-scoped** write. The periodic autosave is a **second,
store-scoped** writer to the same slot — it re-reads the store at fire time — and it had **zero**
phase awareness. A 30 s tick landing inside the settling window persisted the preview regardless.
`draftStreamPhase` is in-memory, so on reload the preview came back **unmarked with the run gate
open**: precisely the fabrication state the skip exists to prevent, reached through the other door.
The server-row path was already guarded (`persistGraphNow` → `shouldPersistGraphForScenario`,
`useScenario.ts:219`); the localStorage path never was.

**Reproduced at pristine** — B2 caught the timer writing the graph while the phase was `settling`.

Both writers now consult `shouldPersistGraphForScenario` — the **same derived read** the server-row
choke point already uses, not a second spelling of the rule. Declining does **not** advance
`lastSavedHashRef`, so content stays dirty and the first tick after the draft settles writes it: a
deferral, not a drop.

## Evidence

`src/canvas/hooks/__tests__/useAutosave.closeWindowFlush.spec.ts` — **10 tests, 8 RED at pristine**
(the 2 green ones are the direction-B twins, vacuous before the fix by construction).

Paired throughout, because a one-sided fix passes either direction alone:

| | |
|---|---|
| **A1/A2/A3** | settled work persists on `pagehide`/`beforeunload` **with the fake clock untouched** — the timing property, not the end state |
| **B1/B2/B4** | an unsettled preview persists from **neither** path |
| **B3** | discrimination control — another scenario's unsettled draft does **not** block this one |
| **B5/B6** | `drafting` still writes; the timer resumes once settled (guard gates the phase, it does not disable the timer) |

**Discriminating mutant pair** (throwaway worktree at an absolute path outside the repo root;
isolation proven by **writing a sentinel** and confirming the source sha256 was unchanged; distinct
inodes verified; restores from a pristine archive, never `git checkout -- <path>`):

| Mutant | Result |
|---|---|
| Control | applied-check **0**, 10/10 green |
| **M1** — remove the close write | **RED**: A1, A2, A3, B3, B5 |
| **M2** — loosen the guard for **all** phases | **RED**: B1, B2, B4, B6 |
| **M3** — loosen only for `drafting`, a phase already permitted | **GREEN 10/10** |
| Trailing control | applied-check **0**, 10/10 green |

M2/M3 is the pair: loosening for *all* objects REDs, loosening for a *different, already-permitted*
object stays green — so the direction-B cases bind to `settling`/`unsettled` specifically, not merely
to any change in the predicate. Source sha256 identical before and after the whole run.

## Gate

`TypeScript + Lint`'s real step sequence run locally in order — `lint` → `typecheck` →
`ci:guard:zustand` → `ci:guard:starters` → `check:vendor` → `ci:guard:schemas-version` →
`ci:guard:ds:enforce`. **All 7 exit 0**; typecheck baseline unchanged at 2252. Regression slice over
the affected seams: **104 files / 1171 tests green**, including the existing
`useScenario.beforeUnloadPendingEdit` and `useScenario.unmountFlushPersistenceGate` specs.

## Named limits

- **Not witnessed in a real browser.** Every result here is jsdom under fake timers. `pagehide` vs
  `beforeunload` firing behaviour, and bfcache, are **not** covered by this evidence.
- **The measured ~25 s window is NOT closed** and this PR does not claim it is. Closing it needs a
  *durable* unsettled marker so a restored preview comes back gated — a real design, deliberately not
  invented here.
- **Trade-off, stated plainly:** direction B makes the timer decline during the settling window, so
  in the case where it would previously have persisted a preview there is now nothing on disk. That
  is the intended honest state, not a regression — but it does mean this PR *reduces* persistence in
  that one window while increasing it everywhere else.
- `Visual Regression (advisory)` is a standing red on current staging and is not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)