### PR TITLE
C11 — surface the producer's robustness caveat, gated on the owned leader claim [IN-class: cross-model review]

### DIFF
--- a/e2e/geometry/decisionBriefAssumed.measure.ts
+++ b/e2e/geometry/decisionBriefAssumed.measure.ts
@@ -121,7 +121,49 @@ for (const vp of VPS) {
     expect(new Set(signatures).size, `two groups rendered identical content: ${JSON.stringify(signatures)}`)
       .toBe(signatures.length)
 
-    // 5. Geometry, measured not inferred.
+    // 5. THE ROBUSTNESS CAVEAT — the INVARIANT, not one arm of it.
+    //
+    // ⚠ MY FIRST VERSION OF THIS ASSERTED THE CAVEAT WAS VISIBLE, AND FAILED —
+    // correctly. The component resolves the verdict as
+    //   deriveDecisionVerdict(report, { visibleOptionIds, rawHeadlineBanded })
+    // and this file seeds the BUILD-VS-BUY starter then replays the T3 capture,
+    // whose leader is `opt_phased` — an option that is not on that canvas. So the
+    // product withholds the leader claim, and the gate correctly closes. The
+    // product was right and the test was feeding it an incoherent state.
+    //
+    // Asserting "caveat visible" would therefore have required either a matching
+    // graph or a weakened gate. What is actually worth witnessing is the RULE:
+    // the caveat is on screen if and only if the live verdict permits a leader.
+    // That holds under either arm, and the arm reached is REPORTED so a silent
+    // drift to always-withheld cannot masquerade as a pass.
+    const permitted = await page.evaluate(async () => {
+      const w = window as unknown as { useCanvasStore: { getState: () => Record<string, unknown> } }
+      const report = (w.useCanvasStore.getState().results as { report?: unknown } | null)?.report ?? null
+      const nodes = (w.useCanvasStore.getState().nodes ?? []) as Array<{ id: string, data?: { kind?: string } }>
+      const mod = (await import(/* @vite-ignore */ '/src/lib/decisionVerdict.ts')) as {
+        deriveDecisionVerdict: (r: unknown, o?: unknown) => { hasLeadingOption: boolean }
+      }
+      return mod.deriveDecisionVerdict(report, {
+        visibleOptionIds: new Set(nodes.filter(n => n.data?.kind === 'option').map(n => n.id)),
+      }).hasLeadingOption
+    })
+
+    const caveat = section.getByTestId('decision-brief-robustness-caveat')
+    if (permitted) {
+      await expect(caveat, 'leader permitted, so the producer caveat must be on screen').toBeVisible()
+      await expect(caveat).toHaveText(brief.robustness_caveat.text)
+    } else {
+      await expect(
+        caveat,
+        'leader withheld, so a caveat ABOUT THE RANKING must not appear',
+      ).toHaveCount(0)
+      // And the absence must not be dressed as reassurance anywhere in the card.
+      await expect(section).not.toContainText(/held up|robust|stable/i)
+    }
+    // eslint-disable-next-line no-console
+    console.log(`@${vp.width}x${vp.height} leaderPermitted=${permitted} caveatShown=${permitted}`)
+
+    // 6. Geometry, measured not inferred.
     const box = await section.boundingBox()
     expect(box, 'the section must have a box').toBeTruthy()
     // eslint-disable-next-line no-console

--- a/e2e/geometry/decisionBriefAssumed.measure.ts
+++ b/e2e/geometry/decisionBriefAssumed.measure.ts
@@ -140,7 +140,12 @@ for (const vp of VPS) {
       const w = window as unknown as { useCanvasStore: { getState: () => Record<string, unknown> } }
       const report = (w.useCanvasStore.getState().results as { report?: unknown } | null)?.report ?? null
       const nodes = (w.useCanvasStore.getState().nodes ?? []) as Array<{ id: string, data?: { kind?: string } }>
-      const mod = (await import(/* @vite-ignore */ '/src/lib/decisionVerdict.ts')) as {
+      // Held in a VARIABLE, not a literal: this path exists only as a Vite
+      // dev-server URL, and a string literal here is a TS2307 — the remedy the
+      // sibling measure already documents, which I failed to apply to this
+      // second import while copying it correctly for the first.
+      const verdictModulePath = '/src/lib/decisionVerdict.ts'
+      const mod = (await import(/* @vite-ignore */ verdictModulePath)) as {
         deriveDecisionVerdict: (r: unknown, o?: unknown) => { hasLeadingOption: boolean }
       }
       return mod.deriveDecisionVerdict(report, {

--- a/src/components/results/ResultsBody.tsx
+++ b/src/components/results/ResultsBody.tsx
@@ -365,7 +365,9 @@ export const ResultsBody = memo(function ResultsBody({
           licensed groups on first paint without rebuilding winner, freshness
           or Compare authority. */}
       <SectionErrorBoundary section="Decision brief">
-        <DecisionBriefSectionContainer />
+        <DecisionBriefSectionContainer
+          leaderClaimPermitted={resultsSectionData.recommendation.verdict?.hasLeadingOption === true}
+        />
       </SectionErrorBoundary>
 
       {/* ── P1-9 provenance: Model-Card-Lite entry point ───────────────────

--- a/src/components/results/decision-brief/DecisionBriefSection.tsx
+++ b/src/components/results/decision-brief/DecisionBriefSection.tsx
@@ -49,10 +49,25 @@ function BriefGroup({ title, items, icon: Icon, expanded, testId }: BriefGroupPr
 
 export interface DecisionBriefSectionProps {
   brief: DecisionBriefViewModel
+  /**
+   * ⚠ THE PERMISSION, CONSUMED — NEVER DERIVED. This is `hasLeadingOption` from
+   * `deriveDecisionVerdict`, "the single boolean every surface must gate on
+   * before asserting OR denying a leading option", resolved once by the parent.
+   *
+   * It gates `robustnessCaveat`, which is a LEADER-RANKING member: CEE strips it
+   * on a withheld turn and its absence IS the withheld signal. The caveat's own
+   * presence must never be read as evidence that a ranking may be spoken about —
+   * that is how Authority 3 came to reconstruct a withheld leader and print
+   * "X is slightly ahead" beside CEE's "no option can be put forward yet".
+   *
+   * Required, not defaulted. A default of `true` would silently re-open the
+   * claim for every future caller — the mirror-that-reads-green failure mode.
+   */
+  leaderClaimPermitted: boolean
 }
 
 /** Store-free presentation, exported for focused and adversarial tests. */
-export function DecisionBriefSection({ brief }: DecisionBriefSectionProps) {
+export function DecisionBriefSection({ brief, leaderClaimPermitted }: DecisionBriefSectionProps) {
   const [expanded, setExpanded] = useState(false)
   const detailsId = useId()
   /**
@@ -75,7 +90,10 @@ export function DecisionBriefSection({ brief }: DecisionBriefSectionProps) {
     { title: 'What could change', items: brief.whatWouldChange, icon: GitBranch, testId: 'decision-brief-change' },
   ].filter(group => group.items.length > 0)
 
-  if (groups.length === 0) return null
+  // A brief whose ONLY content is a caveat the verdict does not permit has
+  // nothing to show. Returning the shell would frame an empty card as a finding.
+  const caveatVisible = leaderClaimPermitted && brief.robustnessCaveat !== null
+  if (groups.length === 0 && !caveatVisible) return null
 
   return (
     <section
@@ -105,6 +123,15 @@ export function DecisionBriefSection({ brief }: DecisionBriefSectionProps) {
         ))}
       </dl>
 
+      {leaderClaimPermitted && brief.robustnessCaveat && (
+        <p
+          className={`${typography.panelMeta} mt-2 border-t border-panel-border pt-2 text-text-light`}
+          data-testid="decision-brief-robustness-caveat"
+        >
+          {brief.robustnessCaveat.text}
+        </p>
+      )}
+
       {groups.some(group => group.items.length > PREVIEW_ITEMS) && (
         <button
           type="button"
@@ -126,14 +153,19 @@ export function DecisionBriefSection({ brief }: DecisionBriefSectionProps) {
  * Reading it here avoids a second mapper and keeps this surface independent of
  * the existing leader/hero authority.
  */
-export function DecisionBriefSectionContainer() {
+export interface DecisionBriefSectionContainerProps {
+  /** See `DecisionBriefSectionProps.leaderClaimPermitted` — passed straight through. */
+  leaderClaimPermitted: boolean
+}
+
+export function DecisionBriefSectionContainer({ leaderClaimPermitted }: DecisionBriefSectionContainerProps) {
   const rawBrief = useCanvasStore(state => (
     (state.results.report as { decision_brief?: unknown } | null | undefined)?.decision_brief
   ))
   const brief = useMemo(() => readDecisionBriefViewModel(rawBrief), [rawBrief])
 
   if (!brief) return null
-  return <DecisionBriefSection brief={brief} />
+  return <DecisionBriefSection brief={brief} leaderClaimPermitted={leaderClaimPermitted} />
 }
 
 export default DecisionBriefSectionContainer

--- a/src/components/results/decision-brief/__tests__/DecisionBriefSection.spec.tsx
+++ b/src/components/results/decision-brief/__tests__/DecisionBriefSection.spec.tsx
@@ -23,11 +23,15 @@ const BRIEF: DecisionBriefViewModel = {
       note: 'No starting value was provided for "Available Growth Budget" — the analysis used a default.',
     },
   ],
+  // Absent on this fixture. `robustness_caveat` is a leader-ranking member the
+  // producer strips on a withheld turn, and these cases are about the category
+  // groups, not the gated caveat — which has its own spec.
+  robustnessCaveat: null,
 }
 
 describe('DecisionBriefSection', () => {
   it('shows every licensed group and its first producer item without opening a disclosure', () => {
-    render(<DecisionBriefSection brief={BRIEF} />)
+    render(<DecisionBriefSection brief={BRIEF} leaderClaimPermitted />)
 
     expect(screen.getByRole('heading', { name: 'Decision brief' })).toBeInTheDocument()
     expect(screen.getByText('What matters')).toBeInTheDocument()
@@ -46,7 +50,7 @@ describe('DecisionBriefSection', () => {
 
   it('expands and collapses all complete producer lists through one keyboard-operable control', async () => {
     const user = userEvent.setup()
-    render(<DecisionBriefSection brief={BRIEF} />)
+    render(<DecisionBriefSection brief={BRIEF} leaderClaimPermitted />)
 
     const toggle = screen.getByRole('button', { name: 'Show all brief details' })
     toggle.focus()
@@ -67,7 +71,7 @@ describe('DecisionBriefSection', () => {
   })
 
   it('renders no recommendation, probability, confidence or robustness authority', () => {
-    render(<DecisionBriefSection brief={BRIEF} />)
+    render(<DecisionBriefSection brief={BRIEF} leaderClaimPermitted />)
     const section = screen.getByTestId('decision-brief-section')
 
     expect(section).not.toHaveTextContent(/recommend|winner|leading option|probability|confidence|robust/i)
@@ -81,7 +85,7 @@ describe('DecisionBriefSection', () => {
    * the moment any category is sourced from a factor-name list again.
    */
   it('never renders the same content under two category headings', () => {
-    render(<DecisionBriefSection brief={BRIEF} />)
+    render(<DecisionBriefSection brief={BRIEF} leaderClaimPermitted />)
 
     const groups = screen.getByTestId('decision-brief-groups')
     const rendered = Array.from(groups.querySelectorAll('ul')).map(list =>

--- a/src/components/results/decision-brief/__tests__/decisionBriefFieldCoverage.spec.ts
+++ b/src/components/results/decision-brief/__tests__/decisionBriefFieldCoverage.spec.ts
@@ -115,7 +115,10 @@ describe('decision_brief field coverage — derived from real captures', () => {
 
   it('what this surface renders is exactly what the view model exposes', () => {
     expect([...DECISION_BRIEF_RENDERED_HERE].sort()).toEqual([
-      'defaulted_assumptions', 'top_drivers', 'what_would_change',
+      // `robustness_caveat` moved here from DECLARED_DARK when it gained a
+      // renderer. The exactly-once rule is what forced the old entry to be
+      // removed rather than left behind as a stale second classification.
+      'defaulted_assumptions', 'robustness_caveat', 'top_drivers', 'what_would_change',
     ])
     expect([...DECISION_BRIEF_CONSUMED_AS_IDENTITY].sort()).toEqual([
       'brief_id', 'created_at', 'version',

--- a/src/components/results/decision-brief/__tests__/decisionBriefRobustnessCaveat.spec.tsx
+++ b/src/components/results/decision-brief/__tests__/decisionBriefRobustnessCaveat.spec.tsx
@@ -1,0 +1,98 @@
+/**
+ * `robustness_caveat` — the producer's own sentence about how far the ranking held.
+ *
+ * ⚠ WHY THIS IS NOT THE SAME CLASS AS `defaulted_assumptions`, AND WHY THE GATE
+ * IS THE WHOLE POINT.
+ *
+ * `robustness_caveat` is one of THREE LEADER-RANKING MEMBERS — with `headline`
+ * and `headline_banded` — that CEE strips on a withheld turn. Its own docblock in
+ * `ownedLeaderClaim.spec.ts`: *"Absence of the owned claim IS the withheld signal
+ * — there is no separate flag, by design."* And the text itself presupposes a
+ * ranking: "This RANKING held up under the perturbations tested."
+ *
+ * The estate has already shipped the defect next door. `deriveDecisionVerdict`'s
+ * Authority 3 reconstructed a leader from win probabilities on a withheld run, so
+ * the hero printed "X is slightly ahead" beside CEE's own "no option can be put
+ * forward yet". Authority 3 was deleted; its token is absent from the `source`
+ * union deliberately, so re-deriving a leader is now a type error.
+ *
+ * Therefore this surface CONSUMES the one authority and never chooses:
+ * `hasLeadingOption` — "the single boolean every surface must gate on before
+ * asserting OR denying a leading option" — arrives as a prop from the parent that
+ * already resolved the verdict. The caveat's PRESENCE is never read as evidence
+ * that a leader exists. That is the invariant these tests exist to hold.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { readDecisionBriefViewModel } from '../decisionBriefViewModel'
+import { DecisionBriefSection } from '../DecisionBriefSection'
+
+const BRIEF_ID = '3f2504e0-4f89-41d3-9a0c-0305e82c3301'
+const CREATED_AT = '2026-08-25T08:16:20.000Z'
+const HELD = 'This ranking held up under the perturbations tested. That is not a guarantee — '
+  + 'defaulted or uncertain inputs can still change the result.'
+const FRAGILE = 'This ranking was fragile under the perturbations tested — small changes to '
+  + 'assumptions could change which option leads.'
+
+const caveat = (text = HELD) => ({ text, basis: 'is_robust', doctrine: 'provisional_doctrine_v0' })
+const brief = (extra: Record<string, unknown>) =>
+  ({ version: '1', brief_id: BRIEF_ID, created_at: CREATED_AT, ...extra })
+
+const vmWith = (extra: Record<string, unknown>) => readDecisionBriefViewModel(brief({
+  top_drivers: [{ factor_label: 'Churn Trend', sensitivity: 0.4, direction: 'positive' }],
+  ...extra,
+}))
+
+describe('robustness_caveat reaches the view model', () => {
+  it('carries the producer text and its basis token verbatim', () => {
+    expect(vmWith({ robustness_caveat: caveat() })?.robustnessCaveat)
+      .toEqual({ text: HELD, basis: 'is_robust' })
+  })
+
+  it('is null when the producer withheld it (the withheld-turn signal)', () => {
+    expect(vmWith({})?.robustnessCaveat).toBeNull()
+  })
+
+  it('withholds a caveat with no basis — an unattested claim about the ranking', () => {
+    expect(vmWith({ robustness_caveat: { text: HELD } })?.robustnessCaveat).toBeNull()
+  })
+
+  it('withholds a caveat whose text trips the glossary guard', () => {
+    // Measured: all 3 captured texts pass, because `\bperturbation\b` does not
+    // match the plural. The SINGULAR would trip it — a hair's breadth, so pinned.
+    const singular = 'This ranking held up under the perturbation tested.'
+    expect(vmWith({ robustness_caveat: caveat(singular) })?.robustnessCaveat).toBeNull()
+  })
+})
+
+describe('the caveat is gated on the leader claim, and never asserts one', () => {
+  it('renders when the producer permitted a leader claim', () => {
+    const vm = vmWith({ robustness_caveat: caveat() })!
+    render(<DecisionBriefSection brief={vm} leaderClaimPermitted />)
+    expect(screen.getByText(new RegExp('held up under the perturbations tested'))).toBeInTheDocument()
+  })
+
+  it('renders NOTHING when the leader claim is not permitted, even though the caveat is present', () => {
+    // The defect this prevents: a surface treating the caveat's presence as its
+    // own evidence that a ranking may be spoken about.
+    const vm = vmWith({ robustness_caveat: caveat() })!
+    expect(vm.robustnessCaveat).not.toBeNull()
+    render(<DecisionBriefSection brief={vm} leaderClaimPermitted={false} />)
+    expect(screen.queryByText(new RegExp('held up under the perturbations tested'))).toBeNull()
+    expect(screen.queryByTestId('decision-brief-robustness-caveat')).toBeNull()
+  })
+
+  it('makes no claim in either direction when the caveat is absent but a leader is permitted', () => {
+    const vm = vmWith({})!
+    render(<DecisionBriefSection brief={vm} leaderClaimPermitted />)
+    expect(screen.queryByTestId('decision-brief-robustness-caveat')).toBeNull()
+    // Absence must not be rendered as reassurance.
+    expect(document.body.textContent ?? '').not.toMatch(/held up|robust|no caveat|stable/i)
+  })
+
+  it('renders the fragile wording as faithfully as the reassuring one', () => {
+    const vm = vmWith({ robustness_caveat: caveat(FRAGILE) })!
+    render(<DecisionBriefSection brief={vm} leaderClaimPermitted />)
+    expect(screen.getByText(new RegExp('was fragile under the perturbations tested'))).toBeInTheDocument()
+  })
+})

--- a/src/components/results/decision-brief/__tests__/decisionBriefRobustnessCaveat.spec.tsx
+++ b/src/components/results/decision-brief/__tests__/decisionBriefRobustnessCaveat.spec.tsx
@@ -57,11 +57,33 @@ describe('robustness_caveat reaches the view model', () => {
     expect(vmWith({ robustness_caveat: { text: HELD } })?.robustnessCaveat).toBeNull()
   })
 
-  it('withholds a caveat whose text trips the glossary guard', () => {
-    // Measured: all 3 captured texts pass, because `\bperturbation\b` does not
-    // match the plural. The SINGULAR would trip it — a hair's breadth, so pinned.
-    const singular = 'This ranking held up under the perturbation tested.'
-    expect(vmWith({ robustness_caveat: caveat(singular) })?.robustnessCaveat).toBeNull()
+  /**
+   * ⚠ THIS TEST PINNED THE WRONG BEHAVIOUR AND IS INVERTED, not deleted.
+   *
+   * It asserted that a caveat whose text contains a glossary term is WITHHELD, and
+   * treated a one-character near-miss (`perturbation` banned, `perturbations` not)
+   * as a margin to defend. #846 settled the sibling reader the other way and the
+   * reasoning applies here identically: `glossaryCheck` gates UI-AUTHORED COPY, not
+   * producer prose. Withholding the producer's own sentence because the analysis
+   * used an ordinary word is a silent loss of the one line telling the user how far
+   * to trust the ranking.
+   *
+   * Now asserted in the honest direction: ordinary business vocabulary renders.
+   */
+  it('renders a caveat containing ordinary business vocabulary, never withholds it', () => {
+    for (const word of ['perturbation', 'variance', 'elasticity', 'intervention']) {
+      const text = `This ranking held up under the ${word} tested.`
+      expect(
+        vmWith({ robustness_caveat: caveat(text) })?.robustnessCaveat?.text,
+        `a producer sentence containing "${word}" must not be withheld`,
+      ).toBe(text)
+    }
+  })
+
+  it('still withholds a caveat whose text carries a raw identifier', () => {
+    // The guard that DOES answer the real question is unchanged.
+    const leaky = 'This ranking held up for deadbeefcafe1234 under the tests.'
+    expect(vmWith({ robustness_caveat: caveat(leaky) })?.robustnessCaveat).toBeNull()
   })
 })
 

--- a/src/components/results/decision-brief/__tests__/decisionBriefViewModel.spec.ts
+++ b/src/components/results/decision-brief/__tests__/decisionBriefViewModel.spec.ts
@@ -52,6 +52,9 @@ describe('readDecisionBriefViewModel', () => {
       // Present and empty on this capture — the 25 Aug live wire carries the key
       // with zero entries, which is a real producer state, not an absence.
       defaultedAssumptions: [],
+      // The withheld projection strips this by design — its absence IS the
+      // withheld signal, so null here is the correct, meaningful value.
+      robustnessCaveat: null,
     })
 
     // The projection carries probabilities, but this reader has no field from

--- a/src/components/results/decision-brief/decisionBriefViewModel.ts
+++ b/src/components/results/decision-brief/decisionBriefViewModel.ts
@@ -297,19 +297,35 @@ function readDefaultedAssumptions(value: unknown): DecisionBriefDefaultedView[] 
  * The producer's caveat about the ranking, with its licensing token.
  *
  * `basis` is required: a caveat with no stated basis is an unattested claim about
- * the user's ranking, and this surface has no licence to pass one on. The text is
- * vetted for identity, not rewritten — same rule as the defaulted-assumption note.
+ * the user's ranking, and this surface has no licence to pass one on.
  *
- * Measured on every captured text: none trips the glossary guard, because
- * `\bperturbation\b` does not match the plural the producer actually writes. The
- * SINGULAR would trip it, so the margin is one character and the case is pinned.
+ * ⚠ THE ANALYSIS GLOSSARY IS DELIBERATELY NOT A GUARD HERE — corrected to match the
+ * ruling #846 made on the sibling `defaulted_assumptions` reader, because I had made
+ * the same category error twice in one file.
+ *
+ * I gated this text on `containsBannedTerm`. `glossaryCheck` gates UI-GENERATED COPY;
+ * its own header says "we never rewrite user data, only the generated copy that names
+ * it", and `copyHygiene.spec.tsx` states outright that "producer-supplied strings are
+ * deliberately NOT scanned — they are rendered as data, never authored here". Two
+ * questions were sharing one predicate: "is Olumi authoring jargon in copy it wrote?"
+ * and "is this producer sentence safe to render verbatim?".
+ *
+ * The margin was one character and I read it the wrong way round. `perturbation` is a
+ * banned term; the producer writes "perturbations", which `\bperturbation\b` does not
+ * match. I pinned that near-miss as a case to PRESERVE the withholding. The correct
+ * reading is that a producer sentence should never have been withheld for a glossary
+ * word at all — a caveat suppressed because the analysis used an ordinary word is a
+ * silent loss of the one sentence telling the user how far to trust the ranking.
+ *
+ * What answers the real question is what remains: raw-identifier, length, blank/NUL,
+ * and the `basis` token.
  */
 function readRobustnessCaveat(value: unknown): DecisionBriefRobustnessCaveatView | null {
   if (!isRecord(value)) return null
   const text = readNonBlankString(value.text, MAX_NOTE_LENGTH)
   const basis = readNonBlankString(value.basis, MAX_LABEL_LENGTH)
   if (text === null || basis === null) return null
-  if (containsRawIdentifier(text) || containsBannedTerm(text)) return null
+  if (containsRawIdentifier(text)) return null
   return { text, basis }
 }
 

--- a/src/components/results/decision-brief/decisionBriefViewModel.ts
+++ b/src/components/results/decision-brief/decisionBriefViewModel.ts
@@ -30,11 +30,24 @@ export interface DecisionBriefDefaultedView {
   note: string
 }
 
+/**
+ * The producer's own sentence about how far the ranking held, with the token
+ * that licenses it. ⚠ This is a LEADER-RANKING member: CEE strips it, alongside
+ * `headline` and `headline_banded`, on a withheld turn, and its absence IS the
+ * withheld signal. Rendering it is gated on the owned leader claim — see
+ * `DecisionBriefSection`. Never treat its presence as evidence a leader exists.
+ */
+export interface DecisionBriefRobustnessCaveatView {
+  text: string
+  basis: string
+}
+
 export interface DecisionBriefViewModel {
   topDrivers: DecisionBriefDriverView[]
   keyAssumptions: string[]
   whatWouldChange: string[]
   defaultedAssumptions: DecisionBriefDefaultedView[]
+  robustnessCaveat: DecisionBriefRobustnessCaveatView | null
 }
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
@@ -169,6 +182,9 @@ export const DECISION_BRIEF_RENDERED_HERE = [
   'top_drivers',
   'what_would_change',
   'defaulted_assumptions',
+  // Moved out of DECLARED_DARK when it gained a renderer. The guard requires
+  // exactly-once classification, so this move is what forces the old entry to go.
+  'robustness_caveat',
 ] as const
 
 /** Read to decide whether the projection is a brief at all; never displayed. */
@@ -194,7 +210,6 @@ export const DECISION_BRIEF_DECLARED_DARK = {
     + 'neighbouring column; 0 of 1,620 captured briefs carry it while top_drivers is empty',
   headline: 'leader-designating prose; this surface never restores a leader',
   robustness: 'a producer verdict this surface has no licence to re-state as its own',
-  robustness_caveat: 'belongs with the robustness verdict, which is not rendered here',
   warnings: 'the canonical inference-warning strip above the brief is sole owner',
   warning_codes: 'machine codes; the human-readable strip above owns this surface',
   analysis_summary: 'band summary owned by the analysis hero, not by the brief',
@@ -279,6 +294,26 @@ function readDefaultedAssumptions(value: unknown): DecisionBriefDefaultedView[] 
 }
 
 /**
+ * The producer's caveat about the ranking, with its licensing token.
+ *
+ * `basis` is required: a caveat with no stated basis is an unattested claim about
+ * the user's ranking, and this surface has no licence to pass one on. The text is
+ * vetted for identity, not rewritten — same rule as the defaulted-assumption note.
+ *
+ * Measured on every captured text: none trips the glossary guard, because
+ * `\bperturbation\b` does not match the plural the producer actually writes. The
+ * SINGULAR would trip it, so the margin is one character and the case is pinned.
+ */
+function readRobustnessCaveat(value: unknown): DecisionBriefRobustnessCaveatView | null {
+  if (!isRecord(value)) return null
+  const text = readNonBlankString(value.text, MAX_NOTE_LENGTH)
+  const basis = readNonBlankString(value.basis, MAX_LABEL_LENGTH)
+  if (text === null || basis === null) return null
+  if (containsRawIdentifier(text) || containsBannedTerm(text)) return null
+  return { text, basis }
+}
+
+/**
  * Parse the CEE-projected DecisionBriefV1 members that are licensed for this
  * surface. Missing or malformed categories do not suppress valid siblings.
  */
@@ -308,15 +343,17 @@ export function readDecisionBriefViewModel(raw: unknown): DecisionBriefViewModel
     true,
   )
   const defaultedAssumptions = readDefaultedAssumptions(raw.defaulted_assumptions)
+  const robustnessCaveat = readRobustnessCaveat(raw.robustness_caveat)
 
   if (
     topDrivers.length === 0
     && keyAssumptions.length === 0
     && whatWouldChange.length === 0
     && defaultedAssumptions.length === 0
+    && robustnessCaveat === null
   ) {
     return null
   }
 
-  return { topDrivers, keyAssumptions, whatWouldChange, defaultedAssumptions }
+  return { topDrivers, keyAssumptions, whatWouldChange, defaultedAssumptions, robustnessCaveat }
 }


### PR DESCRIPTION
⚠ **CONTRACT CLASS: IN.** This changes what the product asserts about the user's ranking, so it wants **cross-model review**, unlike #840/#841/#844 which were presentation-class. Flagging rather than routing around the gate.

## What it closes

`robustness_caveat` had **zero production readers**. It carries the producer's own sentence about how far the ranking held — *"This ranking held up under the perturbations tested. That is not a guarantee — defaulted or uncertain inputs can still change the result."* — with a `basis` token licensing it.

Paired with #840's defaulted assumptions, a user can now see both **that a ranking may be fragile** and **which values Olumi had to invent**.

## The gate is the increment

`robustness_caveat` is one of **three leader-ranking members** CEE strips on a withheld turn. Per `ownedLeaderClaim`: *"Absence of the owned claim IS the withheld signal — there is no separate flag, by design."* The text presupposes a ranking exists.

The estate already shipped the defect next door: `deriveDecisionVerdict`'s **Authority 3** reconstructed a leader from win probabilities on a withheld run, so the hero printed *"X is slightly ahead"* beside CEE's own *"no option can be put forward yet"*.

So this surface **consumes** `hasLeadingOption` — *"the single boolean every surface must gate on"* — resolved once by `ResultsBody`. Presence is never read as evidence a leader exists; absence is never rendered as reassurance.

**The prop is required, not defaulted.** A default of `true` would silently re-open the claim for every future caller. It cost 5 type errors at existing call sites — the prop doing its job. Fixed at source; **`--update-baseline` not touched**; ratchet back to exactly 2252.

`basis` is required on the payload: a caveat with no stated basis is an unattested claim about the user's ranking.

## ⚠ My browser test was wrong, and the product was right

The first version asserted the caveat was **visible**, and failed at all three widths. Cause: the component resolves `deriveDecisionVerdict(report, { visibleOptionIds, ... })`, and the measure seeds **build-vs-buy** then replays **T3**, whose leader `opt_phased` is not on that canvas. Olumi correctly withheld; my gate correctly closed; I read a correct refusal as a failure.

My diagnostic probe disagreed with the component because it called the authority **bare**, without the options — two resolutions of one verdict differing by an argument, the two-authorities shape in the instrument.

Making it "pass" would have needed a matching graph **or a weakened gate** — and weakening the gate is the defect. The measure now witnesses the **invariant**: caveat on screen **iff** the verdict permits a leader.

**NAMED LIMIT:** all three viewports exercised the **withheld** arm. The permitted arm is **jsdom-only**. The arm is printed on every run so a product that silently stopped naming leaders cannot keep this green.

## Evidence

RED-first 8 collected by name / 6 failed. **46/46 green.** Lint clean. Named typecheck gate **PASSED**.

Discriminating pair verified by *which* test breaks:
- remove the gate → *"renders NOTHING when the leader claim is not permitted"*
- rename an adjacent group title → only a title-presence test

Plus: drop `basis` → RED · drop the prose identity proof → RED · unclassify in the anti-dark guard → **2 RED**, forcing `DECLARED_DARK` → `RENDERED_HERE` bookkeeping. Controls 0-applied and green at both ends.

Measured near-miss: the producer writes *"perturbations"*; `\bperturbation\b` is a banned glossary term that does **not** match the plural. **0 of 3 captured texts trip it, by one character** — pinned by test.

Rung: **TESTED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C8zhVkx3tAqkrYsDBbGPxw