### PR TITLE
A4 — render the producer's blocker message verbatim, instead of a substitute pointing at a chat that cannot answer

### DIFF
--- a/src/canvas/components/__tests__/OutputsDock.canonicalReadinessWiring.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.canonicalReadinessWiring.spec.tsx
@@ -250,7 +250,17 @@ describe('the frozen capture, on the mounted control', () => {
     expect(footer).not.toHaveTextContent(FOOTER_COPY.notReady)
   }, 30_000)
 
-  it('AC2 — real blockers: DISABLED, and the tooltip NAMES one, not a constant', async () => {
+  it('AC2 — real blockers: DISABLED, and the tooltip carries the PRODUCER\'S OWN sentence', async () => {
+    // ⭐ A4, ON THE MOUNTED CONTROL. This is the strongest evidence short of a
+    // browser that `blocker.message` reaches the user: it is asserted on the
+    // rendered DOM attribute, through the real component tree and the real
+    // render seam (`gateBlockedSubline` → `vetBlockedReason` → `guardCeeText`),
+    // not on the composer's return value.
+    //
+    // The message is CEE's own spelling and NAMES ITS SCOPE, so the assertion
+    // still discriminates a derived sentence from a constant — and it now also
+    // proves the substituting guard left the producer's words alone.
+    const PRODUCER_MESSAGE = 'Choose the missing effect value for "Extend the free trial".'
     seedCapturedCanvas()
     useCanvasStore.setState({
       analysisStateV1: analysisState({
@@ -259,7 +269,7 @@ describe('the frozen capture, on the mounted control', () => {
           {
             code: 'OPTION_NOT_READY',
             category: 'options',
-            message: 'The option has no effect values.',
+            message: PRODUCER_MESSAGE,
             repairability: 'user_repairable',
             option_id: 'opt_extend',
             option_label: 'Extend the free trial',
@@ -276,18 +286,19 @@ describe('the frozen capture, on the mounted control', () => {
 
     const analyse = await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
     expect(analyse).toBeDisabled()
-    expect(analyse).toHaveAttribute(
+    expect(analyse).toHaveAttribute('title', PRODUCER_MESSAGE)
+    // Never the generic sentence, never the discarded substitute, never the id.
+    expect(analyse).not.toHaveAttribute('title', BLOCKED_REASON_COPY.unspecified)
+    expect(analyse).not.toHaveAttribute(
       'title',
       BLOCKED_REASON_COPY.canonicalOneBlocker('Extend the free trial'),
     )
-    // Never the generic sentence, and never the raw identifier.
-    expect(analyse).not.toHaveAttribute('title', BLOCKED_REASON_COPY.unspecified)
     expect(analyse.getAttribute('title')).not.toContain('opt_extend')
+    // The remedy the user cannot perform is gone from the surface.
+    expect(analyse.getAttribute('title')).not.toContain('Ask in the chat')
 
     // One state, one story: the footer subline says the SAME thing as the title.
-    expect(screen.getByTestId('pre-analysis-v3-footer')).toHaveTextContent(
-      BLOCKED_REASON_COPY.canonicalOneBlocker('Extend the free trial'),
-    )
+    expect(screen.getByTestId('pre-analysis-v3-footer')).toHaveTextContent(PRODUCER_MESSAGE)
   }, 30_000)
 
   it('DISCRIMINATION — the two cases above differ ONLY in the producer verdict', async () => {

--- a/src/canvas/components/__tests__/OutputsDock.readinessSurvivesTabChange.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.readinessSurvivesTabChange.spec.tsx
@@ -119,7 +119,8 @@ import { useReadinessStore } from '../../stores/readinessStore'
 import { useUIStore } from '../../../stores/uiStore'
 import { useFloatingPanelState } from '../../hooks/useFloatingPanelState'
 import { clearInflightCache } from '../../hooks/useGraphReadiness'
-import { BLOCKED_REASON_COPY } from '../../utils/composeBlockedReason'
+import { composeAnalysisBlockedReason } from '../../utils/composeBlockedReason'
+import { actionableBlockers } from '../../utils/canRunAnalysis'
 import { FOOTER_COPY } from '../pre-analysis-v3/constants'
 import { WORKSPACE_SURFACES, presentedSurfaces } from '../workspaceShell/shellContract'
 import { isAiPanelV2Enabled, isPreAnalysisV3Enabled } from '../../../flags'
@@ -127,11 +128,6 @@ import { isAiPanelV2Enabled, isPreAnalysisV3Enabled } from '../../../flags'
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
-
-/** The witnessed sentence, DERIVED from the producer's own copy factory rather
- *  than re-typed — 4 blockers is what `composeAnalysisBlockedReason` turns into
- *  the count rung, and the count rung is what the fresh guest read on screen. */
-const WITNESSED_REASON = BLOCKED_REASON_COPY.canonicalManyBlockers(4)
 
 const OPTION_LABELS: Record<string, string> = {
   opt_extend: 'Extend the free trial',
@@ -177,19 +173,38 @@ function analysisState(readiness: AnalysisStateV1['readiness']): AnalysisStateV1
   } as AnalysisStateV1
 }
 
-/** Four blockers, each scoped to a named element — the shape that produces the
- *  witnessed count sentence. */
+/** Four blockers, each scoped to a named element.
+ *
+ *  ⚠ THE MESSAGES ARE CEE'S OWN SPELLING (A4, 24 Aug). They were placeholders
+ *  (`'no effect values'`) while the composed refusal ignored them; since A4 the
+ *  refusal IS the message, so a placeholder here would put a placeholder on the
+ *  surface this spec renders and assert it as the witnessed sentence. */
+const FOUR_BLOCKERS: AnalysisStateV1['readiness']['blockers'] = [
+  { code: 'OPTION_NOT_READY', category: 'options', message: `Choose the missing effect value for "${OPTION_LABELS.opt_extend}".`, repairability: 'user_repairable', option_id: 'opt_extend', option_label: OPTION_LABELS.opt_extend },
+  { code: 'OPTION_NOT_READY', category: 'options', message: `Choose the missing effect value for "${OPTION_LABELS.opt_hold}".`, repairability: 'user_repairable', option_id: 'opt_hold', option_label: OPTION_LABELS.opt_hold },
+  { code: 'OPTION_NOT_READY', category: 'options', message: `Choose the missing effect value for "${OPTION_LABELS.opt_bundle}".`, repairability: 'user_repairable', option_id: 'opt_bundle', option_label: OPTION_LABELS.opt_bundle },
+  { code: 'FACTOR_NOT_READY', category: 'factors', message: 'Set the observed value for "Support headcount".', repairability: 'user_repairable', factor_id: 'f1', factor_label: 'Support headcount' },
+]
+
 function fourBlockers(): AnalysisStateV1['readiness'] {
   return {
     status: 'not_ready',
-    blockers: [
-      { code: 'OPTION_NOT_READY', category: 'options', message: 'no effect values', repairability: 'user_repairable', option_id: 'opt_extend', option_label: OPTION_LABELS.opt_extend },
-      { code: 'OPTION_NOT_READY', category: 'options', message: 'no effect values', repairability: 'user_repairable', option_id: 'opt_hold', option_label: OPTION_LABELS.opt_hold },
-      { code: 'OPTION_NOT_READY', category: 'options', message: 'no effect values', repairability: 'user_repairable', option_id: 'opt_bundle', option_label: OPTION_LABELS.opt_bundle },
-      { code: 'FACTOR_NOT_READY', category: 'factors', message: 'no observed value', repairability: 'user_repairable', factor_id: 'f1', factor_label: 'Support headcount' },
-    ],
+    blockers: FOUR_BLOCKERS,
   } as AnalysisStateV1['readiness']
 }
+
+/**
+ * The witnessed sentence, DERIVED BY RUNNING THE PRODUCTION EXPRESSION rather
+ * than re-typed or named by rung (trap 12 — a hand-copied expectation drifts
+ * the first time the composer changes, and the drift reads as green).
+ *
+ * ⚠ It was `BLOCKED_REASON_COPY.canonicalManyBlockers(4)` until A4. That named
+ * the COUNT rung, which is now the DEGRADE rather than the answer — pinning it
+ * by name would have pinned the fallback and hidden the fix at exactly the
+ * surface this spec renders. This expression is the one `canRunAnalysis:718`
+ * evaluates, filter included.
+ */
+const WITNESSED_REASON = composeAnalysisBlockedReason(actionableBlockers(FOUR_BLOCKERS))
 
 function ensureMatchMedia() {
   if (typeof window.matchMedia !== 'function') {

--- a/src/canvas/conversation/__tests__/conversationPanel.runRefusalIsAudible.spec.tsx
+++ b/src/canvas/conversation/__tests__/conversationPanel.runRefusalIsAudible.spec.tsx
@@ -90,13 +90,24 @@ function analysisState(
 
 const PRODUCER_READY = analysisState({ status: 'ready', blockers: [] })
 
+/**
+ * ⚠ THE MESSAGE NAMES ITS SCOPE, BECAUSE CEE'S REAL ONES DO (A4, 24 Aug 2026).
+ *
+ * It was `'The option has no effect values.'` — a placeholder that ignored its
+ * own `option_label`, which was harmless while the composed refusal was built
+ * from the label and discarded the message. Since A4 the refusal IS the message,
+ * rendered verbatim, so a placeholder here would put a placeholder on the
+ * surface this spec asserts against and the "names the blocker" test would fail
+ * for a fixture reason rather than a product one. Shaped on the producer's own
+ * spelling.
+ */
 const PRODUCER_BLOCKED = analysisState({
   status: 'not_ready',
   blockers: [
     {
       code: 'OPTION_NOT_READY',
       category: 'options',
-      message: 'The option has no effect values.',
+      message: 'Choose the missing effect value for "Extend the free trial".',
       repairability: 'user_repairable',
       option_id: 'n2',
       option_label: 'Extend the free trial',

--- a/src/canvas/utils/__tests__/canonicalReadinessAuthority.spec.ts
+++ b/src/canvas/utils/__tests__/canonicalReadinessAuthority.spec.ts
@@ -95,10 +95,21 @@ const SIDE_CAR_PERMITS: GraphReadiness = {
 }
 
 function blocker(overrides: Partial<AnalysisBlocker> = {}): AnalysisBlocker {
+  const scope = overrides.option_label ?? overrides.factor_label
   return {
     code: 'OPTION_NOT_READY',
     category: 'options',
-    message: 'The option has no effect values.',
+    // ⚠ THE MESSAGE NAMES THE SCOPE, BECAUSE CEE'S REAL ONES DO (A4, 24 Aug).
+    // Since A4 the composed refusal IS `blocker.message`, rendered verbatim —
+    // so a fixture whose message ignored its own scope label would stop
+    // exercising the "the sentence DERIVES from the list" property these tests
+    // exist for, and would pass by naming nothing rather than by naming the
+    // right thing. Shaped on the producer's own spelling
+    // (`Choose the missing effect value for "Launch in Q1".`). An explicit
+    // `message` override still wins, via the spread below.
+    message: scope
+      ? `Choose the missing effect value for "${scope}".`
+      : 'The option has no effect values.',
     repairability: 'user_repairable',
     ...overrides,
   }
@@ -314,7 +325,7 @@ describe('AC2 — real blockers close the gate and NAME themselves', () => {
     expect(result.reason).toContain('Support headcount')
   })
 
-  it('two blockers name both; more than two publish the producer COUNT', () => {
+  it('two blockers name both; four name all four', () => {
     const two = gate({
       analysisReadiness: {
         status: 'not_ready',
@@ -327,24 +338,56 @@ describe('AC2 — real blockers close the gate and NAME themselves', () => {
     expect(two).toContain('Extend the free trial')
     expect(two).toContain('Hold the current price')
 
-    // Four unnameable blockers: the count is still drawn from the LIST, so it
-    // moves with the list. A constant cannot do that either.
+    // ⚠ AMENDED BY A4. This half used to assert that four blockers publish the
+    // COUNT ("4 parts of your model are not ready…"). That rung is now the
+    // DEGRADE, not the answer: the producer wrote a sentence for each blocker
+    // and the contract says render them. So the property under test moves from
+    // "the count moves with the list" to the stronger "EVERY scoped element the
+    // producer named reaches the user" — which a constant cannot satisfy either,
+    // and which the count rung could satisfy only by naming none of them.
+    const labels = ['Extend the free trial', 'Hold the current price', 'Bundle the tiers', 'Do nothing']
     const four = gate({
       analysisReadiness: {
         status: 'not_ready',
-        blockers: [blocker(), blocker(), blocker(), blocker()],
+        blockers: labels.map((option_label) => blocker({ option_label })),
       },
+    }).reason
+    for (const label of labels) {
+      expect(four, `the producer named "${label}" and the user never saw it`).toContain(label)
+    }
+    expect(four).not.toBe(BLOCKED_REASON_COPY.unspecified)
+  })
+
+  it('the COUNT rung is still reached — when no message can be rendered as written', () => {
+    // The degrade half of the pair above, kept because the count rung is still
+    // live and must still derive from the LIST rather than from a constant.
+    // Driven through the only door that now opens it: messages the render seam
+    // would rewrite (`\bnodes\b` is in `CEE_EXTRA_TERMS`), on blockers whose
+    // labels are equally unquotable, so neither the message nor the scope rungs
+    // can speak.
+    const unrenderable = (n: number) =>
+      Array.from({ length: n }, (_, i) =>
+        blocker({
+          option_id: `opt_${i}`,
+          option_label: 'Rebuild the graph layer',
+          message: 'Two nodes in the decision graph need values.',
+        }),
+      )
+
+    const four = gate({
+      analysisReadiness: { status: 'not_ready', blockers: unrenderable(4) },
     }).reason
     const three = gate({
-      analysisReadiness: {
-        status: 'not_ready',
-        blockers: [blocker(), blocker(), blocker()],
-      },
+      analysisReadiness: { status: 'not_ready', blockers: unrenderable(3) },
     }).reason
+
     expect(four).toContain('4')
     expect(three).toContain('3')
     expect(four).not.toBe(three)
     expect(four).not.toBe(BLOCKED_REASON_COPY.unspecified)
+    // And the unrenderable prose never leaks on the way past.
+    expect(four).not.toContain('nodes')
+    expect(four).not.toContain('connections')
   })
 
   it('an unquotable label degrades to the count, never to a leaked identifier', () => {
@@ -749,12 +792,22 @@ describe('advisory blockers on a READY payload do not close the gate', () => {
 // substring another rung could satisfy.
 // ═══════════════════════════════════════════════════════════════════════════
 
-/** The actionable blocker AS CEE SHIPS IT, scoped to a quotable option. */
+/**
+ * The actionable blocker AS CEE SHIPS IT, scoped to a quotable option.
+ *
+ * ⚠ The message is DERIVED FROM THE SCOPE, not fixed (A4). It was a literal
+ * naming "Launch in Q1"; since the composed refusal is now the message itself,
+ * a fixed message would have made the TWO-ACTIONABLE twin below vacuous — both
+ * blockers would carry the same sentence, de-duplicate to one, and the twin
+ * would pass while naming only the first element. Exactly the "passes by naming
+ * FEWER things" failure its own comment warns about.
+ */
 function actionableBlocker(overrides: Partial<AnalysisBlocker> = {}): AnalysisBlocker {
+  const scope = overrides.option_label ?? 'Launch in Q1'
   return blocker({
     code: 'MISSING_OPTION_VALUE',
     category: 'option_values',
-    message: 'Choose the missing effect value for "Launch in Q1".',
+    message: `Choose the missing effect value for "${scope}".`,
     repairability: 'human_input_required',
     option_id: 'opt_launch_q1',
     option_label: 'Launch in Q1',
@@ -779,9 +832,10 @@ describe('the refusal names the blockers the gate actually decided on', () => {
     ])
 
     expect(result.allowed).toBe(false)
-    // Bound by IDENTITY through the factory: the one-blocker rung, quoting the
-    // ACTIONABLE element's own label.
-    expect(result.reason).toBe(BLOCKED_REASON_COPY.canonicalOneBlocker('Launch in Q1'))
+    // Bound by IDENTITY through the factory: the ACTIONABLE blocker's own
+    // producer-authored sentence, verbatim (A4 — was the synthesised
+    // `canonicalOneBlocker` rung until 24 Aug).
+    expect(result.reason).toBe(actionableBlocker().message)
     // And the advisory element is named NOWHERE — not in the primary sentence,
     // not in a `+N more` tail, not in any other blocking reason.
     expect(result.reason).not.toContain('Burn rate')
@@ -809,9 +863,15 @@ describe('the refusal names the blockers the gate actually decided on', () => {
     })
 
     expect(result.allowed).toBe(false)
+    // BOTH producer sentences, in the producer's own order. This is the half
+    // that REDs if the fix degrades to "name one thing" or "name the first
+    // thing" — including via de-duplication, which is why the factory derives
+    // its message from its scope.
     expect(result.reason).toBe(
-      BLOCKED_REASON_COPY.canonicalTwoBlockers('Launch in Q1', 'Hold until Q3'),
+      `${actionableBlocker().message} ${actionableBlocker({ option_label: 'Hold until Q3' }).message}`,
     )
+    expect(result.reason).toContain('Launch in Q1')
+    expect(result.reason).toContain('Hold until Q3')
   })
 
   it('ADVISORY-ONLY ON A `blocked` STATUS degrades to the non-committal rung', () => {

--- a/src/canvas/utils/__tests__/composeBlockedReason.producerMessage.spec.ts
+++ b/src/canvas/utils/__tests__/composeBlockedReason.producerMessage.spec.ts
@@ -1,0 +1,407 @@
+/**
+ * A4 — THE PRODUCER'S REPAIR GUIDANCE MUST REACH THE USER, VERBATIM.
+ *
+ * `composeAnalysisBlockedReason` received the full `AnalysisBlocker` — every
+ * field in scope — and deliberately DISCARDED `blocker.message`, returning
+ * instead `"{label}" is not ready for analysis yet. Ask in the chat what it
+ * needs.`
+ *
+ * Two things were wrong with that, and this spec pins both:
+ *
+ *  1. THE CONTRACT MANDATES THE OPPOSITE. `AnalysisBlockerSchema.message`
+ *     (`@talchain/schemas/boundary` 0.48.0) describes itself as "the
+ *     producer-authored, user-facing sentence for this blocker, rendered
+ *     VERBATIM… a consumer must not rewrite, summarise, truncate for meaning,
+ *     or synthesise a substitute when it dislikes the wording."
+ *
+ *  2. THE SUBSTITUTE WAS ACTIVELY WRONG. "Ask in the chat what it needs"
+ *     points at a path only a readiness CHIP opens; typing in the chat does
+ *     not reach it. The product named a remedy the user cannot perform.
+ *
+ * ── WHY THE VET IS `isSafeCeeText`, NOT `containsBannedTerm` (MEASURED) ─────
+ * The obvious vet is the canonical glossary (`containsBannedTerm`), which is
+ * what `safeDisplayLabel` uses for LABELS. It is not sufficient here, and the
+ * difference is not theoretical — it was measured at this tip before the fix
+ * was written:
+ *
+ *   'Choose the missing effect value for "Move billing to edge computing".'
+ *     containsBannedTerm → false      (canonical list has no bare "edge")
+ *     isSafeCeeText      → false      (`CEE_EXTRA_TERMS` does)
+ *     guardCeeText(…)    → 'Choose the missing effect value for
+ *                           "Move billing to connection computing".'
+ *
+ * i.e. a message vetted only against the canonical glossary still reaches the
+ * render seam's substituting guard and has the USER'S OWN OPTION LABEL rewritten
+ * into an option that exists on no canvas — the exact corruption
+ * `vetBlockedReason`'s header records, reproduced on the producer's sentence.
+ * So the compose-time vet uses the RENDER SEAM'S OWN PREDICATE, which is the
+ * only vet that can promise what ships is what was checked.
+ *
+ * That is also HOW THE GUARD IS BYPASSED, and it is deliberately not a bypass:
+ * `guardCeeText` returns its input UNCHANGED when `isSafeCeeText(text)` is true
+ * (`ceeTextGuard.ts:112`). Vetting with that same predicate makes the guard a
+ * PROVEN IDENTITY on everything this composer emits, so no surface has to be
+ * taught a new provenance and no surface can be forgotten. `SEAM` below pins
+ * exactly that, end to end, rather than assuming it.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import type { AnalysisBlocker } from '@talchain/schemas/boundary'
+import { AnalysisBlockerSchema } from '@talchain/schemas/boundary'
+
+import {
+  BLOCKED_REASON_COPY,
+  composeAnalysisBlockedReason,
+} from '../composeBlockedReason'
+import { vetBlockedReason } from '../vetBlockedReason'
+import {
+  isSafeCeeText,
+  guardCeeText,
+} from '../../components/pre-analysis-v3/signals/ceeTextGuard'
+
+// ═══════════════════════════════════════════════════════════════════════════
+// FIXTURES — PINNED TO THE CONTRACT, NOT TO THE AUTHOR'S MODEL OF IT.
+//
+// Trap 16-inverse: a fixture the author wrote is not evidence about the wire.
+// Every blocker below is `safeParse`d against the REAL `AnalysisBlockerSchema`
+// at construction, so a fixture outside the producer's admissible domain fails
+// loudly here instead of certifying the code over inputs that cannot arrive.
+// ═══════════════════════════════════════════════════════════════════════════
+
+function blocker(overrides: Partial<AnalysisBlocker> = {}): AnalysisBlocker {
+  const built = {
+    code: 'MISSING_OPTION_VALUE',
+    category: 'option_values',
+    message: 'Choose the missing effect value for "Launch in Q1".',
+    repairability: 'human_input_required',
+    option_id: 'opt_launch_q1',
+    option_label: 'Launch in Q1',
+    ...overrides,
+  }
+  const parsed = AnalysisBlockerSchema.safeParse(built)
+  if (!parsed.success) {
+    throw new Error(
+      `fixture is not a valid AnalysisBlocker: ${JSON.stringify(parsed.error.issues)}`,
+    )
+  }
+  return parsed.data
+}
+
+/** The five messages CEE actually ships, as captured in this repo's fixtures. */
+const CANONICAL_CEE_MESSAGES = [
+  'Choose the missing effect value for "Launch in Q1".',
+  'Choose the missing effect value.',
+  'Review the unresolved constraint for "Cut burn rate by 30%".',
+  'Review the unresolved constraint.',
+  'The option has no effect values.',
+] as const
+
+// ═══════════════════════════════════════════════════════════════════════════
+// A4 — THE MESSAGE REACHES THE USER.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('A4 — the producer message is rendered verbatim', () => {
+  it('VERBATIM — one blocker renders its own message, not a synthesised substitute', () => {
+    const message = 'Choose the missing effect value for "Launch in Q1" on "Revenue".'
+    // Precondition pinned IN-TEST (trap 13b): this payload must genuinely be
+    // one the vet admits, or a green result below could mean "the fixture
+    // stopped reproducing the case" rather than "the code is right".
+    expect(isSafeCeeText(message)).toBe(true)
+
+    const reason = composeAnalysisBlockedReason([
+      blocker({ code: 'MISSING_OPTION_VALUE', message }),
+    ])
+
+    expect(reason).toBe(message)
+    // …and the substitute is gone. Bound to the discarded rung by IDENTITY
+    // through the copy factory, never by a substring another rung could satisfy.
+    expect(reason).not.toBe(BLOCKED_REASON_COPY.canonicalOneBlocker('Launch in Q1'))
+    expect(reason).not.toContain('Ask in the chat')
+  })
+
+  it('IDENTITY — the message rendered is the one belonging to the named CODE, not to a position', () => {
+    // The discriminating case for trap 19. Two blockers, and the assertion is
+    // about WHICH message belongs to WHICH code — so an implementation that
+    // read `blockers[0]` for everything, or matched on a value predicate the
+    // other blocker also satisfies, cannot pass by coincidence.
+    const first = blocker({
+      code: 'MISSING_OPTION_VALUE',
+      message: 'Choose the missing effect value for "Launch in Q1".',
+      option_id: 'opt_launch_q1',
+      option_label: 'Launch in Q1',
+    })
+    const second = blocker({
+      code: 'AMBIGUOUS_OPTION_VALUE',
+      message: 'Confirm which effect value applies to "Hold until Q3".',
+      option_id: 'opt_hold',
+      option_label: 'Hold until Q3',
+    })
+
+    const byCode = (code: string, list: readonly AnalysisBlocker[]): string => {
+      const found = list.find((b) => b.code === code)
+      if (!found) throw new Error(`fixture lost the blocker coded ${code}`)
+      return found.message
+    }
+
+    const reason = composeAnalysisBlockedReason([first, second])
+
+    expect(reason).toContain(byCode('MISSING_OPTION_VALUE', [first, second]))
+    expect(reason).toContain(byCode('AMBIGUOUS_OPTION_VALUE', [first, second]))
+    // Order is the PRODUCER'S own array order — deterministic, and not ours to
+    // choose. Asserted as a whole string so a reordering REDs.
+    expect(reason).toBe(`${first.message} ${second.message}`)
+  })
+
+  it('ALL FIVE canonical CEE messages survive the vet and render verbatim', () => {
+    for (const message of CANONICAL_CEE_MESSAGES) {
+      // Verified here, not inherited from a prior sweep's claim.
+      expect(isSafeCeeText(message), `vet rejects: ${message}`).toBe(true)
+      expect(composeAnalysisBlockedReason([blocker({ message })])).toBe(message)
+    }
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// BOTH DIRECTIONS — a one-sided guard is the defect one level up.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('A4 — a message the render seam would corrupt is handled safely', () => {
+  const CORRUPTIBLE = 'Choose the missing effect value for "Move billing to edge computing".'
+
+  it('PRECONDITION — this message really is one the seam would rewrite', () => {
+    // Without this, the test below could pass because the message is harmless,
+    // not because the code declined it. Pins its own precondition, and pins the
+    // MEASURED corruption so a change to the guard REDs here rather than
+    // silently making this case vacuous.
+    expect(isSafeCeeText(CORRUPTIBLE)).toBe(false)
+    expect(guardCeeText(CORRUPTIBLE, 'FALLBACK').text).toBe(
+      'Choose the missing effect value for "Move billing to connection computing".',
+    )
+  })
+
+  it('DEGRADES WHOLE — never a rewritten label, never a partial mix', () => {
+    const reason = composeAnalysisBlockedReason([
+      blocker({ message: CORRUPTIBLE, option_label: 'Move billing to edge computing' }),
+    ])
+
+    // The user's own words are never rewritten…
+    expect(reason).not.toContain('connection computing')
+    // …and the producer's unsafe sentence is not rendered either.
+    expect(reason).not.toBe(CORRUPTIBLE)
+    // The answer is the structured rung: a LESS SPECIFIC TRUE claim, composed
+    // from the scope label. Bound by identity through the copy factory.
+    expect(reason).toBe(
+      BLOCKED_REASON_COPY.canonicalOneBlocker('Move billing to edge computing'),
+    )
+  })
+
+  it('ALL-OR-NOTHING — one unsafe message in a list degrades the WHOLE sentence', () => {
+    // Rendering only the safe half would understate the work outstanding by
+    // exactly the entries we declined — the A2 rule, inherited. And mixing the
+    // producer's prose with ours would attribute our sentence to the producer.
+    const safe = blocker({
+      code: 'MISSING_OPTION_VALUE',
+      message: 'Choose the missing effect value for "Launch in Q1".',
+    })
+    const unsafe = blocker({
+      code: 'AMBIGUOUS_OPTION_VALUE',
+      message: CORRUPTIBLE,
+      option_id: 'opt_billing',
+      option_label: 'Move billing to edge computing',
+    })
+
+    const reason = composeAnalysisBlockedReason([safe, unsafe])
+
+    expect(reason).not.toContain('connection computing')
+    expect(reason).not.toBe(safe.message)
+    expect(reason).toBe(
+      BLOCKED_REASON_COPY.canonicalTwoBlockers('Launch in Q1', 'Move billing to edge computing'),
+    )
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE ABSENT-MESSAGE FALLBACK — honest, never a fabricated sentence.
+//
+// SCOPE, STATED PRECISELY (trap 20): at this tip a blocker CANNOT reach the
+// composer without a non-empty `message`. All three writers of
+// `analysisStateV1` Zod-parse the payload first
+// (`v5/applyV5State.ts:1180`, `adapters/cee/scenarioGraph.ts:222` via
+// `hydrate/applyScenarioAnalysisRead.ts:241`, and
+// `hooks/useProvisionalAnalysisDelivery.ts:215` which only exposes the setter),
+// and `message` is `z.string().min(1)` REQUIRED on a `.strict()` schema — so an
+// absent or empty message fails the parse and CLEARS the verdict to null.
+//
+// These cases are therefore DEFENCE IN DEPTH for a function whose own docstring
+// promises to be total, not a claim that the wire can produce them. They are
+// here because the function is exported and its type is not a runtime guarantee.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('A4 — an unusable message falls back honestly, never to a fabrication', () => {
+  it('CONTRACT PRECONDITION — the schema really does refuse an empty message', () => {
+    // The derivation above, executed rather than asserted in a comment.
+    expect(AnalysisBlockerSchema.safeParse({
+      code: 'X', category: 'y', message: '', repairability: 'z',
+    }).success).toBe(false)
+    expect(AnalysisBlockerSchema.safeParse({
+      code: 'X', category: 'y', repairability: 'z',
+    }).success).toBe(false)
+  })
+
+  it('a blank message falls to the structured rung, not to a synthesised cause', () => {
+    // Constructed past the schema on purpose: this is the runtime shape the
+    // TYPE cannot exclude, which is the whole reason the guard exists.
+    const unusable = {
+      ...blocker(),
+      message: '   ',
+    } as AnalysisBlocker
+
+    const reason = composeAnalysisBlockedReason([unusable])
+
+    expect(reason).toBe(BLOCKED_REASON_COPY.canonicalOneBlocker('Launch in Q1'))
+  })
+
+  it('MIXED — one usable and one blank message degrades the WHOLE sentence', () => {
+    // ⭐ ADDED AFTER A SURVIVING MUTANT, and the gap is worth recording: every
+    // blank-message case above uses a SINGLE blocker, and with one blocker
+    // `return null` and `continue` produce the identical answer — so the
+    // all-or-nothing rule for BLANK messages was asserted nowhere. Changing
+    // `return null` to `continue` left the whole suite GREEN while the composer
+    // silently rendered only the usable half, understating the work outstanding
+    // by exactly the entry it dropped (the A2 rule this module inherited).
+    //
+    // This is the opposite-direction twin the unsafe-message case already had
+    // (`ALL-OR-NOTHING`) and the blank-message case did not. One direction
+    // tested is a guard watching one door.
+    const usable = blocker({
+      code: 'MISSING_OPTION_VALUE',
+      message: 'Choose the missing effect value for "Launch in Q1".',
+    })
+    const blank = {
+      ...blocker({ code: 'UNKNOWN_BLOCKER', option_id: 'opt_hold', option_label: 'Hold until Q3' }),
+      message: '   ',
+    } as AnalysisBlocker
+
+    const reason = composeAnalysisBlockedReason([usable, blank])
+
+    // NOT the usable half on its own — that is the silent understatement.
+    expect(reason).not.toBe(usable.message)
+    expect(reason).not.toContain('Choose the missing effect value')
+    // The honest answer names BOTH scopes through the structured rung.
+    expect(reason).toBe(
+      BLOCKED_REASON_COPY.canonicalTwoBlockers('Launch in Q1', 'Hold until Q3'),
+    )
+  })
+
+  it('a missing message on an UNSCOPED blocker falls to the count, claiming nothing more', () => {
+    const unusable = {
+      code: 'UNKNOWN', category: 'other', repairability: 'unknown',
+    } as unknown as AnalysisBlocker
+
+    const reason = composeAnalysisBlockedReason([unusable])
+
+    // No label to quote and no message to render: the honest answer names a
+    // COUNT and no cause at all.
+    expect(reason).toBe(BLOCKED_REASON_COPY.canonicalManyBlockers(1))
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE SEAM — the guard is a PROVEN IDENTITY, not an assumed one.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('A4 SEAM — what the composer emits survives the render path unchanged', () => {
+  it('vetBlockedReason returns every emitted producer message byte-for-byte', () => {
+    for (const message of CANONICAL_CEE_MESSAGES) {
+      const composed = composeAnalysisBlockedReason([blocker({ message })])
+      // The composer emitted it…
+      expect(composed).toBe(message)
+      // …and the ONE render seam hands it back untouched. This is the assertion
+      // that would RED if `guardCeeText` ever started substituting on text its
+      // own `isSafeCeeText` calls safe — i.e. it pins the coupling the fix
+      // relies on, rather than trusting today's implementation of it.
+      expect(vetBlockedReason(composed)).toBe(message)
+    }
+  })
+
+  it('EVERY emitted sentence survives the render seam unchanged, on BOTH arms', () => {
+    // Stated as the general property rather than as samples, so a future rung
+    // cannot pass by not being sampled.
+    //
+    // ⚠ THE TWO ARMS ARE NOT INTERCHANGEABLE, and asserting `isSafeCeeText` over
+    // all of them would be WRONG — it was, in this spec's first draft. A
+    // DEGRADED sentence may legitimately quote a user label carrying "edge"
+    // (`safeDisplayLabel` vets against the canonical glossary, which has no bare
+    // "edge"); it reaches the user through `classifyBlockedReason`'s
+    // `composed-safe` arm, which never consults `isSafeCeeText` at all. Only the
+    // PRODUCER-MESSAGE arm needs that predicate, because only it is classified
+    // `foreign` and routed through the substituting guard.
+    //
+    // So the shared property is the one that actually matters at the surface —
+    // the seam returns the string untouched — and the stricter per-arm claims
+    // are made separately below.
+    const emitted = [
+      ...CANONICAL_CEE_MESSAGES.map((m) => composeAnalysisBlockedReason([blocker({ message: m })])),
+      composeAnalysisBlockedReason([
+        blocker({ message: 'Choose the missing effect value for "Move billing to edge computing".' }),
+      ]),
+      composeAnalysisBlockedReason([]),
+    ]
+    for (const text of emitted) {
+      expect(vetBlockedReason(text), `seam altered: ${text}`).toBe(text)
+    }
+  })
+
+  it('DERIVED COUPLING — producer-authored output is a PROVEN identity under guardCeeText', () => {
+    // The coupling the fix rests on, asserted as the general property over
+    // everything the producer-message arm can emit — including a joined
+    // multi-blocker sentence, whose SEAMS are where a cross-boundary banned
+    // phrase would appear.
+    const producerAuthored = [
+      ...CANONICAL_CEE_MESSAGES.map((m) => composeAnalysisBlockedReason([blocker({ message: m })])),
+      composeAnalysisBlockedReason([
+        blocker({ code: 'A', message: CANONICAL_CEE_MESSAGES[0] }),
+        blocker({ code: 'B', message: CANONICAL_CEE_MESSAGES[2] }),
+      ]),
+    ]
+    for (const text of producerAuthored) {
+      expect(isSafeCeeText(text), `emitted sentence is not seam-safe: ${text}`).toBe(true)
+      const guarded = guardCeeText(text, 'FALLBACK')
+      expect(guarded.text).toBe(text)
+      expect(guarded.degraded).toBe(false)
+      expect(guarded.sanitised).toBe(false)
+    }
+  })
+
+  it('the JOIN is what gets vetted, not the parts — a phrase formed across the seam degrades', () => {
+    // A1's rule one level up: what is vetted must be exactly what ships. Two
+    // messages that are individually safe form "confidence score" across the
+    // space between them, which the canonical glossary bans as a phrase.
+    const left = 'Set the option confidence'
+    const right = 'score is missing for "Launch in Q1".'
+    // Precondition pinned in-test: each half must genuinely pass on its own, or
+    // this case proves nothing about the JOIN.
+    expect(isSafeCeeText(left)).toBe(true)
+    expect(isSafeCeeText(right)).toBe(true)
+    expect(isSafeCeeText(`${left} ${right}`)).toBe(false)
+
+    const reason = composeAnalysisBlockedReason([
+      blocker({ code: 'A', message: left, option_label: 'Launch in Q1' }),
+      blocker({ code: 'B', message: right, option_id: 'opt_hold', option_label: 'Hold until Q3' }),
+    ])
+
+    expect(reason).toBe(BLOCKED_REASON_COPY.canonicalTwoBlockers('Launch in Q1', 'Hold until Q3'))
+  })
+
+  it('an exactly-repeated message is rendered once, not twice', () => {
+    // The one list-level transformation. Every surviving sentence is
+    // byte-identical to a producer message; nothing is rewritten.
+    const message = 'Choose the missing effect value.'
+    const reason = composeAnalysisBlockedReason([
+      blocker({ code: 'A', message, option_id: 'opt_a', option_label: 'A' }),
+      blocker({ code: 'B', message, option_id: 'opt_b', option_label: 'B' }),
+    ])
+    expect(reason).toBe(message)
+  })
+})

--- a/src/canvas/utils/composeBlockedReason.ts
+++ b/src/canvas/utils/composeBlockedReason.ts
@@ -41,6 +41,7 @@ import {
   containsBannedTerm,
   safeInterpolatedLabel,
 } from '../../components/results/utils/glossaryCheck'
+import { isSafeCeeText } from '../components/pre-analysis-v3/signals/ceeTextGuard'
 
 /** An option CEE graded as not-yet-ready, with the label the user sees. */
 export interface OptionNeedingValues {
@@ -155,17 +156,44 @@ export const BLOCKED_REASON_COPY = {
    * sentence because it is the right SHAPE is how this module acquired the
    * false claims its header records.
    *
-   * ⚠ AND THEY DO NOT QUOTE `blocker.message`. That is producer PROSE, and this
-   * module's founding rule is that user-facing copy is composed from STRUCTURED
-   * fields, never derived from the engine's sentences — parsing or passing
-   * through prose is the same hand-maintained mirror in a new place. What is
-   * quoted is `option_label` / `factor_label`: the user's OWN words about their
-   * own decision, vetted by `safeDisplayLabel` exactly as the option rungs vet
-   * theirs.
+   * ⚠⚠ THESE ARE NOW THE FALLBACK, NOT THE FIRST ANSWER (A4, 24 Aug 2026).
    *
-   * The claim each one makes is deliberately thin — the element is not ready,
-   * and the chat can say what it needs. It is true for every blocker category
-   * the contract admits, which is what qualifies it to stand for all of them.
+   * This block used to read "AND THEY DO NOT QUOTE `blocker.message`. That is
+   * producer PROSE, and this module's founding rule is that user-facing copy is
+   * composed from STRUCTURED fields, never derived from the engine's sentences."
+   * That rule was written against `readiness.confidence_explanation` and CEE's
+   * old refusal line — UNTYPED prose with no contract behind it — and it was
+   * right about those. It is WRONG about `blocker.message`, and the module was
+   * standing in direct contradiction to the contract it imports:
+   *
+   *   `AnalysisBlockerSchema.message` (`@talchain/schemas/boundary` 0.48.0)
+   *   "The producer-authored, user-facing sentence for this blocker, rendered
+   *    VERBATIM. CEE owns all user-facing language; a consumer must not
+   *    rewrite, summarise, truncate for meaning, or SYNTHESISE A SUBSTITUTE
+   *    WHEN IT DISLIKES THE WORDING."
+   *
+   * `message` is not "the engine's prose" in the sense this module banned. It
+   * is a CONTRACTED, typed, `.min(1)` field whose whole declared purpose is to
+   * be rendered — the structured field for "what to say", exactly as
+   * `option_label` is the structured field for "what to call it". Refusing it
+   * was not caution; it was the consumer overriding the producer on the one
+   * question the contract assigns to the producer.
+   *
+   * And the substitute was ACTIVELY WRONG, which is what made this a defect
+   * rather than a preference: "Ask in the chat what it needs" names a remedy
+   * the user cannot perform. The typed readiness arm is gated on
+   * `isReadinessChipClick`, so TYPING in the chat does not reach it — the
+   * sentence points at a path only a chip opens. A dead end of exactly the kind
+   * POC-DONE's PC1 bans, printed in place of the producer's real instruction
+   * ("Choose the missing effect value for …"), which was in scope the whole
+   * time and was discarded.
+   *
+   * SO THE ORDER IS NOW: the producer's own sentences first (see
+   * `producerAuthoredReason`), and these rungs when — and only when — the
+   * producer's messages cannot be rendered as they were written. They keep
+   * their old job of being a LESS SPECIFIC TRUE CLAIM, which is the only thing
+   * this module ever allowed a degrade to be. Their thinness is what qualifies
+   * them for that: each is true for every blocker category the contract admits.
    */
   /** One blocker, scoped to an element we can quote by name. */
   canonicalOneBlocker: (label: string) =>
@@ -413,6 +441,82 @@ export function composeReadinessBlockedReason(
 }
 
 /**
+ * The producer's own repair guidance, ready to render — or `null` when it
+ * cannot ship as written.
+ *
+ * ── WHY THE VET IS `isSafeCeeText` AND NOT `containsBannedTerm` (MEASURED) ──
+ * `safeDisplayLabel` vets LABELS against the canonical glossary. That is the
+ * wrong instrument here, and the gap is not theoretical — it was measured at
+ * this tip before this function was written:
+ *
+ *   'Choose the missing effect value for "Move billing to edge computing".'
+ *     containsBannedTerm → false   (the canonical list carries no bare "edge")
+ *     isSafeCeeText      → false   (`CEE_EXTRA_TERMS` does)
+ *     guardCeeText(…)    → '…for "Move billing to connection computing".'
+ *
+ * A message admitted by the canonical glossary alone still reaches the render
+ * seam's SUBSTITUTING guard, and the user's own option label comes out as an
+ * option that exists on no canvas — the precise corruption `vetBlockedReason`'s
+ * header records, reproduced on the producer's sentence instead of on ours.
+ *
+ * ── AND THIS IS HOW THE GUARD IS BYPASSED — BY MAKING IT AN IDENTITY ────────
+ * `guardCeeText` returns its input UNCHANGED when `isSafeCeeText(text)` is true
+ * (`ceeTextGuard.ts:112`). So vetting with the seam's OWN predicate is not a
+ * route around the guard, it is a proof that the guard has nothing to do:
+ * everything this function returns passes through `vetBlockedReason`'s
+ * `foreign` arm byte-for-byte.
+ *
+ * That is deliberately preferred over threading a provenance flag from here to
+ * the render seam. The string reaches SIX surfaces — `PanelFooter`'s subline
+ * and its disabled control's `title`, `AnalysisReadinessBar`, the ⌘Enter toast
+ * (`PreAnalysisPanelV3:61`, which calls `guardCeeText` DIRECTLY and never sees
+ * `vetBlockedReason`), the legacy `StickyFooter`, `derivePostFooterMeta` and
+ * `getRunButtonAriaLabel` — and three of those render the string RAW with no
+ * guard at all. A provenance channel would have to reach every one of them, and
+ * a surface that forgot it would silently get the corrupting arm. Making the
+ * TEXT safe is the only answer that cannot be forgotten by a call site, and it
+ * also survives `canRunAnalysis`'s ` (+N more issues)` concatenation, which
+ * destroys any structure a channel could have carried.
+ *
+ * ── WHAT IS VETTED IS EXACTLY WHAT SHIPS (A1, one level up) ─────────────────
+ * The JOIN is vetted, not the parts. Two individually-safe messages can form a
+ * banned phrase across the seam between them ("…the confidence" + "score is…"),
+ * which is the same class as A1's truncate-then-vet finding: check the bytes
+ * that ship, not the bytes you started with.
+ *
+ * ── ALL OR NOTHING ─────────────────────────────────────────────────────────
+ * One unusable message degrades the WHOLE sentence to the scope rungs. Two
+ * reasons, both inherited: rendering the safe subset would understate the work
+ * outstanding by exactly the entries declined (A2's rule), and mixing the
+ * producer's prose with ours in one sentence attributes our words to the
+ * producer — the failure this module exists to end, with the authorship
+ * reversed.
+ *
+ * Order is the producer's own array order: deterministic, and not ours to
+ * choose. NOTHING is truncated and nothing is summarised — the contract forbids
+ * both, so a list too long for one line degrades whole rather than being cut.
+ * The single list-level transformation is EXACT de-duplication: every sentence
+ * returned is byte-identical to a message the producer wrote, no message is
+ * altered, and repeating one verbatim conveys nothing the first rendering did
+ * not while reading as a defect.
+ */
+function producerAuthoredReason(blockers: readonly AnalysisBlocker[]): string | null {
+  const sentences: string[] = []
+  for (const blocker of blockers) {
+    // The TYPE says `string` and the schema says `.min(1)`, but this function is
+    // exported and total: a type is not a runtime guarantee. An unusable message
+    // is a DEGRADE, never a synthesised stand-in for what the producer meant.
+    const message = typeof blocker.message === 'string' ? blocker.message.trim() : ''
+    if (message.length === 0) return null
+    if (!sentences.includes(message)) sentences.push(message)
+  }
+  if (sentences.length === 0) return null
+
+  const joined = sentences.join(' ')
+  return isSafeCeeText(joined) ? joined : null
+}
+
+/**
  * Compose the refusal from the PRODUCER's own readiness blockers.
  *
  * The counterpart to `composeReadinessBlockedReason`, for the authority that
@@ -427,12 +531,18 @@ export function composeReadinessBlockedReason(
  * The guard below returns the non-committal rung rather than inventing a cause,
  * but the real protection is `readinessObjectsToRun`, which never asks.
  *
- * Scope labels only, never `blocker.message`: see the rung docs above.
+ * ⭐ THE PRODUCER'S OWN SENTENCES FIRST (A4). `blocker.message` is contracted to
+ * be rendered VERBATIM; the scope-label rungs below are the DEGRADE, reached
+ * only when those sentences cannot ship as written. See `producerAuthoredReason`
+ * for the vet, and the rung docs above for why the old order was a defect.
  */
 export function composeAnalysisBlockedReason(
   blockers: readonly AnalysisBlocker[],
 ): string {
   if (blockers.length === 0) return BLOCKED_REASON_COPY.unspecified
+
+  const authored = producerAuthoredReason(blockers)
+  if (authored !== null) return authored
 
   // `option_label` and `factor_label` are the two scopes the contract carries.
   // Read in that order because an option is the more actionable of the two and


### PR DESCRIPTION
## The decision this changes

Whether a user with a non-analysable model gets **the producer's actual repair guidance**, or a synthesised substitute telling them to ask in a chat that cannot answer. Closes Core System A exit **A4**.

## The defect

`composeAnalysisBlockedReason` (`src/canvas/utils/composeBlockedReason.ts`) receives `readonly AnalysisBlocker[]` — every field in scope — and **deliberately discarded `blocker.message`**, returning instead:

> `"{label}" is not ready for analysis yet. Ask in the chat what it needs.`

**The pinned contract mandates the opposite.** `AnalysisBlockerSchema.message` (`@talchain/schemas/boundary` 0.48.0, `dist/boundary/analysis-state.js:104`, verified at the bytes):

> *"The producer-authored, user-facing sentence for this blocker, rendered VERBATIM. CEE owns all user-facing language; a consumer must not rewrite, summarise, truncate for meaning, or synthesise a substitute when it dislikes the wording."*

The module's own doctrine block said the opposite (`they do NOT quote blocker.message — that is producer PROSE`). Two authorities, never reconciled — and the module was the one contradicting the contract it imports. That rule was written against `readiness.confidence_explanation` and CEE's old refusal line, which are untyped prose with no contract behind them; it was right about those and wrong about `message`, which is a contracted, typed, `.min(1)` field whose declared purpose is to be rendered.

**And the substitute was actively wrong**: the typed readiness arm is gated on `isReadinessChipClick`, so *typing* in the chat does not reach it. The product named a remedy the user cannot perform, in place of the producer's real instruction (`Choose the missing effect value for "…".`).

## How `guardCeeText` is bypassed — by making it a proven identity

`guardCeeText` returns its input **unchanged** when `isSafeCeeText(text)` is true (`ceeTextGuard.ts:112`). So the compose-time vet uses the **render seam's own predicate** — not a route around the guard, but a proof that the guard has nothing to do.

**`containsBannedTerm` alone is not sufficient — measured at this tip before the fix was written:**

| message | `containsBannedTerm` | `isSafeCeeText` | `guardCeeText` output |
|---|---|---|---|
| `Choose the missing effect value for "Launch in Q1".` | false | **true** | *unchanged* |
| `Choose the missing effect value for "Move billing to edge computing".` | **false** | **false** | `…"Move billing to connection computing".` |

A message vetted only against the canonical glossary still reaches the substituting guard and has **the user's own option label rewritten into an option that exists on no canvas** — the exact corruption `vetBlockedReason`'s header records, reproduced on the producer's sentence. Mutant **M2** pins this choice.

All five canonical CEE messages in this repo's fixtures were re-verified (not inherited): all pass **both** predicates, so `guardCeeText` is identity on all five.

Preferred over threading a provenance flag because the string reaches **six surfaces**, three of which render it raw with no guard at all, and because `canRunAnalysis`'s ` (+N more issues)` concatenation destroys any structure a channel could have carried.

### The six surfaces

| # | Surface | Guarding |
|---|---|---|
| 1 | `PanelFooter.tsx:127` disabled control `title` | `gateBlockedSubline` → `vetBlockedReason` → `guardCeeText` |
| 2 | `readinessDisplay.ts:246` subline (PanelFooter **and** `AnalysisReadinessBar`) | same |
| 3 | `PreAnalysisPanelV3.tsx:61` ⌘Enter toast | `guardCeeText` **directly** — never sees `vetBlockedReason` |
| 4 | `pre-analysis/StickyFooter.tsx:129,146` | **raw**, no guard |
| 5 | `utils/postAnalysisFooter.ts:201` | **raw**, no guard |
| 6 | `canRunAnalysis.ts:795` `getRunButtonAriaLabel` | **raw**, no guard |

Measured separately: the ` (+N more issue/issues)` tail keeps the whole concatenated string seam-safe, so the producer's message survives the multi-reason path verbatim too.

## Policy

- All actionable blockers' messages, **verbatim**, in the **producer's own array order**.
- **Nothing truncated, nothing summarised** — the contract forbids both. A list too long for one line degrades whole rather than being cut.
- **The JOIN is vetted, not the parts** (A1's rule one level up: two individually-safe messages can form a banned phrase across the seam between them — pinned by a test).
- **All-or-nothing.** One unusable message degrades the *whole* sentence to the scope-label rungs. Rendering the safe subset would understate the work outstanding by exactly the entries declined (A2's rule), and mixing the producer's prose with ours attributes our words to the producer.
- Exact duplicates removed — the one list-level transformation; every surviving sentence is byte-identical to a producer message.

## The absent-message fallback

At this tip a blocker **cannot** reach the composer without a non-empty message. All three writers of `analysisStateV1` Zod-parse first — `v5/applyV5State.ts:1180`, `adapters/cee/scenarioGraph.ts:222` via `hydrate/applyScenarioAnalysisRead.ts:241`, and `hooks/useProvisionalAnalysisDelivery.ts:215` (which only exposes the setter) — and `message` is `z.string().min(1)` **required** on a `.strict()` schema, so an empty message fails the parse and clears the verdict to `null`.

The guard is therefore **defence in depth** for an exported, total function, not a claim the wire can produce it. It degrades to a structured claim; it never synthesises a cause.

## Evidence

- **RED-first**, at pristine: 4 failures, e.g. `VERBATIM — one blocker renders its own message, not a synthesised substitute`, `IDENTITY — the message rendered is the one belonging to the named CODE, not to a position`.
- **Mutants 6/6 as predicted**, in a worktree at an absolute path outside the repo root, isolation proven by **writing a sentinel** (source sha unchanged, worktree sha changed) and by distinct inodes; restored from a **pristine archive**, never `git checkout --`. Applied-check scoped to `src/`: control **exactly 0**, per-mutant exactly 1, final 0, trailing control green. Each RED mutant fails on a **different** assertion.
  - `M1 revert-the-fix` → RED · `M2 vet-with-canonical-glossary-only` → RED · `M3 vet-the-parts-not-the-join` → RED · `M4 render-only-the-first-message` → RED · `M5 drop-all-or-nothing` → RED · `M6 reword-the-degrade-rung` → **GREEN** (the adjacent partner: the producer-verbatim tests bind to the producer's message and to the copy factories, never to fallback copy).
  - ⭐ **M5 initially SURVIVED**, and that is recorded in the spec. Every blank-message case was single-blocker, where `return null` and `continue` are indistinguishable, so the all-or-nothing rule for *blank* messages was asserted nowhere — the unsafe-message case had its opposite-direction twin and the blank-message case did not. Test added (`MIXED — one usable and one blank message degrades the WHOLE sentence`); M5 now bites.
- **Mounted evidence**: `OutputsDock.canonicalReadinessWiring.spec.tsx` asserts the producer's sentence on the rendered `title` **DOM attribute**, through the real component tree and the real render seam.

## Blast radius

Two production callers (`canRunAnalysis.ts:718`, `usePreAnalysisModel.ts:456`); six surfaces above.

**Five** existing specs updated. Their fixtures carried placeholder messages (`'no effect values'`, `'The option has no effect values.'`) that ignored their own scope label — harmless while the composer discarded the message, but since A4 they would put a placeholder on the surface and assert it as the witnessed sentence. Messages reshaped to CEE's own spelling; discriminating pairs preserved; the witnessed sentence in `readinessSurvivesTabChange` is now **derived by running the production expression** rather than named by rung.

Complete manifest — every file constructing an `AnalysisBlocker` (discriminated by the required `repairability` field), 7 in total: 5 updated, and `crossSurfaceCoherence.{contractDerivation,pairs}` unaffected (schema-parse only, verified passing).

## Gate

`pnpm run lint` → 0 errors, hooks ratchet 229/13 exact. `pnpm run typecheck` → gate PASSED, ratchet **2252 = baseline**, coverage 3645/3685.

## Named limits

1. **Footer line length is unsettled — only a real browser can settle it.** A model with several blockers now renders several producer sentences joined. The footer was designed as one line (`MAX_LABEL_CHARS = 48` exists "so the footer stays one line"). Whether a long join wraps, clips or overflows is a CSS question no jsdom test can answer. The `title` tooltip and the raw surfaces are unaffected.
2. **The fix's *benefit* is contingent on CEE's message vocabulary, and nothing in this repo observes CEE.** If CEE reworded a message to contain `node`/`edge`/`graph`, this would silently degrade to the scope-label rung — fail-safe for honesty, but the A4 benefit would vanish with no red anywhere. The same limitation `canRunAnalysis`'s `ADVISORY_BLOCKER_CODES` header already records for the blocker vocabulary. A live capture or a CEE-side guard is the only detector.
3. **No wire witness.** All evidence here is repo-level and mounted-DOM-level. Nothing in this lane drove deployed staging.
4. ⚠ `Visual Regression (advisory)` is a standing red and this change alters rendered text — expect it. Not a blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
