### PR TITLE
docs(canvas): name the right branch for may_run staleness (comment-only, zero behaviour change)

### DIFF
--- a/src/canvas/utils/canRunAnalysis.ts
+++ b/src/canvas/utils/canRunAnalysis.ts
@@ -545,18 +545,57 @@ export function readinessObjectsToRun(
     //
     // ⭐⭐ WHY IT WAIVES (b) ALONE AND NOT `(a) || (b)`. The whole-predicate
     // form is the obvious shape and it RE-OPENS THE DEFECT (a) EXISTS TO CLOSE,
-    // because `may_run` CAN GO STALE ACROSS A REFUSAL TURN:
-    //   · `buildAnalysisRefusalReadiness` (cee `analysis-ready-helper.ts:1488`)
-    //     emits `{status: 'blocked', options: [], goal_node_id: ''}` and sets NO
-    //     `may_run` — the field is written in exactly one place, `:1221`.
-    //   · That degenerate payload is REJECTED by our own normaliser
-    //     (`applyV5State.ts:233-234`), and `:1219` writes the slice only
-    //     `if (normalised)` — so `ceeAnalysisReady` KEEPS THE PREVIOUS TURN'S
-    //     value, stale `may_run: true` included, while `analysisStateV1` moves
-    //     to blocked.
+    // because `may_run` CAN GO STALE ACROSS A REFUSAL TURN.
+    //
+    // ⚠⚠ THE MECHANISM BELOW WAS RE-DERIVED 2026-08-26 AND THIS COMMENT NAMED
+    // THE WRONG BRANCH. The conclusion — that `may_run` can be a PREVIOUS
+    // turn's answer, so the waiver must not span (a) — is UNCHANGED and still
+    // correct. Only the route was wrong, and a comment naming the wrong
+    // mechanism is how the next lane inherits a wrong belief.
+    //
+    // ~~It said: the degenerate refusal payload is rejected by our normaliser,
+    // and `:1219` writes the slice only `if (normalised)`, so `ceeAnalysisReady`
+    // KEEPS THE PREVIOUS TURN'S value.~~ **That branch CLEARS, it does not
+    // preserve.** Derived at `applyV5State.ts:1228-1300`, there are FOUR
+    // branches and exactly one preserves:
+    //
+    //   1. `analysis_ready` present, normalises      → WRITE (unless the inline
+    //                                                  path owns it, `:1231`)
+    //   2. present, normaliser REJECTS               → `setCeeAnalysisReady(null)`
+    //                                                  — CLEARS ("clear stale
+    //                                                  store state from prior
+    //                                                  turns rather than leaving
+    //                                                  it to mislead")
+    //   3. ABSENT + response IS analyse-shaped       → `setCeeAnalysisReady(null)`
+    //                                                  — CLEARS
+    //   4. ABSENT + NOT analyse-shaped               → ⭐ NO WRITE. THE SLICE IS
+    //                                                  PRESERVED, stale
+    //                                                  `may_run: true` included.
+    //
+    // ⭐ BRANCH 4 IS THE SURVIVING STALENESS PATH, and it is deliberate, with
+    // its own recorded rationale: "Conversational turns preserve the existing
+    // slice — clearing would race a legit just-set value from a parallel turn."
+    // `responseIsAnalyseShaped` (`applyV5State.ts:1453`) is true ONLY for
+    // `stage === 'analyse'` or an `analysis_result` block — so an ordinary
+    // conversational or EDIT turn that carries no `analysis_ready` lands here
+    // and leaves the previous turn's admission verdict standing.
+    //
     // A waiver spanning (a) would then hand the user an ENABLED control one turn
     // after CEE refused the run — verbatim the harm recorded at (a) above. The
     // producer's refusal is not a blocker count and is not negotiable.
+    //
+    // ⚠ AND THE DEEPER POINT, WHICH THE BRANCH DETAIL CAN OBSCURE: this control
+    // is gated on `may_run` — CEE's ADMISSION verdict — and NOT on
+    // `can_run_analysis`, which lives on the readiness side-car. Two fields,
+    // two lifetimes, similar names (trap 21). `may_run` is turn-scoped and, via
+    // branch 4, can outlive the turn that produced it; `can_run_analysis` is
+    // the field that actually answers "may this model be analysed now". A
+    // control reading the one that does not answer its question is the design
+    // issue here — branch 4 is only the route by which it becomes visible.
+    // Behaviour is UNCHANGED by this comment; the repair is rowed, and it
+    // belongs in the slice's freshness (`applyV5State.ts`), NOT in this
+    // predicate — every surface consumes this answer, so fixing the input is
+    // safe where fixing the shared predicate is not.
     //
     // ⚠ `=== true`, NOT `!== false`. ABSENCE means a pre-`may_run` CEE, never
     // "no", so an omitted or malformed value must leave the refusal exactly as


### PR DESCRIPTION
## Comment-only. Zero behaviour change, proven line by line.

Every changed line in the diff is a comment — asserted mechanically, not claimed:

```
git diff -U0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' \
  | sed -E 's/^[+-]//' | grep -vE '^\s*(//|$)'
→ empty
```

## What was wrong

`canRunAnalysis.ts` explains why the `may_run` waiver spans clause (b) alone, and grounds it in a staleness mechanism. **The mechanism it named is the wrong branch.**

It said the degenerate refusal payload is rejected by our normaliser and `:1219` writes the slice only `if (normalised)`, so `ceeAnalysisReady` **keeps the previous turn's value**.

Derived at `applyV5State.ts:1228-1300`, that branch **clears**:

| branch | condition | effect |
|---|---|---|
| 1 | `analysis_ready` present, normalises | WRITE (unless the inline path owns it) |
| 2 | present, normaliser **rejects** | **`setCeeAnalysisReady(null)` — CLEARS** ← the comment claimed this preserves |
| 3 | **absent** + response IS analyse-shaped | **`setCeeAnalysisReady(null)` — CLEARS** |
| 4 | **absent** + NOT analyse-shaped | ⭐ **NO WRITE — the slice is PRESERVED**, stale `may_run: true` included |

**Branch 4 is the surviving staleness path**, and it is deliberate, with its own recorded rationale: *"Conversational turns preserve the existing slice — clearing would race a legit just-set value from a parallel turn."* `responseIsAnalyseShaped` (`:1453`) is true only for `stage === 'analyse'` or an `analysis_result` block, so an ordinary conversational or edit turn carrying no `analysis_ready` lands there.

**The conclusion is unchanged and still correct** — `may_run` can be a previous turn's answer, so the waiver must not span clause (a). Only the route was wrong.

## The deeper point, now recorded

This control is gated on **`may_run`** — CEE's *admission* verdict — and **not on `can_run_analysis`**, which lives on the readiness side-car. Two fields, two lifetimes, similar names. `may_run` is turn-scoped and, via branch 4, can outlive the turn that produced it; `can_run_analysis` is the field that actually answers *"may this model be analysed now"*.

**A durable control reading the field that does not answer its question** is the design issue; branch 4 is only the route by which it becomes visible.

## Why comment-only, and why now

A comment naming the wrong mechanism is how the next lane inherits a wrong belief — and this one sits in the file that governs whether a user may run an analysis.

The **behavioural** fix is deliberately **not** here. It is held pending a wire capture of the failed-edit turn: *"CEE omitted `analysis_ready`"* is the derived mechanism consistent with the observation, **not a witnessed fact**. If the capture instead shows a degenerate `analysis_ready`, branch 2 would have cleared the slice and the diagnosis moves.

When it is built, it belongs in the **slice's freshness** (`applyV5State.ts`), **not** in this predicate: every surface consumes `readinessObjectsToRun`'s answer, so fixing the *input* is safe where fixing the *shared predicate* is not.

## Verification

- lint exit 0 · typecheck exit 0, **exactly** at the 2252 baseline
- targeted: 5 files / 77 tests green (`canRunAnalysis` + `analyseControlFalseBlock` suites)
- full suite not run locally by standing ruling (machine under 11-lane contention); CI is the authority
