### PR TITLE
fix(canvas): server merge on hydrate marks the analysis stale (A3)

### DIFF
--- a/src/canvas/utils/__tests__/mergeServerGraph.staleness.spec.ts
+++ b/src/canvas/utils/__tests__/mergeServerGraph.staleness.spec.ts
@@ -1,0 +1,202 @@
+/**
+ * The STALENESS pin — Core System A exit A3.
+ *
+ * `mergeServerGraphOnHydrate` changes canvas values on reload and, before this
+ * spec, never marked the analysis stale. The user-visible consequence: the
+ * canvas shows the merged (edited) graph while the Analysis panel shows the
+ * PRE-EDIT result labelled current, and the only signal is a ~2s pulse.
+ *
+ * ⭐ WHY NOTHING ELSE CATCHES IT — each of these is real, and each is blind here:
+ *   · `analysisFreshness.ts` compares `graph_hash_at_run` to
+ *     `current_graph_hash`, and both are fields of the SAME stored blob — the
+ *     check compares a value against itself, so it cannot see a canvas that
+ *     moved after the blob was restored.
+ *   · `validateCeeAnalysisReady` (`ceeAnalysisReadyValidation.ts:31`) compares
+ *     NODE IDS ONLY, so a VALUE-ONLY edit passes and a stale result is upgraded
+ *     to `fresh`.
+ *   · `resultsLoadHistorical` (`store.ts:4142`) sets `graphEditedSinceLastRun:
+ *     false`, and the server merge runs AFTER that, never flipping it back.
+ *
+ * ⚠ THE PREDICATE IS `changed`, NOT `overwroteExistingValues` — AND THAT
+ * DIVERGENCE FROM THE PULSE/HISTORY GATES BESIDE IT IS DELIBERATE. Three
+ * different questions share this commit block, and aligning them would be the
+ * defect, not the tidy-up:
+ *   · `pushHistory()`        — "is the user's work about to be destroyed?"
+ *                              Only an OVERWRITE destroys. Additions do not.
+ *   · `pulseAppliedTargets()`— "did a number move under the user's eyes?"
+ *                              Only an OVERWRITE moves one. Additions do not.
+ *   · `markGraphStructurallyEdited()`
+ *                            — "is the canvas graph now different from the
+ *                              graph the CURRENT FRESHNESS VERDICT was
+ *                              established against?" ANY change makes the
+ *                              verdict unsupported — an addition just as much
+ *                              as an overwrite.
+ * The ADDITION case is pinned below precisely so a later "make these three
+ * consistent" pass goes RED instead of silently re-opening the lie.
+ *
+ * ⚠ AND IT IS NOT UNCONDITIONAL — marking every boot stale would be its own
+ * defect (a false stale on the most common boot of all, the idempotent one).
+ * The `if (!changed) return result` early return above the mark is what buys
+ * that, and the no-op case below is what pins it.
+ *
+ * ⚠ jsdom/dev-branch note: this spec calls `mergeServerGraphOnHydrate`
+ * DIRECTLY. The reload restore path in `ReactFlowGraph.tsx:1504-1691` sits
+ * inside `if (import.meta.env.PROD)`, so no dev-mode *reload* observation would
+ * be evidence about the shipped path. The merge function itself carries ZERO
+ * `import.meta.env` references (derived at this tip), so it has no dev/prod
+ * branch to take — the unit under test is byte-identical in both modes.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+
+import { useCanvasStore } from '../../store'
+import { mergeServerGraphOnHydrate } from '../mergeServerGraph'
+
+const SCENARIO = '11111111-2222-4333-8444-555555555555'
+
+/**
+ * Seed the exact post-restore posture the defect lives in: a graph on the
+ * canvas and an analysis the store believes is CURRENT.
+ */
+function seedRestoredWithCurrentAnalysis(): void {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO,
+    nodes: [
+      {
+        id: 'factor-1',
+        type: 'factor',
+        position: { x: 10, y: 20 },
+        data: { label: 'Spend', kind: 'factor', value: 100 },
+      },
+      {
+        id: 'goal-1',
+        type: 'goal',
+        position: { x: 300, y: 400 },
+        data: { label: 'Profit', kind: 'goal', value: 5 },
+      },
+    ] as never,
+    edges: [] as never,
+    lastAuthoritativeGraph: null,
+    serverGraphIdentity: null,
+    history: { past: [], future: [] },
+    // The "analysis reflects the current model" posture, as
+    // `resultsLoadHistorical` + the freshness upgrade leave it.
+    graphEditedSinceLastRun: false,
+    analysisStateReady: true,
+    analysisFreshnessDirty: false,
+  } as never)
+}
+
+/**
+ * PIN THE PRECONDITION IN-TEST. Without this, every assertion below could pass
+ * on a store that was already dirty for some unrelated reason, and the spec
+ * would be a tautology with no red anywhere.
+ */
+function assertAnalysisReadsCurrent(): void {
+  const s = useCanvasStore.getState()
+  expect(s.graphEditedSinceLastRun).toBe(false)
+  expect(s.analysisStateReady).toBe(true)
+  expect(s.analysisFreshnessDirty).toBe(false)
+}
+
+beforeEach(() => {
+  seedRestoredWithCurrentAnalysis()
+})
+
+describe('mergeServerGraphOnHydrate — a merge that moves the model marks the analysis STALE', () => {
+  it('marks stale when the server merge CHANGES AN EXISTING NODE VALUE', () => {
+    assertAnalysisReadsCurrent()
+
+    const result = mergeServerGraphOnHydrate({
+      nodes: [
+        // The overwrite: the canvas shows 100, the server holds 250.
+        { id: 'factor-1', kind: 'factor', label: 'Spend', value: 250 },
+        { id: 'goal-1', kind: 'goal', label: 'Profit', value: 5 },
+      ],
+      edges: [],
+    })
+
+    // Bind by IDENTITY, not by a value predicate another node could satisfy:
+    // it is factor-1 specifically whose value the merge moved.
+    expect(result.updatedNodeCount).toBe(1)
+    const factor1 = useCanvasStore.getState().nodes.find((n: any) => n.id === 'factor-1') as any
+    expect(factor1?.data?.value).toBe(250)
+
+    // …and the analysis must no longer claim to be current, on ALL THREE flags.
+    // The legacy pair and the freshness overlay have DISJOINT readers; setting
+    // one and missing the other is how #344 shipped a false "current".
+    const s = useCanvasStore.getState()
+    expect(s.graphEditedSinceLastRun).toBe(true)
+    expect(s.analysisStateReady).toBe(false)
+    expect(s.analysisFreshnessDirty).toBe(true)
+  })
+
+  it('marks stale when the server merge only ADDS a node the canvas never had', () => {
+    assertAnalysisReadsCurrent()
+
+    const result = mergeServerGraphOnHydrate({
+      nodes: [
+        { id: 'factor-1', kind: 'factor', label: 'Spend', value: 100 },
+        { id: 'goal-1', kind: 'goal', label: 'Profit', value: 5 },
+        { id: 'factor-2', kind: 'factor', label: 'Headcount' },
+      ],
+      edges: [],
+    })
+
+    // Nothing was OVERWRITTEN — this is the case the pulse and the history
+    // snapshot deliberately sit out …
+    expect(result.updatedNodeCount).toBe(0)
+    expect(result.updatedEdgeCount).toBe(0)
+    expect(result.addedNodeCount).toBe(1)
+    expect(useCanvasStore.getState().nodes).toHaveLength(3)
+
+    // … and yet the freshness verdict was established against a TWO-node graph
+    // that is no longer on the canvas, so it is unsupported and must say so.
+    const s = useCanvasStore.getState()
+    expect(s.graphEditedSinceLastRun).toBe(true)
+    expect(s.analysisStateReady).toBe(false)
+    expect(s.analysisFreshnessDirty).toBe(true)
+  })
+
+  it('does NOT mark stale on a NO-OP merge — the idempotent boot stays current', () => {
+    assertAnalysisReadsCurrent()
+
+    const result = mergeServerGraphOnHydrate({
+      nodes: [
+        { id: 'factor-1', kind: 'factor', label: 'Spend', value: 100 },
+        { id: 'goal-1', kind: 'goal', label: 'Profit', value: 5 },
+      ],
+      edges: [],
+    })
+
+    // The server was READ and it already matched — accepted, not changed.
+    expect(result.accepted).toBe(true)
+    expect(result.refusedReason).toBeNull()
+    expect(result.changed).toBe(false)
+
+    // A one-sided guard here would convert an under-report into an
+    // over-report: every idempotent boot would falsely read stale.
+    const s = useCanvasStore.getState()
+    expect(s.graphEditedSinceLastRun).toBe(false)
+    expect(s.analysisStateReady).toBe(true)
+    expect(s.analysisFreshnessDirty).toBe(false)
+  })
+
+  it('does NOT mark stale when the merge is REFUSED — nothing was observed', () => {
+    assertAnalysisReadsCurrent()
+
+    // Zero node-id overlap with a non-empty canvas — two unrelated graphs.
+    const result = mergeServerGraphOnHydrate({
+      nodes: [{ id: 'unrelated-99', kind: 'factor', label: 'Elsewhere', value: 7 }],
+      edges: [],
+    })
+
+    expect(result.accepted).toBe(false)
+    expect(result.refusedReason).toBe('zeroOverlap')
+
+    const s = useCanvasStore.getState()
+    expect(s.graphEditedSinceLastRun).toBe(false)
+    expect(s.analysisStateReady).toBe(true)
+    expect(s.analysisFreshnessDirty).toBe(false)
+  })
+})

--- a/src/canvas/utils/mergeServerGraph.ts
+++ b/src/canvas/utils/mergeServerGraph.ts
@@ -56,6 +56,15 @@
  * and (2) pulses the changed elements on the existing applied-edit surface, so
  * a number cannot move under the user unannounced. Neither fires on a pure
  * addition or a no-op. See the commit block below.
+ *
+ * ⚠ AND (3), ON A WIDER PREDICATE THAN (1)/(2) — A3: whenever this merge changes
+ * the graph AT ALL, it marks the analysis STALE. Without it the canvas showed
+ * the merged graph while the Analysis panel showed the pre-merge result labelled
+ * CURRENT, with the 2s pulse as the only signal. (1) and (2) answer "was the
+ * user's work destroyed / did a number move under their eyes", which only an
+ * OVERWRITE does; this answers "does the current freshness verdict still
+ * describe what is on the canvas", which an ADDITION breaks just as completely.
+ * Three questions, two predicates — deliberately. See the commit block below.
  */
 
 import { useCanvasStore } from '../store'
@@ -454,6 +463,53 @@ export function mergeServerGraphOnHydrate(
   } finally {
     useCanvasStore.getState().endExternalGraphMutation?.()
   }
+
+  // ── THE ANALYSIS NO LONGER DESCRIBES THIS CANVAS (A3) ─────────────────────
+  //
+  // THE DEFECT THIS CLOSES: this merge changed the canvas on reload and left
+  // the Analysis panel showing the PRE-MERGE result labelled CURRENT. The only
+  // signal the user got was the ~2s pulse below.
+  //
+  // Nothing upstream catches it, and each near-miss is worth naming because
+  // each one LOOKS like it would:
+  //   · `analysisFreshness.ts:455-458` compares `graph_hash_at_run` to
+  //     `current_graph_hash` — both fields of the SAME stored blob, so it is
+  //     comparing a value against itself and cannot see a canvas that moved
+  //     after the blob was restored;
+  //   · `validateCeeAnalysisReady` (`ceeAnalysisReadyValidation.ts:31`) compares
+  //     NODE IDS ONLY, so a VALUE-ONLY change passes and a stale result is
+  //     UPGRADED to `fresh` — and that upgrade runs BEFORE this merge;
+  //   · `resultsLoadHistorical` (`store.ts:4142`) sets `graphEditedSinceLastRun:
+  //     false` on every hydrate, and nothing flipped it back.
+  //
+  // ⚠ AND `pushHistory()` ABOVE IS NOT THIS. Measured at this tip: `pushToHistory`
+  // sets the LEGACY PAIR (`graphEditedSinceLastRun`/`analysisStateReady`) but
+  // NEVER `analysisFreshnessDirty` — and the freshness banners read the OVERLAY,
+  // not the pair. It also EARLY-RETURNS when the pre-merge state hashes equal to
+  // the last snapshot (`store.ts:1266-1273`), so even the pair's flip is
+  // incidental. That is the #344 shape exactly: one staleness system set, the
+  // other missed, shipping a false "analysis reflects the current model". Hence
+  // the EXPLICIT, ATOMIC 3-flag call — `markGraphStructurallyEdited` is the
+  // store's declared API for external mutators for this reason.
+  //
+  // ⚠ THE PREDICATE IS `changed`, NOT `overwroteExistingValues`, AND THE
+  // DIVERGENCE FROM THE TWO GATES EITHER SIDE OF IT IS DELIBERATE — DO NOT
+  // "TIDY" THESE INTO ONE. Three different questions share this block:
+  //   · pushHistory            — "is the user's work about to be destroyed?"
+  //                              Only an OVERWRITE destroys.
+  //   · pulseAppliedTargets    — "did a number move under the user's eyes?"
+  //                              Only an OVERWRITE moves one.
+  //   · THIS                   — "is the canvas graph now different from the
+  //                              graph the current freshness verdict was
+  //                              established against?" ANY change makes that
+  //                              verdict unsupported, an ADDITION included.
+  // Aligning the three would re-open the lie on the addition path.
+  //
+  // ⚠ NOT UNCONDITIONAL: marking every boot stale would be its own defect — a
+  // false stale on the commonest boot of all, the idempotent one. The
+  // `if (!changed) return result` above is what buys that, and both directions
+  // are pinned in `mergeServerGraph.staleness.spec.ts`.
+  useCanvasStore.getState().markGraphStructurallyEdited?.()
 
   // ── DISCLOSURE: never move a number the user is looking at in silence ──────
   //


### PR DESCRIPTION
## The decision this changes

Whether, after a reload, Olumi shows an **edited graph beside a pre-edit analysis result labelled current**. It does today. This closes it.

## The defect, derived at `c7d4310e`

`mergeServerGraphOnHydrate` changes canvas values on reload and never marks the analysis stale. The canvas shows the merged graph, the Analysis panel shows the **pre-merge result labelled current**, and the only signal is the ~2s disclosure pulse.

**Why every other guard is blind to it** — each of these looks like it would catch it:

| Guard | Why it misses |
|---|---|
| `analysisFreshness.ts:455-458` | Compares `graph_hash_at_run` to `current_graph_hash` — **both fields of the same stored blob**. A value compared against itself; blind to a canvas that moved *after* restore. |
| `validateCeeAnalysisReady` (`ceeAnalysisReadyValidation.ts:31`) | Compares **node IDs only**, so a value-only change passes and a stale result is **upgraded to `fresh`** — and that upgrade runs *before* this merge. |
| `resultsLoadHistorical` (`store.ts:4142`) | Sets `graphEditedSinceLastRun: false` on every hydrate; nothing flipped it back. |

**And `pushHistory()` is not this.** Measured at this tip: `pushToHistory` (`store.ts:1279-1289`) sets the **legacy pair** but never `analysisFreshnessDirty` — the flag the freshness banners actually read — and it **early-returns** when the pre-merge state hashes equal to the last snapshot (`store.ts:1266-1273`), so even that flip is incidental. This is the **#344 shape** exactly: one staleness system set, the other missed, shipping a false "analysis reflects the current model".

Observed in the RED-first run: on the value-change case the legacy pair had *already* flipped via `pushHistory`, and only `analysisFreshnessDirty` was false. On the addition-only case **nothing** flipped.

## The fix

One call — `markGraphStructurallyEdited()`, the store's declared atomic 3-flag API for external mutators — placed after the commit, mirroring the sibling `mergeAppliedGraph.ts:717`.

### The predicate is `changed`, NOT `overwroteExistingValues` — deliberately

Three different questions share this commit block. Aligning them would be the defect, not the tidy-up:

- `pushHistory()` — *"is the user's work about to be destroyed?"* → only an **overwrite** destroys.
- `pulseAppliedTargets()` — *"did a number move under the user's eyes?"* → only an **overwrite** moves one.
- `markGraphStructurallyEdited()` — *"does the current freshness verdict still describe the canvas?"* → **any** change breaks it, an **addition** as completely as an overwrite.

The sibling agrees: its `changed` includes `addedNodeCount`, and its spec pins `marks the freshness overlay dirty on a structural add — the banner must never keep claiming currency`.

**Not unconditional** — the pre-existing `if (!changed) return result` keeps the idempotent boot (the commonest boot of all) honestly current. Marking every boot stale would be its own defect, the over-report inversion.

## Evidence

**RED-first at pristine** (`c7d4310e`, `src` 0 modified) — 2 failed / 2 passed:
- `marks stale when the server merge CHANGES AN EXISTING NODE VALUE` → `AssertionError: expected false to be true` at `:131` (`analysisFreshnessDirty`)
- `marks stale when the server merge only ADDS a node the canvas never had` → at `:156` (`graphEditedSinceLastRun`)

**Both directions** — a merge that changes values marks stale; a **no-op** merge and a **refused** merge do not.

**Mutants** (throwaway worktree at an absolute path outside the repo root; isolation proven by **writing** a sentinel and asserting the source sha was unchanged; distinct inodes confirmed; restored from a **pristine archive**, never `git checkout -- <path>`; applied-check scoped to `src/`, control exactly 0):

| # | Mutation | Expected | Result |
|---|---|---|---|
| M1 | Delete the mark | RED | RED — both "marks stale" tests |
| M2 | Narrow to `overwroteExistingValues` | RED | RED — **only** the addition test |
| M3 | Hoist above `!changed` | RED | RED — **only** the no-op test |
| M4 | **Adjacent**: widen the *pulse* gate to `changed` | **GREEN** | **GREEN** — and the disclosure spec went RED, proving M4 is real, not equivalent |
| M5 | Hoist above all refusal guards | RED | RED — no-op **and** refusal |

M4 is the discriminating half: my spec is bound to the **staleness flags**, not merely sensitive to any edit in the file. M5's first attempt had an ambiguous anchor and the **applied-check read 0**, catching a false survivor before it was believed.

**Regression** — `src/canvas/utils/__tests__` + `hydrate` + `registration`: **84 files / 1670 tests green**, including the sibling `mergeServerGraph.disclosure.spec.ts` (pulse behaviour unchanged). My spec collected **4 tests by name**.

**Gate, in CI's real order** — `pnpm run lint` (0 errors; hooks ratchet exactly at baseline) → `pnpm run typecheck` (ratchet **2252 = 2252**, no new diagnostics).

## The dev-branch trap, avoided

The reload restore path in `ReactFlowGraph.tsx:1504-1691` sits inside `if (import.meta.env.PROD)`, so **no dev-mode reload observation would be evidence about the shipped path**. This spec calls `mergeServerGraphOnHydrate` **directly**, and the merge module carries **zero** `import.meta.env` references (derived; contrast control — `ReactFlowGraph.tsx` has 12 — so the probe was not blind). The unit under test has no dev/prod branch to take.

## Blast radius — every consumer of the three flags

`markGraphStructurallyEdited` sets `graphEditedSinceLastRun`, `analysisStateReady`, `analysisFreshnessDirty`. Non-test readers:

- **`graphEditedSinceLastRun`** — `CompareTabBody.tsx`, `deriveAnalysisDisplayState.ts`, `mergeAppliedGraph.ts`, `ReanalyseBar.tsx`, `OutputsDock.tsx`, `store.ts`, `useConversation.ts`, `ConversationPanel.tsx`, `ActionStrip.tsx`, `selectors.ts`, `V5GraphPatchBlock.tsx`, `exportBundle.ts`
- **`analysisStateReady`** — `mergeAppliedGraph.ts`, `store.ts`, `useConversation.ts`, `ConversationPanel.tsx`, `useScenario.ts`
- **`analysisFreshnessDirty`** — `mergeAppliedGraph.ts`, `analysisStateSelector.ts`, `ReactFlowGraph.tsx`, `store.ts`, `useCoachingCurrency.ts`, `coachingCurrency.ts`, `StrengthenContainer.tsx`, `AnalysisFreshnessNotice.tsx`, `exportBundle.ts`

The user-visible effect is intended: the freshness notice and the re-analyse affordance now tell the truth after a merging reload. The sibling already writes these three on the same class of producer mutation.

## Named limits

- **Not journey-witnessed.** This is unit-level evidence on the merge function. No deployed reload has been driven; the rung is TESTED, not WIRE- or JOURNEY-witnessed.
- **`analysisStateReady` is also a request-shaping flag**, not only a display flag — it gates whether a CEE turn carries `analysis_state`. After a merging reload a turn will now omit it until the next run. That is the correct posture (the cached snapshot no longer matches the canvas) but it is a **behaviour change on the turn wire**, not only on screen, and it is not covered by this spec.
- **Edge-only value changes** are covered by the same `changed` predicate but are not separately pinned; only node cases are in the spec.
- **`Visual Regression (advisory)` is a standing red** on current staging and is not a blocker.