### PR TITLE
fix(canvas): a verdict may not become authoritative over a graph the user does not have (provisional-delivery divergence guards)

### DIFF
--- a/src/canvas/hooks/__tests__/useProvisionalAnalysisDelivery.realStoreBinding.spec.ts
+++ b/src/canvas/hooks/__tests__/useProvisionalAnalysisDelivery.realStoreBinding.spec.ts
@@ -127,8 +127,22 @@ describe('readProvisionalApplyStore is bound to the REAL canvas store', () => {
     // (`lastAuthoritativeGraph`), and the boundary it must respect is that the
     // SLICE ITSELF never crosses — the applier gets an answer, not the graph.
     //
-    // A future edit that "simplifies" this by handing over `lastAuthoritativeGraph`
-    // (or `nodes`) would satisfy a looser key check and REDs here instead.
+    // ⚠ WHAT THIS TEST ACTUALLY CATCHES — measured, not assumed, because the
+    // first version of this comment OVERSTATED it and was false.
+    //
+    // It claimed a future edit handing over `lastAuthoritativeGraph` "REDs
+    // here". IT DOES NOT: that field is an OBJECT, and the `Array.isArray`
+    // loop below only catches ARRAYS (i.e. `nodes`). Leaking the object REDs
+    // the MEMBER-SET IDENTITY BINDING in the test above, not this one.
+    //
+    // So the two tests split the work and neither covers both:
+    //   leak `nodes`                  → REDs here AND the member-set test
+    //   leak `lastAuthoritativeGraph` → REDs the member-set test ONLY
+    //
+    // Recorded rather than quietly corrected: a false guarantee in a test is
+    // worse than no guarantee, because the next reader trusts it. This PR
+    // corrected exactly that defect class one file over, and then reproduced it
+    // here in the same commit — which is how ordinary the failure is.
     const view = readProvisionalApplyStore()
     expect(typeof view.graphAcceptedForCanvas).toBe('boolean')
     for (const value of Object.values(view)) {

--- a/src/canvas/hooks/__tests__/useProvisionalAnalysisDelivery.realStoreBinding.spec.ts
+++ b/src/canvas/hooks/__tests__/useProvisionalAnalysisDelivery.realStoreBinding.spec.ts
@@ -106,8 +106,54 @@ describe('readProvisionalApplyStore is bound to the REAL canvas store', () => {
     // so that boundary was documented rather than real. Bind it by identity to
     // the exact member set.
     expect(Object.keys(view).sort()).toEqual(
-      ['currentResultsHash', 'resultsComplete', 'setAnalysisStateV1'].sort(),
+      [
+        'currentResultsHash',
+        // ⚠ ADDED BY THE DIVERGENCE GUARDS, AND THIS SPEC CORRECTLY OBJECTED.
+        // The applier now needs ONE more fact — whether the canvas on screen
+        // derives from a server graph we accepted — so the member set genuinely
+        // changed and this expectation had to move with it. Recorded rather
+        // than quietly widened: the whole point of an identity binding is that
+        // adding a member is a decision someone makes on purpose.
+        'graphAcceptedForCanvas',
+        'resultsComplete',
+        'setAnalysisStateV1',
+      ].sort(),
     )
+  })
+
+  it('⭐ the new member is a DERIVED BOOLEAN — no graph slice crosses the boundary', () => {
+    // This is the guard the member-set assertion above was really protecting,
+    // now made explicit. `graphAcceptedForCanvas` is derived FROM a graph slice
+    // (`lastAuthoritativeGraph`), and the boundary it must respect is that the
+    // SLICE ITSELF never crosses — the applier gets an answer, not the graph.
+    //
+    // A future edit that "simplifies" this by handing over `lastAuthoritativeGraph`
+    // (or `nodes`) would satisfy a looser key check and REDs here instead.
+    const view = readProvisionalApplyStore()
+    expect(typeof view.graphAcceptedForCanvas).toBe('boolean')
+    for (const value of Object.values(view)) {
+      expect(Array.isArray(value)).toBe(false)
+    }
+  })
+
+  it('⭐ it tracks the REAL store, both ways — not a constant', () => {
+    // Trap 13b: a guard whose discrimination is unpinned. Asserting only `true`
+    // (or only `false`) would pass against a hardcoded literal. Drive the actual
+    // store fields both ways and require the derived answer to MOVE.
+    useCanvasStore.setState({
+      lastAuthoritativeGraph: null,
+      nodes: [{ id: 'local-1', type: 'factor', position: { x: 0, y: 0 }, data: {} }] as never,
+    } as never)
+    expect(readProvisionalApplyStore().graphAcceptedForCanvas).toBe(false)
+
+    useCanvasStore.setState({
+      lastAuthoritativeGraph: { nodeIds: ['server-a'], edgePairs: [] },
+    } as never)
+    expect(readProvisionalApplyStore().graphAcceptedForCanvas).toBe(true)
+
+    // An EMPTY canvas is not divergent — nothing local for a verdict to misdescribe.
+    useCanvasStore.setState({ lastAuthoritativeGraph: null, nodes: [] as never } as never)
+    expect(readProvisionalApplyStore().graphAcceptedForCanvas).toBe(true)
   })
 
   it('⭐ carries `currentResultsHash` sourced from the REAL store at `results.hash`', () => {

--- a/src/canvas/hooks/useProvisionalAnalysisDelivery.ts
+++ b/src/canvas/hooks/useProvisionalAnalysisDelivery.ts
@@ -246,13 +246,40 @@ export function readProvisionalApplyStore(): ScenarioAnalysisApplyStore {
     // the signal either way, and a store read keeps the change inside this file
     // instead of reaching into `serverGraphHydration`'s options.
     //
-    // `lastAuthoritativeGraph` — NOT `serverGraphIdentity`. Acceptance is
-    // defined structurally as "control reached the body that records
-    // `lastAuthoritativeGraph`" (`mergeServerGraph.ts:154-157`), whereas
-    // `serverGraphIdentity` is null BOTH when nothing was accepted and when an
-    // accepted merge carried no CEE token — which would decline on an honest
-    // canvas. `mergeAppliedGraph.ts:474-477` asks this same question of this
-    // same field.
+    // `lastAuthoritativeGraph` — NOT `serverGraphIdentity`. The latter is null
+    // BOTH when nothing was accepted AND when an accepted merge carried no CEE
+    // token, so it would decline on an honest canvas.
+    //
+    // ⚠⚠ BUT THIS FIELD IS NOT AN ACCEPTANCE FLAG, AND AN EARLIER VERSION OF
+    // THIS COMMENT SAID IT WAS. It claimed acceptance is "defined structurally"
+    // so the two "cannot drift apart". That is true of `mergeServerGraph` — the
+    // accepted path is exactly the body that records — and FALSE OF THE FIELD,
+    // which has THREE recorders and a seed. Derived at the bytes:
+    //
+    //   `mergeServerGraph.ts:412`    accepted server merge      ← genuine acceptance
+    //   `mergeAppliedGraph.ts:606`   applied-edit receipt
+    //   `applyDraftResult.ts:292`    a fresh DRAFT — records `identityFromCanvasGraph`
+    //                                of the LOCAL canvas, which CEE may never have seen
+    //   `store.ts:6084`              COLD-LOAD SEED, property-assignment form
+    //   `useConversation.ts:502`     nulled, and NOT on un-acceptance
+    //
+    // **A MERGE REFUSAL DOES NOT CLEAR IT.** So once any recorder has fired,
+    // this reads `true` and the guards below do not fire — reachable mid-session
+    // via draft → `recoverDraftFromServer` → refused merge → armed run.
+    //
+    // The field answers "which element identities may the reconciler remove?"
+    // (`mergeAppliedGraph.ts:474-477`: fresh draft, prior receipt, OR DB
+    // hydration — three sources, which is what I misread as one). This guard
+    // asks "does the canvas derive from a server-accepted graph?" Two questions,
+    // one name — trap 21, and I wrote the fused version.
+    //
+    // WHAT IT STILL BUYS: it is a genuine NECESSARY condition. `false` proves
+    // divergence, and every case it catches is caught correctly. It is not
+    // SUFFICIENT, so the guard is incomplete over its own defect class — pinned
+    // as KNOWN-OPEN in
+    // `hydrate/__tests__/provisionalDelivery.graphAcceptance.reachability.spec.ts`
+    // rather than left to this comment. Closing it needs new state meaning
+    // "derives from a server-accepted graph"; that is rowed, not done here.
     //
     // ⚠ AN EMPTY CANVAS IS NOT DIVERGENT. There is no local graph for a verdict
     // to misdescribe, and this is the case the zero-overlap guard itself calls

--- a/src/canvas/hooks/useProvisionalAnalysisDelivery.ts
+++ b/src/canvas/hooks/useProvisionalAnalysisDelivery.ts
@@ -256,11 +256,26 @@ export function readProvisionalApplyStore(): ScenarioAnalysisApplyStore {
     // accepted path is exactly the body that records — and FALSE OF THE FIELD,
     // which has THREE recorders and a seed. Derived at the bytes:
     //
-    //   `mergeServerGraph.ts:412`    accepted server merge      ← genuine acceptance
+    //   RECORDERS (non-null):
+    //   `mergeServerGraph.ts:412`    accepted server merge  ← the ONLY genuine
+    //                                server acceptance
     //   `mergeAppliedGraph.ts:606`   applied-edit receipt
-    //   `applyDraftResult.ts:292`    a fresh DRAFT — records `identityFromCanvasGraph`
-    //                                of the LOCAL canvas, which CEE may never have seen
+    //   `applyDraftResult.ts:292`    a fresh DRAFT. ⚠ NOT "the local canvas CEE
+    //                                has never seen" — an earlier version of this
+    //                                comment said that and it is FALSE at the
+    //                                bytes: `nodes`/`edges` are mapped from
+    //                                `draftData` (`:209`,`:212`) and applied as a
+    //                                wholesale replacement, so at the instant of
+    //                                recording the canvas IS CEE's own draft. The
+    //                                accurate distinction is narrower and still
+    //                                decisive: CEE DRAFTED it, but never ACCEPTED
+    //                                it as this scenario's authoritative SERVER
+    //                                graph. A draft still defeats the guard.
     //   `store.ts:6084`              COLD-LOAD SEED, property-assignment form
+    //
+    //   NULLERS (all fail-safe — they can only make the guard MORE cautious):
+    //   `store.ts:1439`              scenario reset
+    //   `store.ts:1999`              initial state
     //   `useConversation.ts:502`     nulled, and NOT on un-acceptance
     //
     // **A MERGE REFUSAL DOES NOT CLEAR IT.** So once any recorder has fired,

--- a/src/canvas/hooks/useProvisionalAnalysisDelivery.ts
+++ b/src/canvas/hooks/useProvisionalAnalysisDelivery.ts
@@ -96,6 +96,20 @@ export const PROVISIONAL_DELIVERY_DEADLINE_MS =
 export type ProvisionalDeliveryOutcome =
   | 'delivered'
   | 'already_held'
+  /**
+   * A terminal verdict arrived and was WITHHELD because it does not describe
+   * the graph on screen. Settles the schedule: divergence is a property of the
+   * canvas, not of the answer's timing, so re-reading cannot change it.
+   *
+   * ⚠ SILENT TODAY, AND KNOWINGLY SO. Four of the five outcomes here are
+   * already `logger.debug` with no UI state, and the missing delivery receipt
+   * is a known, separately-rowed gap. This adds one case to an existing silence
+   * rather than creating a new silent-failure class — the distinction that
+   * separates a strict improvement from trap 23. Telling the user their canvas
+   * and the analysed model have diverged is the right answer and is rowed with
+   * the receipt, because either alone leaves the other half silent.
+   */
+  | 'withheld'
   | 'deadline'
   | 'aborted'
   | 'unreadable'
@@ -172,6 +186,16 @@ export async function runProvisionalDeliverySchedule(deps: {
       return 'delivered'
     }
     if (outcome.outcome === 'alreadyHeld') return 'already_held'
+    if (outcome.outcome === 'declined') {
+      // The REASON is logged, never collapsed: the two harms must stay
+      // distinguishable in telemetry or the next reader sees one rule.
+      logger.debug('provisional_analysis_delivery.withheld', {
+        scenarioId: deps.scenarioId,
+        kind: outcome.kind,
+        reason: outcome.reason,
+      })
+      return 'withheld'
+    }
     // `notYet` — the H4 path. NOTHING was written; keep waiting.
   }
   // H3: the bound expired. Write nothing; leave CEE's verdict standing.
@@ -215,6 +239,27 @@ export function readProvisionalApplyStore(): ScenarioAnalysisApplyStore {
     setAnalysisStateV1: s.setAnalysisStateV1,
     resultsComplete: s.resultsComplete,
     currentResultsHash: s.results?.hash ?? null,
+    // ── Does the canvas on screen derive from a server graph we ACCEPTED? ──
+    //
+    // Read STRAIGHT FROM THE STORE here rather than threaded down from the
+    // hydration path: this leg is structurally blind to acceptance, so it needs
+    // the signal either way, and a store read keeps the change inside this file
+    // instead of reaching into `serverGraphHydration`'s options.
+    //
+    // `lastAuthoritativeGraph` — NOT `serverGraphIdentity`. Acceptance is
+    // defined structurally as "control reached the body that records
+    // `lastAuthoritativeGraph`" (`mergeServerGraph.ts:154-157`), whereas
+    // `serverGraphIdentity` is null BOTH when nothing was accepted and when an
+    // accepted merge carried no CEE token — which would decline on an honest
+    // canvas. `mergeAppliedGraph.ts:474-477` asks this same question of this
+    // same field.
+    //
+    // ⚠ AN EMPTY CANVAS IS NOT DIVERGENT. There is no local graph for a verdict
+    // to misdescribe, and this is the case the zero-overlap guard itself calls
+    // "the whole point of the feature" — it hydrates in full. Treating it as
+    // divergent would withhold the verdict on a fresh scenario, which is the
+    // over-fix that closes the lie by opening a gap.
+    graphAcceptedForCanvas: s.lastAuthoritativeGraph !== null || s.nodes.length === 0,
   }
 }
 

--- a/src/canvas/hydrate/__tests__/provisionalDelivery.graphAcceptance.reachability.spec.ts
+++ b/src/canvas/hydrate/__tests__/provisionalDelivery.graphAcceptance.reachability.spec.ts
@@ -1,0 +1,350 @@
+/**
+ * A VERDICT MAY NOT BECOME AUTHORITATIVE OVER A GRAPH THE USER DOES NOT HAVE
+ * — the provisional-delivery divergence guards.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE DEFECT, ESTABLISHED BY EXERCISING THE REAL MODULES AT `3953d958`
+ * ═══════════════════════════════════════════════════════════════════════════
+ * `applyScenarioAnalysisRead` wrote CEE's verdict with NO acceptance gate. The
+ * gate added for the boot leg lives in `serverGraphHydration`, and this leg
+ * does not go through it.
+ *
+ * Its own header's safety argument is that the polling leg asks *"has the run I
+ * just watched start finished?"* — premise: **the canvas has not moved since
+ * that run was armed**. A REFUSED BOOT falsifies exactly that premise. After
+ * `mergeRefused` the canvas holds the user's graph and CEE holds a different
+ * one, and this leg READS the server graph but never merges it, so nothing
+ * reconciles them before the verdict lands.
+ *
+ * THE SEQUENCE (pinned below, end to end, with the REAL modules):
+ *   refused boot → a NEW run arms this leg → the poll delivers CEE's verdict
+ *   about ITS graph as the wire authority over the user's own.
+ * Boot alone cannot arm it — it arms on `running`, which is boot-declined — so
+ * this needed its own repair rather than riding the boot fix.
+ *
+ * ⚠⚠ SCOPE, AND IT TRAVELS WITH THIS FIX EVERYWHERE:
+ * REACHABLE IN CODE, CONDITIONAL ON A REFUSED BOOT, WHICH HAS NOT BEEN OBSERVED
+ * LIVE. These tests prove that GIVEN a refused boot the harm follows. They do
+ * NOT prove refused boots reach real users. And they are store-level: jsdom
+ * cannot show the rendered sentence.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * TWO HARMS, PARAMETERISED SEPARATELY — the point of the whole change
+ * ═══════════════════════════════════════════════════════════════════════════
+ *   `divergent_currency_claim`  MISINFORMS — a freshness claim about a graph
+ *                               the user never had.
+ *   `divergent_block_claim`     REMOVES THE USER'S ACTION — strictly worse, in
+ *                               this module's own words.
+ * They decline on the same FACT today and are still kept apart, so that
+ * relaxing one can never silently relax the other. Each has its own kind-set,
+ * its own reason, and its own tests below.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
+
+import { useCanvasStore } from '../../store'
+import { hydrateCanvasFromServer } from '../serverGraphHydration'
+import { fetchScenarioGraph } from '../../../adapters/cee/scenarioGraph'
+import {
+  runProvisionalDeliverySchedule,
+  readProvisionalApplyStore,
+} from '../../hooks/useProvisionalAnalysisDelivery'
+import {
+  applyScenarioAnalysisRead,
+  DIVERGENT_DECLINED_CURRENCY_KINDS,
+  DIVERGENT_DECLINED_BLOCK_KINDS,
+  READ_TERMINAL_RUN_STATE_KINDS,
+} from '../applyScenarioAnalysisRead'
+
+const SCENARIO_ID = '11111111-2222-4333-8444-555555555555'
+const CEE_TOKEN = 'c'.repeat(63) + '9'
+const SERVER_INSTANT = '2026-08-25T09:00:00.000Z'
+
+function envelope() {
+  return {
+    kind: 'graph_identity_hash',
+    value: CEE_TOKEN,
+    algorithm: 'sha256',
+    projection_version: 'identity.v1',
+    graph_schema_version: 'graph_v3',
+    normaliser_version: '1',
+  }
+}
+
+function verdict(runState: AnalysisStateV1['run_state']): AnalysisStateV1 {
+  return {
+    run_state: runState,
+    readiness: { status: 'ready', blockers: [] },
+    leader_claim: { permitted: false, withheld_reason: 'separation_unavailable' },
+    robustness: {},
+    usable_for_prose: false,
+    usable_for_chips: false,
+    usable_for_followup: false,
+    requires_rerun: true,
+    blocked_unusable: false,
+    contradictions: [],
+  } as AnalysisStateV1
+}
+
+const SERVER_VERDICT = verdict({
+  kind: 'complete_stale',
+  computed_at: SERVER_INSTANT,
+  cause: 'graph_changed',
+})
+
+const RUNNING_VERDICT = verdict({
+  kind: 'running',
+  started_at: '2026-08-25T10:00:00.000Z',
+} as never)
+
+/**
+ * ⚠ `blocked_unusable: true` IS REQUIRED alongside `kind: 'blocked'`.
+ * Paired with `false`, the `.strict()` schema rejects the verdict, it arrives
+ * as `null`, and the leg returns `deadline` — WHICH IS INDISTINGUISHABLE FROM
+ * THE GUARD WORKING. A malformed fixture manufactures the exact result these
+ * tests exist to detect, so the parse control below is what makes any assertion
+ * about `blocked` mean anything at all.
+ */
+function blockedVerdict(): AnalysisStateV1 {
+  const v = verdict({ kind: 'blocked', reason_code: 'no_options', blockers: [] } as never)
+  ;(v as { blocked_unusable: boolean }).blocked_unusable = true
+  return v
+}
+
+function unrelatedGraph() {
+  return {
+    nodes: [
+      { id: 'server-a', kind: 'factor', label: 'Their factor' },
+      { id: 'server-b', kind: 'goal', label: 'Their goal' },
+    ],
+    edges: [],
+  }
+}
+
+function okBody(over: Record<string, unknown> = {}) {
+  return {
+    schema: 'scenario_graph.v1',
+    scenario_id: SCENARIO_ID,
+    graph: unrelatedGraph(),
+    graph_present: true,
+    brief_text: null,
+    graph_identity_hash: envelope(),
+    layout_present: false,
+    request_id: 'divergence-guard',
+    ...over,
+  }
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return { ok: status >= 200 && status < 300, status, json: async () => body } as unknown as Response
+}
+
+/** The user's OWN graph. Node ids deliberately disjoint from the server's. */
+function seedLocalCanvas(over: Record<string, unknown> = {}): void {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_ID,
+    nodes: [
+      { id: 'local-1', type: 'factor', position: { x: 10, y: 20 }, data: { label: 'My spend', kind: 'factor' } },
+      { id: 'local-2', type: 'goal', position: { x: 300, y: 400 }, data: { label: 'My profit', kind: 'goal' } },
+    ] as never,
+    edges: [] as never,
+    lastAuthoritativeGraph: null,
+    serverGraphIdentity: null,
+    importPendingServerRegistration: false,
+    history: { past: [], future: [] },
+    analysisStateV1: null,
+    analysisFreshnessDirty: false,
+    ...over,
+  } as never)
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchSpy = vi.fn()
+  vi.stubGlobal('fetch', fetchSpy)
+  seedLocalCanvas()
+})
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+const storedVerdict = () => useCanvasStore.getState().analysisStateV1 ?? null
+const canvasIds = () => useCanvasStore.getState().nodes.map((n: { id: string }) => n.id)
+const immediate = async () => {}
+
+function poll() {
+  return runProvisionalDeliverySchedule({
+    scenarioId: SCENARIO_ID,
+    userId: null,
+    signal: new AbortController().signal,
+    read: fetchScenarioGraph,
+    wait: immediate,
+    delays: [0],
+  })
+}
+
+/** Drive the real refused boot, then arm a new run. Returns at the armed state. */
+async function refusedBootThenNewRun(): Promise<void> {
+  fetchSpy.mockResolvedValue(jsonResponse(200, okBody({ analysis_state: SERVER_VERDICT })))
+  expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('mergeRefused')
+  expect(storedVerdict()).toBeNull()
+  useCanvasStore.getState().setAnalysisStateV1(RUNNING_VERDICT)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+describe('the two kind-sets partition the terminal set — derived, not mirrored', () => {
+  it('their union EQUALS READ_TERMINAL_RUN_STATE_KINDS, with no overlap', () => {
+    // Trap 12d: derivation proves agreement, a corpus proves completeness. This
+    // is the completeness half — a NEW terminal kind landing in neither set
+    // would slip through both guards unclassified, and this REDs if it does.
+    const union = [...DIVERGENT_DECLINED_CURRENCY_KINDS, ...DIVERGENT_DECLINED_BLOCK_KINDS]
+    expect([...union].sort()).toEqual([...READ_TERMINAL_RUN_STATE_KINDS].sort())
+    expect(new Set(union).size).toBe(union.length)
+  })
+})
+
+describe('⭐ DIVERGENT — a verdict about a graph the user does not have is WITHHELD', () => {
+  it('POSITIVE CONTROL — the boot genuinely refuses, so the divergence is real', async () => {
+    await refusedBootThenNewRun()
+    expect(canvasIds()).toEqual(['local-1', 'local-2'])
+    expect(useCanvasStore.getState().lastAuthoritativeGraph).toBeNull()
+    // And the store view actually reports divergence — otherwise every
+    // assertion below would pass because the guard never ran.
+    expect(readProvisionalApplyStore().graphAcceptedForCanvas).toBe(false)
+  })
+
+  it('⭐ MISINFORMATION HARM — `complete_stale` is withheld, and NOTHING is written', async () => {
+    await refusedBootThenNewRun()
+
+    expect(await poll()).toBe('withheld')
+
+    // The armed `running` verdict is still standing — withholding must not
+    // DESTROY a belief, only decline to add a false one.
+    expect(storedVerdict()?.run_state.kind).toBe('running')
+    expect(canvasIds()).toEqual(['local-1', 'local-2'])
+  })
+
+  it('⭐ ACTION-REMOVAL HARM — a `blocked` verdict is withheld (the worse half)', async () => {
+    await refusedBootThenNewRun()
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody({ analysis_state: blockedVerdict() })))
+
+    // PARSE CONTROL FIRST — prove the fixture survives `.strict()`, or a
+    // rejected verdict would fake this exact result.
+    const parsed = await fetchScenarioGraph(SCENARIO_ID)
+    expect(parsed.status === 'graph' && parsed.analysisState?.run_state.kind).toBe('blocked')
+
+    expect(await poll()).toBe('withheld')
+    expect(storedVerdict()?.run_state.kind).toBe('running')
+  })
+
+  it('the two harms are reported as DIFFERENT reasons, never fused', () => {
+    const divergent = { graphAcceptedForCanvas: false, setAnalysisStateV1: () => {} }
+    const currency = applyScenarioAnalysisRead({
+      analysisState: SERVER_VERDICT, analysisResult: null, store: divergent,
+    })
+    const block = applyScenarioAnalysisRead({
+      analysisState: blockedVerdict(), analysisResult: null, store: divergent,
+    })
+    expect(currency).toEqual({ outcome: 'declined', kind: 'complete_stale', reason: 'divergent_currency_claim' })
+    expect(block).toEqual({ outcome: 'declined', kind: 'blocked', reason: 'divergent_block_claim' })
+    // The load-bearing assertion: the reasons DIFFER. A single fused predicate
+    // would still withhold both and pass every test above.
+    expect(currency.outcome === 'declined' && currency.reason)
+      .not.toBe(block.outcome === 'declined' && block.reason)
+  })
+
+  it('a divergent read writes no RESULTS either — declined before hydration', async () => {
+    const writes: string[] = []
+    const out = applyScenarioAnalysisRead({
+      analysisState: SERVER_VERDICT,
+      analysisResult: { type: 'analysis_result' },
+      store: {
+        graphAcceptedForCanvas: false,
+        setAnalysisStateV1: () => writes.push('verdict'),
+        resultsComplete: () => writes.push('results'),
+        currentResultsHash: null,
+      },
+    })
+    expect(out.outcome).toBe('declined')
+    // Showing results computed on a graph the user does not have is the same
+    // lie with a bigger surface.
+    expect(writes).toEqual([])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+describe('⭐ THE OTHER DOOR — an honest canvas still receives its verdict', () => {
+  it('an ACCEPTED boot leaves no divergence, and delivery proceeds', async () => {
+    useCanvasStore.setState({
+      nodes: [
+        { id: 'server-a', type: 'factor', position: { x: 0, y: 0 }, data: { label: 'Their factor', kind: 'factor' } },
+        { id: 'server-b', type: 'goal', position: { x: 1, y: 1 }, data: { label: 'Their goal', kind: 'goal' } },
+      ] as never,
+    } as never)
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody({ analysis_state: SERVER_VERDICT })))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('merged')
+    expect(readProvisionalApplyStore().graphAcceptedForCanvas).toBe(true)
+
+    useCanvasStore.getState().setAnalysisStateV1(RUNNING_VERDICT)
+    expect(await poll()).toBe('delivered')
+    expect(storedVerdict()?.run_state.kind).toBe('complete_stale')
+    expect((storedVerdict()?.run_state as { computed_at?: string })?.computed_at).toBe(SERVER_INSTANT)
+  })
+
+  it('an EMPTY canvas is NOT divergent — there is no local graph to misdescribe', async () => {
+    // The over-fix this guards against: treating an empty canvas as divergent
+    // would withhold the verdict on a fresh scenario, closing the lie by
+    // opening a gap. The zero-overlap guard calls this case "the whole point".
+    seedLocalCanvas({ nodes: [] as never })
+    expect(readProvisionalApplyStore().graphAcceptedForCanvas).toBe(true)
+
+    useCanvasStore.getState().setAnalysisStateV1(RUNNING_VERDICT)
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody({ analysis_state: SERVER_VERDICT })))
+    expect(await poll()).toBe('delivered')
+    expect(storedVerdict()?.run_state.kind).toBe('complete_stale')
+  })
+
+  it('an UNSUPPLIED store field fails OPEN — a caller without the concept is unchanged', () => {
+    const out = applyScenarioAnalysisRead({
+      analysisState: SERVER_VERDICT,
+      analysisResult: null,
+      store: { setAnalysisStateV1: () => {} },
+    })
+    expect(out.outcome).toBe('applied')
+  })
+
+  it('`graphAcceptedForCanvas: true` applies the verdict, including `blocked`', () => {
+    const seen: string[] = []
+    const out = applyScenarioAnalysisRead({
+      analysisState: blockedVerdict(),
+      analysisResult: null,
+      store: { graphAcceptedForCanvas: true, setAnalysisStateV1: () => seen.push('w') },
+    })
+    expect(out).toEqual({ outcome: 'applied', kind: 'blocked', resultsHydrated: false })
+    expect(seen).toEqual(['w'])
+  })
+})
+
+describe('the pre-existing declines are untouched by the divergence guards', () => {
+  it('a NON-TERMINAL kind is still `notYet`, even when divergent', () => {
+    const out = applyScenarioAnalysisRead({
+      analysisState: RUNNING_VERDICT,
+      analysisResult: null,
+      store: { graphAcceptedForCanvas: false, setAnalysisStateV1: () => {} },
+    })
+    // Ordering matters: the H4 guard must win, or `running` would be reported
+    // as a divergence decline and the caller would stop polling a live run.
+    expect(out).toEqual({ outcome: 'notYet', reason: 'non_terminal_kind' })
+  })
+
+  it('an ABSENT verdict is still `no_verdict`, even when divergent', () => {
+    const out = applyScenarioAnalysisRead({
+      analysisState: null,
+      analysisResult: null,
+      store: { graphAcceptedForCanvas: false, setAnalysisStateV1: () => {} },
+    })
+    expect(out).toEqual({ outcome: 'notYet', reason: 'no_verdict' })
+  })
+})

--- a/src/canvas/hydrate/__tests__/provisionalDelivery.graphAcceptance.reachability.spec.ts
+++ b/src/canvas/hydrate/__tests__/provisionalDelivery.graphAcceptance.reachability.spec.ts
@@ -41,6 +41,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { readdirSync, readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
 import type { AnalysisStateV1 } from '@talchain/schemas/boundary'
 
 import { useCanvasStore } from '../../store'
@@ -324,6 +326,107 @@ describe('⭐ THE OTHER DOOR — an honest canvas still receives its verdict', (
     })
     expect(out).toEqual({ outcome: 'applied', kind: 'blocked', resultsHydrated: false })
     expect(seen).toEqual(['w'])
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+// ⚠⚠ KNOWN-OPEN — THE GUARD IS INCOMPLETE OVER ITS OWN DEFECT CLASS
+// ═══════════════════════════════════════════════════════════════════════════
+//
+// `graphAcceptedForCanvas` is derived from `lastAuthoritativeGraph`, which is
+// NOT an acceptance flag: it has three recorders plus a cold-load seed, and a
+// MERGE REFUSAL DOES NOT CLEAR IT. So once any recorder has fired, the guards
+// read `true` and do not fire — and the defect this file exists to close
+// survives on that path.
+//
+// This block PINS that gap as an executing test rather than a comment or a
+// skip. Its two halves fail in opposite directions on purpose:
+//   · the chain test REDs if someone CLOSES the gap without updating this pin
+//   · the derived-set test REDs if someone ADDS a recorder, growing the gap
+// A gap recorded in the suite is honest. A gap only prose knows about is how a
+// class silently reopens — which is exactly how this one got past my own review.
+describe('⚠ KNOWN-OPEN: a prior recorder defeats the guard (pinned, not fixed)', () => {
+  it('PINNED GAP — draft-then-refused-boot still DELIVERS the divergent verdict', async () => {
+    // Reproduces the reachable chain: a draft records `lastAuthoritativeGraph`
+    // from the LOCAL canvas (`applyDraftResult.ts:292`), then
+    // `recoverDraftFromServer` re-enters hydration mid-session
+    // (`useConversation.ts:5627`), the merge REFUSES, a run arms — and the
+    // guard cannot see that the canvas never derived from a server graph.
+    seedLocalCanvas({
+      lastAuthoritativeGraph: { nodeIds: ['local-1', 'local-2'], edgePairs: [] },
+    })
+    // The guard is DEFEATED — this is the gap, asserted rather than described.
+    expect(readProvisionalApplyStore().graphAcceptedForCanvas).toBe(true)
+
+    fetchSpy.mockResolvedValue(jsonResponse(200, okBody({ analysis_state: SERVER_VERDICT })))
+    expect(await hydrateCanvasFromServer(SCENARIO_ID)).toBe('mergeRefused')
+    useCanvasStore.getState().setAnalysisStateV1(RUNNING_VERDICT)
+
+    // ⚠ THE PIN. Today this DELIVERS a verdict about a graph the user does not
+    // have. When the stronger fix lands, this line REDs — and that RED is the
+    // signal to delete this block, not to loosen it.
+    expect(await poll()).toBe('delivered')
+    expect(storedVerdict()?.run_state.kind).toBe('complete_stale')
+    expect(canvasIds()).toEqual(['local-1', 'local-2'])
+  })
+
+  it('CONTRAST — the same chain WITHOUT a prior recorder is correctly withheld', async () => {
+    // Proves the pin above is about the DEFEATER, not about the guard being
+    // broken outright. Same fixtures, same sequence, field never recorded.
+    await refusedBootThenNewRun()
+    expect(readProvisionalApplyStore().graphAcceptedForCanvas).toBe(false)
+    expect(await poll()).toBe('withheld')
+  })
+
+  it('⭐ the DEFEATER SET is DERIVED from the tree — REDs if a recorder is added', () => {
+    // NOT a hand-maintained list (trap 12). Scans src/ for every non-null write
+    // to `lastAuthoritativeGraph`, in BOTH syntactic forms — the call form and
+    // the property-assignment form that hid a writer from my own #849 sweep.
+    // ⚠ NOT `import.meta.url` — under vitest's transform it is not a `file:`
+    // URL and `fileURLToPath` throws, which reads as a RED about the codebase
+    // when it is really a RED about the probe. Anchored on cwd and asserted to
+    // exist, so a wrong root fails loudly instead of scanning nothing.
+    const srcRoot = join(process.cwd(), 'src') + '/'
+    expect(existsSync(srcRoot)).toBe(true)
+    const files: string[] = []
+    const walk = (dir: string): void => {
+      for (const e of readdirSync(dir, { withFileTypes: true })) {
+        const p = join(dir, e.name)
+        if (e.isDirectory()) {
+          if (e.name !== '__tests__' && e.name !== 'node_modules') walk(p)
+        } else if (/\.tsx?$/.test(e.name) && !/\.(spec|test)\.tsx?$/.test(e.name)) {
+          files.push(p)
+        }
+      }
+    }
+    walk(srcRoot)
+
+    const recorders = new Set<string>()
+    for (const f of files) {
+      const text = readFileSync(f, 'utf8')
+      // Strip line comments so prose mentioning the symbol cannot inflate the set.
+      const code = text.replace(/^\s*(\/\/|\*|\/\*).*$/gm, '')
+      const rel = f.slice(srcRoot.length)
+      // Form 1: the setter invoked with an argument (a non-null record).
+      if (/setLastAuthoritativeGraph\s*\(\s*[^)\s]/.test(code)) recorders.add(rel)
+      // Form 2: property assignment to something other than `null`.
+      if (/lastAuthoritativeGraph\s*=\s*(?!null)[A-Za-z{]/.test(code)) recorders.add(rel)
+    }
+
+    // POSITIVE CONTROL — the scan must SEE something, or the assertion below is
+    // vacuous and would pass against a broken walk (trap 13).
+    expect(files.length).toBeGreaterThan(200)
+    expect(recorders.size).toBeGreaterThan(0)
+
+    // THE PIN: exactly these four, three of which do NOT imply server acceptance.
+    expect([...recorders].sort()).toEqual(
+      [
+        'canvas/store.ts', //                 cold-load seed (property-assignment form)
+        'canvas/utils/applyDraftResult.ts', // a fresh DRAFT — CEE may never have seen it
+        'canvas/utils/mergeAppliedGraph.ts', // applied-edit receipt
+        'canvas/utils/mergeServerGraph.ts', //  the ONLY genuine server acceptance
+      ].sort(),
+    )
   })
 })
 

--- a/src/canvas/hydrate/__tests__/provisionalDelivery.graphAcceptance.reachability.spec.ts
+++ b/src/canvas/hydrate/__tests__/provisionalDelivery.graphAcceptance.reachability.spec.ts
@@ -348,10 +348,17 @@ describe('⭐ THE OTHER DOOR — an honest canvas still receives its verdict', (
 describe('⚠ KNOWN-OPEN: a prior recorder defeats the guard (pinned, not fixed)', () => {
   it('PINNED GAP — draft-then-refused-boot still DELIVERS the divergent verdict', async () => {
     // Reproduces the reachable chain: a draft records `lastAuthoritativeGraph`
-    // from the LOCAL canvas (`applyDraftResult.ts:292`), then
-    // `recoverDraftFromServer` re-enters hydration mid-session
-    // (`useConversation.ts:5627`), the merge REFUSES, a run arms — and the
-    // guard cannot see that the canvas never derived from a server graph.
+    // (`applyDraftResult.ts:292`), then `recoverDraftFromServer` re-enters
+    // hydration mid-session (`useConversation.ts:5627`), the merge REFUSES, a
+    // run arms — and the guard cannot see that the canvas never derived from an
+    // ACCEPTED server graph.
+    //
+    // ⚠ PRECISION, because an earlier version of this comment got it wrong: the
+    // draft is NOT "the local canvas CEE has never seen". Its nodes come from
+    // `draftData`, so CEE authored it. The distinction that matters is DRAFTED
+    // vs ACCEPTED — CEE drafted this graph but never accepted it as the
+    // scenario's authoritative server graph, and only the latter licenses a
+    // verdict about it.
     seedLocalCanvas({
       lastAuthoritativeGraph: { nodeIds: ['local-1', 'local-2'], edgePairs: [] },
     })

--- a/src/canvas/hydrate/applyScenarioAnalysisRead.ts
+++ b/src/canvas/hydrate/applyScenarioAnalysisRead.ts
@@ -139,7 +139,68 @@ export function isReadTerminalRunState(kind: string): kind is ReadTerminalRunSta
  * a wider type would let a later edit reach the graph slices, which belong to
  * `serverGraphHydration`.
  */
+/**
+ * ── THE TWO DIVERGENCE HARMS, PARAMETERISED SEPARATELY ─────────────────────
+ *
+ * Two sets, not one predicate. Today both decline on the same FACT (a canvas
+ * that derives from no accepted server graph), and they are still kept apart,
+ * because they answer different questions and will not necessarily move
+ * together. A single `DIVERGENT_DECLINED_KINDS` would make "relax the currency
+ * rule" and "relax the block rule" the same edit — and the second is far more
+ * dangerous than the first.
+ *
+ * Their union is asserted EQUAL to `READ_TERMINAL_RUN_STATE_KINDS` in
+ * `__tests__/`, derived from the contract rather than mirrored here, so a new
+ * terminal kind cannot land in neither set and slip through unclassified
+ * (trap 12d: derivation proves agreement, a corpus proves completeness).
+ */
+
+/** MISINFORMS: a freshness claim about a graph the user does not have. */
+export const DIVERGENT_DECLINED_CURRENCY_KINDS = [
+  'complete_current',
+  'complete_stale',
+] as const
+
+/**
+ * REMOVES THE USER'S ACTION: an analysability claim about a graph the user does
+ * not have. The boot leg declines these outright, merge or no merge; here there
+ * is no merge at all, so its justification applies at least as strongly.
+ */
+export const DIVERGENT_DECLINED_BLOCK_KINDS = ['blocked', 'refused'] as const
+
+function isDivergentCurrencyClaim(kind: string): boolean {
+  return (DIVERGENT_DECLINED_CURRENCY_KINDS as readonly string[]).includes(kind)
+}
+
+function isDivergentBlockClaim(kind: string): boolean {
+  return (DIVERGENT_DECLINED_BLOCK_KINDS as readonly string[]).includes(kind)
+}
+
 export interface ScenarioAnalysisApplyStore {
+  /**
+   * Whether the canvas on screen DERIVES FROM a server graph we accepted.
+   *
+   * ⚠ A FACT, NOT A POLICY. It answers one question — "is what the user is
+   * looking at the graph CEE is talking about?" — and the two guards below turn
+   * it into two different decisions. Deliberately not named `mayApply`: a
+   * predicate here would fuse two harms under one name, which is the mistake
+   * this seam is being repaired for.
+   *
+   * DERIVED FROM `lastAuthoritativeGraph`, and that choice is load-bearing.
+   * `mergeServerGraph.ts:154-157` defines acceptance STRUCTURALLY — "`accepted`
+   * is true exactly when control reaches the body that records
+   * `lastAuthoritativeGraph`" — so the two cannot drift apart. The obvious
+   * alternative, `serverGraphIdentity`, is WRONG here: it is `null` both when no
+   * merge was accepted AND when an accepted merge carried no CEE token
+   * (`serverGraphHydration.ts` stores `null` for an identity-empty graph), so it
+   * conflates "never accepted" with "accepted without a token" and would decline
+   * on an honest canvas. `mergeAppliedGraph.ts:474-477` already asks this same
+   * question of this same field.
+   *
+   * `undefined` (an un-supplied store view) is treated as NOT divergent, so a
+   * caller that never had this concept behaves exactly as it does today.
+   */
+  readonly graphAcceptedForCanvas?: boolean
   readonly setAnalysisStateV1?: (verdict: AnalysisStateV1 | null) => void
   readonly resultsComplete?: (params: {
     report: ReturnType<typeof mapV5AnalysisToReport>
@@ -159,6 +220,37 @@ export type ScenarioAnalysisApplyOutcome =
   | { readonly outcome: 'notYet'; readonly reason: 'no_verdict' | 'non_terminal_kind' }
   /** A terminal verdict whose result we already hold. Stop polling; no rewrite. */
   | { readonly outcome: 'alreadyHeld'; readonly kind: ReadTerminalRunStateKind }
+  /**
+   * A terminal verdict WITHHELD because it does not describe the graph on
+   * screen. Nothing was written — not `null`, for the same reason as the
+   * `no_verdict` path: a standing belief must not be replaced by a claim of
+   * ignorance.
+   *
+   * ⚠ THE TWO REASONS ARE SEPARATE ON PURPOSE AND MUST STAY SEPARATE. They are
+   * two different harms with two different truth conditions, and fusing them
+   * under one name is exactly how this estate has repeatedly bought one defect
+   * while selling another (trap 21):
+   *
+   *   `divergent_currency_claim`  MISINFORMS. A freshness statement about a
+   *                               graph the user never had, asserted over the
+   *                               one they are looking at.
+   *   `divergent_block_claim`     REMOVES THE USER'S ACTION. Strictly worse —
+   *                               this file's own boot leg says so: "a false
+   *                               currency claim misinforms, a false block
+   *                               REMOVES THE USER'S ACTION."
+   *
+   * Distinct in telemetry and in tests, so a future relaxation of one cannot
+   * silently relax the other.
+   *
+   * SETTLES THE CALLER. Polling again cannot help: divergence is a property of
+   * the canvas, not of the answer's timing, so a re-read would return the same
+   * verdict against the same divergent canvas until the deadline expired.
+   */
+  | {
+      readonly outcome: 'declined'
+      readonly kind: ReadTerminalRunStateKind
+      readonly reason: 'divergent_currency_claim' | 'divergent_block_claim'
+    }
 
 export interface ApplyScenarioAnalysisReadInput {
   readonly analysisState: AnalysisStateV1 | null
@@ -191,6 +283,47 @@ export function applyScenarioAnalysisRead(
     // THE H4 GUARD. `never_run` lands here, and this early return is the
     // difference between the capability and a regression.
     return { outcome: 'notYet', reason: 'non_terminal_kind' }
+  }
+
+  // ── ⚠⚠ THE DIVERGENCE GUARDS — DOES THIS VERDICT DESCRIBE THE GRAPH ON
+  //       SCREEN? ────────────────────────────────────────────────────────────
+  //
+  // THE DEFECT THEY CLOSE, established by exercising the real modules end to
+  // end (`__tests__/provisionalDelivery.graphAcceptance.reachability.spec.ts`):
+  // this leg applied CEE's verdict with NO acceptance gate of any kind. Its own
+  // header's safety argument is that "the canvas has not moved since that run
+  // was armed" — and a REFUSED BOOT falsifies exactly that. After
+  // `mergeRefused` the canvas holds the user's graph and CEE holds a different
+  // one, and this leg READS the server graph but never merges it, so nothing
+  // reconciles them before the verdict lands.
+  //
+  // The sequence is: refused boot → a NEW run arms this leg → the poll delivers
+  // CEE's verdict about ITS graph as the wire authority over the user's own.
+  // Boot alone cannot arm it (`running` is boot-declined), which is why this
+  // needed its own repair rather than riding the boot fix.
+  //
+  // ⚠ SCOPE, CARRIED WITH THE FIX: reachable IN CODE, conditional on a refused
+  // boot, which has NOT been observed live. Given a refused boot the harm
+  // follows; that refused boots reach real users is unproven.
+  //
+  // ⚠ PLACED BEFORE THE RESULTS HYDRATION BELOW, AND THAT IS A DECISION.
+  // Declining the verdict while still writing the REPORT would show the user
+  // analysis output computed on a graph they do not have — the same lie with a
+  // bigger surface. A divergent read writes NOTHING: no verdict, no results.
+  //
+  // ⚠ FAIL-OPEN ON ABSENCE, deliberately. `graphAcceptedForCanvas === undefined`
+  // (a store view predating this field) is NOT treated as divergence: inventing
+  // a decline for a caller that never had the concept would be a regression, and
+  // the one production caller supplies it.
+  if (input.store.graphAcceptedForCanvas === false) {
+    // TWO GUARDS, NOT ONE BRANCH WITH TWO LABELS. Each names its own harm and
+    // owns its own kind-set, so relaxing one cannot silently relax the other.
+    if (isDivergentBlockClaim(kind)) {
+      return { outcome: 'declined', kind, reason: 'divergent_block_claim' }
+    }
+    if (isDivergentCurrencyClaim(kind)) {
+      return { outcome: 'declined', kind, reason: 'divergent_currency_claim' }
+    }
   }
 
   // ── Results FIRST (see the header) ────────────────────────────────────────

--- a/src/canvas/hydrate/applyScenarioAnalysisRead.ts
+++ b/src/canvas/hydrate/applyScenarioAnalysisRead.ts
@@ -186,16 +186,23 @@ export interface ScenarioAnalysisApplyStore {
    * predicate here would fuse two harms under one name, which is the mistake
    * this seam is being repaired for.
    *
-   * DERIVED FROM `lastAuthoritativeGraph`, and that choice is load-bearing.
-   * `mergeServerGraph.ts:154-157` defines acceptance STRUCTURALLY — "`accepted`
-   * is true exactly when control reaches the body that records
-   * `lastAuthoritativeGraph`" — so the two cannot drift apart. The obvious
-   * alternative, `serverGraphIdentity`, is WRONG here: it is `null` both when no
-   * merge was accepted AND when an accepted merge carried no CEE token
-   * (`serverGraphHydration.ts` stores `null` for an identity-empty graph), so it
-   * conflates "never accepted" with "accepted without a token" and would decline
-   * on an honest canvas. `mergeAppliedGraph.ts:474-477` already asks this same
-   * question of this same field.
+   * ⚠⚠ A NECESSARY CONDITION, NOT A SUFFICIENT ONE — AND AN EARLIER VERSION OF
+   * THIS DOC OVERSTATED IT. It said the source field's acceptance is "defined
+   * structurally … so the two cannot drift apart". True of `mergeServerGraph`,
+   * FALSE of the field it reads (see `useProvisionalAnalysisDelivery.ts`'s
+   * derivation: three recorders, a cold-load seed, and no clear on refusal).
+   *
+   * `false` PROVES divergence, and every case caught here is caught correctly.
+   * `true` does NOT prove acceptance. **So these guards are incomplete over
+   * their own defect class**, and the residual is pinned as KNOWN-OPEN in
+   * `__tests__/provisionalDelivery.graphAcceptance.reachability.spec.ts` rather
+   * than described in prose. A gap recorded in the suite is honest; a gap only a
+   * comment knows about is how a class silently reopens.
+   *
+   * The supplier still uses `lastAuthoritativeGraph` rather than
+   * `serverGraphIdentity`, which is `null` both when no merge was accepted AND
+   * when an accepted merge carried no CEE token — it would decline on an honest
+   * canvas, trading this gap for a worse one.
    *
    * `undefined` (an un-supplied store view) is treated as NOT divergent, so a
    * caller that never had this concept behaves exactly as it does today.


### PR DESCRIPTION
## The defect

`applyScenarioAnalysisRead` (`:243`) wrote CEE's verdict with **no acceptance gate of any kind**. The gate added for the boot leg in #849 lives in `serverGraphHydration`, and this leg does not go through it.

Its own header's safety argument is that the polling leg asks *"has the run I just watched start finished?"* — premise: **the canvas has not moved since that run was armed**. A **refused boot falsifies exactly that premise**. After `mergeRefused` the canvas holds the user's graph and CEE holds a different one, and this leg **reads** the server graph but never merges it, so nothing reconciles them before the verdict lands.

**The sequence, exercised end to end with the real modules:**
1. Refused boot — canvas holds `local-1`/`local-2`, CEE holds a disjoint graph. Verdict correctly not written (#849 holding).
2. A **new run** starts. A turn writes `running` — the only thing that arms this leg. Boot cannot produce it (`running` is boot-declined), which is why this needed its own repair rather than riding #849.
3. The poll delivers CEE's verdict **about its own graph** as the wire authority over the user's.

### ⚠ Scope — this bound travels with the finding everywhere

**Reachable in code, conditional on a refused boot, which has NOT been observed live.** The tests prove that *given* a refused boot the harm follows. They do **not** prove refused boots reach real users. And they are store-level: jsdom cannot show the rendered sentence.

## Why this is worse than the boot defect

| | terminal here | boot-restorable |
|---|---|---|
| `complete_current` / `complete_stale` | yes | `complete_stale` only |
| **`blocked` / `refused`** | **yes** | **declined outright** |

The boot leg declines `blocked`/`refused` because *"the boot merge can falsify 'not analysable'"*. Here there is **no merge at all**, so that justification applies at least as strongly — yet they were applied. #849 could only ever restore a staleness claim; this leg could restore a **false block**, and by this module's own words: *a false currency claim misinforms, a false block **removes the user's action***.

## The remedy — two harms, parameterised separately

Both fail-closed, and deliberately **not** one predicate:

- **`divergent_block_claim`** — declines `blocked`/`refused`. Kills the action-removing harm.
- **`divergent_currency_claim`** — declines `complete_current`/`complete_stale`. Kills the misinformation harm.

Each owns its **own exported kind-set**, its **own guard**, and its **own reason** in the outcome union and in telemetry. They decline on the same fact today and are still kept apart, so that relaxing one can never silently relax the other — the mistake this estate keeps paying for (trap 21). **M3 below is the mutant that proves this is enforced rather than merely named.**

A partition test asserts their union **equals** `READ_TERMINAL_RUN_STATE_KINDS` with no overlap, so a new terminal kind cannot land in neither set and slip through unclassified (trap 12d: derivation proves agreement, a corpus proves completeness).

### The signal: `lastAuthoritativeGraph`, not `serverGraphIdentity`

`serverGraphIdentity` would be **wrong**: it is `null` both when nothing was accepted *and* when an accepted merge carried no CEE token, so it would decline on an **honest** canvas. **M6 proves the choice is enforced.**

### ⚠ CORRECTED AFTER REVIEW — my justification for this signal was FALSE as written

An earlier version of this PR said acceptance is *"defined structurally … so the two cannot drift apart"*. That is true of `mergeServerGraph` and **false of the field**. Re-derived independently at the bytes, by syntactic form:

| writer | implies server acceptance? |
|---|---|
| `mergeServerGraph.ts:412` | **yes** — the only genuine one |
| `mergeAppliedGraph.ts:606` | no — applied-edit receipt |
| `applyDraftResult.ts:292` | **no** — a fresh **draft**. ⚠ *Corrected after review:* not "the local canvas CEE has never seen" — its `nodes`/`edges` map from `draftData` (`:209`,`:212`), so CEE authored it. The decisive distinction is **DRAFTED vs ACCEPTED**: CEE drafted this graph but never accepted it as the scenario's authoritative server graph. |
| `store.ts:6084` | **no** — cold-load seed, in **property-assignment form** (the very form that hid a writer from my own #849 sweep) |
| `store.ts:1439` / `:1999` | nulls it — scenario reset and initial state |
| `useConversation.ts:502` | nulls it — and **not** on un-acceptance |

The three nullers are all **fail-safe**: they can only make the guard more cautious, never less.

**A merge refusal does not clear it.** The field answers *"which element identities may the reconciler remove?"* — three sources, per `mergeAppliedGraph.ts:474-477`. My guard asks *"does the canvas derive from a server-accepted graph?"* Two questions under one name: trap 21, and I shipped the fused reading.

The signal is a genuine **necessary** condition — `false` proves divergence, and every case it catches is caught correctly — but it is **not sufficient**.

### Three deliberate decisions

1. **An empty canvas is NOT divergent** — no local graph for a verdict to misdescribe. Treating it as divergent would close the lie by opening a gap. **M7 guards it.**
2. **An unsupplied field fails OPEN** — a caller predating this concept behaves exactly as today. **M5 guards it.**
3. **Declined before results hydration** — writing the *report* while withholding the verdict would show analysis output computed on a graph the user does not have: the same lie with a bigger surface. A divergent read writes **nothing**.

### On the silence, explicitly

`withheld` is `logger.debug` only. That is **adding one case to an existing silence**, not creating a new silent-failure class: this hook already returns four of five outcomes with no UI state, and the missing delivery receipt is a known, separately-rowed gap. Trading a false claim for a *new* silence would be trap 23. **Telling the user their canvas and the analysed model have diverged is the right answer and is rowed with the delivery receipt**, because either alone leaves the other half silent.

## RED-first

Source reverted to pristine with the spec present: **8 failed | 4 passed of 12**. The 4 that passed are the fail-open and pre-existing-decline cases, which correctly behave identically either way — recorded rather than presented as a fuller RED than it was. Restored from a pristine archive (never from the index): **12 passed**.

## Discriminating mutants

Worktree **outside** the repo root, committed state only, applied-check scoped to `src/` with the baseline control reading **exactly 0**, clean-tree assertions before and after each mutant, restores via `git checkout HEAD --`, trailing control. **Isolation proven by writing** a sentinel and asserting the source SHA-256 unchanged (inodes `719434316` vs `719676088`). Every run asserts ≥20 collected.

| Mutant | RED | Proves |
|---|---|---|
| CONTROL | none (21 green, applied=0) | baseline |
| **M1** drop the BLOCK guard only | the block test (+ fused-reason) | the block harm is independently gated |
| **M2** drop the CURRENCY guard only | the currency test (+ results, fused-reason) | **pair with M1** — each harm gated separately |
| **M3** FUSE both reasons into one label | **only** the "different reasons, never fused" test | the separation is enforced by a test, not by naming |
| **M4** REVERT the divergence gate | 4 tests | reverting the fix REDs the suite |
| **M5** fail CLOSED on an unsupplied field | only the fail-open test | absence handling is deliberate |
| **M6** use `serverGraphIdentity` instead | 6 tests | the signal choice is enforced |
| **M7** drop the empty-canvas exemption | 7, incl. the empty-canvas test | the over-fix is guarded against |
| **M8** don't settle on decline | 2 tests | a decline settles rather than burning the schedule |
| TRAILING CONTROL | none (21 green, clean) | no mutation leaked |

M6/M7 also RED some pre-existing dedupe/default-store-view tests, because changing the store view's shape reaches them — noted rather than presented as extra discrimination.

## A pre-existing spec correctly objected, and I strengthened it

`useProvisionalAnalysisDelivery.realStoreBinding.spec.ts` binds the store view **by identity** to an exact member set, and my new member REDed it. That guard exists because a previous spread handed the applier the entire store. Rather than quietly widen it:

- the expected member set is updated **with the reason recorded** — an identity binding exists so that adding a member is a decision someone makes on purpose;
- **two new assertions** make the real boundary explicit: `graphAcceptedForCanvas` must be a **derived boolean** (a future "simplification" handing over `lastAuthoritativeGraph` or `nodes` REDs), and it must **track the real store both ways** rather than being a constant (trap 13b — asserting only one direction would pass against a hardcoded literal).

⚠ **Scope note on that first assertion, so nobody trusts the wrong half:** its `Array.isArray` loop catches `nodes` but **not** `lastAuthoritativeGraph`, which is an **object**. The object case is carried by the **member-set identity binding**, not by the array loop. Two guards, one intent — worth stating because the array loop reads as if it covered both.

## Named limits

- **No live witness.** Rung is TESTED. The conditional bound above is the honest statement of reachability.
- **jsdom** — store-level only; the rendered sentence is unshown.
- **⚠ THE GUARD IS INCOMPLETE OVER ITS OWN DEFECT CLASS.** This is the limit a reader most needs and it was missing from the first version of this PR. Because `lastAuthoritativeGraph` has three non-acceptance recorders, the guards **do not fire** once any of them has run — so the exact defect this PR closes remains reachable mid-session (draft → `recoverDraftFromServer` → refused merge → armed run). Pinned as an executing KNOWN-OPEN test below, and rowed.
- **The divergence signal is session-scoped, but it does NOT decay.** An earlier version of this section said a "long-lived session that lost the field would withhold" — that reason is inaccurate. The field is `null` only if it was never recorded or was explicitly nulled, and a cold load re-seeds it. The real cost is bounded at roughly the 60 s write-back window and **self-heals on the next accepted interaction**. A genuine cost, correctly stated.
- I did **not** audit whether other consumers of `analysisStateV1` have the same gap; this PR addresses the one leg measured.

## Boundaries

Two source files (`applyScenarioAnalysisRead.ts`, `useProvisionalAnalysisDelivery.ts`) and two specs. **No** changes to `serverGraphHydration.ts`, `absentGraphRetry.ts`, `draftRecovery.ts` (S3's regions), `components/results/**`, or any CEE file. The acceptance signal is read from the store in the hook rather than threaded through the hydration path, exactly to avoid crossing into S3.

## Rebase safety — measured, not assumed

`staging` moved after I branched (base `3953d958`). Derived rather than trusted:

- commits since my base: **#852** (`6afa41f8`, lower-left toolbar onto the upper-left toolbar's surface)
- files it touches: `CanvasLegendPopover.tsx`, `DebugPanel.tsx`, `CanvasFloatingToolbar.module.css`, `CanvasViewportControls.tsx`, `LeftSidebar.tsx`
- **intersection with my four files: EMPTY**

So the rebase is clean by measurement. Note this is *file-level* disjointness: it says nothing about a shared-contract collision, and a purely cosmetic toolbar change is not plausibly one here — but the distinction is the reason the check is stated rather than the conclusion assumed.

## ⚠⚠ KNOWN-OPEN: the residual gap, pinned in the suite rather than in prose

Review found the guards are **defeated whenever `lastAuthoritativeGraph` is already non-null**, which is reachable mid-session. I reproduced the chain end-to-end with the real modules and **it delivers**:

```
draft applies (records identityFromCanvasGraph of the LOCAL canvas, applyDraftResult.ts:292)
→ recoverDraftFromServer re-enters hydrateCanvasFromServer mid-session (useConversation.ts:5627)
→ merge REFUSES → run arms → guard does NOT fire
→ CEE's verdict about ITS graph lands over the user's disjoint canvas
CHAIN_RESULT {"graphAcceptedForCanvas":true,"outcome":"delivered","storedKind":"complete_stale"}
```

Contrast control in the same run: field `null` → `withheld`. **That is precisely the defect this PR exists to close, surviving on that path.**

It is now an **executing test**, not a skip, a TODO or a comment — `⚠ KNOWN-OPEN: a prior recorder defeats the guard (pinned, not fixed)`. Three parts:

1. **PINNED GAP** — asserts the chain currently returns `delivered`. **REDs when someone closes the gap**, and that RED is the signal to delete the block rather than loosen it.
2. **CONTRAST** — the same chain without a prior recorder is correctly `withheld`, proving the pin is about the *defeater*, not a broken guard.
3. **DEFEATER SET, DERIVED FROM THE TREE** — scans `src/` for every non-null write in **both** syntactic forms (call and property-assignment), with a positive control asserting the walk saw >200 files and >0 recorders. **REDs if a recorder is added.** Not a hand-maintained list.

**Both directions proven by mutants**, in an isolated worktree with isolation proven by writing:

| mutant | result |
|---|---|
| **close the gap** (fail-closed on defeat) | **PINNED GAP REDs** ✓ |
| **add a 5th recorder** (`draftRecovery.ts`) | **DEFEATER SET REDs, and only it** ✓ |
| trailing control | clean tree, 15/15 green |

My independent form-based sweep found **exactly** the four recorders review named — arrived at separately, which is why I trust the set.

### Rowed, deliberately not built here

Closing this needs a field meaning **"the canvas derives from a server-accepted graph"** — genuinely new state, not a re-reading of existing state. Conjoining acceptance with real server provenance is a larger change than this PR's scope and would be a "while we're here" expansion. The chain above is recorded verbatim so whoever takes it does not re-derive it.

**Rowed as `ROADMAP.md` 2.1305** — minted with the chain verbatim, the derived writer manifest, and both scope limits, after a token-exact free-id assertion and a clean duplicate sweep. A PR body is not a register and nothing re-surfaces it after merge.

**Why ship the partial fix rather than wait:** it is a strict improvement — it closes every case where no recorder has fired, including the whole cold-start class, and it fires correctly in every case it catches. The residual is smaller than the original defect and is now *visible to the suite*, which the original was not.
