### PR TITLE
D — the panel names what is missing instead of sending the user to the chat for it [IN-class]

### DIFF
--- a/src/canvas/stores/__tests__/readinessStore.improvementFabrication.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.improvementFabrication.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * readinessStore — THE PRECONDITION BEHIND THE BLOCKED-REASON REFUSAL.
+ *
+ * `composeBlockedReason`'s producer-authored rung renders readiness
+ * `improvements[].action` to the user as THE PRODUCER NAMING WHAT IS MISSING.
+ * That claim is only true while every action it renders came from the producer.
+ * This store breaks that: an improvement arriving with neither `action` nor
+ * `recommendation` is mapped to a SYNTHESISED line so the improvements LIST
+ * still has a row.
+ *
+ * Measured before the refusal was written, the composer emitted:
+ *
+ *   'Choose the missing effect value for "rebuild our product" on "Cash runway
+ *    consumed". Review this area'
+ *
+ * — a real producer remedy and a UI invention, joined seamlessly and
+ * indistinguishable in the field. That is a worse failure than the generic copy
+ * the rung replaced: generic copy is visibly generic.
+ *
+ * ── WHY THIS SPEC EXISTS SEPARATELY FROM THE COMPOSER'S ────────────────────
+ * The composer spec builds its own fixture from `IMPROVEMENT_ACTION_PLACEHOLDER`
+ * and asserts the refusal. It would therefore keep passing if THIS store stopped
+ * fabricating that exact value — the refusal would be dead and nothing would go
+ * red. A discriminator must pin its own precondition (CLAUDE.md trap 13b), and
+ * the precondition is a fact about the STORE, so it is measured here, against the
+ * real mapping, through the real fetch seam.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useReadinessStore } from '../readinessStore'
+import { useCanvasStore } from '../../store'
+import { clearInflightCache } from '../../hooks/useGraphReadiness'
+import { IMPROVEMENT_ACTION_PLACEHOLDER } from '../../utils/improvementActionPlaceholder'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+vi.stubGlobal('crypto', { randomUUID: () => 'test-uuid' })
+
+const PRODUCER_ACTION = 'Choose the missing effect value for "rebuild our product".'
+
+function ok(improvements: unknown[]) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () =>
+      Promise.resolve({
+        readiness_score: 62,
+        readiness_level: 'fair',
+        can_run_analysis: false,
+        confidence_explanation: 'Not ready',
+        improvements,
+      }),
+    text: () => Promise.resolve(''),
+    headers: new Headers(),
+  }
+}
+
+function seedCanvasWithNodes(count: number) {
+  const nodes = Array.from({ length: count }, (_, i) => ({
+    id: `node-${i}`,
+    type: 'factor',
+    position: { x: 0, y: 0 },
+    data: { label: `Factor ${i}`, kind: 'factor' },
+  }))
+  useCanvasStore.setState({ nodes: nodes as never, edges: [] as never })
+}
+
+async function drive(improvements: unknown[]) {
+  mockFetch.mockResolvedValue(ok(improvements))
+  seedCanvasWithNodes(3)
+  useReadinessStore.getState().startListening()
+  await vi.runAllTimersAsync()
+  return useReadinessStore.getState().readiness?.improvements ?? []
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockFetch.mockReset()
+  useReadinessStore.getState().reset()
+  useCanvasStore.setState({ nodes: [] as never, edges: [] as never, graphHealth: null } as never)
+  clearInflightCache()
+})
+
+afterEach(() => {
+  useReadinessStore.getState().reset()
+  vi.useRealTimers()
+})
+
+describe('readinessStore fabricates an improvement action, and it is THIS constant', () => {
+  it('PRECONDITION — an improvement with no action and no recommendation arrives as the placeholder', async () => {
+    const improvements = await drive([{ category: 'values' }])
+
+    expect(improvements).toHaveLength(1)
+    // Identity against the shared constant, not a copied literal: this is the
+    // exact value `composeBlockedReason` refuses, so the two cannot drift apart
+    // without one of them failing to compile.
+    expect(improvements[0].action).toBe(IMPROVEMENT_ACTION_PLACEHOLDER)
+  })
+
+  it('PRECONDITION — an empty-string action is fabricated over too', async () => {
+    const improvements = await drive([{ category: 'values', action: '' }])
+    expect(improvements[0].action).toBe(IMPROVEMENT_ACTION_PLACEHOLDER)
+  })
+
+  // ── The discriminating half (trap 13b) ──────────────────────────────────
+  // Without this the spec is satisfied by "fabricate everything", which would
+  // make the composer's refusal swallow every real remedy and still be green.
+  it('DISCRIMINATING — a producer-authored action survives byte-identically', async () => {
+    const improvements = await drive([{ category: 'values', action: PRODUCER_ACTION }])
+    expect(improvements[0].action).toBe(PRODUCER_ACTION)
+    expect(improvements[0].action).not.toBe(IMPROVEMENT_ACTION_PLACEHOLDER)
+  })
+
+  it('DISCRIMINATING — the legacy `recommendation` spelling is producer prose, not a fabrication', async () => {
+    const improvements = await drive([{ category: 'values', recommendation: PRODUCER_ACTION }])
+    expect(improvements[0].action).toBe(PRODUCER_ACTION)
+  })
+})

--- a/src/canvas/stores/readinessStore.ts
+++ b/src/canvas/stores/readinessStore.ts
@@ -10,6 +10,7 @@
  * thin wrapper useGraphReadiness() for backward compatibility.
  */
 import { create } from 'zustand'
+import { IMPROVEMENT_ACTION_PLACEHOLDER } from '../utils/improvementActionPlaceholder'
 import { useCanvasStore } from '../store'
 import type { Node, Edge } from '@xyflow/react'
 import type {
@@ -846,7 +847,7 @@ async function fetchReadiness(): Promise<void> {
         improvements: Array.isArray(data.improvements)
           ? data.improvements.map((imp: any): GraphImprovement => ({
               category: imp.category || 'general',
-              action: imp.action || imp.recommendation || 'Review this area',
+              action: imp.action || imp.recommendation || IMPROVEMENT_ACTION_PLACEHOLDER,
               current_gap: imp.current_gap || '',
               quality_impact:
                 typeof imp.quality_impact === 'number'

--- a/src/canvas/utils/__tests__/blockedReasonNamesImprovements.spec.ts
+++ b/src/canvas/utils/__tests__/blockedReasonNamesImprovements.spec.ts
@@ -31,21 +31,30 @@ const readinessWith = (improvements: unknown[]): GraphReadiness => ({
 } as unknown as GraphReadiness)
 
 describe('the blocked reason names the producer\'s own remedies', () => {
-  it('names a single improvement rather than deferring to the chat', () => {
+  /*
+   * ⭐ EXACT EQUALITY, NOT `toContain` — INVENT NOTHING IS A CLAIM ABOUT THE WHOLE
+   * STRING. Measured before this was written: making the composer return
+   * `` `Olumi needs: ${joined}` `` SURVIVED all 359 tests, because every
+   * assertion here was `toContain` / `not.toBe(unspecified)`. A UI prefix welded
+   * onto producer prose shipped green — "a nicer-sounding sentence" passing
+   * unobserved, which is the exact thing the producer-verbatim rule exists to
+   * prevent. A containment assertion cannot see anything ADDED; only equality can.
+   */
+  it('names a single improvement — and emits the producer text and NOTHING else', () => {
     const out = composeReadinessBlockedReason(readinessWith([{ action: ACTION_A }]))
-    expect(out).toContain('Cash runway consumed')
+    expect(out).toBe(ACTION_A)
     expect(out).not.toBe(BLOCKED_REASON_COPY.unspecified)
   })
 
   it('names ALL of them — withholding some understates the work outstanding', () => {
     const out = composeReadinessBlockedReason(readinessWith([{ action: ACTION_A }, { action: ACTION_B }]))
-    expect(out).toContain('Cash runway consumed')
-    expect(out).toContain('discount hard to win logos back')
+    // The join is exactly the producer's sentences and the single separator.
+    expect(out).toBe(`${ACTION_A} ${ACTION_B}`)
   })
 
   it('de-duplicates rather than repeating one remedy', () => {
     const out = composeReadinessBlockedReason(readinessWith([{ action: ACTION_A }, { action: ACTION_A }]))
-    expect(out.split('Cash runway consumed').length - 1).toBe(1)
+    expect(out).toBe(ACTION_A)
   })
 
   /*
@@ -99,8 +108,36 @@ describe('the blocked reason names the producer\'s own remedies', () => {
     const out = composeReadinessBlockedReason(
       readinessWith([{ action: ACTION_A }, { action: IMPROVEMENT_ACTION_PLACEHOLDER }]),
     )
-    expect(out).not.toContain(IMPROVEMENT_ACTION_PLACEHOLDER)
-    expect(out).not.toContain(ACTION_A)
+    expect(out).toBe(BLOCKED_REASON_COPY.unspecified)
+  })
+
+  /**
+   * G3 — THE OTHER PATH TO `unspecified`. `composeReadinessBlockedReason` has TWO
+   * exits to the non-committal rung and only the final one consulted the
+   * producer. When the client's option list and the verdict's arithmetic
+   * disagree — `optionsNeedingValues` non-empty, `options_total - options_ready`
+   * zero — it returned the generic sentence at the EARLIER exit while holding
+   * the producer's repair action.
+   *
+   * The two inputs come from DIFFERENT STORES, so the skew is structurally
+   * reachable rather than hypothetical. Naming the improvement there is a less
+   * specific TRUE claim from the same readiness object the count came from.
+   */
+  it('names the producer even when the option list and the verdict disagree', () => {
+    const readiness = { ...readinessWith([{ action: ACTION_A }]), options_ready: 2, options_total: 2 }
+    const out = composeReadinessBlockedReason(readiness, [
+      { id: 'o1', label: 'Rebuild' },
+    ] as never)
+    expect(out).toBe(ACTION_A)
+  })
+
+  it('DISCRIMINATING — that skew still floors at the generic sentence with no usable improvement', () => {
+    // Without this, "always return something specific" would satisfy the case
+    // above while inventing a cause at exactly the moment the inputs disagree.
+    const readiness = { ...readinessWith([]), options_ready: 2, options_total: 2 }
+    const out = composeReadinessBlockedReason(readiness, [
+      { id: 'o1', label: 'Rebuild' },
+    ] as never)
     expect(out).toBe(BLOCKED_REASON_COPY.unspecified)
   })
 

--- a/src/canvas/utils/__tests__/blockedReasonNamesImprovements.spec.ts
+++ b/src/canvas/utils/__tests__/blockedReasonNamesImprovements.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * The panel must not say "ask in the chat" while holding the answer.
+ *
+ * ⚠ WITNESSED. A mounted footer read "Not ready for analysis yet. Olumi needs
+ * something more from this model before the next analysis. Ask in the chat and
+ * it will explain what is missing." — while the `graph-readiness` payload that
+ * same panel had just received carried three specific, human-readable actions
+ * ("Choose the missing effect value for X on Y", and two more). The chat recited
+ * all three faithfully when asked. The panel discarded detail it was holding and
+ * sent the user elsewhere for it.
+ *
+ * ⚠ SCOPE. This pins the GRAPH-readiness fall-through only. The richer path —
+ * `composeAnalysisBlockedReason` over the analysis authority's blockers — is
+ * unchanged and still preferred; this rung only runs when that authority is
+ * absent and the structured rungs above did not match.
+ */
+import { describe, it, expect } from 'vitest'
+import { composeReadinessBlockedReason, BLOCKED_REASON_COPY } from '../composeBlockedReason'
+import type { GraphReadiness } from '../../hooks/useGraphReadiness'
+
+const ACTION_A = 'Choose the missing effect value for "rebuild our product" on "Cash runway consumed".'
+const ACTION_B = 'Choose which factor "discount hard to win logos back" changes and by how much.'
+
+const readinessWith = (improvements: unknown[]): GraphReadiness => ({
+  readiness_score: 40,
+  readiness_level: 'needs_work',
+  can_run_analysis: false,
+  confidence_explanation: '',
+  improvements,
+} as unknown as GraphReadiness)
+
+describe('the blocked reason names the producer\'s own remedies', () => {
+  it('names a single improvement rather than deferring to the chat', () => {
+    const out = composeReadinessBlockedReason(readinessWith([{ action: ACTION_A }]))
+    expect(out).toContain('Cash runway consumed')
+    expect(out).not.toBe(BLOCKED_REASON_COPY.unspecified)
+  })
+
+  it('names ALL of them — withholding some understates the work outstanding', () => {
+    const out = composeReadinessBlockedReason(readinessWith([{ action: ACTION_A }, { action: ACTION_B }]))
+    expect(out).toContain('Cash runway consumed')
+    expect(out).toContain('discount hard to win logos back')
+  })
+
+  it('de-duplicates rather than repeating one remedy', () => {
+    const out = composeReadinessBlockedReason(readinessWith([{ action: ACTION_A }, { action: ACTION_A }]))
+    expect(out.split('Cash runway consumed').length - 1).toBe(1)
+  })
+
+  /*
+   * ⭐ DEGRADE TO LESS SPECIFIC TRUE COPY, NEVER TO A DIFFERENT CLAIM. This
+   * module's standing rule, and the reason each case below returns the generic
+   * sentence rather than a partial list that would read as complete.
+   */
+  it('degrades to the generic sentence when there are no improvements', () => {
+    expect(composeReadinessBlockedReason(readinessWith([]))).toBe(BLOCKED_REASON_COPY.unspecified)
+  })
+
+  it('degrades when ANY entry is unusable — never a partial list', () => {
+    const out = composeReadinessBlockedReason(readinessWith([{ action: ACTION_A }, { action: '   ' }]))
+    expect(out, 'a blank entry must degrade the whole sentence, not silently drop one remedy')
+      .toBe(BLOCKED_REASON_COPY.unspecified)
+  })
+
+  it('degrades when the payload is not the declared shape', () => {
+    expect(composeReadinessBlockedReason(readinessWith([{ notAnAction: 1 }])))
+      .toBe(BLOCKED_REASON_COPY.unspecified)
+    expect(composeReadinessBlockedReason(null)).toBe(BLOCKED_REASON_COPY.unspecified)
+  })
+
+  /*
+   * ⚠ THE STALE SHORT-CIRCUIT MUST STILL WIN. A stale verdict's improvements
+   * describe a graph the user has already changed, so naming them would tell
+   * someone to do something they may have just done.
+   */
+  it('never quotes improvements from a STALE verdict', () => {
+    const out = composeReadinessBlockedReason(readinessWith([{ action: ACTION_A }]), [], true)
+    expect(out).not.toContain('Cash runway consumed')
+  })
+})

--- a/src/canvas/utils/__tests__/blockedReasonNamesImprovements.spec.ts
+++ b/src/canvas/utils/__tests__/blockedReasonNamesImprovements.spec.ts
@@ -17,6 +17,7 @@
 import { describe, it, expect } from 'vitest'
 import { composeReadinessBlockedReason, BLOCKED_REASON_COPY } from '../composeBlockedReason'
 import type { GraphReadiness } from '../../hooks/useGraphReadiness'
+import { IMPROVEMENT_ACTION_PLACEHOLDER } from '../improvementActionPlaceholder'
 
 const ACTION_A = 'Choose the missing effect value for "rebuild our product" on "Cash runway consumed".'
 const ACTION_B = 'Choose which factor "discount hard to win logos back" changes and by how much.'
@@ -73,6 +74,36 @@ describe('the blocked reason names the producer\'s own remedies', () => {
    * describe a graph the user has already changed, so naming them would tell
    * someone to do something they may have just done.
    */
+  /**
+   * ⚠ THE STORE FABRICATES. `readinessStore` maps
+   * `action: imp.action || imp.recommendation || IMPROVEMENT_ACTION_PLACEHOLDER`,
+   * so an improvement the producer sent with NO action still arrives here as a
+   * non-empty string. This rung's whole claim is that the sentence is the
+   * PRODUCER naming what is missing — so rendering the synthesised line would
+   * present a UI invention as the producer's own words, which is a worse failure
+   * than the generic sentence it replaced: the generic one is visibly generic,
+   * this one is indistinguishable from a real remedy.
+   *
+   * Bound by IDENTITY to the store's exported constant, never to a copy of the
+   * literal — a copy would keep passing the day the wording changes.
+   */
+  it('REFUSES the store\'s synthesised action — a fabrication is not producer prose', () => {
+    const out = composeReadinessBlockedReason(
+      readinessWith([{ action: IMPROVEMENT_ACTION_PLACEHOLDER }]),
+    )
+    expect(out).not.toContain(IMPROVEMENT_ACTION_PLACEHOLDER)
+    expect(out).toBe(BLOCKED_REASON_COPY.unspecified)
+  })
+
+  it('MIXED — one synthesised action degrades the WHOLE sentence, not just its own row', () => {
+    const out = composeReadinessBlockedReason(
+      readinessWith([{ action: ACTION_A }, { action: IMPROVEMENT_ACTION_PLACEHOLDER }]),
+    )
+    expect(out).not.toContain(IMPROVEMENT_ACTION_PLACEHOLDER)
+    expect(out).not.toContain(ACTION_A)
+    expect(out).toBe(BLOCKED_REASON_COPY.unspecified)
+  })
+
   it('never quotes improvements from a STALE verdict', () => {
     const out = composeReadinessBlockedReason(readinessWith([{ action: ACTION_A }]), [], true)
     expect(out).not.toContain('Cash runway consumed')

--- a/src/canvas/utils/composeBlockedReason.ts
+++ b/src/canvas/utils/composeBlockedReason.ts
@@ -37,6 +37,7 @@
 import type { AnalysisBlocker } from '@talchain/schemas/boundary'
 
 import type { GraphReadiness } from '../hooks/useGraphReadiness'
+import { IMPROVEMENT_ACTION_PLACEHOLDER } from './improvementActionPlaceholder'
 import {
   containsBannedTerm,
   safeInterpolatedLabel,
@@ -425,6 +426,14 @@ function producerAuthoredImprovement(
     // sentence rather than publishing a partial list that reads as complete.
     const action = typeof improvement?.action === 'string' ? improvement.action.trim() : ''
     if (action.length === 0) return null
+    // ⚠ THE STORE FABRICATES ON THIS FIELD. An improvement that arrived with no
+    // `action` and no `recommendation` is mapped to a synthesised line so the
+    // improvements LIST still has a row. It is non-empty, so the check above
+    // passes it — and this rung claims the sentence is the PRODUCER naming what
+    // is missing, which that line is not. Refused by IDENTITY against the
+    // store's own constant: a copied literal would keep passing the day the
+    // wording changes, an import cannot.
+    if (action === IMPROVEMENT_ACTION_PLACEHOLDER) return null
     if (!sentences.includes(action)) sentences.push(action)
   }
   if (sentences.length === 0) return null

--- a/src/canvas/utils/composeBlockedReason.ts
+++ b/src/canvas/utils/composeBlockedReason.ts
@@ -419,27 +419,17 @@ function producerAuthoredImprovement(
   const improvements = readiness?.improvements
   if (!Array.isArray(improvements) || improvements.length === 0) return null
 
-  const sentences: string[] = []
-  for (const improvement of improvements) {
-    // The type says `string`, but this path is fed by a network payload and a
-    // type is not a runtime guarantee. One unusable entry degrades the WHOLE
-    // sentence rather than publishing a partial list that reads as complete.
-    const action = typeof improvement?.action === 'string' ? improvement.action.trim() : ''
-    if (action.length === 0) return null
-    // ⚠ THE STORE FABRICATES ON THIS FIELD. An improvement that arrived with no
-    // `action` and no `recommendation` is mapped to a synthesised line so the
-    // improvements LIST still has a row. It is non-empty, so the check above
-    // passes it — and this rung claims the sentence is the PRODUCER naming what
-    // is missing, which that line is not. Refused by IDENTITY against the
-    // store's own constant: a copied literal would keep passing the day the
-    // wording changes, an import cannot.
-    if (action === IMPROVEMENT_ACTION_PLACEHOLDER) return null
-    if (!sentences.includes(action)) sentences.push(action)
-  }
-  if (sentences.length === 0) return null
-
-  const joined = sentences.join(' ')
-  return isSafeCeeText(joined) ? joined : null
+  // The ONLY rule specific to this authority: the STORE FABRICATES on this
+  // field. An improvement that arrived with neither `action` nor
+  // `recommendation` is mapped to a synthesised line so the improvements LIST
+  // still renders a row — non-empty, and therefore not caught by the shared
+  // emptiness degrade. Mapped to `undefined` so the shared body degrades the
+  // WHOLE sentence, which is what a fabricated entry deserves.
+  return composeProducerAuthoredSentences(
+    improvements.map(improvement =>
+      improvement?.action === IMPROVEMENT_ACTION_PLACEHOLDER ? undefined : improvement?.action,
+    ),
+  )
 }
 
 export function composeReadinessBlockedReason(
@@ -483,7 +473,20 @@ export function composeReadinessBlockedReason(
     // after a failed cross-check would be a specific numeric claim built on
     // evidence this function had, in the line above, declared stale.
     const count = verdictNotReadyCount(readiness) ?? (trustNames ? optionsNeedingValues.length : 0)
-    if (count <= 0) return BLOCKED_REASON_COPY.unspecified
+    if (count <= 0) {
+      // ⚠ THE SECOND PATH TO `unspecified`, AND IT USED TO SKIP THE PRODUCER.
+      // Reaching here means the client's option list and the verdict's own
+      // arithmetic DISAGREE (`optionsNeedingValues` non-empty, verdict count
+      // zero) — the two come from different stores, which is the skew
+      // `verifyAgainstVerdict` exists for. Returning the non-committal rung is
+      // the right answer to the DISAGREEMENT, but it was also discarding the
+      // producer's own repair actions, which are carried on the SAME readiness
+      // object as the count and are therefore consistent with it. Naming them is
+      // a LESS SPECIFIC TRUE claim from the same authority, which is this
+      // module's standing rule; `unspecified` remains the floor.
+      const authoredAtSkew = producerAuthoredImprovement(readiness)
+      return authoredAtSkew ?? BLOCKED_REASON_COPY.unspecified
+    }
     return BLOCKED_REASON_COPY.manyOptions(count, canRunAfter)
   }
 
@@ -574,20 +577,52 @@ export function composeReadinessBlockedReason(
  * altered, and repeating one verbatim conveys nothing the first rendering did
  * not while reading as a defect.
  */
-function producerAuthoredReason(blockers: readonly AnalysisBlocker[]): string | null {
+/**
+ * ⭐ THE ONE COMPOSER for producer-authored refusal prose. Both authorities —
+ * `analysisReadiness.blockers[].message` and `graph-readiness
+ * improvements[].action` — are the same rule over a different field, so they are
+ * the same BODY over a mapped field rather than two implementations that happen
+ * to agree today.
+ *
+ * ⚠ THEY WERE TWO, AND THE COPY HAD ALREADY LOST A GUARD. The improvement path
+ * was written as "deliberately the same shape, not a second rule" — which is the
+ * sentence that lets a mirror ship. Measured: deleting `isSafeCeeText` from the
+ * improvement path ONLY survived all 359 tests, and under that mutant
+ * `'Add an edge from "Pilot" to "Cash Burn Rate".'` reaches the render seam raw,
+ * where `guardCeeText` rewrites it to
+ * `'Add an connection from "Pilot" to "Cash Burn Rate".'` — the exact corruption
+ * this module's own header exists to record. One body cannot drift from itself.
+ *
+ * The rule, in one place:
+ *  · DEGRADE WHOLE — one unusable entry degrades the entire sentence rather than
+ *    publishing a partial list that reads as complete. A type is not a runtime
+ *    guarantee, and these values arrive over a network.
+ *  · DE-DUPLICATE — an exactly-repeated sentence is rendered once.
+ *  · VET THE JOIN, NOT THE PARTS — a phrase can be formed ACROSS the seam
+ *    between two individually-safe sentences, so the vetted string is the one
+ *    that ships.
+ *  · INVENT NOTHING — the return value is the producer's own text and nothing
+ *    else. No prefix, no framing, no connective of ours.
+ */
+function composeProducerAuthoredSentences(
+  values: readonly (string | undefined)[],
+): string | null {
   const sentences: string[] = []
-  for (const blocker of blockers) {
-    // The TYPE says `string` and the schema says `.min(1)`, but this function is
-    // exported and total: a type is not a runtime guarantee. An unusable message
-    // is a DEGRADE, never a synthesised stand-in for what the producer meant.
-    const message = typeof blocker.message === 'string' ? blocker.message.trim() : ''
-    if (message.length === 0) return null
-    if (!sentences.includes(message)) sentences.push(message)
+  for (const value of values) {
+    const text = typeof value === 'string' ? value.trim() : ''
+    if (text.length === 0) return null
+    if (!sentences.includes(text)) sentences.push(text)
   }
   if (sentences.length === 0) return null
 
   const joined = sentences.join(' ')
   return isSafeCeeText(joined) ? joined : null
+}
+
+function producerAuthoredReason(blockers: readonly AnalysisBlocker[]): string | null {
+  // The TYPE says `string` and the schema says `.min(1)`; the shared body still
+  // re-checks at runtime, because a type is not a runtime guarantee here.
+  return composeProducerAuthoredSentences(blockers.map(blocker => blocker.message))
 }
 
 /**

--- a/src/canvas/utils/composeBlockedReason.ts
+++ b/src/canvas/utils/composeBlockedReason.ts
@@ -382,6 +382,57 @@ function promiseIsLicensed(readiness: GraphReadiness | null | undefined): boolea
  * hand-remembered argument is the trap-12 mirror; a derived guard on top of a
  * safe default is not.
  */
+/**
+ * The producer's own repair guidance from the GRAPH-readiness verdict, ready to
+ * render — or `null` when it cannot ship as written.
+ *
+ * ⚠ WHY THIS EXISTS. The panel has two authorities. When the ANALYSIS authority
+ * is present, `composeAnalysisBlockedReason` names the producer's blockers and
+ * the user is told exactly what is missing. When it is ABSENT, the footer falls
+ * to this composer — which read `options_ready`, `goal_node_valid` and
+ * `options_total`, and if none of those rungs matched, said "Olumi needs
+ * something more from this model … ask in the chat and it will explain what is
+ * missing".
+ *
+ * ⭐ It was holding the answer while it said that. `GraphReadiness.improvements`
+ * carries the producer's own `action` strings — "Choose the missing effect value
+ * for X on Y" — and nothing in this module ever read them. The panel discarded
+ * named, structured, user-readable remedies and sent the user elsewhere for
+ * them. Witnessed mounted with three such actions in the payload.
+ *
+ * ⚠ DELIBERATELY THE SAME SHAPE AS `producerAuthoredReason`, NOT A SECOND RULE.
+ * Same degrade-to-null on any unusable entry, same de-duplication, same join,
+ * and the SAME vet: `isSafeCeeText`, never `guardCeeText`. That choice is not
+ * stylistic — the sibling's header records it measured: the substituting guard
+ * rewrites a user's own quoted option label into one that exists on no canvas
+ * ("Move billing to edge computing" -> "… to connection computing"). Producer
+ * prose is VETTED here and rewritten nowhere.
+ *
+ * ⚠ AND IT NAMES ALL OF THEM. Truncating to the first would understate the work
+ * outstanding by exactly the number withheld — the defect this module's A2 rung
+ * already forbids for counts.
+ */
+function producerAuthoredImprovement(
+  readiness: GraphReadiness | null | undefined,
+): string | null {
+  const improvements = readiness?.improvements
+  if (!Array.isArray(improvements) || improvements.length === 0) return null
+
+  const sentences: string[] = []
+  for (const improvement of improvements) {
+    // The type says `string`, but this path is fed by a network payload and a
+    // type is not a runtime guarantee. One unusable entry degrades the WHOLE
+    // sentence rather than publishing a partial list that reads as complete.
+    const action = typeof improvement?.action === 'string' ? improvement.action.trim() : ''
+    if (action.length === 0) return null
+    if (!sentences.includes(action)) sentences.push(action)
+  }
+  if (sentences.length === 0) return null
+
+  const joined = sentences.join(' ')
+  return isSafeCeeText(joined) ? joined : null
+}
+
 export function composeReadinessBlockedReason(
   readiness: GraphReadiness | null | undefined,
   optionsNeedingValues: readonly OptionNeedingValues[] = [],
@@ -436,7 +487,21 @@ export function composeReadinessBlockedReason(
     return BLOCKED_REASON_COPY.tooFewOptions
   }
 
-  // 4. Nothing specific enough to name. Say exactly that, and nothing more.
+  // 4. Nothing the STRUCTURED fields can name — but the verdict may still carry
+  //    the producer's own repair guidance, and until now this rung discarded it.
+  //
+  //    Ordered last on purpose: the rungs above compose OUR sentence from the
+  //    verdict's typed fields and are preferred where they match, because they
+  //    are the ones this module can guarantee. This is the step before giving
+  //    up, not a new preference over them.
+  //
+  //    ⚠ It cannot outrank the stale short-circuit either: that returns at the
+  //    top of this function, so a stale verdict's improvements — which describe
+  //    a graph the user has already changed — never reach here.
+  const authoredImprovement = producerAuthoredImprovement(readiness)
+  if (authoredImprovement !== null) return authoredImprovement
+
+  // 5. Now there is genuinely nothing specific to name. Say exactly that.
   return BLOCKED_REASON_COPY.unspecified
 }
 

--- a/src/canvas/utils/improvementActionPlaceholder.ts
+++ b/src/canvas/utils/improvementActionPlaceholder.ts
@@ -1,0 +1,24 @@
+/**
+ * ⚠ UI-AUTHORED TEXT, NOT PRODUCER PROSE.
+ *
+ * When a readiness improvement arrives with neither `action` nor
+ * `recommendation`, `readinessStore` SYNTHESISES this line so the improvements
+ * LIST still renders a row. That is legitimate for a list of suggestions. It is
+ * NOT legitimate anywhere the text is presented as the producer naming what is
+ * missing — once it is in the field a synthesised sentence is indistinguishable
+ * from a real one, which is a worse failure than generic copy: generic copy is
+ * visibly generic.
+ *
+ * ── WHY THIS IS ITS OWN MODULE ─────────────────────────────────────────────
+ * The fabricating module (`stores/readinessStore`) and the refusing module
+ * (`utils/composeBlockedReason`) must agree by IDENTITY, never by two copies of
+ * a literal — a copy is a hand-maintained mirror and would drift silently the
+ * day this wording changes, leaving the refusal passing while the fabrication
+ * ships. An import cannot drift; it breaks the build.
+ *
+ * It lives in a LEAF with no imports of its own because the alternative — the
+ * composer importing the store — is a value import that would drag store module
+ * side effects into every consumer of `canRunAnalysis`, which is most of the
+ * canvas. A shared constant should not carry a store's initialisation with it.
+ */
+export const IMPROVEMENT_ACTION_PLACEHOLDER = 'Review this area'


### PR DESCRIPTION
⚠ **CONTRACT CLASS: IN** — it changes what the product tells a user about their own model.

## What it closes

A mounted footer read:

> **Not ready for analysis yet.** Olumi needs something more from this model before the next analysis. **Ask in the chat and it will explain what is missing.**

…while the `graph-readiness` payload **that same panel had just received** carried three specific, human-readable actions — *"Choose the missing effect value for X on Y"*, and two more. The chat recited all three faithfully when asked.

**The panel was holding the answer while saying it did not have it.**

## Where it actually went wrong — narrower than it first looked

The panel has **two** authorities (`usePreAnalysisModel.ts:457-478`):

- **analysis authority present** → already names the producer's blockers via `composeAnalysisBlockedReason`. **Correct, and untouched here.**
- **absent** → falls to `composeReadinessBlockedReason`, whose rungs read `options_ready`, `goal_node_valid`, `options_total` — and if none matched, the generic sentence.

`GraphReadiness.improvements` carries the producer's own `action` strings, and this module read them **zero** times.

⚠ **The obvious culprit was ruled out by measurement, not assumed.** `actionableBlockers` filters on `ADVISORY_BLOCKER_CODES`, which is **exactly one code** (`CONSTRAINT_REVIEW_REQUIRED`, `canRunAnalysis.ts:406`). Those three issues pass straight through it. **The filter is not the defect.**

## ⭐ The mechanism already existed — this nearly shipped as a duplicate

`producerAuthoredReason` (`:503`) already collects producer prose, de-duplicates, joins, and vets with `isSafeCeeText`. The new `producerAuthoredImprovement` is deliberately **the same shape rather than a second rule**, because the sibling's header records a *measured* reason for that vet:

> `guardCeeText` PREFERS IN-PLACE SUBSTITUTION and enforces terms beyond the canonical glossary — it rewrote *"Move billing to edge computing"* into *"…to connection computing"*, an option that exists on no canvas.

Producer prose is **vetted** here and **rewritten nowhere**. A second renderer would have skipped a rule someone had already measured the need for.

## What the new rung does *not* do

- **Does not outrank the structured rungs** — it runs only where they did not match.
- **Does not outrank the stale short-circuit** (`:398`), which returns at the top, so a stale verdict's improvements — describing a graph the user has already changed — never reach it.
- **Never publishes a partial list.** One unusable entry degrades the whole sentence to generic copy: a partial list reads as complete and would understate the work outstanding by exactly the number withheld.
- **Invents nothing.** If the payload's actions are what we have, those are what render.

## On the silently-disabled Analyse button

`Analyse first pass` is correctly gated but silently so. **This change is its explanation**: the footer now names the specific missing values immediately beside it, so the dead button has a stated cause. Adding separate button copy would be a second authority for one fact — the defect this module's own header warns about.

## Evidence

| | |
|---|---|
| named gate | **PASSED** at exactly baseline 2252/556; `--update-baseline` untouched |
| suites | **119 files / 2259 tests**, 0 failures |
| new spec | 7 cases by name — names one · names **all** · de-duplicates · four degrade paths · the stale short-circuit |

---

## Follow-up commit — the rung could render a UI invention as the producer's words

Reviewing this PR against a second fallback string surfaced a defect **inside the change itself**, and it is worse than the copy it replaced.

`readinessStore` maps:

```ts
action: imp.action || imp.recommendation || 'Review this area',
```

So an improvement the producer sent with **no action and no recommendation** still arrives here as a non-empty string. The rung fails closed on an *empty* action — a fabricated one is not empty. Measured at this tip before the fix, the composer emitted:

> `Choose the missing effect value for "rebuild our product" on "Cash runway consumed". Review this area`

A real producer remedy and a UI invention, joined seamlessly. **That is a worse failure than the generic copy this PR replaced: generic copy is visibly generic; a synthesised remedy is indistinguishable from a real one once it is in the field.**

**The fix.** The literal now has exactly one home (`utils/improvementActionPlaceholder.ts`), imported by the module that fabricates it and the module that refuses it. Two copies of a literal would be a hand-maintained mirror and would drift silently the day the wording changes, leaving the refusal dead and nothing red. It is a **leaf with no imports** because the alternative — the composer importing the store — is a *value* import that would drag store module side effects into every consumer of `canRunAnalysis`, which is most of the canvas.

**The precondition is pinned where the precondition lives.** The composer spec builds its own fixture and would keep passing if the store stopped fabricating that exact value. So `readinessStore.improvementFabrication.spec.ts` drives the **real store through the real fetch seam**, with a discriminating half proving a producer-authored action still survives byte-identically — otherwise "fabricate everything" satisfies every assertion while destroying the feature.

**Mutants** (pristine archive outside the tree, isolation proven by sentinel write, inodes compared, applied-check 1 each, trailing control clean):

| mutant | result |
|---|---|
| delete the refusal line | **RED** 2/9 |
| store fabricates a *different* literal (coupling broken) | **RED** 2/4 |
| trailing control | GREEN 9/9 and 4/4 |

The second is the load-bearing one: it proves the precondition spec catches the exact drift that would leave the refusal dead with nothing red.

Typecheck gate **PASSED at exactly baseline 2252 errors / 556 files**.

### On the second fallback string — checked, and it is not a half-closure

`canRunAnalysis.ts:87` `DRAFT_VALUES_SETTLING_REFUSAL` — *"Your model is still being drafted — its values are still settling"* — is a **different question**, not a second fall-through of this one.

It is returned at **gate 2.4, which exits early** and never reaches the composer dispatch at `:786`. Its condition is `draftValuesAreUnsettled(draftStreamPhase)`: the draft stream is in flight or terminally unsettled. **At that gate the values have not arrived, so there are no producer specifics to discard** — the sentence is a fact read off the frame (`status: in_progress`), exactly as its docstring states, and an adversarial review has already split it into two phase-accurate sentences because one string was false in the terminal phase.

Attaching producer `improvements` there would advise the user to set values the draft is about to write, and would add a third sentence to a surface deliberately split into two. **Not fixed, because it is not broken.**

### Not changed, deliberately

`PreAnalysisHealth.tsx:392` also renders `improvement.action` and can still show the synthesised line. That surface is a **list of suggestions**, where a generic row reads as a generic suggestion rather than as a claim about what the producer said. Reported rather than widened.
