### PR TITLE
style(canvas): lead the zoom group with the read-out, not sandwich it

### DIFF
--- a/src/components/layout/CanvasViewportControls.tsx
+++ b/src/components/layout/CanvasViewportControls.tsx
@@ -57,20 +57,11 @@ export const CanvasViewportControls = memo(function CanvasViewportControls({
 
   return (
     <nav aria-label="Viewport controls" className={styles.viewportControls}>
-      {/* Zoom group: out, read-out/reset, in */}
+      {/* Zoom group: read-out/reset, out, in */}
       <div className={styles.group}>
-        <Tooltip content="Zoom out (⌘-)">
-          <button
-            type="button"
-            className={styles.iconButton}
-            aria-label="Zoom out"
-            onClick={onZoomOut}
-          >
-            <ZoomOut className={styles.icon} aria-hidden="true" />
-          </button>
-        </Tooltip>
-
-        {/* Zoom percentage — click resets to 100% */}
+        {/* Zoom read-out — click resets to 100%. Leads the group rather than
+            sitting between the two zoom buttons: it is a state display you can
+            act on, not a third step in a -/+ sequence. */}
         <Tooltip content="Reset to 100%">
           <button
             type="button"
@@ -79,6 +70,17 @@ export const CanvasViewportControls = memo(function CanvasViewportControls({
             onClick={onZoomReset}
           >
             {zoomPct}
+          </button>
+        </Tooltip>
+
+        <Tooltip content="Zoom out (⌘-)">
+          <button
+            type="button"
+            className={styles.iconButton}
+            aria-label="Zoom out"
+            onClick={onZoomOut}
+          >
+            <ZoomOut className={styles.icon} aria-hidden="true" />
           </button>
         </Tooltip>
 


### PR DESCRIPTION
Follow-up to #852, on founder feedback: *"I don't like the 100% reset in the middle. I think it should be at the top."*

The zoom percentage sat between zoom-out and zoom-in, which reads as a third step in a `-`/`+` sequence. It is not one — it is the current state, which you can click to reset. Moving it to the top of the group lets the two zoom buttons sit together as the pair they are, and puts the value where the eye lands first.

**Order only.** No change to what the control does, its tooltip, or its accessible name. One file, 14/12 lines.

### Still open — the read-out's own treatment

The founder also asked whether a bare number is right, or whether it should sit in a circle like every other control. That is **not in this PR**; it is a separate decision because the answer turns out to force a copy change, and the measurement is worth recording either way.

Measured in the real font (Inter), inside the shared 32px button the usable width is **30px**:

| | 10px | 11px | 12px |
|---|---|---|---|
| `400%` (widest reachable value, maxZoom 4) | 28.6px | 31.2px ✗ | 33.8px ✗ |
| `400` (no unit) | 19.3px | 21.0px | **22.7px** |

So a circle that keeps the `%` fits **only** at 10px, with 0.7px of clearance — below a comfortable size for the one element in the toolbar carrying information. A circle at the normal 12px is only possible if the `%` goes.

Also ruled out: a filled/tonal circle. A filled circle is already this toolbar's **pressed** state (`iconButtonActive`), so a filled read-out would read as permanently switched on.

Awaiting the founder's call. Whichever way it goes it is a small, local change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)