### PR TITLE
fix(canvas): stop the Analyse control false-blocking a run CEE would admit

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -181,6 +181,7 @@ import {
   selectAnalysisReadinessAuthority,
   useAnalysisReadinessAuthority,
 } from '../state/analysisStateSelector'
+import { useAnalysisMayRun } from '../hooks/useAnalysisReady'
 // ROADMAP 2.635 (I-4) — read at DISPATCH time, not via a render-scope selector:
 // the whole point of the licence barrier is to see the store as it is when the
 // run actually goes out, not as it was when the gate was computed.
@@ -1128,6 +1129,9 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   // is the cheapest possible reminder of which one decides. `canRunAnalysis`
   // applies the precedence; this surface never does.
   const analysisReadiness = useAnalysisReadinessAuthority()
+  // CEE's admission verdict for this turn — the same fact the chat chip gates
+  // on, so the two affordances cannot tell different stories about one payload.
+  const analysisMayRun = useAnalysisMayRun()
 
   // C1 review: the orphan-banner footer suppression is GONE. It rested on a
   // premise that is false at this ref — it claimed the footer would carry
@@ -1192,6 +1196,16 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     graphHealth: graphHealth ?? null,
     readiness,
     analysisReadiness,
+    // ⭐ CEE's own admission verdict — a DIFFERENT question from
+    // `analysisReadiness`, off a DIFFERENT slice. Without it this control
+    // refuses a model CEE would analyse now, while `SuggestedChips` offers a
+    // live "Run analysis" chip on the same payload. See `readinessObjectsToRun`.
+    //
+    // ⚠ Read through `useAnalysisMayRun`, NOT off `ceeAnalysisReadyForCopy`
+    // above: that value is documented as feeding the blocked-state COPY and
+    // never `allowed`, and quietly widening its remit would falsify its own
+    // comment. Same selector the chip gate uses, so one fact, one owner.
+    mayRun: analysisMayRun,
     hasBlockers: hasValidationBlockers,
     nodeCount: nodes.length,
     isRunning,
@@ -1291,6 +1305,12 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
     const analysisReadinessAtDispatch = selectAnalysisReadinessAuthority(
       useCanvasStore.getState().analysisStateV1,
     )
+    // ⭐ Read at DISPATCH time for the same reason as the authority beside it:
+    // the flush is a real window and a fresh turn can land inside it. Closing
+    // over the render-scope `analysisMayRun` would answer with an admission
+    // verdict the store may already have replaced — and this barrier exists
+    // precisely to catch the state as it is when the run goes out.
+    const mayRunAtDispatch = useCanvasStore.getState().ceeAnalysisReady?.may_run
     if (
       verdictLicenceSuperseded(licensedByVerdict, {
         verdictAtMs: licenceAtDispatch.verdictAtMs,
@@ -1300,7 +1320,11 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
       // argument this asks the SIDE-CAR about a run the PRODUCER licensed, so a
       // gate that correctly opened would be re-refused between the click and
       // the wire — the silent-death class, re-created by omission.
-      readinessObjectsToRun(licenceAtDispatch.readiness, analysisReadinessAtDispatch)
+      readinessObjectsToRun(
+        licenceAtDispatch.readiness,
+        analysisReadinessAtDispatch,
+        mayRunAtDispatch,
+      )
     ) {
       console.warn('[OutputsDock] run licence superseded before dispatch', {
         licensedByVerdictAtMs: licensedByVerdict.verdictAtMs,

--- a/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
@@ -17,6 +17,7 @@ import {
   readinessWillScaffold,
 } from '../../../utils/canRunAnalysis'
 import { useAnalysisReadinessAuthority } from '../../../state/analysisStateSelector'
+import { useAnalysisMayRun } from '../../../hooks/useAnalysisReady'
 import { composeAnalysisBlockedReason } from '../../../utils/composeBlockedReason'
 import { resolveStarterId } from '../../../starters/loadStarter'
 import { isReviewedByUser } from '../../pre-analysis/utils/isReviewedByUser'
@@ -223,6 +224,11 @@ export function usePreAnalysisModel(): PreAnalysisModel {
   // The producer's own readiness verdict for this turn. See `canRun` below.
   const analysisReadiness = useAnalysisReadinessAuthority()
 
+  // …and the producer's own ADMISSION verdict, which answers a different
+  // question ("will the run proceed if asked?") from a different slice. The two
+  // are separate on purpose — see `readinessObjectsToRun`.
+  const analysisMayRun = useAnalysisMayRun()
+
   // UI-SEM-091: runnable-via-scaffold. CEE (#612) rides a scaffold intent on
   // the readiness response; when it will draft the remaining options the graph
   // is runnable despite can_run_analysis being false. Both the footer and the
@@ -254,7 +260,12 @@ export function usePreAnalysisModel(): PreAnalysisModel {
   // an answer, so a panel that had one would otherwise report itself as still
   // waiting to hear.
   const nothingHasAnswered = readinessNothingHasAnswered(readiness, analysisReadiness)
-  const canRun = nothingHasAnswered ? null : !readinessObjectsToRun(readiness, analysisReadiness)
+  // ⭐ CEE's own admission verdict, from the `analysis_ready` slice. Without it
+  // this panel refuses a model CEE would analyse now — while the chat offers a
+  // live "Run analysis" chip on the same payload. See `readinessObjectsToRun`.
+  const canRun = nothingHasAnswered
+    ? null
+    : !readinessObjectsToRun(readiness, analysisReadiness, analysisMayRun)
 
   const ladder = useMemo(
     () =>

--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -36,6 +36,7 @@ import { useThreadPersistence } from './hooks/useThreadPersistence'
 import { beginInteractionChain, getUiSurfaceState, recordCrossSurfaceEvent, recordInteractionEvent, recordUserAction, type InteractionStateSnapshot } from '../../lib/debug-state'
 import { canRunAnalysis as canRunAnalysisUtil, getRunButtonTooltip } from '../utils/canRunAnalysis'
 import { useAnalysisReadinessAuthority } from '../state/analysisStateSelector'
+import { useAnalysisMayRun } from '../hooks/useAnalysisReady'
 import { BLOCKED_REASON_COPY } from '../utils/composeBlockedReason'
 import { useShowToastSafe } from '../ToastContext'
 import { analysisHeldOn } from '../utils/analysisHeldOnInjectedModel'
@@ -558,17 +559,24 @@ export const ConversationPanel = memo(function ConversationPanel({
   // consulted different authorities on two surfaces is the two-surfaces-one-state
   // defect this file's own comments already record fixing twice.
   const analysisReadiness = useAnalysisReadinessAuthority()
+  // ⭐ …and CEE's ADMISSION verdict, for the same reason again — and with extra
+  // force on THIS surface: `SuggestedChips`, which renders inside this very
+  // panel, already gates its "Run analysis" chip on this exact value. A run
+  // gate here that ignored it would let one panel offer the run in the chat and
+  // refuse it in the composer, on one payload, at one moment.
+  const analysisMayRun = useAnalysisMayRun()
   const runGateResult = useMemo(() => canRunAnalysisUtil({
     graphHealth: graphHealth ?? null,
     readiness,
     analysisReadiness,
+    mayRun: analysisMayRun,
     hasBlockers,
     nodeCount,
     isRunning: isAnalysisRunning,
     analysisHeldOn: heldOn,
     draftStreamPhase,
     readinessStale,
-  }), [graphHealth, readiness, analysisReadiness, hasBlockers, nodeCount, isAnalysisRunning, heldOn, draftStreamPhase, readinessStale])
+  }), [graphHealth, readiness, analysisReadiness, analysisMayRun, hasBlockers, nodeCount, isAnalysisRunning, heldOn, draftStreamPhase, readinessStale])
 
   // In-flight takes priority over structural reasons: the composer button
   // is disabled for either cause, but the user-visible tooltip should explain

--- a/src/canvas/utils/__tests__/analyseControlFalseBlock.spec.ts
+++ b/src/canvas/utils/__tests__/analyseControlFalseBlock.spec.ts
@@ -1,0 +1,436 @@
+/**
+ * THE ANALYSE CONTROL IS DISABLED ON A MODEL CEE WOULD ANALYSE THIS INSTANT,
+ * WHILE THE CHAT SIMULTANEOUSLY OFFERS A LIVE "Run analysis" CHIP.
+ *
+ * ── THE DEFECT THIS PINS (derived at both producers, 25 Aug 2026) ───────────
+ * CEE's `resolveRunAdmission` waives three blocker codes by EXCLUDING the
+ * incomplete option and running on the rest:
+ *
+ *   WAIVABLE_BY_EXCLUSION = { MISSING_OPTION_VALUE,
+ *                             OPTION_NEEDS_ENCODING,
+ *                             OPTION_NEEDS_MAPPING }
+ *   (cee `orchestrator-v5/tools/handlers/analysis-ready-core.ts:378-382`)
+ *
+ * On such a turn CEE emits `status: 'needs_user_input'` AND `may_run: true`.
+ * Its own comment says so, at the payload builder, citing a measured capture:
+ *
+ *   "Measured on the `live-4day-week` capture: one unconfigured option gives
+ *    `status: needs_user_input, willProceed: TRUE`, while two and three give
+ *    `needs_user_input, willProceed: false` — one status, both verdicts, which
+ *    is exactly why no reading of `status` can recover the answer."
+ *   (cee `orchestrator/tools/analysis-ready-helper.ts:1190-1194`)
+ *
+ * Those waived codes are `option_values` / `option_mapping`, so `hardBlocked`
+ * is false and the status is NOT `'blocked'`. The blockers themselves still
+ * ride the wire — `analysis-state-v1.ts` maps `input.readiness.blockers`
+ * straight through — and the UI's advisory set is a single member
+ * (`CONSTRAINT_REVIEW_REQUIRED`), so every one of them is ACTIONABLE here.
+ *
+ * `readinessObjectsToRun` therefore counts them and REFUSES, while
+ * `SuggestedChips.tsx:267` renders the "Run analysis" chip on
+ * `admitsRunAffordance(status, may_run)` — which the same payload satisfies.
+ * Two Olumi affordances contradict each other on one screen: the chat offers
+ * the run, the panel says the model is not ready for it.
+ *
+ * ── WHY THE UI CANNOT SEE THE WAIVER ANY OTHER WAY ──────────────────────────
+ * CEE stamps `waived_by_exclusion: true` on the waived issue. `@talchain/schemas`
+ * 0.48.0 types `AnalysisBlockerSchema` as `.strict()` with exactly eight fields,
+ * and `waived_by_exclusion` is not one of them; `AnalysisReadinessSchema` is
+ * `.strict()` with exactly `{status, blockers}` and carries no `may_run`. So the
+ * authority object the gate is handed CANNOT carry the waiver, and `may_run`
+ * must arrive as its own value off the `analysis_ready` slice — which is
+ * precisely where `useAnalysisMayRun()` already reads it.
+ *
+ * ── THE FIX THIS FILE SPECIFIES ─────────────────────────────────────────────
+ * `readinessObjectsToRun` gains a third argument, `mayRun`, and the ACTIONABLE
+ * BLOCKER clause alone becomes waivable by it:
+ *
+ *   status === 'blocked' || (actionableBlockers(...).length > 0 && mayRun !== true)
+ *
+ * ⭐⭐ THE `blocked` CLAUSE IS DELIBERATELY *NOT* WAIVABLE, AND THIS IS THE
+ * LOAD-BEARING CORRECTION. The obvious shape — `(A || B) && mayRun !== true` —
+ * re-opens a defect that clause was written to close, because `may_run` CAN GO
+ * STALE ACROSS A REFUSAL TURN:
+ *
+ *   · `buildAnalysisRefusalReadiness` (cee `analysis-ready-helper.ts:1478-1493`)
+ *     emits `{status: 'blocked', blocked_reason, options: [], goal_node_id: ''}`
+ *     and sets NO `may_run` — the field is written in exactly one place,
+ *     `buildCanonicalAnalysisReadyFromGraph:1221`.
+ *   · That degenerate payload is REJECTED by the UI's own normaliser
+ *     (`applyV5State.ts:233-234`), and `applyV5State.ts:1219` only writes the
+ *     slice `if (normalised)` — so `ceeAnalysisReady` KEEPS ITS PREVIOUS VALUE,
+ *     stale `may_run: true` included, while `analysisStateV1` moves to blocked.
+ *
+ * A waiver spanning both clauses would then hand the user an ENABLED Analyse
+ * control one turn after CEE refused the run — which is, verbatim, the harm
+ * `canRunAnalysis.ts:457-460` records the `blocked` clause as existing to
+ * prevent: "the Analyse control would turn ENABLED one turn after CEE refused
+ * the run. The user clicks, and is refused again."
+ *
+ * ── WHAT EACH TEST BELOW IS FOR ─────────────────────────────────────────────
+ * The suite fails in BOTH directions, because a gate guards two opposite harms:
+ *   · A4-1 / A4-2 RED at pristine — the false block, and the two affordances
+ *     disagreeing on one payload. They are the reason this lane exists.
+ *   · A4-3 / A4-4 are GREEN at pristine and MUST STAY GREEN — absent or false
+ *     `may_run` must leave today's refusal byte-identical, sentence included.
+ *   · A4-5 is GREEN at pristine and MUST STAY GREEN — it is the guard against
+ *     the `(A || B) && mayRun !== true` shape, and it REDs under it.
+ *   · A4-6 is the CONTRAST CONTROL: green at pristine, proving this file is
+ *     bound to the real gate and is not vacuous (trap 13e).
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { AnalysisBlocker, AnalysisStateV1 } from '@talchain/schemas/boundary'
+
+import {
+  actionableBlockers,
+  canRunAnalysis,
+  readinessObjectsToRun,
+  type CanRunAnalysisParams,
+} from '../canRunAnalysis'
+import { selectAnalysisReadinessAuthority } from '../../state/analysisStateSelector'
+import { admitsRunAffordance } from '../../hooks/useAnalysisReady'
+import type { GraphReadiness } from '../../hooks/useGraphReadiness'
+
+// ───────────────────────────────────────────────────────────────────────────
+// Fixtures — every field DERIVED FROM THE PRODUCER, not invented.
+//
+// `MISSING_OPTION_VALUE` carries `category: 'option_values'`, the message
+// `Choose the missing effect value${suffix}.` and
+// `repairability: 'human_input_required'`, all read at CEE
+// `orchestrator/tools/analysis-ready-helper.ts:714-720` (+ `:947` for the
+// repairability on the same `common` spread).
+// ───────────────────────────────────────────────────────────────────────────
+
+/** The option the user left open, named once so every assertion binds to IT. */
+const WAIVED_OPTION_ID = 'opt_hire_contractor'
+const WAIVED_OPTION_LABEL = 'Hire a contractor'
+
+/** A SECOND, DIFFERENT option — the discriminating partner for identity tests. */
+const OTHER_OPTION_ID = 'opt_do_nothing'
+const OTHER_OPTION_LABEL = 'Do nothing'
+
+function missingValueBlocker(
+  optionId: string,
+  optionLabel: string,
+): AnalysisBlocker {
+  return {
+    code: 'MISSING_OPTION_VALUE',
+    category: 'option_values',
+    message: `Choose the missing effect value for "${optionLabel}".`,
+    repairability: 'human_input_required',
+    option_id: optionId,
+    option_label: optionLabel,
+  }
+}
+
+/**
+ * The single member of the UI's advisory set
+ * (`canRunAnalysis.ts:391` — `ADVISORY_BLOCKER_CODES`). Used ONLY by the
+ * contrast control, which must stay green with no `may_run` in play at all.
+ */
+const ADVISORY_BLOCKER: AnalysisBlocker = {
+  code: 'CONSTRAINT_REVIEW_REQUIRED',
+  category: 'option_values',
+  message: 'Confirm the constraint that was dropped.',
+  repairability: 'human_input_required',
+}
+
+/**
+ * The side-car verdict, field-for-field the one `readinessStore` composes and
+ * RETAINS on its empty-canvas arm. It OBJECTS — so any test whose gate opens
+ * proves the producer branch decided, never this.
+ */
+const SIDE_CAR_OBJECTS: GraphReadiness = {
+  readiness_score: 0,
+  readiness_level: 'needs_work',
+  can_run_analysis: false,
+  confidence_explanation: 'Add some nodes to get started',
+  improvements: [],
+}
+
+/**
+ * A full `AnalysisStateV1` as the wire carries it, so every case travels
+ * through `selectAnalysisReadinessAuthority` — THE REAL SEAM — rather than
+ * hand-building the authority object the gate happens to accept.
+ */
+function wireState(readiness: AnalysisStateV1['readiness']): AnalysisStateV1 {
+  return {
+    run_state: { kind: 'never_run' },
+    readiness,
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: false,
+    blocked_unusable: false,
+    contradictions: [],
+  } as AnalysisStateV1
+}
+
+/**
+ * ⭐ THE PAYOFF TURN, as CEE emits it: `needs_user_input` (NOT `blocked`) with
+ * one waivable blocker naming ONE option, on a graph the run will admit by
+ * leaving that option out.
+ */
+const PAYOFF_TURN_AUTHORITY = selectAnalysisReadinessAuthority(
+  wireState({
+    status: 'needs_user_input',
+    blockers: [missingValueBlocker(WAIVED_OPTION_ID, WAIVED_OPTION_LABEL)],
+  }),
+)
+
+/** A refusal turn: the producer's hard stop. */
+const REFUSED_TURN_AUTHORITY = selectAnalysisReadinessAuthority(
+  wireState({ status: 'blocked', blockers: [] }),
+)
+
+/**
+ * The gate as the deployed canvas calls it: a real model on screen, nothing
+ * held, nothing streaming, no validation issues. Only the readiness inputs and
+ * `mayRun` vary, so any difference in the verdict is attributable to them.
+ */
+function gate(overrides: Partial<CanRunAnalysisParams> = {}) {
+  return canRunAnalysis({
+    graphHealth: null,
+    readiness: SIDE_CAR_OBJECTS,
+    hasBlockers: false,
+    nodeCount: 16,
+    isRunning: false,
+    analysisHeldOn: null,
+    draftStreamPhase: 'idle',
+    optionsNeedingValues: [],
+    readinessStale: false,
+    ...overrides,
+  })
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// A4-1 — THE FALSE BLOCK. RED at pristine.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('A4-1 — CEE will run this graph now, so the Analyse control is ENABLED', () => {
+  it('opens the gate when may_run is true despite a waivable actionable blocker', () => {
+    expect(
+      readinessObjectsToRun(SIDE_CAR_OBJECTS, PAYOFF_TURN_AUTHORITY, true),
+    ).toBe(false)
+  })
+
+  it('threads may_run through canRunAnalysis itself, not only the predicate', () => {
+    const result = gate({ analysisReadiness: PAYOFF_TURN_AUTHORITY, mayRun: true })
+
+    expect(result.allowed).toBe(true)
+    // An open gate makes NO refusal at all — not a softer one.
+    expect(result.reason).toBeUndefined()
+    expect(result.blockingReasons ?? []).toEqual([])
+  })
+
+  it('stops naming the waived option as the thing standing in the way', () => {
+    const result = gate({ analysisReadiness: PAYOFF_TURN_AUTHORITY, mayRun: true })
+
+    // ⭐ BOUND BY IDENTITY: the LABEL of the specific option CEE is excluding,
+    // not a value predicate a different option could satisfy. Under the defect
+    // this string is exactly what the disabled control's title carried.
+    expect(JSON.stringify(result)).not.toContain(WAIVED_OPTION_LABEL)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// A4-2 — THE TWO AFFORDANCES AGREE. RED at pristine.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('A4-2 — the chat chip and the Analyse control cannot contradict each other', () => {
+  it('agrees with admitsRunAffordance on the exact payload that splits them today', () => {
+    const chipIsOffered = admitsRunAffordance('needs_user_input', true)
+    const controlIsEnabled = !readinessObjectsToRun(
+      SIDE_CAR_OBJECTS,
+      PAYOFF_TURN_AUTHORITY,
+      true,
+    )
+
+    // The chip renders today — that half is already shipped and must not move.
+    expect(chipIsOffered).toBe(true)
+    // …and the control must reach the SAME verdict from the SAME two facts.
+    expect(controlIsEnabled).toBe(chipIsOffered)
+  })
+
+  it('still agrees when neither affordance is admitted', () => {
+    const chipIsOffered = admitsRunAffordance('needs_user_input', false)
+    const controlIsEnabled = !readinessObjectsToRun(
+      SIDE_CAR_OBJECTS,
+      PAYOFF_TURN_AUTHORITY,
+      false,
+    )
+
+    expect(chipIsOffered).toBe(false)
+    expect(controlIsEnabled).toBe(chipIsOffered)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// A4-3 / A4-4 — THE OTHER DOOR. GREEN at pristine, and MUST STAY GREEN.
+//
+// A widening that changed anything when the producer did NOT say `may_run`
+// would trade one silent failure for its inverse. `undefined` is a pre-`may_run`
+// CEE and MUST behave byte-identically to today — sentence included.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('A4-3 — an absent may_run leaves today’s refusal byte-identical', () => {
+  it('still refuses when may_run is undefined', () => {
+    expect(
+      readinessObjectsToRun(SIDE_CAR_OBJECTS, PAYOFF_TURN_AUTHORITY, undefined),
+    ).toBe(true)
+  })
+
+  it('refuses identically whether the argument is omitted or passed as undefined', () => {
+    expect(readinessObjectsToRun(SIDE_CAR_OBJECTS, PAYOFF_TURN_AUTHORITY)).toBe(
+      readinessObjectsToRun(SIDE_CAR_OBJECTS, PAYOFF_TURN_AUTHORITY, undefined),
+    )
+  })
+
+  it('still explains the refusal with the producer’s own sentence for THAT option', () => {
+    const withoutMayRun = gate({ analysisReadiness: PAYOFF_TURN_AUTHORITY })
+    const omittedEntirely = gate({
+      analysisReadiness: PAYOFF_TURN_AUTHORITY,
+      mayRun: undefined,
+    })
+
+    expect(withoutMayRun.allowed).toBe(false)
+    // ⭐ IDENTITY: the producer's verbatim sentence naming the specific option.
+    expect(withoutMayRun.reason).toContain(WAIVED_OPTION_LABEL)
+    // Byte-identical, not merely "also refused".
+    expect(omittedEntirely).toEqual(withoutMayRun)
+  })
+})
+
+describe('A4-4 — an explicit may_run:false leaves today’s refusal byte-identical', () => {
+  it('still refuses when the producer says the run will not proceed', () => {
+    expect(
+      readinessObjectsToRun(SIDE_CAR_OBJECTS, PAYOFF_TURN_AUTHORITY, false),
+    ).toBe(true)
+  })
+
+  it('produces the same gate result as the pre-may_run path', () => {
+    const withFalse = gate({ analysisReadiness: PAYOFF_TURN_AUTHORITY, mayRun: false })
+    const withoutIt = gate({ analysisReadiness: PAYOFF_TURN_AUTHORITY })
+
+    expect(withFalse.allowed).toBe(false)
+    expect(withFalse).toEqual(withoutIt)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// A4-5 ⭐⭐ THE CORRECTION — A REFUSAL IS NOT WAIVABLE BY A STALE `may_run`.
+//
+// GREEN at pristine (the argument is ignored there) and MUST STAY GREEN. It
+// REDs under the `(A || B) && mayRun !== true` shape, which is the whole reason
+// it is written down.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('A4-5 — status:blocked keeps refusing even when may_run says true', () => {
+  it('does not let a stale may_run re-enable the control after a refusal turn', () => {
+    // The store state one turn after CEE refused: the authority has moved to
+    // `blocked`, while `ceeAnalysisReady` still holds the PREVIOUS turn's
+    // `may_run: true` because the degenerate refusal payload was discarded by
+    // `normaliseV5AnalysisReady` and the slice was never rewritten.
+    expect(
+      readinessObjectsToRun(SIDE_CAR_OBJECTS, REFUSED_TURN_AUTHORITY, true),
+    ).toBe(true)
+  })
+
+  it('keeps the gate shut through canRunAnalysis on that same state', () => {
+    const result = gate({ analysisReadiness: REFUSED_TURN_AUTHORITY, mayRun: true })
+
+    expect(result.allowed).toBe(false)
+  })
+
+  it('refuses a blocked status carrying a waivable blocker too', () => {
+    // Belt and braces: `blocked` must dominate the waiver even when the list
+    // happens to hold a code the exclusion could otherwise answer.
+    const blockedWithWaivable = selectAnalysisReadinessAuthority(
+      wireState({
+        status: 'blocked',
+        blockers: [missingValueBlocker(WAIVED_OPTION_ID, WAIVED_OPTION_LABEL)],
+      }),
+    )
+
+    expect(readinessObjectsToRun(SIDE_CAR_OBJECTS, blockedWithWaivable, true)).toBe(
+      true,
+    )
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// A4-6 — CONTRAST CONTROL. Green at pristine, green after, and it proves this
+// file is bound to the REAL gate rather than passing vacuously.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('A4-6 — contrast control: the untouched paths still behave as they did', () => {
+  it('an advisory-only blocker list never blocked, and still does not', () => {
+    const advisoryOnly = selectAnalysisReadinessAuthority(
+      wireState({ status: 'ready', blockers: [ADVISORY_BLOCKER] }),
+    )
+
+    // No `may_run` anywhere in this case — if it were load-bearing here, the
+    // widening would have reached a path it had no business touching.
+    expect(readinessObjectsToRun(SIDE_CAR_OBJECTS, advisoryOnly)).toBe(false)
+    expect(actionableBlockers(advisoryOnly!.blockers)).toEqual([])
+  })
+
+  it('the actionable filter still sees the waivable code as actionable', () => {
+    // The waiver lives in the GATE, not in the filter: the blocker is real and
+    // is still itemised for any surface that lists impediments. Moving the fix
+    // into `actionableBlockers` would silently delete it from those lists.
+    expect(actionableBlockers(PAYOFF_TURN_AUTHORITY!.blockers)).toHaveLength(1)
+    expect(actionableBlockers(PAYOFF_TURN_AUTHORITY!.blockers)[0]!.option_id).toBe(
+      WAIVED_OPTION_ID,
+    )
+  })
+
+  it('the side-car branch is untouched when no producer verdict exists', () => {
+    // `mayRun` must not reach the side-car fallback: that branch answers a
+    // different question, from a different authority, and CEE's admission
+    // verdict says nothing about it.
+    expect(readinessObjectsToRun(SIDE_CAR_OBJECTS, null, true)).toBe(true)
+    expect(readinessObjectsToRun(SIDE_CAR_OBJECTS, undefined, true)).toBe(true)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// A4-7 — IDENTITY BINDING, proved by a DIFFERENT object in the same shape.
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('A4-7 — the verdict follows the blocker list, not the fixture’s shape', () => {
+  it('opens on a two-blocker list only because may_run says the run proceeds', () => {
+    const twoOpenOptions = selectAnalysisReadinessAuthority(
+      wireState({
+        status: 'needs_user_input',
+        blockers: [
+          missingValueBlocker(WAIVED_OPTION_ID, WAIVED_OPTION_LABEL),
+          missingValueBlocker(OTHER_OPTION_ID, OTHER_OPTION_LABEL),
+        ],
+      }),
+    )
+
+    // CEE declines two open options (`willProceed: false` on the measured
+    // capture) — and with `may_run: false` the control must agree.
+    expect(readinessObjectsToRun(SIDE_CAR_OBJECTS, twoOpenOptions, false)).toBe(true)
+    // The SAME list opens when — and only when — the producer admits the run.
+    expect(readinessObjectsToRun(SIDE_CAR_OBJECTS, twoOpenOptions, true)).toBe(false)
+  })
+
+  it('names the other option when the other option is the one blocking', () => {
+    const otherOnly = selectAnalysisReadinessAuthority(
+      wireState({
+        status: 'needs_user_input',
+        blockers: [missingValueBlocker(OTHER_OPTION_ID, OTHER_OPTION_LABEL)],
+      }),
+    )
+    const result = gate({ analysisReadiness: otherOnly })
+
+    expect(result.allowed).toBe(false)
+    expect(result.reason).toContain(OTHER_OPTION_LABEL)
+    expect(result.reason).not.toContain(WAIVED_OPTION_LABEL)
+  })
+})

--- a/src/canvas/utils/__tests__/analyseControlFalseBlock.spec.ts
+++ b/src/canvas/utils/__tests__/analyseControlFalseBlock.spec.ts
@@ -67,6 +67,35 @@
  * prevent: "the Analyse control would turn ENABLED one turn after CEE refused
  * the run. The user clicks, and is refused again."
  *
+ * ── AND CLAUSE (a) DOES NOT CARRY THE FALSE-BLOCK ANYWAY: A PROOF ───────────
+ * The question was put directly — can CEE emit `status: 'blocked'` on a turn
+ * where `resolveRunAdmission` returned `willProceed: true`? Derived at CEE
+ * `4a064e60`, read-only. **It cannot.** `may_run` and `status` are taken from
+ * ONE assessment in ONE expression (`analysis-ready-helper.ts:1218-1221`:
+ * `payload = admission.assessment.analysisReady`, `may_run =
+ * admission.willProceed`), so the two can only be paired as that assessment
+ * produced them. Inside the assessor `status: 'blocked'` has exactly two
+ * writers (`:1130` and `:1136`), and there are exactly two `willProceed: true`
+ * returns (`analysis-ready-core.ts:493` and `:562`):
+ *
+ *   · `:493` fires when `strict.status !== 'unrecoverable'`, which by
+ *     `readinessResultFrom:148` means `assessment.safeToAnalyse === true`,
+ *     which by `analysis-ready-helper.ts:1144` is DEFINED as
+ *     `blockingIssues.length === 0 && analysisReady.status === 'ready'`.
+ *     The status is therefore `'ready'` by construction.
+ *   · `:562` fires only when every blocking issue is waivable by exclusion
+ *     (`:538`), i.e. every code is one of the three, i.e. every category is
+ *     `option_values` / `option_mapping`. Writer 1 (`:1130`) needs
+ *     `hardBlocked` — some issue in `graph_structure` / `numeric_integrity` /
+ *     `internal` — and those category sets are DISJOINT, so it cannot fire.
+ *     Writer 2 (`:1136`) needs `!semantic`, but this path already asserted
+ *     `wireOptions.length > 0` at `:500-503`, so it cannot fire either.
+ *
+ * `status: 'blocked'` and `may_run: true` are therefore MUTUALLY EXCLUSIVE on
+ * any single payload. Guarding clause (a) with `mayRun` would be a no-op on a
+ * same-turn payload — and, on a cross-turn STALE one, actively harmful for the
+ * reason above. A4-5 pins that boundary in the only direction the UI can see.
+ *
  * ── WHAT EACH TEST BELOW IS FOR ─────────────────────────────────────────────
  * The suite fails in BOTH directions, because a gate guards two opposite harms:
  *   · A4-1 / A4-2 RED at pristine — the false block, and the two affordances

--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -180,6 +180,21 @@ export interface CanRunAnalysisParams {
    * is how an absence becomes a fabricated finding.
    */
   analysisReadiness?: AnalysisReadinessAuthority | null
+  /**
+   * ⭐ CEE's own admission verdict for this turn (`analysis_ready.may_run`) —
+   * *"will the run proceed if asked, right now?"*, which is ALSO true when it
+   * proceeds by excluding options the user left open.
+   *
+   * A SEPARATE PARAMETER, NOT A FIELD ON `AnalysisReadinessAuthority`: that type
+   * is projected from a `.strict()` schema that cannot carry it, and the value
+   * arrives on a different slice (`ceeAnalysisReady`) from a different key
+   * (`analysis_ready`, not `analysis_state`). Read it with `useAnalysisMayRun()`.
+   *
+   * `undefined` = a pre-`may_run` CEE. It is load-bearing and must never be
+   * collapsed to `false`; see `readinessObjectsToRun` for why the polarity is
+   * strict `=== true`.
+   */
+  mayRun?: boolean
   /** Whether there are critical/blocking actions */
   hasBlockers: boolean
   /** Number of nodes in graph */
@@ -425,6 +440,7 @@ export function actionableBlockers(
 export function readinessObjectsToRun(
   readiness: GraphReadiness | null | undefined,
   analysisReadiness?: AnalysisReadinessAuthority | null,
+  mayRun?: boolean,
 ): boolean {
   // ⭐ SUPERSESSION, APPLIED ONCE, HERE (19 Aug 2026).
   //
@@ -503,9 +519,58 @@ export function readinessObjectsToRun(
     // So the honest predicate refuses what is provably unrunnable and lets the
     // producer's itemised list decide the rest. Refusing on a status whose cause
     // we cannot name would re-create the original defect in a new spelling.
+    // ⭐ (c) `mayRun` — CEE'S OWN ADMISSION VERDICT, WAIVING (b) AND ONLY (b).
+    //
+    // THE DEFECT. `resolveRunAdmission` waives three blocker codes by EXCLUDING
+    // the incomplete option and running on the rest
+    // (`analysis-ready-core.ts:378-382` — MISSING_OPTION_VALUE,
+    // OPTION_NEEDS_ENCODING, OPTION_NEEDS_MAPPING). Those are `option_values` /
+    // `option_mapping`, so nothing is hard-blocked and the status stays
+    // `needs_user_input` — yet the blockers still ride the wire, and every one
+    // of them is ACTIONABLE here. So (b) counted them and this control refused a
+    // model CEE would have analysed that instant, while `SuggestedChips.tsx:267`
+    // rendered a live "Run analysis" chip on the very same payload. Two Olumi
+    // affordances contradicting each other on one screen.
+    //
+    // ⚠ THE UI CANNOT RECOVER THIS FROM THE AUTHORITY. CEE stamps
+    // `waived_by_exclusion: true` on the waived issue, but `@talchain/schemas`
+    // 0.48.0 types `AnalysisBlockerSchema` `.strict()` with exactly eight fields
+    // and `AnalysisReadinessSchema` `.strict()` with exactly `{status,
+    // blockers}` — neither can carry it, and no reading of `status` recovers it
+    // either (CEE measured ONE status carrying BOTH admission verdicts on the
+    // `live-4day-week` capture, `analysis-ready-helper.ts:1190-1194`). Hence a
+    // separate argument, sourced from the `analysis_ready` slice where CEE does
+    // publish it — the same value `admitsRunAffordance` already gates the chip
+    // on, so the two affordances now answer from one fact.
+    //
+    // ⭐⭐ WHY IT WAIVES (b) ALONE AND NOT `(a) || (b)`. The whole-predicate
+    // form is the obvious shape and it RE-OPENS THE DEFECT (a) EXISTS TO CLOSE,
+    // because `may_run` CAN GO STALE ACROSS A REFUSAL TURN:
+    //   · `buildAnalysisRefusalReadiness` (cee `analysis-ready-helper.ts:1488`)
+    //     emits `{status: 'blocked', options: [], goal_node_id: ''}` and sets NO
+    //     `may_run` — the field is written in exactly one place, `:1221`.
+    //   · That degenerate payload is REJECTED by our own normaliser
+    //     (`applyV5State.ts:233-234`), and `:1219` writes the slice only
+    //     `if (normalised)` — so `ceeAnalysisReady` KEEPS THE PREVIOUS TURN'S
+    //     value, stale `may_run: true` included, while `analysisStateV1` moves
+    //     to blocked.
+    // A waiver spanning (a) would then hand the user an ENABLED control one turn
+    // after CEE refused the run — verbatim the harm recorded at (a) above. The
+    // producer's refusal is not a blocker count and is not negotiable.
+    //
+    // ⚠ `=== true`, NOT `!== false`. ABSENCE means a pre-`may_run` CEE, never
+    // "no", so an omitted or malformed value must leave the refusal exactly as
+    // it is today — the two services stay deploy-order independent, and this
+    // change can only ever NARROW the refusal. Same polarity, same reasoning as
+    // `admitsRunAffordance` (`useAnalysisReady.ts:64-68`).
+    //
+    // ⚠ AND IT DOES NOT MOVE INTO `actionableBlockers`. The blocker is REAL and
+    // must stay itemised for every surface that lists impediments; waiving it
+    // there would delete it from those lists as well as from the gate. The
+    // waiver is about admission, not about actionability.
     return (
       analysisReadiness.status === ANALYSIS_READINESS_BLOCKED ||
-      actionableBlockers(analysisReadiness.blockers).length > 0
+      (actionableBlockers(analysisReadiness.blockers).length > 0 && mayRun !== true)
     )
   }
 
@@ -582,7 +647,10 @@ export const RUN_LICENCE_SUPERSEDED_REFUSAL =
  * @returns CanRunAnalysisResult with allowed status and reason
  */
 export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResult {
-  const { graphHealth, readiness, analysisReadiness = null, hasBlockers, nodeCount, isRunning = false, analysisHeldOn = null, draftStreamPhase = 'idle', optionsNeedingValues, readinessStale = false } = params
+  // ⚠ `mayRun` is deliberately NOT defaulted here. `undefined` is the signal
+  // "the producer did not say", and a default would erase the very distinction
+  // `readinessObjectsToRun` reads it for.
+  const { graphHealth, readiness, analysisReadiness = null, mayRun, hasBlockers, nodeCount, isRunning = false, analysisHeldOn = null, draftStreamPhase = 'idle', optionsNeedingValues, readinessStale = false } = params
 
   const blockingReasons: string[] = []
 
@@ -687,7 +755,7 @@ export function canRunAnalysis(params: CanRunAnalysisParams): CanRunAnalysisResu
   // asserts a fact the panel's own counts could contradict.
   // ROADMAP 2.635 (I-5) — the rung's predicate is `readinessObjectsToRun`, so
   // the dispatch barrier can ask the SAME question without re-implementing it.
-  if (readinessObjectsToRun(readiness, analysisReadiness)) {
+  if (readinessObjectsToRun(readiness, analysisReadiness, mayRun)) {
     // ⭐ The reason comes from WHICHEVER AUTHORITY DECIDED, never from the other
     // one. A refusal explained by a verdict that did not make it is the
     // two-questions-one-name defect wearing the fix's clothes: the gate would


### PR DESCRIPTION
**DO NOT MERGE** — opened for review. UI-only.

## The defect

The Analyse control was **disabled on models CEE would have analysed that instant**, while `SuggestedChips` rendered a live **"Run analysis"** chip on the *same payload*. Two Olumi affordances contradicting each other on one screen.

CEE's `resolveRunAdmission` waives three blocker codes by **excluding** the incomplete option and running on the rest (`analysis-ready-core.ts:378-382` — `MISSING_OPTION_VALUE`, `OPTION_NEEDS_ENCODING`, `OPTION_NEEDS_MAPPING`). On such a turn it emits `status: 'needs_user_input'` **and** `may_run: true`. Its own comment says so, citing a measured capture:

> "Measured on the `live-4day-week` capture: one unconfigured option gives `status: needs_user_input, willProceed: TRUE`, while two and three give `needs_user_input, willProceed: false` — one status, both verdicts, which is exactly why no reading of `status` can recover the answer."
> — cee `orchestrator/tools/analysis-ready-helper.ts:1190-1194`

Those blockers still ride the wire, and the UI's advisory set has a single member (`CONSTRAINT_REVIEW_REQUIRED`), so every one of them is **actionable** — `readinessObjectsToRun` counted them and refused.

## Why the UI cannot recover this from the authority

CEE stamps `waived_by_exclusion: true` on the waived issue. But `@talchain/schemas` 0.48.0 types `AnalysisBlockerSchema` `.strict()` with exactly **eight** fields (no `waived_by_exclusion`) and `AnalysisReadinessSchema` `.strict()` with exactly `{status, blockers}` (no `may_run`) — verified at the vendored tarball. So `may_run` must arrive as its **own argument**, off the `analysis_ready` slice, which is exactly where `useAnalysisMayRun()` already reads it and where `admitsRunAffordance` already gates the chip.

## The change

```diff
- status === 'blocked' || actionableBlockers(blockers).length > 0
+ status === 'blocked' || (actionableBlockers(blockers).length > 0 && mayRun !== true)
```

This **narrows** the refusal only. `undefined` changes nothing, so the two services stay deploy-order independent.

Threaded at all four gate call sites: `OutputsDock` gate + dispatch barrier, `ConversationPanel`, `usePreAnalysisModel`. `readinessDisplay.ts` and `AnalysisReadinessBar` are documented pass-throughs (`"the run gate, not a copy of it"`), so they inherit it.

## ⭐ The load-bearing correction — the waiver is scoped to clause (b) alone

The obvious shape `(A || B) && mayRun !== true` **re-opens the defect clause (a) exists to close**, because `may_run` can go stale across a refusal turn:

- `buildAnalysisRefusalReadiness` emits `{status: 'blocked', options: [], goal_node_id: ''}` and sets **no** `may_run` (the field is written in exactly one place, `:1221`).
- That degenerate payload is **rejected** by our own `normaliseV5AnalysisReady` (`applyV5State.ts:233-234`), and `:1219` writes the slice only `if (normalised)` — so `ceeAnalysisReady` **keeps the previous turn's `may_run: true`** while `analysisStateV1` moves to blocked.

That is verbatim the harm recorded at `canRunAnalysis.ts:457-460`: *"the Analyse control would turn ENABLED one turn after CEE refused the run."*

**And clause (a) does not carry the false-block anyway** — proven at CEE `4a064e60`. `may_run` and `status` come from one assessment in one expression, and:

- `willProceed: true` at `:493` requires `strict.status !== 'unrecoverable'` ⇒ `safeToAnalyse` ⇒ `status === 'ready'` **by definition** (`analysis-ready-helper.ts:1144`);
- `willProceed: true` at `:562` requires every blocking issue be waivable ⇒ every category is `option_values`/`option_mapping`, which is **disjoint** from `hardBlocked`'s `graph_structure`/`numeric_integrity`/`internal` (`:1122-1126`); and `wireOptions.length > 0` was asserted at `:500-503`, so the `!semantic` writer cannot fire either.

`status: 'blocked'` and `may_run: true` are **mutually exclusive on any single payload**. Guarding (a) would be a no-op same-turn and harmful cross-turn.

## Evidence

**RED-first** — `analyseControlFalseBlock.spec.ts`, **18 tests collected (asserted by name)**, 5 failed / 13 passed at pristine. After: 18/18, same collected count.

**Mutants** (throwaway worktree outside the repo root; isolation proven by a **sentinel write** — source sha256 unchanged, distinct inodes; restores `git checkout HEAD --`; applied-check scoped to `src/` reading exactly 1; leading and trailing controls both 18/18):

| Mutant | Effect | Result |
|---|---|---|
| M1 revert the fix (tighten for ALL) | 5 RED | A4-1/A4-2/A4-7 bite |
| M2 waiver spans clause (a) — *the shape first proposed* | 3 RED | **all of A4-5 bites** |
| M3 polarity `mayRun === false` | 4 RED | A4-3 binds to `undefined` |
| M4 waiver scoped to a DIFFERENT blocker code | 5 RED | A4-1 binds to `MISSING_OPTION_VALUE` by identity |
| M5 extra waiver on an UNUSED status (loosen for a DIFFERENT object) | **18/18 GREEN** | tests don't merely respond to any loosening |

M2/M5 are the discriminating pair for A4-5; M1/M4 for A4-1.

**Gate:** `pnpm typecheck` PASSED (3648/3688 files; ratchet 2252 = baseline 2252, no new diagnostics). `pnpm build` PASSED.

## Named limits

- **jsdom proves the predicate and the accessible name, never layout.** No browser witness that the control renders enabled, and no wire witness of a `may_run: true` turn on staging. Rung: **TESTED**, not deployed, not journey-witnessed.
- The CEE-side facts are **source-derived at `4a064e60`**, read-only — not wire-witnessed.
- **Disclosure gap, deliberately not fixed here:** when the gate opens, the footer rests on *"Analysis available" / "Ready when you are"* — true, but it does not disclose that an option will be excluded. Reusing `FOOTER_COPY.scaffoldSub(n)` was considered and **rejected as false**: it promises *"Olumi will draft the remaining N options"*, whereas the waiver **excludes** them. The UI also cannot name which options are dropped — `waived_by_exclusion` cannot cross the `.strict()` boundary. This belongs with CEE, which owns the copy and holds `waivedOptionIds`.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
