### PR TITLE
fix(canvas): bounded re-ask when the boot graph read answers graph_present:false

### DIFF
--- a/src/canvas/components/ServerGraphRetryNotice.tsx
+++ b/src/canvas/components/ServerGraphRetryNotice.tsx
@@ -1,0 +1,133 @@
+/**
+ * ServerGraphRetryNotice — the honest interim state for the boot re-ask.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHY A NOTICE EXISTS HERE AT ALL, given `serverGraphHydration`'s header
+ * ═══════════════════════════════════════════════════════════════════════════
+ * That header says a non-graph answer leaves the canvas alone "with no error
+ * surfaced", because a user who is offline or whose guest scenario the server
+ * has never seen "is in a normal state and has nothing to act on". THAT RULING
+ * IS UNCHANGED AND THIS COMPONENT KEEPS IT: `notReadable`, `unavailable`,
+ * `refused` and `unusable` surface NOTHING, exactly as today.
+ *
+ * This notice covers a case that ruling did not contemplate — the one measured
+ * on 2026-08-25: a scenario that answers `absent` while the server write-back is
+ * still in flight, on a canvas that is EMPTY. There the user is NOT in a normal
+ * state and DOES have something to act on; they are looking at a blank canvas
+ * believing their work is gone, when the server holds it. Silence is what made
+ * that defect invisible.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * ⚠⚠ THE COPY — WHAT IT MAY NOT SAY, AND WHY
+ * ═══════════════════════════════════════════════════════════════════════════
+ * A sibling probe settled the storage mechanism on 2026-08-25. ALL THREE of
+ * "saved locally", "only in this browser" and "sign in to save your work" are
+ * FALSE — a guest's graph exists server-side too, and `ScenarioListPage.tsx`
+ * (lines 369-380) carries the full derivation of why the second is the worst of
+ * them (it reads as a PRIVACY claim, and nothing about it is true).
+ *
+ * So this copy makes NO claim about where the user's work lives. It is confined
+ * to what THIS CLIENT OBSERVED:
+ *
+ *  · while retrying — "Looking for your model…". True at exactly the moment it
+ *    shows, because a re-ask is scheduled. It does not promise a model exists,
+ *    does not say the work is gone, and cannot read as "loading forever":
+ *    the schedule is bounded and this string is replaced when it expires.
+ *
+ *  · on exhaustion — "Olumi did not return a model for this decision." This is
+ *    the literal, complete truth: we asked eight times over 100 seconds and got
+ *    no model. It deliberately does NOT say "your model could not be loaded",
+ *    which presupposes one exists, nor anything about saving. The action offered
+ *    is the one MEASURED to work every time: a plain reload.
+ *
+ * Neither string forecasts, gives a completion proximity, or compares — so it
+ * would pass the narration-honesty invariants if it were ever moved under them.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * ⚠ THE THREE GATES, AND WHY EACH IS LOAD-BEARING
+ * ═══════════════════════════════════════════════════════════════════════════
+ * 1. STAGE is not `idle`. Nothing to say otherwise.
+ * 2. The stage's scenario MATCHES the live one. `contextIntegrityStore`'s header
+ *    records a P0 from omitting exactly this: an unkeyed value rendered a
+ *    PREVIOUS decision's content and survived every transition. Keying at the
+ *    point of use fails safe without a clear to remember (trap 12).
+ * 3. THE CANVAS IS EMPTY. This is what keeps the notice honest rather than
+ *    alarming. If the autosave restored the user's work, it is ON SCREEN — a
+ *    strip saying "looking for your model", let alone "did not return a model",
+ *    would be frightening and false-to-experience. It also makes the notice
+ *    SELF-CLEARING: the moment a late graph merges, `nodes.length` is non-zero
+ *    and this unmounts, with no store write needed to retract it.
+ */
+import { useCanvasStore } from '../store'
+import { useServerGraphRetryStore } from '../stores/serverGraphRetryStore'
+import { typography } from '../../styles/typography'
+
+export const SERVER_GRAPH_RETRY_NOTICE_TESTID = 'server-graph-retry-notice'
+
+/** Present tense, about this client's own behaviour. No storage claim. */
+export const SERVER_GRAPH_RETRY_LOOKING_COPY = 'Looking for your model…'
+
+/** What actually happened, stated completely. Presupposes nothing. */
+export const SERVER_GRAPH_RETRY_EXHAUSTED_COPY =
+  'Olumi did not return a model for this decision.'
+
+/** The action measured to recover it every time. */
+export const SERVER_GRAPH_RETRY_ACTION_COPY = 'Reload the page'
+
+export function ServerGraphRetryNotice(): JSX.Element | null {
+  const stage = useServerGraphRetryStore((s) => s.stage)
+  const noticeScenarioId = useServerGraphRetryStore((s) => s.scenarioId)
+  const currentScenarioId = useCanvasStore((s) => s.currentScenarioId)
+  const nodeCount = useCanvasStore((s) => s.nodes.length)
+
+  // GATE 1 — nothing to say.
+  if (stage === 'idle') return null
+
+  // GATE 2 — never another decision's notice. Both ids must be present AND
+  // equal; a null on either side is "cannot attribute", which renders nothing.
+  if (
+    noticeScenarioId === null ||
+    currentScenarioId === null ||
+    currentScenarioId === undefined ||
+    noticeScenarioId !== currentScenarioId
+  ) {
+    return null
+  }
+
+  // GATE 3 — the user's work is on screen; there is nothing to reassure about.
+  if (nodeCount > 0) return null
+
+  const exhausted = stage === 'exhausted'
+
+  return (
+    <div
+      data-testid={SERVER_GRAPH_RETRY_NOTICE_TESTID}
+      data-stage={stage}
+      role="status"
+      aria-live="polite"
+      className="pointer-events-auto absolute left-1/2 top-3 z-10 flex -translate-x-1/2 items-center gap-2 rounded-full border border-panel-border bg-panel px-3 py-1.5 shadow-sm"
+    >
+      {!exhausted && (
+        <div
+          className="h-3.5 w-3.5 flex-none animate-spin rounded-full border-2 border-text-light border-t-transparent motion-reduce:animate-none"
+          aria-hidden="true"
+        />
+      )}
+      <span className={`${typography.panelMeta} text-text-body`}>
+        {exhausted ? SERVER_GRAPH_RETRY_EXHAUSTED_COPY : SERVER_GRAPH_RETRY_LOOKING_COPY}
+      </span>
+      {exhausted && (
+        <button
+          type="button"
+          data-testid={`${SERVER_GRAPH_RETRY_NOTICE_TESTID}-action`}
+          onClick={() => {
+            window.location.reload()
+          }}
+          className={`${typography.panelMeta} rounded text-info underline hover:text-text-body focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+        >
+          {SERVER_GRAPH_RETRY_ACTION_COPY}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/canvas/components/__tests__/ServerGraphRetryNotice.spec.tsx
+++ b/src/canvas/components/__tests__/ServerGraphRetryNotice.spec.tsx
@@ -1,0 +1,191 @@
+/**
+ * ServerGraphRetryNotice — the honest interim state, and its three gates.
+ *
+ * Each gate is pinned SEPARATELY and by identity, so a mutant that removes one
+ * reds exactly one test rather than the file. That separation is what makes the
+ * discriminating mutant pair possible: loosening the scenario gate must red the
+ * "another decision" test and LEAVE the empty-canvas test green, and vice versa.
+ *
+ * The copy tests are not decoration. A sibling probe settled on 2026-08-25 that
+ * "saved locally", "only in this browser" and "sign in to save your work" are
+ * all FALSE for a guest, whose graph also exists server-side. A notice shown at
+ * precisely the moment a user fears their work is gone is the worst possible
+ * place to assert something untrue about where it lives, so the banned claims
+ * are asserted ABSENT rather than left to review.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import {
+  ServerGraphRetryNotice,
+  SERVER_GRAPH_RETRY_NOTICE_TESTID,
+  SERVER_GRAPH_RETRY_LOOKING_COPY,
+  SERVER_GRAPH_RETRY_EXHAUSTED_COPY,
+  SERVER_GRAPH_RETRY_ACTION_COPY,
+} from '../ServerGraphRetryNotice'
+import { useServerGraphRetryStore } from '../../stores/serverGraphRetryStore'
+import { useCanvasStore } from '../../store'
+
+const A = '11111111-2222-4333-8444-555555555555'
+const B = '22222222-3333-4444-8555-666666666666'
+
+function setCanvas(scenarioId: string | null, nodeCount: number): void {
+  useCanvasStore.setState({
+    currentScenarioId: scenarioId,
+    nodes: Array.from({ length: nodeCount }, (_, i) => ({
+      id: `n${i}`,
+      position: { x: 0, y: 0 },
+      data: {},
+    })),
+  } as never)
+}
+
+beforeEach(() => {
+  useServerGraphRetryStore.getState().clear()
+  setCanvas(A, 0)
+})
+
+describe('ServerGraphRetryNotice — what it says', () => {
+  it('says it is LOOKING while retrying, and offers no action yet', () => {
+    useServerGraphRetryStore.getState().setRetryStage({ scenarioId: A, stage: 'retrying' })
+    render(<ServerGraphRetryNotice />)
+
+    const el = screen.getByTestId(SERVER_GRAPH_RETRY_NOTICE_TESTID)
+    expect(el).toHaveTextContent(SERVER_GRAPH_RETRY_LOOKING_COPY)
+    expect(el.getAttribute('data-stage')).toBe('retrying')
+    expect(
+      screen.queryByTestId(`${SERVER_GRAPH_RETRY_NOTICE_TESTID}-action`),
+    ).toBeNull()
+  })
+
+  it('states what happened on exhaustion and offers the reload that works', () => {
+    useServerGraphRetryStore.getState().setRetryStage({ scenarioId: A, stage: 'exhausted' })
+    render(<ServerGraphRetryNotice />)
+
+    const el = screen.getByTestId(SERVER_GRAPH_RETRY_NOTICE_TESTID)
+    expect(el).toHaveTextContent(SERVER_GRAPH_RETRY_EXHAUSTED_COPY)
+    expect(el.getAttribute('data-stage')).toBe('exhausted')
+    expect(
+      screen.getByTestId(`${SERVER_GRAPH_RETRY_NOTICE_TESTID}-action`),
+    ).toHaveTextContent(SERVER_GRAPH_RETRY_ACTION_COPY)
+  })
+
+  it('is a polite live region, never an alert', () => {
+    useServerGraphRetryStore.getState().setRetryStage({ scenarioId: A, stage: 'retrying' })
+    render(<ServerGraphRetryNotice />)
+
+    const el = screen.getByTestId(SERVER_GRAPH_RETRY_NOTICE_TESTID)
+    expect(el.getAttribute('role')).toBe('status')
+    expect(el.getAttribute('aria-live')).toBe('polite')
+  })
+})
+
+describe('ServerGraphRetryNotice — what it must NEVER say', () => {
+  /**
+   * All three are measured falsehoods for a guest. `ScenarioListPage.tsx`
+   * (369-380) carries the derivation; "only in this browser" is the worst
+   * because it reads as a privacy claim and nothing about it is true.
+   */
+  it.each([
+    'saved locally',
+    'only in this browser',
+    'sign in to save',
+    'your work is gone',
+    'lost',
+  ])('never claims %s', (banned) => {
+    const all = [
+      SERVER_GRAPH_RETRY_LOOKING_COPY,
+      SERVER_GRAPH_RETRY_EXHAUSTED_COPY,
+      SERVER_GRAPH_RETRY_ACTION_COPY,
+    ]
+      .join(' ')
+      .toLowerCase()
+    expect(all).not.toContain(banned)
+  })
+
+  /**
+   * The retrying string must not read as an unbounded wait. It is present-tense
+   * about what the client is doing and carries no forecast, no "almost there",
+   * and no elapsed/remaining time — the same register the narration-honesty
+   * invariants enforce elsewhere.
+   */
+  it.each(['almost', 'usually', 'soon', 'any moment', 'shortly'])(
+    'makes no completion-proximity claim (%s)',
+    (banned) => {
+      expect(SERVER_GRAPH_RETRY_LOOKING_COPY.toLowerCase()).not.toContain(banned)
+    },
+  )
+})
+
+describe('ServerGraphRetryNotice — GATE 1: stage', () => {
+  it('renders NOTHING when idle', () => {
+    render(<ServerGraphRetryNotice />)
+    expect(screen.queryByTestId(SERVER_GRAPH_RETRY_NOTICE_TESTID)).toBeNull()
+  })
+})
+
+describe('ServerGraphRetryNotice — GATE 2: scenario identity', () => {
+  /**
+   * The P0 `contextIntegrityStore`'s header records, in this surface's shape:
+   * a stage recorded for decision A must never render over decision B.
+   *
+   * Binds by IDENTITY — the stage is present and the canvas is empty, so every
+   * OTHER gate is satisfied. Only the id differs, which is what makes this test
+   * sensitive to the id comparison and to nothing else.
+   */
+  it('never renders for another decision', () => {
+    useServerGraphRetryStore.getState().setRetryStage({ scenarioId: A, stage: 'exhausted' })
+    setCanvas(B, 0)
+
+    render(<ServerGraphRetryNotice />)
+    expect(screen.queryByTestId(SERVER_GRAPH_RETRY_NOTICE_TESTID)).toBeNull()
+  })
+
+  it('renders for the matching decision — the positive control for the gate above', () => {
+    useServerGraphRetryStore.getState().setRetryStage({ scenarioId: A, stage: 'exhausted' })
+    setCanvas(A, 0)
+
+    render(<ServerGraphRetryNotice />)
+    expect(screen.getByTestId(SERVER_GRAPH_RETRY_NOTICE_TESTID)).toBeInTheDocument()
+  })
+
+  it('never renders when the canvas has no scenario at all', () => {
+    useServerGraphRetryStore.getState().setRetryStage({ scenarioId: A, stage: 'retrying' })
+    setCanvas(null, 0)
+
+    render(<ServerGraphRetryNotice />)
+    expect(screen.queryByTestId(SERVER_GRAPH_RETRY_NOTICE_TESTID)).toBeNull()
+  })
+})
+
+describe('ServerGraphRetryNotice — GATE 3: the canvas is empty', () => {
+  /**
+   * If the autosave restored the user's work it is ON SCREEN, and a strip
+   * saying "Olumi did not return a model" over a populated canvas would be
+   * frightening and false to experience.
+   *
+   * This is also what makes the notice SELF-CLEARING: when a late graph merges,
+   * node count goes non-zero and this unmounts with no store write to retract.
+   */
+  it('never renders over a canvas that already has the work on screen', () => {
+    useServerGraphRetryStore.getState().setRetryStage({ scenarioId: A, stage: 'exhausted' })
+    setCanvas(A, 14)
+
+    render(<ServerGraphRetryNotice />)
+    expect(screen.queryByTestId(SERVER_GRAPH_RETRY_NOTICE_TESTID)).toBeNull()
+  })
+
+  it('DISAPPEARS when the late graph lands — the fix, seen from the surface', () => {
+    useServerGraphRetryStore.getState().setRetryStage({ scenarioId: A, stage: 'retrying' })
+    setCanvas(A, 0)
+
+    const { rerender } = render(<ServerGraphRetryNotice />)
+    expect(screen.getByTestId(SERVER_GRAPH_RETRY_NOTICE_TESTID)).toBeInTheDocument()
+
+    // The write-back lands and the merge applies it.
+    setCanvas(A, 11)
+    rerender(<ServerGraphRetryNotice />)
+    expect(screen.queryByTestId(SERVER_GRAPH_RETRY_NOTICE_TESTID)).toBeNull()
+  })
+})

--- a/src/canvas/hooks/__tests__/useServerGraphHydration.absentRetry.spec.tsx
+++ b/src/canvas/hooks/__tests__/useServerGraphHydration.absentRetry.spec.tsx
@@ -1,0 +1,227 @@
+/**
+ * useServerGraphHydration — THE RETURNING-GUEST WRITE-BACK WINDOW.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE DEFECT THIS PINS (journey-witnessed 2026-08-25, build `55807813`)
+ * ═══════════════════════════════════════════════════════════════════════════
+ * The server write-back completes 30–90s AFTER the model first appears on
+ * screen. A guest who closes the tab and returns inside that window gets
+ * `graph_present:false`, and because the boot read fires EXACTLY ONCE per
+ * scenario id, the canvas stays empty for the life of the page. Nothing is
+ * lost — the client stops looking. A plain reload recovers it every time.
+ *
+ * Measured, 5 trials: restart at +15s → 0 nodes, `graph_present:false`, no
+ * re-ask; restart at +180s → 14 and 11 nodes immediately. In one trial the
+ * server held the graph by +47s while the canvas sat at 0 and never re-asked.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * BOTH DIRECTIONS — the trap here is obvious and it is the one to guard
+ * ═══════════════════════════════════════════════════════════════════════════
+ * A scenario that WILL populate must render without a manual reload; a
+ * scenario that NEVER populates must TERMINATE rather than spin. An unbounded
+ * poll against a scenario that will never populate is a worse defect than the
+ * one being fixed, so the CALL COUNT is asserted, not just the eventual
+ * render — a test that only proves it eventually renders cannot see a runaway.
+ *
+ * And a 404 must behave EXACTLY as today: no retry, no notice, no change.
+ *
+ * ⚠ ASSERTIONS BIND BY IDENTITY. Every count check is paired with the
+ * scenario id the call was made for, so a retry aimed at a DIFFERENT scenario
+ * cannot satisfy a bare `toHaveBeenCalledTimes`.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+import { useServerGraphHydration } from '../useServerGraphHydration'
+import * as hydration from '../../hydrate/serverGraphHydration'
+import type { HydrationOutcome } from '../../hydrate/serverGraphHydration'
+
+const A = '11111111-2222-4333-8444-555555555555'
+const B = '22222222-3333-4444-8555-666666666666'
+
+let user: { id: string } | null = { id: 'guest' }
+vi.mock('../../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user }),
+}))
+
+/** Calls made FOR a given scenario id — identity binding, never a bare count. */
+function callsFor(
+  spy: { mock: { calls: unknown[][] } },
+  scenarioId: string,
+): unknown[][] {
+  return spy.mock.calls.filter((c) => c[0] === scenarioId)
+}
+
+function spyHydrate() {
+  return vi.spyOn(hydration, 'hydrateCanvasFromServer')
+}
+
+let spy: ReturnType<typeof spyHydrate>
+
+beforeEach(() => {
+  user = { id: 'guest' }
+  vi.useFakeTimers()
+  spy = spyHydrate()
+})
+
+/**
+ * ⚠ NO `vi.runOnlyPendingTimers()` HERE, AND THE REASON IS AN INSTRUMENT DEFECT
+ * THIS SPEC ALREADY HIT ONCE.
+ *
+ * `tests/setup/rtl.ts:48` calls `vi.useRealTimers()` in a global `afterEach`
+ * that runs BEFORE this file's. A teardown that assumes the fake clock is still
+ * installed therefore THROWS — and vitest attributes that throw to the test that
+ * just finished, so every case in the file reds regardless of its body.
+ *
+ * That is exactly how it presented: 10/10 red on the first run, INCLUDING the
+ * 404 control whose body had in fact passed (its debug log showed the single
+ * call). A RED-first run where the control also reds is reporting on the
+ * harness, not on the code — CLAUDE.md trap 20's uniformity heuristic.
+ * `useRealTimers` is idempotent and safe from either state.
+ */
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+/** Let the effect's promise chain settle without advancing the clock. */
+async function flush(): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0)
+  })
+}
+
+/** Advance the fake clock inside `act` so React state writes are captured. */
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+  })
+}
+
+describe('useServerGraphHydration — the write-back window (populates late)', () => {
+  /**
+   * THE RED. At pristine this asserts 1 > 1 and fails: the hook fires once,
+   * records the scenario id in `attemptedRef`, and never re-asks.
+   */
+  it('RE-ASKS for THIS scenario after graph_present:false and hydrates the graph that lands late', async () => {
+    spy.mockResolvedValueOnce('absent').mockResolvedValue('merged')
+
+    renderHook(() => useServerGraphHydration(A))
+    await flush()
+    expect(callsFor(spy, A)).toHaveLength(1)
+
+    // The measured window is 30–90s. Cover it with margin.
+    await advance(120_000)
+
+    const forA = callsFor(spy, A)
+    expect(forA.length).toBeGreaterThan(1)
+    // IDENTITY: the second ask was for A, not for some other scenario.
+    expect(forA[1][0]).toBe(A)
+  })
+
+  it('STOPS re-asking once a graph arrives — a success is terminal', async () => {
+    spy.mockResolvedValueOnce('absent').mockResolvedValue('merged')
+
+    renderHook(() => useServerGraphHydration(A))
+    await flush()
+    await advance(120_000)
+
+    const afterSuccess = callsFor(spy, A).length
+    await advance(600_000)
+    expect(callsFor(spy, A)).toHaveLength(afterSuccess)
+  })
+})
+
+describe('useServerGraphHydration — the never-populates case (must TERMINATE)', () => {
+  /**
+   * The both-directions twin. A scenario whose graph never lands must stop.
+   * The count is asserted at a bound, and then asserted AGAIN after ten more
+   * minutes of clock — a schedule that merely backs off would pass the first
+   * assertion and fail the second.
+   */
+  it('TERMINATES on a scenario that never populates, and the call count is BOUNDED', async () => {
+    spy.mockResolvedValue('absent')
+
+    renderHook(() => useServerGraphHydration(A))
+    await flush()
+    await advance(300_000)
+
+    const settled = callsFor(spy, A).length
+    expect(settled).toBeGreaterThan(1)
+    expect(settled).toBeLessThanOrEqual(12)
+
+    // TEN MORE MINUTES. A bounded schedule has stopped; a backoff has not.
+    await advance(600_000)
+    expect(callsFor(spy, A)).toHaveLength(settled)
+  })
+})
+
+describe('useServerGraphHydration — 404 is UNCHANGED (byte-identical to today)', () => {
+  /**
+   * `notReadable` is the 404 union: absent ∪ not-yours ∪ oracle-unresolvable.
+   * It is a stable answer, not a window. Retrying it would spend the shared
+   * per-IP read budget to earn the same refusal three more times.
+   */
+  it('makes EXACTLY ONE call for a 404 and never re-asks', async () => {
+    spy.mockResolvedValue('notReadable')
+
+    renderHook(() => useServerGraphHydration(A))
+    await flush()
+    expect(callsFor(spy, A)).toHaveLength(1)
+
+    await advance(600_000)
+    expect(callsFor(spy, A)).toHaveLength(1)
+  })
+
+  /**
+   * The DISCRIMINATING half. If the guard were "retry on anything that is not
+   * a graph", this test and the 404 test would both pass while the product
+   * hammered a dead server. Each stable non-absent answer is pinned by NAME.
+   */
+  it.each<HydrationOutcome>(['refused', 'unusable', 'unavailable', 'mergeRefused'])(
+    'makes EXACTLY ONE call for %s and never re-asks',
+    async (outcome) => {
+      spy.mockResolvedValue(outcome)
+
+      renderHook(() => useServerGraphHydration(A))
+      await flush()
+      expect(callsFor(spy, A)).toHaveLength(1)
+
+      await advance(600_000)
+      expect(callsFor(spy, A)).toHaveLength(1)
+    },
+  )
+})
+
+describe('useServerGraphHydration — the retry follows the live scenario', () => {
+  it('ABANDONS the retry when the scenario changes, and never asks for the old id again', async () => {
+    spy.mockResolvedValue('absent')
+
+    const { rerender } = renderHook(({ id }) => useServerGraphHydration(id), {
+      initialProps: { id: A },
+    })
+    await flush()
+    expect(callsFor(spy, A)).toHaveLength(1)
+
+    rerender({ id: B })
+    await flush()
+    const aAtSwitch = callsFor(spy, A).length
+
+    await advance(600_000)
+    // A's schedule is aborted; B gets its own.
+    expect(callsFor(spy, A)).toHaveLength(aAtSwitch)
+    expect(callsFor(spy, B).length).toBeGreaterThan(0)
+  })
+
+  it('ABANDONS the retry on unmount', async () => {
+    spy.mockResolvedValue('absent')
+
+    const { unmount } = renderHook(() => useServerGraphHydration(A))
+    await flush()
+    const atUnmount = callsFor(spy, A).length
+    unmount()
+
+    await advance(600_000)
+    expect(callsFor(spy, A)).toHaveLength(atUnmount)
+  })
+})

--- a/src/canvas/hooks/useServerGraphHydration.ts
+++ b/src/canvas/hooks/useServerGraphHydration.ts
@@ -18,12 +18,28 @@
  * A→B hydrates B while a re-render of A does not re-request. An in-flight read
  * is aborted when the id changes: the answer would describe the previous
  * scenario, and `hydrateCanvasFromServer` refuses it anyway.
+ *
+ * ⚠ "ONCE PER SCENARIO" HAD A MEASURED COST, AND IT IS WHY THE RE-ASK BELOW
+ * EXISTS. The server write-back completes 30–90s AFTER the model first appears
+ * on screen, so a guest who returns inside that window got `graph_present:false`
+ * — and because the read fired exactly once, the canvas stayed empty FOR THE
+ * LIFE OF THE PAGE while their model sat intact on the server (journey-witnessed
+ * 2026-08-25, 5 trials, build `55807813`; a plain reload recovered it every
+ * time). `absent` is the ONE outcome that is a "not yet" rather than an answer,
+ * so it — and only it — arms a bounded re-ask. Every other outcome, the 404
+ * included, still fires exactly once and behaves byte-identically to before.
+ * See `hydrate/absentGraphRetry.ts` for the schedule and the allow-list.
  */
 
 import { useEffect, useRef } from 'react'
 import { useCanvasStore } from '../store'
 import { useAuth } from '../../contexts/AuthContext'
 import { hydrateCanvasFromServer } from '../hydrate/serverGraphHydration'
+import {
+  runAbsentGraphRetrySchedule,
+  waitForRetry,
+} from '../hydrate/absentGraphRetry'
+import { useServerGraphRetryStore } from '../stores/serverGraphRetryStore'
 import { logger } from '../../lib/logger'
 
 export function useServerGraphHydration(scenarioIdFromRoute?: string | null): void {
@@ -45,16 +61,60 @@ export function useServerGraphHydration(scenarioIdFromRoute?: string | null): vo
     const controller = new AbortController()
     let settled = false
 
+    // Any stage from a previous scenario stops describing this one the moment
+    // we begin. Cleared here rather than on unmount so a route change A→B never
+    // leaves B looking at A's notice even for a frame.
+    useServerGraphRetryStore.getState().clear()
+
     // Fire-and-forget by design: hydration is an improvement on what is already
     // on screen, never a precondition for it. `hydrateCanvasFromServer` never
     // rejects, so the canvas cannot be left mid-boot by a failure here.
     void hydrateCanvasFromServer(scenarioId, {
       userId: user?.id ?? null,
       signal: controller.signal,
-    }).then((outcome) => {
-      settled = true
-      logger.debug('server_graph_hydration.outcome', { scenarioId, outcome })
     })
+      .then(async (outcome) => {
+        logger.debug('server_graph_hydration.outcome', { scenarioId, outcome })
+
+        // ── THE RETURNING-GUEST WINDOW ────────────────────────────────────
+        // `absent` alone means "exists, no graph YET". Everything else is a
+        // settled answer and returns here unchanged, having cost exactly one
+        // request — which is what keeps the 404 path byte-identical.
+        if (outcome !== 'absent') return outcome
+
+        const retry = await runAbsentGraphRetrySchedule({
+          scenarioId,
+          userId: user?.id ?? null,
+          signal: controller.signal,
+          hydrate: hydrateCanvasFromServer,
+          wait: waitForRetry,
+          // The stage is keyed by scenario, so a late write cannot describe a
+          // decision the user has since left (`serverGraphRetryStore` header).
+          onStage: (stage) =>
+            useServerGraphRetryStore.getState().setRetryStage({ scenarioId, stage }),
+        })
+
+        // A graph arrived, or the scenario turned out to be something other
+        // than "not written back yet". Either way there is nothing to say, so
+        // retract whatever the schedule put up. `exhausted` is deliberately NOT
+        // cleared — that stage IS the honest terminal message.
+        //
+        // ⚠ GATED ON THIS EFFECT STILL OWNING THE CANVAS. Without the abort
+        // check this is a RACE, and StrictMode's dev double-mount hits it every
+        // time: effect 1 is torn down, its schedule returns `'aborted'`, and its
+        // clear would wipe the `'retrying'` stage EFFECT 2 had already armed —
+        // leaving a re-asking canvas with no notice at all. The replacement
+        // effect clears on entry, so an aborted chain has nothing to tidy.
+        if (!controller.signal.aborted && retry !== 'exhausted') {
+          useServerGraphRetryStore.getState().clear()
+        }
+
+        logger.debug('server_graph_hydration.absent_retry', { scenarioId, retry })
+        return outcome
+      })
+      .finally(() => {
+        settled = true
+      })
 
     return () => {
       controller.abort()

--- a/src/canvas/hydrate/__tests__/absentGraphRetry.spec.ts
+++ b/src/canvas/hydrate/__tests__/absentGraphRetry.spec.ts
@@ -1,0 +1,254 @@
+/**
+ * absentGraphRetry — THE BOUNDED RE-ASK, proven on the extracted core.
+ *
+ * Pins the four properties that make this retry safe, without React, so each is
+ * provable rather than inferred from a rendered surface:
+ *
+ *  WINDOW    · a scenario that answers `absent` and then populates is hydrated,
+ *              with no reload. This is the defect being fixed.
+ *  BOUNDED   · a scenario that NEVER populates TERMINATES. The read COUNT is
+ *              asserted, not just the eventual return — a test that only proves
+ *              it stops eventually cannot see a schedule that grew a tail.
+ *  ALLOW-LIST· ONLY `absent` is re-asked. Every other outcome stops the
+ *              schedule on its FIRST answer, pinned BY NAME so a future outcome
+ *              cannot join the retry set silently.
+ *  HONESTY   · the surface is told `retrying` only while re-asking, and
+ *              `exhausted` only when the bound expires. It is told NOTHING on
+ *              success, on a terminal answer, or on abort.
+ *
+ * ⚠ NO FAKE TIMERS. The `wait` seam is injected, so the schedule runs at full
+ * speed with the DELAYS OBSERVED rather than elapsed — the pattern
+ * `useProvisionalAnalysisDelivery.spec.ts` sets out: a fake-timer harness proves
+ * the loop ran; injecting the clock proves WHAT IT ASKED FOR.
+ */
+
+import { describe, it, expect } from 'vitest'
+
+import {
+  runAbsentGraphRetrySchedule,
+  ABSENT_GRAPH_RETRY_DELAYS_MS,
+  ABSENT_GRAPH_RETRY_DEADLINE_MS,
+  type AbsentGraphRetryStage,
+} from '../absentGraphRetry'
+import type { HydrationOutcome } from '../serverGraphHydration'
+
+const SCENARIO = 'a6ccf5cf-aab0-4f01-b889-e0d6c072067c'
+const OTHER = 'b7ddf6d0-bbc1-4012-c990-f1e7d1830178'
+
+/**
+ * ⚠ `hydrate` IS TYPED AS THE SEAM, NOT AS `ReturnType<typeof vi.fn>`.
+ * That widens to `Mock<any[], unknown>`, which the narrower inferred mock is not
+ * assignable to — the typecheck gate caught it as a genuine new error. Naming
+ * the real signature also removes the `as never` this file used to need at the
+ * call site, so a drift in `AbsentGraphRetryDeps` reds `tsc` here.
+ */
+interface Harness {
+  readonly waits: number[]
+  readonly asked: string[]
+  readonly stages: AbsentGraphRetryStage[]
+  readonly wait: (ms: number, signal: AbortSignal) => Promise<void>
+  readonly hydrate: (scenarioId: string) => Promise<HydrationOutcome>
+  readonly onStage: (s: AbsentGraphRetryStage) => void
+}
+
+function harness(outcomes: HydrationOutcome[] | HydrationOutcome): Harness {
+  const waits: number[] = []
+  const asked: string[] = []
+  const stages: AbsentGraphRetryStage[] = []
+  const queue = Array.isArray(outcomes) ? [...outcomes] : null
+  const constant = Array.isArray(outcomes) ? null : outcomes
+
+  const hydrate = async (scenarioId: string): Promise<HydrationOutcome> => {
+    asked.push(scenarioId)
+    if (constant !== null) return constant
+    return queue!.length > 0 ? queue!.shift()! : 'absent'
+  }
+
+  return {
+    waits,
+    asked,
+    stages,
+    hydrate,
+    onStage: (s) => stages.push(s),
+    wait: async (ms, signal) => {
+      waits.push(ms)
+      if (signal.aborted) throw new Error('aborted')
+    },
+  }
+}
+
+function deps(h: Harness, extra: Record<string, unknown> = {}) {
+  return {
+    scenarioId: SCENARIO,
+    userId: null,
+    signal: new AbortController().signal,
+    hydrate: h.hydrate,
+    wait: h.wait,
+    onStage: h.onStage,
+    ...extra,
+  }
+}
+
+describe('absentGraphRetry — the schedule itself', () => {
+  it('is strictly increasing, and its deadline IS its last delay', () => {
+    const d = ABSENT_GRAPH_RETRY_DELAYS_MS
+    expect(d.length).toBeGreaterThan(0)
+    for (let i = 1; i < d.length; i++) {
+      expect(d[i]).toBeGreaterThan(d[i - 1])
+    }
+    expect(ABSENT_GRAPH_RETRY_DEADLINE_MS).toBe(d[d.length - 1])
+  })
+
+  /**
+   * BUDGET. CEE's `read` tier is 90 rpm keyed per CLIENT IP and shared with
+   * `useProvisionalAnalysisDelivery` and draft recovery. This asserts the spend
+   * so a later "just poll every second" fails a test rather than a rate limit.
+   */
+  it('covers the measured 30–90s write-back window without exceeding 10 reads', () => {
+    expect(ABSENT_GRAPH_RETRY_DEADLINE_MS).toBeGreaterThanOrEqual(90_000)
+    expect(ABSENT_GRAPH_RETRY_DELAYS_MS.length).toBeLessThanOrEqual(10)
+  })
+})
+
+describe('absentGraphRetry — WINDOW: the scenario that populates late', () => {
+  it('re-asks and returns "hydrated" when a graph arrives on a later attempt', async () => {
+    const h = harness(['absent', 'absent', 'merged'])
+    const outcome = await runAbsentGraphRetrySchedule(deps(h))
+
+    expect(outcome).toBe('hydrated')
+    // IDENTITY: every re-ask was for THIS scenario, never a bare count.
+    expect(h.asked).toEqual([SCENARIO, SCENARIO, SCENARIO])
+  })
+
+  it('accepts "unchanged" as a graph — the server answered, there was nothing to apply', async () => {
+    const h = harness(['absent', 'unchanged'])
+    expect(await runAbsentGraphRetrySchedule(deps(h))).toBe('hydrated')
+    expect(h.asked).toHaveLength(2)
+  })
+
+  it('SAYS NOTHING to the surface beyond "retrying" when it succeeds', async () => {
+    const h = harness(['absent', 'merged'])
+    await runAbsentGraphRetrySchedule(deps(h))
+    expect(h.stages).toEqual(['retrying'])
+  })
+
+  it('asks for the delays the schedule declares, in order', async () => {
+    const h = harness('absent')
+    await runAbsentGraphRetrySchedule(deps(h))
+
+    // Observed gaps must reconstruct the declared absolute schedule.
+    const absolute: number[] = []
+    h.waits.reduce((acc, gap) => {
+      const next = acc + gap
+      absolute.push(next)
+      return next
+    }, 0)
+    expect(absolute).toEqual([...ABSENT_GRAPH_RETRY_DELAYS_MS])
+  })
+})
+
+describe('absentGraphRetry — BOUNDED: the scenario that never populates', () => {
+  it('TERMINATES with "exhausted" after exactly the declared number of reads', async () => {
+    const h = harness('absent')
+    const outcome = await runAbsentGraphRetrySchedule(deps(h))
+
+    expect(outcome).toBe('exhausted')
+    expect(h.asked).toHaveLength(ABSENT_GRAPH_RETRY_DELAYS_MS.length)
+    expect(h.asked.every((id) => id === SCENARIO)).toBe(true)
+  })
+
+  it('reports "retrying" then "exhausted", in that order and nothing else', async () => {
+    const h = harness('absent')
+    await runAbsentGraphRetrySchedule(deps(h))
+    expect(h.stages).toEqual(['retrying', 'exhausted'])
+  })
+})
+
+describe('absentGraphRetry — ALLOW-LIST: only `absent` is ever re-asked', () => {
+  /**
+   * The both-directions guard. Each stable outcome stops the schedule on its
+   * FIRST answer. Pinned by NAME rather than by "anything that is not absent",
+   * so adding an outcome to `HydrationOutcome` forces a deliberate decision.
+   *
+   * `notReadable` is the 404 and is the one the brief singles out: it must
+   * behave byte-identically to before this change.
+   */
+  it.each<HydrationOutcome>([
+    'notReadable',
+    'refused',
+    'unusable',
+    'unavailable',
+    'mergeRefused',
+    'skipped',
+  ])('stops on %s after ONE re-ask and returns "terminal"', async (outcome) => {
+    const h = harness(outcome)
+    const result = await runAbsentGraphRetrySchedule(deps(h))
+
+    expect(result).toBe('terminal')
+    // ONE read, not the full schedule — the answer was settled, not "not yet".
+    expect(h.asked).toEqual([SCENARIO])
+    // And it tells the surface nothing terminal — silence, exactly as today.
+    expect(h.stages).toEqual(['retrying'])
+  })
+
+  /**
+   * The CONTRAST that makes the table above mean something. Run in the same
+   * suite with the same harness, `absent` consumes the WHOLE schedule — so a
+   * "stops after one read" result is a property of the outcome under test, not
+   * of a harness that stopped early for its own reasons.
+   */
+  it('CONTRAST — `absent` alone consumes the whole schedule', async () => {
+    const h = harness('absent')
+    const result = await runAbsentGraphRetrySchedule(deps(h))
+
+    expect(result).toBe('exhausted')
+    expect(h.asked.length).toBe(ABSENT_GRAPH_RETRY_DELAYS_MS.length)
+    expect(h.asked.length).toBeGreaterThan(1)
+  })
+})
+
+describe('absentGraphRetry — abort', () => {
+  it('returns "aborted" and sets NO stage when the signal is already aborted', async () => {
+    const h = harness('absent')
+    const c = new AbortController()
+    c.abort()
+
+    const outcome = await runAbsentGraphRetrySchedule(deps(h, { signal: c.signal }))
+
+    expect(outcome).toBe('aborted')
+    expect(h.stages).toEqual([])
+    expect(h.asked).toEqual([])
+  })
+
+  it('stops mid-schedule when the signal aborts, and never reports "exhausted"', async () => {
+    const h = harness('absent')
+    const c = new AbortController()
+    const wait = async (ms: number, signal: AbortSignal) => {
+      h.waits.push(ms)
+      if (h.waits.length === 3) c.abort()
+      if (signal.aborted) throw new Error('aborted')
+    }
+
+    const outcome = await runAbsentGraphRetrySchedule(
+      deps(h, { signal: c.signal, wait }),
+    )
+
+    expect(outcome).toBe('aborted')
+    expect(h.stages).toEqual(['retrying'])
+    expect(h.asked.length).toBeLessThan(ABSENT_GRAPH_RETRY_DELAYS_MS.length)
+  })
+})
+
+describe('absentGraphRetry — identity', () => {
+  /**
+   * The discriminating half of the identity binding: the schedule re-asks for
+   * the scenario it was GIVEN. A mutant that re-asks a hardcoded different id
+   * satisfies every bare call-count assertion and fails this one.
+   */
+  it('re-asks the scenario it was given, never another', async () => {
+    const h = harness('absent')
+    await runAbsentGraphRetrySchedule(deps(h, { scenarioId: OTHER }))
+    expect(h.asked.every((id) => id === OTHER)).toBe(true)
+    expect(h.asked).not.toContain(SCENARIO)
+  })
+})

--- a/src/canvas/hydrate/absentGraphRetry.ts
+++ b/src/canvas/hydrate/absentGraphRetry.ts
@@ -1,0 +1,243 @@
+/**
+ * absentGraphRetry — the bounded re-ask for a graph the server has not written
+ * back YET.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE DEFECT (journey-witnessed 2026-08-25, 5 trials, build `55807813`)
+ * ═══════════════════════════════════════════════════════════════════════════
+ * `useServerGraphHydration` issues EXACTLY ONE `POST /bff/cee/scenarios/:id/graph`
+ * per scenario id. If that answer carries `graph_present:false` the canvas stays
+ * empty for the life of the page — there is no retry.
+ *
+ * That collides with a second measured fact: the server write-back completes
+ * 30–90s AFTER the model first appears on screen. A guest who closes the tab and
+ * returns inside that window is told nothing, shown nothing, and left with a
+ * blank canvas while their model is intact on the server and lands moments
+ * later. Restart at +15s → 0 nodes, twice. Restart at +180s → 14 and 11 nodes,
+ * immediately. In one trial the server held the graph by +47s while the canvas
+ * sat at 0 and never re-asked. A plain reload recovers it every time.
+ *
+ * NOTHING IS LOST. THE CLIENT STOPS LOOKING. This module makes it keep looking,
+ * for a bounded time, and then tell the truth.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHY HERE AND NOT IN THE ADAPTER OR THE ORCHESTRATOR
+ * ═══════════════════════════════════════════════════════════════════════════
+ * `fetchScenarioGraph` already retries — but only a 503, and only because that
+ * is a TRANSPORT answer. Adding an `absent` retry there would change the
+ * semantics for every caller: `useProvisionalAnalysisDelivery` runs its own
+ * bounded schedule over the same route and would then be retrying twice over,
+ * and `recoverDraftFromServer` is an in-session user-triggered read for which
+ * `absent` is a final answer. Both would silently start spending the shared
+ * per-client-IP read budget several times over.
+ *
+ * `hydrateCanvasFromServer` is likewise the wrong home: it is `await`ed by
+ * `recoverDraftFromServer`, so a loop inside it would block that call for the
+ * length of this schedule.
+ *
+ * So the policy lives at the BOOT path, which is the only caller that has the
+ * returning-guest problem, and it re-enters `hydrateCanvasFromServer` — the
+ * whole orchestrator, not the adapter — so a late graph is merged, identity-
+ * tokened, context-integrity-recorded and boot-verdict-applied by EXACTLY the
+ * same code as a first-load graph. There is no second ingestion path.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * ⚠ IT MUST TERMINATE — AN UNBOUNDED POLL IS A WORSE DEFECT THAN THE ONE FIXED
+ * ═══════════════════════════════════════════════════════════════════════════
+ * A scenario can answer `absent` forever (a draft that never completed, a graph
+ * CEE never wrote). The schedule below is a FIXED LIST, not a backoff loop with
+ * a stop condition bolted on: when the list is consumed the function returns and
+ * nothing reschedules. The read COUNT is asserted in the spec precisely so a
+ * later "just poll every few seconds" cannot land without failing a test.
+ *
+ * BUDGET. CEE's `read` tier is 90 rpm, keyed per CLIENT IP and shared with
+ * `useProvisionalAnalysisDelivery` (7 reads/60s) and draft recovery. This
+ * schedule spends 7 reads over 100s. Front-loaded, because the window's lower
+ * bound is 30s and a guest who returns late in it should not wait the full span.
+ */
+
+import { logger } from '../../lib/logger'
+import type { HydrationOutcome } from './serverGraphHydration'
+
+/**
+ * Delays between re-asks, in ms, measured from the FIRST `absent` answer.
+ *
+ * Covers the measured 30–90s write-back window with margin, in 7 reads. Exported
+ * so the spec asserts the SCHEDULE rather than restating it (trap 12), and so
+ * the budget claim above is checkable rather than asserted in prose.
+ */
+export const ABSENT_GRAPH_RETRY_DELAYS_MS: readonly number[] = [
+  3_000, 8_000, 16_000, 30_000, 50_000, 75_000, 100_000,
+]
+
+/** The bound. Past this the schedule STOPS. */
+export const ABSENT_GRAPH_RETRY_DEADLINE_MS =
+  ABSENT_GRAPH_RETRY_DELAYS_MS[ABSENT_GRAPH_RETRY_DELAYS_MS.length - 1]
+
+export type AbsentGraphRetryOutcome =
+  /** A re-ask produced a graph. This is the defect's fix, observed. */
+  | 'hydrated'
+  /** Every attempt answered `absent`. The bound expired; tell the truth. */
+  | 'exhausted'
+  /**
+   * A re-ask returned a NON-absent answer that is not a graph — a 404, a
+   * refusal, a transport failure. The scenario stopped being "not written back
+   * yet" and became something else. Stop, and surface nothing: these are the
+   * states `serverGraphHydration`'s header already rules must pass silently.
+   */
+  | 'terminal'
+  /** The scenario changed or the canvas unmounted. */
+  | 'aborted'
+
+/**
+ * The stages a surface may show. `retrying` and `exhausted` are the only two
+ * this module reports; `idle` is the store's initial and cleared value.
+ */
+export type AbsentGraphRetryStage = 'retrying' | 'exhausted'
+
+/**
+ * ⚠ THE ONLY OUTCOME THAT MAY BE RE-ASKED.
+ *
+ * `absent` is `200 + graph_present:false` for a scenario id we hold a pointer to
+ * — the server answered, it exists, it has no graph YET. Every other outcome is
+ * a STABLE answer and re-asking it spends the shared read budget to earn the
+ * same refusal again:
+ *
+ *   · `notReadable` — 404. Absent ∪ not-yours ∪ oracle-unresolvable. A stable
+ *     answer, and NEVER deletion. Must behave byte-identically to today.
+ *   · `refused`     — 401/403/429. An auth or rate answer; retrying 429 in
+ *     particular is actively harmful.
+ *   · `unusable`    — transport failure or a self-contradicting shape. This is
+ *     the "cannot distinguish from a dead server" case and is deliberately NOT
+ *     retried here; the adapter already made three attempts.
+ *   · `unavailable` — 503 through all three adapter attempts. Already retried.
+ *   · `mergeRefused`— a graph ARRIVED. The problem is the merge, not absence.
+ *   · `merged` / `unchanged` — success.
+ *   · `skipped`     — no pointer, or the scenario moved under the read.
+ *
+ * Written as an explicit allow-list of ONE rather than a `!== 'graph'` style
+ * negation: a future outcome added to `HydrationOutcome` must be considered
+ * deliberately, and will default to NOT retrying.
+ */
+function isStillWaitingForWriteBack(outcome: HydrationOutcome): boolean {
+  return outcome === 'absent'
+}
+
+/** A re-ask that produced a graph — the schedule's success condition. */
+function isGraph(outcome: HydrationOutcome): boolean {
+  return outcome === 'merged' || outcome === 'unchanged'
+}
+
+export interface AbsentGraphRetryDeps {
+  readonly scenarioId: string
+  readonly userId: string | null
+  readonly signal: AbortSignal
+  /**
+   * Re-entry point. This is `hydrateCanvasFromServer` in production — the whole
+   * orchestrator, so a late graph is ingested by the first-load code path.
+   */
+  readonly hydrate: (
+    scenarioId: string,
+    opts: { userId?: string | null; signal?: AbortSignal },
+  ) => Promise<HydrationOutcome>
+  /**
+   * The clock, injected.
+   *
+   * ⚠ NO FAKE TIMERS IN THE CORE SPEC, for the reason
+   * `useProvisionalAnalysisDelivery.spec.ts` states: injecting the clock proves
+   * WHAT THE SCHEDULE ASKED FOR, where a fake-timer harness only proves the loop
+   * ran. The delays are OBSERVED, not elapsed.
+   */
+  readonly wait: (ms: number, signal: AbortSignal) => Promise<void>
+  readonly delays?: readonly number[]
+  /**
+   * Stage reporting for the surface. Called at most twice: `retrying` when the
+   * schedule arms, `exhausted` when the bound expires. NEVER called on
+   * `hydrated`, `terminal` or `aborted` — the caller clears instead, so a stale
+   * stage cannot outlive the schedule that set it.
+   */
+  readonly onStage?: (stage: AbsentGraphRetryStage) => void
+}
+
+/**
+ * Run the bounded re-ask once, for one scenario that has just answered `absent`.
+ *
+ * Never throws; every exit is an outcome. Extracted from the hook so the bound,
+ * the allow-list and the termination are provable without mounting React.
+ */
+export async function runAbsentGraphRetrySchedule(
+  deps: AbsentGraphRetryDeps,
+): Promise<AbsentGraphRetryOutcome> {
+  const delays = deps.delays ?? ABSENT_GRAPH_RETRY_DELAYS_MS
+
+  if (deps.signal.aborted) return 'aborted'
+
+  // The surface may now say we are looking. It may NOT say the work is gone,
+  // and it disappears on any exit below.
+  deps.onStage?.('retrying')
+
+  let previous = 0
+  for (const at of delays) {
+    try {
+      await deps.wait(at - previous, deps.signal)
+    } catch {
+      return 'aborted'
+    }
+    previous = at
+    if (deps.signal.aborted) return 'aborted'
+
+    const outcome = await deps.hydrate(deps.scenarioId, {
+      userId: deps.userId,
+      signal: deps.signal,
+    })
+    if (deps.signal.aborted) return 'aborted'
+
+    if (isGraph(outcome)) {
+      logger.debug('absent_graph_retry.hydrated', {
+        scenarioId: deps.scenarioId,
+        atMs: at,
+        outcome,
+      })
+      return 'hydrated'
+    }
+
+    if (!isStillWaitingForWriteBack(outcome)) {
+      // The scenario stopped being "not written back yet". Stop, and surface
+      // nothing — `serverGraphHydration`'s header rules these pass silently.
+      logger.debug('absent_graph_retry.terminal', {
+        scenarioId: deps.scenarioId,
+        atMs: at,
+        outcome,
+      })
+      return 'terminal'
+    }
+  }
+
+  // THE BOUND EXPIRED. Nothing reschedules. The surface may now say — truthfully
+  // — that no model was returned, and offer the reload that demonstrably works.
+  logger.debug('absent_graph_retry.exhausted', {
+    scenarioId: deps.scenarioId,
+    deadlineMs: ABSENT_GRAPH_RETRY_DEADLINE_MS,
+    attempts: delays.length,
+  })
+  deps.onStage?.('exhausted')
+  return 'exhausted'
+}
+
+/** The production clock. Rejects on abort so the loop exits promptly. */
+export function waitForRetry(ms: number, signal: AbortSignal): Promise<void> {
+  if (ms <= 0) {
+    return signal.aborted ? Promise.reject(new Error('aborted')) : Promise.resolve()
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+    const onAbort = (): void => {
+      clearTimeout(timer)
+      reject(new Error('aborted'))
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+  })
+}

--- a/src/canvas/stores/serverGraphRetryStore.ts
+++ b/src/canvas/stores/serverGraphRetryStore.ts
@@ -1,0 +1,69 @@
+/**
+ * Server-Graph-Retry Store — what the boot re-ask may tell the user.
+ *
+ * `useServerGraphHydration` is fire-and-forget: its outcome goes to
+ * `logger.debug` and NOTHING about it is observable by React. That is correct
+ * for the outcomes that need no surface, and it is why the returning-guest
+ * defect was invisible in the product — the canvas simply sat empty. A bounded
+ * re-ask needs somewhere to say "still looking" and "that did not work", so this
+ * is that somewhere, and it holds nothing else.
+ *
+ * ── WHY A STORE RATHER THAN A PROP ─────────────────────────────────────────
+ * Same reason as `contextIntegrityStore`: the read happens in a boot hook at the
+ * route, the surface renders inside the canvas area, and zustand is the house
+ * pattern for that gap (see also `guidanceStore`, `layoutProgressStore`).
+ *
+ * ── ⚠ THE STAGE IS KEYED BY SCENARIO, AND THAT IS LOAD-BEARING ─────────────
+ * `contextIntegrityStore`'s header records a P0 caused by exactly the omission
+ * this avoids: an unkeyed value survived a scenario change and rendered A
+ * PREVIOUS DECISION'S content. An unkeyed clear must be remembered at every
+ * transition (trap 12, the hand-maintained mirror); content that carries its own
+ * identity fails safe at the point of use instead. So `ServerGraphRetryNotice`
+ * refuses to render unless this id matches the live `currentScenarioId`, and a
+ * stale stage cannot reach the screen even if nothing clears it.
+ *
+ * ── ⚠ WHAT THIS STORE MAY NEVER BE USED TO SAY ─────────────────────────────
+ * Nothing about WHERE the user's work lives. "Saved locally", "only in this
+ * browser" and "sign in to save your work" are all FALSE for a guest — a guest's
+ * graph also exists server-side, and `ScenarioListPage.tsx:369-380` records the
+ * derivation. The copy this store drives is confined to what the CLIENT
+ * observed: it asked, and it did or did not get a model back.
+ */
+import { create } from 'zustand'
+
+import type { AbsentGraphRetryStage } from '../hydrate/absentGraphRetry'
+
+/** `idle` = nothing to say. The initial value, and the value after any clear. */
+export type ServerGraphRetryStageValue = 'idle' | AbsentGraphRetryStage
+
+export interface ServerGraphRetryState {
+  /**
+   * The scenario this stage describes. `null` when idle.
+   *
+   * ⚠ HAS A READER AND MUST KEEP ONE. `ServerGraphRetryNotice` gates its entire
+   * render on this matching the live scenario; if a future change drops that
+   * comparison, a previous decision's "could not load" strip can appear over a
+   * healthy canvas. The pinning spec is `ServerGraphRetryNotice.spec.tsx` →
+   * "never renders for another decision".
+   */
+  scenarioId: string | null
+  stage: ServerGraphRetryStageValue
+  /**
+   * `scenarioId` is REQUIRED, deliberately — a stage this store cannot attribute
+   * to a decision is a stage the surface must never show, and making the caller
+   * state it means a new writer cannot omit it by accident.
+   */
+  setRetryStage: (input: {
+    scenarioId: string
+    stage: AbsentGraphRetryStage
+  }) => void
+  clear: () => void
+}
+
+const EMPTY = { scenarioId: null, stage: 'idle' } as const
+
+export const useServerGraphRetryStore = create<ServerGraphRetryState>((set) => ({
+  ...EMPTY,
+  setRetryStage: ({ scenarioId, stage }) => set({ scenarioId, stage }),
+  clear: () => set({ ...EMPTY }),
+}))

--- a/src/routes/CanvasMVP.tsx
+++ b/src/routes/CanvasMVP.tsx
@@ -17,6 +17,7 @@ import { getScenario } from '../canvas/store/scenarios'
 import { buildShareLink } from '../canvas/utils/shareLink'
 import { useScenario } from '../hooks/useScenario'
 import { useServerGraphHydration } from '../canvas/hooks/useServerGraphHydration'
+import { ServerGraphRetryNotice } from '../canvas/components/ServerGraphRetryNotice'
 // ROADMAP 2.1271 — deliver the auto-run's provisional analysis without another
 // turn. Mounted HERE, beside boot hydration, deliberately: the trigger is the
 // draft turn's own `running` verdict in the store, so the hook needs no
@@ -260,6 +261,17 @@ export default function CanvasMVP() {
             onCanvasInteraction={handleCanvasInteraction}
           />
         </main>
+
+        {/*
+          The boot re-ask's honest interim state. Mounted at the ROUTE, beside
+          the hook that drives it, and NOT inside the first-use hero: the hero
+          mounts only under `isAiPanelV2Enabled()`, and binding a notice to a
+          surface the deployed flags can switch off is how row 2.466's badge
+          shipped dark twice (CLAUDE.md trap 3b). Self-gating and prop-less —
+          it renders only while a re-ask is live or exhausted, only for the
+          scenario on screen, and only while the canvas is empty.
+        */}
+        <ServerGraphRetryNotice />
 
         {/* Templates Panel */}
         <Suspense fallback={null}>


### PR DESCRIPTION
## The decision this changes

A returning guest saw an empty canvas and concluded their work was gone — while the server held their complete model and the client had simply stopped asking.

## The defect

Journey-witnessed 2026-08-25, 5 trials, build `55807813`. On page load the canvas issues **exactly one** `POST /bff/cee/scenarios/<uuid>/graph`. If that answer carries `graph_present:false`, **the canvas stays empty for the life of the page. There is no retry.**

That collides with a second measured fact: **the server write-back completes 30–90s AFTER the model first appears on screen.**

| arm | restart at | nodes | graph call |
|---|---|---|---|
| window | +15s | **0** | `graph_present:false` |
| window | +15s | **0** | `graph_present:false` |
| control | +180s | **14, immediately** | present |
| control | +180s | **11, immediately** | present |

In one trial the server held the graph by **+47s** while the canvas sat at 0 nodes and never re-asked. A plain reload recovers it every time.

**Nothing is lost. The client stops looking.**

Confirmed at the bytes: `scenarioGraph.ts:375-381` retries only `503`; `graph_present:false` returns `absent` immediately (`:269-277`), `serverGraphHydration.ts:116` maps it straight to the `'absent'` outcome, and `useServerGraphHydration.ts`'s `attemptedRef` guarantees one attempt per scenario id.

## The design, and why

`hydrate/absentGraphRetry.ts` — a **bounded** schedule of 7 re-asks over 100s: **3 / 8 / 16 / 30 / 50 / 75 / 100s**. Front-loaded (the window's lower bound is 30s, and a guest returning late in it should not wait the full span) and covering the measured 90s upper bound with margin.

- **Budget**: 7 reads over 100s against CEE's `read` tier of 90rpm, which is keyed per **client IP** and shared with `useProvisionalAnalysisDelivery` (7 reads/60s) and draft recovery. Asserted in-spec so a later "just poll every second" fails a test rather than a rate limit.
- **It re-enters `hydrateCanvasFromServer`**, not the adapter — so a late graph is merged, identity-tokened, context-integrity-recorded and boot-verdict-applied by *exactly* the first-load code path. There is no second ingestion path.
- **Placement**: not in `fetchScenarioGraph` (whose `absent` is a final answer for `useProvisionalAnalysisDelivery` and `recoverDraftFromServer`, both of which would start double-spending the shared read budget), and not in `hydrateCanvasFromServer` (which `recoverDraftFromServer` awaits, and would block for the length of the schedule).

**Only `absent` is re-asked**, written as an explicit allow-list of one rather than a `!== 'graph'` negation, so a future `HydrationOutcome` defaults to *not* retrying. `notReadable` (404), `refused` (401/403/429), `unusable` (transport — the "cannot distinguish from a dead server" case), `unavailable` (503 already retried) and `mergeRefused` all still fire exactly once.

### What the user sees

| stage | copy |
|---|---|
| re-asking | "Looking for your model…" |
| exhausted | "Olumi did not return a model for this decision." + **Reload the page** |

The copy makes **no claim about where the user's work lives**. "Saved locally", "only in this browser" and "sign in to save your work" are all **false** for a guest whose graph also exists server-side (`ScenarioListPage.tsx:369-380` carries the derivation). It says only what this client observed. The exhaustion string deliberately avoids "your model could not be loaded", which presupposes one exists.

The notice is gated on **an empty canvas**, which is what keeps it honest and makes it **self-clearing** — when the late graph merges, node count goes non-zero and it unmounts with no store write to retract. Mounted at the **route**, not in the first-use hero, which mounts only under `isAiPanelV2Enabled()` (trap 3b).

Read side only: **the write-back path and the pointer are untouched.**

## Both directions

| case | evidence |
|---|---|
| **populates late** | `RE-ASKS for THIS scenario after graph_present:false and hydrates the graph that lands late` — RED at pristine (`expected 1 to be greater than 1`), green after |
| **never populates** | `TERMINATES on a scenario that never populates, and the call count is BOUNDED` — asserts the count at a bound, then asserts it **again after ten more minutes of clock**; a backoff would pass the first and fail the second |
| **404 unchanged** | `makes EXACTLY ONE call for a 404 and never re-asks` — **passed at pristine and still passes**, plus the same assertion by name for `refused` / `unusable` / `unavailable` / `mergeRefused` |

## Verification

**RED-first**, 10 collected in `useServerGraphHydration.absentRetry.spec.tsx`: 2 failed (both `expected 1 to be greater than 1` — the defect), **8 passed** — every stable-answer control green at pristine.

> An earlier run of that spec reported **10/10 red, including the 404 control whose body had in fact passed**. Cause was this file's own teardown: `tests/setup/rtl.ts:48` restores real timers in a global `afterEach` that runs first, so `vi.runOnlyPendingTimers()` threw and vitest attributed it to each test. A RED-first run where the *control* also reds is reporting on the harness (trap 20). Fixed and re-run before any conclusion was drawn.

**Named collected counts** (zero = hard error): `absentGraphRetry.spec.ts` **18** · `ServerGraphRetryNotice.spec.tsx` **19** · `useServerGraphHydration.absentRetry.spec.tsx` **10**. The 7 pre-existing `useServerGraphHydration.spec.tsx` tests are unchanged and green.

**Mutants** — throwaway worktree at an absolute path outside the repo root, mutating only committed state. Isolation proven by an **asserted sentinel write** (distinct inodes; sentinel landed in the worktree; source byte-identical; restore clean), not by inspecting paths. Applied-check scoped to `src/`, control exactly **0**; restores are `git checkout HEAD --`, never bare.

| # | mutation | result |
|---|---|---|
| control | none | **0 applied, 54 passed** |
| M1 | allow-list → retry EVERY outcome | RED ×6 — all six allow-list tests incl. `notReadable` |
| M2 | allow-list → never retry (**pristine defect restored**) | RED ×7 incl. the window case |
| M3 | `isGraph` → a graph is never success | RED ×2 |
| M4 | schedule grows an unbounded tail | RED ×2 — incl. the BOUNDED call-count guard |
| M5 | never reports `exhausted` (silent give-up) | RED ×1 |
| M6 | hook's own arming guard removed | RED ×5 — incl. the hook-level 404 |
| M7 | notice gate 2 (scenario identity) removed | RED ×1 |
| M8 | notice gate 3 (emptiness) loosened | RED ×2 |
| M9 | re-asks a **hardcoded different scenario id** | RED ×11 |
| trailing control | tree restored | **54 passed** |

**Discriminating pairs.** Retry: target `stops on notReadable after ONE re-ask` — **M1 (loosen for ALL) → RED**, **M3 (a DIFFERENT predicate) → GREEN**. Notice: target `never renders for another decision` — **M7 (loosen gate 2 for ALL) → RED and only it**, **M8 (a DIFFERENT gate) → GREEN**. M9 is the identity proof: it satisfies every bare call-count assertion and is caught only by identity-bound ones.

M1 and M6 together show the 404 is protected by **two independent guards**, each with its own biting test.

**Gate steps run locally at this tip**: `lint` ✅ (hooks ratchet exactly at baseline) · `typecheck` ✅ (**556 files / 2252 errors — exactly baseline, no drift**; it caught two genuine new errors in my spec, both fixed at source, never absorbed into the baseline) · regression sweep over `src/canvas/hydrate src/canvas/hooks src/routes src/canvas/stores` → **101 files / 1094 tests passed**.

## Named limits

- **Rung: TESTED.** Not deployed, not wire-witnessed, not journey-witnessed. The 30–90s window and the "reload recovers it" fact are inherited from the dispatching probe's journey witness, not re-measured here.
- The **schedule's fit** to that window is a design choice against *measured* bounds, not a proof. A write-back slower than 100s exhausts and shows the honest terminal message.
- **Not behind the PROD gate.** Seven of eight changed files contain zero `import.meta.env.PROD|DEV`; `CanvasMVP.tsx`'s four are all `DEV` console logging in effects (lines 41–122), and the mount at line 274 is unconditional JSX. Contrast control: 9 files repo-wide do carry a PROD gate, so the probe can see presences.
- The notice's **visual** placement is jsdom-tested for presence and gating only — jsdom cannot prove visibility (trap 3). `Visual Regression (advisory)` is a standing estate-wide red and is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)