### PR TITLE
feat(canvas): boot restores CEE's analysis verdict, currency-withholding only (A3 link 6)

### DIFF
--- a/src/canvas/hydrate/__tests__/applyBootAnalysisVerdict.spec.ts
+++ b/src/canvas/hydrate/__tests__/applyBootAnalysisVerdict.spec.ts
@@ -1,0 +1,201 @@
+/**
+ * `applyBootAnalysisVerdict` — the unit, driven per contract kind.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * ⚠ THE DEV-BRANCH TRAP, AND HOW THIS FILE AVOIDS IT
+ * ═══════════════════════════════════════════════════════════════════════════
+ * The canvas's localStorage restore path sits inside `if (import.meta.env.PROD)`
+ * (`ReactFlowGraph.tsx:1504`), so under vitest — where `PROD` is false — that
+ * whole branch is dead and a spec routed through the reload effect would be
+ * exercising a path production never takes, against a key production never
+ * writes. This file therefore drives the FUNCTION DIRECTLY, with an injected
+ * store, and never mounts a component. `bootAnalysisVerdictRestore.spec.ts`
+ * likewise drives `hydrateCanvasFromServer` directly rather than through
+ * `useServerGraphHydration`.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * ⭐ WHY THE DECLINE *REASON* IS ASSERTED AND NOT JUST THE WRITE
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WRITTEN IN RESPONSE TO A SURVIVING MUTANT, and the survivor is the reason
+ * this file exists at all. Deleting the explicit `complete_current` decline
+ * from `applyBootAnalysisVerdict` left the whole suite GREEN (21/21, with the
+ * applied-check reading 1, so it was genuinely applied): the kind is ALSO
+ * excluded by `BOOT_RESTORABLE_RUN_STATE_KINDS`, so behaviour was unchanged and
+ * only the reason moved — `asserts_currency` → `not_restorable`.
+ *
+ * The gate is doubly defended, which is good, and NEITHER defence was pinned on
+ * its own, which is not. A survivor is a claim either way and must be
+ * demonstrated rather than asserted (trap 13c). Asserting the REASON separates
+ * the two defences, so removing either one REDs by name instead of hiding
+ * behind the other.
+ *
+ * That distinction is not bookkeeping: `asserts_currency` is the only decline
+ * that turns away a verdict CEE genuinely stated and genuinely means. Collapsing
+ * it into the "said nothing" bucket is how a later reader concludes the kind is
+ * simply unhandled and "fixes" it.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { ANALYSIS_RUN_STATE_KINDS } from '@talchain/schemas/boundary'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+
+import {
+  applyBootAnalysisVerdict,
+  BOOT_RESTORABLE_RUN_STATE_KINDS,
+  type BootAnalysisVerdictStore,
+} from '../applyScenarioAnalysisRead'
+
+type SetVerdictFn = NonNullable<BootAnalysisVerdictStore['setAnalysisStateV1']>
+
+function makeStore(): {
+  store: BootAnalysisVerdictStore
+  setAnalysisStateV1: ReturnType<typeof vi.fn>
+} {
+  const setAnalysisStateV1 = vi.fn<Parameters<SetVerdictFn>, ReturnType<SetVerdictFn>>(
+    () => {},
+  )
+  return { store: { setAnalysisStateV1 }, setAnalysisStateV1 }
+}
+
+/**
+ * A run_state for every kind the CONTRACT admits, built from the contract's own
+ * vocabulary rather than a hand-listed table — so a new kind arrives here
+ * automatically instead of being silently untested (trap 12).
+ *
+ * The per-kind required members come from the vendored 0.48.0 bytes, including
+ * the 0.47.0 cross-check CC-A that forces `blocked_unusable: true` under
+ * `blocked`.
+ */
+function runStateFor(kind: string): {
+  runState: AnalysisStateV1['run_state']
+  over: Partial<AnalysisStateV1>
+} {
+  const at = '2026-08-25T09:00:00.000Z'
+  switch (kind) {
+    case 'never_run':
+      return { runState: { kind: 'never_run' } as never, over: {} }
+    case 'running':
+      return { runState: { kind: 'running', started_at: at } as never, over: {} }
+    case 'blocked':
+      return {
+        runState: { kind: 'blocked', reason_code: 'no_options', blockers: [] } as never,
+        over: { blocked_unusable: true },
+      }
+    case 'refused':
+      return {
+        runState: { kind: 'refused', reason_code: 'declined_by_policy' } as never,
+        over: {},
+      }
+    case 'complete_current':
+      return { runState: { kind: 'complete_current', computed_at: at } as never, over: {} }
+    case 'complete_stale':
+      return {
+        runState: {
+          kind: 'complete_stale',
+          computed_at: at,
+          cause: 'graph_changed',
+        } as never,
+        over: {},
+      }
+    case 'unknown_degraded':
+      return {
+        runState: { kind: 'unknown_degraded', cause: 'store_unreadable' } as never,
+        over: {},
+      }
+    default:
+      throw new Error(`unmapped contract kind: ${kind}`)
+  }
+}
+
+function verdictFor(kind: string): AnalysisStateV1 {
+  const { runState, over } = runStateFor(kind)
+  return {
+    run_state: runState,
+    readiness: { status: 'ready', blockers: [] },
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: true,
+    blocked_unusable: false,
+    contradictions: [],
+    ...over,
+  } as AnalysisStateV1
+}
+
+describe('applyBootAnalysisVerdict — every contract kind, outcome AND reason', () => {
+  it('POSITIVE CONTROL — the contract vocabulary is reachable and every kind is mapped', () => {
+    expect(ANALYSIS_RUN_STATE_KINDS.length).toBeGreaterThanOrEqual(7)
+    // Proves the fixture builder covers the contract; an unmapped kind throws
+    // rather than silently skipping, so the loop below cannot be short.
+    for (const kind of ANALYSIS_RUN_STATE_KINDS) {
+      expect(() => verdictFor(kind)).not.toThrow()
+    }
+  })
+
+  it('a restorable kind WRITES the verdict verbatim, and reports `restored`', () => {
+    for (const kind of BOOT_RESTORABLE_RUN_STATE_KINDS) {
+      const { store, setAnalysisStateV1 } = makeStore()
+      const v = verdictFor(kind)
+      const outcome = applyBootAnalysisVerdict({ analysisState: v, store })
+      expect({ kind, outcome }).toEqual({ kind, outcome: { outcome: 'restored', kind } })
+      // VERBATIM — the same object, not a reconstruction. A leg that rebuilt the
+      // verdict could quietly drop a producer field.
+      expect(setAnalysisStateV1).toHaveBeenCalledTimes(1)
+      expect(setAnalysisStateV1.mock.calls[0]![0]).toBe(v)
+    }
+  })
+
+  it('⭐ `complete_current` declines with `asserts_currency` — NOT with the generic reason', () => {
+    // THE ASSERTION THAT KILLS THE SURVIVING MUTANT. Deleting the explicit
+    // `complete_current` branch leaves the kind declined (the set excludes it)
+    // but changes the reason to `not_restorable`, and this REDs on exactly that.
+    const { store, setAnalysisStateV1 } = makeStore()
+    const outcome = applyBootAnalysisVerdict({
+      analysisState: verdictFor('complete_current'),
+      store,
+    })
+    expect(outcome).toEqual({ outcome: 'declined', reason: 'asserts_currency' })
+    // A decline is a NO-OP — never a write of `null`, which is itself a claim.
+    expect(setAnalysisStateV1).not.toHaveBeenCalled()
+  })
+
+  it('the kinds that say NOTHING decline with `not_restorable` — a different fact', () => {
+    // The opposite-direction twin of the assertion above. Without it, a mutant
+    // that reported `asserts_currency` for EVERY decline would pass the test
+    // above while destroying the distinction it exists to make.
+    for (const kind of ['never_run', 'running', 'unknown_degraded']) {
+      const { store, setAnalysisStateV1 } = makeStore()
+      const outcome = applyBootAnalysisVerdict({ analysisState: verdictFor(kind), store })
+      expect({ kind, outcome }).toEqual({
+        kind,
+        outcome: { outcome: 'declined', reason: 'not_restorable' },
+      })
+      expect(setAnalysisStateV1).not.toHaveBeenCalled()
+    }
+  })
+
+  it('a null verdict declines with `no_verdict` and writes nothing — absence is not a state', () => {
+    const { store, setAnalysisStateV1 } = makeStore()
+    expect(applyBootAnalysisVerdict({ analysisState: null, store })).toEqual({
+      outcome: 'declined',
+      reason: 'no_verdict',
+    })
+    expect(setAnalysisStateV1).not.toHaveBeenCalled()
+  })
+
+  it('EVERY contract kind gets an outcome — none falls through undefined', () => {
+    for (const kind of ANALYSIS_RUN_STATE_KINDS) {
+      const { store } = makeStore()
+      const outcome = applyBootAnalysisVerdict({ analysisState: verdictFor(kind), store })
+      expect(outcome.outcome === 'restored' || outcome.outcome === 'declined').toBe(true)
+    }
+  })
+
+  it('never throws on a store with NO writer — the boot leg may not cost the user anything', () => {
+    expect(() =>
+      applyBootAnalysisVerdict({ analysisState: verdictFor('complete_stale'), store: {} }),
+    ).not.toThrow()
+  })
+})

--- a/src/canvas/hydrate/__tests__/applyBootAnalysisVerdict.spec.ts
+++ b/src/canvas/hydrate/__tests__/applyBootAnalysisVerdict.spec.ts
@@ -35,7 +35,7 @@
  * simply unhandled and "fixes" it.
  */
 
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, type Mock } from 'vitest'
 import { ANALYSIS_RUN_STATE_KINDS } from '@talchain/schemas/boundary'
 import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
 
@@ -47,9 +47,20 @@ import {
 
 type SetVerdictFn = NonNullable<BootAnalysisVerdictStore['setAnalysisStateV1']>
 
+/**
+ * ⚠ TYPED BY IDENTITY OFF THE STORE CONTRACT, NOT AS `ReturnType<typeof vi.fn>`.
+ * That widens to `Mock<any[], unknown>` while `vi.fn<Parameters<…>, …>` infers
+ * the real tuple, and vitest's `Mock` is INVARIANT in its argument tuple
+ * (`mock.calls` puts `TArgs` in both positions), so the two do not assign —
+ * TS2322, caught by the typecheck ratchet. Deriving both the declaration and
+ * the implementation from `BootAnalysisVerdictStore` fixes it at the source AND
+ * keeps `mock.calls[0]![0]` checked against the REAL parameter, which a widened
+ * `any[]` would have silently stopped checking. Same lesson as the sibling
+ * `applyScenarioAnalysisRead.spec.ts:73-83`.
+ */
 function makeStore(): {
   store: BootAnalysisVerdictStore
-  setAnalysisStateV1: ReturnType<typeof vi.fn>
+  setAnalysisStateV1: Mock<Parameters<SetVerdictFn>, ReturnType<SetVerdictFn>>
 } {
   const setAnalysisStateV1 = vi.fn<Parameters<SetVerdictFn>, ReturnType<SetVerdictFn>>(
     () => {},

--- a/src/canvas/hydrate/__tests__/bootAnalysisVerdict.contractPartition.spec.ts
+++ b/src/canvas/hydrate/__tests__/bootAnalysisVerdict.contractPartition.spec.ts
@@ -1,0 +1,108 @@
+/**
+ * THE BOOT-RESTORABLE SET MUST NOTICE THE CONTRACT GROWING — A3 link 6.
+ *
+ * The sibling of `applyScenarioAnalysisRead.contractPartition.spec.ts`, and it
+ * exists for the same reason: `BOOT_RESTORABLE_RUN_STATE_KINDS` is a JUDGEMENT
+ * about what a boot read may safely say, not a fact the contract carries, so it
+ * cannot be derived — deriving it from the contract would just be the contract,
+ * and every kind would be restorable.
+ *
+ * What IS checkable is that the judgement has been made for every kind the
+ * producer admits. Trap 12d: a derived guard proves agreement and can never
+ * prove completeness; completeness needs a check NOT derived from the list under
+ * test. Here that is `ANALYSIS_RUN_STATE_KINDS`, imported at runtime from the
+ * contract itself.
+ *
+ * ⭐ AND ONE ASSERTION THIS FILE HAS THAT ITS SIBLING DOES NOT: the boot set must
+ * be a STRICT SUBSET of the read-terminal set, and `complete_current` must be
+ * the exact difference. That relationship IS derivable, it is the whole safety
+ * argument of the boot leg, and pinning it means a later widening of either set
+ * cannot silently re-admit the currency claim.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { ANALYSIS_RUN_STATE_KINDS } from '@talchain/schemas/boundary'
+
+import {
+  BOOT_RESTORABLE_RUN_STATE_KINDS,
+  BOOT_DECLINED_RUN_STATE_KINDS,
+  READ_TERMINAL_RUN_STATE_KINDS,
+  isBootRestorableRunState,
+} from '../applyScenarioAnalysisRead'
+
+describe('the boot-restorable partition tracks the CONTRACT, not a copy of it', () => {
+  it('POSITIVE CONTROL — the contract vocabulary is reachable and non-trivial', () => {
+    // Without this, a broken import resolving to `undefined`/`[]` makes every
+    // assertion below pass vacuously (trap 13). Magnitude matters as much as
+    // sign: an empty array satisfies "is an array".
+    expect(Array.isArray(ANALYSIS_RUN_STATE_KINDS)).toBe(true)
+    expect(ANALYSIS_RUN_STATE_KINDS.length).toBeGreaterThanOrEqual(7)
+    expect(ANALYSIS_RUN_STATE_KINDS).toContain('complete_current')
+  })
+
+  it('⭐ the two boot sets PARTITION the contract vocabulary exactly — a new kind REDs here', () => {
+    const classified = [
+      ...BOOT_RESTORABLE_RUN_STATE_KINDS,
+      ...BOOT_DECLINED_RUN_STATE_KINDS,
+    ].sort()
+    const contract = [...ANALYSIS_RUN_STATE_KINDS].sort()
+
+    // GROWTH: a kind the contract has and we have not classified. A new kind
+    // must be reasoned about explicitly, not fall silently into the safe
+    // default — silence is how a new state stops being noticed.
+    expect(contract.filter((k) => !classified.includes(k))).toEqual([])
+    // INVENTION: a kind we classify that the contract does not have.
+    expect(classified.filter((k) => !contract.includes(k as never))).toEqual([])
+    // Exact equality, which also catches a duplicate in either set.
+    expect(classified).toEqual(contract)
+  })
+
+  it('the two boot sets are DISJOINT — no kind is both restorable and declined', () => {
+    const overlap = BOOT_RESTORABLE_RUN_STATE_KINDS.filter((k) =>
+      (BOOT_DECLINED_RUN_STATE_KINDS as readonly string[]).includes(k),
+    )
+    expect(overlap).toEqual([])
+  })
+
+  it('the predicate agrees with the declared sets over the WHOLE contract vocabulary', () => {
+    for (const kind of ANALYSIS_RUN_STATE_KINDS) {
+      const expected = (BOOT_RESTORABLE_RUN_STATE_KINDS as readonly string[]).includes(kind)
+      expect({ kind, restorable: isBootRestorableRunState(kind) }).toEqual({
+        kind,
+        restorable: expected,
+      })
+    }
+  })
+
+  it('⭐ boot ⊂ read-terminal, and `complete_current` is EXACTLY the difference', () => {
+    // THE SAFETY ARGUMENT, PINNED. The boot leg may restore only kinds the
+    // polling leg already considers terminal — it can never be MORE permissive
+    // — and the one kind it additionally refuses is the one that asserts
+    // currency the client cannot verify.
+    const terminal = [...READ_TERMINAL_RUN_STATE_KINDS]
+    const boot = [...BOOT_RESTORABLE_RUN_STATE_KINDS]
+
+    // Subset: nothing restorable at boot is outside the terminal set.
+    expect(boot.filter((k) => !(terminal as readonly string[]).includes(k))).toEqual([])
+    // STRICT subset, and the difference is named — not merely non-empty.
+    const difference = terminal.filter((k) => !(boot as readonly string[]).includes(k))
+    expect(difference).toEqual(['complete_current'])
+  })
+
+  it('`complete_current` is NEVER boot-restorable — the assertion the whole leg rests on', () => {
+    expect(isBootRestorableRunState('complete_current')).toBe(false)
+    expect(BOOT_RESTORABLE_RUN_STATE_KINDS).not.toContain('complete_current' as never)
+    // ...and it IS a real contract kind, so the assertion above is about the
+    // producer's vocabulary rather than about a string nobody emits.
+    expect(ANALYSIS_RUN_STATE_KINDS).toContain('complete_current')
+  })
+
+  it('CONTRAST CONTROL — the predicate rejects a kind the contract does not carry', () => {
+    // Proves the predicate discriminates rather than answering broadly.
+    expect(isBootRestorableRunState('complete_stale_XYZ')).toBe(false)
+    expect(ANALYSIS_RUN_STATE_KINDS).not.toContain('complete_stale_XYZ' as never)
+    // ...against a member it DOES accept, in the same run. Absence is only
+    // proven when the target reads false AND the contrast reads true.
+    expect(isBootRestorableRunState('complete_stale')).toBe(true)
+  })
+})

--- a/src/canvas/hydrate/__tests__/bootAnalysisVerdict.contractPartition.spec.ts
+++ b/src/canvas/hydrate/__tests__/bootAnalysisVerdict.contractPartition.spec.ts
@@ -74,19 +74,34 @@ describe('the boot-restorable partition tracks the CONTRACT, not a copy of it', 
     }
   })
 
-  it('⭐ boot ⊂ read-terminal, and `complete_current` is EXACTLY the difference', () => {
+  it('⭐ boot ⊂ read-terminal, and the difference is NAMED — three kinds, one reason each', () => {
     // THE SAFETY ARGUMENT, PINNED. The boot leg may restore only kinds the
-    // polling leg already considers terminal — it can never be MORE permissive
-    // — and the one kind it additionally refuses is the one that asserts
-    // currency the client cannot verify.
+    // polling leg already considers terminal — never MORE permissive — and the
+    // kinds it ADDITIONALLY refuses are refused because THE BOOT MERGE CAN
+    // FALSIFY THEM in the interval between CEE composing the verdict and the
+    // client reading it:
+    //
+    //   `complete_current`  asserts CURRENCY the client cannot verify
+    //   `blocked`           asserts the model is NOT ANALYSABLE — and the merge
+    //                       may supply the very values CEE refused over
+    //   `refused`           same shape: a previous session's refusal, asserted
+    //                       as still true
+    //
+    // Only `complete_stale` survives, because staleness is MONOTONE: it cannot
+    // become false without a new run, and a new run yields a new verdict.
+    //
+    // ⚠ THIS ASSERTION EARNED ITS KEEP. It RED-ed when `blocked` / `refused`
+    // were removed from the boot set, forcing this reasoning to be restated
+    // rather than silently widened — which is exactly what a partition guard is
+    // for (trap 12d).
     const terminal = [...READ_TERMINAL_RUN_STATE_KINDS]
     const boot = [...BOOT_RESTORABLE_RUN_STATE_KINDS]
 
-    // Subset: nothing restorable at boot is outside the terminal set.
     expect(boot.filter((k) => !(terminal as readonly string[]).includes(k))).toEqual([])
-    // STRICT subset, and the difference is named — not merely non-empty.
     const difference = terminal.filter((k) => !(boot as readonly string[]).includes(k))
-    expect(difference).toEqual(['complete_current'])
+    expect(difference).toEqual(['complete_current', 'blocked', 'refused'])
+    // STRICTLY smaller, stated separately so a future widening to equality REDs.
+    expect(boot.length).toBeLessThan(terminal.length)
   })
 
   it('`complete_current` is NEVER boot-restorable — the assertion the whole leg rests on', () => {

--- a/src/canvas/hydrate/__tests__/bootAnalysisVerdictRestore.spec.ts
+++ b/src/canvas/hydrate/__tests__/bootAnalysisVerdictRestore.spec.ts
@@ -182,7 +182,7 @@ function storedVerdict(): AnalysisStateV1 | null {
   return useCanvasStore.getState().analysisStateV1 ?? null
 }
 
-describe('boot restores a currency-WITHHOLDING verdict CEE already sent', () => {
+describe('boot restores ONLY a verdict the boot merge cannot falsify', () => {
   it('POSITIVE CONTROL — the fixture verdict actually PARSES at the adapter', async () => {
     // Without this the whole file is vacuous: a verdict that fails
     // `AnalysisStateV1Schema.safeParse` arrives as `null`, and "the store holds
@@ -235,7 +235,7 @@ describe('boot restores a currency-WITHHOLDING verdict CEE already sent', () => 
     expect(storedVerdict()?.run_state.kind).toBe('complete_stale')
   })
 
-  it('a `blocked` verdict restores — the model is not analysable, and that is provable from a read', async () => {
+  it('⚠ a `blocked` verdict is DECLINED — the boot merge can falsify "not analysable"', async () => {
     fetchSpy.mockResolvedValue(
       jsonResponse(
         200,
@@ -254,10 +254,16 @@ describe('boot restores a currency-WITHHOLDING verdict CEE already sent', () => 
       ),
     )
     await hydrateCanvasFromServer(SCENARIO_ID)
-    expect(storedVerdict()?.run_state.kind).toBe('blocked')
+    // ⚠ WAS `toBe('blocked')` UNTIL INDEPENDENT REVIEW REFUTED IT. Restoring a
+    // `blocked` verdict forces `ceeAnalysisReadyStatus: 'blocked'` at
+    // `analysisStateSelector.ts:632-633` REGARDLESS of readiness, which
+    // `deriveAnalysisDisplayState` turns into a not-ready/refusal banner that
+    // OVERRIDES a populated report — strictly less information than no verdict,
+    // on the surface this slice exists to improve.
+    expect(storedVerdict()).toBeNull()
   })
 
-  it('a `refused` verdict restores — the currency of any visible result is explicitly not vouched for', async () => {
+  it('⚠ a `refused` verdict is DECLINED — a previous session`s refusal is not evidence about now', async () => {
     fetchSpy.mockResolvedValue(
       jsonResponse(
         200,
@@ -267,7 +273,7 @@ describe('boot restores a currency-WITHHOLDING verdict CEE already sent', () => 
       ),
     )
     await hydrateCanvasFromServer(SCENARIO_ID)
-    expect(storedVerdict()?.run_state.kind).toBe('refused')
+    expect(storedVerdict()).toBeNull()
   })
 })
 

--- a/src/canvas/hydrate/__tests__/bootAnalysisVerdictRestore.spec.ts
+++ b/src/canvas/hydrate/__tests__/bootAnalysisVerdictRestore.spec.ts
@@ -1,0 +1,372 @@
+/**
+ * BOOT RESTORES CEE'S ANALYSIS VERDICT — the A3 link-6 spec.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE DEFECT, DERIVED AT THIS TIP
+ * ═══════════════════════════════════════════════════════════════════════════
+ * `fetchScenarioGraph` PARSES CEE's composed verdict off the boot response
+ * (`adapters/cee/scenarioGraph.ts:296`, with the contract's own `.strict()`
+ * schema). `hydrateCanvasFromServer` then consumes `graph` / `briefText` /
+ * `notModelled` / `identity` and DROPS `analysisState` on the floor.
+ *
+ * The only consumer of that parsed verdict is `useProvisionalAnalysisDelivery`,
+ * which arms solely when `analysisStateV1.run_state.kind === 'running'`
+ * (`useProvisionalAnalysisDelivery.ts:248-253`) — and `hydrateGraphSlice` nulls
+ * `analysisStateV1` at boot (`store.ts:6043`) BEFORE that could ever be true.
+ * React runs child effects before parent effects, so the localStorage restore
+ * (and its null) always precedes this hydration (`useServerGraphHydration.ts:8-15`).
+ *
+ * So on every ordinary reload CEE's verdict is fetched, validated, and thrown
+ * away, and the panel falls back to the LOCAL derivation — which #837 had to
+ * patch from the other end.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * ⚠⚠ WHY THE RESTORE IS NARROWER THAN "RESTORE THE VERDICT"
+ * ═══════════════════════════════════════════════════════════════════════════
+ * `AnalysisStateV1` carries NO graph hashes (derived at the vendored 0.48.0
+ * bytes — `run_state.kind` IS the freshness statement, and there is no
+ * `graph_hash_at_run`/`current_graph_hash` pair anywhere on it). The verdict is
+ * CEE's statement about CEE'S OWN persisted graph.
+ *
+ * And the selector is FEATURE-DETECTED on this field: a non-null
+ * `analysisStateV1` takes the WIRE branch, where `semantic` comes from
+ * `mapRunStateKindToSemantic(kind, hasReport)` and the local dirty overlay is
+ * NOT CONSULTED (`analysisStateSelector.ts:551-554`).
+ *
+ * Therefore restoring `complete_current` would produce `semantic: 'current'`,
+ * `wireForcesStale: false`, `analysisChanged: false` — a green "Analysis
+ * complete" OVER A CANVAS #837 HAS JUST MARKED STALE. The naive restore does
+ * not rescue #837; it DEFEATS it. That is the inverted falsehood, and it is why
+ * the currency-ASSERTING kind is declined here.
+ *
+ * The client cannot establish the precondition that would make it honest: it
+ * has no access to CEE's hash function, and saying otherwise is the
+ * two-hash-functions trap (`store/analysisFreshness.ts:441-445` says exactly
+ * this about the sibling attestation path).
+ *
+ * So the restore is FAIL-CLOSED BY CONSTRUCTION: it may only ever WITHHOLD
+ * currency, never assert it.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+
+import { useCanvasStore } from '../../store'
+import { hydrateCanvasFromServer } from '../serverGraphHydration'
+
+const SCENARIO_ID = '11111111-2222-4333-8444-555555555555'
+const CEE_TOKEN = 'c'.repeat(63) + '9'
+
+function envelope(value = CEE_TOKEN, projection = 'identity.v1') {
+  return {
+    kind: 'graph_identity_hash',
+    value,
+    algorithm: 'sha256',
+    projection_version: projection,
+    graph_schema_version: 'graph_v3',
+    normaliser_version: '1',
+  }
+}
+
+/**
+ * A verdict that VALIDATES against the vendored contract — the adapter parses
+ * with `AnalysisStateV1Schema.safeParse` and a shape that fails yields `null`,
+ * which would make every assertion below pass for the WRONG REASON. The
+ * positive control in the first test is what proves it parses.
+ */
+function verdict(
+  runState: AnalysisStateV1['run_state'],
+  over: Partial<AnalysisStateV1> = {},
+): AnalysisStateV1 {
+  return {
+    run_state: runState,
+    readiness: { status: 'ready', blockers: [] },
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: true,
+    blocked_unusable: false,
+    contradictions: [],
+    ...over,
+  } as AnalysisStateV1
+}
+
+const STALE_VERDICT = verdict({
+  kind: 'complete_stale',
+  computed_at: '2026-08-25T09:00:00.000Z',
+  // `cause`, NOT `stale_cause`. The schema is `.strict()`, so the wrong spelling
+  // produced a parse failure that arrived as `null` — indistinguishable from the
+  // defect under test. The positive control above is the only reason that was
+  // caught rather than shipped as a spec that passes for the wrong reason.
+  cause: 'graph_changed',
+})
+
+const CURRENT_VERDICT = verdict({
+  kind: 'complete_current',
+  computed_at: '2026-08-25T09:00:00.000Z',
+})
+
+function okBody(over: Record<string, unknown> = {}) {
+  return {
+    schema: 'scenario_graph.v1',
+    scenario_id: SCENARIO_ID,
+    graph: {
+      nodes: [
+        // A DIFFERENT value from the seeded canvas below, so the merge genuinely
+        // `changed` the graph and #837's mark actually fires. A merge that
+        // changes nothing would make the disjointness assertions vacuous.
+        { id: 'factor-1', kind: 'factor', label: 'Spend', value: 250 },
+        { id: 'goal-1', kind: 'goal', label: 'Profit', value: 9 },
+      ],
+      edges: [],
+    },
+    graph_present: true,
+    brief_text: null,
+    graph_identity_hash: envelope(),
+    layout_present: false,
+    request_id: 'req-boot-1',
+    ...over,
+  }
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response
+}
+
+function seedCanvas(): void {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_ID,
+    nodes: [
+      {
+        id: 'factor-1',
+        type: 'factor',
+        position: { x: 10, y: 20 },
+        data: { label: 'Spend', kind: 'factor', value: 100 },
+      },
+      {
+        id: 'goal-1',
+        type: 'goal',
+        position: { x: 300, y: 400 },
+        data: { label: 'Profit', kind: 'goal', value: 5 },
+      },
+    ] as never,
+    edges: [] as never,
+    lastAuthoritativeGraph: null,
+    serverGraphIdentity: null,
+    history: { past: [], future: [] },
+    // The state `hydrateGraphSlice` leaves behind at boot (`store.ts:6043`).
+    analysisStateV1: null,
+    analysisFreshnessDirty: false,
+  } as never)
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchSpy = vi.fn()
+  vi.stubGlobal('fetch', fetchSpy)
+  seedCanvas()
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function storedVerdict(): AnalysisStateV1 | null {
+  return useCanvasStore.getState().analysisStateV1 ?? null
+}
+
+describe('boot restores a currency-WITHHOLDING verdict CEE already sent', () => {
+  it('POSITIVE CONTROL — the fixture verdict actually PARSES at the adapter', async () => {
+    // Without this the whole file is vacuous: a verdict that fails
+    // `AnalysisStateV1Schema.safeParse` arrives as `null`, and "the store holds
+    // null" would then be indistinguishable from the defect under test.
+    // Proven through the REAL adapter, not by re-parsing here.
+    const { fetchScenarioGraph } = await import('../../../adapters/cee/scenarioGraph')
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ analysis_state: STALE_VERDICT })),
+    )
+    const result = await fetchScenarioGraph(SCENARIO_ID)
+    expect(result.status).toBe('graph')
+    expect(result.status === 'graph' && result.analysisState).not.toBeNull()
+    expect(
+      result.status === 'graph' && result.analysisState?.run_state.kind,
+    ).toBe('complete_stale')
+  })
+
+  it('⭐ RED-FIRST — a MERGING boot restores CEE`s `complete_stale` into the store', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ analysis_state: STALE_VERDICT })),
+    )
+
+    const outcome = await hydrateCanvasFromServer(SCENARIO_ID)
+
+    // The boot genuinely merged — otherwise this is not the case under test.
+    expect(outcome).toBe('merged')
+    // THE DEFECT: at pristine this is `null`. CEE said `complete_stale` in the
+    // very response the merge came from, and the boot path dropped it.
+    expect(storedVerdict()).not.toBeNull()
+    expect(storedVerdict()?.run_state.kind).toBe('complete_stale')
+  })
+
+  it('the `unchanged` re-boot ALSO restores — that is the commonest boot of all', async () => {
+    // The server graph has not moved since the last hydration, so
+    // `hydrateCanvasFromServer` short-circuits WITHOUT merging. The verdict is
+    // dropped there too, and this is precisely the boot on which a user is most
+    // likely to open the panel (the module's own note at
+    // `serverGraphHydration.ts:141-145` makes the same argument for the
+    // context-integrity write).
+    useCanvasStore.setState({
+      serverGraphIdentity: { value: CEE_TOKEN, projectionVersion: 'identity.v1' },
+    } as never)
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ analysis_state: STALE_VERDICT })),
+    )
+
+    const outcome = await hydrateCanvasFromServer(SCENARIO_ID)
+
+    expect(outcome).toBe('unchanged')
+    expect(storedVerdict()?.run_state.kind).toBe('complete_stale')
+  })
+
+  it('a `blocked` verdict restores — the model is not analysable, and that is provable from a read', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(
+        200,
+        okBody({
+          // `blocked_unusable: true` is REQUIRED by the contract's own
+          // cross-check CC-A (0.47.0): "run_state.kind 'blocked' is produced by
+          // the same status that forces blocked_unusable true; a payload
+          // asserting otherwise cannot come from the producer". Without it the
+          // fixture fails validation and arrives as `null` — a green-for-the-
+          // wrong-reason test the positive control exists to prevent.
+          analysis_state: verdict(
+            { kind: 'blocked', reason_code: 'no_options', blockers: [] },
+            { blocked_unusable: true },
+          ),
+        }),
+      ),
+    )
+    await hydrateCanvasFromServer(SCENARIO_ID)
+    expect(storedVerdict()?.run_state.kind).toBe('blocked')
+  })
+
+  it('a `refused` verdict restores — the currency of any visible result is explicitly not vouched for', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(
+        200,
+        okBody({
+          analysis_state: verdict({ kind: 'refused', reason_code: 'declined_by_policy' }),
+        }),
+      ),
+    )
+    await hydrateCanvasFromServer(SCENARIO_ID)
+    expect(storedVerdict()?.run_state.kind).toBe('refused')
+  })
+})
+
+describe('⭐ BOTH DIRECTIONS — the restore may never ASSERT currency', () => {
+  it('`complete_current` is DECLINED — restoring it would render "Analysis complete" over a canvas #837 marked stale', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ analysis_state: CURRENT_VERDICT })),
+    )
+
+    const outcome = await hydrateCanvasFromServer(SCENARIO_ID)
+    expect(outcome).toBe('merged')
+
+    // Declined: the store stays on the DERIVED branch, where #837's dirty
+    // overlay is still consulted. Restoring the wire verdict here would switch
+    // the selector to the wire branch and silence that overlay outright.
+    expect(storedVerdict()).toBeNull()
+  })
+
+  it('a genuinely-current model is NOT marked stale by this change', async () => {
+    // The inverse harm. Marking unconditionally converts silence into a
+    // permanent false alarm, which users learn to ignore. Nothing in the
+    // restore path may fabricate a stale claim from a `complete_current` read.
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ analysis_state: CURRENT_VERDICT })),
+    )
+    await hydrateCanvasFromServer(SCENARIO_ID)
+
+    const held = storedVerdict()
+    expect(held?.run_state.kind).not.toBe('complete_stale')
+    expect(held?.run_state.kind).not.toBe('refused')
+  })
+
+  it('a NON-TERMINAL `never_run` read restores nothing — it is indistinguishable from in-flight', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ analysis_state: verdict({ kind: 'never_run' }) })),
+    )
+    await hydrateCanvasFromServer(SCENARIO_ID)
+    expect(storedVerdict()).toBeNull()
+  })
+
+  it('an ABSENT verdict leaves the store exactly as boot left it', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody()))
+    await hydrateCanvasFromServer(SCENARIO_ID)
+    expect(storedVerdict()).toBeNull()
+  })
+
+  it('a MALFORMED verdict is absence, never authority', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ analysis_state: { run_state: { kind: 'not_a_kind' } } })),
+    )
+    await hydrateCanvasFromServer(SCENARIO_ID)
+    expect(storedVerdict()).toBeNull()
+  })
+})
+
+describe('the restore and #837`s stale mark are DISJOINT writes', () => {
+  it('⭐ restoring the verdict does NOT clear the dirty overlay the merge just set', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ analysis_state: STALE_VERDICT })),
+    )
+
+    await hydrateCanvasFromServer(SCENARIO_ID)
+
+    // #837: `mergeServerGraphOnHydrate` calls `markGraphStructurallyEdited()`
+    // when the merge `changed` the graph. Both facts must stand together — the
+    // restore writes `analysisStateV1`, the mark writes the freshness trio, and
+    // neither may stand on the other's field.
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+    expect(storedVerdict()?.run_state.kind).toBe('complete_stale')
+  })
+
+  it('the DECLINED path also leaves #837`s mark standing', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ analysis_state: CURRENT_VERDICT })),
+    )
+    await hydrateCanvasFromServer(SCENARIO_ID)
+    // The decline must be a NO-OP, not a write of `null` over a live mark.
+    expect(useCanvasStore.getState().analysisFreshnessDirty).toBe(true)
+  })
+})
+
+describe('a non-graph answer restores nothing — a refusal is never a verdict', () => {
+  it('404 (not readable) writes no verdict', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(404, {}))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('notReadable')
+    expect(storedVerdict()).toBeNull()
+  })
+
+  it('a 200 with no graph writes no verdict', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, {
+        schema: 'scenario_graph.v1',
+        scenario_id: SCENARIO_ID,
+        graph_present: false,
+        request_id: 'req-absent',
+        analysis_state: STALE_VERDICT,
+      }),
+    )
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('absent')
+    expect(storedVerdict()).toBeNull()
+  })
+})

--- a/src/canvas/hydrate/__tests__/bootVerdictCausalChain.spec.ts
+++ b/src/canvas/hydrate/__tests__/bootVerdictCausalChain.spec.ts
@@ -1,0 +1,222 @@
+/**
+ * THE CAUSAL CHAIN, PINNED — and TWO CORRECTED PREMISES, one of them mine.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * ⚠⚠ CORRECTION 1 — THE CHAIN THIS PR WAS BRIEFED TO ASSERT DOES NOT EXIST
+ * ═══════════════════════════════════════════════════════════════════════════
+ * The dispatch held that consuming the persisted verdict at boot makes the
+ * FRESHNESS SLICE non-null, so a turn-1 verdict equal to it hits
+ * `if (!verdictChanged) return {}` (`store.ts:4902`) and the dirty overlay
+ * survives.
+ *
+ * That describes a DIFFERENT FIELD, and this PR cannot produce it:
+ *   · `setAnalysisFreshness` reduces `state.analysisFreshness`, sourced ONLY
+ *     from `response.analysis_ready` (`store/analysisFreshness.ts:15`);
+ *   · the scenario-graph read carries `analysis_state` and `analysis_result`
+ *     and nothing else (`adapters/cee/scenarioGraph.ts:296,301`). Measured with
+ *     contrast controls: `analysis_ready` appears 0× in that adapter, while
+ *     `analysis_state` appears 2× there and `analysis_ready` 40× in
+ *     `v5/applyV5State.ts` — the zero is real absence, not a blind probe;
+ *   · this PR writes `analysisStateV1`, never `analysisFreshness`, which is
+ *     STILL NULL after a boot-consume.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * ⚠ CORRECTION 2 — MY OWN FIRST DRAFT OF THIS FILE WAS WRONG TOO
+ * ═══════════════════════════════════════════════════════════════════════════
+ * It asserted that with a null freshness slice "the overlay is the only thing
+ * talking". MEASURED, it is not talking at all. The derived branch, driven
+ * directly through `classifyFreshnessForDisplay`:
+ *
+ *   null slice,  dirty=true  → 'none'      null slice,  dirty=false → 'none'
+ *   fresh slice, dirty=true  → 'changed'   fresh slice, dirty=false → 'current'
+ *
+ * The overlay only discriminates once a verdict is PRESENT — with no verdict
+ * there is nothing for it to downgrade. That changes where the harm lives and
+ * what this PR is entitled to claim, so it is written down rather than quietly
+ * patched around.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHAT THIS PR'S CHAIN ACTUALLY IS, AND THE WINDOW IT GOVERNS
+ * ═══════════════════════════════════════════════════════════════════════════
+ *   boot restores `analysisStateV1`
+ *     → `composeAnalysisState` feature-detects a non-null verdict
+ *     → the WIRE branch answers
+ *     → `semantic` = `mapRunStateKindToSemantic(kind, hasReport)`
+ *     → the local dirty overlay is not consulted at all
+ *
+ * AT BOOT the freshness slice is null, so without this PR the derived branch
+ * says `'none'` — the product states NOTHING about staleness while CEE's
+ * verdict, sitting in the very response the graph arrived in, says
+ * `complete_stale`. With it, the product says `'changed'`, which is what #839's
+ * Rerun affordance is built to state.
+ *
+ * ⚠ THE WINDOW IS BOOT → FIRST TURN, AND NO FURTHER. `applyV5State` overwrites
+ * `analysisStateV1` with the turn's own verdict, and CLEARS it on a turn that
+ * carries none (`applyV5State.ts:1176-1184`). Both are correct — a turn is a
+ * fresher authority than a boot read — and both end this PR's governance. The
+ * post-turn-1 freshness defect is NOT fixed here and is named in the PR limits.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+
+import { composeAnalysisState, mapRunStateKindToSemantic } from '../../state/analysisStateSelector'
+import type { AnalysisFreshnessState } from '../../store/analysisFreshness'
+
+function verdict(
+  runState: AnalysisStateV1['run_state'],
+  over: Partial<AnalysisStateV1> = {},
+): AnalysisStateV1 {
+  return {
+    run_state: runState,
+    readiness: { status: 'ready', blockers: [] },
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: true,
+    blocked_unusable: false,
+    contradictions: [],
+    ...over,
+  } as AnalysisStateV1
+}
+
+const RESTORED_STALE = verdict({
+  kind: 'complete_stale',
+  computed_at: '2026-08-25T09:00:00.000Z',
+  cause: 'graph_changed',
+})
+
+const TURN_CURRENT = verdict({
+  kind: 'complete_current',
+  computed_at: '2026-08-25T10:00:00.000Z',
+})
+
+/** What the live capture measured on turn 1: `fresh` / `graph_hash_match`. */
+const TURN1_FRESH: AnalysisFreshnessState = {
+  freshness: 'fresh',
+  freshnessReason: 'graph_hash_match',
+}
+
+function compose(over: {
+  analysisState: AnalysisStateV1 | null
+  freshness: AnalysisFreshnessState | null
+  dirty: boolean
+}) {
+  return composeAnalysisState({
+    analysisState: over.analysisState,
+    freshness: over.freshness,
+    dirty: over.dirty,
+    source: 'none',
+    resultsStatus: 'complete',
+    resultsStartedAt: undefined,
+    importHold: false,
+    hasReport: true,
+    ceeAnalysisReadyStatus: 'ready',
+    aiPanelV2On: true,
+  } as never)
+}
+
+describe('PRECONDITIONS — measured, so nothing below passes for the wrong reason', () => {
+  it('⭐ THE HARM the capture recorded: with a verdict present, clearing the overlay flips changed → current', () => {
+    // `store.ts:4934-4940` fired on turn 1 in 4/4 captured runs. THIS is what it
+    // buys: "Analysis reflects the current model" over a canvas the boot merge
+    // had changed. The overlay is genuinely load-bearing HERE.
+    const kept = compose({ analysisState: null, freshness: TURN1_FRESH, dirty: true })
+    const cleared = compose({ analysisState: null, freshness: TURN1_FRESH, dirty: false })
+    expect(kept.semantic).toBe('changed')
+    expect(cleared.semantic).toBe('current')
+  })
+
+  it('⚠ AT BOOT the overlay is INERT — the freshness slice is null, so it has nothing to downgrade', () => {
+    // The correction that rewrote this file. Both arms are 'none': at boot the
+    // derived branch cannot say anything about staleness at all, whatever the
+    // overlay holds. So the boot-time gap is not "the overlay got cleared" — it
+    // is that there is NO VERDICT TO SHOW.
+    expect(compose({ analysisState: null, freshness: null, dirty: true }).semantic).toBe('none')
+    expect(compose({ analysisState: null, freshness: null, dirty: false }).semantic).toBe('none')
+  })
+})
+
+describe('⭐ the chain: restored verdict → wire branch → the overlay stops deciding', () => {
+  it('⭐⭐ THE CAPABILITY: at boot, a restored `complete_stale` turns silence into a stated verdict', () => {
+    // Without the restore the product says NOTHING (`'none'`, pinned above)
+    // while CEE's verdict — in the same response the graph came from — says the
+    // analysis is stale. This is the user-visible change, and it is what #839's
+    // Rerun affordance consumes.
+    const before = compose({ analysisState: null, freshness: null, dirty: false })
+    const after = compose({ analysisState: RESTORED_STALE, freshness: null, dirty: false })
+
+    expect(before.authority).toBe('derived')
+    expect(before.semantic).toBe('none')
+    expect(after.authority).toBe('wire')
+    expect(after.runStateKind).toBe('complete_stale')
+    expect(after.semantic).toBe('changed')
+    // #839 gates its affordance on this; it is producer-composed under the wire.
+    expect(after.requiresRerun).toBe(true)
+  })
+
+  it('⭐ the wire branch does NOT consult the overlay — its fate stops mattering', () => {
+    // The honest form of "the overlay survives the next turn". It may or may not
+    // survive; while a verdict stands, the answer is the same either way.
+    const overlayIntact = compose({
+      analysisState: RESTORED_STALE,
+      freshness: TURN1_FRESH,
+      dirty: true,
+    })
+    const overlayCleared = compose({
+      analysisState: RESTORED_STALE,
+      freshness: TURN1_FRESH,
+      dirty: false,
+    })
+    expect(overlayIntact.semantic).toBe('changed')
+    expect(overlayCleared.semantic).toBe('changed')
+    expect(overlayCleared.displayState).toEqual(overlayIntact.displayState)
+  })
+
+  it('DISCRIMINATING TWIN — the same clearing WITHOUT a verdict DOES change the answer', () => {
+    // Without this, the test above would pass equally well if `dirty` were
+    // ignored everywhere, and would be evidence about nothing. Same inputs, one
+    // difference: no wire verdict.
+    const kept = compose({ analysisState: null, freshness: TURN1_FRESH, dirty: true })
+    const cleared = compose({ analysisState: null, freshness: TURN1_FRESH, dirty: false })
+    expect(cleared.semantic).not.toBe(kept.semantic)
+  })
+
+  it('the wire semantic is DERIVED from the kind, not restated here', () => {
+    const composed = compose({
+      analysisState: RESTORED_STALE,
+      freshness: null,
+      dirty: false,
+    })
+    expect(composed.semantic).toBe(mapRunStateKindToSemantic('complete_stale', true))
+  })
+})
+
+describe('⭐ BOTH DIRECTIONS — the restored verdict must not become a STUCK "changed"', () => {
+  it('a turn-1 verdict that DIFFERS replaces the restored one, and the product moves on', () => {
+    // The inversion risk at the seam where it lives. `applyV5State` writes the
+    // turn's verdict over whatever boot restored — a turn is a fresher
+    // authority and must win, or this PR trades a false "current" for a
+    // permanent "changed", which users learn to ignore just as fast.
+    const atBoot = compose({ analysisState: RESTORED_STALE, freshness: null, dirty: true })
+    const afterTurn = compose({ analysisState: TURN_CURRENT, freshness: null, dirty: true })
+
+    expect(atBoot.semantic).toBe('changed')
+    expect(afterTurn.semantic).toBe('current')
+    // The two verdicts genuinely differ — bound by identity, not by a predicate
+    // a second object could satisfy (trap 19).
+    expect(afterTurn.runStateKind).not.toBe(atBoot.runStateKind)
+  })
+
+  it('a turn carrying NO verdict clears back to the derived branch — and the UNFIXED defect is there', () => {
+    // `applyV5State` clears on absence, deliberately. So the restored verdict is
+    // not sticky. ⚠ On that branch the overlay decides again, so if turn 1
+    // cleared it the product is back to the capture's behaviour. Pinned here so
+    // the limit is visible in the suite rather than only in the PR text.
+    const cleared = compose({ analysisState: null, freshness: TURN1_FRESH, dirty: false })
+    expect(cleared.authority).toBe('derived')
+    expect(cleared.semantic).toBe('current')
+  })
+})

--- a/src/canvas/hydrate/__tests__/bootVerdictCausalChain.spec.ts
+++ b/src/canvas/hydrate/__tests__/bootVerdictCausalChain.spec.ts
@@ -93,6 +93,25 @@ const TURN_CURRENT = verdict({
   computed_at: '2026-08-25T10:00:00.000Z',
 })
 
+/**
+ * ⭐ THE ORDINARY JOURNEY'S BOOT STATE, and it is NOT a null slice.
+ *
+ * `restoreAnalysisFromAutosave` calls `resultsLoadHistorical`, which sets
+ * `{ freshness: 'unknown', freshnessReason: 'hydrated_without_capture' }` AND
+ * `analysisFreshnessDirty: false` (`store.ts:4156-4157`). A deployed-staging
+ * capture (runs m1+m2, across a deploy boundary) read exactly that row after
+ * reload: *"Cannot confirm whether this analysis is current."*
+ *
+ * So on the journey a real user takes — analyse, edit, reload — boot is
+ * CANNOT-CONFIRM, not silence. The null-slice `'none'` case below is the
+ * NARROWER one: a scenario CEE has an analysis for while the client holds no
+ * autosaved report (cleared storage, another device, a shared link).
+ */
+const BOOT_HYDRATED: AnalysisFreshnessState = {
+  freshness: 'unknown',
+  freshnessReason: 'hydrated_without_capture',
+}
+
 /** What the live capture measured on turn 1: `fresh` / `graph_hash_match`. */
 const TURN1_FRESH: AnalysisFreshnessState = {
   freshness: 'fresh',
@@ -218,5 +237,54 @@ describe('⭐ BOTH DIRECTIONS — the restored verdict must not become a STUCK "
     const cleared = compose({ analysisState: null, freshness: TURN1_FRESH, dirty: false })
     expect(cleared.authority).toBe('derived')
     expect(cleared.semantic).toBe('current')
+  })
+})
+
+describe('⭐ THE ORDINARY JOURNEY — what the restore is actually worth there', () => {
+  it('PRECONDITION — boot after an autosaved analysis reads CANNOT-CONFIRM, not silence', () => {
+    // Matches the deployed capture's post-reload row exactly. Pinned so the
+    // claim below is measured against the real boot state, not a convenient one.
+    const booted = compose({ analysisState: null, freshness: BOOT_HYDRATED, dirty: false })
+    expect(booted.authority).toBe('derived')
+    expect(booted.semantic).toBe('cannot_confirm')
+  })
+
+  it('⭐ the restore upgrades CANNOT-CONFIRM to CHANGED — precision, not breaking silence', () => {
+    // ⚠ THIS IS THE HONEST CLAIM, and it is smaller than "none -> changed".
+    // The product already said something true at boot; the restore replaces the
+    // client's own admission of ignorance with the producer's specific verdict,
+    // one turn earlier than CEE would otherwise supply it.
+    const before = compose({ analysisState: null, freshness: BOOT_HYDRATED, dirty: false })
+    const after = compose({
+      analysisState: RESTORED_STALE,
+      freshness: BOOT_HYDRATED,
+      dirty: false,
+    })
+    expect(before.semantic).toBe('cannot_confirm')
+    expect(after.semantic).toBe('changed')
+    expect(after.authority).toBe('wire')
+  })
+
+  it('the NARROWER none-case is real but is NOT the ordinary journey', () => {
+    // Both states exist; they differ by whether an autosaved analysis was
+    // restored. Asserted together so neither can be quietly read as the other.
+    const noAnalysis = compose({ analysisState: null, freshness: null, dirty: false })
+    const withAnalysis = compose({ analysisState: null, freshness: BOOT_HYDRATED, dirty: false })
+    expect(noAnalysis.semantic).toBe('none')
+    expect(withAnalysis.semantic).toBe('cannot_confirm')
+    expect(noAnalysis.semantic).not.toBe(withAnalysis.semantic)
+  })
+
+  it('⚠ AND CEE RE-ASSERTS THE TRUTH ON THE NEXT TURN REGARDLESS — bounding the win', () => {
+    // The capture saw `analysis_ready.freshness = "stale"` on the ordinary turn
+    // after reload, in both runs. So post-turn-1 the product is honest whether
+    // or not this PR exists: the restore's value is EARLIER truth in the
+    // boot -> turn-1 window, plus robustness if that turn is ever silent.
+    const afterCeeStale = compose({
+      analysisState: null,
+      freshness: { freshness: 'stale', freshnessReason: 'graph_hash_diverged' },
+      dirty: false,
+    })
+    expect(afterCeeStale.semantic).toBe('changed')
   })
 })

--- a/src/canvas/hydrate/__tests__/bootVerdictNoDisplayRegression.spec.ts
+++ b/src/canvas/hydrate/__tests__/bootVerdictNoDisplayRegression.spec.ts
@@ -1,0 +1,199 @@
+/**
+ * ⚠⚠ F1 — A RESTORED VERDICT MUST NEVER LEAVE THE USER WITH LESS THAN NO VERDICT.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE DEFECT, AND WHY THE PREVIOUS SUITE COULD NOT SEE IT
+ * ═══════════════════════════════════════════════════════════════════════════
+ * `bootVerdictRunGate.spec.ts` defined its oracle as
+ *
+ *     gateObjects(v) = readinessObjectsToRun(null, selectAnalysisReadinessAuthority(v))
+ *
+ * which is BYTE-IDENTICAL to the guard it was testing. So it bit when the guard
+ * was DELETED (mutant M4 proved that) and could never bite on the guard ASKING
+ * THE WRONG QUESTION. A guard agreeing with itself (trap 13b) — the oracle was
+ * derived from the implementation instead of from the spec the consumer parses.
+ *
+ * It was wrong in exactly that way. The guard reads `readiness`; this harm
+ * travels via `run_state.kind`, which the guard never reads:
+ *
+ *   `analysisStateSelector.ts:632-633`  wireKind === 'blocked' → forces
+ *                                        ceeAnalysisReadyStatus: 'blocked'
+ *                                        ⚠ REGARDLESS of readiness.status
+ *   `deriveAnalysisDisplayState.ts:106` EXPLICIT_NOT_READY_STATUSES = every
+ *                                        ANALYSIS_READY_STATUS except 'ready'
+ *   `:79-81`                             those "MUST override a prior populated
+ *                                        report"
+ *
+ * So a contract-valid payload — `run_state.kind: 'blocked'` with a perfectly
+ * READY readiness — passed the old guard, restored, and turned the freshness
+ * notice into a not-ready/refusal banner over a model that HAS a report.
+ * Strictly LESS information than before the restore existed, on the very
+ * surface this slice was written to improve.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE ORACLE HERE IS THE CONSUMER, NOT THE GUARD
+ * ═══════════════════════════════════════════════════════════════════════════
+ * Every assertion below is made against `composeAnalysisState` — the thing the
+ * product actually renders from. That is what makes this suite capable of
+ * failing when the guard is correct-but-aimed-wrong, which is the failure the
+ * previous one was structurally blind to.
+ *
+ * ⭐ AND THE ASYMMETRY THAT DECIDES THE REMEDY: staleness is MONOTONE. A stale
+ * result cannot become current without a new run, and a new run produces a new
+ * verdict — so a restored `complete_stale` cannot be falsified by anything the
+ * boot merge does. `blocked` and `refused` assert something about
+ * ANALYSABILITY, and the boot merge CAN falsify that: it may supply the very
+ * values whose absence CEE was refusing over.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+import { ANALYSIS_RUN_STATE_KINDS } from '@talchain/schemas/boundary'
+
+import { applyBootAnalysisVerdict } from '../applyScenarioAnalysisRead'
+import { composeAnalysisState } from '../../state/analysisStateSelector'
+
+function v(
+  runState: AnalysisStateV1['run_state'],
+  readiness: { status: string; blockers: readonly unknown[] },
+  over: Partial<AnalysisStateV1> = {},
+): AnalysisStateV1 {
+  return {
+    run_state: runState,
+    readiness,
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: true,
+    blocked_unusable: false,
+    contradictions: [],
+    ...over,
+  } as AnalysisStateV1
+}
+
+const READY = { status: 'ready', blockers: [] as readonly unknown[] }
+
+/** THE CONSUMER. A booted canvas that HAS a report — the F1 population. */
+function display(analysisState: AnalysisStateV1 | null) {
+  return composeAnalysisState({
+    analysisState,
+    freshness: { freshness: 'unknown', freshnessReason: 'hydrated_without_capture' },
+    dirty: false,
+    source: 'none',
+    resultsStatus: 'complete',
+    resultsStartedAt: undefined,
+    importHold: false,
+    hasReport: true,
+    ceeAnalysisReadyStatus: 'ready',
+    aiPanelV2On: true,
+  } as never)
+}
+
+/** Every contract kind, in a payload that VALIDATES and whose readiness is READY. */
+function verdictForKind(kind: string): AnalysisStateV1 {
+  const at = '2026-08-25T09:00:00.000Z'
+  switch (kind) {
+    case 'never_run': return v({ kind: 'never_run' } as never, READY)
+    case 'running': return v({ kind: 'running', started_at: at } as never, READY)
+    case 'blocked':
+      return v({ kind: 'blocked', reason_code: 'no_options', blockers: [] } as never, READY, { blocked_unusable: true })
+    case 'refused': return v({ kind: 'refused', reason_code: 'declined_by_policy' } as never, READY)
+    case 'complete_current': return v({ kind: 'complete_current', computed_at: at } as never, READY)
+    case 'complete_stale': return v({ kind: 'complete_stale', computed_at: at, cause: 'graph_changed' } as never, READY)
+    case 'unknown_degraded': return v({ kind: 'unknown_degraded', cause: 'store_unreadable' } as never, READY)
+    default: throw new Error(`unmapped kind: ${kind}`)
+  }
+}
+
+function restores(verdict: AnalysisStateV1): boolean {
+  return applyBootAnalysisVerdict({
+    analysisState: verdict,
+    store: { setAnalysisStateV1: vi.fn() },
+  }).outcome === 'restored'
+}
+
+describe('PRECONDITIONS — the consumer oracle discriminates', () => {
+  it('POSITIVE CONTROL — the no-verdict baseline with a report is NOT not_ready', () => {
+    const baseline = display(null)
+    expect(baseline.displayState.state).not.toBe('not_ready')
+    // Named, so a change to the baseline is visible rather than absorbed.
+    expect(baseline.authority).toBe('derived')
+  })
+
+  it('CONTRAST — a `blocked` verdict DOES drive the consumer to not_ready, whatever its readiness says', () => {
+    // Proves the oracle can see the harm at all. This payload has a READY
+    // readiness, so the readiness-only guard is blind to it by construction.
+    const blockedWithReadyReadiness = verdictForKind('blocked')
+    expect(blockedWithReadyReadiness.readiness.status).toBe('ready')
+    expect(display(blockedWithReadyReadiness).displayState.state).toBe('not_ready')
+  })
+})
+
+describe('⭐ F1 — the invariant, over EVERY contract kind', () => {
+  it('⭐⭐ nothing this applier restores may drive the consumer to `not_ready`', () => {
+    const baseline = display(null).displayState.state
+    const offenders: string[] = []
+    let restoredCount = 0
+
+    for (const kind of ANALYSIS_RUN_STATE_KINDS) {
+      const verdict = verdictForKind(kind)
+      if (!restores(verdict)) continue
+      restoredCount += 1
+      const after = display(verdict).displayState.state
+      if (after === 'not_ready' && baseline !== 'not_ready') offenders.push(kind)
+    }
+
+    expect(offenders).toEqual([])
+    // ...and the loop is not vacuous: declining EVERYTHING would satisfy the
+    // invariant perfectly. A guard too strict to fail is the same defect.
+    expect(restoredCount).toBeGreaterThan(0)
+  })
+
+  it('⭐ a restored verdict never REMOVES the CTA the user had without it', () => {
+    // The reviewer's measured delta included `cta: null`. Losing the action is
+    // the same class of harm as the false block, one surface down.
+    const baselineCta = display(null).displayState.cta
+    for (const kind of ANALYSIS_RUN_STATE_KINDS) {
+      const verdict = verdictForKind(kind)
+      if (!restores(verdict)) continue
+      if (baselineCta !== null) {
+        expect({ kind, cta: display(verdict).displayState.cta === null }).toEqual({ kind, cta: false })
+      }
+    }
+  })
+})
+
+describe('⭐ BOTH DIRECTIONS — the narrowing must not cost the stated win', () => {
+  it('⭐⭐ `complete_stale` still restores and still upgrades the notice', () => {
+    const stale = verdictForKind('complete_stale')
+    expect(restores(stale)).toBe(true)
+    const before = display(null)
+    const after = display(stale)
+    expect(before.semantic).toBe('cannot_confirm')
+    expect(after.semantic).toBe('changed')
+    expect(after.authority).toBe('wire')
+    expect(after.displayState.state).not.toBe('not_ready')
+  })
+
+  it('⭐ and it carries CEE`s CAUSE — a reason the local derivation cannot produce', () => {
+    // The understatement worth pinning: the win is not merely a sharper label.
+    const stale = verdictForKind('complete_stale')
+    expect(restores(stale)).toBe(true)
+    const runState = stale.run_state as { kind: string; cause?: string }
+    expect(runState.kind).toBe('complete_stale')
+    expect(runState.cause).toBe('graph_changed')
+    // The derived branch has no such field to offer.
+    expect(display(null).wire).toBeNull()
+    expect(display(stale).wire?.run_state).toEqual(stale.run_state)
+  })
+
+  it('`blocked` and `refused` are DECLINED — they assert analysability the boot merge can falsify', () => {
+    // Staleness is monotone and cannot be falsified between the verdict and the
+    // boot; analysability is not, because the merge may supply the very values
+    // CEE was refusing over. That asymmetry is the whole remedy.
+    expect(restores(verdictForKind('blocked'))).toBe(false)
+    expect(restores(verdictForKind('refused'))).toBe(false)
+  })
+})

--- a/src/canvas/hydrate/__tests__/bootVerdictRunGate.spec.ts
+++ b/src/canvas/hydrate/__tests__/bootVerdictRunGate.spec.ts
@@ -41,8 +41,27 @@
  * second authority for one question — this estate's most repeated defect.
  *
  * ⚠ AND THE LESSON THAT PRODUCED THIS FILE: the original guard was correct and
- * POINTED AT THE WRONG BYTES. Hence the two identity tests at the end, which
- * assert the gate inspects `readiness` and not `run_state`.
+ * POINTED AT THE WRONG BYTES. Hence the identity tests at the end.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * ⚠⚠ AND THE LESSON THIS FILE THEN LEARNED ABOUT ITSELF
+ * ═══════════════════════════════════════════════════════════════════════════
+ * `gateObjects` below is BYTE-IDENTICAL to the guard it tests. That makes this
+ * suite able to prove the guard is PRESENT (mutant M4: delete it, six tests
+ * RED) and structurally UNABLE to prove the guard asks the RIGHT QUESTION — a
+ * guard agreeing with itself (trap 13b), because the oracle was derived from
+ * the implementation rather than from the spec the consumer parses.
+ *
+ * It was wrong in exactly that way: a `blocked` verdict with a READY readiness
+ * passed this gate and still degraded the product, because that harm travels
+ * via `run_state.kind`, which the gate never reads. This file's earlier
+ * `blocked`/`refused` cases PINNED THE DEFECTIVE PAYLOAD AS CORRECT.
+ *
+ * The consumer-level invariant now lives in
+ * `bootVerdictNoDisplayRegression.spec.ts`, whose oracle is
+ * `composeAnalysisState`. THIS file keeps a narrower and still-real job: the
+ * run-gate guard, which remains live and necessary because a `complete_stale`
+ * verdict can itself carry a blocking readiness.
  */
 
 import { describe, it, expect, vi } from 'vitest'
@@ -105,24 +124,29 @@ describe('PRECONDITIONS — the oracle is the gate, and it discriminates', () =>
 })
 
 describe('⭐ RED-FIRST — a verdict that would close the Analyse gate is DECLINED', () => {
-  it('⭐ restored `blocked` (readiness "blocked") is declined and writes NOTHING', () => {
+  it('⚠ `blocked` is declined by the KIND rule, which now runs FIRST', () => {
+    // ⚠ THIS ASSERTED `closes_run_gate` UNTIL `blocked` LEFT THE RESTORABLE SET.
+    // The reason moved because the ORDER matters: the kind rule precedes the
+    // gate rule, so a kind that may never be restored is refused on its own
+    // terms rather than incidentally, by a readiness that happens to object.
+    // Relying on the gate to catch it was the defect — a `blocked` verdict with
+    // a READY readiness sails straight past the gate.
     const { store, setAnalysisStateV1 } = makeStore()
     const verdict = v(BLOCKED, GATE_CLOSING, { blocked_unusable: true })
-    // Bind the premise: this verdict genuinely closes the gate, per the gate.
-    expect(gateObjects(verdict)).toBe(true)
-
-    const outcome = applyBootAnalysisVerdict({ analysisState: verdict, store })
-    expect(outcome).toEqual({ outcome: 'declined', reason: 'closes_run_gate' })
+    expect(applyBootAnalysisVerdict({ analysisState: verdict, store })).toEqual({
+      outcome: 'declined',
+      reason: 'not_restorable',
+    })
     expect(setAnalysisStateV1).not.toHaveBeenCalled()
   })
 
-  it('⭐ restored `refused` (readiness "blocked") is declined and writes NOTHING', () => {
+  it('⚠ `refused` likewise — declined by kind, not by readiness', () => {
     const { store, setAnalysisStateV1 } = makeStore()
     const verdict = v(REFUSED, GATE_CLOSING)
-    expect(gateObjects(verdict)).toBe(true)
-
-    const outcome = applyBootAnalysisVerdict({ analysisState: verdict, store })
-    expect(outcome).toEqual({ outcome: 'declined', reason: 'closes_run_gate' })
+    expect(applyBootAnalysisVerdict({ analysisState: verdict, store })).toEqual({
+      outcome: 'declined',
+      reason: 'not_restorable',
+    })
     expect(setAnalysisStateV1).not.toHaveBeenCalled()
   })
 
@@ -180,15 +204,22 @@ describe('⭐ BOTH DIRECTIONS — the capability must survive the new guard', ()
     expect(setAnalysisStateV1.mock.calls[0]![0]).toBe(verdict)
   })
 
-  it('`blocked` / `refused` with a non-objecting readiness still restore — the guard is not a set narrowing', () => {
-    // Proves the new rule keys on the GATE, not on the kind. If it had been
-    // implemented as "drop the refusal-shaped kinds", these would decline.
+  it('⚠⚠ `blocked` / `refused` are declined EVEN WITH A NON-OBJECTING READINESS', () => {
+    // ⭐ THIS TEST ASSERTED THE OPPOSITE, AND THE OPPOSITE WAS THE DEFECT. It
+    // read "these still restore — the guard is not a set narrowing", which
+    // PINNED THE DEFECTIVE PAYLOAD AS CORRECT BEHAVIOUR: a `blocked` verdict
+    // whose readiness is READY passes the gate guard and still degrades the
+    // product, because the harm travels via `run_state.kind`.
+    //
+    // The premise is kept and inverted rather than deleted — the readiness
+    // genuinely does not object, which is precisely why the gate guard could
+    // never have caught this and why the narrowing was the right remedy.
     for (const runState of [BLOCKED, REFUSED]) {
       const { store, setAnalysisStateV1 } = makeStore()
       const verdict = v(runState, READY, { blocked_unusable: runState === BLOCKED })
       expect(gateObjects(verdict)).toBe(false)
-      expect(applyBootAnalysisVerdict({ analysisState: verdict, store }).outcome).toBe('restored')
-      expect(setAnalysisStateV1).toHaveBeenCalledTimes(1)
+      expect(applyBootAnalysisVerdict({ analysisState: verdict, store }).outcome).toBe('declined')
+      expect(setAnalysisStateV1).not.toHaveBeenCalled()
     }
   })
 
@@ -214,10 +245,16 @@ describe('⭐ IDENTITY — the guard inspects the member the GATE inspects', () 
     expect(b.outcome).toBe('declined')
   })
 
-  it('holding `readiness` CONSTANT, changing ONLY `run_state` does NOT change it — for restorable kinds', () => {
-    // The discriminating twin. Together with the test above this pins WHICH
-    // member decides: `readiness` does, `run_state.kind` does not (beyond the
-    // restorable-set membership the other spec already covers).
+  it('⭐ holding `readiness` CONSTANT, changing ONLY `run_state` DOES change it — both members decide', () => {
+    // ⭐ THIS ALSO ASSERTED THE OPPOSITE, AND THE COMMENT BESIDE IT — "`readiness`
+    // decides, `run_state.kind` does not" — was TRUE OF THE GUARD AND FALSE OF
+    // THE PRODUCT. That sentence is the whole defect in one line.
+    //
+    // The corrected truth is that TWO members decide, for two different reasons:
+    //   · `run_state.kind` decides MEMBERSHIP — may this kind ever be restored?
+    //   · `readiness`      decides ADMISSIBILITY — would this instance close the
+    //                      Analyse gate?
+    // Neither subsumes the other, which is why both guards exist.
     const outcomes = [STALE, BLOCKED, REFUSED].map(
       (rs) =>
         applyBootAnalysisVerdict({
@@ -225,6 +262,6 @@ describe('⭐ IDENTITY — the guard inspects the member the GATE inspects', () 
           store: makeStore().store,
         }).outcome,
     )
-    expect(outcomes).toEqual(['restored', 'restored', 'restored'])
+    expect(outcomes).toEqual(['restored', 'declined', 'declined'])
   })
 })

--- a/src/canvas/hydrate/__tests__/bootVerdictRunGate.spec.ts
+++ b/src/canvas/hydrate/__tests__/bootVerdictRunGate.spec.ts
@@ -1,0 +1,230 @@
+/**
+ * ⚠⚠ THE BOOT RESTORE MUST NOT CLOSE THE ANALYSE GATE.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE DEFECT THIS CLOSES, MEASURED BEFORE IT WAS WRITTEN
+ * ═══════════════════════════════════════════════════════════════════════════
+ * The first cut of the boot restore reasoned about `run_state.kind` ONLY. But
+ * `selectAnalysisReadinessAuthority` (`analysisStateSelector.ts:809`) NEVER
+ * LOOKS AT `run_state` — it reads `readiness.status` and `readiness.blockers`
+ * and hands them to `readinessObjectsToRun`, the run gate's one predicate
+ * (`canRunAnalysis.ts:425`), which objects on
+ * `status === 'blocked' || actionableBlockers(blockers).length > 0`.
+ *
+ * So `readiness` RIDES ALONG on every restored verdict and reaches the Analyse
+ * control on three mounted surfaces (`usePreAnalysisModel.ts:257`,
+ * `OutputsDock.tsx:1130,1303`, `ConversationPanel.tsx:560`). Measured:
+ *
+ *   PRE-PR   verdict null                        -> false  (Analyse ENABLED)
+ *   restored `blocked`  (readiness 'blocked')    -> TRUE   (Analyse DISABLED)
+ *   restored `refused`  (readiness 'blocked')    -> TRUE   (Analyse DISABLED)
+ *   restored `complete_stale` (readiness ready)  -> false  (contrast control)
+ *
+ * A verdict from a PREVIOUS session could therefore disable Analyse on a model
+ * that is analysable right now — the same false-block harm a parallel lane is
+ * fixing, arriving by a different route, and NOT caught by that fix: it objects
+ * through clause (a) (`status === 'blocked'` with an EMPTY blocker list), while
+ * the `mayRun` work addresses clause (b). Two fixes for one harm, each correct
+ * in isolation, recreating it between them (trap 21).
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE RULE, SYMMETRIC WITH THE `complete_current` DECLINE
+ * ═══════════════════════════════════════════════════════════════════════════
+ * `complete_current` is declined because the client cannot verify a currency
+ * claim. A previous session's REFUSAL is equally unverifiable — and worse in
+ * consequence: a false currency claim misinforms, a false block REMOVES THE
+ * USER'S ACTION. So: restore a verdict only when it cannot close the gate.
+ *
+ * ⚠ THE OBJECTION IS IMPORTED, NEVER MIRRORED. The expectations below are
+ * derived by calling the GATE'S OWN predicate, so this suite cannot drift from
+ * the gate on the next change to either. A local re-implementation would be a
+ * second authority for one question — this estate's most repeated defect.
+ *
+ * ⚠ AND THE LESSON THAT PRODUCED THIS FILE: the original guard was correct and
+ * POINTED AT THE WRONG BYTES. Hence the two identity tests at the end, which
+ * assert the gate inspects `readiness` and not `run_state`.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+
+import { applyBootAnalysisVerdict } from '../applyScenarioAnalysisRead'
+import { selectAnalysisReadinessAuthority } from '../../state/analysisStateSelector'
+import { readinessObjectsToRun } from '../../utils/canRunAnalysis'
+
+function v(
+  runState: AnalysisStateV1['run_state'],
+  readiness: { status: string; blockers: readonly unknown[] },
+  over: Partial<AnalysisStateV1> = {},
+): AnalysisStateV1 {
+  return {
+    run_state: runState,
+    readiness,
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: true,
+    blocked_unusable: false,
+    contradictions: [],
+    ...over,
+  } as AnalysisStateV1
+}
+
+const STALE = { kind: 'complete_stale', computed_at: '2026-08-25T09:00:00.000Z', cause: 'graph_changed' } as never
+const BLOCKED = { kind: 'blocked', reason_code: 'no_options', blockers: [] } as never
+const REFUSED = { kind: 'refused', reason_code: 'declined_by_policy' } as never
+
+const READY = { status: 'ready', blockers: [] as readonly unknown[] }
+/** The shape `buildAnalysisRefusalReadiness` emits: 'blocked' with NO blockers. */
+const GATE_CLOSING = { status: 'blocked', blockers: [] as readonly unknown[] }
+
+function makeStore() {
+  const setAnalysisStateV1 = vi.fn()
+  return { store: { setAnalysisStateV1 }, setAnalysisStateV1 }
+}
+
+/** THE ORACLE — the gate's own predicate, not a restatement of it. */
+function gateObjects(verdict: AnalysisStateV1): boolean {
+  return readinessObjectsToRun(null, selectAnalysisReadinessAuthority(verdict))
+}
+
+describe('PRECONDITIONS — the oracle is the gate, and it discriminates', () => {
+  it('POSITIVE CONTROL — the gate objects to a blocking readiness and not to a ready one', () => {
+    // Without this the whole file could pass against an oracle that always says
+    // the same thing (trap 20: sameness across inputs that ought to differ is
+    // evidence about the instrument).
+    expect(gateObjects(v(STALE, GATE_CLOSING))).toBe(true)
+    expect(gateObjects(v(STALE, READY))).toBe(false)
+  })
+
+  it('a null verdict cannot close the gate — the pre-PR boot baseline', () => {
+    expect(readinessObjectsToRun(null, selectAnalysisReadinessAuthority(null))).toBe(false)
+  })
+})
+
+describe('⭐ RED-FIRST — a verdict that would close the Analyse gate is DECLINED', () => {
+  it('⭐ restored `blocked` (readiness "blocked") is declined and writes NOTHING', () => {
+    const { store, setAnalysisStateV1 } = makeStore()
+    const verdict = v(BLOCKED, GATE_CLOSING, { blocked_unusable: true })
+    // Bind the premise: this verdict genuinely closes the gate, per the gate.
+    expect(gateObjects(verdict)).toBe(true)
+
+    const outcome = applyBootAnalysisVerdict({ analysisState: verdict, store })
+    expect(outcome).toEqual({ outcome: 'declined', reason: 'closes_run_gate' })
+    expect(setAnalysisStateV1).not.toHaveBeenCalled()
+  })
+
+  it('⭐ restored `refused` (readiness "blocked") is declined and writes NOTHING', () => {
+    const { store, setAnalysisStateV1 } = makeStore()
+    const verdict = v(REFUSED, GATE_CLOSING)
+    expect(gateObjects(verdict)).toBe(true)
+
+    const outcome = applyBootAnalysisVerdict({ analysisState: verdict, store })
+    expect(outcome).toEqual({ outcome: 'declined', reason: 'closes_run_gate' })
+    expect(setAnalysisStateV1).not.toHaveBeenCalled()
+  })
+
+  it('⭐ THE GENERAL EXPOSURE: even `complete_stale` is declined when ITS readiness would object', () => {
+    // Narrowing the restorable set to `complete_stale` would NOT have closed
+    // this — `readiness` rides along on every verdict, whatever its kind.
+    const { store, setAnalysisStateV1 } = makeStore()
+    const verdict = v(STALE, GATE_CLOSING)
+    expect(gateObjects(verdict)).toBe(true)
+
+    expect(applyBootAnalysisVerdict({ analysisState: verdict, store })).toEqual({
+      outcome: 'declined',
+      reason: 'closes_run_gate',
+    })
+    expect(setAnalysisStateV1).not.toHaveBeenCalled()
+  })
+
+  it('⭐ END-TO-END: nothing this applier restores can close the gate', () => {
+    // The invariant stated against the SPEC rather than against the cases in
+    // hand: for every verdict, if it was restored then the gate does not object.
+    const cases = [
+      v(STALE, READY), v(STALE, GATE_CLOSING),
+      v(BLOCKED, READY, { blocked_unusable: true }), v(BLOCKED, GATE_CLOSING, { blocked_unusable: true }),
+      v(REFUSED, READY), v(REFUSED, GATE_CLOSING),
+    ]
+    let restoredCount = 0
+    for (const verdict of cases) {
+      const { store } = makeStore()
+      const outcome = applyBootAnalysisVerdict({ analysisState: verdict, store })
+      if (outcome.outcome === 'restored') {
+        restoredCount += 1
+        expect({ kind: verdict.run_state.kind, objects: gateObjects(verdict) }).toEqual({
+          kind: verdict.run_state.kind,
+          objects: false,
+        })
+      }
+    }
+    // ...and the loop is not vacuous. Without this, declining EVERYTHING would
+    // satisfy the invariant perfectly (a guard too strict to fail).
+    expect(restoredCount).toBeGreaterThan(0)
+  })
+})
+
+describe('⭐ BOTH DIRECTIONS — the capability must survive the new guard', () => {
+  it('⭐⭐ `complete_stale` with a NON-objecting readiness STILL restores — the whole none→changed win', () => {
+    const { store, setAnalysisStateV1 } = makeStore()
+    const verdict = v(STALE, READY)
+    expect(gateObjects(verdict)).toBe(false)
+
+    expect(applyBootAnalysisVerdict({ analysisState: verdict, store })).toEqual({
+      outcome: 'restored',
+      kind: 'complete_stale',
+    })
+    expect(setAnalysisStateV1).toHaveBeenCalledTimes(1)
+    expect(setAnalysisStateV1.mock.calls[0]![0]).toBe(verdict)
+  })
+
+  it('`blocked` / `refused` with a non-objecting readiness still restore — the guard is not a set narrowing', () => {
+    // Proves the new rule keys on the GATE, not on the kind. If it had been
+    // implemented as "drop the refusal-shaped kinds", these would decline.
+    for (const runState of [BLOCKED, REFUSED]) {
+      const { store, setAnalysisStateV1 } = makeStore()
+      const verdict = v(runState, READY, { blocked_unusable: runState === BLOCKED })
+      expect(gateObjects(verdict)).toBe(false)
+      expect(applyBootAnalysisVerdict({ analysisState: verdict, store }).outcome).toBe('restored')
+      expect(setAnalysisStateV1).toHaveBeenCalledTimes(1)
+    }
+  })
+
+  it('an ACTIONABLE blocker also declines, even under a `ready` status — clause (b), not just (a)', () => {
+    const { store } = makeStore()
+    const withBlocker = v(STALE, {
+      status: 'ready',
+      blockers: [{ code: 'missing_option_value', category: 'input', message: 'x', repairability: 'user' }],
+    })
+    // Premise pinned via the gate: this really does object, by the other clause.
+    expect(gateObjects(withBlocker)).toBe(true)
+    expect(applyBootAnalysisVerdict({ analysisState: withBlocker, store }).outcome).toBe('declined')
+  })
+})
+
+describe('⭐ IDENTITY — the guard inspects the member the GATE inspects', () => {
+  it('holding `run_state` CONSTANT, changing ONLY `readiness` changes the decision', () => {
+    // Proves the guard is pointed at `readiness`. The original defect was a
+    // guard that was correct and pointed at the wrong bytes.
+    const a = applyBootAnalysisVerdict({ analysisState: v(STALE, READY), store: makeStore().store })
+    const b = applyBootAnalysisVerdict({ analysisState: v(STALE, GATE_CLOSING), store: makeStore().store })
+    expect(a.outcome).toBe('restored')
+    expect(b.outcome).toBe('declined')
+  })
+
+  it('holding `readiness` CONSTANT, changing ONLY `run_state` does NOT change it — for restorable kinds', () => {
+    // The discriminating twin. Together with the test above this pins WHICH
+    // member decides: `readiness` does, `run_state.kind` does not (beyond the
+    // restorable-set membership the other spec already covers).
+    const outcomes = [STALE, BLOCKED, REFUSED].map(
+      (rs) =>
+        applyBootAnalysisVerdict({
+          analysisState: v(rs, READY, { blocked_unusable: rs === BLOCKED }),
+          store: makeStore().store,
+        }).outcome,
+    )
+    expect(outcomes).toEqual(['restored', 'restored', 'restored'])
+  })
+})

--- a/src/canvas/hydrate/applyScenarioAnalysisRead.ts
+++ b/src/canvas/hydrate/applyScenarioAnalysisRead.ts
@@ -284,52 +284,78 @@ export function applyScenarioAnalysisRead(
 // restore does not rescue #837; it SILENCES it. That is the same defect this
 // slice exists to fix, running backwards.
 //
-// Hence: FAIL-CLOSED BY CONSTRUCTION. This leg may only ever WITHHOLD currency,
-// never assert it. Every kind that makes a positive currency claim is declined,
-// and the decline is a NO-OP — never a write of `null`, which would itself be a
-// claim (`applyScenarioAnalysisRead`'s own "absence is not a state" rule).
+// ⚠⚠ THE RULE WAS FIRST WRITTEN AS "MAY ONLY EVER WITHHOLD CURRENCY, NEVER
+// ASSERT IT", AND THAT UNIVERSAL WAS FALSE — refuted by independent review.
+// It is true of `complete_stale`. It was NOT true of `blocked` / `refused`,
+// which withhold currency and ASSERT SOMETHING ELSE: that the model is not
+// analysable. See BOOT_RESTORABLE_RUN_STATE_KINDS for the measured chain by
+// which that assertion replaced the freshness notice with a refusal banner.
+//
+// THE CORRECTED RULE, and it is narrower AND stronger: this leg restores only a
+// verdict that CANNOT BE FALSIFIED BY THE BOOT MERGE. The decline is a NO-OP —
+// never a write of `null`, which would itself be a claim (this file's own
+// "absence is not a state" rule).
 
 /**
- * The kinds a BOOT read may restore. Each one WITHHOLDS currency, so restoring
- * it can only ever downgrade what the product is willing to say — and a
- * downgrade is safe against a canvas whose relationship to CEE's graph the
- * client cannot establish.
+ * The ONE kind a BOOT read may restore.
  *
- * One line of reasoning per member, against the contract's own text:
+ * ⭐ THE TEST IS MONOTONICITY, NOT "DOES IT WITHHOLD CURRENCY". Restore a
+ * verdict only if NOTHING THE BOOT MERGE DOES CAN FALSIFY IT.
  *
- *   `complete_stale`  CEE states the result is NO LONGER CURRENT and states the
- *                     cause. This is the capture's case, and restoring it is
- *                     strictly more informative than the local derivation it
- *                     replaces — CEE knows WHY.
- *   `blocked`         "THE MODEL IS NOT ANALYSABLE as it stands … no run was
- *                     attempted." A statement about the model, and a model that
- *                     was unanalysable for CEE is not made analysable by a
- *                     client-side merge.
- *   `refused`         CEE explicitly declines to vouch for the currency of any
- *                     visible result. Restoring a refusal to vouch cannot
- *                     over-claim.
+ *   `complete_stale`  SAFE, and provably so. Staleness is MONOTONE: a stale
+ *                     result cannot become current without a new run, and a new
+ *                     run produces a new verdict. So no merge, and no local
+ *                     edit, can make this claim false in the interval between
+ *                     CEE composing it and the client reading it. It also
+ *                     carries CEE's `cause` (e.g. `graph_changed`) — a REASON
+ *                     the local derivation cannot produce at all.
  *
- * ⚠ THIS LIST CANNOT BE DERIVED, exactly as its polling-leg twin cannot: which
- * kinds are safe to restore against an unverifiable canvas is a JUDGEMENT, and
- * no field in the contract states it. What the judgement owes is that it has
+ * ⚠⚠ `blocked` AND `refused` WERE HERE AND WERE REMOVED — independent review,
+ * and the removal costs the stated capability NOTHING (the whole
+ * cannot-confirm → changed win is carried by `complete_stale`).
+ *
+ * They are NOT monotone: they assert the model is not ANALYSABLE, and the boot
+ * merge can falsify exactly that by supplying the values CEE was refusing over.
+ * Worse, the harm does not travel through `readiness` — where the run-gate guard
+ * below looks — but through `run_state.kind`, measured hop by hop:
+ *
+ *   `analysisStateSelector.ts:632-633`   wireKind === 'blocked' forces
+ *                                        `ceeAnalysisReadyStatus: 'blocked'`
+ *                                        ⚠ REGARDLESS of `readiness.status`
+ *   `deriveAnalysisDisplayState.ts:106`  EXPLICIT_NOT_READY_STATUSES is every
+ *                                        status except `ready`, and `:79-81`
+ *                                        says those "MUST override a prior
+ *                                        populated report"
+ *
+ * So a CONTRACT-VALID `blocked` verdict with a perfectly READY readiness sailed
+ * past the run-gate guard, restored, and turned the freshness notice into a
+ * not-ready/refusal banner over a model that HAS a report — strictly LESS
+ * information than no verdict at all, on the one surface this slice exists to
+ * improve. Pinned in `__tests__/bootVerdictNoDisplayRegression.spec.ts` against
+ * the CONSUMER, not against this guard.
+ *
+ * ⚠ THIS LIST CANNOT BE DERIVED: which kinds survive the boot merge is a
+ * JUDGEMENT no contract field states. What the judgement owes is that it has
  * been made for every kind — asserted against the contract's own exported
  * `ANALYSIS_RUN_STATE_KINDS` in
  * `__tests__/bootAnalysisVerdict.contractPartition.spec.ts` (trap 12d).
  */
-export const BOOT_RESTORABLE_RUN_STATE_KINDS = [
-  'complete_stale',
-  'blocked',
-  'refused',
-] as const
+export const BOOT_RESTORABLE_RUN_STATE_KINDS = ['complete_stale'] as const
 
 /**
  * The twin: kinds a BOOT read must NOT restore, and why each is declined.
  *
- *   `complete_current`   THE SAFETY DECLINE, and the reason this set exists
- *                        separately from the polling leg's. It asserts currency
- *                        the client cannot verify, and on the wire branch that
- *                        assertion SILENCES #837's stale mark outright. Declined
- *                        even though it is terminal and even though CEE means it.
+ *   `complete_current`   Asserts CURRENCY the client cannot verify, and on the
+ *                        wire branch that assertion SILENCES #837's stale mark
+ *                        outright. Declined though terminal and though CEE
+ *                        means it.
+ *   `blocked`            Asserts the model is NOT ANALYSABLE — which the boot
+ *                        merge can falsify by supplying the missing values. And
+ *                        it reaches the display through `run_state.kind`, not
+ *                        through `readiness`, so the run-gate guard cannot see
+ *                        it. See the restorable set above for the measured chain.
+ *   `refused`            Same shape: a previous session's refusal to analyse,
+ *                        asserted as current, over a model that may now be fine.
  *   `never_run`          Indistinguishable from in-flight on a read leg (H4).
  *   `running`            A read cannot produce it today; if a future CEE gains
  *                        an in-flight marker, a boot is not the leg that should
@@ -341,6 +367,8 @@ export const BOOT_RESTORABLE_RUN_STATE_KINDS = [
  */
 export const BOOT_DECLINED_RUN_STATE_KINDS = [
   'complete_current',
+  'blocked',
+  'refused',
   'never_run',
   'running',
   'unknown_degraded',

--- a/src/canvas/hydrate/applyScenarioAnalysisRead.ts
+++ b/src/canvas/hydrate/applyScenarioAnalysisRead.ts
@@ -241,3 +241,172 @@ export function applyScenarioAnalysisRead(
   input.store.setAnalysisStateV1?.(verdict)
   return { outcome: 'applied', kind, resultsHydrated }
 }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// THE BOOT LEG — A3 link 6. A STRICTLY NARROWER SET THAN THE POLLING LEG'S.
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// `hydrateCanvasFromServer` reads the scenario graph at boot, and that response
+// CARRIES CEE'S COMPOSED VERDICT — parsed at `adapters/cee/scenarioGraph.ts:296`
+// and, until now, dropped. The only consumer was the polling hook above, which
+// arms solely on a standing `running` verdict that `store.ts:6043` has just
+// nulled. So on every ordinary reload the verdict was fetched, validated and
+// thrown away.
+//
+// ⚠⚠ WHY THIS IS NOT SIMPLY `applyScenarioAnalysisRead` CALLED AT BOOT.
+// The two legs answer questions that differ in ONE decisive respect (trap 21):
+//
+//   the POLLING leg asks  "has the run I just watched start finished?"
+//                         → the canvas has not moved since that run was armed
+//   the BOOT leg asks     "what did CEE last say about a graph I am
+//                          simultaneously MERGING INTO THE CANVAS?"
+//
+// `AnalysisStateV1` carries NO graph hashes — derived at the vendored 0.48.0
+// bytes: `run_state.kind` IS the currency statement and there is no
+// `graph_hash_at_run`/`current_graph_hash` pair on it anywhere. The verdict is
+// CEE's statement about CEE'S OWN persisted graph, and at boot the canvas is a
+// MERGE of that graph onto the local one — local-only nodes survive, and the
+// client cannot prove the two are equal. It has no access to CEE's hash
+// function, and claiming otherwise is the two-hash-functions trap that
+// `store/analysisFreshness.ts:441-445` already refuses on the sibling path.
+//
+// ⚠⚠ AND THE HARM IS ASYMMETRIC, WHICH IS WHAT MAKES THE NARROWING NECESSARY
+// RATHER THAN MERELY CAUTIOUS. `canvas/state/analysisStateSelector.ts` is
+// FEATURE-DETECTED on this field: a non-null verdict takes the WIRE branch,
+// where `semantic` comes from `mapRunStateKindToSemantic(kind, hasReport)` and
+// THE LOCAL DIRTY OVERLAY IS NOT CONSULTED (`analysisStateSelector.ts:551-554`).
+//
+// So restoring `complete_current` at boot would yield `semantic: 'current'`,
+// `wireForcesStale: false`, `analysisChanged: false` — a green "Analysis
+// complete" rendered OVER A CANVAS #837 HAS JUST MARKED STALE. The naive
+// restore does not rescue #837; it SILENCES it. That is the same defect this
+// slice exists to fix, running backwards.
+//
+// Hence: FAIL-CLOSED BY CONSTRUCTION. This leg may only ever WITHHOLD currency,
+// never assert it. Every kind that makes a positive currency claim is declined,
+// and the decline is a NO-OP — never a write of `null`, which would itself be a
+// claim (`applyScenarioAnalysisRead`'s own "absence is not a state" rule).
+
+/**
+ * The kinds a BOOT read may restore. Each one WITHHOLDS currency, so restoring
+ * it can only ever downgrade what the product is willing to say — and a
+ * downgrade is safe against a canvas whose relationship to CEE's graph the
+ * client cannot establish.
+ *
+ * One line of reasoning per member, against the contract's own text:
+ *
+ *   `complete_stale`  CEE states the result is NO LONGER CURRENT and states the
+ *                     cause. This is the capture's case, and restoring it is
+ *                     strictly more informative than the local derivation it
+ *                     replaces — CEE knows WHY.
+ *   `blocked`         "THE MODEL IS NOT ANALYSABLE as it stands … no run was
+ *                     attempted." A statement about the model, and a model that
+ *                     was unanalysable for CEE is not made analysable by a
+ *                     client-side merge.
+ *   `refused`         CEE explicitly declines to vouch for the currency of any
+ *                     visible result. Restoring a refusal to vouch cannot
+ *                     over-claim.
+ *
+ * ⚠ THIS LIST CANNOT BE DERIVED, exactly as its polling-leg twin cannot: which
+ * kinds are safe to restore against an unverifiable canvas is a JUDGEMENT, and
+ * no field in the contract states it. What the judgement owes is that it has
+ * been made for every kind — asserted against the contract's own exported
+ * `ANALYSIS_RUN_STATE_KINDS` in
+ * `__tests__/bootAnalysisVerdict.contractPartition.spec.ts` (trap 12d).
+ */
+export const BOOT_RESTORABLE_RUN_STATE_KINDS = [
+  'complete_stale',
+  'blocked',
+  'refused',
+] as const
+
+/**
+ * The twin: kinds a BOOT read must NOT restore, and why each is declined.
+ *
+ *   `complete_current`   THE SAFETY DECLINE, and the reason this set exists
+ *                        separately from the polling leg's. It asserts currency
+ *                        the client cannot verify, and on the wire branch that
+ *                        assertion SILENCES #837's stale mark outright. Declined
+ *                        even though it is terminal and even though CEE means it.
+ *   `never_run`          Indistinguishable from in-flight on a read leg (H4).
+ *   `running`            A read cannot produce it today; if a future CEE gains
+ *                        an in-flight marker, a boot is not the leg that should
+ *                        adopt it — the polling hook is.
+ *   `unknown_degraded`   The absence of an outcome, not an outcome.
+ *
+ * Not used for control flow — `isBootRestorableRunState` is the only predicate.
+ * It exists so "we have classified every kind" is checkable rather than assumed.
+ */
+export const BOOT_DECLINED_RUN_STATE_KINDS = [
+  'complete_current',
+  'never_run',
+  'running',
+  'unknown_degraded',
+] as const
+
+export type BootRestorableRunStateKind = (typeof BOOT_RESTORABLE_RUN_STATE_KINDS)[number]
+
+export function isBootRestorableRunState(kind: string): kind is BootRestorableRunStateKind {
+  return (BOOT_RESTORABLE_RUN_STATE_KINDS as readonly string[]).includes(kind)
+}
+
+/**
+ * The store surface the boot leg may touch. DELIBERATELY ONE MEMBER, and
+ * narrower than `ScenarioAnalysisApplyStore` by one more than it looks.
+ *
+ * The polling leg writes RESULTS as well as the verdict, because a run it was
+ * watching has just produced them. A boot has no such warrant: results are
+ * already restored from the localStorage autosave by
+ * `store/restoreAnalysisFromAutosave.ts`, and adding a second writer for that
+ * one fact is the two-restorers defect this estate keeps paying for. So the
+ * boot leg restores the VERDICT ONLY and cannot reach `resultsComplete` at all
+ * — enforced by the type, not by a comment.
+ */
+export interface BootAnalysisVerdictStore {
+  readonly setAnalysisStateV1?: (verdict: AnalysisStateV1 | null) => void
+}
+
+export type BootAnalysisVerdictOutcome =
+  /** A currency-withholding verdict was restored. */
+  | { readonly outcome: 'restored'; readonly kind: BootRestorableRunStateKind }
+  /**
+   * Nothing was written — and NOTHING is the operative word: not `null`, which
+   * would replace a standing belief with a claim of ignorance.
+   *
+   * `asserts_currency` is kept DISTINCT from `not_restorable` deliberately. It
+   * is the one decline that turns away a verdict CEE genuinely stated and
+   * genuinely means, so it must be visible as its own fact in telemetry and in
+   * tests, rather than lumped in with the non-terminal kinds that say nothing.
+   */
+  | {
+      readonly outcome: 'declined'
+      readonly reason: 'no_verdict' | 'asserts_currency' | 'not_restorable'
+    }
+
+/**
+ * Restore a BOOT read's verdict, or decline to. Pure with respect to everything
+ * except the single store action it may call; never throws.
+ */
+export function applyBootAnalysisVerdict(input: {
+  readonly analysisState: AnalysisStateV1 | null
+  readonly store: BootAnalysisVerdictStore
+}): BootAnalysisVerdictOutcome {
+  const verdict = input.analysisState
+  // Absence is not a state — an older CEE, a graphless scenario and a verdict
+  // that failed the contract's validation all arrive here as `null`. `== null`
+  // for the same one-seam-past-the-guard reason as the polling leg.
+  if (verdict == null) return { outcome: 'declined', reason: 'no_verdict' }
+
+  const kind = verdict.run_state.kind
+  if (kind === 'complete_current') {
+    // THE SAFETY DECLINE. Named separately from the fall-through below so that
+    // a reader — and a mutant — can tell the two apart.
+    return { outcome: 'declined', reason: 'asserts_currency' }
+  }
+  if (!isBootRestorableRunState(kind)) {
+    return { outcome: 'declined', reason: 'not_restorable' }
+  }
+
+  input.store.setAnalysisStateV1?.(verdict)
+  return { outcome: 'restored', kind }
+}

--- a/src/canvas/hydrate/applyScenarioAnalysisRead.ts
+++ b/src/canvas/hydrate/applyScenarioAnalysisRead.ts
@@ -83,6 +83,8 @@
 import type { AnalysisResultBlock, AnalysisStateV1 } from '@talchain/schemas/boundary'
 
 import { mapV5AnalysisToReport } from '../../v5/mapV5AnalysisToReport'
+import { selectAnalysisReadinessAuthority } from '../state/analysisStateSelector'
+import { readinessObjectsToRun } from '../utils/canRunAnalysis'
 
 /**
  * The kinds a FACT READ is entitled to report as an outcome. Exported so the
@@ -380,7 +382,11 @@ export type BootAnalysisVerdictOutcome =
    */
   | {
       readonly outcome: 'declined'
-      readonly reason: 'no_verdict' | 'asserts_currency' | 'not_restorable'
+      readonly reason:
+        | 'no_verdict'
+        | 'asserts_currency'
+        | 'not_restorable'
+        | 'closes_run_gate'
     }
 
 /**
@@ -405,6 +411,54 @@ export function applyBootAnalysisVerdict(input: {
   }
   if (!isBootRestorableRunState(kind)) {
     return { outcome: 'declined', reason: 'not_restorable' }
+  }
+
+  // ── ⚠⚠ THE GATE GUARD, AND IT IS THE MIRROR OF THE `complete_current` ONE ──
+  //
+  // THE DEFECT IT CLOSES, and it was live in this function's first cut: every
+  // rule above reasons about `run_state.kind`, and THE RUN GATE DOES NOT READ
+  // `run_state` AT ALL. `selectAnalysisReadinessAuthority` (:809 of the
+  // selector) reads `readiness.status` / `readiness.blockers` and hands them to
+  // `readinessObjectsToRun`, which objects on
+  // `status === 'blocked' || actionableBlockers(blockers).length > 0`.
+  //
+  // So `readiness` RIDES ALONG on every verdict this function restores, and
+  // reaches the Analyse control on three mounted surfaces
+  // (`usePreAnalysisModel.ts:257`, `OutputsDock.tsx:1130,1303`,
+  // `ConversationPanel.tsx:560`). Measured before this guard existed:
+  //
+  //   verdict null (pre-restore)              -> false   Analyse ENABLED
+  //   restored `blocked`  (readiness blocked) -> TRUE    Analyse DISABLED
+  //   restored `refused`  (readiness blocked) -> TRUE    Analyse DISABLED
+  //
+  // A verdict from a PREVIOUS session could therefore disable Analyse on a
+  // model that is analysable right now. That is a false block arriving by a
+  // route the parallel `mayRun` fix does not cover: this objects through clause
+  // (a) — `status: 'blocked'` with an EMPTY blocker list, the shape
+  // `buildAnalysisRefusalReadiness` emits — while that work addresses clause
+  // (b). Two fixes for one harm, each correct alone (trap 21).
+  //
+  // ⭐ WHY HERE AND NOT IN THE GATE. The gate is right to respect a stated
+  // verdict; the mistake is restoring a claim we cannot verify. Fixing it at the
+  // gate would teach the gate to distrust its own authority, and the seam has
+  // one writer. So the decline lives on the RESTORE side.
+  //
+  // ⭐ SYMMETRY, which is the actual principle: `complete_current` is declined
+  // because the client cannot verify a CURRENCY claim. A previous session's
+  // REFUSAL is equally unverifiable, and worse in consequence — a false currency
+  // claim misinforms, a false block REMOVES THE USER'S ACTION. Fail-closed has to
+  // point both ways or it is just caution in one direction.
+  //
+  // ⚠ THE PREDICATE IS IMPORTED, NEVER MIRRORED. Re-deriving "would this object?"
+  // here would be a second authority for one question, and it would diverge on
+  // the next change to either. `null` is passed for the side-car because
+  // `readinessObjectsToRun` ignores its first argument entirely once the
+  // producer has spoken (`canRunAnalysis.ts:443`) — so this asks exactly the
+  // question the gate will ask, and nothing else. A `null` authority (not
+  // stated, or the UNSUPPLIED sentinel) yields `false`: an unstated readiness
+  // cannot close the gate, and must not be read as if it had.
+  if (readinessObjectsToRun(null, selectAnalysisReadinessAuthority(verdict))) {
+    return { outcome: 'declined', reason: 'closes_run_gate' }
   }
 
   input.store.setAnalysisStateV1?.(verdict)

--- a/src/canvas/hydrate/applyScenarioAnalysisRead.ts
+++ b/src/canvas/hydrate/applyScenarioAnalysisRead.ts
@@ -460,11 +460,26 @@ export function applyBootAnalysisVerdict(input: {
   //   restored `refused`  (readiness blocked) -> TRUE    Analyse DISABLED
   //
   // A verdict from a PREVIOUS session could therefore disable Analyse on a
-  // model that is analysable right now. That is a false block arriving by a
-  // route the parallel `mayRun` fix does not cover: this objects through clause
-  // (a) — `status: 'blocked'` with an EMPTY blocker list, the shape
-  // `buildAnalysisRefusalReadiness` emits — while that work addresses clause
-  // (b). Two fixes for one harm, each correct alone (trap 21).
+  // model that is analysable right now — a false block, and the mirror of the
+  // `complete_current` decline.
+  //
+  // ⚠ KNOWN COUPLING WITH PR #843 (`a4-analyse-control-false-block`), DISCLOSED
+  // RATHER THAN FIXED HERE. #843 adds a third optional `mayRun` parameter to
+  // `readinessObjectsToRun`. After it lands there are four real call sites and
+  // THIS IS THE ONLY ONE NOT SUPPLYING IT. On the class
+  // `status !== 'blocked'` AND actionable blockers AND CEE `may_run === true`,
+  // the Analyse control will be ENABLED while this restore still DECLINES.
+  //
+  // Direction is FAIL-SAFE — we withhold a verdict the product could have shown,
+  // never enable an action the gate would refuse — so it is a divergence, not a
+  // defect, and it is left for #843's owner to close by threading `mayRun` here
+  // (one seam, one writer). ⚠ It is SILENT: nothing reds in either merge order.
+  //
+  // ⚠ AND IT FALSIFIES A SENTENCE THAT USED TO SIT HERE. This comment claimed
+  // the harm objects through "clause (a)" while #843 addresses "clause (b)",
+  // implying the two are disjoint. After #843 that split no longer partitions
+  // the space: `mayRun` can waive clause (b) for payloads this leg still
+  // declines. Corrected rather than left to age.
   //
   // ⭐ WHY HERE AND NOT IN THE GATE. The gate is right to respect a stated
   // verdict; the mistake is restoring a claim we cannot verify. Fixing it at the
@@ -481,8 +496,16 @@ export function applyBootAnalysisVerdict(input: {
   // here would be a second authority for one question, and it would diverge on
   // the next change to either. `null` is passed for the side-car because
   // `readinessObjectsToRun` ignores its first argument entirely once the
-  // producer has spoken (`canRunAnalysis.ts:443`) — so this asks exactly the
-  // question the gate will ask, and nothing else. A `null` authority (not
+  // producer has spoken (`canRunAnalysis.ts:443`).
+  //
+  // ⚠ IT ASKS THE QUESTION THE GATE ASKS TODAY — NOT NECESSARILY TOMORROW'S.
+  // An earlier version of this sentence said "exactly the question the gate will
+  // ask, and nothing else". That is false the moment PR #843 lands: it adds a
+  // `mayRun` argument this call site does not supply, so the gate can answer
+  // "runnable" where this answers "objects". Importing the predicate guarantees
+  // ONE IMPLEMENTATION, not one ANSWER — a distinction worth keeping, because
+  // the first is what stops the two drifting in CODE and only the second would
+  // stop them drifting in BEHAVIOUR. A `null` authority (not
   // stated, or the UNSUPPLIED sentinel) yields `false`: an unstated readiness
   // cannot close the gate, and must not be read as if it had.
   if (readinessObjectsToRun(null, selectAnalysisReadinessAuthority(verdict))) {

--- a/src/canvas/hydrate/serverGraphHydration.ts
+++ b/src/canvas/hydrate/serverGraphHydration.ts
@@ -22,6 +22,7 @@ import { useContextIntegrityStore } from '../stores/contextIntegrityStore'
 import { logger } from '../../lib/logger'
 import { fetchScenarioGraph } from '../../adapters/cee/scenarioGraph'
 import { mergeServerGraphOnHydrate } from '../utils/mergeServerGraph'
+import { applyBootAnalysisVerdict } from './applyScenarioAnalysisRead'
 
 export type HydrationOutcome =
   /** The server's graph was read and merged onto the canvas. */
@@ -156,6 +157,47 @@ export async function hydrateCanvasFromServer(
     scenarioId,
     briefText: result.briefText,
     manifest: result.notModelled,
+  })
+
+  // ── A3 LINK 6 — CONSUME THE VERDICT THIS RESPONSE ALREADY CARRIES ─────────
+  //
+  // `fetchScenarioGraph` parses CEE's composed `AnalysisStateV1` off the SAME
+  // body the graph came in (`adapters/cee/scenarioGraph.ts:296`), and this
+  // function used to drop it. Its only consumer was the provisional-delivery
+  // hook, which arms exclusively on a standing `running` verdict that
+  // `hydrateGraphSlice` has just nulled at boot (`store.ts:6043`) — so the
+  // verdict was fetched, validated against the contract, and discarded on every
+  // ordinary reload.
+  //
+  // ⚠ PLACED BEFORE THE `unchanged` SHORT-CIRCUIT, for the reason the
+  // context-integrity note above already establishes: that branch is the COMMON
+  // case on every re-boot of an existing scenario, and it is exactly when the
+  // user is most likely to open the panel. Restoring after it would leave the
+  // verdict absent for the very sessions this is meant to serve.
+  //
+  // ⚠ ORDERING AGAINST #837, WHICH WAS THE QUESTION TO SETTLE: the two writes
+  // are DISJOINT and neither can overwrite the other. `markGraphStructurallyEdited`
+  // (fired inside `mergeServerGraphOnHydrate`, `mergeServerGraph.ts:512`) writes
+  // `graphEditedSinceLastRun` / `analysisStateReady` / `analysisFreshnessDirty`;
+  // this writes `analysisStateV1` and nothing else. Pinned in BOTH directions in
+  // `__tests__/bootAnalysisVerdictRestore.spec.ts` rather than left to this
+  // comment — a disjointness that only a comment asserts is one refactor from
+  // being false.
+  //
+  // ⚠ AND IT MAY ONLY EVER WITHHOLD CURRENCY. `applyBootAnalysisVerdict`
+  // declines `complete_current` outright: on the selector's WIRE branch the
+  // local dirty overlay is not consulted, so restoring a currency claim here
+  // would render "Analysis complete" over a canvas the merge below is about to
+  // mark stale. See that function's header for the full derivation.
+  const verdictOutcome = applyBootAnalysisVerdict({
+    analysisState: result.analysisState,
+    store: { setAnalysisStateV1: useCanvasStore.getState().setAnalysisStateV1 },
+  })
+  logger.debug('server_graph_hydration.boot_verdict', {
+    scenarioId,
+    outcome: verdictOutcome.outcome,
+    detail:
+      verdictOutcome.outcome === 'restored' ? verdictOutcome.kind : verdictOutcome.reason,
   })
 
   const stored = useCanvasStore.getState().serverGraphIdentity


### PR DESCRIPTION
## What this changes

`hydrateCanvasFromServer` **consumes the analysis verdict the boot response already carries** — restoring exactly one kind, `complete_stale`, chosen by a test that survived two rounds of falsification.

## The rule: monotonicity, not "does it withhold currency"

**Restore a verdict only if nothing the boot merge can do will falsify it.**

- **`complete_stale` — safe, provably.** Staleness is **monotone**: a stale result cannot become current without a new run, and a new run produces a new verdict. Nothing in the interval can make the claim false. It also carries CEE's **`cause`** (`graph_changed`) — a **reason** the local derivation cannot produce at all. The product gains an explanation, not just a sharper label.
- **`complete_current` — declined.** Asserts currency the client cannot verify; on the wire branch that assertion would silence #837's stale mark outright.
- **`blocked` / `refused` — declined.** They assert **analysability**, which the boot merge *can* falsify by supplying the very values CEE refused over.

## ⚠ F1 — a blocking defect, found by independent review, fixed here

An earlier revision restored `blocked` and `refused` under a rule stated as a universal: *"may only ever WITHHOLD currency, never assert it."* **That universal was false.** Those kinds withhold currency and assert something else.

Worse, the harm bypassed my guard entirely. The guard reads `readiness`; **the harm travels via `run_state.kind`**, measured hop by hop:

```
analysisStateSelector.ts:632-633   wireKind==='blocked' forces
                                   ceeAnalysisReadyStatus:'blocked'
                                   ⚠ REGARDLESS of readiness.status
deriveAnalysisDisplayState.ts:106  EXPLICIT_NOT_READY_STATUSES = every
                                   status except 'ready'
                       :79-81      those "MUST override a prior populated report"
```

So a **contract-valid `blocked` verdict with a perfectly READY readiness** sailed past the guard, restored, and turned the freshness notice into a not-ready/refusal banner over a model that *has* a report — **strictly less information than no verdict at all**, on the one surface this slice exists to improve.

**Remedy: `BOOT_RESTORABLE_RUN_STATE_KINDS = ['complete_stale']`.** It costs the stated capability **nothing** — the whole win is carried by `complete_stale`. The contract-partition spec RED'd on the narrowing and forced the reasoning to be restated, which is what it is for.

## ⭐ Why my suite could not see it — the part worth keeping

`bootVerdictRunGate.spec.ts` defined its oracle as **byte-identical to the guard it tested**. It could prove the guard was *present* (mutant M4: delete it, six RED) and was **structurally incapable** of proving the guard asked the *right question*. A **guard agreeing with itself** (trap 13b) — the oracle was derived from the implementation instead of from the spec the consumer parses. Its `blocked`/`refused` cases **pinned the defective payload as correct**.

The new invariant lives in `bootVerdictNoDisplayRegression.spec.ts` and its oracle is **`composeAnalysisState` — the consumer**. Two inverted tests keep their original premise rather than being deleted, because the readiness genuinely does *not* object, which is precisely why the gate guard could never have caught this.

## The capability, scoped honestly

| boot state | reachable when | without | with |
|---|---|---|---|
| `hydrated_without_capture` | **the ordinary journey** (autosaved analysis) | `cannot_confirm` | **`changed` + a cause** |
| `null` | narrower: no autosaved report | `none` | **`changed` + a cause** |

Settled at `store.ts:4156-4157`. On the ordinary journey the win is **precision, not breaking silence**. It is **bounded**: CEE re-sends `stale` on the next ordinary turn, so the value is **earlier truth in the boot → turn-1 window**, plus robustness if that turn is silent. Both rows and the bound are asserted in-suite.

## Corrected premise (carried from the original brief)

Restoring the verdict **cannot** make `analysisFreshnessDirty` survive the next turn: that clear keys on `analysisFreshness`, sourced only from `analysis_ready`, and the scenario-graph read carries **no `analysis_ready`** (0× in the adapter; contrast controls `analysis_state` 2× there, `analysis_ready` 40× in `applyV5State.ts`). **Two defects, not one**; the freshness one is not fixed here.

## Evidence

**RED-first three times.** Defect A: 5 failed / 9 passed of 14 by name. Defect B (run gate): 6 failed / 5 passed of 11. **F1: 2 failed / 5 passed of 7**, with a contrast precondition proving the consumer oracle can see the harm the old oracle could not.

**Mutants** — throwaway worktree at an absolute path outside the repo, **isolation proven by writing a sentinel** (distinct inodes every round), restores from a **pristine archive**, applied-check scoped to `src/`, control **0**, trailing control green.

| Mutant | Applied | Result | Verdict |
|---|---|---|---|
| M1 remove `complete_stale` | 1 | decisive **RED** | sensitive |
| M2 remove `refused` instead | 1 | decisive **GREEN**, own test RED | binds by identity |
| M3a delete explicit `complete_current` decline | 1 | **survived 21/21** → now REDs | real gap, closed |
| M4 delete the gate guard (pre-narrowing) | 1 | 6 RED | sensitive |
| M5 swap only the decline reason | 1 | capability GREEN, reason RED | discriminates |
| **M6 re-admit `blocked`** | 1 | **F1 invariant 2 RED** | the new oracle bites |
| **M7 delete the gate guard (post-narrowing)** | 1 | **4 RED** | guard **still load-bearing** |
| **M8 reorder `BOOT_DECLINED`** | 1 | **108 GREEN** | binds to set, not order |

M7 answers a question the narrowing raises: the gate guard is **still necessary**, because a `complete_stale` verdict can itself carry a blocking readiness.

**Dev-branch trap avoided by construction** — the localStorage restore path is inside `if (import.meta.env.PROD)` (`ReactFlowGraph.tsx:1504`), dead under vitest. Every spec drives `applyBootAnalysisVerdict`, `composeAnalysisState` or `hydrateCanvasFromServer` **directly**; no component is mounted.

**Gate, in the required order.** `lint` 0 errors, hooks ratchet exactly at baseline · `typecheck` **2252 = baseline, no drift** · gate neighbourhood **876 passed** · full local suite **26,186 passed / 0 failed** (earlier revision).

## ⚠ F2 — known coupling with PR #843, disclosed not fixed

#843 adds a third optional `mayRun` to `readinessObjectsToRun`. After it lands there are **four real call sites and this boot leg is the only one not supplying it**. On the class `status !== 'blocked'` ∧ actionable blockers ∧ CEE `may_run === true`, the Analyse control will be **enabled** while this restore still **declines** — and my `not_restorable`/actionable-blocker test uses `missing_option_value`, the **first member of #843's waivable set**.

Direction is **fail-safe** (we withhold a verdict, never enable an action the gate would refuse), so it is a divergence, not a defect — but it is **silent in both merge orders**. Left for #843's owner to close by threading `mayRun` here: one seam, one writer. **Written at the seam**, not only here.

**Two sentences retracted because #843 falsifies them:** the clause-(a)/clause-(b) split (implied the two routes are disjoint; `mayRun` can waive clause (b) for payloads this leg still declines), and *"this asks exactly the question the gate will ask, and nothing else."* Importing the predicate guarantees **one implementation, not one answer** — the first stops drift in code, only the second would stop it in behaviour.

## Named limits

1. **Post-turn-1 freshness defect NOT fixed** — separate seam (`store.ts:4901-4940`). Governance is **boot → turn 1 only**; asserted in-suite.
2. **What `readiness` CEE composes on the scenario-READ leg is unverified here.** Rowed, not chased — fail-closed is correct either way.
3. **No wire or journey witness.** TESTED, not WIRE-WITNESSED.
4. **`complete_current` permanently declined at boot**, including when the canvas genuinely equals CEE's graph. Lifting it needs a client-readable identity token the contract does not carry.
5. **Instrument failures, disclosed:** an unquoted `$SPECS` did not word-split under zsh (vitest got one arg, found no files, exited 0) — readings voided and re-run; a broken jq escape printed "querying" thirteen times — void, re-run; a "partition spec collects 0" scare resolved by a contrast control showing the pre-existing sibling also read 0.

## Merge sequencing

Touches **no** file #843 edits — `canRunAnalysis.ts`, `usePreAnalysisModel.ts`, `OutputsDock.tsx` are **unmodified here**. It *imports* `readinessObjectsToRun`; if that signature changes this needs a recompile-level rebase only. Either order merges, with F2 above as the known behavioural coupling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
