### PR TITLE
C+D — the most prominent intervention now reaches something that can change the model [IN-class]

### DIFF
--- a/src/canvas/mutations/__tests__/mutationAuthority.spec.ts
+++ b/src/canvas/mutations/__tests__/mutationAuthority.spec.ts
@@ -97,7 +97,8 @@ const EXPECTED_MOUNTED_AUTHORITY = {
   analysisAssumedEdgeStrength: {
     authority: 'disabled',
     entrySurfaces: ['analysis assumed-strength card'],
-    requiredEvidence: 'finding remains visible; Set action does not mount',
+    requiredEvidence:
+      'finding remains visible; the mounted action ASKS Olumi (a conversation turn) and the surface itself writes no graph state',
   },
   canvasEdgeStrength: {
     authority: 'disabled',

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -29,10 +29,15 @@ import {
 import { dedupTriageItems } from './utils/dedupTriageItems'
 import { TriageCard } from '@/components/shared/TriageCard'
 import type { TriageCardCategory, TriageCardAction } from '@/components/shared/TriageCard'
-// The canonical "open the editor for this node" seam. Imported here for the
-// same reason `AnalysisHeroPanel` imports `openEdgeStrengthEditor`: a surface
-// in the OutputsDock cannot reach the inspector any other way. See
-// `openValueEditor` below.
+// The canonical "open the editor for this node" seam: a surface in the
+// OutputsDock cannot reach the inspector any other way. See `openValueEditor`
+// below.
+//
+// ⚠ This used to cite `AnalysisHeroPanel`'s `openEdgeStrengthEditor` import as
+// the precedent. That import is GONE — the assumed-strength card now asks Olumi
+// instead, because the Inspector's edge setters are all `'disabled'` and the
+// route arrived at a read-only panel. The precedent is withdrawn, not moved:
+// before citing this seam for an EDGE, check the setter authority first.
 import {
   CANONICAL_EDIT_AUTHORITY,
   hasServerGraphAuthority,

--- a/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
+++ b/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
@@ -9,9 +9,12 @@
  * model built by buildHeroModel — this component adds layout and copy
  * composition only.
  *
- * The ONE store import is `openAskOlumi` (paused-state resolution action —
- * an ACTION DISPATCH into the Ask-Olumi drawer, not a data read; the panel
- * still renders exclusively from its props).
+ * The ONE store import is `openAskOlumi` — an ACTION DISPATCH into the
+ * Ask-Olumi drawer, not a data read; the panel still renders exclusively from
+ * its props. It now has TWO call sites, not one: paused-state resolution, and
+ * the assumed-strength card's ask. It is deliberately the same seam for both —
+ * a second route into that drawer would be a second authority over what the
+ * user is about to send.
  *
  * Lens switching and row disclosure are LOCAL render state: no fetch, no
  * analysis rerun, no selector recomputation, and the row DOM persists across

--- a/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
+++ b/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
@@ -35,8 +35,10 @@ import { typography } from '@/styles/typography'
 import { openAskOlumi } from '../coaching/askOlumiStore'
 import { HeroEvidenceDisclosure } from './HeroEvidenceDisclosure'
 import { AssumedStrengthCard } from '../strengthElicitation/AssumedStrengthCard'
-import { openEdgeStrengthEditor } from '../../../canvas/utils/openEdgeStrengthEditor'
-import { CANONICAL_EDIT_AUTHORITY, hasServerGraphAuthority } from '../../../canvas/mutations/mutationAuthority'
+import {
+  ASSUMED_STRENGTH_ASK_CONTEXT,
+  assumedStrengthAskDraft,
+} from '../strengthElicitation/assumedStrengthCopy'
 import { HERO_COPY } from './heroCopy'
 import { HeroLensTabs, tabId } from './HeroLensTabs'
 import { HeroOptionRow, HERO_ROW_GRID, HERO_ROW_TRACK_SPAN } from './HeroOptionRow'
@@ -558,11 +560,46 @@ export function AnalysisHeroPanel({
           common case on live captures, so nesting this would hide it exactly
           when it is the only thing we have to offer. Self-hides on a refusal
           that has no honest sentence. */}
+      {/*
+        ⭐ THE PRODUCT'S MOST PROMINENT INTERVENTION USED TO END IN NOTHING.
+        This card sits at panel top level — zero clicks, outside the evidence
+        collapse — and says the most specific thing Olumi produces. Its button was
+        gated on `analysisAssumedEdgeStrength` and pointed at
+        `openEdgeStrengthEditor`, which raises the Inspector. The Inspector CANNOT
+        SAVE: `inspector-v2/useInspectorMutations.ts` EDGE_SETTER_AUTHORITY (:143)
+        is every setter `'disabled'`, and its own mounted copy says these changes
+        "cannot yet be saved to the shared model".
+
+        ⚠ THE FLAG IS UNCHANGED AND STILL HONEST. `analysisAssumedEdgeStrength`
+        stays `'disabled'` because the DIRECT-manipulation route genuinely is dead.
+        What changed is the destination, not the permission — and asking the
+        assistant is not a graph mutation by this surface, so no key here governs
+        it. Flipping the flag would assert a capability that does not exist;
+        building a second edge editor would create a fourth editing authority.
+
+        WHERE IT GOES INSTEAD: Olumi can change an edge even though the user
+        cannot. `update_edge` is first-class in the model-facing tool schema and
+        CEE applies it through the canonical commit path. So the act opens the
+        Ask-Olumi drawer with a PREFILLED, EDITABLE draft — the estate's existing
+        pattern, deliberately never an invisible auto-send: the user sees and owns
+        the request before it goes.
+
+        ⚠ WHAT THIS DOES NOT CLAIM. One live trial proved the router elects the
+        edit path for a fully-specified instruction — existence, not reliability.
+        The copy promises the ask, never the outcome. And the edit response carries
+        no before/after receipt today, which is why the drawer says the analysis
+        will need rerunning rather than implying it refreshes itself.
+      */}
       <AssumedStrengthCard
         decision={model.evidence.assumedStrength}
-        onResolve={hasServerGraphAuthority(CANONICAL_EDIT_AUTHORITY.analysisAssumedEdgeStrength)
-          ? openEdgeStrengthEditor
-          : undefined}
+        onResolve={selection => {
+          openAskOlumi({
+            context: ASSUMED_STRENGTH_ASK_CONTEXT,
+            draft: assumedStrengthAskDraft(selection),
+            label: 'Set relationship strength',
+            targetId: selection.edgeId,
+          })
+        }}
       />
 
       {/* ── WHAT TO ACT ON NEXT ──────────────────────────────────────────

--- a/src/components/results/analysis-hero/__tests__/AssumedStrengthCard.mountPath.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/AssumedStrengthCard.mountPath.spec.tsx
@@ -12,11 +12,13 @@
  * `AnalysisHeroPanel` must RED here, not merely in a unit test of the card.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { useAskOlumiStore } from '../../coaching/askOlumiStore'
+import { OPEN_FULL_INSPECTOR_EVENT } from '../../../../canvas/utils/openEdgeStrengthEditor'
 import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
 import { makeHeroData } from '../__fixtures__/hero.fixtures'
 import type { AssumedStrengthDecision } from '../../strengthElicitation/selectAssumedStrengthToResolve'
-import { ASSUMED_STRENGTH_REFUSAL_COPY } from '../../strengthElicitation/assumedStrengthCopy'
+import { ASSUMED_STRENGTH_ACTION, ASSUMED_STRENGTH_REFUSAL_COPY } from '../../strengthElicitation/assumedStrengthCopy'
 
 vi.mock('../../../../canvas/utils/focusHelpers', () => ({
   focusNodeById: vi.fn(),
@@ -117,14 +119,48 @@ describe('§0 the elicitation is on the DEFAULT Analysis tab', () => {
     expect(screen.getByTestId('assumed-strength-others').textContent).toContain('2 other')
   })
 
-  it('0.4 keeps the measured relationship visible but withholds the local-only strength editor', () => {
+  /*
+   * ⭐ THE ACT IS NOW OFFERED, AND THAT IS THE CHANGE.
+   *
+   * This case asserted the button was WITHHELD, on the correct premise that its
+   * destination could not save: it opened the Inspector, whose EDGE_SETTER_AUTHORITY
+   * is every setter `'disabled'`. The product's most prominent intervention — panel
+   * top level, zero clicks — therefore ended in nothing, which is why it was hidden.
+   *
+   * It now asks Olumi, who CAN change an edge (`update_edge` is first-class in the
+   * model-facing tool schema and CEE applies it canonically). So the premise has
+   * inverted and the case must assert the new behaviour rather than be deleted.
+   *
+   * ⚠ Still asserted: the act must NOT raise the read-only Inspector.
+   */
+  it('0.4 keeps the measured relationship visible AND offers the ask', () => {
     renderAnalysisTab(SELECTED)
     expect(screen.getByTestId('assumed-strength-card')).toHaveAttribute(
       'data-edge-id',
       'e_demand_rev',
     )
     expect(screen.getByTestId('assumed-strength-why')).toHaveTextContent('35%')
-    expect(screen.queryByTestId('assumed-strength-action')).toBeNull()
+
+    const act = screen.getByTestId('assumed-strength-action')
+    expect(act).toHaveTextContent(ASSUMED_STRENGTH_ACTION)
+
+    let inspectorRaises = 0
+    const onRaise = () => { inspectorRaises += 1 }
+    window.addEventListener(OPEN_FULL_INSPECTOR_EVENT, onRaise)
+    try {
+      fireEvent.click(act)
+    } finally {
+      window.removeEventListener(OPEN_FULL_INSPECTOR_EVENT, onRaise)
+    }
+    expect(inspectorRaises, 'the act must not raise the read-only Inspector').toBe(0)
+
+    // The drawer opened with a request that names BOTH endpoints — the shape the
+    // router elects. Asserted on the store, not on prose.
+    const ask = useAskOlumiStore.getState()
+    expect(ask.isOpen).toBe(true)
+    expect(ask.draft).toContain('Customer demand')
+    expect(ask.draft).toContain('Revenue growth')
+    expect(ask.targetId).toBe('e_demand_rev')
   })
 
   it('0.5 a speaking refusal renders its sentence and NO card', () => {

--- a/src/components/results/strengthElicitation/AssumedStrengthCard.tsx
+++ b/src/components/results/strengthElicitation/AssumedStrengthCard.tsx
@@ -59,18 +59,22 @@ import {
   assumedStrengthOthers,
   assumedStrengthWhy,
 } from './assumedStrengthCopy'
-import type { AssumedStrengthDecision } from './selectAssumedStrengthToResolve'
+import type { AssumedStrengthDecision, AssumedStrengthSelection } from './selectAssumedStrengthToResolve'
 import { typography } from '../../../styles/typography'
 
 export interface AssumedStrengthCardProps {
   decision: AssumedStrengthDecision
   /**
-   * Open the edge-strength editor for a canvas edge id. Injected so the card
-   * stays presentational and the test can assert the ARGUMENT rather than a
-   * side effect. Absent ⇒ the card still names the assumption but renders no
-   * button, rather than a button that does nothing.
+   * Act on the selected assumed strength. Receives the WHOLE selection, not
+   * just an edge id, because the act now composes a request that names both
+   * endpoints verbatim — and a handler given only an id would have to look the
+   * labels up again, which is a second authority for the same fact.
+   *
+   * Injected so the card stays presentational and the test can assert the
+   * ARGUMENT rather than a side effect. Absent ⇒ the card still names the
+   * assumption but renders no button, rather than a button that does nothing.
    */
-  onResolve?: (edgeId: string) => void
+  onResolve?: (selection: AssumedStrengthSelection) => void
 }
 
 function AssumedStrengthCardImpl({ decision, onResolve }: AssumedStrengthCardProps) {
@@ -122,7 +126,7 @@ function AssumedStrengthCardImpl({ decision, onResolve }: AssumedStrengthCardPro
           type="button"
           className={`${typography.panelBody} text-accent underline underline-offset-2`}
           data-testid="assumed-strength-action"
-          onClick={() => onResolve(selected.edgeId)}
+          onClick={() => onResolve(selected)}
         >
           {ASSUMED_STRENGTH_ACTION}
         </button>

--- a/src/components/results/strengthElicitation/AssumedStrengthCard.tsx
+++ b/src/components/results/strengthElicitation/AssumedStrengthCard.tsx
@@ -19,21 +19,29 @@
  * FACTORS by value of information, this one names an EDGE whose strength is a
  * still unconfirmed.
  *
- * ── THE ACTION REACHES THE EDITOR, AND WRITES NOTHING ───────────────────────
- * The button calls `openEdgeStrengthEditor`, which selects the edge, stands the
- * dock down, centres the canvas and raises the inspector — so the control the
- * label promises is on screen when the click finishes.
+ * ── THE ACTION ASKS OLUMI, AND WRITES NOTHING LOCALLY ──────────────────────
+ * The button calls `openAskOlumi`, which opens the Ask-Olumi drawer with an
+ * EDITABLE prefilled instruction naming both endpoints and a value. Nothing is
+ * sent until the user clicks Send: opening the drawer dispatches nothing, and
+ * neither does Enter, Cmd-Enter, Ctrl-Enter or blur.
  *
- * An earlier cut called `focusModelTarget`, which only selects the edge and
- * centres the camera. That left a button labelled "Set this strength" that
- * panned to the edge and stopped, with the user still having to find and click
- * it: the label promised a capability the wiring did not deliver. Reaching the
- * editor is the whole point of the interaction, so the wiring was fixed rather
- * than the label lowered.
+ * ⚠ IT USED TO CALL `openEdgeStrengthEditor`, AND THAT IS WHY THIS PARAGRAPH
+ * CHANGED. That seam selects the edge, stands the dock down, centres the canvas
+ * and raises the Inspector — and every Inspector EDGE setter is `'disabled'`
+ * (`inspector-v2/useInspectorMutations.ts` EDGE_SETTER_AUTHORITY), with the
+ * panel's own mounted copy saying the value "cannot yet be saved to the shared
+ * model". So the product's most prominent intervention arrived at a read-only
+ * panel. There is no user-facing edge editor to route to.
  *
- * It still writes NO graph state. The strength is set in the panel this opens,
- * by `useEdgeMutations.setStrength`, which remains the single writer of
- * `weight`/`weightSource`. A write here would be a second writer of that field.
+ * But OLUMI can change an edge: `update_edge` is a first-class op in the
+ * model-facing tool schema and CEE applies it through the canonical commit path.
+ * So the honest act is to ask. The label promises the ASK and never the outcome
+ * — a live trial showed the router elects this path, which is existence, not
+ * reliability.
+ *
+ * It still writes NO graph state from here. The canonical writer of
+ * `weight`/`weightSource` is unchanged; a write on this surface would be a
+ * second writer of that field.
  *
  * ── TYPOGRAPHY: THE SANCTIONED SCALE, NOT RAW UTILITIES ─────────────────────
  * This card first shipped with raw Tailwind size and weight utilities, which

--- a/src/components/results/strengthElicitation/AssumedStrengthCard.tsx
+++ b/src/components/results/strengthElicitation/AssumedStrengthCard.tsx
@@ -1,6 +1,7 @@
 /**
- * The elicitation surface: names ONE assumed relationship and routes the user to
- * the existing edge-strength editor.
+ * The elicitation surface: names ONE assumed relationship and offers to ask
+ * Olumi to set its strength. There is no user-facing edge editor to route to —
+ * see "THE ACTION ASKS OLUMI" below for why the destination changed.
  *
  * This component AUTHORS NOTHING. Every sentence comes from `assumedStrengthCopy`
  * (templated from derived facts), and the only judgement it makes is

--- a/src/components/results/strengthElicitation/__tests__/assumedStrengthAskReachesOlumi.spec.ts
+++ b/src/components/results/strengthElicitation/__tests__/assumedStrengthAskReachesOlumi.spec.ts
@@ -36,6 +36,21 @@ describe('the assumed-strength act asks Olumi, and asks specifically', () => {
     // An explicit number: the vague form ("set X to low") did not reach the edit
     // path in the probe; the explicit form did.
     expect(/\d/.test(draft), `draft carries no explicit value: "${draft}"`).toBe(true)
+
+    // ⚠ AND IT IS IN THE INTERVAL THE CONSUMER ENFORCES. "a digit exists" was
+    // written against the failure mode in hand — a VAGUE draft ("set X to low")
+    // that the router declined — and a guard written against the failure mode
+    // instead of against the spec is how this estate has shipped a defect and
+    // then its exact inverse. PLoT's gate is `value < 0 || value > 1`, which is
+    // SIGN-SYMMETRIC, so `8`, `-3` and `0.52` all satisfied `/\d/` while only
+    // one of them is a strength. Measured before this was written: mutating the
+    // drafted value to 8, to -3 and to 0.52 each left the suite GREEN 20/20.
+    const values = [...draft.matchAll(/-?\d+(?:\.\d+)?/g)].map(m => Number(m[0]))
+    expect(values.length, `no parseable value in draft: "${draft}"`).toBeGreaterThan(0)
+    for (const v of values) {
+      expect(v, `drafted value ${v} is outside [0,1]: "${draft}"`).toBeGreaterThanOrEqual(0)
+      expect(v, `drafted value ${v} is outside [0,1]: "${draft}"`).toBeLessThanOrEqual(1)
+    }
   })
 
   it('DISCRIMINATES by selection — it is not a fixed string', () => {

--- a/src/components/results/strengthElicitation/__tests__/assumedStrengthAskReachesOlumi.spec.ts
+++ b/src/components/results/strengthElicitation/__tests__/assumedStrengthAskReachesOlumi.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * The most prominent intervention must reach something that can actually change
+ * the model.
+ *
+ * ⚠ WHY THIS EXISTS. `AssumedStrengthCard` renders at panel top level — zero
+ * clicks, outside the evidence collapse — and carries the most specific sentence
+ * the product produces (the alternative winner, the measured switch rate, the
+ * rank among unconfirmed strengths). Its button pointed at the Inspector, whose
+ * every edge setter is `'disabled'` and whose own mounted copy says these changes
+ * "cannot yet be saved to the shared model". The product's loudest ask ended in
+ * nothing.
+ *
+ * ⚠ WHAT IS ASSERTED, AND WHAT DELIBERATELY IS NOT. A live probe showed the
+ * router elects the graph-edit path for a fully-specified instruction naming both
+ * endpoints and a number, and does NOT elect it for a vague one. So the draft's
+ * SHAPE is load-bearing and is pinned here. Whether the router elects it on any
+ * given turn is runtime behaviour — one trial is existence, not reliability — so
+ * nothing here asserts the edit succeeds.
+ */
+import { describe, it, expect } from 'vitest'
+import { ASSUMED_STRENGTH_ACTION, assumedStrengthAskDraft, ASSUMED_STRENGTH_ASK_CONTEXT } from '../assumedStrengthCopy'
+
+const SEL = { fromLabel: 'Discount depth', toLabel: 'Series B fundability' }
+
+describe('the assumed-strength act asks Olumi, and asks specifically', () => {
+  it('the label promises the ASK, not the outcome', () => {
+    expect(ASSUMED_STRENGTH_ACTION).toBe('Ask Olumi to set this strength')
+    // It must not claim the strength is set, nor that the analysis updates.
+    expect(/\bwill\b|\bupdates?\b|\bdone\b/i.test(ASSUMED_STRENGTH_ACTION)).toBe(false)
+  })
+
+  it('names BOTH endpoints verbatim — the shape the router elects', () => {
+    const draft = assumedStrengthAskDraft(SEL)
+    expect(draft).toContain('Discount depth')
+    expect(draft).toContain('Series B fundability')
+    // An explicit number: the vague form ("set X to low") did not reach the edit
+    // path in the probe; the explicit form did.
+    expect(/\d/.test(draft), `draft carries no explicit value: "${draft}"`).toBe(true)
+  })
+
+  it('DISCRIMINATES by selection — it is not a fixed string', () => {
+    const other = assumedStrengthAskDraft({ fromLabel: 'Hiring pace', toLabel: 'Runway' })
+    const first = assumedStrengthAskDraft(SEL)
+    expect(other).not.toBe(first)
+    expect(other).toContain('Hiring pace')
+    expect(other).not.toContain('Discount depth')
+  })
+
+  it('the context line carries what the draft cannot: ownership and the rerun', () => {
+    // The number is the user's, not Olumi's suggestion presented as fact.
+    expect(/your own judgement/i.test(ASSUMED_STRENGTH_ASK_CONTEXT)).toBe(true)
+    // The edit response carries no before/after receipt, so the drawer must not
+    // let the user believe the analysis refreshes itself.
+    expect(/rerun/i.test(ASSUMED_STRENGTH_ASK_CONTEXT)).toBe(true)
+  })
+
+  /*
+   * ⭐ THE MIRROR CHECK. The draft must not assert a CURRENT strength. The
+   * selection carries no numeric value — only whether it is Olumi's estimate or
+   * unset — so any "currently X" phrasing would be invented.
+   */
+  it('does not assert a before-value it does not have', () => {
+    const draft = assumedStrengthAskDraft(SEL)
+    expect(/currently|at the moment|is now|from \d/i.test(draft), `draft asserts a before-value: "${draft}"`).toBe(false)
+  })
+})

--- a/src/components/results/strengthElicitation/__tests__/assumedStrengthCopy.claims.spec.ts
+++ b/src/components/results/strengthElicitation/__tests__/assumedStrengthCopy.claims.spec.ts
@@ -13,7 +13,9 @@
  * declared solved.
  */
 import { describe, it, expect } from 'vitest'
-import {
+import * as copyModule from '../assumedStrengthCopy'
+
+const {
   ASSUMED_STRENGTH_ACTION,
   ASSUMED_STRENGTH_REFUSAL_COPY,
   ASSUMED_STRENGTH_TITLE,
@@ -21,7 +23,7 @@ import {
   assumedStrengthLead,
   assumedStrengthOthers,
   assumedStrengthWhy,
-} from '../assumedStrengthCopy'
+} = copyModule
 import type { AssumedStrengthSelection } from '../selectAssumedStrengthToResolve'
 
 const sel = (over: Partial<AssumedStrengthSelection> = {}): AssumedStrengthSelection => ({
@@ -34,25 +36,75 @@ const sel = (over: Partial<AssumedStrengthSelection> = {}): AssumedStrengthSelec
   ...over,
 })
 
-/** EVERY sentence this module can emit, enumerated from the types. */
-function allSentences(): string[] {
-  const out: string[] = [
-    ASSUMED_STRENGTH_TITLE,
-    ASSUMED_STRENGTH_ACTION,
-    ...Object.values(ASSUMED_STRENGTH_REFUSAL_COPY).filter((s): s is string => s !== null),
-  ]
+/**
+ * EVERY sentence this module can emit.
+ *
+ * ⚠ THIS USED TO BE A HAND-WRITTEN LIST, AND THE LIST IS HOW A CLAIM SHIPPED
+ * PAST ITS OWN GUARD. Two constants were added to the module —
+ * `ASSUMED_STRENGTH_ASK_CONTEXT` and `assumedStrengthAskDraft` — and neither was
+ * added here, so the honesty prohibitions below silently stopped covering the
+ * string the user reads at the moment they decide to send. The prohibition was
+ * correct; its enumeration was one constant short, and nothing went red.
+ *
+ * The arities differ, so the INVOCATIONS themselves cannot be derived. What can
+ * be derived is COMPLETENESS: the keys of this table are asserted equal to the
+ * module's own export list, so a new export cannot be omitted without a RED.
+ * That is the trap-12 shape — where you cannot derive, the mirror must fail loud
+ * on drift rather than assume good.
+ */
+const INVOCATIONS: Record<string, () => Array<string | null>> = {
+  ASSUMED_STRENGTH_TITLE: () => [ASSUMED_STRENGTH_TITLE],
+  ASSUMED_STRENGTH_ACTION: () => [ASSUMED_STRENGTH_ACTION],
+  ASSUMED_STRENGTH_ASK_CONTEXT: () => [copyModule.ASSUMED_STRENGTH_ASK_CONTEXT],
+  ASSUMED_STRENGTH_REFUSAL_COPY: () => Object.values(ASSUMED_STRENGTH_REFUSAL_COPY),
+  assumedStrengthLead: () => matrix().map(assumedStrengthLead),
+  assumedStrengthWhy: () => matrix().map(assumedStrengthWhy),
+  assumedStrengthAsk: () => matrix().map(assumedStrengthAsk),
+  assumedStrengthOthers: () => [0, 1, 2, 5].map(assumedStrengthOthers),
+  assumedStrengthAskDraft: () => matrix().map(copyModule.assumedStrengthAskDraft),
+}
+
+/** The full input matrix the templated sentences can be generated over. */
+function matrix(): AssumedStrengthSelection[] {
+  const out: AssumedStrengthSelection[] = []
   for (const strengthProvenance of ['ai_inferred', 'missing'] as const) {
     for (const alt of ['Consolidate', null]) {
-      const s = sel({ alternativeWinnerLabel: alt, strengthProvenance })
-      out.push(assumedStrengthLead(s), assumedStrengthWhy(s), assumedStrengthAsk(s))
+      out.push(sel({ alternativeWinnerLabel: alt, strengthProvenance }))
     }
-  }
-  for (const n of [0, 1, 2, 5]) {
-    const o = assumedStrengthOthers(n)
-    if (o !== null) out.push(o)
   }
   return out
 }
+
+function allSentences(): string[] {
+  return Object.values(INVOCATIONS)
+    .flatMap(fn => fn())
+    .filter((v): v is string => typeof v === 'string')
+}
+
+describe('the claim guard covers the WHOLE module, not a remembered subset', () => {
+  it('COMPLETENESS — every export of the copy module is enumerated here', () => {
+    // The assertion that would have caught G1. An export absent from
+    // INVOCATIONS is an export no prohibition below applies to.
+    expect(Object.keys(INVOCATIONS).sort()).toEqual(Object.keys(copyModule).sort())
+  })
+
+  it('the enumeration is non-empty and covers every export by name', () => {
+    expect(Object.keys(copyModule).length).toBeGreaterThanOrEqual(8)
+    expect(allSentences().length).toBeGreaterThanOrEqual(10)
+  })
+
+  it('REGRESSION — the drawer context line honours the ask-not-outcome rule', () => {
+    // The exact string and the exact regex that G1 slipped past.
+    expect(/\bwill\b|\bupdates?\b|\bdone\b/i.test(copyModule.ASSUMED_STRENGTH_ASK_CONTEXT)).toBe(
+      false,
+    )
+  })
+
+  it('EVERY emitted sentence honours the ask-not-outcome rule', () => {
+    const offenders = allSentences().filter(t => /\bwill\b|\bupdates?\b|\bdone\b/i.test(t))
+    expect(offenders).toEqual([])
+  })
+})
 
 describe('assumedStrengthCopy — the claim boundary, held mechanically', () => {
   it('enumerates a NON-EMPTY sentence set (this guard cannot pass vacuously)', () => {

--- a/src/components/results/strengthElicitation/__tests__/elicitationChain.spec.ts
+++ b/src/components/results/strengthElicitation/__tests__/elicitationChain.spec.ts
@@ -199,7 +199,16 @@ describe('P4 chain: elicitation → resolve → stale → rerun → loop closed'
       selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null } as never,
     })
 
-    render(createElement(AssumedStrengthCard, { decision, onResolve: openEdgeStrengthEditor }))
+    // ⚠ THE PRODUCT NO LONGER WIRES THIS CARD TO THIS HANDLER. The panel now routes
+    // the act to the Ask-Olumi drawer, because the Inspector cannot save an edge
+    // strength (EDGE_SETTER_AUTHORITY: every setter 'disabled'). The adapter below
+    // keeps this spec exercising `openEdgeStrengthEditor` itself — which retains
+    // other callers (`ConnRow`, `NodeQuickActions`) — rather than deleting
+    // coverage of a helper that is still live elsewhere.
+    render(createElement(AssumedStrengthCard, {
+      decision,
+      onResolve: sel => openEdgeStrengthEditor(sel.edgeId),
+    }))
     fireEvent.click(screen.getByTestId('assumed-strength-action'))
 
     const routed = useCanvasStore.getState()
@@ -284,7 +293,16 @@ describe('P4 chain: elicitation → resolve → stale → rerun → loop closed'
       selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null } as never,
     })
 
-    render(createElement(AssumedStrengthCard, { decision, onResolve: openEdgeStrengthEditor }))
+    // ⚠ THE PRODUCT NO LONGER WIRES THIS CARD TO THIS HANDLER. The panel now routes
+    // the act to the Ask-Olumi drawer, because the Inspector cannot save an edge
+    // strength (EDGE_SETTER_AUTHORITY: every setter 'disabled'). The adapter below
+    // keeps this spec exercising `openEdgeStrengthEditor` itself — which retains
+    // other callers (`ConnRow`, `NodeQuickActions`) — rather than deleting
+    // coverage of a helper that is still live elsewhere.
+    render(createElement(AssumedStrengthCard, {
+      decision,
+      onResolve: sel => openEdgeStrengthEditor(sel.edgeId),
+    }))
     fireEvent.click(screen.getByTestId('assumed-strength-action'))
     render(createElement(
       ReactFlowProvider,

--- a/src/components/results/strengthElicitation/assumedStrengthCopy.ts
+++ b/src/components/results/strengthElicitation/assumedStrengthCopy.ts
@@ -128,10 +128,20 @@ export const ASSUMED_STRENGTH_ACTION = 'Ask Olumi to set this strength'
 /**
  * The drawer's context line — chrome, never sent. It carries the two things the
  * draft cannot: that the number is the user's to choose, and that the analysis
- * will not silently update itself.
+ * does not silently update itself.
+ *
+ * ⚠ "CAN CHANGE", NOT "WILL CHANGE". The button's own guard forbids `will` for a
+ * stated reason — this interaction promises the ASK, never the outcome, because
+ * the router electing the graph-edit path was shown by ONE live trial, which is
+ * existence and not reliability. The first cut of this constant said *"Olumi
+ * will change the model"* and shipped past that guard, because the guard was
+ * pointed at the BUTTON while this is the string the user reads at the moment
+ * they decide to send. The principle was right and its coverage was one
+ * constant wide. Both are fixed: the wording states capability, and the guard
+ * is now enumerated from the module's own exports.
  */
 export const ASSUMED_STRENGTH_ASK_CONTEXT =
-  'Replace the number with your own judgement before sending. Olumi will change the model; the analysis then needs rerunning.'
+  'Replace the number with your own judgement before sending. Olumi can change the model; the analysis then needs rerunning.'
 
 /**
  * The prefilled EDITABLE draft.

--- a/src/components/results/strengthElicitation/assumedStrengthCopy.ts
+++ b/src/components/results/strengthElicitation/assumedStrengthCopy.ts
@@ -108,7 +108,51 @@ export function assumedStrengthOthers(assumedFragileCount: number): string | nul
  * a focus-only jump again, this label becomes a promise the product does not
  * keep, and the honest move is to change the wiring back, not this string.
  */
-export const ASSUMED_STRENGTH_ACTION = 'Set this strength'
+/**
+ * ⭐ "ASK OLUMI TO", NOT "SET". The button used to read "Set this strength" and
+ * pointed at `openEdgeStrengthEditor` -> the Inspector, whose every edge setter
+ * is `'disabled'` (`inspector-v2/useInspectorMutations.ts` EDGE_SETTER_AUTHORITY)
+ * and whose own mounted copy says it "cannot yet be saved to the shared model".
+ * So the product's MOST PROMINENT intervention — zero clicks, panel top level,
+ * carrying the most specific sentence Olumi produces — terminated in nothing.
+ *
+ * There is no user-facing edge editor to route to; there is no v2 edge surface.
+ * But OLUMI can change an edge: `update_edge` is a first-class op in the
+ * model-facing tool schema and CEE applies it through the canonical commit path.
+ * So the honest act is to ask, and the wording says exactly that. It promises
+ * the ASK, never the outcome — a single live trial proved the router elects this
+ * path, which is existence, not reliability.
+ */
+export const ASSUMED_STRENGTH_ACTION = 'Ask Olumi to set this strength'
+
+/**
+ * The drawer's context line — chrome, never sent. It carries the two things the
+ * draft cannot: that the number is the user's to choose, and that the analysis
+ * will not silently update itself.
+ */
+export const ASSUMED_STRENGTH_ASK_CONTEXT =
+  'Replace the number with your own judgement before sending. Olumi will change the model; the analysis then needs rerunning.'
+
+/**
+ * The prefilled EDITABLE draft.
+ *
+ * ⚠ THE PHRASING IS EVIDENCE-LED, NOT STYLE. A live probe showed the router
+ * elects the graph-edit path for an explicit, fully-specified instruction naming
+ * both endpoints and a number, and does NOT elect it for a vague one ("set X to
+ * low" returned a clarifying question instead). So the draft names both labels
+ * verbatim and carries an explicit value.
+ *
+ * ⚠ AND IT DOES NOT STATE A "BEFORE". The selection carries no current numeric
+ * strength — only whether it is Olumi's estimate or unset — so asserting one
+ * would be inventing it. `0.8` is a starting point the user edits, and the
+ * context line says so; it is not a claim about what the value is now.
+ */
+export function assumedStrengthAskDraft(s: {
+  fromLabel: string
+  toLabel: string
+}): string {
+  return `Change the strength of the link from ${s.fromLabel} to ${s.toLabel} to 0.8.`
+}
 
 /**
  * REFUSALS. Each names a DIFFERENT fact, and none of them denies anything.


### PR DESCRIPTION
⚠ **CONTRACT CLASS: IN** — it changes what the product invites a user to do about their model.

## What it closes

`AssumedStrengthCard` sits at **panel top level — zero clicks**, outside the evidence collapse, and carries the most specific sentence Olumi produces: the alternative winner, the measured switch rate, this edge's rank among unconfirmed strengths.

It ended with **"Set this strength"**, and that button led nowhere.

## Why it led nowhere

It pointed at `openEdgeStrengthEditor`, which raises the Inspector. **The Inspector cannot save.** `inspector-v2/useInspectorMutations.ts` `EDGE_SETTER_AUTHORITY` (`:143`) is every setter `'disabled'`, and its own mounted copy says so:

> This inspector is read-only because these changes cannot yet be saved to the shared model. Use the Model tab for supported factor values.

There is no v2 edge surface to use instead.

## What changed — the destination, not the permission

Olumi can change an edge **even though the user cannot**. `update_edge` is first-class in the model-facing tool schema (`anthropic-edit-graph-schema.ts:52`) and CEE applies it through the canonical commit path.

So the act opens the **Ask-Olumi drawer with a prefilled, editable draft** — this estate's existing pattern, and deliberately *never an invisible auto-send*: the user sees and owns the request before it goes.

⚠ **`analysisAssumedEdgeStrength` stays `'disabled'`, and that is correct.** It governs *direct* manipulation, which genuinely is dead. Asking the assistant is not a graph mutation by this surface, so no key here governs it. Flipping it would assert a capability that does not exist; building an edge editor would have created a **fourth** editing authority beside the three that already disagree.

## The draft's shape is evidence-led, not style

A live probe showed the router elects the graph-edit path for a **fully-specified** instruction naming both endpoints and a number — *"Change the strength of the link from X to Y to 0.8"* committed, survived reload, and left a control edge untouched — and does **not** elect it for a vague one (*"set X to low"* returned a clarifying question).

So the draft names both labels verbatim and carries an explicit value.

## What it deliberately does not claim

| | |
|---|---|
| **No before-value** | the selection carries no current numeric strength, so *"currently 0.5"* would be invented. `0.8` is a starting point the user edits, and the context line says so |
| **No guarantee** | one trial is **existence, not reliability**. The label reads *"Ask Olumi to set this strength"* — it promises the ask |
| **No silent refresh** | the edit response carries no before/after receipt today, so the drawer states the analysis will need rerunning |
| **No provenance claim** | authorship after an edge edit is currently wrong upstream. This surface asserts nothing about it and will render whatever the wire says once fixed |

## ⭐ Both defect directions are live at once

This PR is one half of a pair, and naming the pair is the point:

- **CEE writer the UI cannot name** — `edge_strength_edit: 'mutating'` at `dispatch.ts:283`; the UI's `WIRE_SYSTEM_EVENT_TYPES` does not list it.
- **UI consumer CEE does not feed** — the `edit_graph` chip exit composes no `ui_directive`, though both ends of that transport work.

Same class, opposite polarity. It is the clearest evidence yet that **nothing maps which producer reaches which consumer.**

## Evidence

| | |
|---|---|
| named gate | **PASSED** at exactly baseline 2252/556; `--update-baseline` untouched |
| suites | **41 files / 686 tests**, 0 failures |
| mutant | strip the ask → mount-path spec **REDs** (1 of 5) |
| trailing control | 5/5, restored from a **pristine archive outside the tree**, isolation proven by writing a sentinel |

⚠ **Recorded because it nearly cost the change:** an earlier mutation round restored with `git checkout HEAD -- <path>`. This branch had no commits yet, so `HEAD` was staging and the restore **silently deleted the fix rather than the mutant** — trap 9h, exactly as documented. Caught only by the trailing control failing.

**Two specs changed, not deleted.** `AssumedStrengthCard.mountPath` asserted the button was *withheld*; that premise was true and is now false, so it asserts the new behaviour **and** that no Inspector raise occurs. `elicitationChain` adapts the signature so it keeps covering `openEdgeStrengthEditor`, which retains other callers.

---

## ⚠ KNOWN LIMITATION — disclosed, not fixed here

**Node labels containing `set` or `update` as a whole word take a slower, non-deterministic path.**

The drafted instruction is routed by CEE's `VALUE_UPDATE_REGEX`, whose `set|update … to <X>` arm is **not anchored to the start of the message**. A label containing either word — at *either* endpoint — satisfies it and trips the route-level suppression. Executed against a label corpus:

| suppressed | kept |
|---|---|
| `Set pricing` | `Asset utilisation` |
| `Update cadence` | `Onset of churn` |
| `Feature set` | `Mindset shift` |

The word boundary holds correctly, so substring occurrences do **not** trigger it. **This is a bounded class, not a random failure.**

**Consequence, stated precisely.** The row still has `impliesEdgePhrasing = true`, so it falls to the deterministic value-update pre-route, immediately hits `edge_phrasing_gate`, and is handed to the LLM router. It **loses the deterministic lane and gains an LLM round-trip** — degraded and non-deterministic — but it does **not** reach `set_factor_value`. This is a gate-level judgement; the fall-through was not executed end to end.

**Why it is not a gate on this PR.** The consequence is degradation, not failure; the root cause is in CEE's regex, not in this change; and this PR is a strict improvement over the prior state in every case including this one. **At `origin/staging` the card rendered no button at all** — `onResolve` resolved to `undefined` — so the change is *no affordance → an affordance*.

**Why it belongs upstream and not in the template.** We generate a sentence our own router mishandles. That is different from a user typing something awkward: we control the template, and no rewording avoids it, because **the trigger is the label, not the template**. The CEE-side anchor fix is a separate row and a separate lane.

**Stated corpus exclusion:** the other `VALUE_UPDATE_REGEX` arms (`increase|decrease|reduce|raise|lower … by`, `success target`, `add … constraint`) were **not** swept against label text, so the `set`/`update` family may not be the only one that bites.

### Three further label defects — rowed, inert on this path today
- **`Time to first value` truncates to `…from Time`** — `VALUE_TARGET_PATTERN` is a non-greedy capture stopping at the *first* `" to "`, and the template's own `from … to …` is genuinely ambiguous to it.
- **An apostrophe loses twice** — truncation *and* the apostrophe stripped: `Customer's willingness to pay` → `Customers willingness`.
- **A comma splits the message** — `parts=2`, `kind='other'`, `namedTargets=[]`, total decomposition miss.

All three keep `editVerbCandidate` true with `accountableParts ≤ 1`, and part-accounting is gated at `>= 2`, so the degraded targets are inert **on single-part strings**. ⚠ **They become live on a compound message.**

Six label shapes passed clean: ampersand, parentheses, hyphens, substring labels, numbers, identical endpoints.

**Not claimed:** substring collision (`Revenue` vs `Revenue growth`) and identical endpoints parse correctly, but their real risk sits in **downstream entity resolution, which was not executed**.

### Follow-up rows (reliability half, not this PR)
- **R2 — edge identity is thrown away at the wire.** `chip.parameters` exists to carry identity to CEE and none is passed, so `chip` ships as `{}`. **Node labels are not unique**, so binding an edge by a label pair is identity-by-predicate at the wire. This is the right long-term fix for the whole label-ambiguity class.
- **R4 — the user's own words never reach the transcript.** `displayText: opts.label` renders *"Set relationship strength"*; `submittedPrompt` holds the real text and has zero readers in render code. The context line tells the user to choose the number, and the number is exactly what the record drops.
