### PR TITLE
fix(canvas): gate boot's analysis verdict on graph ACCEPTANCE — a refused graph must not become the wire authority (A3)

### DIFF
--- a/src/canvas/hydrate/__tests__/bootVerdictGraphAcceptance.spec.ts
+++ b/src/canvas/hydrate/__tests__/bootVerdictGraphAcceptance.spec.ts
@@ -1,0 +1,482 @@
+/**
+ * BOOT'S ANALYSIS VERDICT IS GATED ON GRAPH ACCEPTANCE — the A3 truth spec.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE DEFECT, DERIVED AT `01755479` (deployed staging tip)
+ * ═══════════════════════════════════════════════════════════════════════════
+ * `hydrateCanvasFromServer` calls `applyBootAnalysisVerdict`
+ * (`serverGraphHydration.ts:192`) BEFORE it knows whether the graph that
+ * carried that verdict was accepted — the `merge.accepted` gate is fifty lines
+ * further down (`:242`). So on every boot where the MERGE REFUSES, CEE's
+ * verdict is still written into `analysisStateV1`.
+ *
+ * That store field is FEATURE-DETECTED by the selector: a non-null
+ * `analysisStateV1` takes the WIRE branch, where the local dirty overlay is not
+ * consulted (`analysisStateSelector.ts:551-554`). So the refused server graph's
+ * verdict becomes AUTHORITATIVE over the user's own local graph — a graph it
+ * has, by the refusal's own definition, nothing to say about.
+ *
+ * The user is then told "Model changed since this analysis" about a model the
+ * analysis never ran on. This is a System-A truth defect: the product asserts
+ * something false about the user's own model.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE FOUR REFUSALS, AND WHY EACH ONE MATTERS HERE
+ * ═══════════════════════════════════════════════════════════════════════════
+ * `mergeServerGraphOnHydrate` refuses on four named reasons
+ * (`mergeServerGraph.ts:103-131`), and this spec exercises ALL FOUR rather than
+ * only the one Codex's trigger names — a fix aimed at `zeroOverlap` alone would
+ * leave three live doors, and the predicate guards one property, not one case:
+ *
+ *   `zeroOverlap`         Codex's trigger. Two unrelated graphs; the server's
+ *                         verdict describes THEIRS, the canvas holds OURS.
+ *   `importUnregistered`  The sharpest one. The canvas holds an import the
+ *                         server has NEVER SEEN (ROADMAP 2.467/2.503), so
+ *                         CEE's verdict is necessarily about the older model.
+ *   `emptyServerGraph`    CEE has no graph; a verdict about nothing.
+ *   `unusableShape`       Not a graph at all.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * ⚠ BOTH DIRECTIONS, DELIBERATELY (trap 22b)
+ * ═══════════════════════════════════════════════════════════════════════════
+ * One predicate here guards two OPPOSITE harms:
+ *
+ *   too narrow → a refused graph's verdict still lands  (the LIE this closes)
+ *   too wide   → an ACCEPTED graph's verdict is dropped (re-opens #842, the
+ *                defect whose fix this is layered on top of)
+ *
+ * A fix that closes the gap must be re-measured against the defect it was
+ * written to close, so the accepted-positive block below re-asserts #842's
+ * `merged` AND `unchanged` restores with the SAME fixtures. They are not
+ * decoration: they are the other door.
+ *
+ * ⚠ `unchanged` IS AN ACCEPTED PATH, AND THAT IS THE SUBTLE PART. It
+ * short-circuits BEFORE the merge runs, so "apply after `merge.accepted`" read
+ * literally would drop it. It is accepted because the identity token it matches
+ * on is only ever recorded AFTER a merge was accepted
+ * (`serverGraphHydration.ts:253`, gated on `!merge.accepted` returning above) —
+ * so a token match is proof of a PRIOR acceptance of that exact server graph.
+ * Pinned here so that reasoning is a test rather than a comment.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+
+import { useCanvasStore } from '../../store'
+import { hydrateCanvasFromServer } from '../serverGraphHydration'
+
+const SCENARIO_ID = '11111111-2222-4333-8444-555555555555'
+const CEE_TOKEN = 'c'.repeat(63) + '9'
+
+/** The exact instant CEE stamped the verdict — the IDENTITY this spec binds to. */
+const COMPUTED_AT = '2026-08-25T09:00:00.000Z'
+
+function envelope(value = CEE_TOKEN, projection = 'identity.v1') {
+  return {
+    kind: 'graph_identity_hash',
+    value,
+    algorithm: 'sha256',
+    projection_version: projection,
+    graph_schema_version: 'graph_v3',
+    normaliser_version: '1',
+  }
+}
+
+function verdict(
+  runState: AnalysisStateV1['run_state'],
+  over: Partial<AnalysisStateV1> = {},
+): AnalysisStateV1 {
+  return {
+    run_state: runState,
+    readiness: { status: 'ready', blockers: [] },
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: true,
+    blocked_unusable: false,
+    contradictions: [],
+    ...over,
+  } as AnalysisStateV1
+}
+
+/**
+ * `complete_stale` is the ONLY boot-restorable kind
+ * (`BOOT_RESTORABLE_RUN_STATE_KINDS`), which is what makes it the right fixture:
+ * every other kind is already declined upstream by `applyBootAnalysisVerdict`,
+ * so a spec built on one of those would pass at pristine for the WRONG REASON —
+ * the verdict would be absent because the KIND was declined, not because the
+ * graph was refused. Codex's trigger names this kind for exactly that reason.
+ *
+ * ⚠ `cause`, NOT `stale_cause` — the contract schema is `.strict()` and the
+ * wrong spelling arrives as `null`, indistinguishable from the fix working.
+ * The positive control below is what proves it parses.
+ */
+const STALE_VERDICT = verdict({
+  kind: 'complete_stale',
+  computed_at: COMPUTED_AT,
+  cause: 'graph_changed',
+})
+
+/** A server graph that SHARES node ids with the seeded canvas — merge ACCEPTS. */
+function overlappingGraph() {
+  return {
+    nodes: [
+      { id: 'factor-1', kind: 'factor', label: 'Spend', value: 250 },
+      { id: 'goal-1', kind: 'goal', label: 'Profit', value: 9 },
+    ],
+    edges: [],
+  }
+}
+
+/** A server graph sharing NO node ids with the seeded canvas — merge REFUSES. */
+function unrelatedGraph() {
+  return {
+    nodes: [
+      { id: 'unrelated-a', kind: 'factor', label: 'Other' },
+      { id: 'unrelated-b', kind: 'goal', label: 'Elsewhere' },
+    ],
+    edges: [],
+  }
+}
+
+function okBody(over: Record<string, unknown> = {}) {
+  return {
+    schema: 'scenario_graph.v1',
+    scenario_id: SCENARIO_ID,
+    graph: overlappingGraph(),
+    graph_present: true,
+    brief_text: null,
+    graph_identity_hash: envelope(),
+    layout_present: false,
+    request_id: 'req-boot-acceptance',
+    ...over,
+  }
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response
+}
+
+/**
+ * A NON-EMPTY canvas — load-bearing. The `zeroOverlap` guard only fires when
+ * `store.nodes.length > 0`; an empty canvas hydrates in full and is the
+ * OPPOSITE case. Seeded with the state `hydrateGraphSlice` leaves at boot.
+ */
+function seedCanvas(over: Record<string, unknown> = {}): void {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_ID,
+    nodes: [
+      {
+        id: 'factor-1',
+        type: 'factor',
+        position: { x: 10, y: 20 },
+        data: { label: 'Spend', kind: 'factor', value: 100 },
+      },
+      {
+        id: 'goal-1',
+        type: 'goal',
+        position: { x: 300, y: 400 },
+        data: { label: 'Profit', kind: 'goal', value: 5 },
+      },
+    ] as never,
+    edges: [] as never,
+    lastAuthoritativeGraph: null,
+    serverGraphIdentity: null,
+    importPendingServerRegistration: false,
+    history: { past: [], future: [] },
+    analysisStateV1: null,
+    analysisFreshnessDirty: false,
+    ...over,
+  } as never)
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>
+let verdictWrites: (AnalysisStateV1 | null)[]
+
+/**
+ * ⚠ CAPTURED ONCE, AT MODULE LOAD — and that is not a style choice.
+ *
+ * Re-reading the action inside `beforeEach` wraps the wrapper installed by the
+ * PREVIOUS test, and because every layer closes over the same module-level
+ * `verdictWrites` binding, each one pushes into the CURRENT array. The write
+ * count then tracks the TEST INDEX rather than the code under test — measured
+ * here at pristine as 8 and 9 writes for a leg that writes at most once.
+ *
+ * It was caught only because the assertion is an exact count. A `toHaveLength`
+ * of "at least one", or an assertion on the store field alone, would have
+ * absorbed it silently and left every refusal assertion below resting on an
+ * instrument that grows without bound (trap 20: a probe whose answer tracks
+ * something other than its input is reporting on itself).
+ */
+const PRISTINE_SET_ANALYSIS_STATE_V1 = useCanvasStore.getState().setAnalysisStateV1
+
+beforeEach(() => {
+  fetchSpy = vi.fn()
+  vi.stubGlobal('fetch', fetchSpy)
+  seedCanvas()
+
+  // ⚠ WHY A WRITE LOG AND NOT JUST `analysisStateV1 === null`.
+  //
+  // `applyBootAnalysisVerdict`'s contract distinguishes WRITING NOTHING from
+  // writing `null` — "not `null`, which would replace a standing belief with a
+  // claim of ignorance" (`applyScenarioAnalysisRead.ts:402-405`). A store field
+  // that reads `null` cannot tell those apart, because boot seeds it to `null`.
+  // Recording the CALLS makes "the boot leg did not touch this seam" assertable
+  // rather than inferred, and it is the assertion a future refactor that writes
+  // an explicit `null` on the refusal path would have to break loudly.
+  verdictWrites = []
+  useCanvasStore.setState({
+    setAnalysisStateV1: (v: AnalysisStateV1 | null) => {
+      verdictWrites.push(v)
+      PRISTINE_SET_ANALYSIS_STATE_V1(v)
+    },
+  } as never)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function storedVerdict(): AnalysisStateV1 | null {
+  return useCanvasStore.getState().analysisStateV1 ?? null
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// POSITIVE CONTROLS — without these the whole file is vacuous
+// ═══════════════════════════════════════════════════════════════════════════
+describe('positive controls — the fixtures are capable of the thing being denied', () => {
+  it('the stale verdict PARSES at the real adapter (not silently null)', async () => {
+    const { fetchScenarioGraph } = await import('../../../adapters/cee/scenarioGraph')
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ analysis_state: STALE_VERDICT })),
+    )
+    const result = await fetchScenarioGraph(SCENARIO_ID)
+    expect(result.status).toBe('graph')
+    expect(result.status === 'graph' && result.analysisState?.run_state.kind).toBe(
+      'complete_stale',
+    )
+    // Bind by IDENTITY, not by kind alone — another verdict could be a
+    // `complete_stale` too. This is the exact object the refusal tests deny.
+    expect(
+      result.status === 'graph' &&
+        (result.analysisState?.run_state as { computed_at?: string })?.computed_at,
+    ).toBe(COMPUTED_AT)
+  })
+
+  it('⭐ CONTRAST CONTROL — the SAME verdict IS restored when the graph is ACCEPTED', async () => {
+    // The discriminating half. Every refusal assertion below claims an ABSENCE;
+    // an absence claim needs a contrast that reads PRESENT in the same run, or
+    // it is indistinguishable from a fixture that never worked (trap 13e).
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ analysis_state: STALE_VERDICT })),
+    )
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('merged')
+    expect(storedVerdict()?.run_state.kind).toBe('complete_stale')
+    expect(verdictWrites).toHaveLength(1)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ⭐ RED-FIRST — THE REFUSAL-NEGATIVE. A refused graph's verdict must not land.
+// ═══════════════════════════════════════════════════════════════════════════
+describe('⭐ a REFUSED server graph never makes its verdict authoritative', () => {
+  it('`zeroOverlap` — Codex`s trigger: an unrelated graph`s `complete_stale` must NOT land', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(
+        200,
+        okBody({ graph: unrelatedGraph(), analysis_state: STALE_VERDICT }),
+      ),
+    )
+
+    const outcome = await hydrateCanvasFromServer(SCENARIO_ID)
+
+    // The merge genuinely refused — otherwise this is not the case under test.
+    expect(outcome).toBe('mergeRefused')
+    // And the canvas was genuinely left alone, so the verdict has nothing to
+    // describe. (`lastAuthoritativeGraph` is recorded only on the accepted path.)
+    expect(useCanvasStore.getState().lastAuthoritativeGraph).toBeNull()
+
+    // THE DEFECT: at pristine `analysisStateV1` holds the refused graph's
+    // `complete_stale`, and the selector's WIRE branch then tells the user their
+    // OWN model changed since an analysis that never ran on it.
+    expect(storedVerdict()).toBeNull()
+    expect(verdictWrites).toEqual([])
+  })
+
+  it('`importUnregistered` — a verdict must not land over an import the server has never seen', async () => {
+    // The sharpest case: the canvas holds the user's imported work and CEE's
+    // verdict is necessarily about the PRE-IMPORT model.
+    seedCanvas({ importPendingServerRegistration: true })
+    fetchSpy.mockResolvedValue(
+      // An OVERLAPPING graph, so the only thing refusing is the import hold —
+      // this fails for the named reason rather than incidentally.
+      jsonResponse(200, okBody({ analysis_state: STALE_VERDICT })),
+    )
+
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('mergeRefused')
+    expect(storedVerdict()).toBeNull()
+    expect(verdictWrites).toEqual([])
+  })
+
+  it('`emptyServerGraph` — a verdict about a graph CEE does not have must NOT land', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(
+        200,
+        okBody({ graph: { nodes: [], edges: [] }, analysis_state: STALE_VERDICT }),
+      ),
+    )
+
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('mergeRefused')
+    expect(storedVerdict()).toBeNull()
+    expect(verdictWrites).toEqual([])
+  })
+
+  it('⚠ `unusableShape` is UNREACHABLE from the wire — the adapter filters it first', async () => {
+    // MEASURED, NOT ASSUMED, and it corrects this spec's own first draft, which
+    // asserted `mergeRefused` here and RED-ed with `'unusable'`.
+    //
+    // `mergeServerGraphOnHydrate`'s `unusableShape` guard (`mergeServerGraph.ts:194`)
+    // cannot be reached through `hydrateCanvasFromServer`: the adapter rejects a
+    // non-object `graph` at `scenarioGraph.ts:267,274` and returns
+    // `{ status: 'unusable' }`, which the hydration leg handles on its NON-GRAPH
+    // path — before the verdict call site exists at all.
+    //
+    // So of the merge's four refusal reasons, exactly THREE are reachable here.
+    // Recorded as a fact rather than deleted, because a later change to the
+    // adapter's shape guard would make the fourth reachable and this test is
+    // where that shows up: it would stop returning `'unusable'`.
+    fetchSpy.mockResolvedValue(
+      jsonResponse(
+        200,
+        okBody({ graph: 'not-a-graph', analysis_state: STALE_VERDICT }),
+      ),
+    )
+
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('unusable')
+    expect(storedVerdict()).toBeNull()
+    expect(verdictWrites).toEqual([])
+  })
+
+  it('a refusal does not DESTROY a verdict already standing — it writes nothing at all', async () => {
+    // The other way a "fix" could be wrong: clearing the seam instead of not
+    // touching it. A standing belief must survive a boot that refused the graph.
+    const standing = verdict({
+      kind: 'complete_stale',
+      computed_at: '2026-08-24T08:00:00.000Z',
+      cause: 'graph_changed',
+    })
+    useCanvasStore.setState({ analysisStateV1: standing } as never)
+    fetchSpy.mockResolvedValue(
+      jsonResponse(
+        200,
+        okBody({ graph: unrelatedGraph(), analysis_state: STALE_VERDICT }),
+      ),
+    )
+
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('mergeRefused')
+    // Bound by IDENTITY: the ORIGINAL instant, not merely "a complete_stale".
+    expect(
+      (storedVerdict()?.run_state as { computed_at?: string })?.computed_at,
+    ).toBe('2026-08-24T08:00:00.000Z')
+    expect(verdictWrites).toEqual([])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ⭐ THE OTHER DOOR — the ACCEPTED-POSITIVE. #842 must still work, unchanged.
+// ═══════════════════════════════════════════════════════════════════════════
+describe('⭐ BOTH DIRECTIONS — an ACCEPTED graph still restores its verdict', () => {
+  it('the `merged` boot restores `complete_stale` — #842 intact', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ analysis_state: STALE_VERDICT })),
+    )
+
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('merged')
+    expect(storedVerdict()?.run_state.kind).toBe('complete_stale')
+    expect(
+      (storedVerdict()?.run_state as { computed_at?: string })?.computed_at,
+    ).toBe(COMPUTED_AT)
+    expect(verdictWrites).toHaveLength(1)
+  })
+
+  it('the `unchanged` re-boot ALSO restores — a token match is proof of a PRIOR acceptance', async () => {
+    // The commonest boot of all, and the one the gate must not swallow. It
+    // short-circuits before the merge, so a literal "after merge.accepted" fix
+    // would silently drop it — this is the test that catches that over-fix.
+    useCanvasStore.setState({
+      serverGraphIdentity: { value: CEE_TOKEN, projectionVersion: 'identity.v1' },
+    } as never)
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ analysis_state: STALE_VERDICT })),
+    )
+
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('unchanged')
+    expect(storedVerdict()?.run_state.kind).toBe('complete_stale')
+    expect(verdictWrites).toHaveLength(1)
+  })
+
+  it('an idempotent ACCEPTED merge (server matched the canvas) still restores', async () => {
+    // `accepted: true, changed: false` — the combination a caller must NOT treat
+    // as a refusal (`mergeServerGraph.ts:162-167`). Gating on `changed` instead
+    // of `accepted` would break exactly here.
+    seedCanvas({
+      nodes: [
+        {
+          id: 'factor-1',
+          type: 'factor',
+          position: { x: 10, y: 20 },
+          data: { label: 'Spend', kind: 'factor', value: 250 },
+        },
+        {
+          id: 'goal-1',
+          type: 'goal',
+          position: { x: 300, y: 400 },
+          data: { label: 'Profit', kind: 'goal', value: 9 },
+        },
+      ] as never,
+    })
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, okBody({ analysis_state: STALE_VERDICT })),
+    )
+
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('merged')
+    expect(storedVerdict()?.run_state.kind).toBe('complete_stale')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// The declines that must survive the reordering
+// ═══════════════════════════════════════════════════════════════════════════
+describe('the kind-level declines are unaffected by the acceptance gate', () => {
+  it('`complete_current` is still DECLINED on an ACCEPTED merge', async () => {
+    // The currency decline lives in `applyBootAnalysisVerdict` and must not be
+    // weakened by moving WHERE that function is called from.
+    fetchSpy.mockResolvedValue(
+      jsonResponse(
+        200,
+        okBody({
+          analysis_state: verdict({
+            kind: 'complete_current',
+            computed_at: COMPUTED_AT,
+          }),
+        }),
+      ),
+    )
+
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('merged')
+    expect(storedVerdict()).toBeNull()
+    expect(verdictWrites).toEqual([])
+  })
+
+  it('a 404 (not readable) writes no verdict — the non-graph legs are untouched', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(404, { error: 'not found' }))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('notReadable')
+    expect(verdictWrites).toEqual([])
+  })
+})

--- a/src/canvas/hydrate/serverGraphHydration.ts
+++ b/src/canvas/hydrate/serverGraphHydration.ts
@@ -169,43 +169,82 @@ export async function hydrateCanvasFromServer(
   // verdict was fetched, validated against the contract, and discarded on every
   // ordinary reload.
   //
-  // ⚠ PLACED BEFORE THE `unchanged` SHORT-CIRCUIT, for the reason the
-  // context-integrity note above already establishes: that branch is the COMMON
-  // case on every re-boot of an existing scenario, and it is exactly when the
-  // user is most likely to open the panel. Restoring after it would leave the
-  // verdict absent for the very sessions this is meant to serve.
-  //
-  // ⚠ ORDERING AGAINST #837, WHICH WAS THE QUESTION TO SETTLE: the two writes
-  // are DISJOINT and neither can overwrite the other. `markGraphStructurallyEdited`
-  // (fired inside `mergeServerGraphOnHydrate`, `mergeServerGraph.ts:512`) writes
-  // `graphEditedSinceLastRun` / `analysisStateReady` / `analysisFreshnessDirty`;
-  // this writes `analysisStateV1` and nothing else. Pinned in BOTH directions in
-  // `__tests__/bootAnalysisVerdictRestore.spec.ts` rather than left to this
-  // comment — a disjointness that only a comment asserts is one refactor from
-  // being false.
-  //
   // ⚠ AND IT MAY ONLY EVER WITHHOLD CURRENCY. `applyBootAnalysisVerdict`
   // declines `complete_current` outright: on the selector's WIRE branch the
   // local dirty overlay is not consulted, so restoring a currency claim here
   // would render "Analysis complete" over a canvas the merge below is about to
   // mark stale. See that function's header for the full derivation.
-  const verdictOutcome = applyBootAnalysisVerdict({
-    analysisState: result.analysisState,
-    store: { setAnalysisStateV1: useCanvasStore.getState().setAnalysisStateV1 },
-  })
-  logger.debug('server_graph_hydration.boot_verdict', {
-    scenarioId,
-    outcome: verdictOutcome.outcome,
-    detail:
-      verdictOutcome.outcome === 'restored' ? verdictOutcome.kind : verdictOutcome.reason,
-  })
+  //
+  // ⚠ ORDERING AGAINST #837: the two writes are DISJOINT and neither can
+  // overwrite the other. `markGraphStructurallyEdited` (fired inside
+  // `mergeServerGraphOnHydrate`, `mergeServerGraph.ts:512`) writes
+  // `graphEditedSinceLastRun` / `analysisStateReady` / `analysisFreshnessDirty`;
+  // this writes `analysisStateV1` and nothing else. Pinned in BOTH directions in
+  // `__tests__/bootAnalysisVerdictRestore.spec.ts` rather than left to this
+  // comment — a disjointness that only a comment asserts is one refactor from
+  // being false.
+  const restoreVerdict = (): void => {
+    const verdictOutcome = applyBootAnalysisVerdict({
+      analysisState: result.analysisState,
+      store: { setAnalysisStateV1: useCanvasStore.getState().setAnalysisStateV1 },
+    })
+    logger.debug('server_graph_hydration.boot_verdict', {
+      scenarioId,
+      outcome: verdictOutcome.outcome,
+      detail:
+        verdictOutcome.outcome === 'restored'
+          ? verdictOutcome.kind
+          : verdictOutcome.reason,
+    })
+  }
 
+  // ── ⚠⚠ THE VERDICT IS GATED ON GRAPH ACCEPTANCE, AND THAT IS THE WHOLE POINT ──
+  //
+  // THE DEFECT THIS CLOSES, live on staging at `01755479`: this call used to sit
+  // HERE, unconditionally, fifty lines above the `merge.accepted` gate below. So
+  // on every boot where the MERGE REFUSED, CEE's verdict was still written into
+  // `analysisStateV1` — and that field is FEATURE-DETECTED by the selector: a
+  // non-null value takes the WIRE branch, where the local dirty overlay is not
+  // consulted (`analysisStateSelector.ts:551-554`).
+  //
+  // The refused graph's verdict therefore became AUTHORITATIVE over the user's
+  // OWN local graph — the one the refusal exists to protect — and the product
+  // told them "Model changed since this analysis" about a model that analysis
+  // never ran on. A System-A truth defect: a false assertion about the user's
+  // own model, which is worse than silence.
+  //
+  // Reachable through three of the merge's four refusal reasons (the fourth,
+  // `unusableShape`, is filtered earlier by the adapter — measured, and pinned
+  // as such in `__tests__/bootVerdictGraphAcceptance.spec.ts`):
+  //   `zeroOverlap`         two unrelated graphs — the verdict describes THEIRS
+  //   `importUnregistered`  the canvas holds an import the server has NEVER seen
+  //   `emptyServerGraph`    a verdict about a graph CEE does not have
+  //
+  // ⚠ THE FIX IS NOT "MOVE IT BELOW `merge.accepted`" — THAT WOULD BREAK THE
+  // COMMONEST BOOT OF ALL. The `unchanged` short-circuit returns BEFORE the
+  // merge runs, so a literal reordering would drop the verdict on every re-boot
+  // of an unmoved scenario — precisely the sessions the original placement note
+  // was right to worry about, and precisely when a user is most likely to open
+  // the panel.
+  //
+  // `unchanged` IS an accepted path, and the reason is structural rather than
+  // conventional: the identity token it matches on is recorded ONLY after a
+  // merge was accepted (the `!merge.accepted` return below precedes the
+  // `setServerGraphIdentity` call). A token match is therefore PROOF OF A PRIOR
+  // ACCEPTANCE of that exact server graph, under that exact projection version.
+  //
+  // So the rule is ACCEPTANCE, not position: restore at each of the two exits
+  // that represent an accepted graph, and at neither refusal. Both directions
+  // are pinned — the refusal-negative AND the accepted-positive — because one
+  // predicate here guards two opposite harms, and a fix aimed only at the lie
+  // would re-open #842's gap on the way past.
   const stored = useCanvasStore.getState().serverGraphIdentity
   if (isSameServerGraph(stored, result.identity)) {
     // The server has not moved since we last hydrated, so there is nothing to
     // apply. Skipping is not merely an optimisation: re-merging would roll a
     // local edit made since that hydration back to the same server value the
     // user has already been shown once.
+    restoreVerdict()
     return 'unchanged'
   }
 
@@ -244,8 +283,27 @@ export async function hydrateCanvasFromServer(
       scenarioId,
       reason: merge.refusedReason,
     })
+    // ⚠ NOTHING is written to `analysisStateV1` here — and NOTHING is the
+    // operative word, not `null`. Writing `null` would replace whatever belief
+    // the user's session already holds with a claim of ignorance, which is a
+    // second falsehood rather than the absence of the first
+    // (`applyScenarioAnalysisRead.ts:402-405` makes the same distinction on the
+    // decline side). The refusal simply does not touch this seam.
     return 'mergeRefused'
   }
+
+  // THE ACCEPTED EXIT. The graph this verdict describes is now on the canvas,
+  // so the verdict is a true statement about what the user is looking at.
+  //
+  // Deliberately AFTER the merge, which inverts the previous order and is the
+  // half of this change that had to be re-measured rather than reasoned about:
+  // `mergeServerGraphOnHydrate` fires #837's `markGraphStructurallyEdited`, so
+  // that write now lands FIRST. The two remain disjoint — the mark writes
+  // `graphEditedSinceLastRun` / `analysisStateReady` / `analysisFreshnessDirty`
+  // and this writes `analysisStateV1` — and the disjointness is pinned in both
+  // orders in `__tests__/bootAnalysisVerdictRestore.spec.ts`, which is what
+  // makes that a measurement instead of this comment's opinion.
+  restoreVerdict()
 
   // Store CEE's token VERBATIM — after the merge, so a throw could not leave a
   // token recorded for a graph that was never applied. `null` when CEE issued


### PR DESCRIPTION
## The defect — LIVE on staging at `01755479`

At boot the UI wrote CEE's analysis verdict into `analysisStateV1` **before it knew whether the graph carrying that verdict had been accepted**. In `serverGraphHydration.ts` the call sat at **:192** and the `merge.accepted` gate at **:242** — fifty lines apart.

`analysisStateV1` is **feature-detected** by the selector: a non-null value takes the **WIRE branch**, where the local dirty overlay is not consulted (`analysisStateSelector.ts:551-554`). So when the merge refused the server's graph, that refused graph's verdict still became **authoritative over the user's own local graph** — the graph the refusal exists to protect.

The user was then told **"Model changed since this analysis"** about a model that analysis never ran on. This is a System-A truth defect: the product asserts something false about the user's own model, which is worse than saying nothing.

**Trigger** (Codex, reviewing `2c83021b`, re-evaluated on deployed merge `55807813`): authenticated reload + non-empty local canvas + valid zero-overlap server graph + `complete_stale`.

## Blast radius is wider than the trigger — three reachable legs, not one

`mergeServerGraphOnHydrate` refuses on four named reasons. I measured which are reachable through this leg:

| Refusal | Reachable here | Why it produces the same lie |
|---|---|---|
| `zeroOverlap` | **yes** | Codex's trigger. Two unrelated graphs; the verdict describes *theirs*, the canvas holds *ours*. |
| `importUnregistered` | **yes** | **The sharpest case.** The canvas holds an import the server has **never seen** (ROADMAP 2.467/2.503), so CEE's verdict is *necessarily* about an older model. Not an edge case — a guaranteed mismatch. |
| `emptyServerGraph` | **yes** | A verdict about a graph CEE does not have. |
| `unusableShape` | **no** | The adapter filters a non-object `graph` at `scenarioGraph.ts:267,274` and returns `'unusable'` **before this call site exists**. |

Fixing only `zeroOverlap` would have left two legs producing the identical user-visible lie, with the fix's own tests unable to see the survivor.

**`unusableShape` was measured, not assumed.** My spec's first draft asserted `mergeRefused` for it and RED-ed with `'unusable'` — that discrimination is what established the boundary. It is pinned as an explicit test rather than deleted, so an adapter change that later makes the fourth leg reachable turns that test red instead of passing silently.

## The remedy — and a material correction to the prescribed one

Codex prescribed *"apply the analysis verdict only after graph acceptance."* **Taken literally that drops the commonest boot of all.**

The `unchanged` short-circuit returns **before the merge runs**, so a literal "move it below `merge.accepted`" would leave the verdict absent on every re-boot of an unmoved scenario — exactly the sessions the original placement note was right to worry about, and exactly when a user is most likely to open the panel. That would trade a false verdict for a missing one: the mirror harm.

`unchanged` **is** an accepted path, for a structural reason rather than a conventional one: the identity token it matches on is recorded **only after a merge was accepted** (the `!merge.accepted` return precedes `setServerGraphIdentity`). A token match is therefore **proof of a prior acceptance** of that exact server graph under that exact projection version.

So the implemented rule is **acceptance, not position**: the verdict is applied at each of the two exits that represent an accepted graph (`merged`, `unchanged`), and at neither refusal. The code change is small — the existing call is wrapped in a `restoreVerdict()` closure and invoked at those two exits.

A refusal writes **nothing** — not `null`. Writing `null` would replace a standing belief with a claim of ignorance, a second falsehood rather than the absence of the first (`applyScenarioAnalysisRead.ts:402-405` draws the same distinction on the decline side).

### The behavioural change is provably confined to one exit

Not an assurance — a complete manifest. `hydrateCanvasFromServer` has **ten** exits. The old call site sat at `:192`, so only the exits **below** it could ever have written a verdict, and there are exactly three:

| Exit | Old | New |
|---|---|---|
| `skipped` (bad id), `absent`, `notReadable`, `unavailable`, `refused`, `unusable`, `skipped` (scenario moved) — 7 exits **above** `:192` | no verdict | no verdict — **untouched** |
| `unchanged` (`01755479:209`) | verdict written | verdict written — **unchanged** |
| `merged` (`01755479:262`) | verdict written | verdict written — **unchanged** |
| `mergeRefused` (`01755479:247`) | **verdict written** | **nothing written** ← the whole change |

So `mergeRefused` is the *only* exit whose behaviour moves. That is the argument the accepted-positive tests exist to hold up, and it is checkable rather than asserted.

**No `HydrationOutcome` value changes.** The fix removes a *side-effect*, never a return value — `mergeRefused` is still returned on exactly the same conditions. So every consumer that switches on the outcome is untouched by construction, including `draftRecovery.ts`, which maps `mergeRefused` to `notRecovered` and is unaffected either way. `absentGraphRetry.ts` and `draftRecovery.ts` have **zero** changes in this PR.

## RED-first, by name, at pristine `01755479`

New spec `src/canvas/hydrate/__tests__/bootVerdictGraphAcceptance.spec.ts` — **12 tests collected** (asserted by name and exact count, not inferred from a suite total).

**Pristine: 4 failed | 8 passed.**

| RED at pristine | Signature |
|---|---|
| `zeroOverlap` | `expected { run_state: {…} } to be null` |
| `importUnregistered` | `expected { run_state: {…} } to be null` |
| `emptyServerGraph` | `expected { run_state: {…} } to be null` |
| a refusal does not DESTROY a standing verdict | `expected '2026-08-25T09:00:00.000Z' to be '2026-08-24T08:00:00.000Z'` |

**After the fix: 12 passed.** The 8 that were green at pristine stayed green.

## Both directions, deliberately

One predicate here guards two opposite harms, so both doors are pinned:

- **refusal-negative** — a refused graph's verdict must not land (the lie this closes);
- **accepted-positive** — an accepted graph's verdict **is** applied, unchanged from today (re-opening #842's gap is the mirror harm). `merged`, `unchanged` and the **idempotent** `accepted: true, changed: false` case are all named tests.

Plus a **contrast control**: the *same* verdict IS restored when the graph is accepted. Every refusal assertion claims an absence; the contrast reads PRESENT in the same run, so a null cannot be mistaken for a fixture that never worked.

`complete_current` is still declined on an accepted merge, and the 404 leg still writes nothing — the reordering does not weaken the kind-level declines.

## Discriminating mutant pairs

Worktree **outside** the repo root (absolute path to `worktree add`), mutating only **committed** state, applied-check scoped to `src/` with the baseline control reading **exactly 0**, clean-tree assertion before and after each mutant, restores via `git checkout HEAD --` (never `git checkout --`, which restores from the index), and a trailing control. **Isolation proven by writing** a sentinel into the worktree and asserting the source's SHA-256 was unchanged; inodes compared (`718488056` vs `718491950`).

Every run asserts **12 collected** — a shrunk collect is a hard error, not a pass.

| Mutant | RED | Proves |
|---|---|---|
| CONTROL (no mutation) | none (12 green, applied=0) | baseline |
| **M1** drop restore at MERGED exit | contrast control, `merged`, idempotent | the merged exit binds |
| **M2** drop restore at UNCHANGED exit | `unchanged` **only** | the unchanged exit binds **independently** — M1/M2 are the pair |
| **M3** REVERT to the pre-fix position | **7 tests**, incl. all 4 original REDs | reverting the fix turns the suite red |
| **M4** gate on `merge.changed` not `.accepted` | idempotent **only** | gating on the right field |
| **M5** loosen for ALL refusals | all 4 refusal tests | the gate is what closes all three legs |
| **M6** loosen for `zeroOverlap` ONLY | `zeroOverlap` (+ the standing-verdict test, which uses that fixture) | per-leg binding |
| **M7** loosen for `emptyServerGraph` ONLY | `emptyServerGraph` **only** | per-leg binding |
| **M8** loosen for `importUnregistered` ONLY | `importUnregistered` **only** | per-leg binding |
| TRAILING CONTROL | none (12 green, tree clean) | no mutation leaked |

M6/M7/M8 are the discriminating set: loosening **all** legs REDs each test (M5), loosening a **different** leg leaves it GREEN. Each test binds to its own leg, not to a shared predicate.

## Named limits — what I did NOT prove

- **No live staging witness.** Everything here is local and wire-level. The rung reached is TESTED, not JOURNEY-WITNESSED. The defect's live status rests on the deployed tip matching this source, not on my having driven it.
- **jsdom proves no visibility.** These are store-level and outcome-level assertions. That the *rendered* panel changes its sentence is **not** shown here — only that the wire authority the panel reads is no longer poisoned.
- **`unusableShape` unreachability is a claim about this leg through this adapter**, at this tip. It is not a claim about `mergeServerGraphOnHydrate`'s other callers.
- **The write-log instrument is test-local.** It proves the boot leg does not call `setAnalysisStateV1`; it does not prove no other writer touches the field during boot.
- The three reachable legs are the three I could reach **from the wire plus the store**. I did not enumerate refusal causes reachable only through states I did not construct.

## Two instrument defects caught and disclosed

Both were caught by controls, not inspection, and neither would have errored:

1. **The write-log wrapper re-wrapped itself.** Reading `setAnalysisStateV1` inside `beforeEach` wrapped the previous test's wrapper; because every layer closed over the same module-level binding, the write count tracked the **test index** (read 8 and 9 for a leg that writes at most once). Only an **exact-count** assertion exposed it — `toHaveLength(1)` rather than "at least one". Fixed by capturing the pristine action once at module load; the reason is written into the spec so it cannot be re-introduced quietly.

2. **The first mutation harness could not report a failure at all.** Its `sed 's/.*spec.ts > //'` stripped the `✓`/`×` marker along with the path, so the RED list was **always empty** and all nine mutants reported "RED: (none)" — *including a full revert of the fix*. The collected-count assertion still read 12, so nothing errored and every mutant agreed with every other. It was caught only by the **uniformity**: a per-item probe returning an identical answer for every item is reporting on itself. Fixed to preserve the mark; the numbers above are from the corrected harness.

## Salvage disposition — ADAPT-SHAPE-ONLY, not adopt

`salvage/review842-adversarial-spec-2026-08-25` @ `abe2cc24` was **not** adopted, and two things in the brief describing it need correcting for the next reader:

- The brief's "9 files / +1901" is the **branch-vs-stale-base** diffstat (base `fa2113aa`, 8 commits behind tip). `abe2cc24` itself is **spec-only, 116 lines**.
- The spec is **not usable as a RED-first basis**. Its test 1 asserts the **buggy** behaviour, so it *passes at pristine* — a test that passes before the fix exists is not a test. Its test 2 asserts a `blocked` verdict becomes the wire authority, which is **false at this tip**: `BOOT_RESTORABLE_RUN_STATE_KINDS` is `['complete_stale']` only, so `blocked` is already declined upstream as `not_restorable`.

I took its *shape* (the fixture and attack framing) and wrote a fresh inverted spec.

## Gate

Run in the required check's real step order, derived at this tip — `lint → typecheck → guards → 4 vitest shards → build` — not a hand-rolled subset.

## Boundaries

Touches only `src/canvas/hydrate/`. No files under `components/results/**`, `decision-brief/**`, `mapV5AnalysisToReport.ts`, `responseMapper.ts`, `ScenarioListPage.tsx`, and no CEE files.
