### PR TITLE
C11 Decision Brief closure — render what Olumi assumed, not the drivers list twice

### DIFF
--- a/e2e/geometry/decisionBriefAssumed.measure.ts
+++ b/e2e/geometry/decisionBriefAssumed.measure.ts
@@ -1,0 +1,132 @@
+/**
+ * Decision Brief — "What Olumi assumed" replaces the duplicate column.
+ *
+ * WHAT THIS MEASURES, AND WHY IT IS A REAL WITNESS RATHER THAN A RE-RUN OF THE
+ * UNIT TESTS. The defect was not visible to jsdom assertions: both categories
+ * rendered correctly, they simply rendered the SAME producer content. The prior
+ * acceptance evidence for this surface recorded "PASS" while its own table showed
+ * `What matters` and `What this rests on` at identical geometry with identical
+ * first values (`User Adoption Uncertainty`, twice). So the check that matters is
+ * a CONTENT-IDENTITY check on a real replayed turn, at real widths.
+ *
+ * The capture is the SAME one that prior evidence used (`T3`), chosen deliberately
+ * so the before/after is comparable: its `top_drivers[0]` and its
+ * `defaulted_assumptions[0]` are both `User Adoption Uncertainty`. Under the old
+ * build that name appeared twice under two headings. Under this build it appears
+ * once, and the second column carries the producer's own sentence instead.
+ *
+ * CLAIM TYPE: rendered text + bounding boxes in a real browser. Visibility claims
+ * are made only where a box is measured; nothing here infers layout from the DOM.
+ */
+import { test, expect } from '@playwright/test'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { repoRoot } from '../visual/repoRoot'
+import type { Page } from '@playwright/test'
+import {
+  openCanvas,
+  preparePage,
+  seedStarterDraft,
+  clearNotifications,
+  minimiseFloatingOlumiPanel,
+} from '../visual/harness'
+
+const CAPTURE = join(repoRoot(), 'src/v5/__tests__/fixtures/live-analysis-turn-T3-20260808T155759Z.json')
+const STARTER = 'build-vs-buy' as const
+const VPS = [
+  { width: 1280, height: 800 },
+  { width: 1440, height: 900 },
+  { width: 1512, height: 982 },
+]
+
+async function openCanvasWarm(page: Page): Promise<void> {
+  try { await openCanvas(page) } catch {
+    await page.reload({ waitUntil: 'domcontentloaded' })
+    await openCanvas(page)
+  }
+}
+
+for (const vp of VPS) {
+  test(`DECISION BRIEF assumed-column @${vp.width}x${vp.height}`, async ({ page }) => {
+    await preparePage(page, vp)
+    await openCanvasWarm(page)
+    await seedStarterDraft(page, STARTER)
+    await clearNotifications(page)
+    await minimiseFloatingOlumiPanel(page).catch(() => {})
+
+    const envelope = JSON.parse(readFileSync(CAPTURE, 'utf8'))
+
+    // PRECONDITION ON THE FIXTURE ITSELF. Without this the test could pass by
+    // replaying a capture that never carried the field, and report a comfortable
+    // absence as a fix.
+    const brief = envelope.blocks
+      ?.map((b: Record<string, unknown>) => (b.enrichment as { decision_brief?: Record<string, unknown> })?.decision_brief)
+      ?.find(Boolean)
+    expect(brief, 'the capture must carry enrichment.decision_brief').toBeTruthy()
+    expect(
+      (brief.defaulted_assumptions as unknown[])?.length,
+      'the capture must carry POPULATED defaulted_assumptions, or this measures nothing',
+    ).toBeGreaterThan(0)
+    expect(
+      brief.top_drivers[0].factor_label,
+      'this capture is chosen because its first driver and first defaulted assumption are the SAME factor',
+    ).toBe(brief.defaulted_assumptions[0].factor_label)
+
+    const applied = await page.evaluate(async (env) => {
+      const modulePath = '/src/v5/applyV5State.ts'
+      const mod = (await import(/* @vite-ignore */ modulePath)) as {
+        applyV5State: (r: unknown, s: unknown, o: unknown) => { applied: string[] }
+      }
+      const w = window as unknown as { useCanvasStore: { getState: () => Record<string, unknown> } }
+      const snap = w.useCanvasStore.getState()
+      return mod.applyV5State(
+        env,
+        { ...snap, currentResultsHash: (snap.results as { hash?: string } | null)?.hash ?? null, backfillGoalThreshold: () => {} },
+        { turnClientId: 'measure', currentClientTurnId: 'measure' },
+      )
+    }, envelope)
+    expect(applied.applied.length, 'applyV5State applied nothing — the turn did not land').toBeGreaterThan(0)
+
+    const resultsTab = page.getByTestId('outputs-dock-tab-results')
+    if (await resultsTab.count()) await resultsTab.click().catch(() => {})
+
+    const section = page.getByTestId('decision-brief-section')
+    await expect(section, 'the brief must mount, or nothing below is a finding').toBeVisible({ timeout: 20_000 })
+
+    // 1. The new column exists and the over-claiming one is gone.
+    await expect(section.getByText('What Olumi assumed')).toBeVisible()
+    await expect(section.getByText('What this rests on')).toHaveCount(0)
+
+    // 2. THE DEFECT ITSELF: the shared factor name appears exactly ONCE.
+    const shared: string = brief.top_drivers[0].factor_label
+    await expect(
+      section.getByText(shared, { exact: true }),
+      `"${shared}" is both a driver and a defaulted assumption; it must appear once, not twice`,
+    ).toHaveCount(1)
+
+    // 3. The producer's own sentence is on screen, unaltered.
+    const producerNote: string = brief.defaulted_assumptions[0].note
+    await expect(
+      section.getByText(producerNote.slice(0, 60), { exact: false }),
+      'the producer note must render verbatim, not a UI paraphrase',
+    ).toBeVisible()
+
+    // 4. No two groups render identical content.
+    const signatures = await section.evaluate(el => {
+      const lists = Array.from(el.querySelectorAll('ul'))
+      return lists.map(list => Array.from(list.querySelectorAll('li'))
+        .map(li => (li.textContent ?? '').trim()).join('␟'))
+    })
+    expect(signatures.length, 'no groups rendered — the measurement is empty').toBeGreaterThan(1)
+    expect(new Set(signatures).size, `two groups rendered identical content: ${JSON.stringify(signatures)}`)
+      .toBe(signatures.length)
+
+    // 5. Geometry, measured not inferred.
+    const box = await section.boundingBox()
+    expect(box, 'the section must have a box').toBeTruthy()
+    // eslint-disable-next-line no-console
+    console.log(`@${vp.width}x${vp.height} brief box y=${box!.y.toFixed(1)}–${(box!.y + box!.height).toFixed(1)} `
+      + `x=${box!.x.toFixed(1)} w=${box!.width.toFixed(1)} groups=${signatures.length}`)
+    expect(box!.width, 'the brief must not overflow its column').toBeLessThanOrEqual(vp.width)
+  })
+}

--- a/src/canvas/__tests__/useKeyboardShortcuts.spec.ts
+++ b/src/canvas/__tests__/useKeyboardShortcuts.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook } from '@testing-library/react'
 import {
   useKeyboardShortcuts,
+  isKeyboardActivationElement,
   isTextEntryElement,
   resolveEffectiveInteractionMode,
   shouldReleaseTextFocusOnCanvasPointerDown,
@@ -104,6 +105,26 @@ describe('useKeyboardShortcuts — interaction mode', () => {
 
       expect(onSpaceHeld).not.toHaveBeenCalled()
       document.body.removeChild(input)
+    })
+
+    it('leaves Space activation to focused native and semantic controls', () => {
+      renderHook(() => useKeyboardShortcuts({ onSpaceHeld }))
+      const button = document.createElement('button')
+      const label = document.createElement('span')
+      button.appendChild(label)
+      document.body.appendChild(button)
+
+      const event = new KeyboardEvent('keydown', {
+        key: ' ',
+        code: 'Space',
+        bubbles: true,
+        cancelable: true,
+      })
+      label.dispatchEvent(event)
+
+      expect(event.defaultPrevented).toBe(false)
+      expect(onSpaceHeld).not.toHaveBeenCalled()
+      document.body.removeChild(button)
     })
   })
 
@@ -243,6 +264,28 @@ describe('isTextEntryElement', () => {
     expect(isTextEntryElement(document.createElement('div'))).toBe(false)
     expect(isTextEntryElement(null)).toBe(false)
     expect(isTextEntryElement(undefined)).toBe(false)
+  })
+})
+
+describe('isKeyboardActivationElement', () => {
+  it('recognises native activation controls and their descendants', () => {
+    const button = document.createElement('button')
+    const child = document.createElement('span')
+    button.appendChild(child)
+    expect(isKeyboardActivationElement(button)).toBe(true)
+    expect(isKeyboardActivationElement(child)).toBe(true)
+
+    const link = document.createElement('a')
+    link.href = '/analysis'
+    expect(isKeyboardActivationElement(link)).toBe(true)
+  })
+
+  it('recognises semantic controls without classifying ordinary canvas content', () => {
+    const semanticButton = document.createElement('div')
+    semanticButton.setAttribute('role', 'button')
+    expect(isKeyboardActivationElement(semanticButton)).toBe(true)
+    expect(isKeyboardActivationElement(document.createElement('div'))).toBe(false)
+    expect(isKeyboardActivationElement(null)).toBe(false)
   })
 })
 

--- a/src/canvas/useKeyboardShortcuts.ts
+++ b/src/canvas/useKeyboardShortcuts.ts
@@ -22,6 +22,35 @@ export function isTextEntryElement(el: Element | null | undefined): boolean {
 }
 
 /**
+ * Controls for which Space is a native activation key.
+ *
+ * Hold-to-pan is window-scoped, so without this guard it prevents Space from
+ * clicking focused buttons and other controls anywhere around the canvas.
+ * Keep this separate from `isTextEntryElement`: text focus and native control
+ * activation have different pointer/shortcut semantics.
+ */
+export function isKeyboardActivationElement(el: Element | null | undefined): boolean {
+  if (!el || typeof el.closest !== 'function') return false
+  return el.closest([
+    'button',
+    'a[href]',
+    'select',
+    'summary',
+    '[role="button"]',
+    '[role="link"]',
+    '[role="checkbox"]',
+    '[role="radio"]',
+    '[role="switch"]',
+    '[role="tab"]',
+    '[role="menuitem"]',
+    '[role="menuitemcheckbox"]',
+    '[role="menuitemradio"]',
+    '[role="option"]',
+    '[role="slider"]',
+  ].join(',')) !== null
+}
+
+/**
  * The mode the canvas is ACTUALLY behaving in right now.
  *
  * `spaceHeld` is a transient hold-to-pan override (Figma grammar): while the
@@ -241,6 +270,9 @@ export function useKeyboardShortcuts(options?: KeyboardShortcutOptions) {
       // A hold started with a modifier already down would never receive its
       // keyup on macOS, so it is refused rather than leaked.
       if (isSpaceKey(event) && !event.repeat) {
+        // Space belongs to the focused native/semantic control. Returning
+        // without preventDefault preserves the browser's activation click.
+        if (isKeyboardActivationElement(event.target as Element | null)) return
         event.preventDefault()
         if (event.metaKey || event.ctrlKey || event.altKey) return
         emitSpaceHeld(true)

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -39,6 +39,7 @@ import { WhatIWasGivenSection } from './contextIntegrity/WhatIWasGivenSection'
 import { openDefineSuccess, HowComputedTrigger } from './modals'
 import { CANONICAL_EDIT_AUTHORITY, hasServerGraphAuthority } from '@/canvas/mutations/mutationAuthority'
 import { isFocusNowPanelEnabled, isStrengthenPanelEnabled } from '@/flags'
+import { DecisionBriefSectionContainer } from './decision-brief'
 
 export interface StrengthCorrectionDisplay {
   edgeId: string
@@ -311,15 +312,6 @@ export const ResultsBody = memo(function ResultsBody({
   return (
     <div className="flex flex-col gap-4" data-testid="outputs-results-redesign">
 
-      {/* ── P1-9 provenance: Model-Card-Lite entry point ───────────────────
-          Sits above every number it explains so "where did that number come
-          from?" is answerable without hunting. Gated on results being on
-          screen — a method note for an analysis that has not run would be
-          explaining numbers that do not exist. */}
-      <HowComputedTrigger
-        hasResults={(resultsSectionData.recommendation.allOptions?.length ?? 0) > 0}
-      />
-
       {/* ══ V7 ASSESSMENT SCAFFOLD — GONE, NOT MOVED (adjudicated) ═════════
           HISTORY, because the intermediate state confused readers twice: the
           V7 top group (`V7TopMatter`) + "Current view" divider — the
@@ -365,6 +357,26 @@ export const ResultsBody = memo(function ResultsBody({
           a flag arm ships dark on the posture that matters). BLOCKER rows
           keep their own surface (ValidationPanel via OutputsDock). */}
       <CritiqueWarningStrip critiques={resultsSectionData.confidence.humanisedCritiques} />
+
+      {/* C11 Decision Brief intelligence — the strategic-reading entry point
+          for the producer's already-transported projected brief. Canonical
+          warnings stay above it so caveats qualify the claims they govern;
+          method, run delta, and the taller cockpit follow. This keeps the
+          licensed groups on first paint without rebuilding winner, freshness
+          or Compare authority. */}
+      <SectionErrorBoundary section="Decision brief">
+        <DecisionBriefSectionContainer />
+      </SectionErrorBoundary>
+
+      {/* ── P1-9 provenance: Model-Card-Lite entry point ───────────────────
+          Sits above every numeric analysis surface it explains so "where did
+          that number come from?" is answerable without hunting. The brief
+          above renders labels/prose only. Gated on results being on screen —
+          a method note for an analysis that has not run would be explaining
+          numbers that do not exist. */}
+      <HowComputedTrigger
+        hasResults={(resultsSectionData.recommendation.allOptions?.length ?? 0) > 0}
+      />
 
       {/* Seamlessness R6 / ROADMAP 2.1 slice 1: run-over-run delta chip.
           Client-side diff of the two most recent stored runs; self-hides on

--- a/src/components/results/__tests__/ResultsBody.decisionBriefLiveMount.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.decisionBriefLiveMount.spec.tsx
@@ -196,10 +196,19 @@ describe('ResultsBody — Decision Brief live mount', () => {
     expect(briefSection.compareDocumentPosition(method) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     expect(briefSection.compareDocumentPosition(hero) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
     const brief = within(screen.getByTestId('decision-brief-section'))
-    // The producer names the same factor independently as a driver and an
-    // assumption; preserving both categories is intentional, not a duplicate
-    // surface.
-    expect(brief.getAllByText('Churn Trend')).toHaveLength(2)
+    // ⚠⚠ THIS ASSERTION WAS THE DEFECT, AND IT ARGUED FOR ITSELF. It required
+    // 'Churn Trend' to appear TWICE and explained the repetition as intentional:
+    // "the producer names the same factor independently as a driver and an
+    // assumption". The producer does — but that is a fact about the PRODUCER's
+    // indexing, not a licence to show a user the same word twice under two
+    // headings and call them different answers. `key_assumptions` is a SUBSET of
+    // `top_drivers` on every capture measured, so the second column could only
+    // ever restate the first.
+    //
+    // The corrected rule: a factor name appears ONCE. What the user gains in its
+    // place is `defaulted_assumptions` — the producer's own sentence about what it
+    // had to assume — which answers a genuinely different question.
+    expect(brief.getAllByText('Churn Trend')).toHaveLength(1)
     expect(brief.getByText('Product-Led Growth Conversion → Reach £1M ARR')).toBeInTheDocument()
   })
 
@@ -233,6 +242,16 @@ describe('ResultsBody — Decision Brief live mount', () => {
             options: [],
             top_drivers: [],
             what_would_change: [],
+            // ⚠ This case used to rely on `key_assumptions` being the last thing
+            // standing. It no longer renders — it is a SUBSET of `top_drivers` on
+            // every capture, so it was restating the neighbouring column. Measured
+            // across 1,620 captured briefs: ZERO have `key_assumptions` populated
+            // while `top_drivers` is empty, so nothing observable is lost. The
+            // producer's real "what did we have to assume" carrier is this one.
+            defaulted_assumptions: [
+              { factor_label: 'Available Growth Budget', note: 'No starting value was provided for "Available Growth Budget" — the analysis used a default.',
+                source: 'value_defaulted', doctrine: 'provisional_doctrine_v0' },
+            ],
           },
         },
       },
@@ -240,8 +259,8 @@ describe('ResultsBody — Decision Brief live mount', () => {
     renderBody({ withheld: true })
 
     const brief = screen.getByTestId('decision-brief-section')
-    expect(brief).toHaveTextContent('What this rests on')
-    expect(brief).toHaveTextContent('October Product Launch Readiness')
+    expect(brief).toHaveTextContent('What Olumi assumed')
+    expect(brief).toHaveTextContent('Available Growth Budget')
     expect(brief).not.toHaveTextContent(/winner|recommended|leading option|eligible|probability/i)
   })
 
@@ -256,6 +275,12 @@ describe('ResultsBody — Decision Brief live mount', () => {
             top_drivers: [],
             what_would_change: [],
             warnings: [],
+            defaulted_assumptions: [
+              { factor_label: 'Available Growth Budget', note: 'No starting value was provided for "Available Growth Budget" — the analysis used a default.',
+                source: 'value_defaulted', doctrine: 'provisional_doctrine_v0' },
+              { factor_label: 'Current ARR', note: 'No starting value was provided for "Current ARR" — the analysis used a default.',
+                source: 'value_defaulted', doctrine: 'provisional_doctrine_v0' },
+            ],
           },
         },
       },
@@ -263,8 +288,8 @@ describe('ResultsBody — Decision Brief live mount', () => {
     renderBody({ withheld: true })
 
     const brief = screen.getByTestId('decision-brief-section')
-    expect(brief).toHaveTextContent('What this rests on')
-    expect(brief).toHaveTextContent('October Product Launch Readiness')
+    expect(brief).toHaveTextContent('What Olumi assumed')
+    expect(brief).toHaveTextContent('Available Growth Budget')
     expect(brief).toHaveTextContent('+1 more')
     expect(brief).not.toHaveTextContent(/certain|confirmed|confidence/i)
   })

--- a/src/components/results/__tests__/ResultsBody.decisionBriefLiveMount.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.decisionBriefLiveMount.spec.tsx
@@ -1,0 +1,331 @@
+/**
+ * Decision Brief live mount proof.
+ *
+ * A real captured V5 turn travels through the real applicator and store before
+ * ResultsBody renders. The withheld and stale cases then prove the new reader
+ * is independent of leader entitlement and freshness authority.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen, within } from '@testing-library/react'
+import { applyV5State } from '@/v5/applyV5State'
+import { useCanvasStore } from '@/canvas/store'
+import { ResultsBody } from '../ResultsBody'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../types'
+import walkTurnFixture from '@/v5/__tests__/fixtures/live-analysis-turn-walkA-2026-08-04.json'
+
+vi.mock('../../../canvas/utils/focusHelpers', () => ({
+  focusNodeById: vi.fn(),
+  focusByTarget: vi.fn(),
+  focusExistingTarget: vi.fn(),
+  focusModelTarget: vi.fn(() => true),
+}))
+
+const PROVENANCE_KEYS = ['__source__', '__captured_at__', '__captured_against__', '__notes__']
+
+function capturedWalkTurn(): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(walkTurnFixture as Record<string, unknown>)
+      .filter(([key]) => !PROVENANCE_KEYS.includes(key)),
+  )
+}
+
+function applyCapturedWalkTurn(): void {
+  const state = useCanvasStore.getState()
+  applyV5State(capturedWalkTurn() as never, {
+    ...state,
+    currentResultsHash: state.results?.hash ?? null,
+  } as never)
+}
+
+function makeData(withheld = false, duplicateBriefWarning = false): ResultsSectionDataReturn {
+  const first = {
+    id: 'opt_a',
+    label: 'Option A',
+    expected: 0.8,
+    outcome: { mean: 0.8, p10: 0.6, p50: 0.78, p90: 0.95 },
+    p10: 0.6,
+    p50: 0.78,
+    p90: 0.95,
+    isRecommended: !withheld,
+    winProbability: 0.51,
+    goalProbability: 0.7,
+  } as unknown as OptionResult
+  const second = {
+    id: 'opt_b',
+    label: 'Option B',
+    expected: 0.79,
+    outcome: { mean: 0.79, p10: 0.59, p50: 0.77, p90: 0.94 },
+    p10: 0.59,
+    p50: 0.77,
+    p90: 0.94,
+    isRecommended: false,
+    winProbability: 0.49,
+    goalProbability: 0.69,
+  } as unknown as OptionResult
+  const recommendation = {
+    recommendedOption: withheld ? null : first,
+    allOptions: [first, second],
+    goalLabel: 'Grow sustainably',
+    goalThreshold: 0.6,
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    isNormalised: false,
+    verdict: {
+      hasLeadingOption: !withheld,
+      leadingOptionId: withheld ? null : 'opt_a',
+      reason: withheld ? 'constraint_verdict_withheld' : 'producer_leader',
+    },
+  } as unknown as DecisionResultData
+  const drivers: DriversSectionData = {
+    drivers: [],
+    topDrivers: [],
+    driversStatus: 'computed',
+    totalCount: 0,
+    hasMagnitudeData: false,
+  }
+  const confidence = {
+    tier: { tier: 'needs_work', icon: 'Alert', label: 'Needs work', description: 'd' },
+    qualityScore: 45,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    evidenceGaps: [],
+    topEvidenceGaps: [],
+    nextActions: [],
+    topNextActions: [],
+    inferenceWarnings: duplicateBriefWarning ? [{
+      code: 'CONSTRAINT_OUT_OF_DOMAIN',
+      affected_nodes: [],
+      message: 'Constraint gc-e9543857-e145-4ed5-a729-905529d9b0dd targets risk node risk_ae_attrition.',
+      severity: 'warning',
+    }] : [],
+    humanisedCritiques: [],
+  } as unknown as ConfidenceSectionData
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  }
+
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: 'Grow sustainably',
+    completeness: { status: 'full', missing: [], reasons: [] },
+    autoNoiseProvenance: null,
+  } as unknown as ResultsSectionDataReturn
+}
+
+function renderBody({
+  withheld = false,
+  isStale = false,
+  duplicateBriefWarning = false,
+} = {}) {
+  return render(
+    <ResultsBody
+      resultsSectionData={makeData(withheld, duplicateBriefWarning)}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      isStale={isStale}
+      onSendMessage={() => {}}
+    />,
+  )
+}
+
+const WITHHELD_BRIEF = {
+  brief_id: '50d0209b-6cfa-4b6a-a22b-84c94a80c06e',
+  version: '1',
+  created_at: '2026-08-25T08:16:07.476Z',
+  top_drivers: [
+    { factor_label: 'October Product Launch Readiness', sensitivity: 1, direction: 'positive' },
+    { factor_label: 'VP Enterprise Sales Scalability', sensitivity: 0.955, direction: 'positive' },
+  ],
+  key_assumptions: ['October Product Launch Readiness', 'VP Enterprise Sales Scalability'],
+  what_would_change: [
+    'October Product Launch Readiness → ARR Growth Trajectory',
+    'ARR Growth Trajectory → Grow ARR to £6m by June 2027',
+  ],
+  warnings: [
+    {
+      code: 'CONSTRAINT_OUT_OF_DOMAIN',
+      message: 'Constraint gc-e9543857-e145-4ed5-a729-905529d9b0dd targets risk node "risk_ae_attrition" with threshold 2 outside [0,1] range',
+      severity: 'warning',
+    },
+    {
+      code: 'INFLUENTIAL_EXTERNALS',
+      message: 'External factors materially affect this outcome and remain uncertain.',
+      severity: 'warning',
+    },
+  ],
+}
+
+describe('ResultsBody — Decision Brief live mount', () => {
+  beforeEach(() => {
+    useCanvasStore.setState({
+      analysisFreshness: null,
+      analysisFreshnessDirty: false,
+      results: { status: 'idle', progress: 0 },
+      runMeta: null,
+    } as never)
+  })
+
+  afterEach(() => cleanup())
+
+  it('real captured V5 turn → mapper → store → canonical Analysis body renders the brief', () => {
+    applyCapturedWalkTurn()
+    renderBody()
+
+    const report = useCanvasStore.getState().results
+    expect(report?.status).toBe('complete')
+    expect((report?.report as { decision_brief?: unknown }).decision_brief).toBeTruthy()
+    expect(screen.getAllByTestId('decision-brief-section')).toHaveLength(1)
+    const briefSection = screen.getByTestId('decision-brief-section')
+    const method = screen.getByTestId('how-computed-trigger')
+    const hero = screen.getByTestId('analysis-hero-panel')
+    expect(briefSection.compareDocumentPosition(method) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(briefSection.compareDocumentPosition(hero) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    const brief = within(screen.getByTestId('decision-brief-section'))
+    // The producer names the same factor independently as a driver and an
+    // assumption; preserving both categories is intentional, not a duplicate
+    // surface.
+    expect(brief.getAllByText('Churn Trend')).toHaveLength(2)
+    expect(brief.getByText('Product-Led Growth Conversion → Reach £1M ARR')).toBeInTheDocument()
+  })
+
+  it('withheld/no-leader run keeps all non-designating groups useful without restoring a winner', () => {
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        progress: 100,
+        report: { decision_brief: WITHHELD_BRIEF },
+      },
+    } as never)
+    renderBody({ withheld: true })
+
+    const brief = screen.getByTestId('decision-brief-section')
+    expect(brief).toHaveTextContent('October Product Launch Readiness')
+    expect(brief).toHaveTextContent('October Product Launch Readiness → ARR Growth Trajectory')
+    expect(brief).not.toHaveTextContent('gc-e9543857')
+    expect(brief).not.toHaveTextContent('risk_ae_attrition')
+    expect(brief).not.toHaveTextContent('Cautions')
+    expect(brief).not.toHaveTextContent(/winner|recommended|leading option|probability/i)
+  })
+
+  it('no eligible option still shows producer assumptions without inventing an outcome', () => {
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        progress: 100,
+        report: {
+          decision_brief: {
+            ...WITHHELD_BRIEF,
+            options: [],
+            top_drivers: [],
+            what_would_change: [],
+          },
+        },
+      },
+    } as never)
+    renderBody({ withheld: true })
+
+    const brief = screen.getByTestId('decision-brief-section')
+    expect(brief).toHaveTextContent('What this rests on')
+    expect(brief).toHaveTextContent('October Product Launch Readiness')
+    expect(brief).not.toHaveTextContent(/winner|recommended|leading option|eligible|probability/i)
+  })
+
+  it('unresolved inputs remain visible as producer assumptions without a UI certainty judgement', () => {
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        progress: 100,
+        report: {
+          decision_brief: {
+            ...WITHHELD_BRIEF,
+            top_drivers: [],
+            what_would_change: [],
+            warnings: [],
+          },
+        },
+      },
+    } as never)
+    renderBody({ withheld: true })
+
+    const brief = screen.getByTestId('decision-brief-section')
+    expect(brief).toHaveTextContent('What this rests on')
+    expect(brief).toHaveTextContent('October Product Launch Readiness')
+    expect(brief).toHaveTextContent('+1 more')
+    expect(brief).not.toHaveTextContent(/certain|confirmed|confidence/i)
+  })
+
+  it('does not re-admit a nested warning while the existing canonical strip remains sole owner', () => {
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        progress: 100,
+        report: { decision_brief: WITHHELD_BRIEF },
+      },
+    } as never)
+    renderBody({ withheld: true, duplicateBriefWarning: true })
+
+    expect(screen.getAllByTestId('inference-warning-strip-entry')).toHaveLength(1)
+    const warning = screen.getByTestId('inference-warning-strip-entry')
+    const brief = screen.getByTestId('decision-brief-section')
+    expect(warning).toHaveAttribute(
+      'data-warning-code',
+      'CONSTRAINT_OUT_OF_DOMAIN',
+    )
+    expect(warning.compareDocumentPosition(brief) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(within(brief).queryByText('Cautions')).toBeNull()
+  })
+
+  it('stale analysis leaves the brief readable and adds no competing freshness claim', () => {
+    useCanvasStore.setState({
+      results: {
+        status: 'complete',
+        progress: 100,
+        report: { decision_brief: WITHHELD_BRIEF },
+      },
+    } as never)
+    renderBody({ withheld: true, isStale: true })
+
+    const brief = screen.getByTestId('decision-brief-section')
+    expect(brief).toHaveTextContent('October Product Launch Readiness')
+    expect(brief).not.toHaveTextContent(/fresh|stale|current|out of date|re-run/i)
+  })
+
+  it('a retained report stays mounted while the canonical run state is preparing', () => {
+    useCanvasStore.setState({
+      results: {
+        status: 'preparing',
+        progress: 0,
+        report: { decision_brief: WITHHELD_BRIEF },
+      },
+    } as never)
+    renderBody({ withheld: true })
+
+    expect(screen.getByTestId('decision-brief-section')).toHaveTextContent(
+      'October Product Launch Readiness',
+    )
+  })
+
+  it('with no producer brief, renders no placeholder or fabricated surface', () => {
+    useCanvasStore.setState({
+      results: { status: 'complete', progress: 100, report: {} },
+    } as never)
+    renderBody()
+
+    expect(screen.queryByTestId('decision-brief-section')).toBeNull()
+  })
+})

--- a/src/components/results/decision-brief/DecisionBriefSection.tsx
+++ b/src/components/results/decision-brief/DecisionBriefSection.tsx
@@ -55,9 +55,23 @@ export interface DecisionBriefSectionProps {
 export function DecisionBriefSection({ brief }: DecisionBriefSectionProps) {
   const [expanded, setExpanded] = useState(false)
   const detailsId = useId()
+  /**
+   * ⭐ "What this rests on" USED to render `key_assumptions`, and that was the
+   * duplication defect: `key_assumptions` is a SUBSET of `top_drivers` on every
+   * capture measured (3 Aug — identical as sets, 3/3; 25 Aug live wire — 3/3
+   * contained). A subset cannot be a distinct answer, so the middle column
+   * restated the first one, and the old heading additionally over-claimed: it
+   * promised everything the analysis rests on while listing only factor names.
+   *
+   * `defaulted_assumptions` answers the question the surface was reaching for —
+   * *what did Olumi have to assume because we did not tell it?* — and answers it
+   * in the producer's own sentence rather than with a third list of labels.
+   * `keyAssumptions` is therefore DELIBERATELY DARK on this surface: it is still
+   * parsed and contract-guarded, it is simply already on screen one column left.
+   */
   const groups = [
     { title: 'What matters', items: brief.topDrivers.map(driver => driver.label), icon: CircleDot, testId: 'decision-brief-drivers' },
-    { title: 'What this rests on', items: brief.keyAssumptions, icon: Layers3, testId: 'decision-brief-assumptions' },
+    { title: 'What Olumi assumed', items: brief.defaultedAssumptions.map(entry => entry.note), icon: Layers3, testId: 'decision-brief-defaulted' },
     { title: 'What could change', items: brief.whatWouldChange, icon: GitBranch, testId: 'decision-brief-change' },
   ].filter(group => group.items.length > 0)
 
@@ -76,7 +90,7 @@ export function DecisionBriefSection({ brief }: DecisionBriefSectionProps) {
             Decision brief
           </h3>
           <p className={`${typography.panelMeta} mt-0.5 text-text-light`}>
-            Top drivers, key assumptions, and what could change.
+            Top drivers, the values Olumi assumed, and what could change.
           </p>
         </div>
       </div>

--- a/src/components/results/decision-brief/DecisionBriefSection.tsx
+++ b/src/components/results/decision-brief/DecisionBriefSection.tsx
@@ -1,0 +1,125 @@
+import { useId, useMemo, useState } from 'react'
+import { BookOpenText, CircleDot, GitBranch, Layers3 } from 'lucide-react'
+import { useCanvasStore } from '@/canvas/store'
+import { typography } from '@/styles/typography'
+import { readDecisionBriefViewModel, type DecisionBriefViewModel } from './decisionBriefViewModel'
+
+interface BriefGroupProps {
+  title: string
+  items: string[]
+  icon: typeof CircleDot
+  expanded: boolean
+  testId: string
+}
+
+const PREVIEW_ITEMS = 1
+
+function BriefGroup({ title, items, icon: Icon, expanded, testId }: BriefGroupProps) {
+  if (items.length === 0) return null
+  const visible = expanded ? items : items.slice(0, PREVIEW_ITEMS)
+  const hiddenCount = items.length - PREVIEW_ITEMS
+
+  return (
+    <div className="min-w-0" data-testid={testId}>
+      <dt className={`${typography.panelMeta} flex items-center gap-1.5 text-text-light`}>
+        <Icon size={13} className="shrink-0 text-info" aria-hidden="true" />
+        <span>{title}</span>
+      </dt>
+      <dd className="mt-1.5 min-w-0">
+        <ul className="space-y-1" aria-label={title}>
+          {visible.map((item, index) => (
+            <li
+              key={`${index}-${item}`}
+              className={`${typography.panelBody} flex min-w-0 items-start gap-1.5 text-text-body`}
+            >
+              <span className="mt-[0.45rem] h-1 w-1 shrink-0 rounded-full bg-text-light/70" aria-hidden="true" />
+              <span className="min-w-0 break-words whitespace-pre-wrap">{item}</span>
+            </li>
+          ))}
+        </ul>
+        {!expanded && hiddenCount > 0 && (
+          <p className={`${typography.panelMeta} mt-1 text-text-light`} aria-hidden="true">
+            +{hiddenCount} more
+          </p>
+        )}
+      </dd>
+    </div>
+  )
+}
+
+export interface DecisionBriefSectionProps {
+  brief: DecisionBriefViewModel
+}
+
+/** Store-free presentation, exported for focused and adversarial tests. */
+export function DecisionBriefSection({ brief }: DecisionBriefSectionProps) {
+  const [expanded, setExpanded] = useState(false)
+  const detailsId = useId()
+  const groups = [
+    { title: 'What matters', items: brief.topDrivers.map(driver => driver.label), icon: CircleDot, testId: 'decision-brief-drivers' },
+    { title: 'What this rests on', items: brief.keyAssumptions, icon: Layers3, testId: 'decision-brief-assumptions' },
+    { title: 'What could change', items: brief.whatWouldChange, icon: GitBranch, testId: 'decision-brief-change' },
+  ].filter(group => group.items.length > 0)
+
+  if (groups.length === 0) return null
+
+  return (
+    <section
+      className="rounded-lg border border-panel-border bg-panel px-3 py-2"
+      aria-labelledby={`${detailsId}-heading`}
+      data-testid="decision-brief-section"
+    >
+      <div className="flex items-start gap-2">
+        <BookOpenText size={16} className="mt-0.5 shrink-0 text-info" aria-hidden="true" />
+        <div className="min-w-0 flex-1">
+          <h3 id={`${detailsId}-heading`} className={`${typography.panelHeader} text-text-header`}>
+            Decision brief
+          </h3>
+          <p className={`${typography.panelMeta} mt-0.5 text-text-light`}>
+            Top drivers, key assumptions, and what could change.
+          </p>
+        </div>
+      </div>
+
+      <dl
+        id={detailsId}
+        className="mt-2 grid min-w-0 grid-cols-2 gap-x-3 gap-y-2 border-t border-panel-border pt-2"
+        data-testid="decision-brief-groups"
+      >
+        {groups.map(group => (
+          <BriefGroup key={group.title} {...group} expanded={expanded} />
+        ))}
+      </dl>
+
+      {groups.some(group => group.items.length > PREVIEW_ITEMS) && (
+        <button
+          type="button"
+          className={`${typography.panelMeta} mt-2 min-h-7 rounded-sm py-1.5 text-info hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+          aria-expanded={expanded}
+          aria-controls={detailsId}
+          onClick={() => setExpanded(value => !value)}
+          data-testid="decision-brief-toggle"
+        >
+          {expanded ? 'Show brief summary' : 'Show all brief details'}
+        </button>
+      )}
+    </section>
+  )
+}
+
+/**
+ * The complete V5 report already reaches the store and persists with analysis.
+ * Reading it here avoids a second mapper and keeps this surface independent of
+ * the existing leader/hero authority.
+ */
+export function DecisionBriefSectionContainer() {
+  const rawBrief = useCanvasStore(state => (
+    (state.results.report as { decision_brief?: unknown } | null | undefined)?.decision_brief
+  ))
+  const brief = useMemo(() => readDecisionBriefViewModel(rawBrief), [rawBrief])
+
+  if (!brief) return null
+  return <DecisionBriefSection brief={brief} />
+}
+
+export default DecisionBriefSectionContainer

--- a/src/components/results/decision-brief/__tests__/DecisionBriefSection.spec.tsx
+++ b/src/components/results/decision-brief/__tests__/DecisionBriefSection.spec.tsx
@@ -10,8 +10,19 @@ const BRIEF: DecisionBriefViewModel = {
     { label: 'VP Enterprise Sales Scalability' },
     { label: 'AE Team Morale' },
   ],
-  keyAssumptions: ['Assumption one', 'Assumption two'],
+  // ⚠ These were 'Assumption one'/'Assumption two' — values that overlap NOTHING.
+  // Real producer data always overlaps: `key_assumptions` is a SUBSET of
+  // `top_drivers` on every capture measured. A fixture that cannot overlap could
+  // never observe the duplication defect this surface actually shipped, which is
+  // why a green suite sat over it. The realistic values are used instead.
+  keyAssumptions: ['October Product Launch Readiness', 'VP Enterprise Sales Scalability'],
   whatWouldChange: ['Factor A → Outcome B', 'Outcome B → Goal C'],
+  defaultedAssumptions: [
+    {
+      factorLabel: 'Available Growth Budget',
+      note: 'No starting value was provided for "Available Growth Budget" — the analysis used a default.',
+    },
+  ],
 }
 
 describe('DecisionBriefSection', () => {
@@ -20,11 +31,11 @@ describe('DecisionBriefSection', () => {
 
     expect(screen.getByRole('heading', { name: 'Decision brief' })).toBeInTheDocument()
     expect(screen.getByText('What matters')).toBeInTheDocument()
-    expect(screen.getByText('What this rests on')).toBeInTheDocument()
+    expect(screen.getByText('What Olumi assumed')).toBeInTheDocument()
     expect(screen.getByText('What could change')).toBeInTheDocument()
 
     expect(screen.getByText('October Product Launch Readiness')).toBeInTheDocument()
-    expect(screen.getByText('Assumption one')).toBeInTheDocument()
+    expect(screen.getByText(/No starting value was provided for "Available Growth Budget"/)).toBeInTheDocument()
     expect(screen.getByText('Factor A → Outcome B')).toBeInTheDocument()
     expect(screen.queryByText('VP Enterprise Sales Scalability')).toBeNull()
 
@@ -44,7 +55,7 @@ describe('DecisionBriefSection', () => {
     expect(toggle).toHaveAttribute('aria-expanded', 'true')
     expect(screen.getByText('VP Enterprise Sales Scalability')).toBeInTheDocument()
     expect(screen.getByText('AE Team Morale')).toBeInTheDocument()
-    expect(screen.getByText('Assumption two')).toBeInTheDocument()
+    expect(screen.getByText('VP Enterprise Sales Scalability')).toBeInTheDocument()
     expect(screen.getByText('Outcome B → Goal C')).toBeInTheDocument()
 
     await user.keyboard(' ')
@@ -61,5 +72,29 @@ describe('DecisionBriefSection', () => {
 
     expect(section).not.toHaveTextContent(/recommend|winner|leading option|probability|confidence|robust/i)
     expect(section).not.toHaveTextContent('%')
+  })
+
+  /**
+   * The defect this surface shipped: two categories rendering the same list.
+   * Bound by IDENTITY to the realistic overlap — `keyAssumptions` here is a
+   * subset of `topDrivers`, exactly as the producer emits — so this test fails
+   * the moment any category is sourced from a factor-name list again.
+   */
+  it('never renders the same content under two category headings', () => {
+    render(<DecisionBriefSection brief={BRIEF} />)
+
+    const groups = screen.getByTestId('decision-brief-groups')
+    const rendered = Array.from(groups.querySelectorAll('ul')).map(list =>
+      Array.from(list.querySelectorAll('li')).map(li => li.textContent?.trim() ?? ''),
+    )
+
+    const signatures = rendered.map(items => items.join('\u241f'))
+    expect(new Set(signatures).size).toBe(signatures.length)
+
+    // And specifically: no driver name appears as the whole content of a second group.
+    const driverNames = new Set(BRIEF.topDrivers.map(d => d.label))
+    const assumedGroup = screen.getByTestId('decision-brief-defaulted')
+    const assumedItems = Array.from(assumedGroup.querySelectorAll('li')).map(li => li.textContent?.trim() ?? '')
+    expect(assumedItems.every(item => !driverNames.has(item))).toBe(true)
   })
 })

--- a/src/components/results/decision-brief/__tests__/DecisionBriefSection.spec.tsx
+++ b/src/components/results/decision-brief/__tests__/DecisionBriefSection.spec.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { DecisionBriefSection } from '../DecisionBriefSection'
+import type { DecisionBriefViewModel } from '../decisionBriefViewModel'
+
+const BRIEF: DecisionBriefViewModel = {
+  topDrivers: [
+    { label: 'October Product Launch Readiness' },
+    { label: 'VP Enterprise Sales Scalability' },
+    { label: 'AE Team Morale' },
+  ],
+  keyAssumptions: ['Assumption one', 'Assumption two'],
+  whatWouldChange: ['Factor A → Outcome B', 'Outcome B → Goal C'],
+}
+
+describe('DecisionBriefSection', () => {
+  it('shows every licensed group and its first producer item without opening a disclosure', () => {
+    render(<DecisionBriefSection brief={BRIEF} />)
+
+    expect(screen.getByRole('heading', { name: 'Decision brief' })).toBeInTheDocument()
+    expect(screen.getByText('What matters')).toBeInTheDocument()
+    expect(screen.getByText('What this rests on')).toBeInTheDocument()
+    expect(screen.getByText('What could change')).toBeInTheDocument()
+
+    expect(screen.getByText('October Product Launch Readiness')).toBeInTheDocument()
+    expect(screen.getByText('Assumption one')).toBeInTheDocument()
+    expect(screen.getByText('Factor A → Outcome B')).toBeInTheDocument()
+    expect(screen.queryByText('VP Enterprise Sales Scalability')).toBeNull()
+
+    const toggle = screen.getByRole('button', { name: 'Show all brief details' })
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+    expect(toggle).toHaveAttribute('aria-controls')
+  })
+
+  it('expands and collapses all complete producer lists through one keyboard-operable control', async () => {
+    const user = userEvent.setup()
+    render(<DecisionBriefSection brief={BRIEF} />)
+
+    const toggle = screen.getByRole('button', { name: 'Show all brief details' })
+    toggle.focus()
+    await user.keyboard('{Enter}')
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByText('VP Enterprise Sales Scalability')).toBeInTheDocument()
+    expect(screen.getByText('AE Team Morale')).toBeInTheDocument()
+    expect(screen.getByText('Assumption two')).toBeInTheDocument()
+    expect(screen.getByText('Outcome B → Goal C')).toBeInTheDocument()
+
+    await user.keyboard(' ')
+    expect(screen.getByRole('button', { name: 'Show all brief details' })).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    )
+    expect(screen.queryByText('AE Team Morale')).toBeNull()
+  })
+
+  it('renders no recommendation, probability, confidence or robustness authority', () => {
+    render(<DecisionBriefSection brief={BRIEF} />)
+    const section = screen.getByTestId('decision-brief-section')
+
+    expect(section).not.toHaveTextContent(/recommend|winner|leading option|probability|confidence|robust/i)
+    expect(section).not.toHaveTextContent('%')
+  })
+})

--- a/src/components/results/decision-brief/__tests__/decisionBriefDefaultedAssumptions.spec.ts
+++ b/src/components/results/decision-brief/__tests__/decisionBriefDefaultedAssumptions.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * Decision Brief — `defaulted_assumptions`, category identity, cap and poison-row behaviour.
+ *
+ * WHY THIS FILE EXISTS. Four defects were found by cross-review and confirmed here at the
+ * bytes against real captures:
+ *
+ *  1. "What this rests on" rendered `key_assumptions`, which is a SUBSET of `top_drivers`
+ *     on every capture measured (3 Aug: identical as sets, 3/3; 25 Aug live: 3/3 contained).
+ *     A subset can never be a distinct answer, so the two categories showed the same list.
+ *     The honest source for "what did the analysis have to assume" is `defaulted_assumptions`,
+ *     which carries the PRODUCER'S OWN PROSE and answers a different question.
+ *  2. A category emptied completely when the producer exceeded its own declared cap
+ *     (`length > max` returned `[]`), so 11 items rendered as zero.
+ *  3. One malformed row emptied its whole category, suppressing valid siblings.
+ *  4. The note interpolates a USER-AUTHORED factor label, and the glossary guard bans
+ *     ordinary business vocabulary (`variance`, `intervention`, `blocked`, `win rate`).
+ *     Measured: 0 of 17 distinct captured notes trip it today — but "Budget Variance" is an
+ *     entirely ordinary factor name, so the collision is REACHABLE and UNOBSERVED. It is
+ *     pinned here rather than discovered in production.
+ *
+ * The rule this file enforces (brief §6): VET the whole rendered join, never REWRITE it.
+ * A row whose producer sentence cannot be shown unchanged is WITHHELD, never repaired —
+ * substituting a fallback into the producer's sentence would change its meaning.
+ */
+import { describe, it, expect } from 'vitest'
+import { readDecisionBriefViewModel } from '../decisionBriefViewModel'
+
+const BRIEF_ID = '3f2504e0-4f89-41d3-9a0c-0305e82c3301'
+const CREATED_AT = '2026-08-25T08:16:20.000Z'
+
+const note = (label: string) =>
+  `No starting value was provided for "${label}" — the analysis used a default. `
+  + 'Setting a real value or range would make this result more trustworthy.'
+
+const defaulted = (label: string) => ({
+  factor_label: label,
+  note: note(label),
+  source: 'value_defaulted',
+  doctrine: 'provisional_doctrine_v0',
+})
+
+function brief(extra: Record<string, unknown>) {
+  return { version: '1', brief_id: BRIEF_ID, created_at: CREATED_AT, ...extra }
+}
+
+describe('defaulted_assumptions reaches the view model', () => {
+  it('carries the producer note verbatim, anchored by its factor label', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [defaulted('Available Growth Budget')],
+    }))
+    expect(vm?.defaultedAssumptions).toEqual([
+      { factorLabel: 'Available Growth Budget', note: note('Available Growth Budget') },
+    ])
+  })
+
+  it('withholds a row whose source is not the producer value_defaulted token', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [
+        { ...defaulted('Current ARR'), source: 'something_else' },
+        defaulted('B2B Market Demand'),
+      ],
+    }))
+    expect(vm?.defaultedAssumptions.map(d => d.factorLabel)).toEqual(['B2B Market Demand'])
+  })
+
+  it('renders nothing for the category when the producer sends an empty list', () => {
+    // Measured on the 25 Aug live wire: the key is present and empty on real runs.
+    const vm = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [],
+      top_drivers: [{ factor_label: 'Churn Trend', sensitivity: 0.4, direction: 'positive' }],
+    }))
+    expect(vm?.defaultedAssumptions).toEqual([])
+  })
+})
+
+describe('producer prose safety — vet, never rewrite (brief §6)', () => {
+  it('WITHHOLDS a row whose note trips the glossary guard, keeping valid siblings', () => {
+    // "Budget Variance" is an ordinary factor name; `variance` is a banned term.
+    const vm = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [defaulted('Budget Variance'), defaulted('Current ARR')],
+    }))
+    expect(vm?.defaultedAssumptions.map(d => d.factorLabel)).toEqual(['Current ARR'])
+  })
+
+  it('never substitutes a fallback into the producer sentence', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [defaulted('Clinical Intervention Cost')],
+    }))
+    // The row is gone entirely; no repaired sentence is emitted in its place.
+    expect(vm?.defaultedAssumptions ?? []).toEqual([])
+    const joined = JSON.stringify(vm ?? {})
+    expect(joined).not.toContain('this factor')
+    expect(joined).not.toContain('Intervention')
+  })
+})
+
+describe('cap at the producer maximum truncates, never empties', () => {
+  it('renders 10 of 11 key assumptions rather than zero', () => {
+    const eleven = Array.from({ length: 11 }, (_, i) => `Assumption ${i + 1}`)
+    const vm = readDecisionBriefViewModel(brief({ key_assumptions: eleven }))
+    expect(vm?.keyAssumptions).toHaveLength(10)
+    expect(vm?.keyAssumptions[0]).toBe('Assumption 1')
+  })
+
+  it('renders 5 of 6 top drivers rather than zero', () => {
+    const six = Array.from({ length: 6 }, (_, i) => ({
+      factor_label: `Driver ${i + 1}`, sensitivity: 1 - i / 10, direction: 'positive' as const,
+    }))
+    const vm = readDecisionBriefViewModel(brief({ top_drivers: six }))
+    expect(vm?.topDrivers.map(d => d.label)).toEqual([
+      'Driver 1', 'Driver 2', 'Driver 3', 'Driver 4', 'Driver 5',
+    ])
+  })
+})
+
+describe('one bad row cannot suppress valid siblings', () => {
+  it('keeps the valid leading rows of a ranked category and truncates at the first bad one', () => {
+    // Ranked data: dropping a middle row would silently re-rank what follows, so the
+    // honest response is a prefix, not a filter.
+    const vm = readDecisionBriefViewModel(brief({
+      what_would_change: ['Demand holds', 'deadbeefcafe1234', 'Costs fall'],
+    }))
+    expect(vm?.whatWouldChange).toEqual(['Demand holds'])
+  })
+
+  it('keeps valid drivers when a later driver row is malformed', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      top_drivers: [
+        { factor_label: 'Churn Trend', sensitivity: 0.9, direction: 'positive' },
+        { factor_label: 'Broken', sensitivity: 'nope', direction: 'positive' },
+      ],
+    }))
+    expect(vm?.topDrivers.map(d => d.label)).toEqual(['Churn Trend'])
+  })
+})

--- a/src/components/results/decision-brief/__tests__/decisionBriefDefaultedAssumptions.spec.ts
+++ b/src/components/results/decision-brief/__tests__/decisionBriefDefaultedAssumptions.spec.ts
@@ -132,4 +132,26 @@ describe('one bad row cannot suppress valid siblings', () => {
     }))
     expect(vm?.topDrivers.map(d => d.label)).toEqual(['Churn Trend'])
   })
+
+  /**
+   * ⚠ ADDED AFTER A SURVIVING MUTANT. Mutating the null-row `break` to `return []`
+   * left the whole suite green, because the only malformed row in the fixture
+   * above is ID-SHAPED and is caught by the *second* break. The corpus therefore
+   * never exercised the first one. That is a gap in this kit, not an equivalent
+   * mutant — a non-string row behaves differently in general — so the case is
+   * added rather than the survivor being explained away.
+   */
+  it('truncates at a non-string row, keeping the valid rows before it', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      what_would_change: ['Demand holds', 42 as unknown as string, 'Costs fall'],
+    }))
+    expect(vm?.whatWouldChange).toEqual(['Demand holds'])
+  })
+
+  it('truncates at a blank row, keeping the valid rows before it', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      key_assumptions: ['Demand holds', '   ', 'Costs fall'],
+    }))
+    expect(vm?.keyAssumptions).toEqual(['Demand holds'])
+  })
 })

--- a/src/components/results/decision-brief/__tests__/decisionBriefFieldCoverage.spec.ts
+++ b/src/components/results/decision-brief/__tests__/decisionBriefFieldCoverage.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * ⭐ THE ANTI-DARK GUARD — derived, not a census.
+ *
+ * The estate's dominant loss class is working code no user can reach. The UI
+ * mappers are key-by-key allow-lists, so a new producer field is DARK BY DEFAULT
+ * and fails silently with green suites at every other hop — measured on this very
+ * surface, where `defaulted_assumptions` sat on the wire with zero readers.
+ *
+ * A hand-written list of "fields we handle" would drift into exactly that. So the
+ * OBSERVED side of this guard is DERIVED: it walks the committed live captures and
+ * takes the real union of `decision_brief` keys the producer has actually sent. The
+ * DECIDED side is the four classification sets in the view model. A member on the
+ * wire that belongs to none of them is unclassified — the guard NAMES it and fails.
+ *
+ * WHAT THIS CANNOT DO, stated plainly: deriving from captures proves agreement with
+ * what the producer HAS sent, never with what it COULD send. A member that has never
+ * appeared in a committed capture is invisible here. That is the known limit of a
+ * derived guard (it moves the risk, it does not remove it), and it is why the
+ * classification carries reasons a human can audit rather than just names.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  DECISION_BRIEF_CLASSIFIED,
+  DECISION_BRIEF_RENDERED_HERE,
+  DECISION_BRIEF_CONSUMED_AS_IDENTITY,
+  DECISION_BRIEF_OWNED_ELSEWHERE,
+  DECISION_BRIEF_DECLARED_DARK,
+} from '../decisionBriefViewModel'
+
+const FIXTURE_ROOTS = [
+  'src/v5/__tests__/fixtures',
+  'src/canvas/compare-tab/__tests__/__fixtures__',
+]
+
+function jsonFiles(dir: string): string[] {
+  let entries: string[]
+  try { entries = readdirSync(dir) } catch { return [] }
+  return entries.flatMap(entry => {
+    const full = join(dir, entry)
+    const st = statSync(full)
+    if (st.isDirectory()) return jsonFiles(full)
+    if (!entry.endsWith('.json') || st.size > 20_000_000) return []
+    return [full]
+  })
+}
+
+function* walk(value: unknown): Generator<[string, unknown]> {
+  if (Array.isArray(value)) {
+    for (const item of value) yield* walk(item)
+  } else if (value && typeof value === 'object') {
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      yield [k, v]
+      yield* walk(v)
+    }
+  }
+}
+
+function observedDecisionBriefKeys(): { keys: Set<string>, briefs: number, files: number } {
+  const keys = new Set<string>()
+  let briefs = 0
+  const files = FIXTURE_ROOTS.flatMap(jsonFiles)
+  for (const file of files) {
+    let parsed: unknown
+    try { parsed = JSON.parse(readFileSync(file, 'utf8')) } catch { continue }
+    for (const [k, v] of walk(parsed)) {
+      if (k === 'decision_brief' && v && typeof v === 'object' && !Array.isArray(v)) {
+        briefs += 1
+        for (const member of Object.keys(v as Record<string, unknown>)) keys.add(member)
+      }
+    }
+  }
+  return { keys, briefs, files: files.length }
+}
+
+describe('decision_brief field coverage — derived from real captures', () => {
+  const { keys, briefs, files } = observedDecisionBriefKeys()
+
+  it('the scan can actually see captures (positive control)', () => {
+    // An absence assertion with a blind instrument proves nothing. If this fails,
+    // every other assertion in this file is vacuous, so it is asserted first.
+    expect(files).toBeGreaterThan(0)
+    expect(briefs).toBeGreaterThan(0)
+    expect(keys.size).toBeGreaterThan(0)
+    // A member that must be present, or the walk is not reaching the object.
+    expect(keys.has('top_drivers')).toBe(true)
+  })
+
+  it('every producer member observed on the wire is classified', () => {
+    const unclassified = [...keys].filter(k => !DECISION_BRIEF_CLASSIFIED.includes(k)).sort()
+    expect(
+      unclassified,
+      unclassified.length === 0 ? '' : `Unclassified decision_brief member(s): ${unclassified.join(', ')}. `
+        + 'A producer field is DARK BY DEFAULT on this surface. Add each to exactly one of '
+        + 'DECISION_BRIEF_RENDERED_HERE, DECISION_BRIEF_CONSUMED_AS_IDENTITY, '
+        + 'DECISION_BRIEF_OWNED_ELSEWHERE or DECISION_BRIEF_DECLARED_DARK (with a reason).',
+    ).toEqual([])
+  })
+
+  it('no member is classified twice', () => {
+    const all = [...DECISION_BRIEF_CLASSIFIED]
+    const duplicates = all.filter((k, i) => all.indexOf(k) !== i)
+    expect(duplicates).toEqual([])
+  })
+
+  it('every deliberately-dark member states why', () => {
+    for (const [member, reason] of Object.entries(DECISION_BRIEF_DECLARED_DARK)) {
+      expect(reason.trim().length, `${member} needs a reason`).toBeGreaterThan(20)
+    }
+    for (const [member, reason] of Object.entries(DECISION_BRIEF_OWNED_ELSEWHERE)) {
+      expect(reason.trim().length, `${member} needs a reason`).toBeGreaterThan(20)
+    }
+  })
+
+  it('what this surface renders is exactly what the view model exposes', () => {
+    expect([...DECISION_BRIEF_RENDERED_HERE].sort()).toEqual([
+      'defaulted_assumptions', 'top_drivers', 'what_would_change',
+    ])
+    expect([...DECISION_BRIEF_CONSUMED_AS_IDENTITY].sort()).toEqual([
+      'brief_id', 'created_at', 'version',
+    ])
+  })
+})

--- a/src/components/results/decision-brief/__tests__/decisionBriefViewModel.spec.ts
+++ b/src/components/results/decision-brief/__tests__/decisionBriefViewModel.spec.ts
@@ -39,7 +39,7 @@ const WITHHELD_LIVE_PROJECTION = {
 }
 
 describe('readDecisionBriefViewModel', () => {
-  it('reads only the three licensed non-leader groups from the live withheld V1 projection', () => {
+  it('reads only the licensed non-leader groups from the live withheld V1 projection', () => {
     const view = readDecisionBriefViewModel(WITHHELD_LIVE_PROJECTION)
 
     expect(view).toEqual({
@@ -49,6 +49,9 @@ describe('readDecisionBriefViewModel', () => {
       ],
       keyAssumptions: WITHHELD_LIVE_PROJECTION.key_assumptions,
       whatWouldChange: WITHHELD_LIVE_PROJECTION.what_would_change,
+      // Present and empty on this capture — the 25 Aug live wire carries the key
+      // with zero entries, which is a real producer state, not an absence.
+      defaultedAssumptions: [],
     })
 
     // The projection carries probabilities, but this reader has no field from
@@ -80,7 +83,24 @@ describe('readDecisionBriefViewModel', () => {
     expect(readDecisionBriefViewModel(null)).toBeNull()
   })
 
-  it('fails a malformed ordered category closed while preserving valid siblings', () => {
+  /**
+   * ⚠ THIS TEST'S EXPECTATION WAS THE DEFECT, and is corrected here rather than
+   * deleted. It asserted `topDrivers === []` when row 1 was VALID and row 2 was
+   * malformed — i.e. it pinned "one bad row empties the whole category", which
+   * is exactly the behaviour cross-review flagged as suppressing valid siblings.
+   * Its title already said "preserving valid siblings"; it only ever preserved
+   * the sibling CATEGORIES, never the valid rows inside the affected one.
+   *
+   * The corrected rule is a PREFIX: ordering is meaningful, so a malformed row
+   * ends the list rather than being filtered out of the middle (which would
+   * silently re-rank what follows) and rather than emptying it (which discards
+   * true rows for one bad one). Every row shown holds its real rank.
+   *
+   * The single-bad-row cases below are unchanged and still pass: when the only
+   * row is unusable the category is still empty. This change is strictly less
+   * destructive, never more permissive.
+   */
+  it('truncates a ranked category at the first malformed row, keeping valid leading rows', () => {
     const view = readDecisionBriefViewModel({
       ...WITHHELD_LIVE_PROJECTION,
       top_drivers: [
@@ -89,7 +109,9 @@ describe('readDecisionBriefViewModel', () => {
       ],
     })
 
-    expect(view?.topDrivers).toEqual([])
+    expect(view?.topDrivers).toEqual([
+      { label: WITHHELD_LIVE_PROJECTION.top_drivers[0].factor_label },
+    ])
     expect(view?.keyAssumptions).toEqual(WITHHELD_LIVE_PROJECTION.key_assumptions)
     expect(view?.whatWouldChange).toEqual(WITHHELD_LIVE_PROJECTION.what_would_change)
   })

--- a/src/components/results/decision-brief/__tests__/decisionBriefViewModel.spec.ts
+++ b/src/components/results/decision-brief/__tests__/decisionBriefViewModel.spec.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import { readDecisionBriefViewModel } from '../decisionBriefViewModel'
+
+const WITHHELD_LIVE_PROJECTION = {
+  brief_id: '50d0209b-6cfa-4b6a-a22b-84c94a80c06e',
+  version: '1',
+  created_at: '2026-08-25T08:16:07.476Z',
+  options: [
+    { option_id: 'opt_cro', label: 'Hire CRO Above VP of Sales', win_probability: 0.548 },
+    { option_id: 'opt_coach', label: 'Coach VP for 90 Days', win_probability: 0.2865 },
+  ],
+  top_drivers: [
+    { factor_label: 'October Product Launch Readiness', sensitivity: 1, direction: 'positive' },
+    { factor_label: 'VP Enterprise Sales Scalability', sensitivity: 0.955, direction: 'positive' },
+  ],
+  key_assumptions: ['October Product Launch Readiness', 'VP Enterprise Sales Scalability'],
+  what_would_change: [
+    'October Product Launch Readiness → ARR Growth Trajectory',
+    'ARR Growth Trajectory → Grow ARR to £6m by June 2027',
+  ],
+  warnings: [
+    {
+      code: 'CONSTRAINT_OUT_OF_DOMAIN',
+      message: 'Constraint gc-e9543857-e145-4ed5-a729-905529d9b0dd targets risk node "risk_ae_attrition" with threshold 2 outside [0,1] range',
+      severity: 'warning',
+    },
+    {
+      code: 'INFLUENTIAL_EXTERNALS',
+      message: 'External factors significantly affect your outcome but are inherently uncertain.',
+      severity: 'warning',
+    },
+    {
+      code: 'M2_UNAVAILABLE',
+      message: 'Decision review was unavailable; brief uses deterministic coaching fallback',
+      severity: 'warning',
+    },
+  ],
+  analysis_summary: { robustness_band: 'fragile' },
+}
+
+describe('readDecisionBriefViewModel', () => {
+  it('reads only the three licensed non-leader groups from the live withheld V1 projection', () => {
+    const view = readDecisionBriefViewModel(WITHHELD_LIVE_PROJECTION)
+
+    expect(view).toEqual({
+      topDrivers: [
+        { label: 'October Product Launch Readiness' },
+        { label: 'VP Enterprise Sales Scalability' },
+      ],
+      keyAssumptions: WITHHELD_LIVE_PROJECTION.key_assumptions,
+      whatWouldChange: WITHHELD_LIVE_PROJECTION.what_would_change,
+    })
+
+    // The projection carries probabilities, but this reader has no field from
+    // which a caller could reconstruct a leader or confidence claim.
+    expect(view).not.toHaveProperty('options')
+    expect(view).not.toHaveProperty('headline')
+    expect(view).not.toHaveProperty('robustness')
+    expect(view).not.toHaveProperty('warnings')
+  })
+
+  it('never re-admits opaque nested warning rows, even when a UI template exists for the code', () => {
+    const view = readDecisionBriefViewModel({
+      ...WITHHELD_LIVE_PROJECTION,
+      warnings: [
+        WITHHELD_LIVE_PROJECTION.warnings[0],
+      ],
+    })
+
+    expect(view).not.toHaveProperty('warnings')
+    expect(view?.topDrivers).toHaveLength(2)
+  })
+
+  it('fails identity/version closed and never treats a similarly named object as this artefact', () => {
+    expect(readDecisionBriefViewModel({ ...WITHHELD_LIVE_PROJECTION, version: '2' })).toBeNull()
+    expect(readDecisionBriefViewModel({ ...WITHHELD_LIVE_PROJECTION, brief_id: 'exported-brief' })).toBeNull()
+    expect(readDecisionBriefViewModel({ ...WITHHELD_LIVE_PROJECTION, created_at: 'today' })).toBeNull()
+    expect(readDecisionBriefViewModel({ ...WITHHELD_LIVE_PROJECTION, created_at: '2026-99-99T99:99:99Z' })).toBeNull()
+    expect(readDecisionBriefViewModel({ ...WITHHELD_LIVE_PROJECTION, created_at: '2026-02-31T08:16:07.000Z' })).toBeNull()
+    expect(readDecisionBriefViewModel(null)).toBeNull()
+  })
+
+  it('fails a malformed ordered category closed while preserving valid siblings', () => {
+    const view = readDecisionBriefViewModel({
+      ...WITHHELD_LIVE_PROJECTION,
+      top_drivers: [
+        WITHHELD_LIVE_PROJECTION.top_drivers[0],
+        { factor_label: 'Unlicensed row', sensitivity: 'high', direction: 'positive' },
+      ],
+    })
+
+    expect(view?.topDrivers).toEqual([])
+    expect(view?.keyAssumptions).toEqual(WITHHELD_LIVE_PROJECTION.key_assumptions)
+    expect(view?.whatWouldChange).toEqual(WITHHELD_LIVE_PROJECTION.what_would_change)
+  })
+
+  it.each([
+    ['top drivers', {
+      top_drivers: [{ factor_label: 'factor_launch_readiness', sensitivity: 1, direction: 'positive' }],
+    }, 'topDrivers'],
+    ['key assumptions', {
+      key_assumptions: ['risk_ae_attrition'],
+    }, 'keyAssumptions'],
+    ['what would change', {
+      what_would_change: ['out_headcount_growth → goal_x'],
+    }, 'whatWouldChange'],
+  ] as const)('fails ID-shaped %s closed while preserving valid siblings', (_name, override, key) => {
+    const view = readDecisionBriefViewModel({
+      ...WITHHELD_LIVE_PROJECTION,
+      ...override,
+    })
+
+    expect(view?.[key]).toEqual([])
+    expect(view).not.toBeNull()
+  })
+
+  it('also rejects UUID, graph-constraint, and opaque-hex identifier shapes', () => {
+    const view = readDecisionBriefViewModel({
+      ...WITHHELD_LIVE_PROJECTION,
+      top_drivers: [
+        { factor_label: 'gc-e9543857-e145-4ed5-a729-905529d9b0dd', sensitivity: 1, direction: 'positive' },
+      ],
+      key_assumptions: ['50d0209b-6cfa-4b6a-a22b-84c94a80c06e'],
+      what_would_change: ['95ba57a8 → e25cc9aa'],
+    })
+
+    expect(view).toBeNull()
+  })
+
+  it('preserves producer order and prose bytes without ranking or rewriting them', () => {
+    const view = readDecisionBriefViewModel(WITHHELD_LIVE_PROJECTION)
+
+    expect(view?.topDrivers.map(driver => driver.label)).toEqual([
+      'October Product Launch Readiness',
+      'VP Enterprise Sales Scalability',
+    ])
+    expect(view?.whatWouldChange).toEqual([
+      'October Product Launch Readiness → ARR Growth Trajectory',
+      'ARR Growth Trajectory → Grow ARR to £6m by June 2027',
+    ])
+  })
+
+  it('returns no surface when none of the licensed categories is usable', () => {
+    expect(readDecisionBriefViewModel({
+      brief_id: WITHHELD_LIVE_PROJECTION.brief_id,
+      version: '1',
+      created_at: WITHHELD_LIVE_PROJECTION.created_at,
+      top_drivers: [],
+      key_assumptions: [],
+      what_would_change: [],
+      warnings: WITHHELD_LIVE_PROJECTION.warnings,
+    })).toBeNull()
+  })
+})

--- a/src/components/results/decision-brief/decisionBriefViewModel.ts
+++ b/src/components/results/decision-brief/decisionBriefViewModel.ts
@@ -10,16 +10,32 @@
  */
 
 import { RAW_ID_PATTERN } from '@/canvas/conversation/friendlyOperation'
+import { containsBannedTerm } from '../utils/glossaryCheck'
 
 export interface DecisionBriefDriverView {
   /** Producer label, preserved verbatim. */
   label: string
 }
 
+/**
+ * One factor the analysis had to default because the user had not supplied a
+ * value, carrying the PRODUCER'S OWN sentence about it.
+ *
+ * The label is the anchor; the `note` is the content. Rendering the labels
+ * alone would reproduce the duplication this category was created to fix —
+ * `key_assumptions` is a SUBSET of `top_drivers` on every capture measured, so
+ * a second list of factor names can never be a distinct answer. The prose is.
+ */
+export interface DecisionBriefDefaultedView {
+  factorLabel: string
+  note: string
+}
+
 export interface DecisionBriefViewModel {
   topDrivers: DecisionBriefDriverView[]
   keyAssumptions: string[]
   whatWouldChange: string[]
+  defaultedAssumptions: DecisionBriefDefaultedView[]
 }
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
@@ -40,6 +56,8 @@ const MAX_TOP_DRIVERS = 5
 const MAX_KEY_ASSUMPTIONS = 10
 const MAX_WHAT_WOULD_CHANGE = 10
 const MAX_LABEL_LENGTH = 300
+const MAX_NOTE_LENGTH = 600
+const MAX_DEFAULTED_ASSUMPTIONS = 10
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -67,23 +85,39 @@ function readStringList(
   rejectRawIdentifiers = false,
 ): string[] {
   if (value == null) return []
-  if (!Array.isArray(value) || value.length > maxItems) return []
+  if (!Array.isArray(value)) return []
 
-  const strings = value.map(item => readNonBlankString(item, MAX_LABEL_LENGTH))
-  // Ordering is meaningful on all three producer arrays. If any row is
-  // malformed, fail the category closed instead of silently changing ranks.
-  if (strings.some(item => item === null)) return []
-  if (rejectRawIdentifiers && strings.some(item => containsRawIdentifier(item!))) return []
-  return strings as string[]
+  // ⭐ CAP BEHAVIOUR. This used to be `value.length > maxItems -> return []`, so a
+  // producer that exceeded its OWN declared maximum emptied the whole category:
+  // eleven assumptions rendered as zero. The cap is the producer's contract, not
+  // a validity test — honour it by TRUNCATING to it, never by discarding the lot.
+  const capped = value.slice(0, maxItems)
+
+  // ⭐ POISON-ROW BEHAVIOUR. Ordering is meaningful on these producer arrays, so a
+  // malformed row may not simply be filtered out — dropping a middle row silently
+  // re-ranks everything after it, which is a quieter lie than showing less. But
+  // emptying the category suppresses valid siblings for one bad row. The honest
+  // response is a PREFIX: every row shown holds its true rank, and nothing after
+  // the first unusable row is claimed.
+  const out: string[] = []
+  for (const item of capped) {
+    const s = readNonBlankString(item, MAX_LABEL_LENGTH)
+    if (s === null) break
+    if (rejectRawIdentifiers && containsRawIdentifier(s)) break
+    out.push(s)
+  }
+  return out
 }
 
 function readTopDrivers(value: unknown): DecisionBriefDriverView[] {
   if (value == null) return []
-  if (!Array.isArray(value) || value.length > MAX_TOP_DRIVERS) return []
+  if (!Array.isArray(value)) return []
 
+  // Cap truncates (see readStringList); a malformed row ends the prefix rather
+  // than emptying a ranked category.
   const drivers: DecisionBriefDriverView[] = []
-  for (const item of value) {
-    if (!isRecord(item)) return []
+  for (const item of value.slice(0, MAX_TOP_DRIVERS)) {
+    if (!isRecord(item)) break
     const label = readNonBlankString(item.factor_label, MAX_LABEL_LENGTH)
     const sensitivity = item.sensitivity
     const direction = item.direction
@@ -95,7 +129,7 @@ function readTopDrivers(value: unknown): DecisionBriefDriverView[] {
       || sensitivity < 0
       || (direction !== 'positive' && direction !== 'negative')
     ) {
-      return []
+      break
     }
     // Sensitivity and direction validate that this is a producer driver row,
     // but stay off-screen: V1 does not license a new UI confidence or causal
@@ -103,6 +137,52 @@ function readTopDrivers(value: unknown): DecisionBriefDriverView[] {
     drivers.push({ label })
   }
   return drivers
+}
+
+/**
+ * ⭐ The producer's own honesty prose about values it had to default.
+ *
+ * PROSE SAFETY (brief §6) — VET, NEVER REWRITE. The note interpolates a
+ * USER-AUTHORED factor label, and the analysis-surface glossary bans ordinary
+ * business vocabulary (`variance`, `intervention`, `blocked`, `win rate`). The
+ * repo's existing helper for this is `safeInterpolatedLabel`, which SUBSTITUTES
+ * a fallback — and substituting into a producer sentence changes what the
+ * producer said. So this reader proves the guard is an IDENTITY on the exact
+ * string it is about to render, and WITHHOLDS the row when it is not. A withheld
+ * row is an absence; a repaired row would be a fabrication.
+ *
+ * Measured against every capture available: 0 of 17 distinct notes and 0 of 15
+ * distinct factor labels trip the guard today. The collision is REACHABLE, not
+ * live — "Budget Variance" is an entirely ordinary factor name — so it is pinned
+ * by test rather than left to be discovered on a user's screen.
+ *
+ * Unlike the ranked arrays above, this is an unordered SET of factors, so an
+ * unusable row is skipped rather than ending a prefix: there is no rank to lie
+ * about, and the remaining rows are each independently true.
+ */
+function readDefaultedAssumptions(value: unknown): DecisionBriefDefaultedView[] {
+  if (value == null) return []
+  if (!Array.isArray(value)) return []
+
+  const out: DecisionBriefDefaultedView[] = []
+  for (const item of value.slice(0, MAX_DEFAULTED_ASSUMPTIONS)) {
+    if (!isRecord(item)) continue
+    // The producer's own token for "we defaulted this". Anything else is a row
+    // this surface has no licence to describe.
+    if (item.source !== 'value_defaulted') continue
+
+    const factorLabel = readNonBlankString(item.factor_label, MAX_LABEL_LENGTH)
+    const note = readNonBlankString(item.note, MAX_NOTE_LENGTH)
+    if (factorLabel === null || note === null) continue
+    if (containsRawIdentifier(factorLabel) || containsRawIdentifier(note)) continue
+
+    // The identity proof. Both the anchor and the whole rendered join must pass
+    // unchanged, or the row does not appear at all.
+    if (containsBannedTerm(factorLabel) || containsBannedTerm(note)) continue
+
+    out.push({ factorLabel, note })
+  }
+  return out
 }
 
 /**
@@ -134,14 +214,16 @@ export function readDecisionBriefViewModel(raw: unknown): DecisionBriefViewModel
     MAX_WHAT_WOULD_CHANGE,
     true,
   )
+  const defaultedAssumptions = readDefaultedAssumptions(raw.defaulted_assumptions)
 
   if (
     topDrivers.length === 0
     && keyAssumptions.length === 0
     && whatWouldChange.length === 0
+    && defaultedAssumptions.length === 0
   ) {
     return null
   }
 
-  return { topDrivers, keyAssumptions, whatWouldChange }
+  return { topDrivers, keyAssumptions, whatWouldChange, defaultedAssumptions }
 }

--- a/src/components/results/decision-brief/decisionBriefViewModel.ts
+++ b/src/components/results/decision-brief/decisionBriefViewModel.ts
@@ -1,0 +1,147 @@
+/**
+ * Read-only projection of the CEE-carried Decision Brief.
+ *
+ * The browser does not receive the complete PLoT DecisionBriefV1 on a
+ * withheld run: CEE deliberately removes leader-designating members while
+ * retaining non-designating reasoning content. The shared response boundary
+ * is also intentionally opaque (`object().passthrough()`), so this module
+ * validates only the live-attested projection it renders. It never rebuilds a
+ * leader, recommendation, confidence judgement, or robustness verdict.
+ */
+
+import { RAW_ID_PATTERN } from '@/canvas/conversation/friendlyOperation'
+
+export interface DecisionBriefDriverView {
+  /** Producer label, preserved verbatim. */
+  label: string
+}
+
+export interface DecisionBriefViewModel {
+  topDrivers: DecisionBriefDriverView[]
+  keyAssumptions: string[]
+  whatWouldChange: string[]
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+const ISO_INSTANT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/
+// PLoT currently falls back from absent display labels to model-element IDs in
+// some brief members. The projected object carries no flag that distinguishes
+// that fallback, so an ID-shaped member fails its whole ordered category
+// closed; the UI never prettifies an identifier into an invented name. Reuse
+// the canonical UI leak guard and supplement it for persisted ID shapes that
+// guard intentionally does not cover.
+const SUPPLEMENTAL_RAW_IDENTIFIER_RE = new RegExp([
+  UUID_RE.source.replace(/^\^|\$$/g, ''),
+  '\\bgc-[0-9a-f-]{8,}\\b',
+  '\\b[0-9a-f]{8,64}\\b',
+].join('|'), 'i')
+
+const MAX_TOP_DRIVERS = 5
+const MAX_KEY_ASSUMPTIONS = 10
+const MAX_WHAT_WOULD_CHANGE = 10
+const MAX_LABEL_LENGTH = 300
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function readNonBlankString(value: unknown, maxLength: number): string | null {
+  if (typeof value !== 'string') return null
+  if (value.trim().length === 0 || value.length > maxLength || value.includes('\0')) return null
+  return value
+}
+
+function isValidIsoInstant(value: string): boolean {
+  if (!ISO_INSTANT_RE.test(value)) return false
+  const parsed = new Date(value)
+  return Number.isFinite(parsed.getTime()) && parsed.toISOString() === value
+}
+
+function containsRawIdentifier(value: string): boolean {
+  return RAW_ID_PATTERN.test(value) || SUPPLEMENTAL_RAW_IDENTIFIER_RE.test(value)
+}
+
+function readStringList(
+  value: unknown,
+  maxItems: number,
+  rejectRawIdentifiers = false,
+): string[] {
+  if (value == null) return []
+  if (!Array.isArray(value) || value.length > maxItems) return []
+
+  const strings = value.map(item => readNonBlankString(item, MAX_LABEL_LENGTH))
+  // Ordering is meaningful on all three producer arrays. If any row is
+  // malformed, fail the category closed instead of silently changing ranks.
+  if (strings.some(item => item === null)) return []
+  if (rejectRawIdentifiers && strings.some(item => containsRawIdentifier(item!))) return []
+  return strings as string[]
+}
+
+function readTopDrivers(value: unknown): DecisionBriefDriverView[] {
+  if (value == null) return []
+  if (!Array.isArray(value) || value.length > MAX_TOP_DRIVERS) return []
+
+  const drivers: DecisionBriefDriverView[] = []
+  for (const item of value) {
+    if (!isRecord(item)) return []
+    const label = readNonBlankString(item.factor_label, MAX_LABEL_LENGTH)
+    const sensitivity = item.sensitivity
+    const direction = item.direction
+    if (
+      label === null
+      || containsRawIdentifier(label)
+      || typeof sensitivity !== 'number'
+      || !Number.isFinite(sensitivity)
+      || sensitivity < 0
+      || (direction !== 'positive' && direction !== 'negative')
+    ) {
+      return []
+    }
+    // Sensitivity and direction validate that this is a producer driver row,
+    // but stay off-screen: V1 does not license a new UI confidence or causal
+    // magnitude interpretation here.
+    drivers.push({ label })
+  }
+  return drivers
+}
+
+/**
+ * Parse the CEE-projected DecisionBriefV1 members that are licensed for this
+ * surface. Missing or malformed categories do not suppress valid siblings.
+ */
+export function readDecisionBriefViewModel(raw: unknown): DecisionBriefViewModel | null {
+  if (!isRecord(raw) || raw.version !== '1') return null
+
+  const briefId = readNonBlankString(raw.brief_id, 64)
+  const createdAt = readNonBlankString(raw.created_at, 64)
+  if (
+    briefId === null
+    || !UUID_RE.test(briefId)
+    || createdAt === null
+    || !isValidIsoInstant(createdAt)
+  ) {
+    return null
+  }
+
+  const topDrivers = readTopDrivers(raw.top_drivers)
+  const keyAssumptions = readStringList(
+    raw.key_assumptions,
+    MAX_KEY_ASSUMPTIONS,
+    true,
+  )
+  const whatWouldChange = readStringList(
+    raw.what_would_change,
+    MAX_WHAT_WOULD_CHANGE,
+    true,
+  )
+
+  if (
+    topDrivers.length === 0
+    && keyAssumptions.length === 0
+    && whatWouldChange.length === 0
+  ) {
+    return null
+  }
+
+  return { topDrivers, keyAssumptions, whatWouldChange }
+}

--- a/src/components/results/decision-brief/decisionBriefViewModel.ts
+++ b/src/components/results/decision-brief/decisionBriefViewModel.ts
@@ -140,6 +140,72 @@ function readTopDrivers(value: unknown): DecisionBriefDriverView[] {
 }
 
 /**
+ * ⭐ THE ANTI-DARK CLASSIFICATION — every member the producer sends must be
+ * accounted for, or the guard REDs.
+ *
+ * This estate's dominant loss class is working code no user can reach: the UI
+ * mappers rebuild payloads as key-by-key allow-lists, so a new producer field is
+ * DARK BY DEFAULT and fails silently with green suites at every other hop. A
+ * hand-maintained census of "fields we handle" would drift the same way.
+ *
+ * So the OBSERVED side is derived — `decisionBriefFieldCoverage.spec.ts` reads the
+ * committed live captures and takes the real union of `decision_brief` keys — and
+ * this is the DECIDED side. A member that appears on the wire and in none of these
+ * four sets is unclassified, and the guard names it and fails.
+ *
+ * The sets are composed into `DECISION_BRIEF_CLASSIFIED` rather than a fifth list
+ * being typed out, so a key cannot be classified twice or belong to none of them
+ * while still counting as handled. (Same shape as `decisionReviewAdapter`'s
+ * `V0_30_CONTENT_KEYS`, for the same reason: a guard that names examples tests the
+ * examples; a guard that iterates the list tests the rule.)
+ */
+export const DECISION_BRIEF_RENDERED_HERE = [
+  'top_drivers',
+  'what_would_change',
+  'defaulted_assumptions',
+] as const
+
+/** Read to decide whether the projection is a brief at all; never displayed. */
+export const DECISION_BRIEF_CONSUMED_AS_IDENTITY = [
+  'brief_id',
+  'created_at',
+  'version',
+] as const
+
+/** Reaches the user, but through a different consumer — must not render twice. */
+export const DECISION_BRIEF_OWNED_ELSEWHERE = {
+  options: 'id-to-label fallback in mapV5AnalysisToReport; the brief must not restate it',
+  headline_banded: 'leader-entitlement band consumed by decisionVerdict/useResultsSectionData',
+} as const
+
+/**
+ * Deliberately not rendered. A reason is REQUIRED — an entry here is a claim that
+ * a user loses nothing, and that claim should have to be written down.
+ */
+export const DECISION_BRIEF_DECLARED_DARK = {
+  key_assumptions:
+    'a SUBSET of top_drivers on every capture measured, so it can only restate the '
+    + 'neighbouring column; 0 of 1,620 captured briefs carry it while top_drivers is empty',
+  headline: 'leader-designating prose; this surface never restores a leader',
+  robustness: 'a producer verdict this surface has no licence to re-state as its own',
+  robustness_caveat: 'belongs with the robustness verdict, which is not rendered here',
+  warnings: 'the canonical inference-warning strip above the brief is sole owner',
+  warning_codes: 'machine codes; the human-readable strip above owns this surface',
+  analysis_summary: 'band summary owned by the analysis hero, not by the brief',
+  lineage: 'audit provenance, not user-facing on this surface',
+  graph_hash: 'identity for the run, shown nowhere as copy',
+  seed: 'simulation input, never user-facing',
+} as const
+
+/** Composed, never listed again. */
+export const DECISION_BRIEF_CLASSIFIED: readonly string[] = [
+  ...DECISION_BRIEF_RENDERED_HERE,
+  ...DECISION_BRIEF_CONSUMED_AS_IDENTITY,
+  ...Object.keys(DECISION_BRIEF_OWNED_ELSEWHERE),
+  ...Object.keys(DECISION_BRIEF_DECLARED_DARK),
+]
+
+/**
  * ⭐ The producer's own honesty prose about values it had to default.
  *
  * PROSE SAFETY (brief §6) — VET, NEVER REWRITE. The note interpolates a

--- a/src/components/results/decision-brief/index.ts
+++ b/src/components/results/decision-brief/index.ts
@@ -1,0 +1,6 @@
+export { DecisionBriefSection, DecisionBriefSectionContainer } from './DecisionBriefSection'
+export { readDecisionBriefViewModel } from './decisionBriefViewModel'
+export type {
+  DecisionBriefDriverView,
+  DecisionBriefViewModel,
+} from './decisionBriefViewModel'


### PR DESCRIPTION
Adapts `codex/c11-decision-brief-intelligence` (`c12e7087`) rather than rebuilding it. Rebased onto staging `fa2113aa`. **Body describes HEAD `33fe69ee`.**

## The defect, and its root cause

"What this rests on" rendered `key_assumptions`. Measured on real captures: **`key_assumptions` is a SUBSET of `top_drivers`** — 3 Aug identical as sets (3/3), 25 Aug live wire 3/3 contained. A subset can never be a distinct answer, so the middle column restated the first one. This is **producer-structural, not a UI bug** — and the heading additionally over-claimed, promising everything the analysis rests on while listing factor names.

The honest source is **`defaulted_assumptions`**: present on the wire, populated on **922 of 1,620** captured briefs, carrying the producer's own sentence plus a `value_defaulted` provenance token. It answers a different question — *what did Olumi have to assume because the user had not supplied it* — and is rendered as that **prose**, not as a third list of labels, because a third list of names would reproduce the defect.

`key_assumptions` is now **declared dark with a reason**, not silently dropped. Across 1,620 captured briefs, **zero** carry it while `top_drivers` is empty, so no observable run loses content.

## Three further defects in the same seam

- **Cap emptied the category.** `length > max` returned `[]`, so a producer exceeding its own declared maximum rendered zero. The cap is the producer's contract, not a validity test — it now truncates.
- **One poison row emptied the category.** Ranked categories now truncate at the first unusable row, so valid leading rows keep their **true rank** and nothing after an unusable row is claimed. A single bad row still yields an empty category: strictly less destructive, never more permissive.
- **Producer prose could be silently rewritten.** The note interpolates a **user-authored** factor label, and the analysis glossary bans ordinary business vocabulary (`variance`, `intervention`, `blocked`, `win rate`). The repo's `safeInterpolatedLabel` *substitutes a fallback*, which would change what the producer said. This **vets** the exact string it is about to render and **withholds** the row when the guard is not an identity on it. Measured 0/17 distinct captured notes trip it today; "Budget Variance" is an ordinary factor name, so the collision is reachable and is pinned by test rather than met in production.

## Three specs were hiding this, and are corrected rather than deleted

- The live-mount spec **required the duplication and argued for it**: `expect(getAllByText('Churn Trend')).toHaveLength(2)`, commented *"preserving both categories is intentional, not a duplicate surface."*
- The view-model spec asserted a whole ranked category empties when row 2 is malformed — under the title *"preserving valid siblings."* It only ever preserved the sibling **categories**.
- The section spec's fixture used non-overlapping synthetic assumptions, so it was **structurally incapable** of observing the duplication. It now uses the realistic overlap and carries a test that fails if any category is sourced from a factor-name list again.

## Anti-recurrence: a derived guard

The estate's dominant loss class is working code no user can reach, because the UI mappers are key-by-key allow-lists. A hand-written census would drift the same way, so only the **decided** side is written: the **observed** side walks committed live captures and takes the real union of `decision_brief` keys (18 members across 17 captures). Any member in none of the four classification sets is unclassified — the guard **names it and fails**. The sets compose into one list, so a member cannot be classified twice nor count as handled while in none. Every dark member must state **why**, enforced by test.

**Known limit, stated:** deriving from captures proves agreement with what the producer *has* sent, never what it *could* send. Derivation moves this risk, it does not remove it — which is why each dark entry carries an auditable reason.

## Evidence

- **RED-first**: 9 collected by name, 8 failed at pristine.
- **38/38** green on the seam; **collateral 358 files / 6036 tests, 0 failures** across `results` + `v5`.
- **Named typecheck gate PASSED** — 3653/3693 files, ratchet identical at baseline (2252). Lint clean.
- **Discriminating mutants**, each failing on different assertions: own-object (middle group reverts to `keyAssumptions`) **6 RED**; adjacent-object (rename a sibling title) 1 RED and **not** a duplication test; cap 1; prose-safety 2; poison-row 2; guard-classification 2 RED **naming the member**; guard rot-mutant RED. Controls 0 applied and green at both ends. Isolation proven **by writing** a sentinel.
- **Browser witness, 3/3** at 1280x800 / 1440x900 / 1512x982 on the same capture prior evidence used: the shared factor name now appears **exactly once**, the producer sentence renders verbatim, no two groups render identical content.

## Disclosed

- A surviving mutant exposed a real gap in this kit's own corpus (the fixture's only bad row was ID-shaped, so the null-row branch was never exercised). Two cases added; the mutant now bites.
- Rung is **TESTED**. Not deployed, not journey-witnessed.

Review class: presentation + producer traceability. Not canonical state, transactions, version identity, or recommendation semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8zhVkx3tAqkrYsDBbGPxw