### PR TITLE
C+D — the record keeps the user's own words, not the chip's caption [IN-class]

### DIFF
--- a/src/components/results/coaching/AskOlumiDrawer.tsx
+++ b/src/components/results/coaching/AskOlumiDrawer.tsx
@@ -37,7 +37,12 @@ export function AskOlumiDrawer() {
   const isOpen = useAskOlumiStore((s) => s.isOpen)
   const context = useAskOlumiStore((s) => s.context)
   const draft = useAskOlumiStore((s) => s.draft)
-  const label = useAskOlumiStore((s) => s.label)
+  // ⚠ `label` IS NO LONGER READ HERE. It was this component's only reader, so
+  // after R4 `askOlumiStore.label` has ONE WRITER AND ZERO READERS. The field
+  // is left in place deliberately: ~10 call sites pass it, and removing it is a
+  // wide change unrelated to this fix. A write-only field has no blast radius —
+  // it is inert, not dangerous — so it is ROWED for a later tidy rather than
+  // swept up here.
   const targetId = useAskOlumiStore((s) => s.targetId)
   const parameters = useAskOlumiStore((s) => s.parameters)
   const source = useAskOlumiStore((s) => s.source)
@@ -92,7 +97,27 @@ export function AskOlumiDrawer() {
       void dispatchAction({
         action_type: 'discuss',
         parameters,
-        label,
+        // ⭐ THE SENT TEXT IS THE DISPLAY TEXT — the user authored it.
+        //
+        // This used to pass the chip's caption (`label`), so a user who was told
+        // to "replace the number with your own judgement", did so, and sent it,
+        // saw the transcript record *"Set relationship strength"*. The record
+        // dropped their own words at exactly the point the product asked them to
+        // author something, and the shared model is meant to be a living record
+        // of the team's reasoning.
+        //
+        // The discriminator lives HERE and not in `dispatchAction`, because
+        // `displayText` answers "what should the bubble show for a chip?" and a
+        // caption is the RIGHT answer for a genuine chip click where the user
+        // typed nothing. This drawer is the surface that knows the text was
+        // authored. Two questions, one name — kept apart rather than aligned.
+        //
+        // Inert for everything except display, derived at the bytes and pinned
+        // by `AskOlumiDrawer.recordsUserWords.spec.tsx`: routing never reads it
+        // on this path (the keyword scan runs only in dispatchAction's
+        // `!action_type` arm, and this always sets `action_type`), and
+        // `buildChipMeta` reads `label` zero times.
+        label: text,
         message: text,
         source,
       })

--- a/src/components/results/coaching/__tests__/AskOlumiDrawer.recordsUserWords.spec.tsx
+++ b/src/components/results/coaching/__tests__/AskOlumiDrawer.recordsUserWords.spec.tsx
@@ -1,0 +1,121 @@
+/**
+ * R4 — THE TRANSCRIPT MUST RECORD WHAT THE USER ACTUALLY SAID.
+ *
+ * The drawer prefills an EDITABLE draft, tells the user to change it ("Replace
+ * the number with your own judgement before sending"), and then dispatched with
+ * `label` — the chip's generic caption — as the bubble's display text. So the
+ * user authored a sentence, sent it, and the record showed *"Set relationship
+ * strength"*. `submittedPrompt` holds the real text and had, measured at this
+ * tip, TWO writers and ZERO readers in render code (contrast: `displayText`,
+ * 61 references — confirmed absence, not a blind probe).
+ *
+ * That is not a cosmetic gap. The shared model is meant to be a living record of
+ * the team's reasoning, and this dropped the user's own words at exactly the
+ * point the product asked them to author something.
+ *
+ * ── WHY THE FIX IS HERE AND NOT IN THE DISPATCHER ──────────────────────────
+ * `displayText` answers *"what should the bubble show for a chip?"* — and for a
+ * genuine chip click, where the user typed nothing, a friendly caption is the
+ * RIGHT answer. The drawer's case is a different question: *"the user authored
+ * this."* Two questions under one name (CLAUDE.md trap 21). Aligning them would
+ * break real chip turns; the discriminator belongs at the call site that knows
+ * the text was authored, which is this drawer.
+ *
+ * ── WHY SUBSTITUTING `label` IS SAFE, DERIVED AT THE BYTES ─────────────────
+ *  1. ROUTING IS UNAFFECTED. `dispatchAction` scans `` `${label} ${message}` ``
+ *     for routing keywords ONLY in its `else if (!opts.action_type)` arm. This
+ *     drawer always passes `action_type: 'discuss'`, so that arm never runs.
+ *     (`discuss` is also absent from `ACTION_TO_TURN_TYPE`, so the first arm
+ *     does not fire either and `turnType` stays at its `'conversation'`
+ *     default — which is what a live trace observed.)
+ *  2. NOTHING ELSE CONSUMES IT. `buildChipMeta` reads `label` zero times
+ *     (contrast: it reads `parameters` 15 times). `label`'s only consumer on
+ *     this path is `displayText`.
+ * Both are pinned below, so the safety argument fails loud if either changes.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { AskOlumiDrawer } from '../AskOlumiDrawer'
+import { openAskOlumi, useAskOlumiStore } from '../askOlumiStore'
+import { useGuidanceStore } from '../../../../canvas/stores/guidanceStore'
+import { ACTION_TO_TURN_TYPE } from '../../../../canvas/conversation/actionTurnTypes'
+
+const CHIP_CAPTION = 'Set relationship strength'
+const PREFILLED = 'Change the strength of the link from Customer demand to Revenue growth to 0.8.'
+const AUTHORED = 'Change the strength of the link from Customer demand to Revenue growth to 0.35.'
+
+const payload = {
+  context: 'Replace the number with your own judgement before sending.',
+  draft: PREFILLED,
+  label: CHIP_CAPTION,
+  parameters: { edge_id: 'e1' },
+}
+
+beforeEach(() => {
+  useAskOlumiStore.setState({ isOpen: false, context: '', draft: '', label: '', targetId: null })
+  useGuidanceStore.setState({ _dispatchAction: null, _sendMessage: null } as never)
+})
+
+function sendWith(draft?: string) {
+  const dispatch = vi.fn()
+  useGuidanceStore.setState({ _dispatchAction: dispatch } as never)
+  render(<AskOlumiDrawer />)
+  act(() => openAskOlumi(payload))
+  if (draft !== undefined) {
+    fireEvent.change(screen.getByTestId('ask-olumi-draft'), { target: { value: draft } })
+  }
+  fireEvent.click(screen.getByRole('button', { name: 'Send' }))
+  return dispatch
+}
+
+describe('R4 — the record keeps the user’s own words', () => {
+  it('an EDITED ask is recorded as the user wrote it, not as the chip caption', () => {
+    const dispatch = sendWith(AUTHORED)
+    const opts = dispatch.mock.calls[0][0]
+
+    expect(opts.message).toBe(AUTHORED)
+    // The display text IS the sent text. Bound to the authored string by
+    // identity — not merely "not the caption", which a truncation would satisfy.
+    expect(opts.label).toBe(AUTHORED)
+    expect(opts.label).not.toBe(CHIP_CAPTION)
+  })
+
+  it('an UNEDITED ask records the sentence that was actually sent', () => {
+    // The user read it and chose to send it. The record shows what went, not a
+    // caption for it — otherwise the transcript is unreadable either way.
+    const dispatch = sendWith()
+    const opts = dispatch.mock.calls[0][0]
+    expect(opts.message).toBe(PREFILLED)
+    expect(opts.label).toBe(PREFILLED)
+  })
+
+  it('DISCRIMINATING — everything else on the dispatch is untouched', () => {
+    // Without this, "pass the text as label" is satisfied by a change that also
+    // drops parameters or the action type, which would break routing and the
+    // contextual-session carrier while this file stayed green.
+    const dispatch = sendWith(AUTHORED)
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action_type: 'discuss',
+        message: AUTHORED,
+        parameters: { edge_id: 'e1' },
+        source: 'chip',
+      }),
+    )
+  })
+
+  describe('the preconditions the safety argument rests on', () => {
+    it('`discuss` is absent from ACTION_TO_TURN_TYPE, so the keyword arm cannot run', () => {
+      // If someone adds it, routing on this path starts depending on the map
+      // and the "substituting label is inert" argument needs re-deriving.
+      expect(ACTION_TO_TURN_TYPE.discuss).toBeUndefined()
+      // Contrast control: the map is populated, so this is not a blind read.
+      expect(Object.keys(ACTION_TO_TURN_TYPE).length).toBeGreaterThan(3)
+    })
+
+    it('the drawer always sets action_type, which is what skips the keyword scan', () => {
+      const dispatch = sendWith(AUTHORED)
+      expect(dispatch.mock.calls[0][0].action_type).toBe('discuss')
+    })
+  })
+})

--- a/src/components/results/coaching/__tests__/AskOlumiDrawer.spec.tsx
+++ b/src/components/results/coaching/__tests__/AskOlumiDrawer.spec.tsx
@@ -48,6 +48,19 @@ describe('AskOlumiDrawer', () => {
     expect((screen.getByTestId('ask-olumi-draft') as HTMLTextAreaElement).value).toBe('My own words')
   })
 
+  /**
+   * ⚠ THIS TEST'S PREMISE INVERTED (R4). It asserted `label: 'Review risk'`
+   * alongside `message: 'Edited ask'` — i.e. it PINNED the defect: the user
+   * authored a sentence and the transcript recorded the chip's caption instead.
+   * The assertion was a faithful description of the behaviour when it was
+   * written; the behaviour was wrong.
+   *
+   * Rewritten rather than deleted, because what it covers — that Send dispatches
+   * a conversation-typed turn, toasts and closes — is still worth pinning, and
+   * deleting a test whose expectation changed loses the coverage along with the
+   * expectation. The display-text half now asserts the corrected behaviour and
+   * is owned in full by `AskOlumiDrawer.recordsUserWords.spec.tsx`.
+   */
   it('Send dispatches a conversation-typed turn with the EDITED draft, toasts, and closes', () => {
     const dispatch = vi.fn()
     useGuidanceStore.setState({ _dispatchAction: dispatch } as never)
@@ -59,7 +72,8 @@ describe('AskOlumiDrawer', () => {
       expect.objectContaining({
         action_type: 'discuss',
         message: 'Edited ask',
-        label: 'Review risk',
+        // The user's own words, not the chip caption 'Review risk' — see R4.
+        label: 'Edited ask',
         parameters: { classification: 'risk' },
         source: 'chip',
       }),


### PR DESCRIPTION
## The user authors a sentence; the record shows a caption

The Ask-Olumi drawer prefills an **editable** draft, tells the user to change it — *"Replace the number with your own judgement before sending"* — and then dispatched with `label`, the chip's generic caption, as the bubble's display text.

So a user was asked to author something, did, sent it, and the transcript recorded:

> **Set relationship strength**

`submittedPrompt` holds what they actually wrote. Measured at this tip: **2 writers, 0 readers in render code.** Contrast control `displayText` → **61 references**, so this is a confirmed absence, not a blind probe.

**This is not cosmetic.** The shared model is meant to be a living record of the team's reasoning. This dropped the user's own words at exactly the point the product asked them to author something — and the context line tells them to choose the number, which is precisely what the record discards.

## ⚠ The obvious fix is wrong

*"Render `submittedPrompt` instead"* would break **genuine chip turns**, where the user typed nothing and a friendly caption is the right answer. The type's own comment says so deliberately.

`displayText` answers *"what should the bubble show for a chip?"*. The drawer's case is *"the user authored this."* **Two questions under one name.** They are kept apart rather than aligned, and the discriminator lives at the call site that knows the text was authored — this drawer — leaving the generic dispatcher untouched.

## Why substituting `label` is inert for everything but display

Derived at the bytes, and **pinned in-test so the safety argument fails loud** if either fact changes:

1. **Routing never reads it here.** `dispatchAction` scans `` `${label} ${message}` `` for keywords **only** in its `else if (!opts.action_type)` arm. This drawer always sets `action_type: 'discuss'`. (`discuss` is also absent from `ACTION_TO_TURN_TYPE`, so the first arm does not fire either and `turnType` stays at its `'conversation'` default — matching a live trace.)
2. **`buildChipMeta` reads `label` zero times** (contrast: it reads `parameters` 15 times).

## Evidence

Pristine archive outside the tree, isolation proven by **sentinel write** (not by locating), inodes compared, applied-check 1 per mutation, trailing control clean.

| mutant | result | what it proves |
|---|---|---|
| revert to the caption | **RED** 2/5 | the fix is load-bearing |
| truncate the recorded text | **RED** 2/5 | binding is by **identity**, not merely "not the caption" |
| drop `parameters` | **RED** 1/5 | a **different** assertion — the rest of the dispatch is genuinely covered |

Spec collects **5 tests, asserted by name** — a spec collecting zero is invisible to every aggregate. Typecheck gate **PASSED at exactly baseline 2252 errors / 556 files**.

### A pre-existing spec pinned the defect

One case asserted `label: 'Review risk'` beside `message: 'Edited ask'` — it pinned the wrong behaviour. **Rewritten, not deleted:** what it covers besides display (conversation-typed turn, toast, close) is still worth pinning, and deleting a test whose expectation changed loses the coverage along with the expectation.

### Rowed, not swept up here

This component was the **only reader** of `askOlumiStore.label`, which now has one writer and zero readers. ~10 call sites pass it; removing it is a wide unrelated change, and a write-only field is inert. Rowed rather than tidied — "while we're here" work is banned.
