### PR TITLE
D — the "Edit value" act reaches the one surface that can save it [IN-class]

### DIFF
--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -37,7 +37,8 @@ import {
   CANONICAL_EDIT_AUTHORITY,
   hasServerGraphAuthority,
 } from '@/canvas/mutations/mutationAuthority'
-import { openNodeInspector } from '@/canvas/nodes/shared/openNodeInspector'
+import { focusModelTarget } from '@/canvas/utils/focusHelpers'
+import { useUIStore } from '@/stores/uiStore'
 import type { ScientificEditorProps } from '@/components/shared/ScientificEditor'
 import { TargetProbabilityBars } from './TargetProbabilityBars'
 import { stripEncodingNotation, cleanFactorLabel } from './utils/cleanFactorLabel'
@@ -253,8 +254,13 @@ function mapNextActionsToCards(data: ResultsSectionDataReturn): MappedActionItem
  * happened to inject. `PreAnalysisPanel`, the other consumer of this
  * component, injects this same helper for the same control.
  *
- * Fail-closed and silent on a node that is not on the canvas, inherited from
- * `openNodeInspector`: a stale target must never open an empty inspector.
+ * Fail-closed and silent on a node that is not on the canvas — now inherited
+ * from `focusModelTarget` rather than `openNodeInspector`, since the act was
+ * re-pointed at the Model tab. Same contract, different helper: a stale target
+ * must never open an empty surface. (⚠ `PreAnalysisPanel`, the other consumer
+ * of this component, still injects the Inspector helper for its own control —
+ * that surface is read-only for the reason given below and is NOT in this
+ * change's scope.)
  *
  * Module-level so the reference is stable across renders of a memoised tree.
  */
@@ -264,8 +270,52 @@ const POST_RUN_VALUE_EDIT_CONNECTED = hasServerGraphAuthority(
 const POST_RUN_FACTOR_CONFIRMATION_CONNECTED = hasServerGraphAuthority(
   CANONICAL_EDIT_AUTHORITY.postRunFactorConfirmation,
 )
+/**
+ * ⭐ THE "EDIT" ACT — RE-POINTED FROM THE INSPECTOR TO THE ONE SURFACE THAT WRITES.
+ *
+ * It used to call `openNodeInspector`, which selects the node and raises
+ * `InspectorModal`. The Inspector CANNOT SAVE. `inspector-v2/useInspectorMutations.ts`
+ * carries its own authority manifest — `NODE_SETTER_AUTHORITY` (:119) and
+ * `EDGE_SETTER_AUTHORITY` (:143) — and EVERY setter in both is `'disabled'`,
+ * `setObservedValue` included. The module says so in a mounted constant:
+ *
+ *   INSPECTOR_READ_ONLY_REASON = 'This inspector is read-only because these
+ *   changes cannot yet be saved to the shared model. Use the Model tab for
+ *   supported factor values …'
+ *
+ * So this control advertised an edit and delivered a read-only panel. It is the
+ * same dead end the resolve-next act was corrected for, on a different surface.
+ *
+ * ⚠ THIS IS NOT A FLAG FLIP, AND DELIBERATELY SO. `postRunFactorValue` stays
+ * `'disabled'` below and that is HONEST: it governs the post-run INLINE editor
+ * (`onSetValue`, which writes through a path with no working writer), and the
+ * Inspector is read-only for a second, independent reason. Flipping it would
+ * assert a capability neither surface has. What changes is the DESTINATION.
+ *
+ * Navigation is not a mutation, so this is not governed by
+ * `CANONICAL_EDIT_AUTHORITY` at all — the same reason the resolve-next act
+ * consults no key. The destination is Model tab v2, whose editor reaches
+ * `useModelEditAuthority.proposeFactorValue` → `factor_value_edit`, which CEE
+ * handles as `'mutating'`. That is the only UI path in the product that ends in
+ * a saved change.
+ *
+ * ⚠ Residual, stated not buried: the write is `'local_only'` when no
+ * conversation panel is mounted to supply `sendSystemEvent`. Pre-existing on the
+ * destination and identical for every existing Model-tab user; not introduced
+ * here, and not witnessed live by this change.
+ */
 const openValueEditor = (nodeId: string): void => {
-  openNodeInspector(nodeId)
+  useUIStore.getState().setActiveOutputTab('diagnostics')
+  // ⚠ PASS THE KEY, NOT THE VALUE. `MODEL_SECTION_TARGET`
+  // (`canvas/components/ModelTabBody.tsx:123`) maps section NAMES to testids,
+  // and the consumer at `:243` does `MODEL_SECTION_TARGET[pending] ?? 'model-tab-v2-panel'`.
+  // Passing the testid misses the lookup and the `??` SILENTLY lands the user at
+  // the panel top with nothing selected — exactly the failure this call exists to
+  // fix. Caught in review on the sibling PR after I wrote it there first; pinned
+  // below by `triageEditActRoutesToFactors.spec.ts`, which asserts the argument is
+  // a KEY of that map rather than any string that happens to look right.
+  useUIStore.getState().requestModelTabSection('factors')
+  focusModelTarget(nodeId)
 }
 
 // ── Section 2: Result checks (Brief 5.8B D2c — flip-risk extracted) ─────────
@@ -995,7 +1045,7 @@ export const TriageActionCardsBody = memo(function TriageActionCardsBody({
                       sourcePill={item.sourcePill}
                       passiveLabels={item.passiveLabels}
                       onConfirm={POST_RUN_FACTOR_CONFIRMATION_CONNECTED ? onConfirm : undefined}
-                      onEdit={POST_RUN_VALUE_EDIT_CONNECTED ? openValueEditor : undefined}
+                      onEdit={openValueEditor}
                       onHoverEnter={onHoverEnter}
                       onHoverLeave={onHoverLeave}
                     />
@@ -1012,7 +1062,7 @@ export const TriageActionCardsBody = memo(function TriageActionCardsBody({
               onHoverEnter={onHoverEnter}
               onHoverLeave={onHoverLeave}
               onConfirm={POST_RUN_FACTOR_CONFIRMATION_CONNECTED ? onConfirm : undefined}
-              onEdit={POST_RUN_VALUE_EDIT_CONNECTED ? openValueEditor : undefined}
+              onEdit={openValueEditor}
             />
           )}
         </div>

--- a/src/components/results/__tests__/ResultsBody.editValueOpensEditor.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.editValueOpensEditor.spec.tsx
@@ -245,12 +245,43 @@ describe('ResultsBody — local-only value actions fail closed', () => {
     localStorage.clear()
   })
 
-  it('keeps both action cards visible while withholding the dead pencil', () => {
+  /*
+   * ⭐ THE PENCIL IS NO LONGER DEAD, AND THAT IS THE CHANGE.
+   *
+   * This case asserted the pencil was WITHHELD, on the correct premise that its
+   * destination could not save: it called `openNodeInspector`, and the Inspector
+   * is read-only by its own policy — `inspector-v2/useInspectorMutations.ts`
+   * `NODE_SETTER_AUTHORITY` (:119) and `EDGE_SETTER_AUTHORITY` (:143) are every
+   * setter `'disabled'`, and `INSPECTOR_READ_ONLY_REASON` says so in user-facing
+   * copy: "these changes cannot yet be saved to the shared model. Use the Model
+   * tab for supported factor values."
+   *
+   * The act now goes where that copy points. Withholding it was right while it
+   * dead-ended; it is wrong now that it reaches the one path that writes.
+   *
+   * ⚠ NOTE WHAT IS NOT CHANGED, because it is the honest half: the INLINE editor
+   * and Confirm stay withheld (next two cases), because those genuinely have no
+   * working carrier. Only the NAVIGATION was re-pointed.
+   */
+  it('MOUNTS the pencil and routes it to the Model tab factors section', () => {
     renderBody()
     expect(cardFor(GAP_LABEL)).toBeInTheDocument()
     expect(cardFor(ACTION_LABEL)).toBeInTheDocument()
-    expect(within(cardFor(ACTION_LABEL)).queryByRole('button', { name: 'Edit value' }))
-      .not.toBeInTheDocument()
+
+    const pencil = within(cardFor(ACTION_LABEL)).getByRole('button', { name: 'Edit value' })
+
+    // No inspector raise — the dead destination must not be reached even once.
+    withInspectorWatch(count => {
+      pencil.click()
+      expect(count(), 'the act must not raise the read-only Inspector').toBe(0)
+    })
+
+    // ⚠ Assert the SECTION KEY, not merely that something was requested. The
+    // consumer coalesces an unknown key to the panel top
+    // (`ModelTabBody.tsx:243`), so a wrong string routes silently — which is
+    // exactly the defect caught on the sibling PR.
+    expect(useUIStore.getState().pendingModelTabSection).toBe('factors')
+    expect(useUIStore.getState().activeOutputTab).toBe('diagnostics')
   })
 
   it('withholds the inline editor even when a caller supplies local callbacks', () => {

--- a/src/components/results/__tests__/triageEditActRoutesToFactors.spec.ts
+++ b/src/components/results/__tests__/triageEditActRoutesToFactors.spec.ts
@@ -1,0 +1,63 @@
+/**
+ * The triage "edit" act must route to the Model tab's FACTORS group.
+ *
+ * ⚠ WRITTEN BECAUSE THE FIRST VERSION PASSED THE WRONG STRING AND NOTHING RED.
+ * `requestModelTabSection` takes a section NAME; `MODEL_SECTION_TARGET` maps that
+ * name to a testid, and its consumer coalesces a miss to the panel top
+ * (`ModelTabBody.tsx:243`, `?? 'model-tab-v2-panel'`). So passing the TESTID is
+ * silently degrading, never throwing: the user lands at the top of the outline
+ * with nothing selected. A silent fallback on a navigation target is exactly the
+ * shape that survives a green suite.
+ *
+ * This asserts the argument is a KEY OF THE MAP — not that it equals a particular
+ * string, which a future rename would satisfy while pointing nowhere.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+
+const CALLER = 'src/components/results/TriageActionCardsBody.tsx'
+const MAP_HOST = 'src/canvas/components/ModelTabBody.tsx'
+
+describe('the triage edit act targets a real Model-tab section', () => {
+  const caller = readFileSync(CALLER, 'utf8')
+  const host = readFileSync(MAP_HOST, 'utf8')
+
+  it('both files are tracked and non-empty (positive control)', () => {
+    for (const f of [CALLER, MAP_HOST]) {
+      expect(execFileSync('git', ['ls-files', f], { encoding: 'utf8' }).trim()).toBe(f)
+    }
+    expect(caller.length).toBeGreaterThan(1000)
+    expect(host.length).toBeGreaterThan(1000)
+  })
+
+  /** The map's KEYS, derived from the host — never restated here (trap 12). */
+  const sectionKeys = (): string[] => {
+    const i = host.indexOf('const MODEL_SECTION_TARGET')
+    expect(i, 'MODEL_SECTION_TARGET not found — has it been renamed?').toBeGreaterThan(-1)
+    const block = host.slice(i, host.indexOf('}', i))
+    return [...block.matchAll(/^\s*([a-zA-Z][a-zA-Z0-9_]*)\s*:/gm)].map(m => m[1])
+  }
+
+  it('derives a plausible key set (guards against a blind parse)', () => {
+    const keys = sectionKeys()
+    expect(keys.length).toBeGreaterThanOrEqual(4)
+    expect(keys).toContain('factors')
+    // Contrast: the TESTID must NOT be a key. If it ever is, this spec's whole
+    // premise is void and it must fail rather than quietly pass.
+    expect(keys).not.toContain('model-group-v2-factors')
+  })
+
+  it('requests the factors section BY KEY, not by testid', () => {
+    const m = caller.match(/requestModelTabSection\(\s*'([^']+)'\s*\)/)
+    expect(m, 'no literal requestModelTabSection call found in the caller').toBeTruthy()
+    const arg = m![1]
+    expect(
+      sectionKeys(),
+      `requestModelTabSection('${arg}') is not a key of MODEL_SECTION_TARGET, so the `
+        + "consumer's `?? 'model-tab-v2-panel'` fallback will land the user at the panel "
+        + 'top with nothing selected.',
+    ).toContain(arg)
+    expect(arg).toBe('factors')
+  })
+})


### PR DESCRIPTION
⚠ **CONTRACT CLASS: IN** — it changes what the product invites a user to do about their model.

## What it closes

The post-run queue tells a user which evidence gaps matter, offers a pencil, and the pencil was withheld — because its destination could not save. Correct, but it left the ask with **no act at all**. This re-points it at the Model tab, which is where the Inspector's own copy already sends people.

## Why the pencil was dead

`openValueEditor` called `openNodeInspector`. **The Inspector is read-only by its own policy** — `inspector-v2/useInspectorMutations.ts` carries `NODE_SETTER_AUTHORITY` (`:119`) and `EDGE_SETTER_AUTHORITY` (`:143`), and **every setter in both is `'disabled'`**. Its mounted constant says so in user-facing words:

> This inspector is read-only because these changes cannot yet be saved to the shared model. **Use the Model tab for supported factor values** or ask Olumi to change structure.

This change does what that sentence says.

## ⚠ Not a flag flip, deliberately

`postRunFactorValue` stays **`'disabled'`**. It governs the post-run **inline editor** (`onSetValue`), which writes through a path with no working writer — and the Inspector is read-only for a *second, independent* reason. Flipping it would assert a capability neither surface has.

Only the **destination** of the navigation changed. Navigation is not a mutation, so it is governed by no authority table — the same reason the resolve-next act consults no key. The destination reaches `useModelEditAuthority.proposeFactorValue` → `factor_value_edit`, which CEE handles as `'mutating'` (`dispatch.ts:270`) — the only UI path in the product that ends in a saved change.

## ⚠ Pass the key, not the value — I wrote this bug before I fixed it

`requestModelTabSection` takes a section **name**. `MODEL_SECTION_TARGET` (`ModelTabBody.tsx:123`) maps names → testids, and its consumer coalesces a miss to the panel top (`:243`, `?? 'model-tab-v2-panel'`).

My first version passed the **testid**, so the deep-link would have silently landed the user at the top of the outline with nothing selected — the exact failure the call was added to fix. Caught in review on the sibling PR and corrected here before it shipped.

`triageEditActRoutesToFactors.spec.ts` pins it by **deriving** the key set from `MODEL_SECTION_TARGET` and asserting the argument is a member — never against a hardcoded string, which a rename would satisfy while pointing nowhere. It carries a contrast assertion that the testid is **not** a key, so if that ever becomes true the spec fails rather than passing on a void premise.

## What is deliberately unchanged — the honest half

The **inline editor** and **Confirm** stay withheld. Those have no working carrier, and their two specs still assert absence. Only the navigation moved.

## Evidence

| | |
|---|---|
| named gate | **PASSED** at exactly baseline 2252/556; `--update-baseline` not touched |
| suites | **579 files / 8643 tests, 0 failures** (results + canvas/components) |
| mutant | revert the argument to the testid → new guard **REDs** (1 of 3) |
| trailing control | 3/3 green |

`ResultsBody.editValueOpensEditor.spec.tsx`'s *"withholding the dead pencil"* case is **rewritten, not deleted**: it now asserts the pencil mounts, raises no Inspector, and requests section key `'factors'`. Its premise (the destination cannot save) was true and is now false — a case whose premise has inverted must change, not be dropped.

## Rung, stated plainly

Source-derived and suite-verified. **Not** driven on authenticated staging — I have not witnessed the write live, and the write is `'local_only'` when no conversation panel is mounted to supply `sendSystemEvent` (pre-existing on the destination, identical for every existing Model-tab user, not introduced here).