### PR TITLE
feat(canvas): the Rerun affordance states the staleness verdict (A3 link 4)

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -171,7 +171,11 @@ import type { MappedRobustness } from '../../lib/mappers/types'
 import type { CritiqueItemV1 } from '../../adapters/plot/types'
 import { verboseDebug } from '../../utils/verboseLog'
 import { AnalysisFooter } from '../shared/AnalysisFooter'
-import { derivePostFooterStatus, derivePostFooterMeta } from './utils/postAnalysisFooter'
+import {
+  derivePostFooterStatus,
+  derivePostFooterMeta,
+  deriveRerunActionLabel,
+} from './utils/postAnalysisFooter'
 import { useGraphReadiness } from '../hooks/useGraphReadiness'
 import {
   selectAnalysisReadinessAuthority,
@@ -973,7 +977,13 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   // Byte-identical when CEE states no verdict: the selector's derived branch IS
   // `resolveDisplayedFreshness` over the same two store fields (plus the orphan
   // fold the strip already applied).
-  const displayedFreshness = useAnalysisState().displayedFreshness
+  // ⭐ ONE CALL, THREE MEMBERS (A3 link 4). `requiresRerun` and `semantic` join
+  // `displayedFreshness` on the SAME composition — the rerun affordance's label
+  // therefore cannot disagree with the strip above it, because neither of them
+  // derives the fact. `requiresRerun` had NO product reader before this: CEE
+  // composed its verdict on every turn and nothing consumed it.
+  const composedAnalysisState = useAnalysisState()
+  const displayedFreshness = composedAnalysisState.displayedFreshness
   const analysisNotConfirmedFresh = displayedFreshness === 'stale' || displayedFreshness === 'unknown'
   // Brief step 6 — the composed run state that decides WHICH truth-state
   // banner this surface may render. It derives nothing new: it maps the
@@ -3368,7 +3378,18 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                     statusText={postRunFooter.label}
                     metaText={postRunMetaText}
                     metaPlacement="stacked"
-                    actionLabel={isRunning ? 'Running analysis…' : 'Rerun'}
+                    // ⭐ A3 LINK 4 — the affordance states the staleness verdict
+                    // instead of the hardcoded 'Rerun' that stood here. The
+                    // label is ALSO the accessible name (`AnalysisFooter`
+                    // leaves `actionAriaLabel` unset). It MARKS, it does not
+                    // gate: `actionDisabled` below is untouched, because a
+                    // stale analysis is rerunnable and disabling the one
+                    // control that fixes it would be a worse lie than silence.
+                    actionLabel={deriveRerunActionLabel({
+                      isRunning,
+                      requiresRerun: composedAnalysisState.requiresRerun,
+                      semantic: composedAnalysisState.semantic,
+                    })}
                     actionVariant="secondary"
                     onAction={handleRunAnalysis}
                     actionDisabled={isRunning || !canRunAnalysis}

--- a/src/canvas/components/__tests__/OutputsDock.rerunAffordanceStaleness.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.rerunAffordanceStaleness.spec.tsx
@@ -1,0 +1,357 @@
+/**
+ * THE RERUN AFFORDANCE STATES THE STALENESS VERDICT (Core System A, exit A3,
+ * link 4).
+ *
+ * THE DEFECT THIS PINS
+ * --------------------
+ * The run affordance never consulted freshness at all. `canRunAnalysisUtil`
+ * takes ten inputs at `OutputsDock.tsx` and none of them is freshness, and the
+ * footer's action label was the hardcoded literal `'Rerun'`. So a user could
+ * edit their model, make the analysis stale, and the one control that would fix
+ * it said nothing — while CEE's own answer sat composed at
+ * `analysisStateSelector.ts:697` (`requiresRerun`) and was READ BY NOTHING
+ * (measured at `9cd7778a`: 4 occurrences repo-wide, all inside the selector and
+ * its specs; contrast controls `displayedFreshness` = 50, `canRunAnalysis` = 53
+ * files, so the sweep was not blind).
+ *
+ * ⚠ THE SCOPE OF THE CLAIM, STATED NARROWLY. The Analysis tab is NOT silent
+ * about staleness overall — `AnalysisFreshnessNotice` states it in prose, and
+ * `TRUTH_BANNER_BY_RUN_STATE` routes `complete_stale` / `unknown_degraded` to
+ * it. What was silent is the AFFORDANCE: the control the user actually presses,
+ * sitting in a footer whose own status slot is derived PURELY from
+ * `robustnessVerdict` (`derivePostFooterStatus` takes no freshness input at
+ * all), so a stale analysis could render a green ✓ "Stable ranking" beside an
+ * unqualified "Rerun". This file pins the affordance, and claims nothing about
+ * the strip.
+ *
+ * BOTH DIRECTIONS, AND WHY THAT IS THE WHOLE POINT
+ * ------------------------------------------------
+ * A one-sided guard that marked everything would convert today's silence into a
+ * permanent false alarm, which is worse — users learn to ignore a warning that
+ * is always on. So `genuinely current renders as current` (an unqualified
+ * "Rerun") is pinned as hard as the stale arms, and a mutant that widens the
+ * qualifier to every state must RED here.
+ *
+ * `'model changed'` IS A POSITIVE CLAIM AND IS MINTED ONLY FROM `'changed'`
+ * ------------------------------------------------------------------------
+ * `classifyFreshnessForDisplay`'s own rule — "'changed' must never be claimed
+ * for a CEE-sourced 'unknown'" — applies to this surface too. A local edit
+ * downgrades a retained `fresh` to `unknown` (never to `stale`), so the EDIT
+ * case honestly reads "can't confirm current"; only a CEE-stated `stale` earns
+ * "model changed". Both arms are pinned, and the pair is what stops the fix
+ * fabricating a change the producer never stated.
+ *
+ * Scaffolding mirrors `OutputsDock.rerunSingleOwner.spec.tsx` (real ResultsBody,
+ * stable useConversation stub, aiPanelV2 OFF).
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+import { OutputsDock } from '../OutputsDock'
+import { useCanvasStore } from '../../store'
+
+const { mockIsV5CanonicalAnalysisEnabled } = vi.hoisted(() => ({
+  mockIsV5CanonicalAnalysisEnabled: vi.fn(() => false),
+}))
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) }
+})
+
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isTelemetryEnabled: () => false,
+    isCompareEnabled: () => true,
+    isOrchestratorV2Enabled: () => true,
+    isLegacyDirectRunEnabled: () => false,
+    isJourneyTabEnabled: () => false,
+    isAiPanelV2Enabled: () => false,
+    isV5CanonicalAnalysisEnabled: mockIsV5CanonicalAnalysisEnabled,
+  }
+})
+
+vi.mock('../../conversation/useConversation', () => ({
+  useConversation: () => ({
+    messages: [],
+    isThinking: false,
+    longRunningHint: null,
+    sendMessage: vi.fn(),
+    sendSystemEvent: vi.fn(),
+    sendChip: vi.fn(),
+    retryLast: vi.fn(),
+    patchBlockStates: new Map(),
+    setPatchBlockState: vi.fn(),
+    patchRejections: new Map(),
+    setPatchRejection: vi.fn(),
+  }),
+}))
+
+vi.mock('../pre-analysis', () => ({ PreAnalysisPanel: () => null }))
+
+vi.mock('../../hooks/useGraphReadiness', () => ({
+  useGraphReadiness: () => ({ readiness: { state: 'ready' } }),
+}))
+
+vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
+  useStageAwarePlaceholder: () => 'Describe your decision…',
+}))
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+
+const fakeReport: Record<string, unknown> = {
+  results: { conservative: 10, likely: 20, optimistic: 30, units: 'percent', unitSymbol: '%' },
+  run: { bands: { p10: 10, p50: 20, p90: 30 } },
+  robustness: { recommendation_stability: 0.87 },
+}
+
+function seedPostRun(overrides: Record<string, unknown> = {}) {
+  useCanvasStore.setState({
+    currentScenarioFraming: null,
+    currentScenarioLastResultHash: null,
+    hasCompletedFirstRun: true,
+    nodes: [
+      { id: 'goal-1', type: 'goal', data: { label: 'Goal', kind: 'goal' }, position: { x: 0, y: 0 } },
+      { id: 'opt-a', type: 'option', data: { label: 'Option A', kind: 'option' }, position: { x: 50, y: 0 } },
+      { id: 'factor-1', type: 'factor', data: { label: 'Factor', kind: 'factor' }, position: { x: 100, y: 0 } },
+    ],
+    edges: [{ id: 'e1', source: 'factor-1', target: 'goal-1', data: { weight: 0.7, direction: 'positive' } }],
+    graphHealth: { status: 'healthy', score: 100, issues: [] },
+    results: { status: 'complete', report: fakeReport },
+    analysisFreshness: null,
+    analysisFreshnessDirty: false,
+    analysisStateV1: null,
+    v5AnalysisFact: null,
+    showDraftChat: false,
+    ...overrides,
+  } as never)
+}
+
+/**
+ * A wire verdict. `kind` and `requires_rerun` are the two members under test;
+ * every other field is the neutral filler this repo's other specs already use.
+ */
+function wireState(
+  kind: AnalysisStateV1['run_state']['kind'],
+  requiresRerun: boolean,
+): AnalysisStateV1 {
+  return {
+    run_state: { kind },
+    readiness: { status: 'ready', blockers: [] },
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: true,
+    usable_for_chips: true,
+    usable_for_followup: true,
+    requires_rerun: requiresRerun,
+    blocked_unusable: false,
+    contradictions: [],
+  } as AnalysisStateV1
+}
+
+/**
+ * THE AFFORDANCE, BOUND BY IDENTITY.
+ *
+ * Role + accessible name, never `getAllByRole(...)[n]`. `AnalysisFooter` leaves
+ * `actionAriaLabel` unset, so `aria-label={actionAriaLabel ?? actionLabel}`
+ * makes the accessible name EQUAL the visible label — which is itself the
+ * property worth having, and why this helper does not read `textContent`.
+ *
+ * The name regex is deliberately loose (`/^Rerun/`) so this helper finds the
+ * button in EVERY arm — including the arms where it is unqualified. A helper
+ * that could only find the qualified button would make the
+ * `genuinely-current` assertion vacuous by construction.
+ */
+function rerunAffordance(): HTMLElement {
+  return screen.getByRole('button', { name: /^Rerun/ })
+}
+
+describe('OutputsDock — the Rerun affordance states the staleness verdict', () => {
+  beforeEach(() => {
+    ensureMatchMedia()
+    try {
+      sessionStorage.clear()
+    } catch {
+      /* jsdom quirk — never block the suite */
+    }
+    mockIsV5CanonicalAnalysisEnabled.mockReturnValue(false)
+  })
+
+  // ── DIRECTION 1: STALE RENDERS AS STALE ────────────────────────────────────
+
+  it('CEE-stated stale (derived branch): the affordance names the change', () => {
+    seedPostRun({ analysisFreshness: { freshness: 'stale', computedAt: 1 } })
+    render(<OutputsDock />)
+
+    // Precondition pinned IN-TEST: the payload really is in the stale state, so
+    // a pass cannot come from the fixture silently failing to reproduce it.
+    expect(screen.getByTestId('analysis-freshness-notice')).toHaveAttribute('data-freshness', 'stale')
+
+    expect(rerunAffordance()).toHaveAccessibleName('Rerun — model changed')
+  })
+
+  it('EDITED SINCE RUN (the brief\'s case): a retained fresh + local dirty overlay NAMES THE CHANGE', () => {
+    // ⚠ THIS EXPECTATION WAS WRONG WHEN FIRST WRITTEN, AND THE CORRECTION IS
+    // THE POINT. It asserted cannot-confirm, reasoning that a local edit must
+    // not mint the positive claim. Measured: the composition returns
+    // `'changed'`, and the CODE IS RIGHT — the expectation had been written
+    // from this author's reading rather than from the producer's declared
+    // semantics (trap 13c: a perfect score against a wrong oracle).
+    //
+    // Derived at `store/analysisFreshness.ts`, `classifyFreshnessForDisplay`:
+    // `displayed === 'unknown'` + `dirty` + (`freshness === 'fresh'` OR
+    // `freshnessReason === VERDICT_ABSENT_FROM_PAYLOAD`) → `'changed'`, because
+    // the dirty overlay IS "the UI's own first-hand knowledge that an
+    // analysis-affecting edit happened". The user edited; the model changed; we
+    // know it first-hand and do not need CEE to say so.
+    //
+    // ⭐ NOTE THE TWO MEMBERS DISAGREEING CORRECTLY, which is what validates
+    // reading BOTH rather than one. `displayedFreshness` stays `'unknown'` —
+    // it must never fabricate a CEE `'stale'` verdict — while `semantic` says
+    // `'changed'`. Different questions, different answers, both true. Had this
+    // surface taken its wording from `displayedFreshness` alone it would say
+    // "can't confirm current" for an edit, which is WEAKER THAN THE TRUTH.
+    seedPostRun({
+      analysisFreshness: { freshness: 'fresh', freshnessReason: 'graph_hash_match', computedAt: 1 },
+      analysisFreshnessDirty: true,
+    })
+    render(<OutputsDock />)
+
+    // Precondition pinned in-test: the strip is on the cannot-confirm VALUE…
+    expect(screen.getByTestId('analysis-freshness-notice')).toHaveAttribute('data-freshness', 'unknown')
+    // …while the affordance makes the stronger, first-hand TRUE claim.
+    expect(rerunAffordance()).toHaveAccessibleName('Rerun — model changed')
+  })
+
+  it('CEE-STATED unknown (no local edit): cannot-confirm — never dressed up as "you edited"', () => {
+    // The genuine cannot-confirm arm on the derived branch. `analysisFreshness.ts`
+    // is explicit that a CEE-stated `'unknown'`, the orphan synthesis and the
+    // run-completion write "must never be dressed up as a factual 'you edited'
+    // claim". Without this arm the suite would contain no derived-branch
+    // cannot-confirm case at all, and a mutant collapsing the two labels into
+    // one would survive.
+    seedPostRun({
+      analysisFreshness: { freshness: 'unknown', computedAt: 1 },
+      analysisFreshnessDirty: false,
+    })
+    render(<OutputsDock />)
+
+    expect(screen.getByTestId('analysis-freshness-notice')).toHaveAttribute('data-freshness', 'unknown')
+    const action = rerunAffordance()
+    expect(action).toHaveAccessibleName("Rerun — can't confirm current")
+    expect(action).not.toHaveAccessibleName('Rerun — model changed')
+  })
+
+  it('wire branch: run_state complete_stale + requires_rerun names the change', () => {
+    seedPostRun({ analysisStateV1: wireState('complete_stale', true) })
+    render(<OutputsDock />)
+
+    expect(rerunAffordance()).toHaveAccessibleName('Rerun — model changed')
+  })
+
+  it('wire branch: unknown_degraded is cannot-confirm — an unrecognised state never earns the positive claim', () => {
+    seedPostRun({ analysisStateV1: wireState('unknown_degraded', true) })
+    render(<OutputsDock />)
+
+    expect(rerunAffordance()).toHaveAccessibleName("Rerun — can't confirm current")
+  })
+
+  // ── DIRECTION 2: GENUINELY CURRENT RENDERS AS CURRENT ──────────────────────
+  //
+  // The other half of the guard. Without these, widening the qualifier to every
+  // state would pass, and the fix would be a permanent false alarm.
+
+  it('genuinely current (derived branch): the affordance is UNQUALIFIED', () => {
+    seedPostRun({
+      analysisFreshness: { freshness: 'fresh', freshnessReason: 'graph_hash_match', computedAt: 1 },
+      analysisFreshnessDirty: false,
+    })
+    render(<OutputsDock />)
+
+    expect(screen.getByTestId('analysis-freshness-notice')).toHaveAttribute('data-freshness', 'fresh')
+    expect(rerunAffordance()).toHaveAccessibleName('Rerun')
+  })
+
+  it('genuinely current (wire branch): complete_current + requires_rerun false is UNQUALIFIED', () => {
+    seedPostRun({ analysisStateV1: wireState('complete_current', false) })
+    render(<OutputsDock />)
+
+    expect(rerunAffordance()).toHaveAccessibleName('Rerun')
+  })
+
+  // ── THE ABSENCE CELL, DECIDED AND DISCLOSED ────────────────────────────────
+
+  it('no verdict at all: the affordance is UNQUALIFIED — silence, never a currency claim', () => {
+    // `analysisStateV1` is CLEAR-ON-ABSENCE, so this cell is routine mid-journey
+    // (CEE omits `analysis_state` on most `sendFinalised200` exits). The base
+    // label asserts NOTHING about currency, so the demotion costs a warning it
+    // could not justify — it never manufactures a false all-clear.
+    seedPostRun({ analysisFreshness: null, analysisStateV1: null })
+    render(<OutputsDock />)
+
+    expect(rerunAffordance()).toHaveAccessibleName('Rerun')
+  })
+
+  // ── THE AFFORDANCE IS NEVER BLOCKED BY STALENESS ───────────────────────────
+
+  it('staleness MARKS the affordance and never GATES it — enabledness is identical across the freshness axis', () => {
+    // ⚠ THIS ASSERTION WAS ALSO WRONG WHEN FIRST WRITTEN, in an instructive
+    // way. It asserted `toBeEnabled()` outright and FAILED — but not because
+    // staleness gated anything: this fixture's readiness verdict disables the
+    // button for an entirely unrelated reason ("Olumi needs something more from
+    // this model before the next analysis"). Asserting an absolute enabled
+    // state made the test a hostage to the READINESS axis, which this lane does
+    // not touch and must not claim anything about.
+    //
+    // The claim that is actually this lane's to make is a DIFFERENCE, not a
+    // level: moving along the freshness axis must not move enabledness. That is
+    // testable whatever readiness says, and it is the invariant that would
+    // break if someone later re-attached a lock to the staleness verdict.
+    const disabledUnder = (freshness: 'stale' | 'fresh') => {
+      seedPostRun({ analysisFreshness: { freshness, computedAt: 1 } })
+      const { unmount } = render(<OutputsDock />)
+      const action = rerunAffordance()
+      const state = {
+        name: action.getAttribute('aria-label'),
+        disabled: (action as HTMLButtonElement).disabled,
+        ariaDisabled: action.getAttribute('aria-disabled'),
+      }
+      unmount()
+      return state
+    }
+
+    const stale = disabledUnder('stale')
+    const fresh = disabledUnder('fresh')
+
+    // The pin is not vacuous: the two arms really are different states — if the
+    // label were identical the comparison below would hold for the wrong reason.
+    expect(stale.name).toBe('Rerun — model changed')
+    expect(fresh.name).toBe('Rerun')
+
+    // …and the enabledness is UNMOVED by that difference. Disabling the one
+    // control that fixes staleness would be a worse lie than the silence this
+    // lane removed.
+    expect(stale.disabled).toBe(fresh.disabled)
+    expect(stale.ariaDisabled).toBe(fresh.ariaDisabled)
+  })
+})

--- a/src/canvas/components/__tests__/OutputsDock.rerunAffordanceStaleness.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.rerunAffordanceStaleness.spec.tsx
@@ -93,8 +93,28 @@ vi.mock('../../conversation/useConversation', () => ({
 
 vi.mock('../pre-analysis', () => ({ PreAnalysisPanel: () => null }))
 
+// ⭐ A RUNNABLE READINESS VERDICT, AND IT IS LOAD-BEARING.
+//
+// The neighbouring specs mock this as `{ readiness: { state: 'ready' } }`,
+// which does NOT open the gate: `canRunAnalysis`'s side-car rung reads
+// `!readiness.can_run_analysis`, and `undefined` refuses. Under that mock the
+// footer's button is ALREADY disabled in every arm, for a readiness reason this
+// lane does not touch.
+//
+// That mattered. The first cut of the "marks, never gates" test below compared
+// enabledness across the freshness axis under that mock and PASSED — then a
+// mutant that re-attached `requiresRerun` to `actionDisabled` ALSO passed,
+// because both arms were disabled either way. The comparison held for the wrong
+// reason: a guard agreeing with itself (trap 13b). The gate must be OPEN for
+// "staleness does not close it" to be a claim about anything at all.
 vi.mock('../../hooks/useGraphReadiness', () => ({
-  useGraphReadiness: () => ({ readiness: { state: 'ready' } }),
+  useGraphReadiness: () => ({
+    readiness: { can_run_analysis: true, blockers: [], state: 'ready' },
+    stale: false,
+    verdictAtMs: 1,
+    error: null,
+    refresh: vi.fn(),
+  }),
 }))
 
 vi.mock('../../hooks/useStageAwarePlaceholder', () => ({
@@ -343,14 +363,23 @@ describe('OutputsDock — the Rerun affordance states the staleness verdict', ()
     const stale = disabledUnder('stale')
     const fresh = disabledUnder('fresh')
 
-    // The pin is not vacuous: the two arms really are different states — if the
-    // label were identical the comparison below would hold for the wrong reason.
+    // PRECONDITION 1 — the two arms really are different states. Without this
+    // the comparison below could hold because nothing moved at all.
     expect(stale.name).toBe('Rerun — model changed')
     expect(fresh.name).toBe('Rerun')
 
-    // …and the enabledness is UNMOVED by that difference. Disabling the one
-    // control that fixes staleness would be a worse lie than the silence this
-    // lane removed.
+    // ⭐ PRECONDITION 2 — THE GATE IS OPEN. This is the assertion whose absence
+    // made the first cut of this test vacuous, proven by a surviving mutant:
+    // with the gate shut, "enabledness is identical" holds trivially because
+    // BOTH arms are disabled, and re-attaching a staleness lock changes
+    // nothing observable. Asserting the affordance is genuinely ENABLED is what
+    // gives the equality below its discriminating power.
+    expect(fresh.disabled).toBe(false)
+    expect(stale.disabled).toBe(false)
+
+    // …and the enabledness is UNMOVED by the freshness difference. Disabling
+    // the one control that fixes staleness would be a worse lie than the
+    // silence this lane removed.
     expect(stale.disabled).toBe(fresh.disabled)
     expect(stale.ariaDisabled).toBe(fresh.ariaDisabled)
   })

--- a/src/canvas/components/utils/postAnalysisFooter.ts
+++ b/src/canvas/components/utils/postAnalysisFooter.ts
@@ -60,6 +60,7 @@
 
 import type { RobustnessDisplayVerdict } from '@/components/results/types'
 import { everyEvidenceGapAddressed } from '@/components/results/utils/evidenceGapConfidenceDisplay'
+import type { FreshnessDisplaySemantic } from '@/canvas/store/analysisFreshness'
 
 export type PostFooterIcon = 'check' | 'warning' | 'unknown'
 
@@ -211,4 +212,135 @@ export function derivePostFooterMeta({
   }
   if (evidenceText) parts.push(evidenceText)
   return parts.length > 0 ? parts.join(' · ') : null
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE RERUN AFFORDANCE'S LABEL (Core System A, exit A3, link 4).
+//
+// ⭐ WHAT WAS BROKEN. The run affordance never consulted freshness at ALL.
+// `canRunAnalysis` takes ten inputs and none of them is freshness; this
+// footer's action label was the literal `'Rerun'`; and this file's OWN status
+// half (`derivePostFooterStatus`) is a pure function of `robustnessVerdict`,
+// so it cannot speak about currency either. A user edited their model, the
+// analysis went stale, and the footer could render a green ✓ "Stable ranking"
+// beside an unqualified "Rerun" — while CEE's own answer sat composed at
+// `analysisStateSelector.ts` (`requiresRerun`) and was read by NOTHING.
+//
+// ⭐ THIS IS NOT A SEVENTH STALENESS COMPUTATION, and that distinction is the
+// whole design. The estate already carries six, three of which can disagree on
+// screen; adding one would BE the defect. This function DERIVES NOTHING about
+// freshness. It takes two members that `useAnalysisState()` has already
+// composed and maps them to a string. It reads no store slice, applies no
+// predicate to a graph hash, and cannot disagree with the strip above it,
+// because both bottom out in the same selector.
+//
+// ⚠ TWO MEMBERS, TWO QUESTIONS — NAMED APART ON PURPOSE (trap 21).
+//   · `requiresRerun` answers *"would a rerun move this user forward?"* It is
+//     the GATE: it alone decides whether the label is qualified at all. Under
+//     the wire branch it is CEE's own `requires_rerun`; under the derived
+//     branch it is the affordance rule the UI has always applied.
+//   · `semantic` answers *"what may I SAY about this result's currency?"* It is
+//     the WORDING only, and it is never allowed to re-open the gate.
+// The estate's chronic defect is two authorities silently answering different
+// questions under similar names. Here they answer different questions ON
+// PURPOSE, the split is stated, and the disagreement cell is decided below
+// rather than left to whichever happens to be read first.
+//
+// ⚠ `'model changed'` IS A POSITIVE CLAIM AND IS MINTED ONLY FROM `'changed'`.
+// `classifyFreshnessForDisplay`'s rule — "'changed' must never be claimed for a
+// CEE-sourced 'unknown'" — binds this surface too. So the DISAGREEMENT CELL
+// (`requiresRerun` true while `semantic` is `'current'` / `'none'`, reachable
+// when CEE sets `requires_rerun` on a `complete_current` run) falls to the
+// WEAKER cannot-confirm wording, never to the change claim. Degrading toward
+// the claim we can defend is the only safe direction: an unrecognised state is
+// precisely when the product has least right to assert what happened.
+//
+// ⚠ THE ABSENCE CELL, DECIDED AND DISCLOSED. `analysisStateV1` is
+// CLEAR-ON-ABSENCE while `analysisFreshness` is RETAIN-ON-ABSENCE, so a turn
+// carrying no `analysis_state` demotes this reader back to the retained legacy
+// verdict — and a retained `fresh` therefore yields the UNQUALIFIED label. That
+// is honest ONLY because the unqualified label asserts NOTHING about currency:
+// the demotion costs a warning we can no longer justify, and never manufactures
+// a false all-clear. Unknown does not render as current — it renders as
+// cannot-confirm, and `'none'` (nothing has run) renders as neither.
+//   And note what SURVIVES the demotion: the local dirty overlay is retained,
+//   so an edit-since-run still downgrades `fresh` → `unknown` → `cannot_confirm`
+//   → `requiresRerun`. The brief's own case — the user edited their model — is
+//   therefore marked even on a silent turn. Pinned in
+//   `OutputsDock.rerunAffordanceStaleness.spec.tsx`.
+//
+// ⛔ IT MARKS, IT NEVER GATES. Nothing here touches `actionDisabled`. A stale
+// analysis is RERUNNABLE, and disabling the one control that fixes staleness
+// would be a worse lie than the silence this replaced.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Label shown while a run is in flight. Unchanged — the run states itself. */
+export const RERUN_LABEL_RUNNING = 'Running analysis…'
+/** The unqualified label. Asserts nothing about currency, deliberately. */
+export const RERUN_LABEL_PLAIN = 'Rerun'
+/** The POSITIVE claim. Only a stated `'changed'` earns it. */
+export const RERUN_LABEL_CHANGED = 'Rerun — model changed'
+/** The weaker, always-defensible claim. Every other rerun-required state. */
+export const RERUN_LABEL_CANNOT_CONFIRM = "Rerun — can't confirm current"
+
+export interface RerunActionLabelInput {
+  /** A run in flight states itself and outranks every currency statement. */
+  isRunning: boolean
+  /**
+   * `useAnalysisState().requiresRerun` — THE GATE. Producer-composed; never
+   * re-derived here.
+   */
+  requiresRerun: boolean
+  /**
+   * `useAnalysisState().semantic` — THE WORDING ONLY. Never re-opens the gate.
+   */
+  semantic: FreshnessDisplaySemantic
+}
+
+/**
+ * The rerun affordance's label, which is ALSO its accessible name —
+ * `AnalysisFooter` leaves `actionAriaLabel` unset, so
+ * `aria-label={actionAriaLabel ?? actionLabel}` keeps the two identical. That
+ * is a property worth keeping: a button whose visible text and accessible name
+ * make different claims is the same divergence one layer down.
+ *
+ * Pure and total, so it is mutation-testable without a store.
+ */
+export function deriveRerunActionLabel({
+  isRunning,
+  requiresRerun,
+  semantic,
+}: RerunActionLabelInput): string {
+  // A run in flight is a run in flight, whatever the currency verdict says —
+  // the same precedence `useAnalysisRunState` applies one level up. Stating
+  // staleness over a run that is already fixing it would be noise.
+  if (isRunning) return RERUN_LABEL_RUNNING
+
+  // THE GATE. Not stale, or nothing to rerun for → say nothing about currency.
+  if (!requiresRerun) return RERUN_LABEL_PLAIN
+
+  // THE WORDING. Only a stated change earns the change claim.
+  switch (semantic) {
+    case 'changed':
+      return RERUN_LABEL_CHANGED
+    case 'cannot_confirm':
+      return RERUN_LABEL_CANNOT_CONFIRM
+    // ⚠ THE DISAGREEMENT CELL. `requiresRerun` says a rerun would help while
+    // the copy classification has no change to report. Both are true
+    // statements about different questions; the honest resolution is the
+    // weaker claim, never silence (the gate did fire) and never the positive
+    // one (nothing stated a change).
+    case 'current':
+    case 'none':
+      return RERUN_LABEL_CANNOT_CONFIRM
+    default: {
+      // RUNTIME FLOOR + COMPILE-TIME EXHAUSTIVENESS, the pair this repo uses
+      // wherever a producer enum can outgrow its pin. A semantic this build
+      // does not recognise degrades to cannot-confirm — never to a completion
+      // claim, and never to the change claim.
+      const unhandled: never = semantic
+      void unhandled
+      return RERUN_LABEL_CANNOT_CONFIRM
+    }
+  }
 }


### PR DESCRIPTION
## The decision this changes

Whether the Run/Rerun affordance tells the user their edit made the analysis stale. It now does.

## The defect, derived at `9cd7778a`

**The run affordance never consulted freshness at all.** `canRunAnalysisUtil` takes ten inputs at `OutputsDock.tsx` and none of them is freshness; the footer's action label was the hardcoded literal `'Rerun'`.

**And CEE already sent the verdict.** `analysisStateSelector.ts:697` composes `requiresRerun` — with **zero product readers**. Measured: 4 occurrences repo-wide, all inside the selector and its own specs. Contrast controls in the same sweep: `displayedFreshness` = 50 hits, `canRunAnalysis` = 53 files. The sweep was not blind; the absence was real.

**Worse than silence, in one reachable state.** This footer's status half (`derivePostFooterStatus`) is a pure function of `robustnessVerdict` and takes no freshness input, so a stale analysis could render a green ✓ **"Stable ranking"** beside an unqualified **"Rerun"**.

### Scope of the claim, stated narrowly

The Analysis tab is **not** silent about staleness overall — `AnalysisFreshnessNotice` states it in prose and `TRUTH_BANNER_BY_RUN_STATE` routes `complete_stale` / `unknown_degraded` to it. What was silent is the **affordance**: the control the user actually presses. This PR changes the affordance and claims nothing about the strip.

## Which verdict is consumed, and why it is not a seventh computation

`useAnalysisState()` — the intended gate. **`OutputsDock` already called it** (`:976` for `displayedFreshness`), so `requiresRerun` and `semantic` join it on the **same composition**: no new hook, no new store subscription, no new predicate over graph state. The label therefore *cannot* disagree with the strip above it, because neither of them derives the fact.

Two members, two questions, named apart on purpose (trap 21):

- **`requiresRerun` is the GATE** — *"would a rerun move this user forward?"* It alone decides whether the label is qualified.
- **`semantic` is the WORDING only** — *"what may I say about currency?"* It never re-opens the gate.

The **disagreement cell** (`requiresRerun` true while `semantic` is `'current'`/`'none'`, reachable when CEE sets `requires_rerun` on a `complete_current` run) falls to the **weaker** cannot-confirm claim — never to the positive one.

## What the affordance now says

| State | Label (= accessible name) |
|---|---|
| running | `Running analysis…` |
| not stale | `Rerun` |
| stated/known change | `Rerun — model changed` |
| every other rerun-required state | `Rerun — can't confirm current` |

`'model changed'` is a **positive claim** and is minted only from a `'changed'` classification, honouring `classifyFreshnessForDisplay`'s own rule that `'changed'` must never be claimed for a CEE-sourced `'unknown'`.

**It MARKS, it does not GATE.** `actionDisabled` is untouched. A stale analysis is rerunnable; disabling the one control that fixes staleness would be a worse lie than the silence this replaces.

## Absent / unknown behaviour

Inherited: `requiresRerun`'s clear-on-absence → derived-fallback. `analysisStateV1` is **clear-on-absence** while `analysisFreshness` is **retain-on-absence**, so a turn carrying no `analysis_state` demotes this reader to the retained legacy verdict, and a retained `fresh` yields the **unqualified** label.

**That is honest only because the unqualified label asserts nothing about currency.** The demotion costs a warning we can no longer justify; it never manufactures a false all-clear. Unknown does not render as current — it renders as cannot-confirm.

And the **local dirty overlay survives the demotion**, so the brief's own case (the user edited) is still marked on a silent turn. Pinned by test.

## Evidence

**RED-first**, at pristine, 8 collected by name: `expect(element).toHaveAccessibleName()` — Expected `Rerun — model changed`, Received `Rerun`. 5 failed / 3 passed (the 3 are the genuinely-current + absence arms, which correctly pass at pristine).

**Both directions.** Stale renders as stale **and** genuinely-current renders as current — the latter pinned as hard as the former, because a one-sided guard converts silence into a permanent false alarm.

**Mutants** — throwaway worktree at an absolute path outside the repo root; isolation **proven by writing a sentinel** (distinct inodes `715091331` vs `715099978`; source SHA unchanged across the write; positive control confirmed the sentinel landed). Restores from a **pristine archive**, never `git checkout -- <path>`. Applied-check scoped to `src/`.

| Mutant | Applied | Result | Expected |
|---|---|---|---|
| control | **0** | GREEN 9/9 | GREEN |
| M1 `'changed'` → cannot-confirm | 1 | **RED** (4) | RED |
| M2 remove the `requiresRerun` gate | 1 | **RED** (4) | RED |
| M3 re-attach staleness to `actionDisabled` | 1 | **RED** (1) | RED |
| M4 **adjacent** robustness status label | 1 | **GREEN** | GREEN |
| trailing control | **0** | GREEN 9/9 | GREEN |

**Discriminating pair = M1 (RED) / M4 (GREEN)** — same file, same footer, adjacent member. The spec binds to the affordance by role + accessible name, not to the footer at large.

### Two of my own instruments were wrong first, and both corrections are in the diff

1. **The edited-since-run expectation was wrong; the code was right.** I asserted cannot-confirm for a local edit. Measured: the composition returns `'changed'`, because `classifyFreshnessForDisplay` treats the dirty overlay as *first-hand knowledge that an edit happened*. I had written the oracle from my own reading rather than the producer's declared semantics (trap 13c). The test now expects `'changed'` — and this is the better outcome: the user's edit gets the **strongest true claim**, not a hedge. It also validates reading both members: `displayedFreshness` alone would have said "can't confirm current" for an edit, **weaker than the truth**.

2. **A surviving mutant exposed a vacuous test of mine.** M3 initially **survived**. The marks-not-gates test compared enabledness across the freshness axis under a readiness mock that never opened the gate — so both arms were already disabled and the equality held for the wrong reason (trap 13b, a guard agreeing with itself). Fixed by opening the gate and making the test **pin its own precondition** (assert the affordance is genuinely enabled before claiming the equality). M3 now REDs, and REDs exactly that one test.

## Gate, run in the required order

- `pnpm run lint` → **0 errors** (1170 pre-existing warnings); rules-of-hooks ratchet exactly at baseline, no new conditional hooks
- `pnpm run typecheck` → **PASSED**, 3646/3686 files, ratchet 2252 = baseline
- `ci:guard:zustand` → PASS · `ci:guard:ds:enforce` → PASS, no net-new (no baseline update accepted)
- Affected-area slice: **653 files, 10,201 passed, 0 failed**
- New spec: **9/9**, asserted non-zero by name

⚠ `Visual Regression (advisory)` is a standing red and this changes rendered text. It is `continue-on-error` and deliberately absent from the `Staging Gate` aggregator's `needs`. Not a blocker.

## Named limits

- **Not journey-witnessed.** jsdom proves DOM presence and accessible name, never layout or a real browser. No staging witness in this lane.
- **The label is the only surface changed.** The footer's status slot still derives purely from `robustnessVerdict`, so "Stable ranking" can still sit beside a qualified Rerun. Narrower than before, not resolved.
- **Other rerun affordances untouched** — `ReanalyseBar` (Model tab), `CompareTabBodyV2`, and the suggested chips keep their own labels.
- **Copy is UI-authored, not producer-owned**, unlike the robustness reason beside it. If CEE later carries a display phrase for `requires_rerun`, this should defer to it.
- **`composeBlockedReason.ts` untouched** per the seam exclusion; no dependency on it arose.
