### PR TITLE
D — stop telling a user with a strategic challenge that they have a decision [IN-class]

### DIFF
--- a/src/components/results/__tests__/coreSurfacesDoNotPresumeADecision.spec.ts
+++ b/src/components/results/__tests__/coreSurfacesDoNotPresumeADecision.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Three MOUNTED Core labels must not tell a user they have a decision.
+ *
+ * ⚠ WITNESSED, NOT DERIVED. These three were seen on the deployed product in a
+ * session where the user had entered a strategic FUNDRAISING CHALLENGE — no
+ * options, nothing being chosen between — and Olumi told them they had a
+ * "Draft decision" under a "Decision overview", beside a "Decision brief". That
+ * is the mislabelling in its clearest form, and it needs no reachability
+ * argument: it was on screen.
+ *
+ * ⚠⚠ SCOPE — THIS IS NOT A TERMINOLOGY MIGRATION GUARD, AND MUST NOT BECOME ONE.
+ * It pins THREE named user-facing strings on THREE named surfaces. It does not
+ * sweep the repo, does not police the word "decision" generally, and must never
+ * be widened into one: "decision" is the RIGHT word wherever the user is
+ * genuinely deciding between alternatives, and a guard that forbade it estate-
+ * wide would swap one presumption for its mirror.
+ *
+ * WHAT IS DELIBERATELY NOT CHANGED, and why this guard does not look at it:
+ *  · `decision-brief-*` testids, the directory names, the view-model types and
+ *    the `SectionErrorBoundary section="Decision brief"` label. That last one is
+ *    INTERNAL — the fallback renders "This section couldn't load" and never
+ *    shows the section name; it reaches only console.error and a telemetry
+ *    label, so renaming it would churn dashboards for no user benefit.
+ */
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
+
+const BRIEF = 'src/components/results/decision-brief/DecisionBriefSection.tsx'
+const OVERVIEW = 'src/components/results/decision-overview/DecisionOverviewCard.tsx'
+
+const read = (f: string) => readFileSync(f, 'utf8')
+
+describe('Core orientation labels do not presume a discrete decision', () => {
+  it('both files are tracked and non-empty (positive control)', () => {
+    for (const f of [BRIEF, OVERVIEW]) {
+      expect(execFileSync('git', ['ls-files', f], { encoding: 'utf8' }).trim()).toBe(f)
+      expect(read(f).length).toBeGreaterThan(500)
+    }
+  })
+
+  it('the brief section heading describes its contents, not a decision', () => {
+    const s = read(BRIEF)
+    // The rendered <h3>, not a comment: match inside the heading element.
+    const h = s.match(/<h3[^>]*>\s*([^<]+?)\s*<\/h3>/)
+    expect(h, 'no <h3> found in the brief section — has the heading moved?').toBeTruthy()
+    const heading = h![1]
+    expect(heading).toBe('Behind this result')
+    expect(
+      /decision/i.test(heading),
+      `the brief heading reads "${heading}" — a user who brought a strategic challenge `
+        + 'is told they have a decision.',
+    ).toBe(false)
+  })
+
+  it('the orientation card label and title fallback presume nothing', () => {
+    const s = read(OVERVIEW)
+    const meta = s.match(/metaLabel:\s*'([^']+)'/)
+    const title = s.match(/titleFallback:\s*'([^']+)'/)
+    expect(meta, 'metaLabel not found').toBeTruthy()
+    expect(title, 'titleFallback not found').toBeTruthy()
+    expect(meta![1]).toBe('Overview')
+    expect(title![1]).toBe('Untitled draft')
+    for (const [name, value] of [['metaLabel', meta![1]], ['titleFallback', title![1]]]) {
+      expect(/decision/i.test(value), `${name} reads "${value}"`).toBe(false)
+    }
+  })
+
+  /*
+   * ⭐ THE MIRROR CHECK. Generalising must not become its own presumption. These
+   * labels are shown for a genuine decision too, so they must not assert
+   * "challenge" either — the right generic asserts neither.
+   */
+  it('does not swap one presumption for its mirror', () => {
+    const s = read(OVERVIEW)
+    const meta = s.match(/metaLabel:\s*'([^']+)'/)![1]
+    const title = s.match(/titleFallback:\s*'([^']+)'/)![1]
+    for (const value of [meta, title]) {
+      expect(
+        /\bchallenge\b/i.test(value),
+        `"${value}" presumes a challenge, which is wrong when the user IS deciding `
+          + 'between options. The generic must assert neither.',
+      ).toBe(false)
+    }
+  })
+})

--- a/src/components/results/decision-brief/DecisionBriefSection.tsx
+++ b/src/components/results/decision-brief/DecisionBriefSection.tsx
@@ -104,8 +104,24 @@ export function DecisionBriefSection({ brief, leaderClaimPermitted }: DecisionBr
       <div className="flex items-start gap-2">
         <BookOpenText size={16} className="mt-0.5 shrink-0 text-info" aria-hidden="true" />
         <div className="min-w-0 flex-1">
+          {/*
+            ⭐ NOT "Decision brief". A user who brought a strategic CHALLENGE —
+            "How can I accelerate securing pre-seed investment?" — was being told
+            they had a decision brief. Witnessed mounted on exactly that session.
+
+            The heading now describes what the section CONTAINS, which is true
+            whether or not the user is deciding anything: the groups below are
+            "What matters", "What Olumi assumed", "What could change". It also
+            avoids stuttering a fourth "What ..." above those three.
+
+            ⚠ Scope: this is a user-facing label only. `decision-brief-*` testids,
+            the directory name and the view-model type keep their legacy names —
+            renaming internals here has no user value and would churn every
+            consumer (founder's ruling: fix mounted Core language contextually,
+            do not globally rename internals).
+          */}
           <h3 id={`${detailsId}-heading`} className={`${typography.panelHeader} text-text-header`}>
-            Decision brief
+            Behind this result
           </h3>
           <p className={`${typography.panelMeta} mt-0.5 text-text-light`}>
             Top drivers, the values Olumi assumed, and what could change.

--- a/src/components/results/decision-brief/__tests__/DecisionBriefSection.spec.tsx
+++ b/src/components/results/decision-brief/__tests__/DecisionBriefSection.spec.tsx
@@ -33,7 +33,10 @@ describe('DecisionBriefSection', () => {
   it('shows every licensed group and its first producer item without opening a disclosure', () => {
     render(<DecisionBriefSection brief={BRIEF} leaderClaimPermitted />)
 
-    expect(screen.getByRole('heading', { name: 'Decision brief' })).toBeInTheDocument()
+    // Heading generalised: a user who brought a strategic challenge was being
+    // told they had a "Decision brief". Pinned in
+    // `results/__tests__/coreSurfacesDoNotPresumeADecision.spec.ts`.
+    expect(screen.getByRole('heading', { name: 'Behind this result' })).toBeInTheDocument()
     expect(screen.getByText('What matters')).toBeInTheDocument()
     expect(screen.getByText('What Olumi assumed')).toBeInTheDocument()
     expect(screen.getByText('What could change')).toBeInTheDocument()

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -47,8 +47,21 @@ export type BriefStateOverride = 'thin' | 'contradictory' | 'unverified'
 type BriefState = 'ready' | 'needs_input' | 'unassessed' | 'blocked' | BriefStateOverride
 
 export const OVERVIEW_COPY = {
-  metaLabel: 'Decision overview',
-  titleFallback: 'Draft decision',
+  // ⭐ NEITHER LABEL MAY PRESUME A DECISION. This card is the ORIENTATION
+  // surface — it shows the title, framing quality and Olumi's framing question,
+  // and no analysis outcomes. It is shown for whatever the user brought, which
+  // is often a broad strategic challenge with no alternatives named yet.
+  //
+  // Both strings were witnessed mounted on a fundraising CHALLENGE: the product
+  // told the user they had a "Draft decision" under a "Decision overview".
+  //
+  // `metaLabel` is deliberately the bare generic rather than "Challenge
+  // overview": this card must read correctly when there genuinely IS a decision
+  // too, and swapping one presumption for its mirror is the same defect.
+  // `titleFallback` says what is true when Olumi has not derived a name yet —
+  // it is untitled, and it is a draft.
+  metaLabel: 'Overview',
+  titleFallback: 'Untitled draft',
   ready: 'Framing has the basics',
   readyNote: 'Goal, context, constraints and options',
   needsInput: 'Olumi needs a little more from you',

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.spec.tsx
@@ -114,7 +114,10 @@ describe('DecisionOverviewCard — ready state (live)', () => {
 
   it('collapsed and quiet: meta label, title, framing-has-the-basics line', () => {
     render(<DecisionOverviewCard title="Launch decision" />)
-    expect(screen.getByText('Decision overview')).toBeInTheDocument()
+    // Meta label generalised — this card is shown for whatever the user brought,
+    // which is often a challenge with no options named. Pinned in
+    // `results/__tests__/coreSurfacesDoNotPresumeADecision.spec.ts`.
+    expect(screen.getByText('Overview')).toBeInTheDocument()
     expect(screen.getByText('Launch decision')).toBeInTheDocument()
     expect(screen.getByText('Framing has the basics')).toBeInTheDocument()
     // Collapsed by default: dimension chips hidden until expanded.


### PR DESCRIPTION
⚠ **CONTRACT CLASS: IN** — it changes what the product tells a user their work *is*.

## What it closes

Three **mounted** labels, witnessed on the deployed product in a session where the user had entered a strategic **fundraising challenge** — no options, nothing being chosen between. Olumi told them they had a **"Draft decision"** under a **"Decision overview"**, beside a **"Decision brief"**.

Olumi helps users think about strategic challenges *whether or not they involve explicit options*. User-facing language must not imply the product only works once a discrete decision has been formulated.

These three needed **no reachability derivation** — they were on screen.

## What changed — three strings, chosen contextually

| file | before | after |
|---|---|---|
| `DecisionBriefSection.tsx` | `Decision brief` | **`Behind this result`** |
| `DecisionOverviewCard.tsx` | `metaLabel: 'Decision overview'` | **`'Overview'`** |
| `DecisionOverviewCard.tsx` | `titleFallback: 'Draft decision'` | **`'Untitled draft'`** |

The heading now describes what the section **contains** — its groups are *"What matters"*, *"What Olumi assumed"*, *"What could change"*, and its own subtitle already reads *"Top drivers, the values Olumi assumed, and what could change."* It also avoids stuttering a fourth *"What …"* above those three.

## ⭐ The generic asserts neither, and that is the point

*"Challenge overview"* would be the **mirror defect**. This card is the **orientation surface** — shown for whatever the user brought — and it must read correctly when there genuinely **is** a decision. Swapping one presumption for its opposite is the same error facing the other way.

A guard case asserts these labels do not say *"challenge"* either.

## What is deliberately NOT changed

- `decision-brief-*` / `decision-overview-*` testids, directory names, view-model types, `OVERVIEW_COPY`'s own name — internal, no user value, and renaming churns every consumer.
- `ResultsBody.tsx` `<SectionErrorBoundary section="Decision brief">` — classified **INTERNAL**, and *verified rather than assumed*: the fallback renders *"This section couldn't load"* and **never shows the section name**. It reaches only `console.error` and a telemetry label, so renaming would churn dashboards for no user benefit.

**This is contextual, not a terminology migration.** "Decision" is the *right* word wherever the user is genuinely deciding between alternatives — a repo-wide rename would break decision reasoning to fix decision framing.

## Evidence

| | |
|---|---|
| named gate | **PASSED** at exactly baseline 2252/556; `--update-baseline` untouched |
| suites | **16 files / 197 tests**, 0 failures, across both surfaces plus the new guard |
| new guard | `coreSurfacesDoNotPresumeADecision.spec.ts`, 4 cases — the three strings, the mirror check, and a tracked-and-non-empty positive control |

The guard is **scoped to three named strings on two named surfaces** and carries an explicit in-file warning against widening it into a repo-wide terminology guard.

Two existing specs asserted the old strings and were **updated, not deleted** — their premise (that the label was correct) is what changed.

## Scope

Mounted user-facing Core language only. **The entry refusal is untouched** — it is a deterministic CEE guard (`frame_no_brief_guard`, `route-v2.ts:5690`, zero LLM calls) and belongs to the runtime owner. Rewording UI copy around it would be compensating for a runtime refusal with copy.