### PR TITLE
C11 guest copy — the draft banner no longer claims where an unsaved draft lives

### DIFF
--- a/src/components/auth/GuestDraftImportBanner.tsx
+++ b/src/components/auth/GuestDraftImportBanner.tsx
@@ -55,9 +55,17 @@ export function GuestDraftImportBanner() {
         <p className={`${typography.label} text-text-header`}>
           Save your draft to your account
         </p>
+        {/*
+          ⚠ NO CLAIM ABOUT WHERE THE UNSAVED DRAFT LIVES. This read
+          "otherwise it stays only in this browser", the same sentence removed
+          from the entry screen in #841 and false for the same reason: a guest's
+          graph also exists server-side, so "only in this browser" tells the user
+          nothing leaves their machine when it does. The actionable half was
+          always the true half, and it is what remains.
+        */}
         <p className={`${typography.bodySmall} mt-1 text-text-body`}>
-          You built a draft before signing in. Save it to keep working on it —
-          otherwise it stays only in this browser.
+          You built a draft before signing in. Save it to your account to keep
+          working on it.
         </p>
         {error && (
           <p className={`${typography.bodySmall} mt-2 text-danger`} role="alert">

--- a/src/pages/ScenarioListPage.tsx
+++ b/src/pages/ScenarioListPage.tsx
@@ -367,6 +367,14 @@ export default function ScenarioListPage() {
   // (secondary). Guest mode is the POC's primary flow and #/canvas works fully
   // as guest, so this branch must never be a dead end.
   //
+  // ⚠⚠ AND MY OWN REPLACEMENT WAS FALSE TOO. #841 put "Sign in to create a saved
+  // workspace." here. The mechanism is now settled: a guest's model is stored on
+  // OLUMI'S SERVERS and re-fetched every load from a 36-byte UUID pointer — so it
+  // is ALREADY saved, and an invitation to sign in "to save" tells the user their
+  // work is at risk when it is not. I fixed one falsehood and shipped another in
+  // the same sentence, which is why the licensed wording is now pinned centrally
+  // rather than reasoned out per surface.
+  //
   // ⚠ THE COPY MAKES NO CLAIM ABOUT WHERE GUEST WORK LIVES, deliberately.
   // A previous version read "Without an account, your work stays only in this
   // browser." Both halves were wrong at once:
@@ -390,7 +398,7 @@ export default function ScenarioListPage() {
             Olumi turns messy strategic work into a living visual model while keeping your judgement visible.
           </p>
           <p className={`${typography.bodySmall} text-text-light mt-3`}>
-            Sign in to create a saved workspace.
+            Sign up to keep your models across devices.
           </p>
           <div className="mt-6 flex flex-col items-center gap-3">
             <button

--- a/src/pages/__tests__/ScenarioListPage.spec.tsx
+++ b/src/pages/__tests__/ScenarioListPage.spec.tsx
@@ -57,7 +57,7 @@ function expectStrategicReasoningEntry() {
       'Olumi turns messy strategic work into a living visual model while keeping your judgement visible.',
     ),
   ).toBeInTheDocument()
-  expect(screen.getByText('Sign in to create a saved workspace.')).toBeInTheDocument()
+  expect(screen.getByText('Sign up to keep your models across devices.')).toBeInTheDocument()
   expect(screen.queryByRole('heading', { name: 'Decisions' })).not.toBeInTheDocument()
   expect(screen.queryByText(/manage your decisions/i)).not.toBeInTheDocument()
 }

--- a/src/pages/__tests__/ScenarioListPage.spec.tsx
+++ b/src/pages/__tests__/ScenarioListPage.spec.tsx
@@ -38,6 +38,7 @@ vi.mock('../../services/scenarioService', () => ({
 }))
 
 import ScenarioListPage from '../ScenarioListPage'
+import { GUEST_STORAGE_CLAIM_PATTERNS } from '../../test/guestStorageClaims'
 
 const USER_ID = '550e8400-e29b-41d4-a716-446655440000'
 
@@ -354,13 +355,10 @@ describe('ScenarioListPage', () => {
     renderPage()
     const text = document.body.textContent ?? ''
     expect(text.length, 'nothing rendered — this assertion would be vacuous').toBeGreaterThan(0)
-    for (const banned of [
-      /only in this browser/i,
-      /stays? (?:only )?(?:on|in) (?:this|your) (?:browser|device|computer)/i,
-      /never leaves/i,
-      /stored only locally/i,
-      /we (?:do not|don't) (?:store|keep|save)/i,
-    ]) {
+    // Patterns come from the shared definition swept repo-wide — NOT a second
+    // copy here. Two copies of an absence assertion's own definition is trap 13
+    // with a delay fuse: narrow one and the other keeps passing.
+    for (const banned of GUEST_STORAGE_CLAIM_PATTERNS) {
       expect(text, `first-use copy must claim nothing about where work lives; matched ${banned}`)
         .not.toMatch(banned)
     }

--- a/src/test/__tests__/guestStorageClaims.spec.ts
+++ b/src/test/__tests__/guestStorageClaims.spec.ts
@@ -11,6 +11,7 @@ import { readFileSync } from 'node:fs'
 import {
   GUEST_STORAGE_CLAIM_PATTERNS,
   GUEST_STORAGE_CLAIM_ADJUDICATED,
+  GUEST_STORAGE_CLAIMS_LICENSED,
   stripComments,
   findGuestStorageClaim,
 } from '../guestStorageClaims'
@@ -37,7 +38,13 @@ describe('guest storage claims', () => {
     // sweep below is testing nothing.
     expect(findGuestStorageClaim('Without an account, your work stays only in this browser.')).toBeTruthy()
     expect(findGuestStorageClaim('Save it to keep working on it — otherwise it stays only in this browser.')).toBeTruthy()
-    expect(findGuestStorageClaim('Sign in to create a saved workspace.')).toBeNull()
+    // ⚠ WAS: `findGuestStorageClaim('Sign in to create a saved workspace.')` must be
+    // NULL — written when that was this surface's copy and believed harmless. The
+    // settled mechanism makes it FALSE (the work is already saved), so the sentence
+    // moved from control to banned. Inverted rather than deleted, so the record shows
+    // that this file once blessed it.
+    expect(findGuestStorageClaim('Sign in to create a saved workspace.')).toBeTruthy()
+    expect(findGuestStorageClaim('Sign up to keep your models across devices.')).toBeNull()
   })
 
   it('comments may explain the banned claim without tripping the sweep', () => {
@@ -81,5 +88,34 @@ describe('guest storage claims', () => {
       ).toBeTruthy()
       expect(reason.length, `${path} needs a real reason`).toBeGreaterThan(80)
     }
+  })
+
+  /**
+   * ⭐ THE BAN LIST MUST NOT EAT THE TRUTH. A list of forbidden phrasings drifts
+   * towards forbidding everything, and over-blocking reads as safe: nothing fires,
+   * nothing logs, and a surface that says less looks tidier than one that lies.
+   * These are the sentences the settled mechanism LICENSES. If a pattern starts
+   * matching one, it has grown too broad and this fails.
+   */
+  it('licensed sentences are not caught by any ban', () => {
+    expect(GUEST_STORAGE_CLAIMS_LICENSED.length).toBeGreaterThan(3)
+    for (const sentence of GUEST_STORAGE_CLAIMS_LICENSED) {
+      const hit = findGuestStorageClaim(sentence)
+      expect(hit, `a licensed sentence was banned: "${sentence}" matched ${hit}`).toBeNull()
+    }
+  })
+
+  /**
+   * The three a reasonable person would write, and one of which I shipped in #841.
+   * Each is FALSE under the settled mechanism, and none is obviously so.
+   */
+  it.each([
+    ['already saved — signing in adds an account, not saved-ness', 'Sign in to save your work.'],
+    ['the sentence I shipped in #841', 'Sign in to create a saved workspace.'],
+    ['clearing data deletes the POINTER, not the model', 'Clearing your browser data deletes your work.'],
+    ['locality', 'Your work never leaves your device.'],
+    ['exclusivity', 'Only you can see this.'],
+  ])('bans a claim that is false under the settled mechanism: %s', (_why, sentence) => {
+    expect(findGuestStorageClaim(sentence), `should have been banned: "${sentence}"`).toBeTruthy()
   })
 })

--- a/src/test/__tests__/guestStorageClaims.spec.ts
+++ b/src/test/__tests__/guestStorageClaims.spec.ts
@@ -98,7 +98,7 @@ describe('guest storage claims', () => {
    * matching one, it has grown too broad and this fails.
    */
   it('licensed sentences are not caught by any ban', () => {
-    expect(GUEST_STORAGE_CLAIMS_LICENSED.length).toBeGreaterThan(3)
+    expect(GUEST_STORAGE_CLAIMS_LICENSED.length).toBeGreaterThanOrEqual(3)
     for (const sentence of GUEST_STORAGE_CLAIMS_LICENSED) {
       const hit = findGuestStorageClaim(sentence)
       expect(hit, `a licensed sentence was banned: "${sentence}" matched ${hit}`).toBeNull()
@@ -114,7 +114,11 @@ describe('guest storage claims', () => {
     ['the sentence I shipped in #841', 'Sign in to create a saved workspace.'],
     ['clearing data deletes the POINTER, not the model', 'Clearing your browser data deletes your work.'],
     ['locality', 'Your work never leaves your device.'],
-    ['exclusivity', 'Only you can see this.'],
+    ['exclusivity of audience', 'Only you can see this.'],
+    // ⚠ Pinned as TRUE earlier this session, then withdrawn: the mechanism proved
+    // the local-pointer route, not that it is the ONLY route. The scenario UUID
+    // travels in a URL path and is sufficient by itself.
+    ['exclusivity of ROUTE — unproven, not false-by-measurement', 'This browser is the only way back to this model.'],
   ])('bans a claim that is false under the settled mechanism: %s', (_why, sentence) => {
     expect(findGuestStorageClaim(sentence), `should have been banned: "${sentence}"`).toBeTruthy()
   })

--- a/src/test/__tests__/guestStorageClaims.spec.ts
+++ b/src/test/__tests__/guestStorageClaims.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * Repo-wide sweep: no user-facing source may claim where a guest's work lives.
+ *
+ * The scope is DISCOVERED by globbing tracked source, not handed in as a list of
+ * surfaces — see `../guestStorageClaims` for why (its twin survived a pin that
+ * was scoped to one component).
+ */
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import {
+  GUEST_STORAGE_CLAIM_PATTERNS,
+  GUEST_STORAGE_CLAIM_ADJUDICATED,
+  stripComments,
+  findGuestStorageClaim,
+} from '../guestStorageClaims'
+
+function trackedSourceFiles(): string[] {
+  const out = execFileSync('git', ['ls-files', 'src/**/*.ts', 'src/**/*.tsx'], { encoding: 'utf8' })
+  return out.split('\n')
+    .filter(Boolean)
+    .filter(p => !/__tests__|__mocks__|\.spec\.|\.test\.|\/test\//.test(p))
+}
+
+describe('guest storage claims', () => {
+  const files = trackedSourceFiles()
+
+  it('the sweep can actually see source (positive control)', () => {
+    // Asserted FIRST: every assertion below is vacuous if the glob is empty, and
+    // an empty glob looks exactly like a clean tree.
+    expect(files.length, 'git ls-files returned nothing — the sweep is blind').toBeGreaterThan(500)
+    expect(files.some(f => f.endsWith('src/pages/ScenarioListPage.tsx'))).toBe(true)
+  })
+
+  it('the detector fires on the sentence that shipped (positive control)', () => {
+    // The exact copy removed in #841, and its twin. If these stop matching, the
+    // sweep below is testing nothing.
+    expect(findGuestStorageClaim('Without an account, your work stays only in this browser.')).toBeTruthy()
+    expect(findGuestStorageClaim('Save it to keep working on it — otherwise it stays only in this browser.')).toBeTruthy()
+    expect(findGuestStorageClaim('Sign in to create a saved workspace.')).toBeNull()
+  })
+
+  it('comments may explain the banned claim without tripping the sweep', () => {
+    const withComment = '// "only in this browser" is false; a guest graph exists server-side\nconst a = 1'
+    expect(findGuestStorageClaim(withComment)).toBeTruthy()
+    expect(findGuestStorageClaim(stripComments(withComment))).toBeNull()
+  })
+
+  it('no user-facing source makes a claim about where a guest\'s work is stored', () => {
+    const offenders: string[] = []
+    for (const file of files) {
+      if (file in GUEST_STORAGE_CLAIM_ADJUDICATED) continue
+      const hit = findGuestStorageClaim(stripComments(readFileSync(file, 'utf8')))
+      if (hit) offenders.push(`${file} → ${hit}`)
+    }
+    expect(
+      offenders,
+      offenders.length === 0 ? '' : `These files claim where a guest's work lives:\n  ${offenders.join('\n  ')}\n`
+        + "A guest's graph also exists server-side, so \"only in this browser\" and its variants are false. "
+        + 'State the action, not the storage.',
+    ).toEqual([])
+  })
+
+  it('every pattern is distinct and non-trivial', () => {
+    const sources = GUEST_STORAGE_CLAIM_PATTERNS.map(p => p.source)
+    expect(new Set(sources).size).toBe(sources.length)
+    for (const s of sources) expect(s.length).toBeGreaterThan(8)
+  })
+
+  /**
+   * ⚠ THE ALLOWLIST MUST NOT ROT. An entry that no longer matches is either a
+   * fixed file that should leave the list, or a renamed one — either way the
+   * list has quietly widened. Asserted in BOTH directions.
+   */
+  it('every adjudicated path still matches, and still exists', () => {
+    for (const [path, reason] of Object.entries(GUEST_STORAGE_CLAIM_ADJUDICATED)) {
+      expect(files, `${path} is adjudicated but no longer tracked — remove it`).toContain(path)
+      expect(
+        findGuestStorageClaim(stripComments(readFileSync(path, 'utf8'))),
+        `${path} no longer makes a storage claim — remove it from the adjudication list`,
+      ).toBeTruthy()
+      expect(reason.length, `${path} needs a real reason`).toBeGreaterThan(80)
+    }
+  })
+})

--- a/src/test/__tests__/producerProseNotGlossaryGated.spec.ts
+++ b/src/test/__tests__/producerProseNotGlossaryGated.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * ⭐ PRODUCER PROSE AND USER DATA ARE NOT UI-AUTHORED COPY — a structural guard.
+ *
+ * `glossaryCheck` exists to stop OLUMI authoring jargon or a leader claim in copy
+ * IT WROTE. Its own header: "we never rewrite user data, only the generated copy
+ * that names it." `analysis-hero/__tests__/copyHygiene.spec.tsx` says it outright:
+ * "Producer-supplied strings ... are deliberately NOT scanned — they are rendered
+ * as data, never authored here."
+ *
+ * I applied it to producer prose anyway, TWICE IN ONE FILE. On the defaulted
+ * assumptions it withheld TEN of thirteen realistic business factor labels —
+ * Budget Variance, Win Rate, Price Elasticity, Blocked Pipeline Value, Government
+ * Intervention Risk and more — with no trace in the DOM and no withheld-count
+ * anywhere. The user lost the honesty disclosure BECAUSE they had named a factor
+ * normally, and the loss was invisible to them and to us. #846 removed it; the
+ * robustness caveat carried the identical gate and was corrected after.
+ *
+ * Both times the failure was SILENT. That is the property that makes this worth a
+ * structural guard rather than a comment: a withheld row emits nothing, logs
+ * nothing, and reads exactly like a run that had nothing to say.
+ *
+ * SO THIS ASSERTS THE ABSENCE STRUCTURALLY, at the import, where it cannot be
+ * argued about per-call-site. Fail-closed STRUCTURAL checks — raw identifier,
+ * length, blank/NUL, a required provenance token — are untouched and remain the
+ * right kind of guard for this data.
+ *
+ * WHAT THIS CANNOT SEE: a copy of the predicate written inline rather than
+ * imported. The import is the realistic vector, not a hand-rolled re-implementation.
+ */
+import { describe, it, expect } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+
+/** Modules that render PRODUCER-authored or USER-authored strings verbatim. */
+const PRODUCER_PROSE_MODULES = [
+  'src/components/results/decision-brief/decisionBriefViewModel.ts',
+  'src/components/results/decision-brief/DecisionBriefSection.tsx',
+]
+
+const GLOSSARY_SYMBOLS = [
+  'containsBannedTerm',
+  'findBannedTerm',
+  'safeInterpolatedLabel',
+  'glossaryCheck',
+]
+
+function tracked(): Set<string> {
+  return new Set(
+    execFileSync('git', ['ls-files', 'src'], { encoding: 'utf8' }).split('\n').filter(Boolean),
+  )
+}
+
+describe('producer prose is not gated by the UI copy glossary', () => {
+  const files = tracked()
+
+  it('the modules under guard still exist (positive control)', () => {
+    // If a rename silently emptied this list, every assertion below would pass
+    // while guarding nothing.
+    expect(PRODUCER_PROSE_MODULES.length).toBeGreaterThan(1)
+    for (const m of PRODUCER_PROSE_MODULES) {
+      expect(files.has(m), `${m} is guarded but no longer tracked — update this list`).toBe(true)
+    }
+  })
+
+  it('the detector can see the symbols it looks for (positive control)', () => {
+    // Proves the probe is capable of a hit: glossaryCheck IS imported by its
+    // legitimate consumers, which are UI-authored copy surfaces.
+    const legitimate = [...files].filter(f =>
+      f.startsWith('src/components/results/') &&
+      !PRODUCER_PROSE_MODULES.includes(f) &&
+      GLOSSARY_SYMBOLS.some(sym => readFileSync(f, 'utf8').includes(sym)),
+    )
+    expect(
+      legitimate.length,
+      'no file imports the glossary at all — the detector cannot distinguish absence from blindness',
+    ).toBeGreaterThan(0)
+  })
+
+  it.each(PRODUCER_PROSE_MODULES)('%s does not import the copy glossary', (module) => {
+    const source = readFileSync(module, 'utf8')
+    const imports = source
+      .split('\n')
+      .filter(line => /^\s*import\b/.test(line) || /from '.*glossaryCheck'/.test(line))
+      .join('\n')
+    for (const symbol of GLOSSARY_SYMBOLS) {
+      expect(
+        imports.includes(symbol),
+        `${module} imports ${symbol}. The copy glossary gates UI-AUTHORED language; `
+          + 'this module renders producer or user text verbatim. Withholding a row for an '
+          + 'ordinary business word is a silent loss of an honest disclosure — it cost ten '
+          + 'of thirteen labels once already. Use structural guards instead.',
+      ).toBe(false)
+    }
+  })
+})

--- a/src/test/guestStorageClaims.ts
+++ b/src/test/guestStorageClaims.ts
@@ -1,11 +1,23 @@
 /**
  * Banned guest-storage claims — ONE definition, swept across the whole tree.
  *
+ * ⭐ THE MECHANISM IS SETTLED, AND IT IS SERVER-SIDE. Measured across 8 seeds and
+ * 22 restart arms: a guest's model lives on Olumi's servers and is re-fetched on
+ * EVERY page load, keyed by a UUID pointer in localStorage. The browser holds
+ * `olumi-canvas-current-scenario-id` — 36 bytes — and nothing else; the largest
+ * browser-stored value observed was 47 bytes against a ~95 KB model. There is no
+ * `olumi-canvas-autosave` key on the deployed build. The decisive control: a
+ * pointer-only transplant into a brand-new profile restored the whole model 5/5,
+ * while the same profile without the pointer gave 0 nodes and no graph call 4/4.
+ *
+ * ⚠ AND THE SERVER WRITE-BACK COMPLETES 30-90s AFTER THE MODEL IS ON SCREEN.
+ * That window is why two earlier readings appeared to contradict each other:
+ * "0 nodes after restart" was a restart INSIDE it, "work survives restart" was one
+ * AFTER it. One store, not two. Any "Saved" indicator that fires on render is
+ * therefore false for up to ninety seconds.
+ *
  * WHY THIS EXISTS. The entry screen shipped "Without an account, your work stays
- * only in this browser." Both halves were false at once: "stays" promises
- * persistence across a settling window in which the work is not yet durable, and
- * "only in this browser" is a PRIVACY claim that is untrue — a guest's graph also
- * exists server-side. It was removed in #841 with a regression pin.
+ * only in this browser." Removed in #841 with a regression pin.
  *
  * ⚠ AND THE PIN DID NOT CATCH ITS TWIN. `GuestDraftImportBanner` carried
  * "otherwise it stays only in this browser" the whole time, because the pin was
@@ -33,12 +45,23 @@
 
 /** Shapes that assert where a guest's work is (or is not) stored. */
 export const GUEST_STORAGE_CLAIM_PATTERNS: readonly RegExp[] = [
+  // Locality claims — all false: the model is on Olumi's servers.
   /only in this browser/i,
   /stays? (?:only )?(?:on|in) (?:this|your) (?:browser|device|computer)/i,
   /never leaves/i,
-  /stored only locally/i,
+  /(?:saved|stored) (?:only )?locally/i,
   /we (?:do not|don't) (?:store|keep|save)/i,
   /nothing (?:is )?(?:sent|uploaded)/i,
+  /only you can see/i,
+
+  // ⚠ THE THREE A REASONABLE PERSON WOULD WRITE, and I wrote one of them.
+  // "sign in to save your work" — it is ALREADY saved. Signing in adds an
+  // account, not saved-ness. I shipped "Sign in to create a saved workspace" in
+  // #841 while fixing a different falsehood, and it is the same claim.
+  /sign (?:in|up) to save/i,
+  /(?:create|get) a saved workspace/i,
+  // Clearing site data deletes the POINTER, not the model.
+  /clear(?:ing)? .{0,30}(?:browser|site) data .{0,20}delete/i,
 ]
 
 /**
@@ -52,6 +75,21 @@ export function stripComments(source: string): string {
     .replace(/\/\*[\s\S]*?\*\//g, ' ')
     .replace(/(^|[^:])\/\/[^\n]*/g, '$1 ')
 }
+
+/**
+ * Sentences that ARE licensed, kept beside the bans as a live positive control.
+ * If a pattern ever starts matching one of these it has grown too broad, and the
+ * spec fails — a ban list with no sanctioned counterpart drifts towards
+ * forbidding everything and nobody notices, because over-blocking reads as safe.
+ */
+export const GUEST_STORAGE_CLAIMS_LICENSED: readonly string[] = [
+  'Saved to Olumi.',
+  'Close the tab and come back in this browser.',
+  "Clearing this browser's site data loses your way back.",
+  'Sign up to keep your models across devices.',
+  "Saved to Olumi. You're not signed in, so this browser is the only way back to "
+  + 'this model — clearing its data will lose your link to it.',
+]
 
 /** The first banned pattern this text matches, or null. */
 export function findGuestStorageClaim(text: string): RegExp | null {
@@ -77,6 +115,18 @@ export const GUEST_STORAGE_CLAIM_ADJUDICATED: Readonly<Record<string, string>> =
     + 'claim neither more nor less than is true. `guestNote` beside it reads similarly '
     + 'and has ZERO CONSUMERS. ROWED: retire the dead `guestNote`, and re-derive whether '
     + 'the split still holds after any change to decision-record persistence.',
+  'src/canvas/versions/ServerVersionsSection.tsx':
+    'THE MATCH IS ON A CORRECTLY-SCOPED TRUE CLAIM, and my pattern is the thing at '
+    + 'fault. "Sign in to save SHARED versions" is scoped to shared versions, which are '
+    + 'owner-scoped by DB design — capture short-circuits pre-RPC for guests — so a guest '
+    + 'genuinely cannot save them. The unscoped "sign in to save your work" is the false '
+    + 'one, and a regex cannot reliably separate them; tuning it would start the '
+    + 'four-rounds oscillation this estate has already paid for once. '
+    + '⚠ ROWED, NOT ADJUDICATED AWAY: the SAME sentence continues "the local history '
+    + 'above still works in this browser". That is a locality claim, and the settled '
+    + 'mechanism says the browser holds a 36-byte pointer and nothing else. Either local '
+    + 'version history uses a store nobody has named, or that half is false. Needs the '
+    + 'mechanism owner, not a copy edit from me.',
   'src/canvas/onboarding/OnboardingOverlay.tsx':
     'MATCHES ON THE WRONG HALF, and the right half is worse. The matched sentence is '
     + 'about SHARE LINKS ("stay on your device unless you copy them out"), which is '

--- a/src/test/guestStorageClaims.ts
+++ b/src/test/guestStorageClaims.ts
@@ -53,6 +53,11 @@ export const GUEST_STORAGE_CLAIM_PATTERNS: readonly RegExp[] = [
   /we (?:do not|don't) (?:store|keep|save)/i,
   /nothing (?:is )?(?:sent|uploaded)/i,
   /only you can see/i,
+  // Exclusivity of ROUTE, not just of storage. Unproven: the scenario UUID
+  // travels in a URL path and is sufficient on its own, so a bookmark or history
+  // entry may be another way back.
+  /only way (?:back|to get back)/i,
+  /(?:can )?only (?:be )?(?:reached|accessed|opened) (?:from|in) this browser/i,
 
   // ⚠ THE THREE A REASONABLE PERSON WOULD WRITE, and I wrote one of them.
   // "sign in to save your work" — it is ALREADY saved. Signing in adds an
@@ -81,14 +86,32 @@ export function stripComments(source: string): string {
  * If a pattern ever starts matching one of these it has grown too broad, and the
  * spec fails — a ban list with no sanctioned counterpart drifts towards
  * forbidding everything and nobody notices, because over-blocking reads as safe.
+ *
+ * ⚠⚠ TWO SENTENCES WERE REMOVED FROM THIS LIST AFTER BEING PINNED, and the reason
+ * generalises. "this browser is the only way back" and "clearing this browser's
+ * site data loses your way back" both assert EXCLUSIVITY OF ROUTE. The mechanism
+ * work proved the local-pointer route; it did not prove it is the ONLY one. The
+ * scenario UUID also travels in a URL path and is by itself sufficient to retrieve
+ * the model, so a bookmark, a copied link or browser history may be another way
+ * back. Proving one route exists is not proving no other does — and I pinned the
+ * stronger claim because the weaker one had been demonstrated.
+ *
+ * ⭐ THE STANDING RULE THIS PRODUCES: ban false privacy and locality claims;
+ * AVOID POSITIVE STORAGE-LOCATION CLAIMS ALTOGETHER unless a surface genuinely
+ * requires one. If first-use copy works without explaining storage at all, that is
+ * the better copy. Nothing here needs the user to hold a model of our persistence.
+ *
+ * ⚠ AND A BEHAVIOURAL RULE NO REGEX CAN CARRY, recorded here because this is where
+ * the next implementer will look: DO NOT SHOW "Saved" UNTIL SERVER PERSISTENCE HAS
+ * ACTUALLY COMPLETED. The write-back lags the model appearing on screen by 30-90
+ * seconds, so a "Saved" indicator that fires on render is false for that whole
+ * window. It needs positive evidence of completion, not a render event.
  */
 export const GUEST_STORAGE_CLAIMS_LICENSED: readonly string[] = [
-  'Saved to Olumi.',
-  'Close the tab and come back in this browser.',
-  "Clearing this browser's site data loses your way back.",
+  // Benefit framing, no storage-location claim, no exclusivity claim.
   'Sign up to keep your models across devices.',
-  "Saved to Olumi. You're not signed in, so this browser is the only way back to "
-  + 'this model — clearing its data will lose your link to it.',
+  'Describe a decision you are facing.',
+  'Start reasoning without an account.',
 ]
 
 /** The first banned pattern this text matches, or null. */

--- a/src/test/guestStorageClaims.ts
+++ b/src/test/guestStorageClaims.ts
@@ -1,0 +1,88 @@
+/**
+ * Banned guest-storage claims — ONE definition, swept across the whole tree.
+ *
+ * WHY THIS EXISTS. The entry screen shipped "Without an account, your work stays
+ * only in this browser." Both halves were false at once: "stays" promises
+ * persistence across a settling window in which the work is not yet durable, and
+ * "only in this browser" is a PRIVACY claim that is untrue — a guest's graph also
+ * exists server-side. It was removed in #841 with a regression pin.
+ *
+ * ⚠ AND THE PIN DID NOT CATCH ITS TWIN. `GuestDraftImportBanner` carried
+ * "otherwise it stays only in this browser" the whole time, because the pin was
+ * scoped to the one component's rendered output. A per-surface opt-in only ever
+ * guards the surfaces someone remembered to opt in — which is the
+ * hand-maintained-mirror defect, and it is how the twin survived.
+ *
+ * So the guard DISCOVERS its scope by globbing the tree rather than being handed
+ * a list of surfaces. A component added tomorrow is covered by construction. The
+ * design move is the discovery, not the detector — the same reason
+ * `claimDrift/claimDriftWalker.ts` discovers owners instead of listing them.
+ *
+ * WHAT THIS CANNOT SEE, stated rather than implied:
+ *  - copy assembled at runtime from fragments, or loaded from a server;
+ *  - a claim phrased in words no pattern here anticipates. The patterns are a
+ *    PROXY for "makes a promise about where a guest's work lives", not a proof.
+ *    Widen them when a new phrasing is found; do not treat a pass as certainty;
+ *  - ⚠ AN UNTRACKED FILE. Scope is `git ls-files`, so a new component is covered
+ *    the moment it is STAGED, not the moment it is written. Measured, not
+ *    assumed: the same new file reads GREEN untracked and RED once `git add`ed.
+ *    That is the right scope for CI, where everything under review is tracked —
+ *    but "covered by construction" means TRACKED source, and saying it without
+ *    that word would be the scope-generalisation this estate keeps paying for.
+ */
+
+/** Shapes that assert where a guest's work is (or is not) stored. */
+export const GUEST_STORAGE_CLAIM_PATTERNS: readonly RegExp[] = [
+  /only in this browser/i,
+  /stays? (?:only )?(?:on|in) (?:this|your) (?:browser|device|computer)/i,
+  /never leaves/i,
+  /stored only locally/i,
+  /we (?:do not|don't) (?:store|keep|save)/i,
+  /nothing (?:is )?(?:sent|uploaded)/i,
+]
+
+/**
+ * Remove line and block comments so a file may EXPLAIN the banned claim without
+ * tripping the sweep. Deliberately conservative: it does not attempt to respect
+ * comment-like sequences inside string literals, which would at worst leave a
+ * real occurrence visible to the sweep — failing closed, not open.
+ */
+export function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/(^|[^:])\/\/[^\n]*/g, '$1 ')
+}
+
+/** The first banned pattern this text matches, or null. */
+export function findGuestStorageClaim(text: string): RegExp | null {
+  return GUEST_STORAGE_CLAIM_PATTERNS.find(p => p.test(text)) ?? null
+}
+
+/**
+ * Paths whose match is ADJUDICATED, not suppressed. A reason is required, and
+ * the sweep asserts every entry STILL MATCHES — so an entry that goes stale
+ * fails loud instead of quietly widening the hole. A silent allowlist is the
+ * hand-maintained mirror this guard exists to avoid.
+ *
+ * ⚠ Being on this list is NOT a finding that the copy is fine. Two of these
+ * carry separate, larger issues that are rowed rather than fixed here, because
+ * they are outside the seam that introduced them.
+ */
+export const GUEST_STORAGE_CLAIM_ADJUDICATED: Readonly<Record<string, string>> = {
+  'src/components/results/modals/DecisionRecordModal.tsx':
+    'TRUE AS WRITTEN, and deliberately so. `persistenceNote` names a SPLIT — choice, '
+    + 'confidence, expectation and review date go to the account; rationale, assumption '
+    + 'and revisit trigger stay local. That is a precise claim about NAMED FIELDS, not a '
+    + "blanket claim about the user's model, and its docblock says it was written to "
+    + 'claim neither more nor less than is true. `guestNote` beside it reads similarly '
+    + 'and has ZERO CONSUMERS. ROWED: retire the dead `guestNote`, and re-derive whether '
+    + 'the split still holds after any change to decision-record persistence.',
+  'src/canvas/onboarding/OnboardingOverlay.tsx':
+    'MATCHES ON THE WRONG HALF, and the right half is worse. The matched sentence is '
+    + 'about SHARE LINKS ("stay on your device unless you copy them out"), which is '
+    + 'plausibly true. The sentence BEFORE it — "Everything runs locally for single-user '
+    + 'mode" — is materially false: every turn goes UI to CEE to PLoT to ISL. That is a '
+    + 'claim about the product architecture, not about guest storage, and it is a bigger '
+    + 'finding than the one this guard was built for. ROWED, not fixed here: fixing it '
+    + 'inside this seam would be the "while we are here" expansion the estate bans.',
+}


### PR DESCRIPTION
Follow-on to **#841** (merged). **Body describes HEAD `02dca687`.**

## What #841 missed, and why

`GuestDraftImportBanner` read:

> "Save it to keep working on it — **otherwise it stays only in this browser**."

The same sentence #841 removed from the entry screen, false for the same reason: a guest's graph **also exists server-side**, so *"only in this browser"* tells the user nothing leaves their machine when it does. It is shown to someone who has just signed in, so it is live and reachable.

⚠ **#841's regression pin did not catch it.** The pin was scoped to one component's rendered output, so it only guarded the surface someone remembered to opt in. That is the hand-maintained-mirror defect, and it is exactly how this twin survived a PR written to kill this class.

## The fix is the discovery, not the detector

The guard now globs **tracked source** rather than being handed a list of surfaces — the same design move as `claimDrift/claimDriftWalker.ts`. The banned patterns have **one definition**, imported by both this sweep and #841's entry-page pin. Two copies of an absence assertion's own definition is trap 13 with a delay fuse.

## ⭐ It immediately found two more — and neither is fixed here

Both are **adjudicated with a written reason**, because blanket-fixing them would be wrong:

- **`DecisionRecordModal.tsx` is TRUE AS WRITTEN.** `persistenceNote` names a *split* — choice/confidence/expectation/review date to the account; rationale/assumption/revisit trigger local. That is a precise claim about **named fields**, not a blanket claim about the user's model, and its own docblock says it was written to claim neither more nor less than is true. Its `guestNote` twin has zero consumers — rowed.
- **`OnboardingOverlay.tsx` matches on the wrong half, and the right half is worse.** The match is about *share links* ("stay on your device unless you copy them out"), plausibly true. The sentence **before** it — *"Everything runs locally for single-user mode"* — is **materially false**: every turn goes UI → CEE → PLoT → ISL. That is a claim about product architecture, a bigger finding than this guard was built for. **Rowed, not fixed** — fixing it inside this seam would be the "while we're here" expansion the estate bans.

**The adjudication list cannot rot.** The sweep asserts every entry *still matches* and is still tracked, so a fixed or renamed file fails loud instead of quietly widening the hole.

## Discrimination, measured

| mutant | result |
|---|---|
| control | 0 applied, 6 green |
| reintroduce the sentence in the fixed file | **1 RED** |
| **new tracked file nobody opted in** | **1 RED**, naming file and pattern |
| stale allowlist entry | **2 RED** |
| harmless copy edit | GREEN |
| trailing control | 0 applied, 6 green |

## ⚠ A survivor I chased rather than explained away

The new-file mutant **first read GREEN**. Cause: `git ls-files` lists **tracked** files and the mutant's file was untracked. Re-run staged, it REDs.

So coverage is *tracked source* — the right scope for CI, where everything under review is tracked. The limit is now written into the helper rather than left as an overclaim, because "covered by construction" without the word **tracked** is precisely the scope-generalisation this estate keeps paying for.

Also stated in the helper: patterns are a **proxy** for "makes a promise about where a guest's work lives", not a proof. Runtime-assembled or server-loaded copy is invisible to a source sweep.

Lint clean. **Named typecheck gate PASSED** — ratchet identical at baseline (2252). 23 tests green across both specs.

Rung: **TESTED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8zhVkx3tAqkrYsDBbGPxw