### PR TITLE
fix(crash-flush): stop a React crash persisting an unsettled draft preview

### DIFF
--- a/src/canvas/persist/__tests__/crashFlush.draftPhaseGate.spec.ts
+++ b/src/canvas/persist/__tests__/crashFlush.draftPhaseGate.spec.ts
@@ -1,0 +1,330 @@
+/**
+ * The CRASH flush must not persist an unsettled streamed draft.
+ *
+ * ⚠ THE THIRD DOOR INTO THE SAME FABRICATION. `applyDraftResult` skips its own
+ * payload-scoped write during a streamed GRAPH_READY preview (`opts.skipAutosave`,
+ * applyDraftResult.ts:319) and #835 closed the two STORE-scoped writers in
+ * `useAutosave`. Neither touched `flushWorkToAutosave`, whose OTHER importer is
+ * `ErrorBoundary.tsx:114` — so a React crash inside the ~25 s settling window
+ * still wrote the unsettled preview to `olumi-canvas-autosave`.
+ *
+ * WHY THAT IS A FABRICATION AND NOT MERELY A STALE SAVE. `draftStreamPhase`
+ * lives in memory. It does not survive the reload the boundary is about to
+ * offer. So the preview comes back UNMARKED, with the run gate OPEN, and the
+ * user analyses in-progress numbers believing they are the model's. The autosave
+ * payload is unversioned, so there is no honest way to mark the row as
+ * provisional on the way out (a durable unsettled marker was designed and
+ * DECLINED — the only versioning mechanism in the tree is dead code that fails
+ * open).
+ *
+ * WHY DECLINING IS NOT DATA LOSS — the tension this lane had to resolve.
+ * Declining looks like it trades a fabrication for losing the user's draft. It
+ * does not, because the draft is not only in the browser:
+ *   · CEE lets the turn finish when the client hangs up and commits the drafted
+ *     graph server-side (`draftRecovery.ts` header, 2.1257);
+ *   · the scenario id survives in its OWN ungated key,
+ *     `olumi-canvas-current-scenario-id` (scenarios.ts:62) — nothing in this
+ *     guard touches it;
+ *   · boot hydration is wired unconditionally at `CanvasMVP.tsx:89`
+ *     (`useServerGraphHydration` → `hydrateCanvasFromServer`), so the reload the
+ *     boundary offers reads the server's committed graph back for that scenario.
+ * The lost quantity is therefore local NODE POSITIONS for one in-flight draft —
+ * which the terminal apply re-lays-out anyway — not the user's work.
+ *
+ * AND THE ASYMMETRY THAT SETTLES IT. A declined flush is HONEST BY
+ * CONSTRUCTION: `flushWorkToAutosave` returns false, `componentDidCatch` stores
+ * that as `workFlushed` (ErrorBoundary.tsx:154) and the "your work is
+ * auto-saved" promise is gated on it (:450). So declining downgrades a promise;
+ * writing tells a lie the user cannot detect. Pinned as case D3.
+ *
+ * WHERE THE GUARD LIVES, AND WHY NOT AT THE CALL SITE. #835 guarded its OWN
+ * call site (useAutosave.ts:384). Guarding `ErrorBoundary` the same way would
+ * make a two-entry list of call sites to keep in step — the shape
+ * `shouldPersistGraphForScenario`'s own header exists to refuse ("a single
+ * derived choke point, not a list of call sites"), and the next importer would
+ * inherit the defect silently. The gate belongs INSIDE the primitive, where the
+ * scenario id the write is actually scoped to has just been resolved. That
+ * matters concretely: the write is scoped to
+ * `snapshot.scenarioId ?? getCurrentScenarioId()`, while a call-site guard tests
+ * whatever id the CALLER happens to hold. Case C2 pins the difference.
+ *
+ * ONE AUTHORITY. Every expectation below is derived from
+ * `shouldPersistGraphForScenario` / `draftValuesAreUnsettled`, never from a
+ * hand-written list of "phases that should block" — a second spelling of the
+ * rule is the two-`generateGraphHash`-twins defect (trap 12).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { flushWorkToAutosave } from '../crashFlush'
+import { useCanvasStore } from '../../store'
+import {
+  useDraftStore,
+  shouldPersistGraphForScenario,
+  draftValuesAreUnsettled,
+  type DraftStreamPhase,
+} from '../../stores/draftStore'
+
+// ---------------------------------------------------------------------------
+// Mock the localStorage persistence boundary ONLY. `importOriginal`-spread, not
+// a bare factory: a factory REPLACES the module and would silently drop
+// `getCurrentScenarioId`, which case C2 depends on being the REAL one (trap 12).
+//
+// ⚠ THE SPY DELEGATES TO THE REAL WRITER rather than swallowing the call. A
+// spy that only counts would make case A3 VACUOUS — with `saveAutosave`
+// stubbed out, "the previous autosave survived" is true even with the guard
+// deleted, because nothing could have overwritten it either way. Delegating
+// means the spy answers "was it called" AND localStorage answers "what is
+// actually on disk", and A3's mutant genuinely bites.
+// ---------------------------------------------------------------------------
+const mockSaveAutosave = vi.fn()
+
+vi.mock('../../store/scenarios', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../store/scenarios')>()
+  return {
+    ...actual,
+    saveAutosave: (...args: unknown[]) => mockSaveAutosave(...args),
+  }
+})
+
+/** The unmocked module, for seeding and reading real persisted state. */
+async function realScenarios() {
+  return vi.importActual<typeof import('../../store/scenarios')>('../../store/scenarios')
+}
+
+const SCENARIO_ID = 'c1c1c1c1-a2a2-4b3b-8c4c-d5d5d5d5d5d5'
+const OTHER_SCENARIO_ID = 'f6f6f6f6-b7b7-4c8c-8d9d-e0e0e0e0e0e0'
+const TURN_ID = 'turn-crash-flush-1'
+const CURRENT_SCENARIO_KEY = 'olumi-canvas-current-scenario-id'
+
+const ALL_PHASES: readonly DraftStreamPhase[] = ['idle', 'drafting', 'settling', 'unsettled']
+
+/**
+ * A plausible graph. Node shape matters: `flushWorkToAutosave`'s crash-time
+ * plausibility gates DROP anything without a string `id` and finite
+ * `position.x/y`, and a graph that filters to empty returns false WITHOUT
+ * writing — which would make every case below pass for a reason that has
+ * nothing to do with the draft phase. `seedPrecondition` asserts against that.
+ */
+function seedCanvas(scenarioId: string | null): void {
+  useCanvasStore.setState({
+    currentScenarioId: scenarioId,
+    nodes: [
+      {
+        id: 'goal-1',
+        type: 'goal',
+        position: { x: 400, y: 40 },
+        data: { kind: 'goal', label: 'Grow recurring revenue' },
+      },
+      {
+        id: 'option-1',
+        type: 'option',
+        position: { x: 120, y: 260 },
+        data: { kind: 'option', label: 'Enter the German market' },
+      },
+    ] as never,
+    edges: [
+      { id: 'edge-1', source: 'option-1', target: 'goal-1', data: { confidence: 0.7 } },
+    ] as never,
+  })
+}
+
+/**
+ * PIN THE PRECONDITION IN-TEST (trap 13b). Every "it declined" assertion below
+ * is only evidence if the flush WOULD otherwise have written. Proven here by
+ * running the flush against a pristine draft store and requiring a real write —
+ * so a fixture that silently stopped being flushable (a plausibility-gate
+ * change, an empty graph, an unregistered provider) REDs as a precondition
+ * failure instead of masquerading as a passing guard.
+ */
+function assertFixtureWouldOtherwiseFlush(): void {
+  useDraftStore.getState().resetDraft()
+  mockSaveAutosave.mockClear()
+  expect(flushWorkToAutosave()).toBe(true)
+  expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
+  mockSaveAutosave.mockClear()
+}
+
+beforeEach(async () => {
+  const actual = await realScenarios()
+  mockSaveAutosave.mockReset()
+  // Delegate, do not swallow — see the mock's header.
+  mockSaveAutosave.mockImplementation((data: unknown) =>
+    actual.saveAutosave(data as Parameters<typeof actual.saveAutosave>[0]),
+  )
+  localStorage.clear()
+  useDraftStore.getState().resetDraft()
+  seedCanvas(SCENARIO_ID)
+})
+
+afterEach(() => {
+  useDraftStore.getState().resetDraft()
+  localStorage.clear()
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// A. THE FABRICATION — a crash inside the settling window must write NOTHING
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('A. the crash flush declines while the streamed draft is unsettled', () => {
+  it('A1: `settling` — the ~25 s preview window is not persisted', () => {
+    assertFixtureWouldOtherwiseFlush()
+    useDraftStore.getState().setDraftStreamPhase('settling', TURN_ID, SCENARIO_ID)
+
+    expect(flushWorkToAutosave()).toBe(false)
+    expect(mockSaveAutosave).not.toHaveBeenCalled()
+  })
+
+  it('A2: `unsettled` — a stream that died leaves nothing on disk either', () => {
+    // The terminal state a stop or a stream loss PRODUCES. It persists
+    // indefinitely until recovery or a new draft releases it, so an unguarded
+    // flush here is the longest-lived version of the fabrication.
+    assertFixtureWouldOtherwiseFlush()
+    useDraftStore.getState().setDraftStreamPhase('unsettled', TURN_ID, SCENARIO_ID)
+
+    expect(flushWorkToAutosave()).toBe(false)
+    expect(mockSaveAutosave).not.toHaveBeenCalled()
+  })
+
+  it('A3: the last good PRE-DRAFT autosave survives the crash intact', () => {
+    // ⭐ THE CASE THAT SETTLES "fabrication vs data loss", and the reason
+    // declining is not a trade at all. `saveAutosave` is a whole-object
+    // REPLACE, not a merge (autosaveProjectionParity's header). During
+    // `settling` the store holds the streamed PREVIEW, which has already
+    // replaced what was on the canvas — so the unguarded flush was not merely
+    // persisting something unsettled, it was DESTROYING the last good
+    // pre-draft snapshot to do it. Declining preserves the user's real work;
+    // writing loses it AND lies about it.
+    //
+    // Non-vacuous because the spy delegates to the real writer: with the guard
+    // removed, this row is genuinely overwritten on disk.
+    const preDraft = {
+      nodes: [
+        {
+          id: 'user-authored-1',
+          type: 'goal',
+          position: { x: 10, y: 20 },
+          data: { kind: 'goal', label: 'The work the user typed themselves' },
+        },
+      ],
+      edges: [],
+      scenarioId: SCENARIO_ID,
+      timestamp: Date.now(),
+    }
+    localStorage.setItem('olumi-canvas-autosave', JSON.stringify(preDraft))
+
+    useDraftStore.getState().setDraftStreamPhase('settling', TURN_ID, SCENARIO_ID)
+    expect(flushWorkToAutosave()).toBe(false)
+
+    const onDisk = JSON.parse(localStorage.getItem('olumi-canvas-autosave') ?? 'null')
+    expect(onDisk?.nodes?.map((n: { id: string }) => n.id)).toEqual(['user-authored-1'])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// B. THE OTHER DIRECTION — the flush must still do its job
+// ═══════════════════════════════════════════════════════════════════════════
+// A one-sided guard is the defect one level up, and that exact shape was found
+// in this file's neighbour (`useAutosave`'s preview skip, #835 section B). These
+// cases pass at pristine and MUST stay passing: they are what stops the fix
+// being "never flush".
+
+describe('B. the crash flush still saves the work it exists to save', () => {
+  it('B1: `idle` — an ordinary crash persists the graph, as before', () => {
+    expect(flushWorkToAutosave()).toBe(true)
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
+  })
+
+  it('B2: `drafting` — nothing is on the canvas yet to be wrong about', () => {
+    // The distinction that keeps this from being a blanket "any streamed turn
+    // blocks everything": before GRAPH_READY there is no preview to
+    // misrepresent, so the pre-draft graph is still the user's real work.
+    // Derived, not asserted: `drafting` is classified NOT-unsettled by the
+    // authority's compiler-checked switch.
+    expect(draftValuesAreUnsettled('drafting')).toBe(false)
+    useDraftStore.getState().setDraftStreamPhase('drafting', TURN_ID, SCENARIO_ID)
+
+    expect(flushWorkToAutosave()).toBe(true)
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
+  })
+
+  it('B3: a draft unsettled on ANOTHER scenario does not block this one', () => {
+    // Otherwise one dead stream freezes crash recovery for the whole app —
+    // review F2's defect wearing a crash-flush hat.
+    useDraftStore.getState().setDraftStreamPhase('unsettled', TURN_ID, OTHER_SCENARIO_ID)
+
+    expect(flushWorkToAutosave()).toBe(true)
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
+  })
+
+  it('B4: release re-opens the flush — not a one-way door', () => {
+    useDraftStore.getState().setDraftStreamPhase('settling', TURN_ID, SCENARIO_ID)
+    expect(flushWorkToAutosave()).toBe(false)
+
+    useDraftStore.getState().setDraftStreamPhase('idle', null, null)
+    expect(flushWorkToAutosave()).toBe(true)
+    expect(mockSaveAutosave).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// C. THE AUTHORITY, AND THE ID THE GUARD MUST TEST
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('C. the guard consumes the one authority, on the right scenario id', () => {
+  it('C1: for EVERY phase, the flush agrees with shouldPersistGraphForScenario', () => {
+    // Exhaustive over the union and derived from the predicate, so a fifth phase
+    // cannot be classified one way for the writer and another for the run gate,
+    // and so this expectation cannot drift into a hand-listed mirror.
+    for (const phase of ALL_PHASES) {
+      useDraftStore.getState().setDraftStreamPhase(phase, TURN_ID, SCENARIO_ID)
+      mockSaveAutosave.mockClear()
+
+      const permitted = shouldPersistGraphForScenario(SCENARIO_ID)
+      expect(flushWorkToAutosave()).toBe(permitted)
+      expect(mockSaveAutosave).toHaveBeenCalledTimes(permitted ? 1 : 0)
+    }
+  })
+
+  it('C2: gates on the id the WRITE is scoped to, not the one a caller holds', () => {
+    // `flushWorkToAutosave` resolves its scenario as
+    // `snapshot.scenarioId ?? getCurrentScenarioId()`. With the store's id null,
+    // the localStorage fallback supplies it — and THAT is the row the write
+    // lands on, so THAT is the id the phase must be tested against.
+    //
+    // This is the case a call-site guard cannot get right without re-deriving
+    // the same fallback, i.e. without becoming a second spelling of it.
+    localStorage.setItem(CURRENT_SCENARIO_KEY, SCENARIO_ID)
+    seedCanvas(null)
+    useDraftStore.getState().setDraftStreamPhase('settling', TURN_ID, SCENARIO_ID)
+
+    expect(flushWorkToAutosave()).toBe(false)
+    expect(mockSaveAutosave).not.toHaveBeenCalled()
+
+    // Discriminator: the SAME null-store shape flushes when the fallback id's
+    // draft is settled — so C2's decline is the phase's doing, not the null.
+    useDraftStore.getState().setDraftStreamPhase('idle', null, null)
+    expect(flushWorkToAutosave()).toBe(true)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// D. THE HONESTY CONSEQUENCE
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('D. a declined flush reports itself, so no promise is made over it', () => {
+  it('D3: returns false rather than throwing or reporting a phantom write', () => {
+    // `ErrorBoundary.componentDidCatch` stores this exact boolean as
+    // `workFlushed` (:154) and gates the "your work is auto-saved" line on it
+    // (:450). A guard that returned true, or threw into the boundary's own
+    // catch, would leave the panel promising a snapshot that does not exist —
+    // trading the fabrication for a different one.
+    useDraftStore.getState().setDraftStreamPhase('settling', TURN_ID, SCENARIO_ID)
+
+    let returned: boolean | undefined
+    expect(() => {
+      returned = flushWorkToAutosave()
+    }).not.toThrow()
+    expect(returned).toBe(false)
+  })
+})

--- a/src/canvas/persist/crashFlush.ts
+++ b/src/canvas/persist/crashFlush.ts
@@ -17,12 +17,64 @@
  * into the entry bundle). Instead the store registers a snapshot provider at
  * module init (see store.ts, next to the window.useCanvasStore exposure), and
  * the boundary calls flushWorkToAutosave() through this tiny module.
+ *
+ * ⚠ AND IT DOES NOT PERSIST AN UNSETTLED STREAMED DRAFT. `applyDraftResult`
+ * skips its payload-scoped write during a streamed GRAPH_READY preview
+ * (`opts.skipAutosave`) and #835 closed the two store-scoped writers in
+ * `useAutosave`. This module was the remaining door: a React crash inside the
+ * ~25 s settling window wrote the preview to `olumi-canvas-autosave`, and
+ * because `draftStreamPhase` is in-memory it came back after the reload
+ * UNMARKED, with the run gate OPEN — the exact fabrication the skip exists to
+ * prevent, reached through a third path.
+ *
+ * DECLINING DOES NOT EVEN COST THE WORK — it PROTECTS it. This looks like a
+ * fabrication-vs-data-loss trade and is not one, because of what is actually in
+ * the store during `settling`: the streamed preview, which has already REPLACED
+ * whatever was on the canvas. And `saveAutosave` is a whole-object REPLACE, not
+ * a merge. So the unguarded flush was not merely writing something unsettled —
+ * it was OVERWRITING the last good pre-draft autosave with it. Declining keeps
+ * that last good snapshot intact. Hand-authored work made BEFORE the draft is
+ * unaffected either way: `drafting` is classified settled, so edits still flush
+ * right up until GRAPH_READY lands.
+ *
+ * The server copy then covers the draft itself: CEE lets the turn finish when
+ * the client hangs up and commits the drafted graph (verified at CEE
+ * `4a064e60`, `routes/streamed-turn-sse.ts` — the turn is dispatched via
+ * `app.inject`, no socket reference crosses into it, and an integration test
+ * destroys a real TCP socket and asserts the commit still lands). The scenario
+ * id survives in its own ungated key (`olumi-canvas-current-scenario-id`), and
+ * boot hydration is wired unconditionally at `CanvasMVP.tsx:89`, so the reload
+ * the boundary offers reads that committed graph back. ⚠ Scope: that holds for
+ * the V5 turn routes, not for `POST /assist/v1/draft-graph`, which does abort
+ * on socket close; and the fence can still refuse a `superseded` write. So
+ * treat server recovery as the common case, not a guarantee — which is why the
+ * argument above is built on the local REPLACE, which needs no server at all.
+ *
+ * And the decline is honest by construction: this
+ * function returns false, `ErrorBoundary` stores that as `workFlushed`, and
+ * the "your work is auto-saved" promise is gated on it. Writing anyway would
+ * be a lie the user cannot detect. Marking the row instead was designed and
+ * DECLINED: the autosave payload is unversioned and the tree's only versioning
+ * mechanism is dead code that fails open.
+ *
+ * THE GATE LIVES HERE, NOT AT THE CALL SITES. `shouldPersistGraphForScenario`
+ * is the single derived authority, and its own header refuses to become "a
+ * list of call sites to keep in step" — guarding each importer would leave the
+ * next one to inherit the defect in silence. Inside the primitive it also
+ * tests the id the write is genuinely scoped to (see the resolution below),
+ * which a caller-side guard cannot do without re-deriving the same fallback.
+ * `useAutosave` keeps its own consult: two consults of ONE authority is defence
+ * in depth, unlike two spellings of one rule (trap 12).
+ *
+ * Importing `stores/draftStore` does not violate the dependency shape above:
+ * it is a 373-line leaf whose only import is `zustand` — not the canvas store.
  */
 
 import { saveAutosave, getCurrentScenarioId } from '../store/scenarios'
 import type { AutosaveData } from '../store/scenarios'
 import { projectAutosaveData } from '../store/autosaveProjection'
 import type { AutosaveProjectionSource } from '../store/autosaveProjection'
+import { shouldPersistGraphForScenario } from '../stores/draftStore'
 
 /**
  * What the store's registered provider must hand back.
@@ -122,7 +174,13 @@ function isPlausibleEdge(e: unknown, keptNodeIds: Set<string>): boolean {
  * - EMPTY graph (after filtering) → false WITHOUT writing: an empty store must
  *   never clobber the last good autosave (the crash may have emptied the
  *   store — the stale autosave is then strictly better than the "fresh"
- *   nothing).
+ *   nothing);
+ * - UNSETTLED streamed draft on this scenario → false WITHOUT writing, for the
+ *   same "a stale truth beats a fresh fabrication" reason (see the header).
+ *
+ * The returned boolean is load-bearing, not diagnostic: `ErrorBoundary` gates
+ * its "your work is auto-saved" promise on it, so every `false` above is a
+ * promise correctly NOT made.
  */
 export function flushWorkToAutosave(): boolean {
   try {
@@ -136,6 +194,18 @@ export function flushWorkToAutosave(): boolean {
     const edges = snapshot.edges.filter((e) => isPlausibleEdge(e, keptNodeIds))
     if (nodes.length === 0 && edges.length === 0) return false
 
+    // THE SCENARIO THIS WRITE LANDS ON. Resolved ONCE, and BEFORE the gate, so
+    // the phase is tested against exactly the row `saveAutosave` is about to
+    // occupy — including the case where the store has no id and the
+    // localStorage fallback supplies it.
+    const scenarioId = snapshot.scenarioId ?? getCurrentScenarioId()
+
+    // ⚠ NEVER PERSIST AN UNSETTLED STREAMED DRAFT — see the header for why a
+    // decline beats both writing and marking. Read at FLUSH time, never at
+    // registration: the phase that matters is the one at the instant of the
+    // crash.
+    if (!shouldPersistGraphForScenario(scenarioId)) return false
+
     // Spread FIRST so any field added to CrashSnapshot flows through without a
     // second edit here; the explicit members below are the ones this path
     // deliberately overrides (filtered graph, scenario-id fallback).
@@ -143,7 +213,7 @@ export function flushWorkToAutosave(): boolean {
       ...snapshot,
       nodes: nodes as AutosaveData['nodes'],
       edges: edges as AutosaveData['edges'],
-      scenarioId: snapshot.scenarioId ?? getCurrentScenarioId(),
+      scenarioId,
       // Boundary cast — see CrashSnapshot doc: restore validates before use.
       ceeAnalysisReady: (snapshot.ceeAnalysisReady ?? undefined) as AutosaveData['ceeAnalysisReady'],
     }


### PR DESCRIPTION
## The defect

`applyDraftResult` skips its payload-scoped autosave write during a streamed GRAPH_READY preview (`opts.skipAutosave`, `applyDraftResult.ts:319`), and #835 closed the two store-scoped writers in `useAutosave`. Neither reached **`flushWorkToAutosave`**, whose other importer is **`ErrorBoundary.tsx:114`**.

So a React crash inside the ~25 s settling window still wrote the unsettled preview to `olumi-canvas-autosave`. `draftStreamPhase` is in-memory and does not survive the reload the boundary offers, so the preview came back **unmarked, with the run gate OPEN** — the user analyses in-progress numbers believing they are the model's. Same fabrication as M4/M7, reached through a third door.

Re-derived at staging tip `131171d5` (i.e. **after** #835): the crash path was still unguarded.

## Fabrication vs data loss — and why this is not actually a trade

Declining looks like it trades a fabrication for losing the user's draft. It does not, on either axis:

- **Locally, declining PROTECTS work.** `saveAutosave` is a whole-object **REPLACE**, not a merge. During `settling` the store holds the *preview*, which has already replaced the canvas. So the unguarded flush was **destroying the last good pre-draft autosave** in order to persist something unsettled. Declining keeps it. Pinned behaviourally as case **A3**.
- **Hand-authored work is unaffected either way**, because `drafting` is classified *settled* by the authority — edits still flush right up until GRAPH_READY lands.
- **The draft itself is separately recoverable.** CEE lets the turn finish when the client hangs up and commits the graph — verified at CEE `4a064e60`: the turn is dispatched via `app.inject` with no socket reference crossing in, and an integration test destroys a real TCP socket then asserts the commit lands. The scenario id survives in its own ungated key (`olumi-canvas-current-scenario-id`), and boot hydration is wired unconditionally at `CanvasMVP.tsx:89`.
- **Declining is honest by construction.** The function returns `false`, `ErrorBoundary` stores it as `workFlushed` (`:154`) and gates the "your work is auto-saved" promise on it (`:450`). Declining downgrades a promise; writing tells a lie the user cannot detect.

**Marking instead was not attempted** — a durable unsettled marker was designed and declined today: the autosave payload is unversioned and the tree's only versioning mechanism is dead code that fails open.

> ⚠ Scope limit on the CEE half: it holds for the V5 turn routes, **not** for `POST /assist/v1/draft-graph`, which does abort on socket close; and the fence can still refuse a `superseded` write. Server recovery is the common case, not a guarantee — which is why the argument above rests on the local REPLACE, which needs no server at all.

## Where the guard lives

**Inside the primitive, not at the call sites.** #835 guarded its own call site (`useAutosave.ts:384`). Guarding `ErrorBoundary` the same way would make a two-entry list of call sites to keep in step — the shape `shouldPersistGraphForScenario`'s own header refuses ("a single derived choke point, not a list of call sites") — and the next importer would inherit the defect in silence.

Inside the primitive the guard also tests **the id the write is genuinely scoped to** (`snapshot.scenarioId ?? getCurrentScenarioId()`), which a caller-side guard cannot do without re-deriving the same fallback into a second spelling. Pinned as **C2**.

`useAutosave` keeps its own consult: two consults of **one** authority is defence in depth, unlike two spellings of one rule (trap 12).

Reuses `shouldPersistGraphForScenario` — the same derived read the other writers use. Importing `stores/draftStore` does not breach the entry-chunk dependency shape: it is a 373-line leaf whose only import is `zustand`.

## Evidence

**RED-first at pristine** (9 cases at the time): `6 failed | 3 passed`. The three passing were exactly the both-directions cases — B1 `idle`, B2 `drafting`, B3 other-scenario — passing **before** the fix and still passing after. A one-sided guard cannot produce that shape. Now **10/10**.

**Discriminating mutant kit** — throwaway worktree at an absolute path outside the repo root, isolation proven by **writing a sentinel** (source sha256 unchanged, distinct inodes), restores from a **pristine archive**, applied-check scoped to `src/`:

| | mutant | applied | result |
|---|---|---|---|
| leading control | — | **0** | 10 passed |
| **M1** | delete the guard (= the pristine defect) | 1 | **RED ×7** — A1 A2 A3 B4 C1 C2 D3; B1–B3 stay green |
| **M2** | invert the guard | 1 | **RED ×10** — *including* B1–B3, which M1 left green |
| **M3** | neutralise the adjacent empty-graph gate | 1 | **GREEN** — binds to the draft-phase decision, not to any edit |
| trailing control | — | **0** | 10 passed, file sha256 back to pristine |

M1 and M2 RED on **different assertion sets**, which is what proves the spec bites in both directions rather than merely being sensitive to something.

**C1** is exhaustive over the phase union and derived from `shouldPersistGraphForScenario` rather than a hand-listed mirror, so a fifth phase cannot be classified one way for the writer and another for the run gate.

## Gate (real step sequence: lint → typecheck → tests)

- `pnpm run lint` — **0 errors**, 1170 pre-existing warnings; hooks ratchet exactly at baseline
- `pnpm run typecheck` — **PASSED**, ratchet at baseline `2252`, no new diagnostics; coverage 3641/3681
- Suites run with `VITE_SUPABASE_URL`/`VITE_SUPABASE_ANON_KEY` exported; the new spec asserted to collect **10** by name on every run

Neighbouring suites green (60 passed): `autosaveProjectionParity`, `useAutosave.closeWindowFlush`, `draftStreamOwnership`, `runGateCallSites.derived`, `ErrorBoundary.autosaveClaimHonesty`.

⚠ `Visual Regression (advisory)` is a standing red on current staging — not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)