### PR TITLE
C11 entry — stop the first screen claiming where a guest's work lives

### DIFF
--- a/src/pages/ScenarioListPage.tsx
+++ b/src/pages/ScenarioListPage.tsx
@@ -365,9 +365,22 @@ export default function ScenarioListPage() {
 
   // Guest mode — offer sign-in (primary) and a guest path into the canvas
   // (secondary). Guest mode is the POC's primary flow and #/canvas works fully
-  // as guest, so this branch must never be a dead end. The copy distinguishes
-  // the product category from the persistence boundary: exploration works
-  // without an account; saving the workspace requires sign-in.
+  // as guest, so this branch must never be a dead end.
+  //
+  // ⚠ THE COPY MAKES NO CLAIM ABOUT WHERE GUEST WORK LIVES, deliberately.
+  // A previous version read "Without an account, your work stays only in this
+  // browser." Both halves were wrong at once:
+  //   · "stays" asserts persistence the product does not guarantee — there is a
+  //     settling window in which a guest's work is not yet durable;
+  //   · "only in this browser" is a PRIVACY claim, and it is false: a guest's
+  //     graph also exists server-side.
+  // The second is the worse half. A reader takes "only in this browser" to mean
+  // nothing leaves their machine, and that is not what happens.
+  //
+  // The remedy is not a more carefully hedged sentence about storage. First use
+  // should say what Olumi IS and how to begin; the storage boundary is System A's
+  // to define and is not settled enough to promise here. So the sign-in benefit
+  // is stated plainly and nothing is claimed about the guest path.
   if (!isPersistenceActive) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-canvas p-8">
@@ -377,7 +390,7 @@ export default function ScenarioListPage() {
             Olumi turns messy strategic work into a living visual model while keeping your judgement visible.
           </p>
           <p className={`${typography.bodySmall} text-text-light mt-3`}>
-            Sign in to create a saved workspace. Without an account, your work stays only in this browser.
+            Sign in to create a saved workspace.
           </p>
           <div className="mt-6 flex flex-col items-center gap-3">
             <button

--- a/src/pages/ScenarioListPage.tsx
+++ b/src/pages/ScenarioListPage.tsx
@@ -365,16 +365,19 @@ export default function ScenarioListPage() {
 
   // Guest mode — offer sign-in (primary) and a guest path into the canvas
   // (secondary). Guest mode is the POC's primary flow and #/canvas works fully
-  // as guest, so this branch must never be a dead end. The guest copy
-  // deliberately promises nothing about persistence — the sign-in copy above
-  // it already frames signing in as the way to save.
+  // as guest, so this branch must never be a dead end. The copy distinguishes
+  // the product category from the persistence boundary: exploration works
+  // without an account; saving the workspace requires sign-in.
   if (!isPersistenceActive) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-canvas p-8">
         <div className="text-center max-w-md">
-          <h1 className={`${typography.h3} text-text-header`}>Decisions</h1>
+          <h1 className={`${typography.h3} text-text-header`}>Strategic reasoning</h1>
           <p className={`${typography.body} text-text-body mt-4`}>
-            Sign in to save and manage your decisions.
+            Olumi turns messy strategic work into a living visual model while keeping your judgement visible.
+          </p>
+          <p className={`${typography.bodySmall} text-text-light mt-3`}>
+            Sign in to save your workspace, or explore without an account.
           </p>
           <div className="mt-6 flex flex-col items-center gap-3">
             <button

--- a/src/pages/ScenarioListPage.tsx
+++ b/src/pages/ScenarioListPage.tsx
@@ -377,7 +377,7 @@ export default function ScenarioListPage() {
             Olumi turns messy strategic work into a living visual model while keeping your judgement visible.
           </p>
           <p className={`${typography.bodySmall} text-text-light mt-3`}>
-            Sign in to save your workspace, or explore without an account.
+            Sign in to create a saved workspace. Without an account, your work stays only in this browser.
           </p>
           <div className="mt-6 flex flex-col items-center gap-3">
             <button

--- a/src/pages/__tests__/ScenarioListPage.spec.tsx
+++ b/src/pages/__tests__/ScenarioListPage.spec.tsx
@@ -49,6 +49,20 @@ function renderPage() {
   )
 }
 
+function expectStrategicReasoningEntry() {
+  expect(screen.getByRole('heading', { name: 'Strategic reasoning' })).toBeInTheDocument()
+  expect(
+    screen.getByText(
+      'Olumi turns messy strategic work into a living visual model while keeping your judgement visible.',
+    ),
+  ).toBeInTheDocument()
+  expect(
+    screen.getByText('Sign in to save your workspace, or explore without an account.'),
+  ).toBeInTheDocument()
+  expect(screen.queryByRole('heading', { name: 'Decisions' })).not.toBeInTheDocument()
+  expect(screen.queryByText(/manage your decisions/i)).not.toBeInTheDocument()
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -303,10 +317,16 @@ describe('ScenarioListPage', () => {
     })
   })
 
-  it('shows sign-in message for guest users', () => {
+  it('frames the guest entry as strategic reasoning', () => {
     mockAuthValue = { user: { id: 'guest' }, authenticated: true }
     renderPage()
-    expect(screen.getByText('Sign in')).toBeTruthy()
+    expectStrategicReasoningEntry()
+  })
+
+  it('frames the signed-out entry as strategic reasoning', () => {
+    mockAuthValue = { user: null, authenticated: false }
+    renderPage()
+    expectStrategicReasoningEntry()
   })
 
   // -------------------------------------------------------------------------

--- a/src/pages/__tests__/ScenarioListPage.spec.tsx
+++ b/src/pages/__tests__/ScenarioListPage.spec.tsx
@@ -59,31 +59,6 @@ function expectStrategicReasoningEntry() {
   expect(screen.getByText('Sign in to create a saved workspace.')).toBeInTheDocument()
   expect(screen.queryByRole('heading', { name: 'Decisions' })).not.toBeInTheDocument()
   expect(screen.queryByText(/manage your decisions/i)).not.toBeInTheDocument()
-
-  // ⚠ REGRESSION PIN. The sentence this replaces was
-  //   "Without an account, your work stays only in this browser."
-  // and it was asserted VERBATIM by this very helper, so the guard cemented the
-  // untruth: correcting the copy REDded the suite, and leaving it green required
-  // keeping a false claim on the first screen a user ever sees.
-  //
-  // Both halves were wrong. "stays" promises persistence across a settling window
-  // in which the work is not yet durable. "only in this browser" is a PRIVACY
-  // claim and is false — a guest's graph also exists server-side.
-  //
-  // Pinned by SHAPE rather than by the one string, so it cannot come back under
-  // another wording. Each pattern is checked against the whole rendered document.
-  for (const banned of [
-    /only in this browser/i,
-    /stays? (?:only )?(?:on|in) (?:this|your) (?:browser|device|computer)/i,
-    /never leaves/i,
-    /stored only locally/i,
-    /we (?:do not|don't) (?:store|keep|save)/i,
-  ]) {
-    expect(
-      document.body.textContent ?? '',
-      `first-use copy must claim nothing about where guest work lives; matched ${banned}`,
-    ).not.toMatch(banned)
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -350,6 +325,45 @@ describe('ScenarioListPage', () => {
     mockAuthValue = { user: null, authenticated: false }
     renderPage()
     expectStrategicReasoningEntry()
+  })
+
+  /**
+   * ⚠ THE REGRESSION PIN LIVES IN ITS OWN TEST, AND THAT IS THE POINT.
+   *
+   * It was first written inside `expectStrategicReasoningEntry`, AFTER the
+   * exact-copy assertions. Measured: a mutant restoring the false sentence never
+   * reached it — `getByText` throws on the changed string first, so the pin only
+   * ran when the copy was already correct, in which case it could never fire. A
+   * guard whose only path to execution is the case it is not guarding is a guard
+   * that reads green forever.
+   *
+   * Here it renders independently and asserts over the whole document, so it
+   * fires on the claim itself regardless of what else changed.
+   *
+   * What it guards: the previous copy read "Without an account, your work stays
+   * only in this browser." "stays" promises persistence across a settling window
+   * in which the work is not yet durable, and "only in this browser" is a PRIVACY
+   * claim that is false — a guest's graph also exists server-side. Pinned by SHAPE
+   * so it cannot return under another wording.
+   */
+  it.each([
+    ['guest', { user: { id: 'guest' }, authenticated: true }],
+    ['signed out', { user: null, authenticated: false }],
+  ] as const)('claims nothing about where a %s user\'s work is stored', (_who, auth) => {
+    mockAuthValue = auth as typeof mockAuthValue
+    renderPage()
+    const text = document.body.textContent ?? ''
+    expect(text.length, 'nothing rendered — this assertion would be vacuous').toBeGreaterThan(0)
+    for (const banned of [
+      /only in this browser/i,
+      /stays? (?:only )?(?:on|in) (?:this|your) (?:browser|device|computer)/i,
+      /never leaves/i,
+      /stored only locally/i,
+      /we (?:do not|don't) (?:store|keep|save)/i,
+    ]) {
+      expect(text, `first-use copy must claim nothing about where work lives; matched ${banned}`)
+        .not.toMatch(banned)
+    }
   })
 
   // -------------------------------------------------------------------------

--- a/src/pages/__tests__/ScenarioListPage.spec.tsx
+++ b/src/pages/__tests__/ScenarioListPage.spec.tsx
@@ -57,7 +57,9 @@ function expectStrategicReasoningEntry() {
     ),
   ).toBeInTheDocument()
   expect(
-    screen.getByText('Sign in to save your workspace, or explore without an account.'),
+    screen.getByText(
+      'Sign in to create a saved workspace. Without an account, your work stays only in this browser.',
+    ),
   ).toBeInTheDocument()
   expect(screen.queryByRole('heading', { name: 'Decisions' })).not.toBeInTheDocument()
   expect(screen.queryByText(/manage your decisions/i)).not.toBeInTheDocument()

--- a/src/pages/__tests__/ScenarioListPage.spec.tsx
+++ b/src/pages/__tests__/ScenarioListPage.spec.tsx
@@ -56,13 +56,34 @@ function expectStrategicReasoningEntry() {
       'Olumi turns messy strategic work into a living visual model while keeping your judgement visible.',
     ),
   ).toBeInTheDocument()
-  expect(
-    screen.getByText(
-      'Sign in to create a saved workspace. Without an account, your work stays only in this browser.',
-    ),
-  ).toBeInTheDocument()
+  expect(screen.getByText('Sign in to create a saved workspace.')).toBeInTheDocument()
   expect(screen.queryByRole('heading', { name: 'Decisions' })).not.toBeInTheDocument()
   expect(screen.queryByText(/manage your decisions/i)).not.toBeInTheDocument()
+
+  // ⚠ REGRESSION PIN. The sentence this replaces was
+  //   "Without an account, your work stays only in this browser."
+  // and it was asserted VERBATIM by this very helper, so the guard cemented the
+  // untruth: correcting the copy REDded the suite, and leaving it green required
+  // keeping a false claim on the first screen a user ever sees.
+  //
+  // Both halves were wrong. "stays" promises persistence across a settling window
+  // in which the work is not yet durable. "only in this browser" is a PRIVACY
+  // claim and is false — a guest's graph also exists server-side.
+  //
+  // Pinned by SHAPE rather than by the one string, so it cannot come back under
+  // another wording. Each pattern is checked against the whole rendered document.
+  for (const banned of [
+    /only in this browser/i,
+    /stays? (?:only )?(?:on|in) (?:this|your) (?:browser|device|computer)/i,
+    /never leaves/i,
+    /stored only locally/i,
+    /we (?:do not|don't) (?:store|keep|save)/i,
+  ]) {
+    expect(
+      document.body.textContent ?? '',
+      `first-use copy must claim nothing about where guest work lives; matched ${banned}`,
+    ).not.toMatch(banned)
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/poc/__tests__/guestGateCanvasTransition.spec.tsx
+++ b/src/poc/__tests__/guestGateCanvasTransition.spec.tsx
@@ -1,8 +1,8 @@
 // src/poc/__tests__/guestGateCanvasTransition.spec.tsx
 //
-// THE FRESH GUEST'S FIRST CLICK. On the landing gate ("Sign in to save and
-// manage your decisions"), "Continue without an account" calls
-// `navigate('/canvas')` (src/pages/ScenarioListPage.tsx:387). The hash changes
+// THE FRESH GUEST'S FIRST CLICK. On the strategic-reasoning landing gate,
+// "Continue without an account" calls `navigate('/canvas')`
+// (src/pages/ScenarioListPage.tsx:390). The hash changes
 // immediately — and, before this spec, the GATE STAYED ON SCREEN for the whole
 // time the canvas chunk was downloading, with no spinner and no disabled
 // button. A fresh guest's first click appeared to do nothing.


### PR DESCRIPTION
Adapts `codex/c11-strategic-workspace-entry` (`c933611d`) rather than rebuilding it. Rebased onto staging. **Body describes HEAD `7c77ff2a`.**

## The problem

That branch replaced promise-nothing copy with:

> "Sign in to create a saved workspace. **Without an account, your work stays only in this browser.**"

Both halves are wrong at once.

- **"stays"** asserts persistence the product does not guarantee — there is a settling window in which a guest's work is not yet durable.
- **"only in this browser"** is a **privacy claim, and it is false**: a guest's graph also exists server-side.

The second is the worse half. A reader takes "only in this browser" to mean nothing leaves their machine, and that is not what happens.

The commit that introduced it was titled *"state guest persistence truthfully"*. Acceptable vagueness was replaced by **false precision**, which is harder to spot than the vagueness it replaced.

## What this does

Keeps the category framing ("Strategic reasoning") and the sign-in benefit. **Removes the storage sentence entirely** rather than hedging it.

The remedy is not a more carefully worded claim about storage. First use should say what Olumi **is** and how to begin; the storage boundary is System A's to define and is not settled enough to promise on the first screen a user sees.

## The spec was cementing the untruth

`expectStrategicReasoningEntry` asserted the false sentence **verbatim**, in a shared helper used by two tests. So correcting the copy REDded the suite, and keeping it green required leaving a false claim in the product.

It now carries a regression pin written by **shape**, not by the one string, so the claim cannot return under another wording.

## ⚠ The pin was itself vacuous when first written, and that was measured

Written inside the copy helper, **after** the exact-copy assertions, a mutant restoring the false sentence **never reached it** — `getByText` throws on the changed string first, so the pin only ran when the copy was already correct, in which case it could never fire. A guard whose only path to execution is the case it is not guarding reads green forever.

It is now an independent `it.each` over both auth states, asserting over the whole rendered document, with a non-empty precondition so it cannot pass vacuously.

## Evidence

Discriminating set, with the pin's own firing counted separately from the suite result:

| mutant | suite | pin fired |
|---|---|---|
| control | 17 passed | 0 |
| exact false sentence restored | 4 failed | **3** |
| same claim, different wording ("never leaves this device") | 4 failed | **3** |
| adjacent copy, no storage claim | 2 failed (exact-copy assertions only) | **0** |
| trailing control | 17 passed | 0 |

So the pin is bound to the **claim's shape**, not to a string, and stays silent on copy that makes no such claim.

Lint 0 errors (2 pre-existing warnings on untouched lines). **Named typecheck gate PASSED** — ratchet identical at baseline (2252). Applied-check 1 per mutant, 0 on both controls.

## Not addressed here, deliberately

The "Strategic reasoning" heading is orphaned ~45 lines later by three other framings ("Describe a decision you're facing", "Start a new decision", "My decisions"). Four reachable framings estate-wide. That is C11's job, not this branch's — rowed, not chased.

Rung: **TESTED**. Not deployed, not journey-witnessed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8zhVkx3tAqkrYsDBbGPxw