### PR TITLE
fix(decision-brief): stop withholding the assumption disclosure for ordinary business words (3/13 -> 13/13)

### DIFF
--- a/src/components/results/decision-brief/__tests__/decisionBriefDefaultedAssumptions.spec.ts
+++ b/src/components/results/decision-brief/__tests__/decisionBriefDefaultedAssumptions.spec.ts
@@ -389,6 +389,26 @@ describe('a malformed row at index 0 (ranked categories)', () => {
     expect(vm?.keyAssumptions).toEqual([])
   })
 
+  /**
+   * ⚠ ADDED AFTER A SURVIVING MUTANT (`isRecord` break -> continue, readTopDrivers).
+   * The driver case below uses a row that IS a record and merely fails the sensitivity
+   * check — so it hits the SECOND break and never exercised the isRecord one. Exactly
+   * the gap the previous change hit in `readStringList`, reproduced here in the driver
+   * reader. A non-record row behaves differently in general, so the case is added
+   * rather than the survivor being explained away.
+   */
+  it('discards the ranked drivers when the first driver row is not an object at all', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      top_drivers: [
+        null as unknown as Record<string, unknown>,
+        { factor_label: 'Churn Trend', sensitivity: 0.9, direction: 'positive' },
+      ],
+      what_would_change: ['Demand holds'],
+    }))
+    expect(vm?.topDrivers).toEqual([])
+    expect(JSON.stringify(vm ?? {})).not.toContain('Churn Trend')
+  })
+
   it('discards the ranked drivers when the FIRST driver row is malformed', () => {
     const vm = readDecisionBriefViewModel(brief({
       top_drivers: [
@@ -411,6 +431,24 @@ describe('a malformed row at index 0 (ranked categories)', () => {
     const vm = readDecisionBriefViewModel(brief({
       defaulted_assumptions: [
         { not: 'a row' } as unknown as Record<string, unknown>,
+        defaulted('Available Growth Budget'),
+        defaulted('Current ARR'),
+      ],
+    }))
+    expect(vm?.defaultedAssumptions.map(d => d.factorLabel))
+      .toEqual(['Available Growth Budget', 'Current ARR'])
+  })
+
+  /**
+   * ⚠ ALSO ADDED AFTER A SURVIVING MUTANT (`isRecord` continue -> break, defaulted set).
+   * The contrast case above leads with `{ not: 'a row' }`, which IS a record — it is
+   * skipped by the `source` guard, so the isRecord branch went untested and flipping it
+   * to `break` left the suite green. This case leads with a genuine non-record.
+   */
+  it('does NOT discard the unordered defaulted set when its first row is not an object', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [
+        null as unknown as Record<string, unknown>,
         defaulted('Available Growth Budget'),
         defaulted('Current ARR'),
       ],

--- a/src/components/results/decision-brief/__tests__/decisionBriefDefaultedAssumptions.spec.ts
+++ b/src/components/results/decision-brief/__tests__/decisionBriefDefaultedAssumptions.spec.ts
@@ -12,15 +12,35 @@
  *  2. A category emptied completely when the producer exceeded its own declared cap
  *     (`length > max` returned `[]`), so 11 items rendered as zero.
  *  3. One malformed row emptied its whole category, suppressing valid siblings.
- *  4. The note interpolates a USER-AUTHORED factor label, and the glossary guard bans
- *     ordinary business vocabulary (`variance`, `intervention`, `blocked`, `win rate`).
- *     Measured: 0 of 17 distinct captured notes trip it today — but "Budget Variance" is an
- *     entirely ordinary factor name, so the collision is REACHABLE and UNOBSERVED. It is
- *     pinned here rather than discovered in production.
+ *  4. ⭐ CORRECTED. The row was additionally gated on the ANALYSIS GLOSSARY
+ *     (`containsBannedTerm`), which bans ordinary business vocabulary — `variance`,
+ *     `intervention`, `blocked`, `win rate`, `graph`, `posterior`, `elasticity`,
+ *     `winner`, `recommended`, `confidence score`. Measured against 13 realistic
+ *     business factor labels, TEN were withheld with no trace anywhere: the user lost
+ *     the honesty disclosure precisely BECAUSE they had named a factor normally.
+ *
+ *     The gate was a CATEGORY ERROR, and three independent statements of this estate's
+ *     own doctrine say so:
+ *       - `glossaryCheck.ts`'s header scopes it to "UI-generated analysis copy" and
+ *         states "we never rewrite user data, only the generated copy that names it";
+ *       - `safeInterpolatedLabel`'s docstring: "The user's original label still appears
+ *         verbatim in row titles and inspector views";
+ *       - `analysis-hero/__tests__/copyHygiene.spec.tsx`, the scanner spec itself:
+ *         "Producer-supplied strings ... are deliberately NOT scanned — they are
+ *         rendered as data, never authored here."
+ *
+ *     The note is PRODUCER PROSE rendered verbatim as data; the label is USER DATA. The
+ *     glossary answers "is Olumi authoring jargon or a leader claim in copy it wrote?",
+ *     which is a different question from "is this producer sentence safe to render?" —
+ *     and the second question is already answered, in full, by the raw-identifier,
+ *     length, blank/NUL and `source` guards that remain. Nothing forced the gate: no
+ *     spec scans this surface for banned terms, and the one source scanner is scoped to
+ *     `src/canvas/components/pre-analysis-v3/`. So it is REMOVED, not narrowed.
  *
  * The rule this file enforces (brief §6): VET the whole rendered join, never REWRITE it.
  * A row whose producer sentence cannot be shown unchanged is WITHHELD, never repaired —
- * substituting a fallback into the producer's sentence would change its meaning.
+ * substituting a fallback into the producer's sentence would change its meaning. That
+ * rule is intact; what changed is which strings count as unshowable.
  */
 import { describe, it, expect } from 'vitest'
 import { readDecisionBriefViewModel } from '../decisionBriefViewModel'
@@ -74,23 +94,120 @@ describe('defaulted_assumptions reaches the view model', () => {
 })
 
 describe('producer prose safety — vet, never rewrite (brief §6)', () => {
-  it('WITHHOLDS a row whose note trips the glossary guard, keeping valid siblings', () => {
-    // "Budget Variance" is an ordinary factor name; `variance` is a banned term.
+  /**
+   * ⭐ THE 13-LABEL CORPUS, drawn from outside this module's head (trap 22): ordinary
+   * business vocabulary a real user would type as a factor name. TEN of these were
+   * silently withheld before the fix. The assertion binds by IDENTITY — the exact
+   * label AND the byte-identical producer sentence — not by a count another row
+   * could satisfy.
+   */
+  const ORDINARY_BUSINESS_LABELS = [
+    'Budget Variance', 'Win Rate', 'Recommended Retail Price', 'Price Elasticity',
+    'Blocked Pipeline Value', 'Government Intervention Risk', 'Knowledge Graph Coverage',
+    'Posterior Demand Estimate', 'Confidence Score Threshold', 'Winner Take All Share',
+    'Available Growth Budget', 'Current ARR', 'Churn Trend',
+  ] as const
+
+  it.each(ORDINARY_BUSINESS_LABELS)(
+    'renders the disclosure for the ordinary factor name %s',
+    (label) => {
+      const vm = readDecisionBriefViewModel(brief({
+        defaulted_assumptions: [defaulted(label)],
+      }))
+      expect(vm?.defaultedAssumptions).toEqual([{ factorLabel: label, note: note(label) }])
+    },
+  )
+
+  it('renders a glossary-colliding row ALONGSIDE its siblings, withholding neither', () => {
     const vm = readDecisionBriefViewModel(brief({
       defaulted_assumptions: [defaulted('Budget Variance'), defaulted('Current ARR')],
     }))
-    expect(vm?.defaultedAssumptions.map(d => d.factorLabel)).toEqual(['Current ARR'])
+    expect(vm?.defaultedAssumptions.map(d => d.factorLabel))
+      .toEqual(['Budget Variance', 'Current ARR'])
   })
 
+  /**
+   * The no-substitution invariant is UNCHANGED and still load-bearing — it is the
+   * reason `safeInterpolatedLabel` is deliberately not used here. What changed is
+   * that the row now appears at all: previously this asserted the row was GONE,
+   * which cemented the defect. It now proves the stronger property — the producer's
+   * sentence reaches the model byte-identically, fallback text nowhere in sight.
+   */
   it('never substitutes a fallback into the producer sentence', () => {
     const vm = readDecisionBriefViewModel(brief({
       defaulted_assumptions: [defaulted('Clinical Intervention Cost')],
     }))
-    // The row is gone entirely; no repaired sentence is emitted in its place.
-    expect(vm?.defaultedAssumptions ?? []).toEqual([])
+    expect(vm?.defaultedAssumptions).toEqual([
+      { factorLabel: 'Clinical Intervention Cost', note: note('Clinical Intervention Cost') },
+    ])
     const joined = JSON.stringify(vm ?? {})
     expect(joined).not.toContain('this factor')
-    expect(joined).not.toContain('Intervention')
+    // The user's own word survives verbatim rather than being repaired away.
+    expect(vm?.defaultedAssumptions[0]?.note).toContain('Clinical Intervention Cost')
+  })
+
+  it('preserves typographic quotes, em dashes and CJK in the producer sentence', () => {
+    const exotic = 'Δ Demand — “peak” 需要 variance ✅'
+    const vm = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [defaulted(exotic)],
+    }))
+    expect(vm?.defaultedAssumptions[0]?.note).toBe(note(exotic))
+  })
+})
+
+/**
+ * ⭐ THE OTHER DIRECTION. Removing the glossary gate must not weaken the guards that
+ * genuinely answer "is this row safe to render?". Each of these must STILL withhold.
+ */
+describe('the remaining safety guards still withhold', () => {
+  it('withholds a row whose LABEL carries a raw identifier', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [
+        defaulted('deadbeefcafe1234'),
+        defaulted('Current ARR'),
+      ],
+    }))
+    expect(vm?.defaultedAssumptions.map(d => d.factorLabel)).toEqual(['Current ARR'])
+  })
+
+  it('withholds a row whose NOTE carries a raw identifier', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [
+        { factor_label: 'Current ARR', note: 'Defaulted from gc-3f2504e04f89 upstream.', source: 'value_defaulted' },
+        defaulted('Churn Trend'),
+      ],
+    }))
+    expect(vm?.defaultedAssumptions.map(d => d.factorLabel)).toEqual(['Churn Trend'])
+  })
+
+  it('withholds an over-length note rather than truncating it', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [
+        { factor_label: 'Current ARR', note: 'x'.repeat(601), source: 'value_defaulted' },
+        defaulted('Churn Trend'),
+      ],
+    }))
+    expect(vm?.defaultedAssumptions.map(d => d.factorLabel)).toEqual(['Churn Trend'])
+    expect(JSON.stringify(vm ?? {})).not.toContain('…')
+  })
+
+  it('withholds a row whose source is not the producer value_defaulted token', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [
+        { ...defaulted('Budget Variance'), source: 'user_provided' },
+        defaulted('Churn Trend'),
+      ],
+    }))
+    expect(vm?.defaultedAssumptions.map(d => d.factorLabel)).toEqual(['Churn Trend'])
+  })
+
+  it('never leaks the provenance token into the view model', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [defaulted('Budget Variance')],
+    }))
+    const joined = JSON.stringify(vm ?? {})
+    expect(joined).not.toContain('value_defaulted')
+    expect(joined).not.toContain('defaulted_assumptions')
   })
 })
 
@@ -153,5 +270,159 @@ describe('one bad row cannot suppress valid siblings', () => {
       key_assumptions: ['Demand holds', '   ', 'Costs fall'],
     }))
     expect(vm?.keyAssumptions).toEqual(['Demand holds'])
+  })
+})
+
+/**
+ * ⭐ DEFECT 2 — the cap was applied BEFORE the validity filter, so leading
+ * non-qualifying rows starved the category to zero. Pure ordering dependence:
+ * the SAME two valid rows rendered 2 when placed first and 0 when placed after
+ * ten `user_provided` rows. This is the same "cap empties the list" defect the
+ * previous change fixed in `readStringList` and did not fix here.
+ *
+ * Currently unreachable — all ten captured briefs carry exactly one `source`
+ * token — but it arms the moment the producer adds a second, which is precisely
+ * how a latent defect ships.
+ */
+describe('the cap counts qualifying rows, not array positions', () => {
+  const tenOtherRows = Array.from({ length: 10 }, (_, i) => ({
+    ...defaulted(`Provided ${i + 1}`), source: 'user_provided',
+  }))
+
+  it('renders valid rows that sit AFTER a full cap of non-qualifying rows', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [
+        ...tenOtherRows,
+        defaulted('Available Growth Budget'),
+        defaulted('Current ARR'),
+      ],
+    }))
+    expect(vm?.defaultedAssumptions).toEqual([
+      { factorLabel: 'Available Growth Budget', note: note('Available Growth Budget') },
+      { factorLabel: 'Current ARR', note: note('Current ARR') },
+    ])
+  })
+
+  it('renders the SAME two rows whether they lead or trail — no ordering dependence', () => {
+    const leading = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [
+        defaulted('Available Growth Budget'), defaulted('Current ARR'), ...tenOtherRows,
+      ],
+    }))
+    const trailing = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [
+        ...tenOtherRows, defaulted('Available Growth Budget'), defaulted('Current ARR'),
+      ],
+    }))
+    expect(trailing?.defaultedAssumptions).toEqual(leading?.defaultedAssumptions)
+    expect(trailing?.defaultedAssumptions).toHaveLength(2)
+  })
+
+  it('interleaved non-qualifying rows do not consume cap budget', () => {
+    const interleaved = Array.from({ length: 12 }, (_, i) => (
+      i % 2 === 0
+        ? defaulted(`Valid ${i / 2 + 1}`)
+        : { ...defaulted(`Other ${i}`), source: 'user_provided' }
+    ))
+    const vm = readDecisionBriefViewModel(brief({ defaulted_assumptions: interleaved }))
+    expect(vm?.defaultedAssumptions.map(d => d.factorLabel))
+      .toEqual(['Valid 1', 'Valid 2', 'Valid 3', 'Valid 4', 'Valid 5', 'Valid 6'])
+  })
+
+  /** THE OTHER DIRECTION — the cap must still cap. */
+  it('still truncates to the producer maximum when all rows qualify', () => {
+    const twelve = Array.from({ length: 12 }, (_, i) => defaulted(`Factor ${i + 1}`))
+    const vm = readDecisionBriefViewModel(brief({ defaulted_assumptions: twelve }))
+    expect(vm?.defaultedAssumptions).toHaveLength(10)
+    expect(vm?.defaultedAssumptions.map(d => d.factorLabel))
+      .toEqual(Array.from({ length: 10 }, (_, i) => `Factor ${i + 1}`))
+  })
+
+  /** A hostile payload must not force unbounded work; the scan is bounded. */
+  it('bounds the scan rather than walking an unbounded hostile array', () => {
+    const hostile = [
+      ...Array.from({ length: 5000 }, () => ({ ...defaulted('Noise'), source: 'user_provided' })),
+      defaulted('Never Reached'),
+    ]
+    const vm = readDecisionBriefViewModel(brief({ defaulted_assumptions: hostile }))
+    expect(vm?.defaultedAssumptions ?? []).toEqual([])
+  })
+})
+
+/**
+ * ⭐ DEFECT 3 — a malformed row at INDEX 0 discards an entire ranked category.
+ *
+ * DECIDED, NOT INCIDENTAL: the prefix `break` is KEPT, at row 0 as everywhere else.
+ * The alternative (`continue`) would render row 1 as though it were row 0 — the UI
+ * would assert a #1 that is not the producer's #1. That is a fabricated ranking, and
+ * this surface's whole design is to withhold rather than to substitute.
+ *
+ * What settles it is the RENDERER: `BriefGroup` collapses to `PREVIEW_ITEMS = 1`, so
+ * the only item most users ever see IS the top-ranked one. A rank shift would land
+ * squarely, and invisibly, on that single previewed row. Losing the category is a
+ * visible absence; showing a shifted #1 is a confident wrongness.
+ *
+ * The cost is real and is accepted: two true sentences are lost to one malformed row.
+ * It is pinned here so the behaviour is deliberate rather than incidental, and so any
+ * future change to `continue` REDs and has to argue with this comment.
+ */
+describe('a malformed row at index 0 (ranked categories)', () => {
+  it('discards the ranked category rather than promoting row 1 into rank 0', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      what_would_change: [
+        { not: 'a string' } as unknown as string,
+        'A genuinely useful sentence',
+        'And another',
+      ],
+      top_drivers: [{ factor_label: 'Churn Trend', sensitivity: 0.4, direction: 'positive' }],
+    }))
+    expect(vm?.whatWouldChange).toEqual([])
+    // The sentences are absent entirely — never re-ranked, never paraphrased.
+    expect(JSON.stringify(vm ?? {})).not.toContain('A genuinely useful sentence')
+  })
+
+  it('discards the ranked category when an ID-shaped row leads it', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      key_assumptions: ['deadbeefcafe1234', 'Demand holds', 'Costs fall'],
+      top_drivers: [{ factor_label: 'Churn Trend', sensitivity: 0.4, direction: 'positive' }],
+    }))
+    expect(vm?.keyAssumptions).toEqual([])
+  })
+
+  it('discards the ranked drivers when the FIRST driver row is malformed', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      top_drivers: [
+        { factor_label: 'Broken', sensitivity: 'nope', direction: 'positive' },
+        { factor_label: 'Churn Trend', sensitivity: 0.9, direction: 'positive' },
+      ],
+      what_would_change: ['Demand holds'],
+    }))
+    expect(vm?.topDrivers).toEqual([])
+    expect(JSON.stringify(vm ?? {})).not.toContain('Churn Trend')
+  })
+
+  /**
+   * ⭐ THE DELIBERATE CONTRAST. `defaulted_assumptions` is an unordered SET, so it
+   * uses `continue` — there is no rank to lie about and each remaining row is
+   * independently true. This test is what makes the two semantics a DECISION rather
+   * than an inconsistency: flipping either one to match the other REDs here.
+   */
+  it('does NOT discard the unordered defaulted set when its first row is malformed', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      defaulted_assumptions: [
+        { not: 'a row' } as unknown as Record<string, unknown>,
+        defaulted('Available Growth Budget'),
+        defaulted('Current ARR'),
+      ],
+    }))
+    expect(vm?.defaultedAssumptions.map(d => d.factorLabel))
+      .toEqual(['Available Growth Budget', 'Current ARR'])
+  })
+
+  it('keeps the ranked category intact when NO row is malformed (positive control)', () => {
+    const vm = readDecisionBriefViewModel(brief({
+      what_would_change: ['A genuinely useful sentence', 'And another'],
+    }))
+    expect(vm?.whatWouldChange).toEqual(['A genuinely useful sentence', 'And another'])
   })
 })

--- a/src/components/results/decision-brief/decisionBriefViewModel.ts
+++ b/src/components/results/decision-brief/decisionBriefViewModel.ts
@@ -10,7 +10,6 @@
  */
 
 import { RAW_ID_PATTERN } from '@/canvas/conversation/friendlyOperation'
-import { containsBannedTerm } from '../utils/glossaryCheck'
 
 export interface DecisionBriefDriverView {
   /** Producer label, preserved verbatim. */
@@ -58,6 +57,13 @@ const MAX_WHAT_WOULD_CHANGE = 10
 const MAX_LABEL_LENGTH = 300
 const MAX_NOTE_LENGTH = 600
 const MAX_DEFAULTED_ASSUMPTIONS = 10
+/**
+ * How far to LOOK for qualifying rows — not how many to show. The cap above is the
+ * producer's contract on the output; this bounds the input scan so a hostile payload
+ * cannot force unbounded regex work. Set at 20x the declared maximum: generous enough
+ * that no realistic mix of `source` kinds starves the category, finite by construction.
+ */
+const MAX_DEFAULTED_SCAN = MAX_DEFAULTED_ASSUMPTIONS * 20
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
@@ -208,30 +214,55 @@ export const DECISION_BRIEF_CLASSIFIED: readonly string[] = [
 /**
  * ⭐ The producer's own honesty prose about values it had to default.
  *
- * PROSE SAFETY (brief §6) — VET, NEVER REWRITE. The note interpolates a
- * USER-AUTHORED factor label, and the analysis-surface glossary bans ordinary
- * business vocabulary (`variance`, `intervention`, `blocked`, `win rate`). The
- * repo's existing helper for this is `safeInterpolatedLabel`, which SUBSTITUTES
- * a fallback — and substituting into a producer sentence changes what the
- * producer said. So this reader proves the guard is an IDENTITY on the exact
- * string it is about to render, and WITHHOLDS the row when it is not. A withheld
- * row is an absence; a repaired row would be a fabrication.
+ * PROSE SAFETY (brief §6) — VET, NEVER REWRITE. The note is PRODUCER PROSE and the
+ * label is USER DATA; both are rendered verbatim, with no transform between wire and
+ * DOM. `safeInterpolatedLabel` is deliberately NOT used: substituting a fallback into
+ * the producer's sentence would change what the producer said. A row that cannot be
+ * shown unchanged is WITHHELD, never repaired — an absence, never a fabrication.
  *
- * Measured against every capture available: 0 of 17 distinct notes and 0 of 15
- * distinct factor labels trip the guard today. The collision is REACHABLE, not
- * live — "Budget Variance" is an entirely ordinary factor name — so it is pinned
- * by test rather than left to be discovered on a user's screen.
+ * ⚠ THE ANALYSIS GLOSSARY IS DELIBERATELY NOT A GUARD HERE, and this is the correction
+ * that matters most on this surface. It used to gate every row on
+ * `containsBannedTerm(factorLabel) || containsBannedTerm(note)`. Measured against 13
+ * realistic business factor labels, that withheld TEN — `Budget Variance`, `Win Rate`,
+ * `Price Elasticity`, `Blocked Pipeline Value`, `Government Intervention Risk`,
+ * `Knowledge Graph Coverage`, `Posterior Demand Estimate`, `Confidence Score Threshold`,
+ * `Winner Take All Share`, `Recommended Retail Price` — with no trace in the DOM and no
+ * withheld-count anywhere. The user lost the honesty disclosure BECAUSE they had named
+ * a factor normally, and the loss was invisible to them and to us.
  *
- * Unlike the ranked arrays above, this is an unordered SET of factors, so an
- * unusable row is skipped rather than ending a prefix: there is no rank to lie
- * about, and the remaining rows are each independently true.
+ * It was a category error. `glossaryCheck` gates UI-GENERATED COPY — its own header
+ * says "we never rewrite user data, only the generated copy that names it", and
+ * `analysis-hero/__tests__/copyHygiene.spec.tsx` states the rule outright:
+ * "Producer-supplied strings ... are deliberately NOT scanned — they are rendered as
+ * data, never authored here." Two questions were sharing one predicate: "is Olumi
+ * authoring jargon or a leader claim in copy it wrote?" (glossary — correct, and
+ * untouched at its seven other consumers) and "is this producer sentence safe to
+ * render verbatim?" (this surface). The second is answered in full by the guards that
+ * remain: raw-identifier, length, blank/NUL, and the `source` token.
+ *
+ * Nothing forced the gate. No spec scans this surface for banned terms, and the estate's
+ * one source scanner walks `src/canvas/components/pre-analysis-v3/` — a different
+ * subtree, and blind to runtime wire data by construction. The gate was also applied to
+ * `factorLabel`, which has ZERO production consumers: `DecisionBriefSection` renders
+ * `entry.note` alone. Rows were being withheld over a string no user could ever see.
+ *
+ * ⭐ CAP AFTER FILTER, NEVER BEFORE. This used to `slice(0, MAX)` and only then test
+ * `source`, so ten leading non-qualifying rows starved the category to zero while the
+ * SAME two valid rows rendered fine when placed first — pure ordering dependence, and
+ * the same "cap empties the list" defect already fixed in `readStringList`. The cap
+ * counts QUALIFYING rows; `MAX_DEFAULTED_SCAN` bounds the input scan separately.
+ *
+ * Unlike the ranked arrays above, this is an unordered SET of factors, so an unusable
+ * row is skipped rather than ending a prefix: there is no rank to lie about, and the
+ * remaining rows are each independently true.
  */
 function readDefaultedAssumptions(value: unknown): DecisionBriefDefaultedView[] {
   if (value == null) return []
   if (!Array.isArray(value)) return []
 
   const out: DecisionBriefDefaultedView[] = []
-  for (const item of value.slice(0, MAX_DEFAULTED_ASSUMPTIONS)) {
+  for (const item of value.slice(0, MAX_DEFAULTED_SCAN)) {
+    if (out.length >= MAX_DEFAULTED_ASSUMPTIONS) break
     if (!isRecord(item)) continue
     // The producer's own token for "we defaulted this". Anything else is a row
     // this surface has no licence to describe.
@@ -241,10 +272,6 @@ function readDefaultedAssumptions(value: unknown): DecisionBriefDefaultedView[] 
     const note = readNonBlankString(item.note, MAX_NOTE_LENGTH)
     if (factorLabel === null || note === null) continue
     if (containsRawIdentifier(factorLabel) || containsRawIdentifier(note)) continue
-
-    // The identity proof. Both the anchor and the whole rendered join must pass
-    // unchanged, or the row does not appear at all.
-    if (containsBannedTerm(factorLabel) || containsBannedTerm(note)) continue
 
     out.push({ factorLabel, note })
   }


### PR DESCRIPTION
Fixes the capability defect an adversarial review demonstrated in the newly-merged
"What Olumi assumed" section (#840), plus the two latent ordering defects in the same
module. **Branched from `staging` @ `e36d3631`** (re-derived; the tip had moved).

## 1 · PRIMARY — the glossary guard withheld ordinary business vocabulary

`readDefaultedAssumptions` gated every row on
`containsBannedTerm(factorLabel) || containsBannedTerm(note)`.

Re-run against the review's 13-label corpus, through the real `readDecisionBriefViewModel`:

| Factor label | Tripped by | Before | After |
|---|---|---|---|
| Budget Variance | `variance` | WITHHELD | **RENDERED** |
| Win Rate | `win rate` | WITHHELD | **RENDERED** |
| Recommended Retail Price | `recommended` | WITHHELD | **RENDERED** |
| Price Elasticity | `elasticity` | WITHHELD | **RENDERED** |
| Blocked Pipeline Value | `blocked` | WITHHELD | **RENDERED** |
| Government Intervention Risk | `intervention` | WITHHELD | **RENDERED** |
| Knowledge Graph Coverage | `graph` | WITHHELD | **RENDERED** |
| Posterior Demand Estimate | `posterior` | WITHHELD | **RENDERED** |
| Confidence Score Threshold | `confidence score` | WITHHELD | **RENDERED** |
| Winner Take All Share | `winner` | WITHHELD | **RENDERED** |
| Available Growth Budget | — | rendered | rendered |
| Current ARR | — | rendered | rendered |
| Churn Trend | — | rendered | rendered |

**3/13 → 13/13.**

### Chosen: **(a) — scope the gate off producer prose entirely.** Not (b), not (c).

**What `glossaryCheck` was built to protect against**, derived from the module and its
consumers: it is the *Olumi Communication Glossary* — a gate on **copy Olumi AUTHORS**.
It stops the product writing jargon (`EVPI`, `posterior`, `stochastic`, `DAG`), internal
names (`ISL`, `PLoT`, `CEE`), and unearned leader designations (`recommend`, `winner`).
Three independent statements of that scope, one of them inside the scanner itself:

- `glossaryCheck.ts` header — gates "UI-generated analysis copy"; "**we never rewrite user
  data, only the generated copy that names it**".
- `safeInterpolatedLabel` — "**The user's original label still appears verbatim in row
  titles and inspector views.**"
- `analysis-hero/__tests__/copyHygiene.spec.tsx` — "**Producer-supplied strings … are
  deliberately NOT scanned — they are rendered as data, never authored here.**"

The `note` is **producer prose rendered verbatim**; the `factorLabel` is **user data**.
Both are exactly the category the estate has already decided it does not scan.

**Two questions were sharing one predicate** (trap 21): *"is Olumi authoring jargon or a
leader claim in copy it wrote?"* and *"is this producer sentence safe to render verbatim?"*
The first is the glossary's job and is **untouched at its seven other consumers**. The
second is answered in full by the guards that remain — raw-identifier, length, blank/NUL,
and the `source` token — all four re-pinned in this PR in the withholding direction.

### The scanner does NOT force the design — derived, with a contrast control

The brief asked this to be checked before choosing (a). It does not:

- **No spec scans this surface for banned terms.** Swept every file importing
  `findBannedTerm`/`containsBannedTerm` for decision-brief overlap: the only hits are three
  *production* files that import the helper, **zero spec files**. Contrast control in the
  same run returned 14 files mentioning `DecisionBrief` — non-zero, so the probe could see.
- **The one source scanner is out of scope by construction.** `registry.spec.ts` walks
  `path.resolve(__dirname, '../..')` = `src/canvas/components/pre-analysis-v3/` — a
  different subtree. `HARD_CODED_SOURCE_ALLOWLIST` is a *source-literal* allowlist and
  cannot see runtime wire data at all.

So the author was **not** forced into the current design, and (b) is not the fallback answer.

### One more finding that settles it

The gate also tested **`factorLabel`, which has ZERO production consumers.**
`DecisionBriefSection.tsx:74` renders `entry.note` alone. Rows were being withheld over a
string that never reaches the DOM.

### On the withheld-count affordance (b), deliberately not added

After this fix the remaining withholding paths are the four genuine safety guards. A
blanket "N items withheld" would **over-claim**: a row with `source: 'user_provided'` is not
a withheld assumption, it is a row this surface never claimed to show, and counting it would
describe the product falsely. Recorded as a named limit rather than built.

## 2 · Cap applied BEFORE the validity filter

`slice(0, MAX)` ran before the `source` test, so leading non-qualifying rows starved the
category — the same two valid rows rendered **2 when placed first and 0 when placed after
ten `user_provided` rows**. The same "cap empties the list" defect #840 fixed in
`readStringList` and did not fix here.

Fixed: the cap now counts **qualifying** rows. A separate `MAX_DEFAULTED_SCAN` (20× the
declared cap) bounds the *input scan*, preserving the resource bound the old `slice`
provided incidentally — a scan bound, not a validity test.

## 3 · A malformed FIRST row empties a ranked category — **behaviour deliberately KEPT, now pinned**

The prefix `break` stays, at row 0 as everywhere else.

`continue` would render row 1 as though it were row 0 — the UI asserting a **#1 that is not
the producer's #1**. What settles it is the renderer: `BriefGroup` collapses to
`PREVIEW_ITEMS = 1`, so **the only item most users ever see IS the top-ranked one**. A rank
shift would land squarely and invisibly on that single previewed row. Losing the category is
a visible absence; a shifted #1 is a confident wrongness, and this module's entire design is
to withhold rather than substitute.

The cost is real and accepted: two true sentences lost to one malformed row. It is now
**pinned by test with the reasoning in the file**, so a future flip to `continue` REDs and
has to argue with the comment. A contrast test pins `defaulted_assumptions` keeping
`continue` (an unordered set has no rank to lie about) — making the two semantics a
**decision**, not an inconsistency.

## Evidence

**RED-first**, `decisionBriefDefaultedAssumptions.spec.ts`, **40 collected BY NAME**:
16 failed / 24 passed at pristine — 10 corpus labels + 3 prose-safety + 3 cap-ordering.
Defect-3's row-0 tests **passed at pristine and are pins, not fixes** — stated rather than
presented as wins. After: **42/42** (2 added to close mutant gaps); **61/61 across the four
decision-brief spec files**; per-file collected counts 42/10/5/4, none shrank.

**Mutants** — throwaway worktree at an absolute path outside the repo root, mutating only
committed state. **Isolation proven by WRITING a sentinel** and asserting the source SHA
unchanged (inodes distinct: 715840265 vs 715935673). Restores are `git checkout HEAD -- <path>`,
never bare. Applied-check per mutant scoped to `src/`; controls read **exactly 0**.

| Mutant | Applied | Result |
|---|---|---|
| **Leading control** | 0 | GREEN 42/42 |
| M1 restore the glossary gate (loosen-for-ALL) | 1 | **RED 13** — all 10 corpus labels |
| M2 delete the raw-identifier guard | 1 | **RED 2** — label + note |
| M3 disable the note-length guard (**ADJACENT object**) | 1 | **RED 1** — over-length only; **corpus stays GREEN** |
| M4 revert cap-before-filter | 1 | **RED 3** — all ordering tests |
| M5 remove the output cap | 1 | **RED 1** — "still truncates to the producer maximum" |
| M6 `readStringList` break → continue | 1 | **RED 3** incl. the row-0 pin |
| M7 `readTopDrivers` isRecord break → continue | 1 | **RED 1** *(survived first pass — gap closed)* |
| M8 defaulted isRecord continue → break | 1 | **RED 1** *(survived first pass — gap closed)* |
| M9 swap `factorLabel`/`note` (identity binding) | 1 | **RED 26** |
| **Trailing control** | 0 | GREEN 42/42 |

**Discriminating pair for defect 1:** M1 loosens for ALL → 10 corpus tests RED; M3 loosens a
DIFFERENT object → corpus GREEN, only the over-length test RED. Binding is by identity, not
by a count another row could satisfy (M9 proves the field binding).

**Two survivors were disclosed and fixed, not explained away.** M7 and M8 both survived the
first battery because my "malformed" first rows were **records** (`{factor_label:'Broken',
sensitivity:'nope'}` and `{not:'a row'}`), so neither test ever reached the `isRecord` branch
— the *same* gap class #840 hit in `readStringList`. Two cases added leading with genuine
non-records; both mutants now RED on their own named assertions.

**Named gate — `bash scripts/ci/typecheck-gate.sh`: PASSED.** 3656/3696 files, ratchet
identical at baseline **2252**. ESLint clean on both changed files.

## What must NOT regress — re-pinned in this PR

Prose byte-identical to the wire (a test now pins typographic quotes, em dash, CJK and emoji
through the model) · over-length withheld, never truncated, and no ellipsis anywhere ·
`safeInterpolatedLabel` still not used — no substitution path exists · poison row in
`defaulted_assumptions` suppresses only itself · derived mapper guard untouched (5/5 green) ·
provenance token never leaked (`value_defaulted`/`defaulted_assumptions` absent from the VM) ·
heading "What Olumi assumed" unchanged.

## NAMED LIMITS

- **Rung: TESTED.** Not deployed, not journey-witnessed. `readDecisionBriefViewModel` is
  exercised directly; the browser witness `e2e/geometry/decisionBriefAssumed.measure.ts` was
  **not re-run** (not wired to CI, and out of scope per the brief). It carries zero glossary
  references, so this change cannot invalidate its assertions — that is a reading of its
  source, **not** an execution result.
- **The 13-label corpus is the reviewer's, not the producer's.** It proves the gate withheld
  ordinary vocabulary; it is not evidence about what CEE actually emits. Measured on the
  captures available, 0/17 distinct notes tripped the guard — so **no captured run's output
  changes**. The gain is on labels users can type, not on today's captures.
- **`MAX_DEFAULTED_SCAN` is a bound, so a valid row beyond position 200 is still lost.** A
  test pins this at 5,000 noise rows. Accepted, and written down rather than implied.
- Defect 2 remains **unreachable at today's producer** (all captures carry one `source`
  token). It is fixed because it arms silently the moment a second appears.
