### PR TITLE
fix(auth): the scenario routes carry a verified token, so CEE can stop trusting the body

### DIFF
--- a/src/adapters/cee/__tests__/scenarioRoutesUserJwt.spec.ts
+++ b/src/adapters/cee/__tests__/scenarioRoutesUserJwt.spec.ts
@@ -36,6 +36,8 @@ const USER_ID = '99999999-8888-4777-8666-555555555555'
 
 /** A JWT-shaped token. Distinctive so an assertion cannot match by accident. */
 const ACCESS_TOKEN = 'eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJzMy1zcGVjIn0.c2lnbmF0dXJl'
+/** A token from a DIFFERENT session — distinct bytes, so a mix-up is visible. */
+const OTHER_TOKEN = 'eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJvdGhlci1zZXNzIn0.b3RoZXJzaWc'
 
 let fetchSpy: ReturnType<typeof vi.fn>
 
@@ -155,6 +157,49 @@ describe('scenario routes — a guest is byte-identical to before this change', 
 
       expect(sentBody().user_id).toBeUndefined()
       expect(sentHeaders()['X-User-Id']).toBeUndefined()
+    })
+  }
+})
+
+/**
+ * ── THE TWO CLASSES THE SIGNED-IN / GUEST PAIR CANNOT SEE ──────────────────
+ *
+ * The pair above varies both fields together: (id + token) or (null + null).
+ * That is structurally blind to every input where the two DISAGREE — and
+ * disagreement is exactly what the call sites were fixed to prevent, so the
+ * corpus has to be able to observe it or the fix is unguarded at rest.
+ *
+ * Neither class is a defect in the adapter. The adapter is a transport and
+ * cannot know which session a value came from. They are pinned so the wire is
+ * documented, and so a future change to either channel has to face them.
+ */
+describe('identity classes the signed-in/guest pair is blind to', () => {
+  for (const route of ROUTES) {
+    it(`${route.name}: a real id with NO token sends the body id and no header`, async () => {
+      fetchSpy.mockResolvedValue(jsonResponse(200, route.ok))
+
+      // The pre-#851 world, and the world any signed-in user is in whenever
+      // the token read fails or the session has gone. CEE resolves this as
+      // `service_legacy`, where the body id is the only identity — which is
+      // precisely the channel the CEE-side strip will close.
+      await route.call({ userId: USER_ID, accessToken: null })
+
+      expect(sentBody().user_id).toBe(USER_ID)
+      expect(sentHeaders().Authorization).toBeUndefined()
+    })
+
+    it(`${route.name}: a real id with ANOTHER session's token sends both verbatim`, async () => {
+      fetchSpy.mockResolvedValue(jsonResponse(200, route.ok))
+
+      await route.call({ userId: USER_ID, accessToken: OTHER_TOKEN })
+
+      // Both go out as given. The adapter does not and cannot arbitrate; the
+      // guarantee that these two never disagree lives at the CALL SITE, which
+      // is why every call site reads both fields from one session object.
+      // CEE is the arbiter: with the flag on, the verified `sub` wins and the
+      // body id is ignored, so a mismatch is telemetry and not a privilege.
+      expect(sentBody().user_id).toBe(USER_ID)
+      expect(sentHeaders().Authorization).toBe(`Bearer ${OTHER_TOKEN}`)
     })
   }
 })

--- a/src/adapters/cee/__tests__/scenarioRoutesUserJwt.spec.ts
+++ b/src/adapters/cee/__tests__/scenarioRoutesUserJwt.spec.ts
@@ -1,0 +1,160 @@
+/**
+ * The scenario routes carry a VERIFIED TOKEN — UI half of the ownership fix.
+ *
+ * ── WHY THIS SPEC EXISTS ────────────────────────────────────────────────────
+ * `CEE_REQUIRE_USER_JWT` is ON in deployed staging (measured at the boot log:
+ * `require_user_jwt: true`; and on the wire: a JWT-shaped invalid Bearer
+ * answers 401 `validator: "user_jwt"`, a branch only reachable with the flag
+ * on). These three adapters nevertheless sent NO `Authorization` header, so
+ * every signed-in caller resolved `service_legacy` at CEE and the body
+ * `user_id` was their ONLY identity — a field an unauthenticated caller can
+ * forge, demonstrated end-to-end against deployed staging.
+ *
+ * CEE cannot strip that field until the token arrives, or it would refuse
+ * signed-in users on their own scenarios. This spec pins the half that makes
+ * the strip safe to land, and pins the guest posture that must not move.
+ *
+ * ── WHAT EACH ASSERTION BINDS TO ────────────────────────────────────────────
+ * Every assertion binds by IDENTITY — the exact header name and the exact
+ * token value — never by "some header was sent". A value predicate another
+ * header could satisfy would pass on the wrong object.
+ *
+ * The pairs are deliberate: for every "sent when signed in" there is a
+ * "NOT sent for a guest" twin. One direction alone cannot tell a working
+ * header from a header that is always on, and always-on here would mean
+ * sending `X-User-Id: guest` — the sentinel that is not a Supabase id.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { fetchScenarioGraph } from '../scenarioGraph'
+import { registerScenarioGraph } from '../registerScenarioGraph'
+import { listModelVersions, saveModelVersion, restoreModelVersion } from '../modelVersions'
+
+const SCENARIO_ID = '11111111-2222-4333-8444-555555555555'
+const USER_ID = '99999999-8888-4777-8666-555555555555'
+
+/** A JWT-shaped token. Distinctive so an assertion cannot match by accident. */
+const ACCESS_TOKEN = 'eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJzMy1zcGVjIn0.c2lnbmF0dXJl'
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: async () => body,
+  } as unknown as Response
+}
+
+/** The headers the adapter actually passed to `fetch`, for the one call made. */
+function sentHeaders(): Record<string, string> {
+  expect(fetchSpy).toHaveBeenCalledTimes(1)
+  const init = fetchSpy.mock.calls[0][1] as RequestInit
+  return (init.headers ?? {}) as Record<string, string>
+}
+
+function sentBody(): Record<string, unknown> {
+  const init = fetchSpy.mock.calls[0][1] as RequestInit
+  return JSON.parse(String(init.body)) as Record<string, unknown>
+}
+
+beforeEach(() => {
+  fetchSpy = vi.fn()
+  vi.stubGlobal('fetch', fetchSpy)
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+/**
+ * One table, five routes. Each entry drives its adapter with a signed-in
+ * identity and then with a guest identity, so the pair is applied uniformly
+ * and a route added later without a token is visible as a missing row.
+ */
+const ROUTES: ReadonlyArray<{
+  readonly name: string
+  readonly ok: unknown
+  readonly call: (opts: { userId: string | null; accessToken: string | null }) => Promise<unknown>
+}> = [
+  {
+    name: 'fetchScenarioGraph (read)',
+    ok: { schema: 'scenario_graph.v1', scenario_id: SCENARIO_ID, graph: { nodes: [], edges: [] } },
+    call: (o) => fetchScenarioGraph(SCENARIO_ID, { ...o, retryDelayMs: 0 }),
+  },
+  {
+    name: 'registerScenarioGraph (write)',
+    ok: { schema: 'scenario_graph_registration.v1', registered: true, node_count: 0, edge_count: 0 },
+    call: (o) => registerScenarioGraph(SCENARIO_ID, { nodes: [], edges: [] }, { ...o, retryDelayMs: 0 }),
+  },
+  {
+    name: 'listModelVersions (read)',
+    ok: { schema: 'model_versions_list.v1', versions: [] },
+    call: (o) => listModelVersions(SCENARIO_ID, o),
+  },
+  {
+    name: 'saveModelVersion (write)',
+    ok: { schema: 'model_version_save.v1', version: {} },
+    call: (o) => saveModelVersion(SCENARIO_ID, o),
+  },
+  {
+    name: 'restoreModelVersion (write)',
+    ok: { schema: 'model_version_restore.v1' },
+    call: (o) => restoreModelVersion(SCENARIO_ID, { ...o, versionId: 'v1' }),
+  },
+]
+
+describe('scenario routes — a signed-in caller presents a verifiable token', () => {
+  for (const route of ROUTES) {
+    it(`${route.name} sends Authorization: Bearer <access token>`, async () => {
+      fetchSpy.mockResolvedValue(jsonResponse(200, route.ok))
+
+      await route.call({ userId: USER_ID, accessToken: ACCESS_TOKEN })
+
+      // Bound by identity: the exact header, carrying the exact token.
+      expect(sentHeaders().Authorization).toBe(`Bearer ${ACCESS_TOKEN}`)
+    })
+
+    it(`${route.name} still sends body user_id (CEE has not stripped it yet)`, async () => {
+      fetchSpy.mockResolvedValue(jsonResponse(200, route.ok))
+
+      await route.call({ userId: USER_ID, accessToken: ACCESS_TOKEN })
+
+      // ⚠ THIS ASSERTION IS A DEPLOY-ORDER FENCE, NOT A PREFERENCE. CEE
+      // resolves `service_legacy` for any caller it cannot verify, and in that
+      // mode the body field is the only identity. Deleting it here before
+      // CEE's strip is deployed would take ownership away from every signed-in
+      // user. It comes out in the SAME change that lands the strip, not before.
+      expect(sentBody().user_id).toBe(USER_ID)
+    })
+  }
+})
+
+describe('scenario routes — a guest is byte-identical to before this change', () => {
+  for (const route of ROUTES) {
+    it(`${route.name} sends NO auth headers for a guest`, async () => {
+      fetchSpy.mockResolvedValue(jsonResponse(200, route.ok))
+
+      await route.call({ userId: null, accessToken: null })
+
+      const headers = sentHeaders()
+      expect(headers.Authorization).toBeUndefined()
+      expect(headers['X-User-Id']).toBeUndefined()
+      // The only header a guest request carries is the content type.
+      expect(Object.keys(headers)).toEqual(['Content-Type'])
+    })
+
+    it(`${route.name} never sends the 'guest' sentinel as an identity`, async () => {
+      fetchSpy.mockResolvedValue(jsonResponse(200, route.ok))
+
+      // The sentinel `AuthContext` mints. It is not a Supabase id and must not
+      // reach CEE through EITHER channel — body or header.
+      await route.call({ userId: 'guest', accessToken: null })
+
+      expect(sentBody().user_id).toBeUndefined()
+      expect(sentHeaders()['X-User-Id']).toBeUndefined()
+    })
+  }
+})

--- a/src/adapters/cee/__tests__/scenarioRoutesUserJwt.spec.ts
+++ b/src/adapters/cee/__tests__/scenarioRoutesUserJwt.spec.ts
@@ -26,6 +26,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { fetchScenarioGraph } from '../scenarioGraph'
 import { registerScenarioGraph } from '../registerScenarioGraph'
@@ -78,31 +81,38 @@ afterEach(() => {
  */
 const ROUTES: ReadonlyArray<{
   readonly name: string
+  /** The exported adapter function this row exercises — the derived guard's key. */
+  readonly fn: string
   readonly ok: unknown
   readonly call: (opts: { userId: string | null; accessToken: string | null }) => Promise<unknown>
 }> = [
   {
     name: 'fetchScenarioGraph (read)',
+    fn: 'fetchScenarioGraph',
     ok: { schema: 'scenario_graph.v1', scenario_id: SCENARIO_ID, graph: { nodes: [], edges: [] } },
     call: (o) => fetchScenarioGraph(SCENARIO_ID, { ...o, retryDelayMs: 0 }),
   },
   {
     name: 'registerScenarioGraph (write)',
+    fn: 'registerScenarioGraph',
     ok: { schema: 'scenario_graph_registration.v1', registered: true, node_count: 0, edge_count: 0 },
     call: (o) => registerScenarioGraph(SCENARIO_ID, { nodes: [], edges: [] }, { ...o, retryDelayMs: 0 }),
   },
   {
     name: 'listModelVersions (read)',
+    fn: 'listModelVersions',
     ok: { schema: 'model_versions_list.v1', versions: [] },
     call: (o) => listModelVersions(SCENARIO_ID, o),
   },
   {
     name: 'saveModelVersion (write)',
+    fn: 'saveModelVersion',
     ok: { schema: 'model_version_save.v1', version: {} },
     call: (o) => saveModelVersion(SCENARIO_ID, o),
   },
   {
     name: 'restoreModelVersion (write)',
+    fn: 'restoreModelVersion',
     ok: { schema: 'model_version_restore.v1' },
     call: (o) => restoreModelVersion(SCENARIO_ID, { ...o, versionId: 'v1' }),
   },
@@ -202,4 +212,57 @@ describe('identity classes the signed-in/guest pair is blind to', () => {
       expect(sentHeaders().Authorization).toBe(`Bearer ${OTHER_TOKEN}`)
     })
   }
+})
+
+/**
+ * ── THE ROUTE TABLE ABOVE IS HAND-MAINTAINED, AND THAT IS THE DEFECT ───────
+ *
+ * A sixth scenario-route adapter added later would get NO coverage here, and
+ * nothing would go red — the table would simply be short, and a short list
+ * reads exactly like a complete one. This estate's dominant defect.
+ *
+ * Review found this shape live: `useProvisionalAnalysisDelivery.ts` was a
+ * SIXTH `fetchScenarioGraph` call site with no token, invisible to the grep
+ * that found the other five because it passes the adapter by reference
+ * (`read: fetchScenarioGraph`) rather than calling it by name.
+ *
+ * So the completeness check is DERIVED FROM SOURCE rather than written down.
+ * The rule: in these three adapter modules, an exported `async function` is a
+ * request-issuing route (each module has exactly one `await fetch(` and the
+ * only other exports are synchronous `*Url` builders). Every one of them must
+ * appear in ROUTES.
+ *
+ * ⚠ Derivation proves AGREEMENT, never completeness (CLAUDE.md trap 12d): this
+ *   guard catches a route the table forgot, and CANNOT catch a request issued
+ *   from somewhere other than these three modules. That is what the
+ *   `accessToken`-manifest check in review is for. Both are needed; neither
+ *   supersedes the other.
+ */
+describe('the route table cannot silently go short', () => {
+  const ADAPTERS = ['scenarioGraph.ts', 'registerScenarioGraph.ts', 'modelVersions.ts']
+
+  function exportedAsyncFunctions(): string[] {
+    const dir = path.dirname(fileURLToPath(import.meta.url))
+    const names: string[] = []
+    for (const file of ADAPTERS) {
+      const src = readFileSync(path.join(dir, '..', file), 'utf8')
+      for (const m of src.matchAll(/^export async function (\w+)/gm)) names.push(m[1])
+    }
+    return names
+  }
+
+  it('POSITIVE CONTROL — the deriver can actually see functions', () => {
+    // Without this, an extractor that silently returned [] would make the
+    // assertion below pass by testing nothing (CLAUDE.md trap 13).
+    const found = exportedAsyncFunctions()
+    expect(found.length).toBeGreaterThanOrEqual(5)
+    expect(found).toContain('fetchScenarioGraph')
+  })
+
+  it('every request-issuing adapter export is covered by ROUTES', () => {
+    const covered = new Set(ROUTES.map((r) => r.fn))
+    const missing = exportedAsyncFunctions().filter((n) => !covered.has(n))
+    // Named, not counted: the failure message must say WHICH route is uncovered.
+    expect(missing).toEqual([])
+  })
 })

--- a/src/adapters/cee/__tests__/signInRefusal.spec.ts
+++ b/src/adapters/cee/__tests__/signInRefusal.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * Both of CEE's sign-in refusals are recognised — the casing split, closed.
+ *
+ * ── THE DEFECT THIS PR CREATED, AND THIS FIXES ─────────────────────────────
+ * CEE emits two structurally different 401s meaning the same thing:
+ *
+ *   guest-on-versions  `details.code: "SIGN_IN_REQUIRED"`   (UPPER)
+ *   JWT refusal        `details.code: "sign_in_required"`   (lower)
+ *                      + `validator: "user_jwt"`
+ *
+ * The UI matched the UPPER form case-sensitively. So the JWT refusal fell
+ * through to a generic refusal and the user was told *"…could not be saved
+ * right now. Try again."* on a response CEE marks `retryable: false` — advice
+ * that cannot work. On the graph read it became a silent hydration failure
+ * with no prompt at all.
+ *
+ * ⚠ THE JWT REFUSAL WAS UNREACHABLE BEFORE THIS PR. `resolveUserIdentity` only
+ *   reaches `refused` when a token is PRESENTED and fails to verify, and the
+ *   UI presented none. Sending tokens is what makes an expired one reachable,
+ *   which is why this is fixed in the same change rather than rowed.
+ *
+ * ── THE JWT BODY BELOW IS WIRE-WITNESSED, NOT INVENTED ─────────────────────
+ * Captured from deployed staging by posting a JWT-shaped but invalid Bearer
+ * to `/bff/cee/scenarios/<uuid>/graph`. A self-authored fixture would encode
+ * this author's model of the producer rather than the producer (CLAUDE.md
+ * trap 16), and the casing is the entire point.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { isSignInRequired } from '../signInRefusal'
+import { fetchScenarioGraph } from '../scenarioGraph'
+import { saveModelVersion, listModelVersions } from '../modelVersions'
+
+const SCENARIO = '11111111-2222-4333-8444-555555555555'
+
+/** VERBATIM from the wire — deployed staging, invalid Bearer, 401. */
+const JWT_REFUSAL = {
+  error: 'INGRESS_CONTRACT_VIOLATION',
+  boundary: 'B1',
+  direction: 'ingress',
+  validator: 'user_jwt',
+  details: {
+    reason: 'sign_in_required',
+    code: 'sign_in_required',
+    recoverable: true,
+    auth_reason: 'invalid_token',
+  },
+  request_id: '17cfcd04-f272-43cc-8c6c-89befe2622fd',
+  retryable: false,
+}
+
+/** The guest form, upper-cased, from `assist.v1.scenario-versions.ts`. */
+const GUEST_REFUSAL = {
+  schema: 'error.v1',
+  code: 'UNAUTHENTICATED',
+  details: { code: 'SIGN_IN_REQUIRED' },
+}
+
+describe('isSignInRequired — recognises both producers', () => {
+  it('recognises the JWT refusal (lower-case code + user_jwt validator)', () => {
+    expect(isSignInRequired(401, JWT_REFUSAL)).toBe(true)
+  })
+
+  it('recognises the guest refusal (UPPER-case code, no validator)', () => {
+    expect(isSignInRequired(401, GUEST_REFUSAL)).toBe(true)
+  })
+
+  it('is NOT true of every 401 — the discriminator', () => {
+    // Without this the predicate could be `status === 401` and both cases
+    // above would still pass, which would route every 403-adjacent refusal to
+    // a sign-in prompt that cannot fix it.
+    expect(isSignInRequired(401, { schema: 'error.v1', code: 'UNAUTHENTICATED' })).toBe(false)
+    expect(isSignInRequired(401, { details: { code: 'RATE_LIMITED' } })).toBe(false)
+  })
+
+  it('is gated on 401 — the same body on another status is not this refusal', () => {
+    expect(isSignInRequired(403, JWT_REFUSAL)).toBe(false)
+    expect(isSignInRequired(200, GUEST_REFUSAL)).toBe(false)
+  })
+
+  it('survives bodies that carry no shape at all', () => {
+    for (const body of [null, undefined, 'not json', 42, []]) {
+      expect(isSignInRequired(401, body)).toBe(false)
+    }
+  })
+})
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: async () => body,
+  } as unknown as Response
+}
+
+beforeEach(() => {
+  fetchSpy = vi.fn()
+  vi.stubGlobal('fetch', fetchSpy)
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('the adapters route the JWT refusal to signInRequired, not to "try again"', () => {
+  it('fetchScenarioGraph: the wire-witnessed 401 becomes signInRequired', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(401, JWT_REFUSAL))
+
+    const result = await fetchScenarioGraph(SCENARIO, { retryDelayMs: 0 })
+
+    // Before this fix: { status: 'refused' } → hydration 'refused' → a canvas
+    // that silently failed to hydrate with no prompt.
+    expect(result).toEqual({ status: 'signInRequired' })
+  })
+
+  it('saveModelVersion: the wire-witnessed 401 becomes signInRequired', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(401, JWT_REFUSAL))
+
+    const result = await saveModelVersion(SCENARIO, {})
+
+    // Before this fix: { status: 'refused' } → "…could not be saved right now.
+    // Try again." on a response CEE marks retryable: false.
+    expect(result).toEqual({ status: 'signInRequired' })
+  })
+
+  it('listModelVersions: gains the branch it never had', async () => {
+    // LIST had NO sign-in handling at all — a guest list was an empty list, so
+    // the only 401 reachable was one the UI could not produce.
+    fetchSpy.mockResolvedValue(jsonResponse(401, JWT_REFUSAL))
+
+    const result = await listModelVersions(SCENARIO, {})
+
+    expect(result).toEqual({ status: 'signInRequired' })
+  })
+
+  it('OPPOSITE-DIRECTION TWIN — a 403 is still a plain refusal', async () => {
+    // Proves signInRequired is not swallowing every refusal. Without this, a
+    // predicate of `status >= 401` would pass all three tests above.
+    fetchSpy.mockResolvedValue(jsonResponse(403, { schema: 'error.v1', code: 'FORBIDDEN' }))
+
+    const result = await fetchScenarioGraph(SCENARIO, { retryDelayMs: 0 })
+
+    expect(result).toEqual({ status: 'refused', httpStatus: 403 })
+  })
+})

--- a/src/adapters/cee/modelVersions.ts
+++ b/src/adapters/cee/modelVersions.ts
@@ -35,13 +35,12 @@
  */
 
 import { logger } from '../../lib/logger'
+import { sanitiseUserId } from '../../lib/guestIdentity'
 import { buildTurnAuthHeaders } from '../../v5/turnAuthHeaders'
 
 /** The same-origin Netlify edge path. NOT `VITE_CEE_BFF_BASE` — see header. */
 export const MODEL_VERSIONS_BASE = '/bff/cee'
 
-/** The guest sentinel `AuthContext` mints; never a Supabase user id. */
-const GUEST_USER_ID = 'guest'
 
 /** Per-attempt deadline — same bound and rationale as scenarioGraph.ts. */
 const DEFAULT_TIMEOUT_MS = 8000
@@ -151,17 +150,6 @@ export interface RestoreOptions extends CommonOptions {
 export interface SaveOptions extends CommonOptions {
   label?: string
   expectedGraphIdentityHash?: string
-}
-
-/**
- * ONE identity rule, feeding BOTH the body field and the auth headers. Two
- * copies of "is this a real user id" is how the body and the header start
- * disagreeing about who the caller is.
- */
-function sanitiseUserId(userId: string | null | undefined): string | null {
-  return typeof userId === 'string' && userId.length > 0 && userId !== GUEST_USER_ID
-    ? userId
-    : null
 }
 
 function identityBody(userId: string | null | undefined): Record<string, unknown> {

--- a/src/adapters/cee/modelVersions.ts
+++ b/src/adapters/cee/modelVersions.ts
@@ -36,6 +36,7 @@
 
 import { logger } from '../../lib/logger'
 import { sanitiseUserId } from '../../lib/guestIdentity'
+import { isSignInRequired } from './signInRefusal'
 import { buildTurnAuthHeaders } from '../../v5/turnAuthHeaders'
 
 /** The same-origin Netlify edge path. NOT `VITE_CEE_BFF_BASE` — see header. */
@@ -82,6 +83,12 @@ export type ListModelVersionsResult =
     }
   /** 404 — absent ∪ not-yours ∪ oracle-unresolvable. NEVER deletion. */
   | { status: 'notReadable' }
+  /**
+   * 401 sign-in refusal. LIST had no such branch before: a guest listing was
+   * an empty list, so the only 401 reachable here was one the UI could not
+   * produce. Sending a token makes an expired one reachable on every call.
+   */
+  | { status: 'signInRequired' }
   /** 503 VERSIONS_DISABLED — versioning is off on this service. */
   | { status: 'disabled' }
   /** 503 (plain) — unknown, try again. */
@@ -234,10 +241,15 @@ function sharedRefusal(
   | { status: 'disabled' }
   | { status: 'unavailable' }
   | { status: 'refused'; httpStatus: number }
+  | { status: 'signInRequired' }
   | { status: 'unusable' }
   | null {
   if (outcome.kind === 'transportFailure') return { status: 'unusable' }
   if (outcome.kind === 'ok') return null
+  // BEFORE the status switch: a sign-in refusal is a 401, and the generic 401
+  // arm below would otherwise swallow it into `refused` — which the callers
+  // render as "try again", on a response CEE marks `retryable: false`.
+  if (isSignInRequired(outcome.status, outcome.body)) return { status: 'signInRequired' }
   const code = detailsCode(outcome.body)
   switch (outcome.status) {
     case 404:
@@ -352,7 +364,6 @@ export async function saveModelVersion(
 
   if (outcome.kind === 'http') {
     const code = detailsCode(outcome.body)
-    if (outcome.status === 401 && code === 'SIGN_IN_REQUIRED') return { status: 'signInRequired' }
     if (outcome.status === 409) return { status: 'conflict' }
     if (outcome.status === 422 && code === 'NOTHING_TO_SAVE') return { status: 'nothingToSave' }
   }
@@ -386,7 +397,6 @@ export async function restoreModelVersion(
 
   if (outcome.kind === 'http') {
     const code = detailsCode(outcome.body)
-    if (outcome.status === 401 && code === 'SIGN_IN_REQUIRED') return { status: 'signInRequired' }
     if (outcome.status === 409) return { status: 'conflict' }
     if (outcome.status === 404 && code === 'VERSION_NOT_FOUND') return { status: 'versionNotFound' }
     if (outcome.status === 503 && code === 'RESTORE_INCOMPLETE') return { status: 'incomplete' }

--- a/src/adapters/cee/modelVersions.ts
+++ b/src/adapters/cee/modelVersions.ts
@@ -13,8 +13,9 @@
  * `VITE_CEE_BFF_BASE` (that var is dashboard-baked to an absolute PLoT URL;
  * resolving from it would leave the edge seam entirely and 404 on a service
  * that has never heard of versions — CLAUDE.md trap 18 in its live form).
- * Identity travels in the BODY (`user_id`), never a URL; the guest sentinel
- * is never sent as a user id.
+ * Identity travels as a VERIFIED TOKEN (`Authorization: Bearer …`), with the
+ * body `user_id` retained as the legacy fallback until CEE strips it. Never a
+ * URL; the guest sentinel is never sent as a user id, in either channel.
  *
  * WHAT THIS CLIENT NEVER SENDS: a graph. A version is a snapshot of the
  * SERVER's shared model — save versions `scenarios.graph` server-side, and
@@ -34,6 +35,7 @@
  */
 
 import { logger } from '../../lib/logger'
+import { buildTurnAuthHeaders } from '../../v5/turnAuthHeaders'
 
 /** The same-origin Netlify edge path. NOT `VITE_CEE_BFF_BASE` — see header. */
 export const MODEL_VERSIONS_BASE = '/bff/cee'
@@ -129,6 +131,12 @@ export type RestoreModelVersionResult =
 interface CommonOptions {
   /** Supabase user id. Omitted for guests. */
   userId?: string | null
+  /**
+   * Supabase access token. Sent as `Authorization: Bearer …` so CEE derives
+   * identity from the verified `sub` instead of trusting the body. Null for
+   * guests, who have no session.
+   */
+  accessToken?: string | null
   signal?: AbortSignal
   timeoutMs?: number
 }
@@ -145,10 +153,22 @@ export interface SaveOptions extends CommonOptions {
   expectedGraphIdentityHash?: string
 }
 
+/**
+ * ONE identity rule, feeding BOTH the body field and the auth headers. Two
+ * copies of "is this a real user id" is how the body and the header start
+ * disagreeing about who the caller is.
+ */
+function sanitiseUserId(userId: string | null | undefined): string | null {
+  return typeof userId === 'string' && userId.length > 0 && userId !== GUEST_USER_ID
+    ? userId
+    : null
+}
+
 function identityBody(userId: string | null | undefined): Record<string, unknown> {
   const body: Record<string, unknown> = {}
-  if (typeof userId === 'string' && userId.length > 0 && userId !== GUEST_USER_ID) {
-    body.user_id = userId
+  const id = sanitiseUserId(userId)
+  if (id !== null) {
+    body.user_id = id
   }
   return body
 }
@@ -185,7 +205,15 @@ async function postOnce(
   try {
     response = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        // Shared builder — see `src/v5/turnAuthHeaders.ts`. Guests: both values
+        // null, no header emitted, byte-identical to before.
+        ...buildTurnAuthHeaders({
+          userId: sanitiseUserId(opts.userId),
+          accessToken: opts.accessToken ?? null,
+        }),
+      },
       body: JSON.stringify(payload),
       signal: controller.signal,
     })

--- a/src/adapters/cee/registerScenarioGraph.ts
+++ b/src/adapters/cee/registerScenarioGraph.ts
@@ -21,6 +21,7 @@
  */
 
 import { logger } from '../../lib/logger'
+import { sanitiseUserId } from '../../lib/guestIdentity'
 import { buildTurnAuthHeaders } from '../../v5/turnAuthHeaders'
 
 /**
@@ -45,8 +46,6 @@ const DEFAULT_RETRY_DELAY_MS = 400
  */
 const DEFAULT_TIMEOUT_MS = 10000
 
-/** The guest sentinel `AuthContext` mints; never a Supabase user id. */
-const GUEST_USER_ID = 'guest'
 
 export interface RegisteredGraphIdentity {
   /** CEE's opaque `identity.v1` token, VERBATIM. Compare CEE-to-CEE only. */
@@ -131,12 +130,7 @@ export async function registerScenarioGraph(
   //     ownership of what they register.
   //
   // Guests have no session: both values null, no auth header, byte-identical.
-  const identityUserId =
-    typeof opts.userId === 'string' &&
-    opts.userId.length > 0 &&
-    opts.userId !== GUEST_USER_ID
-      ? opts.userId
-      : null
+  const identityUserId = sanitiseUserId(opts.userId)
 
   const body: Record<string, unknown> = { graph }
   if (identityUserId !== null) {

--- a/src/adapters/cee/registerScenarioGraph.ts
+++ b/src/adapters/cee/registerScenarioGraph.ts
@@ -21,6 +21,7 @@
  */
 
 import { logger } from '../../lib/logger'
+import { buildTurnAuthHeaders } from '../../v5/turnAuthHeaders'
 
 /**
  * The same-origin Netlify edge path. NOT `VITE_CEE_BFF_BASE` — see the header.
@@ -75,6 +76,12 @@ export type RegisterScenarioGraphResult =
 
 export interface RegisterScenarioGraphOptions {
   readonly userId?: string | null
+  /**
+   * Supabase access token. Sent as `Authorization: Bearer …` so CEE DERIVES
+   * identity from the verified `sub` rather than trusting the body. Null for
+   * guests — see the identity note in `registerScenarioGraph`.
+   */
+  readonly accessToken?: string | null
   readonly signal?: AbortSignal
   readonly timeoutMs?: number
   readonly retryDelayMs?: number
@@ -108,17 +115,39 @@ export async function registerScenarioGraph(
 ): Promise<RegisterScenarioGraphResult> {
   const retryDelayMs = opts.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS
 
-  // Identity travels in the BODY: with `CEE_REQUIRE_USER_JWT` off, CEE's
-  // ownership pre-flight reads `user_id` from the request extensions, and it
-  // must be a UUID — the guest sentinel is not one and is never sent as one.
-  const body: Record<string, unknown> = { graph }
-  if (
+  // ── IDENTITY: the TOKEN is the authority; the body is the legacy fallback ──
+  //
+  // ⚠ AN EARLIER VERSION OF THIS COMMENT SAID `CEE_REQUIRE_USER_JWT` IS OFF.
+  //   IT IS ON — measured at the deployed boot log and on the wire. With a
+  //   token present CEE verifies it and derives identity from the `sub`; with
+  //   none it resolves `service_legacy`, where the body `user_id` is the only
+  //   identity. That fallback is why this call kept working while the comment
+  //   was wrong, and it is why the body field is still sent.
+  //
+  //   ⚠ THIS ROUTE IS A WRITE, and until CEE strips caller-asserted identity
+  //     the body field is forgeable by an unauthenticated caller. Sending the
+  //     token is the half that makes the strip safe to land; do not delete the
+  //     body field here before that strip is deployed, or signed-in users lose
+  //     ownership of what they register.
+  //
+  // Guests have no session: both values null, no auth header, byte-identical.
+  const identityUserId =
     typeof opts.userId === 'string' &&
     opts.userId.length > 0 &&
     opts.userId !== GUEST_USER_ID
-  ) {
-    body.user_id = opts.userId
+      ? opts.userId
+      : null
+
+  const body: Record<string, unknown> = { graph }
+  if (identityUserId !== null) {
+    body.user_id = identityUserId
   }
+
+  // ONE builder, shared with the turn path (`src/v5/turnAuthHeaders.ts`).
+  const authHeaders = buildTurnAuthHeaders({
+    userId: identityUserId,
+    accessToken: opts.accessToken ?? null,
+  })
 
   const url = scenarioGraphRegisterUrl(scenarioId)
   const payload = JSON.stringify(body)
@@ -137,7 +166,7 @@ export async function registerScenarioGraph(
     try {
       response = await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
         body: payload,
         signal: attemptController.signal,
       })

--- a/src/adapters/cee/scenarioGraph.ts
+++ b/src/adapters/cee/scenarioGraph.ts
@@ -60,6 +60,7 @@ import { AnalysisStateV1Schema } from '@talchain/schemas/boundary'
 import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
 
 import { logger } from '../../lib/logger'
+import { buildTurnAuthHeaders } from '../../v5/turnAuthHeaders'
 import { parseNotModelled, type NotModelledManifest } from './notModelled'
 
 /**
@@ -165,6 +166,12 @@ export type ScenarioGraphResult =
 export interface FetchScenarioGraphOptions {
   /** Supabase user id. Omitted for guest/unowned scenarios. */
   userId?: string | null
+  /**
+   * Supabase access token. Sent as `Authorization: Bearer …` so CEE can DERIVE
+   * identity from the verified `sub` instead of trusting the body. Null for
+   * guests, who have no session — see the identity note in `fetchScenarioGraph`.
+   */
+  accessToken?: string | null
   signal?: AbortSignal
   /** Backoff between 503 retries. Tests pass 0. */
   retryDelayMs?: number
@@ -317,17 +324,42 @@ export async function fetchScenarioGraph(
 ): Promise<ScenarioGraphResult> {
   const retryDelayMs = opts.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS
 
-  // Identity travels in the BODY: with `CEE_REQUIRE_USER_JWT` off (staging),
-  // CEE's ownership pre-flight reads `user_id` from the request extensions.
-  // The guest sentinel is not a Supabase id and must never be sent as one.
-  const body: Record<string, unknown> = {}
-  if (
+  // ── IDENTITY: the TOKEN is the authority; the body is the legacy fallback ──
+  //
+  // ⚠ AN EARLIER VERSION OF THIS COMMENT SAID `CEE_REQUIRE_USER_JWT` IS OFF ON
+  //   STAGING. IT IS ON — measured at the deployed boot log (`require_user_jwt:
+  //   true`) and on the wire (a JWT-shaped invalid Bearer answers 401
+  //   `validator: "user_jwt"`, a branch only reachable with the flag on).
+  //
+  // What that changes: when we send a token, CEE verifies it and DERIVES
+  // identity from the `sub`, ignoring any body `user_id`. When we send none,
+  // CEE resolves `service_legacy` and the body `user_id` is the ONLY identity —
+  // which is why this call kept working while the comment was wrong, and why
+  // the body field is still sent here. It is not redundant yet: CEE's strip of
+  // caller-asserted identity on these routes lands only after this half is
+  // deployed and a signed-in user is witnessed resolving `verified`.
+  //
+  // Guests have no session, so both values are null, no auth header is emitted
+  // and the request is byte-identical to before this change.
+  const identityUserId =
     typeof opts.userId === 'string' &&
     opts.userId.length > 0 &&
     opts.userId !== GUEST_USER_ID
-  ) {
-    body.user_id = opts.userId
+      ? opts.userId
+      : null
+
+  const body: Record<string, unknown> = {}
+  if (identityUserId !== null) {
+    body.user_id = identityUserId
   }
+
+  // ONE builder, shared with the turn path (`src/v5/turnAuthHeaders.ts`) — a
+  // second way of turning a session into headers is how two answers to one
+  // identity question get into a codebase.
+  const authHeaders = buildTurnAuthHeaders({
+    userId: identityUserId,
+    accessToken: opts.accessToken ?? null,
+  })
 
   const url = scenarioGraphUrl(scenarioId)
 
@@ -348,7 +380,7 @@ export async function fetchScenarioGraph(
     try {
       response = await fetch(url, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...authHeaders },
         body: JSON.stringify(body),
         signal: attemptController.signal,
       })

--- a/src/adapters/cee/scenarioGraph.ts
+++ b/src/adapters/cee/scenarioGraph.ts
@@ -57,6 +57,7 @@
  */
 
 import { AnalysisStateV1Schema } from '@talchain/schemas/boundary'
+import { sanitiseUserId } from '../../lib/guestIdentity'
 import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
 
 import { logger } from '../../lib/logger'
@@ -90,8 +91,6 @@ const DEFAULT_RETRY_DELAY_MS = 400
  */
 const DEFAULT_TIMEOUT_MS = 8000
 
-/** The guest sentinel `AuthContext` mints; never a Supabase user id. */
-const GUEST_USER_ID = 'guest'
 
 /**
  * CEE's `identity.v1` envelope, reduced to the two fields a consumer may act on.
@@ -341,12 +340,7 @@ export async function fetchScenarioGraph(
   //
   // Guests have no session, so both values are null, no auth header is emitted
   // and the request is byte-identical to before this change.
-  const identityUserId =
-    typeof opts.userId === 'string' &&
-    opts.userId.length > 0 &&
-    opts.userId !== GUEST_USER_ID
-      ? opts.userId
-      : null
+  const identityUserId = sanitiseUserId(opts.userId)
 
   const body: Record<string, unknown> = {}
   if (identityUserId !== null) {

--- a/src/adapters/cee/scenarioGraph.ts
+++ b/src/adapters/cee/scenarioGraph.ts
@@ -62,6 +62,7 @@ import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
 
 import { logger } from '../../lib/logger'
 import { buildTurnAuthHeaders } from '../../v5/turnAuthHeaders'
+import { isSignInRequired } from './signInRefusal'
 import { parseNotModelled, type NotModelledManifest } from './notModelled'
 
 /**
@@ -157,6 +158,13 @@ export type ScenarioGraphResult =
   | { status: 'notReadable' }
   /** 503 after every attempt — unknown, try again. NEVER an empty canvas. */
   | { status: 'unavailable' }
+  /**
+   * 401 and CEE says the token is the problem. Distinct from `refused`
+   * BECAUSE THE RECOVERY IS DIFFERENT: signing in fixes this and retrying
+   * cannot (CEE sets `retryable: false`). Collapsing the two is how a signed-in
+   * user got a silent hydration failure and no prompt.
+   */
+  | { status: 'signInRequired' }
   /** 401 / 403 / 429 — a stable refusal; not retried. */
   | { status: 'refused'; httpStatus: number }
   /** Transport failure, unparseable body, or a shape that contradicts itself. */
@@ -415,6 +423,20 @@ export async function fetchScenarioGraph(
       response.status === 403 ||
       response.status === 429
     ) {
+      // Checked BEFORE the generic arm: the body distinguishes "your token is
+      // bad" from "you are not allowed", and only the first is recoverable by
+      // the user. Reading the body is safe here — a refusal body is small and
+      // the failure mode of an unparseable one is the generic refusal below.
+      let body: unknown = null
+      try {
+        body = await response.json()
+      } catch {
+        body = null
+      }
+      if (isSignInRequired(response.status, body)) {
+        logger.warn('scenario_graph.sign_in_required', { attempt })
+        return { status: 'signInRequired' }
+      }
       return { status: 'refused', httpStatus: response.status }
     }
 

--- a/src/adapters/cee/signInRefusal.ts
+++ b/src/adapters/cee/signInRefusal.ts
@@ -1,0 +1,57 @@
+/**
+ * "You need to sign in again" — recognised from EITHER producer, one rule.
+ *
+ * ── WHY THIS EXISTS: TWO REFUSALS, DIFFERENT CASING, ONE CONSUMER ──────────
+ * CEE emits two structurally different 401s that mean the same thing to a user:
+ *
+ *   · guest-on-versions  `details.code: "SIGN_IN_REQUIRED"`   (UPPER)
+ *   · JWT refusal        `details.code: "sign_in_required"`   (lower)
+ *                        + `validator: "user_jwt"`
+ *
+ * The UI matched the UPPER form case-sensitively, so the JWT refusal fell
+ * through to a generic refusal and the user was told *"…could not be saved
+ * right now. Try again."* — while CEE sets `retryable: false`, so retrying
+ * cannot work. On the graph read the same 401 became a silent hydration
+ * failure with no sign-in prompt at all.
+ *
+ * ⚠ THE JWT REFUSAL WAS UNREACHABLE UNTIL THE UI STARTED SENDING A TOKEN.
+ *   `resolveUserIdentity` only reaches `refused` when a token is PRESENTED and
+ *   fails to verify. So this bug is created by the change that sends tokens,
+ *   which is why it is fixed in the same PR rather than rowed.
+ *
+ * ── THE PREDICATE DELIBERATELY HAS TWO DISJUNCTS ───────────────────────────
+ * `validator === 'user_jwt'` is the ROBUST signal: it is a producer identity
+ * and does not depend on the casing of a string constant maintained in two
+ * services. The case-insensitive `code` match is the compatible one, and it
+ * covers the guest form plus any future producer that keeps the code but not
+ * the validator. Either alone would be a narrower guard than the domain.
+ */
+
+/** The `details.code`, if the body carries one. */
+function detailsCode(body: unknown): string | null {
+  if (body === null || typeof body !== 'object') return null
+  const details = (body as Record<string, unknown>).details
+  if (details === null || typeof details !== 'object') return null
+  const code = (details as Record<string, unknown>).code
+  return typeof code === 'string' ? code : null
+}
+
+/** The top-level `validator`, if the body is a BoundaryError. */
+function validator(body: unknown): string | null {
+  if (body === null || typeof body !== 'object') return null
+  const v = (body as Record<string, unknown>).validator
+  return typeof v === 'string' ? v : null
+}
+
+/**
+ * Whether this response is CEE telling the caller to sign in.
+ *
+ * Gated on 401 as well as the body: a `sign_in_required` code arriving on some
+ * other status is not this refusal, and treating it as one would route a user
+ * to a sign-in prompt that cannot fix their problem.
+ */
+export function isSignInRequired(httpStatus: number, body: unknown): boolean {
+  if (httpStatus !== 401) return false
+  if (validator(body) === 'user_jwt') return true
+  return detailsCode(body)?.toLowerCase() === 'sign_in_required'
+}

--- a/src/canvas/conversation/useConversation.ts
+++ b/src/canvas/conversation/useConversation.ts
@@ -5626,6 +5626,10 @@ export function useConversation(): UseConversationReturn {
             const recovery = await recoverDraftFromServer({
               scenarioId: scenarioIdAtDispatch,
               userId: v5UserId,
+              // Same identity this turn was dispatched with — read once at
+              // dispatch, not re-read here, so the recovery read cannot be
+              // attributed to a different session than the turn it recovers.
+              accessToken: v5Identity.accessToken,
               turnClientId,
             })
             if (recovery === 'recovered') {

--- a/src/canvas/hooks/__tests__/useProvisionalAnalysisDelivery.realStoreBinding.spec.ts
+++ b/src/canvas/hooks/__tests__/useProvisionalAnalysisDelivery.realStoreBinding.spec.ts
@@ -301,6 +301,9 @@ describe('⭐ the DEFAULT store view — what production actually runs', () => {
     const outcome = await runProvisionalDeliverySchedule({
       scenarioId: 'scn_1',
       userId: null,
+      // Required, not optional: this schedule re-enters the graph read, so a
+      // caller that forgot the token would silently make every re-ask anonymous.
+      accessToken: null,
       signal: new AbortController().signal,
       // ⭐ NO `getStore`. This is the production configuration.
       read: async () => TERMINAL_READ as never,
@@ -321,6 +324,7 @@ describe('⭐ the DEFAULT store view — what production actually runs', () => {
     const outcome = await runProvisionalDeliverySchedule({
       scenarioId: 'scn_1',
       userId: null,
+      accessToken: null,
       signal: new AbortController().signal,
       read: async () => TERMINAL_READ as never,
       wait: async () => {},

--- a/src/canvas/hooks/__tests__/useProvisionalAnalysisDelivery.spec.ts
+++ b/src/canvas/hooks/__tests__/useProvisionalAnalysisDelivery.spec.ts
@@ -97,6 +97,9 @@ describe('H3 — the wait is bounded and expiry invents nothing', () => {
     const outcome = await runProvisionalDeliverySchedule({
       scenarioId: SCENARIO,
       userId: null,
+      // Required, not optional: this schedule re-enters the graph read, so a
+      // caller that forgot the token would silently make every re-ask anonymous.
+      accessToken: null,
       signal: new AbortController().signal,
       getStore: () => h.store,
       read: read as never,
@@ -115,6 +118,7 @@ describe('H3 — the wait is bounded and expiry invents nothing', () => {
     await runProvisionalDeliverySchedule({
       scenarioId: SCENARIO,
       userId: null,
+      accessToken: null,
       signal: new AbortController().signal,
       getStore: () => h.store,
       read: (async () => graphResult(verdict({ kind: 'never_run' }))) as never,
@@ -150,6 +154,7 @@ describe('H4 — a non-terminal read keeps waiting; a terminal one settles', () 
     const outcome = await runProvisionalDeliverySchedule({
       scenarioId: SCENARIO,
       userId: null,
+      accessToken: null,
       signal: new AbortController().signal,
       getStore: () => h.store,
       read: read as never,
@@ -176,6 +181,7 @@ describe('H4 — a non-terminal read keeps waiting; a terminal one settles', () 
     const outcome = await runProvisionalDeliverySchedule({
       scenarioId: SCENARIO,
       userId: null,
+      accessToken: null,
       signal: new AbortController().signal,
       getStore: () => h.store,
       read: read as never,
@@ -192,6 +198,7 @@ describe('H4 — a non-terminal read keeps waiting; a terminal one settles', () 
     const outcome = await runProvisionalDeliverySchedule({
       scenarioId: SCENARIO,
       userId: null,
+      accessToken: null,
       signal: new AbortController().signal,
       getStore: () => h.store,
       read: read as never,
@@ -211,6 +218,7 @@ describe('it yields immediately on abort', () => {
     const outcome = await runProvisionalDeliverySchedule({
       scenarioId: SCENARIO,
       userId: null,
+      accessToken: null,
       signal: controller.signal,
       getStore: () => h.store,
       read: read as never,
@@ -232,6 +240,7 @@ describe('it yields immediately on abort', () => {
     const outcome = await runProvisionalDeliverySchedule({
       scenarioId: SCENARIO,
       userId: null,
+      accessToken: null,
       signal: controller.signal,
       getStore: () => h.store,
       read: read as never,
@@ -253,6 +262,7 @@ describe('the store is read LAZILY, per attempt', () => {
     await runProvisionalDeliverySchedule({
       scenarioId: SCENARIO,
       userId: null,
+      accessToken: null,
       signal: new AbortController().signal,
       getStore,
       read: (async () => graphResult(verdict({ kind: 'never_run' }))) as never,

--- a/src/canvas/hooks/__tests__/useServerGraphHydration.spec.tsx
+++ b/src/canvas/hooks/__tests__/useServerGraphHydration.spec.tsx
@@ -21,6 +21,28 @@ vi.mock('../../../contexts/AuthContext', () => ({
 }))
 
 /**
+ * The identity the hook SENDS comes from `getSessionIdentity`, not from
+ * `useAuth` — deliberately. `useAuth` stays the effect's DEPENDENCY (re-hydrate
+ * when the signed-in user changes), but an access token rotates, so the value
+ * on the wire must be read at request time. Taking both fields from ONE atomic
+ * read is what guarantees the body `user_id` and the `Authorization` header
+ * describe the same session; splitting them across two sources is two answers
+ * to one identity question.
+ *
+ * `importOriginal` spread, not a hand-listed factory: a `vi.mock` factory
+ * REPLACES the module, so every other export this module has would silently
+ * vanish (CLAUDE.md trap 12).
+ */
+let sessionIdentity: { userId: string | null; accessToken: string | null } = {
+  userId: null,
+  accessToken: null,
+}
+vi.mock('../../../lib/supabase', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getSessionIdentity: async () => sessionIdentity,
+}))
+
+/**
  * Typed through a factory rather than `ReturnType<typeof vi.spyOn>`, which
  * widens to `MockInstance<unknown[], unknown>` and does not accept the real
  * spy — the typecheck gate caught that as a genuine new error.
@@ -33,6 +55,7 @@ let spy: ReturnType<typeof spyOnHydrate>
 
 beforeEach(() => {
   user = { id: 'guest' }
+  sessionIdentity = { userId: null, accessToken: null }
   spy = spyOnHydrate()
 })
 
@@ -110,10 +133,28 @@ describe('useServerGraphHydration — StrictMode (A6)', () => {
 })
 
 describe('useServerGraphHydration — identity', () => {
-  it('passes the auth user id through', async () => {
+  it('passes the signed-in user id through', async () => {
     user = { id: 'user-42' }
+    sessionIdentity = { userId: 'user-42', accessToken: 'token-42' }
     renderHook(() => useServerGraphHydration(A))
     await waitFor(() => expect(spy).toHaveBeenCalled())
     expect((spy.mock.calls[0][1] as any).userId).toBe('user-42')
+  })
+
+  it('passes the access token through, so CEE can verify rather than trust', async () => {
+    user = { id: 'user-42' }
+    sessionIdentity = { userId: 'user-42', accessToken: 'token-42' }
+    renderHook(() => useServerGraphHydration(A))
+    await waitFor(() => expect(spy).toHaveBeenCalled())
+    expect((spy.mock.calls[0][1] as any).accessToken).toBe('token-42')
+  })
+
+  it('sends NO token for a guest — the opposite-direction twin', async () => {
+    user = { id: 'guest' }
+    sessionIdentity = { userId: null, accessToken: null }
+    renderHook(() => useServerGraphHydration(A))
+    await waitFor(() => expect(spy).toHaveBeenCalled())
+    expect((spy.mock.calls[0][1] as any).accessToken).toBeNull()
+    expect((spy.mock.calls[0][1] as any).userId).toBeNull()
   })
 })

--- a/src/canvas/hooks/__tests__/useServerGraphHydration.spec.tsx
+++ b/src/canvas/hooks/__tests__/useServerGraphHydration.spec.tsx
@@ -149,7 +149,21 @@ describe('useServerGraphHydration — identity', () => {
     expect((spy.mock.calls[0][1] as any).accessToken).toBe('token-42')
   })
 
-  it('sends NO token for a guest — the opposite-direction twin', async () => {
+  /**
+   * ⚠⚠ THIS TEST IS THE ONLY THING PINNING THE IDENTITY SOURCE. DO NOT DELETE
+   *    IT AS A DUPLICATE OF THE TWO ABOVE.
+   *
+   *    Measured, not argued: mutating the hook back to reading `useAuth()`
+   *    leaves BOTH positive tests GREEN, because they set `user` and
+   *    `sessionIdentity` to the SAME value and therefore cannot tell the two
+   *    sources apart. Only this case makes them disagree — `user` is
+   *    `{ id: 'guest' }` while the session is empty — so only this case goes
+   *    RED. The three assertions are stronger than the one they replaced, but
+   *    the DISCRIMINATION rests on this one alone.
+   *
+   *    If you need to change it, replace the discriminator before removing it.
+   */
+  it('sends NO token for a guest — and is the SOLE source-discriminator', async () => {
     user = { id: 'guest' }
     sessionIdentity = { userId: null, accessToken: null }
     renderHook(() => useServerGraphHydration(A))

--- a/src/canvas/hooks/useProvisionalAnalysisDelivery.ts
+++ b/src/canvas/hooks/useProvisionalAnalysisDelivery.ts
@@ -73,6 +73,7 @@ import { useEffect, useRef } from 'react'
 
 import { useAuth } from '../../contexts/AuthContext'
 import { fetchScenarioGraph } from '../../adapters/cee/scenarioGraph'
+import { getSessionIdentity } from '../../lib/supabase'
 import { logger } from '../../lib/logger'
 import { useCanvasStore } from '../store'
 import {
@@ -122,6 +123,13 @@ export type ProvisionalDeliveryOutcome =
 export async function runProvisionalDeliverySchedule(deps: {
   readonly scenarioId: string
   readonly userId: string | null
+  /**
+   * Supabase access token, travelling the SAME route as `userId` and read from
+   * the SAME session object. Required, not optional: this schedule re-enters
+   * the scenario-graph read, so a caller that forgot the token would silently
+   * make every re-ask anonymous. The compiler is the guard.
+   */
+  readonly accessToken: string | null
   readonly signal: AbortSignal
   /**
    * The applier's store view, read LAZILY per attempt.
@@ -156,6 +164,7 @@ export async function runProvisionalDeliverySchedule(deps: {
 
     const result = await deps.read(deps.scenarioId, {
       userId: deps.userId ?? undefined,
+      accessToken: deps.accessToken,
       signal: deps.signal,
     })
     if (deps.signal.aborted) return 'aborted'
@@ -350,16 +359,26 @@ export function useProvisionalAnalysisDelivery(scenarioIdFromRoute?: string | nu
     const controller = new AbortController()
     let settled = false
 
-    void runProvisionalDeliverySchedule({
-      scenarioId,
-      userId,
-      signal: controller.signal,
-      read: fetchScenarioGraph,
-      wait: waitFor,
-    }).then((outcome) => {
+    // ⚠ IDENTITY READ AT REQUEST TIME, BOTH FIELDS FROM ONE SESSION OBJECT.
+    // `useAuth()` stays the effect DEPENDENCY (re-arm when the signed-in user
+    // changes) but is not what is sent: it is React state, populated
+    // asynchronously and defaulting to the literal 'guest', and an access
+    // token rotates. This schedule is armed on a run and fires up to its whole
+    // delay ladder later, so the gap between the render that captured a user id
+    // and the request that carries it is one of the widest in the app.
+    void (async (): Promise<void> => {
+      const identity = await getSessionIdentity()
+      const outcome = await runProvisionalDeliverySchedule({
+        scenarioId,
+        userId: identity.userId,
+        accessToken: identity.accessToken,
+        signal: controller.signal,
+        read: fetchScenarioGraph,
+        wait: waitFor,
+      })
       settled = true
       logger.debug('provisional_analysis_delivery.outcome', { scenarioId, outcome })
-    })
+    })()
 
     return () => {
       controller.abort()

--- a/src/canvas/hooks/useServerGraphHydration.ts
+++ b/src/canvas/hooks/useServerGraphHydration.ts
@@ -41,6 +41,7 @@ import {
 } from '../hydrate/absentGraphRetry'
 import { useServerGraphRetryStore } from '../stores/serverGraphRetryStore'
 import { logger } from '../../lib/logger'
+import { getSessionIdentity } from '../../lib/supabase'
 
 export function useServerGraphHydration(scenarioIdFromRoute?: string | null): void {
   const currentScenarioId = useCanvasStore((s) => s.currentScenarioId)
@@ -69,22 +70,35 @@ export function useServerGraphHydration(scenarioIdFromRoute?: string | null): vo
     // Fire-and-forget by design: hydration is an improvement on what is already
     // on screen, never a precondition for it. `hydrateCanvasFromServer` never
     // rejects, so the canvas cannot be left mid-boot by a failure here.
-    void hydrateCanvasFromServer(scenarioId, {
-      userId: user?.id ?? null,
-      signal: controller.signal,
-    })
-      .then(async (outcome) => {
+    // ⚠ IDENTITY IS READ AT REQUEST TIME, NEVER CAPTURED AT RENDER TIME.
+    // `useAuth()` stays the effect's DEPENDENCY (re-hydrate when the signed-in
+    // user changes), but it must not be the source of the value we send: an
+    // access token ROTATES, so a token captured in a render can already be
+    // expired when this fire-and-forget effect's request goes out. And it is
+    // the same accessor the turn path uses (`useConversation` →
+    // `getSessionIdentity` → `buildTurnAuthHeaders`), so there is exactly one
+    // way to turn a session into identity in this codebase.
+    void (async (): Promise<void> => {
+      try {
+        const identity = await getSessionIdentity()
+
+        const outcome = await hydrateCanvasFromServer(scenarioId, {
+          userId: identity.userId,
+          accessToken: identity.accessToken,
+          signal: controller.signal,
+        })
         logger.debug('server_graph_hydration.outcome', { scenarioId, outcome })
 
         // ── THE RETURNING-GUEST WINDOW ────────────────────────────────────
         // `absent` alone means "exists, no graph YET". Everything else is a
         // settled answer and returns here unchanged, having cost exactly one
         // request — which is what keeps the 404 path byte-identical.
-        if (outcome !== 'absent') return outcome
+        if (outcome !== 'absent') return
 
         const retry = await runAbsentGraphRetrySchedule({
           scenarioId,
-          userId: user?.id ?? null,
+          userId: identity.userId,
+          accessToken: identity.accessToken,
           signal: controller.signal,
           hydrate: hydrateCanvasFromServer,
           wait: waitForRetry,
@@ -110,11 +124,10 @@ export function useServerGraphHydration(scenarioIdFromRoute?: string | null): vo
         }
 
         logger.debug('server_graph_hydration.absent_retry', { scenarioId, retry })
-        return outcome
-      })
-      .finally(() => {
+      } finally {
         settled = true
-      })
+      }
+    })()
 
     return () => {
       controller.abort()

--- a/src/canvas/hydrate/__tests__/absentGraphRetry.spec.ts
+++ b/src/canvas/hydrate/__tests__/absentGraphRetry.spec.ts
@@ -81,6 +81,10 @@ function deps(h: Harness, extra: Record<string, unknown> = {}) {
   return {
     scenarioId: SCENARIO,
     userId: null,
+    // Required, not optional, and deliberately so: the schedule re-enters the
+    // hydration path, so a caller that forgets the token would silently make
+    // every re-ask anonymous. The compiler is the guard.
+    accessToken: null,
     signal: new AbortController().signal,
     hydrate: h.hydrate,
     wait: h.wait,

--- a/src/canvas/hydrate/__tests__/provisionalDelivery.graphAcceptance.reachability.spec.ts
+++ b/src/canvas/hydrate/__tests__/provisionalDelivery.graphAcceptance.reachability.spec.ts
@@ -180,6 +180,10 @@ function poll() {
   return runProvisionalDeliverySchedule({
     scenarioId: SCENARIO_ID,
     userId: null,
+    // Required since the schedule began carrying a verified token. `null` is
+    // the honest value for this fixture — it exercises the unauthenticated
+    // shape deliberately, and stating it beats inheriting it by omission.
+    accessToken: null,
     signal: new AbortController().signal,
     read: fetchScenarioGraph,
     wait: immediate,

--- a/src/canvas/hydrate/absentGraphRetry.ts
+++ b/src/canvas/hydrate/absentGraphRetry.ts
@@ -131,6 +131,8 @@ function isGraph(outcome: HydrationOutcome): boolean {
 export interface AbsentGraphRetryDeps {
   readonly scenarioId: string
   readonly userId: string | null
+  /** Supabase access token, travelling the same route as `userId`. */
+  readonly accessToken: string | null
   readonly signal: AbortSignal
   /**
    * Re-entry point. This is `hydrateCanvasFromServer` in production — the whole
@@ -138,7 +140,7 @@ export interface AbsentGraphRetryDeps {
    */
   readonly hydrate: (
     scenarioId: string,
-    opts: { userId?: string | null; signal?: AbortSignal },
+    opts: { userId?: string | null; accessToken?: string | null; signal?: AbortSignal },
   ) => Promise<HydrationOutcome>
   /**
    * The clock, injected.
@@ -188,6 +190,7 @@ export async function runAbsentGraphRetrySchedule(
 
     const outcome = await deps.hydrate(deps.scenarioId, {
       userId: deps.userId,
+      accessToken: deps.accessToken,
       signal: deps.signal,
     })
     if (deps.signal.aborted) return 'aborted'

--- a/src/canvas/hydrate/draftRecovery.ts
+++ b/src/canvas/hydrate/draftRecovery.ts
@@ -50,6 +50,8 @@ export interface RecoverDraftArgs {
   scenarioId: string | null
   /** Supabase user id when signed in; null/'guest' handled by the adapter. */
   userId?: string | null
+  /** Supabase access token when signed in; travels the same route as `userId`. */
+  accessToken?: string | null
   /**
    * The `client_turn_id` of the turn that marked the draft unsettled. Phase
    * release is keyed on it — identity, not coincidence.
@@ -68,6 +70,7 @@ export async function recoverDraftFromServer(
 ): Promise<DraftRecoveryOutcome> {
   const hydration = await hydrateCanvasFromServer(args.scenarioId, {
     userId: args.userId,
+    accessToken: args.accessToken,
   })
   logger.debug('draft_recovery.outcome', {
     scenarioId: args.scenarioId,

--- a/src/canvas/hydrate/serverGraphHydration.ts
+++ b/src/canvas/hydrate/serverGraphHydration.ts
@@ -52,6 +52,11 @@ export type HydrationOutcome =
 export interface HydrateFromServerOptions {
   /** Supabase user id, when signed in. Omitted for guests. */
   userId?: string | null
+  /**
+   * Supabase access token, when signed in. Travels the SAME route as `userId`
+   * so CEE can verify the caller rather than trust the body. Null for guests.
+   */
+  accessToken?: string | null
   signal?: AbortSignal
   retryDelayMs?: number
   /** Per-attempt deadline — bounds the silent-rollback window (review A3). */
@@ -101,6 +106,7 @@ export async function hydrateCanvasFromServer(
 
   const result = await fetchScenarioGraph(scenarioId, {
     userId: opts.userId,
+    accessToken: opts.accessToken,
     signal: opts.signal,
     retryDelayMs: opts.retryDelayMs,
     timeoutMs: opts.timeoutMs,

--- a/src/canvas/hydrate/serverGraphHydration.ts
+++ b/src/canvas/hydrate/serverGraphHydration.ts
@@ -42,6 +42,13 @@ export type HydrationOutcome =
   | 'notReadable'
   /** 503 through every attempt. Canvas untouched. */
   | 'unavailable'
+  /**
+   * CEE refused the caller's TOKEN (401 `sign_in_required`). Canvas untouched.
+   * Distinct from `'refused'` because the recovery differs: signing in fixes
+   * this and retrying cannot. Kept separate so a caller cannot accidentally
+   * render "try again" over a session that has expired.
+   */
+  | 'signInRequired'
   /** 401 / 403 / 429. Canvas untouched. */
   | 'refused'
   /** Transport failure or a shape we cannot act on. Canvas untouched. */
@@ -125,6 +132,8 @@ export async function hydrateCanvasFromServer(
         return 'notReadable'
       case 'unavailable':
         return 'unavailable'
+      case 'signInRequired':
+        return 'signInRequired'
       case 'refused':
         return 'refused'
       default:

--- a/src/canvas/registration/useImportRegistration.ts
+++ b/src/canvas/registration/useImportRegistration.ts
@@ -39,6 +39,7 @@
 import { useEffect, useRef } from 'react'
 
 import { useAuth } from '../../contexts/AuthContext'
+import { getSessionIdentity } from '../../lib/supabase'
 import { logger } from '../../lib/logger'
 import { registerScenarioGraph } from '../../adapters/cee/registerScenarioGraph'
 import { useCanvasStore } from '../store'
@@ -121,8 +122,14 @@ export function useImportRegistration(): void {
     let cancelled = false
 
     void (async () => {
+      // Token read at REQUEST time, not render time — tokens rotate, and this
+      // registration can fire long after the render that captured `userId`.
+      // `userId` stays the effect dependency; the identity SENT comes from the
+      // one shared accessor.
+      const identity = await getSessionIdentity()
       const result = await registerScenarioGraph(scenarioId, projected.graph, {
         userId,
+        accessToken: identity.accessToken,
         signal: controller.signal,
       })
       if (cancelled) return

--- a/src/canvas/registration/useImportRegistration.ts
+++ b/src/canvas/registration/useImportRegistration.ts
@@ -122,13 +122,17 @@ export function useImportRegistration(): void {
     let cancelled = false
 
     void (async () => {
-      // Token read at REQUEST time, not render time — tokens rotate, and this
-      // registration can fire long after the render that captured `userId`.
-      // `userId` stays the effect dependency; the identity SENT comes from the
-      // one shared accessor.
+      // ⚠ BOTH FIELDS COME FROM THE SAME READ, and that is the whole point.
+      //    `useAuth().user.id` is React state — populated asynchronously by
+      //    `onAuthStateChange` and defaulting to the literal 'guest' — so
+      //    pairing it with a freshly-read token can put a body id and an
+      //    Authorization header from DIFFERENT sessions on one request.
+      //    `getSessionIdentity()` reads one session object, so the two cannot
+      //    disagree. `userId` (from `useAuth`) remains the effect DEPENDENCY;
+      //    it is not what is sent.
       const identity = await getSessionIdentity()
       const result = await registerScenarioGraph(scenarioId, projected.graph, {
-        userId,
+        userId: identity.userId,
         accessToken: identity.accessToken,
         signal: controller.signal,
       })

--- a/src/canvas/versions/ServerVersionsSection.tsx
+++ b/src/canvas/versions/ServerVersionsSection.tsx
@@ -183,12 +183,25 @@ export function ServerVersionsSection() {
     // ⚠ BOTH FIELDS FROM ONE READ. These three handlers are user-initiated
     //    and have no AbortController and no cancellation, so the gap between
     //    the click and the request is the widest in this change: `userId` would
-    //    be bound from the render closure, and `getSessionIdentity()` performs
-    //    a NETWORK REFRESH on an expired token, stretching that gap from
-    //    microseconds to hundreds of milliseconds with `autoRefreshToken` and
-    //    multi-tab both on. Two of these three are WRITES. Reading both fields
-    //    from the same session object closes the window by construction rather
-    //    than by guard.
+    //    be bound from the render closure while the token is read fresh.
+    //
+    //    VERIFIED at the dependency's bytes (@supabase/gotrue-js 2.62.2,
+    //    `GoTrueClient.js:778-787`): `getSession()` compares
+    //    `expires_at <= Date.now()/1000` and, when expired, performs a NETWORK
+    //    REFRESH — so the token returned is fresh, never the stale one, and a
+    //    refresh FAILURE yields `session: null`, i.e. a guest-shaped request
+    //    with no headers rather than a 401-bait one.
+    //
+    //    ⚠ THE ONE CASE THAT CHECK DOES NOT COVER: the comparison is HARD, with
+    //      no margin on this path (`EXPIRY_MARGIN` is referenced only in the
+    //      background `_recoverAndRefresh`, not in `getSession()`), so a token
+    //      expiring moments from now is returned as-is and can expire in
+    //      flight. `autoRefreshToken: true` mitigates it in practice. No claim
+    //      is made about the margin's VALUE — only about where it is and is
+    //      not referenced.
+    //
+    //    Two of these three handlers are WRITES. Reading both fields from the
+    //    same session object closes the mismatch window by construction.
     const identity = await getSessionIdentity()
     const result = await saveModelVersion(scenarioId, {
       userId: identity.userId,

--- a/src/canvas/versions/ServerVersionsSection.tsx
+++ b/src/canvas/versions/ServerVersionsSection.tsx
@@ -35,6 +35,7 @@ import { UploadCloud, RotateCcw } from 'lucide-react'
 import { PanelSection } from '../panels/_shared/PanelSection'
 import { typography } from '../../styles/typography'
 import { useAuth } from '../../contexts/AuthContext'
+import { getSessionIdentity } from '../../lib/supabase'
 import { useCanvasStore } from '../store'
 import {
   listModelVersions,
@@ -125,7 +126,8 @@ export function ServerVersionsSection() {
 
   const refresh = useCallback(async () => {
     if (!addressable || !signedIn || typeof scenarioId !== 'string') return
-    const result = await listModelVersions(scenarioId, { userId })
+    const { accessToken } = await getSessionIdentity()
+    const result = await listModelVersions(scenarioId, { userId, accessToken })
     if (!mountedRef.current) return
     if (result.status === 'list') {
       setPhase({
@@ -175,8 +177,10 @@ export function ServerVersionsSection() {
     setBusy(true)
     setMessage(null)
     const label = draftLabel.trim()
+    const { accessToken } = await getSessionIdentity()
     const result = await saveModelVersion(scenarioId, {
       userId,
+      accessToken,
       ...(label.length > 0 ? { label } : {}),
     })
     if (!mountedRef.current) return
@@ -219,8 +223,10 @@ export function ServerVersionsSection() {
     // snapshot, so a concurrent change fails loudly instead of silently losing.
     const head =
       phase.versions.find((v) => v.id === phase.currentVersionId) ?? phase.versions[0]
+    const { accessToken } = await getSessionIdentity()
     const result = await restoreModelVersion(scenarioId, {
       userId,
+      accessToken,
       versionId,
       ...(head !== undefined ? { expectedGraphIdentityHash: head.graphIdentityHash } : {}),
     })

--- a/src/canvas/versions/ServerVersionsSection.tsx
+++ b/src/canvas/versions/ServerVersionsSection.tsx
@@ -31,6 +31,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { sanitiseUserId } from '../../lib/guestIdentity'
 import { UploadCloud, RotateCcw } from 'lucide-react'
 import { PanelSection } from '../panels/_shared/PanelSection'
 import { typography } from '../../styles/typography'
@@ -49,8 +50,6 @@ import { logger } from '../../lib/logger'
 /** A scenario CEE can address is a UUID (scenarios.id is a uuid column). */
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
-/** The guest sentinel AuthContext mints; never a Supabase user id. */
-const GUEST_USER_ID = 'guest'
 
 /** Storage-scope disclosure — the shared counterpart of the local one. */
 export const SERVER_VERSIONS_DISCLOSURE =
@@ -114,7 +113,7 @@ export function ServerVersionsSection() {
 
   const userId = user?.id ?? null
   const signedIn =
-    typeof userId === 'string' && userId.length > 0 && userId !== GUEST_USER_ID
+    sanitiseUserId(userId) !== null
   const addressable = typeof scenarioId === 'string' && UUID_RE.test(scenarioId)
 
   useEffect(() => {
@@ -126,8 +125,12 @@ export function ServerVersionsSection() {
 
   const refresh = useCallback(async () => {
     if (!addressable || !signedIn || typeof scenarioId !== 'string') return
-    const { accessToken } = await getSessionIdentity()
-    const result = await listModelVersions(scenarioId, { userId, accessToken })
+    // Both fields from ONE read — see the note on `handleSave` below.
+    const identity = await getSessionIdentity()
+    const result = await listModelVersions(scenarioId, {
+      userId: identity.userId,
+      accessToken: identity.accessToken,
+    })
     if (!mountedRef.current) return
     if (result.status === 'list') {
       setPhase({
@@ -177,10 +180,19 @@ export function ServerVersionsSection() {
     setBusy(true)
     setMessage(null)
     const label = draftLabel.trim()
-    const { accessToken } = await getSessionIdentity()
+    // ⚠ BOTH FIELDS FROM ONE READ. These three handlers are user-initiated
+    //    and have no AbortController and no cancellation, so the gap between
+    //    the click and the request is the widest in this change: `userId` would
+    //    be bound from the render closure, and `getSessionIdentity()` performs
+    //    a NETWORK REFRESH on an expired token, stretching that gap from
+    //    microseconds to hundreds of milliseconds with `autoRefreshToken` and
+    //    multi-tab both on. Two of these three are WRITES. Reading both fields
+    //    from the same session object closes the window by construction rather
+    //    than by guard.
+    const identity = await getSessionIdentity()
     const result = await saveModelVersion(scenarioId, {
-      userId,
-      accessToken,
+      userId: identity.userId,
+      accessToken: identity.accessToken,
       ...(label.length > 0 ? { label } : {}),
     })
     if (!mountedRef.current) return
@@ -223,10 +235,11 @@ export function ServerVersionsSection() {
     // snapshot, so a concurrent change fails loudly instead of silently losing.
     const head =
       phase.versions.find((v) => v.id === phase.currentVersionId) ?? phase.versions[0]
-    const { accessToken } = await getSessionIdentity()
+    // Both fields from ONE read — see the note on `handleSave`.
+    const identity = await getSessionIdentity()
     const result = await restoreModelVersion(scenarioId, {
-      userId,
-      accessToken,
+      userId: identity.userId,
+      accessToken: identity.accessToken,
       versionId,
       ...(head !== undefined ? { expectedGraphIdentityHash: head.graphIdentityHash } : {}),
     })

--- a/src/canvas/versions/__tests__/ServerVersionsSection.spec.tsx
+++ b/src/canvas/versions/__tests__/ServerVersionsSection.spec.tsx
@@ -63,10 +63,12 @@ vi.mock('../../../contexts/AuthContext', () => ({
  * These three handlers are user-initiated, have no AbortController and no
  * cancellation, and two of them are WRITES. Binding the body id from the render
  * closure and then awaiting a token read means the two can come from different
- * sessions: `getSessionIdentity()` performs a NETWORK REFRESH on an expired
- * token, so the gap is hundreds of milliseconds with `autoRefreshToken` and
- * multi-tab both on. Reading both fields from ONE session object closes that
- * by construction. `useAuth` remains the signed-in GATE only.
+ * sessions — verified at the dependency's bytes (@supabase/gotrue-js 2.62.2,
+ * `GoTrueClient.js:778-787`): `getSession()` performs a NETWORK REFRESH when
+ * `expires_at <= now`, so the read is not free. The comparison is HARD, with no
+ * margin on this path, so a token expiring moments from now is returned as-is.
+ * Reading both fields from ONE session object closes the mismatch window by
+ * construction. `useAuth` remains the signed-in GATE only.
  *
  * `importOriginal` spread, not a hand-listed factory: a factory REPLACES the
  * module and every other `lib/supabase` export would silently vanish.

--- a/src/canvas/versions/__tests__/ServerVersionsSection.spec.tsx
+++ b/src/canvas/versions/__tests__/ServerVersionsSection.spec.tsx
@@ -56,6 +56,30 @@ vi.mock('../../../contexts/AuthContext', () => ({
   useAuth: () => ({ user: authState.user }),
 }))
 
+/**
+ * The identity these handlers SEND comes from `getSessionIdentity`, not from
+ * `useAuth` — deliberately, and this spec's file is where that matters most.
+ *
+ * These three handlers are user-initiated, have no AbortController and no
+ * cancellation, and two of them are WRITES. Binding the body id from the render
+ * closure and then awaiting a token read means the two can come from different
+ * sessions: `getSessionIdentity()` performs a NETWORK REFRESH on an expired
+ * token, so the gap is hundreds of milliseconds with `autoRefreshToken` and
+ * multi-tab both on. Reading both fields from ONE session object closes that
+ * by construction. `useAuth` remains the signed-in GATE only.
+ *
+ * `importOriginal` spread, not a hand-listed factory: a factory REPLACES the
+ * module and every other `lib/supabase` export would silently vanish.
+ */
+const sessionState: { userId: string | null; accessToken: string | null } = {
+  userId: USER,
+  accessToken: 'token-for-USER',
+}
+vi.mock('../../../lib/supabase', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  getSessionIdentity: async () => sessionState,
+}))
+
 import { ServerVersionsSection } from '../ServerVersionsSection'
 import { useCanvasStore } from '../../store'
 
@@ -86,6 +110,8 @@ const TWO_VERSIONS = [
 beforeEach(() => {
   vi.clearAllMocks()
   authState.user = { id: USER }
+  sessionState.userId = USER
+  sessionState.accessToken = 'token-for-USER'
   useCanvasStore.setState({ currentScenarioId: SCENARIO } as never)
   listModelVersions.mockResolvedValue({
     status: 'list',
@@ -135,6 +161,8 @@ describe('ServerVersionsSection — list', () => {
 describe('ServerVersionsSection — guests (pin 5)', () => {
   it('invites sign-in and never calls the network', () => {
     authState.user = null
+    sessionState.userId = null
+    sessionState.accessToken = null
     render(<ServerVersionsSection />)
 
     expect(screen.getByTestId('server-versions-signin')).toBeInTheDocument()

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useCallback } from 'react';
+import { GUEST_USER_ID } from '../lib/guestIdentity'
 import { useNavigate } from 'react-router-dom';
 import type { Session, User } from '@supabase/supabase-js';
 import { supabase, getProfile } from '../lib/supabase';
@@ -468,7 +469,7 @@ function OptionalAuthProvider({ children }: { children: React.ReactNode }) {
   }, [pendingUser]);
 
   const value = React.useMemo((): AuthContextType => ({
-    user: session?.user ?? ({ id: 'guest', email: 'guest@poc' } as User),
+    user: session?.user ?? ({ id: GUEST_USER_ID, email: 'guest@poc' } as User),
     profile: session?.profile ?? null,
     // Never true: a guest is ready immediately, and AuthGuard must not spin.
     loading: false,

--- a/src/lib/guestIdentity.ts
+++ b/src/lib/guestIdentity.ts
@@ -1,0 +1,40 @@
+/**
+ * The guest sentinel, and the one rule for turning a caller identity into
+ * something safe to send as a user id.
+ *
+ * ── WHY THIS MODULE EXISTS ──────────────────────────────────────────────────
+ * `'guest'` was defined FOUR times independently (three CEE adapters and the
+ * versions panel) and the "is this a real user id" predicate existed in THREE
+ * forms — while the value itself is MINTED in a fifth place, `AuthContext`.
+ * Five hand-maintained copies of one identity rule, and the rule is now
+ * load-bearing for authorization: it decides what goes in the request body AND
+ * what goes in the `Authorization`/`X-User-Id` headers. A copy that drifts
+ * would put a sentinel where CEE expects a UUID, or send an identity for
+ * someone who has none.
+ *
+ * Derived from one place, so the copies cannot disagree. The mint imports it
+ * too — otherwise the constant here would just be a sixth copy that happens to
+ * match today.
+ */
+
+/**
+ * The sentinel `AuthContext` mints for a visitor with no Supabase session.
+ * It is NOT a Supabase user id and must never be sent to CEE as one, through
+ * the body or through a header — CEE's `scenarios.user_id` is a `uuid` column
+ * and its ownership pre-flight compares against it.
+ */
+export const GUEST_USER_ID = 'guest'
+
+/**
+ * The caller's id if it is a real one, else `null`.
+ *
+ * ONE predicate, feeding BOTH the request body and the auth headers at every
+ * call site. Two copies of "is this a real user id" is how a body and a header
+ * start disagreeing about who the caller is — and after the ownership fix, a
+ * disagreement is an authorization question rather than a cosmetic one.
+ */
+export function sanitiseUserId(userId: string | null | undefined): string | null {
+  return typeof userId === 'string' && userId.length > 0 && userId !== GUEST_USER_ID
+    ? userId
+    : null
+}

--- a/src/v5/__tests__/failureTypeRetryability.test.ts
+++ b/src/v5/__tests__/failureTypeRetryability.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { FAILURE_USER_TEXT } from '@talchain/schemas/boundary'
 import type { BoundaryError, FailureTypeLiteral } from '@talchain/schemas/boundary'
 import {
+  resolveIngressViolationGuidance,
   isRetryable,
   checkRetryableAgreement,
   extractReason,
@@ -589,3 +590,79 @@ describe('resolveFailureBaseCopy — DERIVED over the whole vendored table', () 
 // instruction) lives in failureTypeRetryability.drift.spec.ts — it needs a
 // module mock, and vi.mock is hoisted file-wide, which would corrupt the
 // verbatim-copy expectations above.
+
+/**
+ * THE REFUSAL CODE ARRIVES IN TWO CASINGS, AND THIS READER COMPARED WITH `===`.
+ *
+ * Measured at this tip: the upper-case spelling reaches 4 files, the lower 10.
+ * The estate's shared predicate already folds case
+ * (`adapters/cee/signInRefusal.ts`: `detailsCode(body)?.toLowerCase() === …`),
+ * so the two readers were answering one question in two ways — and this one
+ * missed the upper-case envelope.
+ *
+ * ⚠ WHY THE `validator` FALLBACK DOES NOT COVER IT: its own docstring scopes it
+ * as a secondary signal "for envelopes that omit the code". An envelope that
+ * CARRIES the code — in the other casing — and no validator therefore falls
+ * through to generic rephrase guidance, which tells the user to reword a message
+ * when signing in is what is actually required.
+ */
+describe('the auth class is recognised in either casing', () => {
+  // The rephrase copy is module-private, so it is pinned here by its value —
+  // and the PRECONDITION case below proves this fixture is the real fallback
+  // rather than a string that merely looks like it.
+  const REPHRASE = 'Please rephrase your message and try again.'
+  const bothCasings = ['sign_in_required', 'SIGN_IN_REQUIRED'] as const
+
+  it.each(bothCasings)('classifies `details.code: %s` as the auth class', (code) => {
+    const guidance = resolveIngressViolationGuidance({ details: { code } } as never)
+    expect(guidance).not.toBe(REPHRASE)
+  })
+
+  /*
+   * ⛔ BOTH DIRECTIONS, because a corpus that tests only the direction just
+   * fixed is a guard watching one door. Folding case closes a false NEGATIVE;
+   * the opposite-direction harm is a false POSITIVE — classifying a non-auth
+   * refusal as auth and telling the user to sign in when rewording is what is
+   * needed. Each non-auth code is asserted in BOTH casings so a future widening
+   * REDs rather than passing quietly.
+   */
+  const nonAuthCodes = ['something_else', 'SOMETHING_ELSE', 'rate_limited', 'RATE_LIMITED']
+
+  it.each(nonAuthCodes)('DISCRIMINATING — `%s` still takes the rephrase path', (code) => {
+    const guidance = resolveIngressViolationGuidance({ details: { code } } as never)
+    expect(guidance).toBe(REPHRASE)
+  })
+
+  it('PRECONDITION — the fixtures are what this test needs them to be', () => {
+    // (a) the two casings are genuinely different strings, so the fold is real;
+    expect(bothCasings[0]).not.toBe(bothCasings[1])
+    expect(bothCasings[0].toLowerCase()).toBe(bothCasings[1].toLowerCase())
+    // (b) REPHRASE really IS the fallback this function returns with no
+    //     envelope — otherwise every `not.toBe(REPHRASE)` above is vacuous.
+    expect(resolveIngressViolationGuidance(undefined)).toBe(REPHRASE)
+  })
+
+  /*
+   * ⭐ THE BLAST-RADIUS MANIFEST, pinned rather than argued.
+   *
+   * The case fold lives in `extractDetailsCode`, which changes what EVERY
+   * consumer of it sees — so the fix is only safe if there is exactly one, and
+   * that one compares against the lower-case constant. Measured: ONE call site
+   * (`:411`), and the extractor is MODULE-PRIVATE, so no consumer outside this
+   * file is possible by construction (contrast: the file has 10 exports).
+   *
+   * This case pins the structural half — if the extractor is ever exported, the
+   * manifest stops being closed and this RED is the notice.
+   */
+  it('BLAST RADIUS — the case fold cannot reach a consumer that expects upper case', async () => {
+    const fs = await import('node:fs/promises')
+    const src = await fs.readFile('src/v5/failureTypeRetryability.ts', 'utf8')
+    // exactly one call site, and it is the auth predicate
+    const callSites = [...src.matchAll(/extractDetailsCode\(/g)].length
+    expect(callSites, 'declaration + one call site').toBe(2)
+    // and it is not exported, so the manifest is closed
+    expect(/export\s+function\s+extractDetailsCode/.test(src)).toBe(false)
+    // contrast: the file really does export things, so the check above is not vacuous
+    expect((src.match(/^export /gm) ?? []).length).toBeGreaterThan(5)
+  })
+})

--- a/src/v5/failureTypeRetryability.ts
+++ b/src/v5/failureTypeRetryability.ts
@@ -372,10 +372,25 @@ const AUTH_REASON_VERIFIER_DOWN = 'verification_unavailable'
 
 const SCENARIO_OWNERSHIP_REASON_PREFIX = 'scenario_ownership'
 
-/** Read `details.code` off a BoundaryError. Fail closed: absent/non-string → ''. */
+/**
+ * Read `details.code` off a BoundaryError. Fail closed: absent/non-string → ''.
+ *
+ * ⚠ NORMALISED TO LOWER CASE, because the code arrives in BOTH casings and this
+ * comparison is `===`. The estate's shared predicate already does exactly this
+ * (`adapters/cee/signInRefusal.ts`: `detailsCode(body)?.toLowerCase() ===
+ * 'sign_in_required'`), so this is the same rule applied at the second reader
+ * rather than a new one — the two were answering one question in two ways.
+ *
+ * Measured at this tip: the upper-case spelling reaches 4 files and the lower 10.
+ * Without the fold, an envelope carrying the upper-case code and NO `validator`
+ * misses the auth branch and takes generic rephrase guidance — telling the user
+ * to reword a message when what is actually needed is to sign in. The
+ * `validator` clause below is documented as a secondary signal "for envelopes
+ * that omit the code", so it cannot be relied on to cover this.
+ */
 function extractDetailsCode(err: BoundaryError): string {
   const code = (err.details as { code?: unknown } | undefined)?.code
-  return typeof code === 'string' ? code : ''
+  return typeof code === 'string' ? code.toLowerCase() : ''
 }
 
 /** Read `details.auth_reason`. Fail closed: absent/non-string → ''. */


### PR DESCRIPTION
UI half of the scenario-ownership fix. **Review gates 1 and 2 addressed.**

## ⚠⚠ WHAT THIS DOES AND DOES NOT CLOSE — read before reviewing

**This is the necessary PRECONDITION for the CEE strip, not the fix.**

An earlier version of this body called it "additive and guest-safe"; a later one over-corrected and implied it closes the forgery. Neither is right.

- **CEE already prefers the verified `sub`** (`route-v2-preflight.ts:188-206`, deployed) — gated only on a token arriving. So the moment this deploys, a signed-in user's ownership is decided by their token subject.
- **But the forgery stays open.** `netlify/edge-functions/cee-proxy.ts` injects the assist key **unconditionally, with no JWT gate**. An anonymous browser that simply omits the header still reaches `service_legacy` and forges via body `user_id`. **The probe table below still returns 200 after this merges.** Closing it is CEE-side (#1109).

Two derivations that looked contradictory answer **different questions**: `:188-206` answers *"token present, who wins?"* → the JWT sub. The strip answers *"token absent, can the caller forge?"* → yes, still. Both true at once.

## The problem, measured

`CEE_REQUIRE_USER_JWT` is **ON**: boot log `"require_user_jwt": true`, and a JWT-shaped invalid Bearer answers `401 {"validator":"user_jwt"}` — reachable only with the flag on. These adapters sent no `Authorization` at all, so every signed-in caller resolved `service_legacy`, where the body `user_id` is the only identity.

| probe (deployed staging) | result |
|---|---|
| **anonymous, no token, `user_id` = owner** | **200 — full graph, brief and analysis; canary present** |
| anonymous, *different* `user_id` | 404, no canary |
| anonymous, **no** `user_id` | 404, no canary |
| anonymous, malformed `user_id` | 404, no canary |

The same channel let an anonymous caller **create** a scenario attributed to an arbitrary id.

## Merge gates addressed

**Gate 1 — a sixth call site.** `useProvisionalAnalysisDelivery.ts` passed the adapter *by reference* (`read: fetchScenarioGraph`), invisible to the grep that found the other five. It sent `user?.id ?? null` and no token. Fixed, and `accessToken` is now **required** on the schedule's deps so it cannot be omitted silently.

**And the enumeration mirror behind it.** The five-route table was hand-maintained — a sixth route would get no coverage and nothing would go red. It is now checked against a set **derived from source** (every exported `async function` in the three adapter modules), with a positive control proving the deriver sees functions, and a failure that **names** the uncovered route. Mutation-verified: renaming a row's key REDs with `expected [ 'restoreModelVersion' ] to deeply equal []`.

**Gate 2 — two sign-in refusals, different casing.** `SIGN_IN_REQUIRED` (guest) vs `sign_in_required` + `validator: "user_jwt"` (JWT). The UI matched UPPER only, so the JWT refusal became *"could not be saved right now. Try again."* on a `retryable: false` response — and a silent hydration failure on the graph read. **This PR creates that reachability** (`refused` needs a token to be *presented*), so it is fixed here. One predicate with two disjuncts: `validator === 'user_jwt'` (robust, casing-immune) plus a case-insensitive code match. Applied in `sharedRefusal`, so LIST gains a branch it never had. Refusal fixture is **verbatim from the wire**.

## What this PR does

Sends the token on all five routes via the existing `buildTurnAuthHeaders`. **Both identity fields come from one `getSessionIdentity()` read at every call site** — six now. Keeps the body `user_id`, pinned by a test, until CEE strips it. Folded five copies of the guest-identity rule into `src/lib/guestIdentity.ts`, **mint included**. Corrects the stale "flag is off" comments.

Guests remain byte-identical: no session → both null → no headers.

## Evidence

- `scenarioRoutesUserJwt.spec.ts` **32** · `signInRefusal.spec.ts` **9** · `useServerGraphHydration.spec.tsx` **9** — counts asserted **by name**. Corpus includes the classes the signed-in/guest pair is blind to: **(real id, null token)** and **(real id, another session's token)**.
- **Mutants, discriminating pairs in both directions.** Dropping `...authHeaders` REDs exactly its own route's tests; always-emit REDs all five guest tests. Worktree outside the repo root, isolation proven by **writing** a sentinel.
- **Negative control on the instrument:** with the Supabase env vars unset the hook spec dies at collect while the run prints `Tests 20 passed` and zero failures.
- Lint **0 errors** · typecheck at exactly baseline (**2252**, zero drift) · **223 files / 2769 tests** green across every touched area.

## ⚠ Not established — do not let these travel as settled

- **The 56-of-64 orphan-owner figure is INHERITED from the coordinator's brief, not corroborated by review.** The reviewer could not authenticate with found credentials (correctly — that constraint is absolute) and did not re-derive it.
- **No verified-mode wire probe exists.** That a valid token is *honoured* on these five routes is derived at the bytes only. The refusal branch is wire-witnessed; the acceptance branch is not.
- **The real-A-owns / real-B-works-on shape is undetectable in the data.** My low-risk reading is an inference from how the UI sources `opts.userId`, not a measurement.

## ⚠ Witness owed — merge is held

**No signed-in journey has been driven against this.** Account minting is outside what this lane may do. Held for the founder.