### PR TITLE
fix(canvas): a fresh browser gets a laid-out model, not a 260-wide column

### DIFF
--- a/src/canvas/utils/__tests__/mergeServerGraph.emptyCanvasLayout.spec.ts
+++ b/src/canvas/utils/__tests__/mergeServerGraph.emptyCanvasLayout.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * ⭐⭐ A FRESH BROWSER GETS A LAID-OUT MODEL, NOT A COLUMN.
+ *
+ * ── THE DEFECT, DRIVEN AND MEASURED ─────────────────────────────────────────
+ * A user reloading a saved scenario with no local autosave — a new device,
+ * cleared storage, incognito, or a scenario first opened elsewhere — got all 15
+ * nodes in ONE VERTICAL LINE: unique `x` of 260, `y` stepping by exactly 140.
+ *
+ * ⚠ THIS IS NOT A PERSISTENCE BUG, AND THE FIRST FRAMING OF IT WAS WRONG.
+ * `scenarios.graph` carrying no geometry is DELIBERATE and declared at the top
+ * of `mergeServerGraph.ts`: "VALUES FROM THE SERVER, LAYOUT FROM LOCAL… The
+ * autosave is the only place a position has ever existed." `layout_present:
+ * false` on the wire is correct and expected. What went wrong is narrower.
+ *
+ * ── THE MECHANISM ───────────────────────────────────────────────────────────
+ * With an empty canvas every server node is "added", so all of them go through
+ * `ADDED_COLUMN_X_GAP` / `ADDED_COLUMN_Y_STEP` — a constant pair whose own
+ * comment says it exists to drop "a few added nodes beside an existing bounding
+ * box" and "never a re-layout of nodes the user has already arranged". It is
+ * being applied to the ONE case it explicitly disclaims. With no existing
+ * nodes, `Math.max(...[])` has nothing to take, `baseX` collapses to `0 + 260`,
+ * and the whole graph stacks in a single column.
+ *
+ * ⭐ AND THE PRODUCT CANNOT SEE IT. `graphNeedsInitialLayout` asks
+ * `xSpread < 40 && ySpread < 40`; a column has `xSpread` 0 but `ySpread` 1960,
+ * so it returns FALSE — no layout is triggered — and `isRestoredModelReady`
+ * returns TRUE, so the camera confidently frames the line. Fifteen nodes in a
+ * vertical row is not a laid-out graph, but nothing in the product disagrees.
+ *
+ * ── WHY THE FIX IS HERE AND NOT IN THE PREDICATE ────────────────────────────
+ * ⚠ Loosening `graphNeedsInitialLayout` so a column counts as "needs layout"
+ * was considered and REJECTED: a user can deliberately arrange nodes in a
+ * column, and a geometric predicate cannot tell their column from ours. That
+ * fix would destroy real work to repair ours — the current bug wastes a layout,
+ * the loosened version deletes an arrangement.
+ *
+ * ⭐ The predicate asks a GEOMETRIC question when the real one is PROVENANCE:
+ * did WE place these, or did the USER arrange them? And that answer is already
+ * in hand at the placement site — `store.nodes.length === 0` means there was
+ * nothing to preserve. No new flag is recorded, because recording one would be
+ * a second source of truth for a fact the site can already see.
+ *
+ * So the branch below is safe BY CONSTRUCTION: it fires only when the canvas
+ * was empty, so there is no arrangement it could damage. `graphNeedsInitialLayout`
+ * is untouched, and the origin placement makes it return TRUE on its own terms —
+ * the existing measurement effect then runs the real layout, the designed path,
+ * unchanged.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useCanvasStore } from '../../store'
+import { mergeServerGraphOnHydrate } from '../mergeServerGraph'
+// ⚠ FROM `mergeAppliedGraph`, WHERE THEY ARE DEFINED — `mergeServerGraph` only
+// imports them and does not re-export. Taking them from the wrong module gave
+// `undefined`, and `new Set([...]).has(undefined)` is FALSE, so the "no column"
+// assertion below passed while testing nothing. Caught by its twin, which
+// compared against `900 + undefined` and reported NaN. A vacuous pass is the
+// exact failure this suite exists to prevent, and it happened in the suite.
+import { ADDED_COLUMN_X_GAP, ADDED_COLUMN_Y_STEP } from '../mergeAppliedGraph'
+import { graphNeedsInitialLayout } from '../graphNeedsInitialLayout'
+
+const SCENARIO_ID = '11111111-2222-4333-8444-555555555555'
+
+/** The server's copy: analytical state only, no geometry — as CEE really sends it. */
+function serverGraph(nodeCount: number) {
+  return {
+    nodes: Array.from({ length: nodeCount }, (_, i) => ({
+      id: `n${i}`,
+      kind: i === 0 ? 'goal' : 'factor',
+      label: `Node ${i}`,
+    })),
+    edges: [],
+  }
+}
+
+function emptyCanvas(): void {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_ID,
+    nodes: [] as never,
+    edges: [] as never,
+    lastAuthoritativeGraph: null,
+    serverGraphIdentity: null,
+    pendingLayout: false,
+    history: { past: [], future: [] },
+  } as never)
+}
+
+function canvasWithUserArrangement(): void {
+  useCanvasStore.setState({
+    currentScenarioId: SCENARIO_ID,
+    nodes: [
+      { id: 'n0', type: 'goal', position: { x: 900, y: 40 }, data: { label: 'Node 0', kind: 'goal' } },
+      { id: 'n1', type: 'factor', position: { x: 40, y: 500 }, data: { label: 'Node 1', kind: 'factor' } },
+    ] as never,
+    edges: [] as never,
+    lastAuthoritativeGraph: null,
+    serverGraphIdentity: null,
+    pendingLayout: false,
+    history: { past: [], future: [] },
+  } as never)
+}
+
+describe('an empty canvas hydrates for LAYOUT, not into a column', () => {
+  beforeEach(emptyCanvas)
+
+  it('the precondition holds: the canvas really is empty before the merge', () => {
+    // PINNED IN-TEST. Without this a fixture that quietly seeded nodes would
+    // make every assertion below agree for the wrong reason.
+    expect(useCanvasStore.getState().nodes).toHaveLength(0)
+  })
+
+  it('⭐ does NOT produce the 260-wide column the drive measured', () => {
+    // The constants must be REAL numbers or every assertion below is vacuous.
+    expect(typeof ADDED_COLUMN_X_GAP).toBe('number')
+    expect(typeof ADDED_COLUMN_Y_STEP).toBe('number')
+    const res = mergeServerGraphOnHydrate(serverGraph(15))
+    expect(res.accepted).toBe(true)
+
+    const nodes = useCanvasStore.getState().nodes as unknown as { position: { x: number; y: number } }[]
+    expect(nodes).toHaveLength(15)
+
+    // The witnessed signature, asserted absent: one x, uniform 140 y-steps.
+    const xs = new Set(nodes.map((n) => n.position.x))
+    expect(xs.has(ADDED_COLUMN_X_GAP), 'nodes are still at the added-column x').toBe(false)
+    const ySteps = new Set(
+      nodes.slice(1).map((n, i) => n.position.y - nodes[i]!.position.y),
+    )
+    expect(ySteps.has(ADDED_COLUMN_Y_STEP), 'nodes still step by the added-column y').toBe(false)
+  })
+
+  it('⭐ leaves a shape the product RECOGNISES as needing layout, and asks for one', () => {
+    // The two halves of the fix, bound to the product's own authority rather
+    // than to coordinates: `graphNeedsInitialLayout` is the estate's declared
+    // answer to "are these positions meaningful", and `pendingLayout` is the
+    // designed request. Neither is re-implemented here.
+    mergeServerGraphOnHydrate(serverGraph(15))
+    const state = useCanvasStore.getState()
+    expect(graphNeedsInitialLayout(state.nodes as never)).toBe(true)
+    expect(state.pendingLayout).toBe(true)
+  })
+})
+
+describe('a canvas the user has arranged is untouched — the guard that makes this safe', () => {
+  beforeEach(canvasWithUserArrangement)
+
+  it('⭐ DISCRIMINATING TWIN — added nodes still take the added-column placement', () => {
+    // The branch must key on "there was nothing here", NOT on "these nodes have
+    // no position". Without this pair the fix above would be satisfied by a
+    // change that re-laid-out every hydration — destroying exactly the
+    // arrangements `mergeServerGraph`'s header promises never to disturb.
+    mergeServerGraphOnHydrate(serverGraph(4))
+    const nodes = useCanvasStore.getState().nodes as unknown as {
+      id: string
+      position: { x: number; y: number }
+    }[]
+    const added = nodes.filter((n) => n.id !== 'n0' && n.id !== 'n1')
+    expect(added.length).toBeGreaterThan(0)
+    // Right of the existing bounding box (max x 900), exactly as before.
+    for (const n of added) expect(n.position.x).toBe(900 + ADDED_COLUMN_X_GAP)
+  })
+
+  it('⭐ and does NOT ask for a layout — the user’s arrangement is not re-run', () => {
+    mergeServerGraphOnHydrate(serverGraph(4))
+    expect(useCanvasStore.getState().pendingLayout).toBe(false)
+  })
+
+  it('the user’s own two nodes keep their exact coordinates', () => {
+    mergeServerGraphOnHydrate(serverGraph(4))
+    const nodes = useCanvasStore.getState().nodes as unknown as {
+      id: string
+      position: { x: number; y: number }
+    }[]
+    expect(nodes.find((n) => n.id === 'n0')!.position).toEqual({ x: 900, y: 40 })
+    expect(nodes.find((n) => n.id === 'n1')!.position).toEqual({ x: 40, y: 500 })
+  })
+})

--- a/src/canvas/utils/mergeServerGraph.ts
+++ b/src/canvas/utils/mergeServerGraph.ts
@@ -335,10 +335,49 @@ export function mergeServerGraphOnHydrate(
   )
   const addedNodes = missingRawNodes.map((n: any) => mapDraftNodeToCanvas(n))
 
+  // ⭐⭐ AN EMPTY CANVAS IS A HYDRATION, NOT AN ADDITION — SO IT GETS A LAYOUT.
+  //
+  // THE DEFECT THIS CLOSES, driven and measured: a user reloading a saved
+  // scenario with no local autosave (new device, cleared storage, incognito, or
+  // a scenario first opened elsewhere) got all 15 nodes in ONE VERTICAL LINE —
+  // unique `x` of 260, `y` stepping by exactly 140.
+  //
+  // With nothing on the canvas EVERY server node is "added", so all of them fell
+  // through the placement below — a constant pair whose own comment says it
+  // exists to drop "a few added nodes beside an existing bounding box" and
+  // "never a re-layout of nodes the user has already arranged". It was being
+  // applied to the ONE case it explicitly disclaims, and with no existing nodes
+  // `Math.max(...[])` has nothing to take, so `baseX` collapses to `0 + 260`.
+  //
+  // ⚠ AND THE PRODUCT COULD NOT SEE IT. `graphNeedsInitialLayout` asks
+  // `xSpread < 40 && ySpread < 40`; a column has xSpread 0 but ySpread ~1960, so
+  // it returns FALSE — no layout is triggered — and the camera then confidently
+  // frames the line. Fifteen nodes in a row is not a laid-out graph, but nothing
+  // in the product disagreed.
+  //
+  // ⚠ THE PREDICATE IS NOT THE PLACE TO FIX THIS, and loosening it was
+  // considered and REJECTED: a user CAN deliberately arrange nodes in a column,
+  // and a geometric test cannot tell their column from ours. That fix would
+  // destroy real work to repair ours — this bug wastes a layout, that one would
+  // delete an arrangement.
+  //
+  // ⭐ The predicate asks a GEOMETRIC question when the real one is PROVENANCE:
+  // did WE place these, or did the USER arrange them? That answer is already in
+  // hand HERE — `store.nodes.length === 0` means there was nothing to preserve.
+  // No flag is recorded, because recording one would be a second source of truth
+  // for a fact this site can already see.
+  //
+  // So this branch is safe BY CONSTRUCTION: it fires only when the canvas was
+  // empty, so there is no arrangement it can damage. The nodes keep the origin
+  // `mapDraftNodeToCanvas` gives them, which makes `graphNeedsInitialLayout`
+  // return TRUE on its own terms, and `setPendingLayout(true)` is the same
+  // request `useInitialLayoutGuard` already makes — the designed path, unchanged.
+  const hydratingEmptyCanvas = store.nodes.length === 0 && addedNodes.length > 0
+
   // Deterministic placement, right of the existing bounding box — never a
   // re-layout of nodes the user has already arranged. Same constants as the
   // receipt path, imported from it.
-  if (addedNodes.length > 0) {
+  if (addedNodes.length > 0 && !hydratingEmptyCanvas) {
     const xs = mergedNodes.map((n: any) => n.position?.x ?? 0)
     const ys = mergedNodes.map((n: any) => n.position?.y ?? 0)
     const baseX = (xs.length ? Math.max(...xs) : 0) + ADDED_COLUMN_X_GAP
@@ -459,6 +498,11 @@ export function mergeServerGraphOnHydrate(
     useCanvasStore.setState({
       nodes: [...mergedNodes, ...addedNodes] as any,
       edges: [...mergedEdges, ...addedEdges] as any,
+      // Requested in the SAME write as the nodes it describes: a separate
+      // `setPendingLayout` call would leave a frame in which the canvas holds an
+      // origin stack that nothing has asked to lay out, and the camera's restore
+      // trigger reads exactly that state.
+      ...(hydratingEmptyCanvas ? { pendingLayout: true } : {}),
     })
   } finally {
     useCanvasStore.getState().endExternalGraphMutation?.()


### PR DESCRIPTION
## The defect, driven and witnessed on the deployed build

A user reloading a saved scenario with **no local autosave** — new device, cleared storage, incognito, or a scenario first opened elsewhere — gets every node in **one vertical line**: unique `x` of `260`, `y` stepping by exactly `140`. **No banner, no console error.** Silent.

Driven on `13b8676d` after deploy, both paths, same session:

| Path | Unique x | y-gaps | Banner | Verdict |
|---|---|---|---|---|
| **Fresh draft** | `24, 206, 388, … 1678` — **10 columns** | irregular | no | proper ELK layout |
| **Reload** | **`260, 640`** | **uniform 140** | no | fallback grid |

**So the layout machinery works.** It is only the boot-merge branch that never asks for it.

## ⚠ This is NOT a persistence bug — the first framing was wrong

`scenarios.graph` carrying no geometry is **deliberate and declared** at the top of this very file:

> *"VALUES FROM THE SERVER, LAYOUT FROM LOCAL… The autosave is the only place a position has ever existed."*

`layout_present: false` on the wire is **correct and expected**. The empty-canvas hydrate is, in the file's own words, *"the whole point of this feature"*.

**The defect is the placement chosen for it.** With an empty canvas every server node is "added", so all of them fall through `ADDED_COLUMN_X_GAP`/`ADDED_COLUMN_Y_STEP` — a constant pair whose own comment says it exists to drop *"a few added nodes beside an existing bounding box"* and *"never a re-layout of nodes the user has already arranged"*. **It is applied to the one case it explicitly disclaims**, and with no existing nodes `Math.max(...[])` has nothing to take, so `baseX` collapses to `0 + 260`.

## ⭐ And the product cannot see it

```
graphNeedsInitialLayout: xSpread < 40 && ySpread < 40
a 260-column:            xSpread = 0 ✓   ySpread ≈ 1960 ✗   → FALSE
```

No layout is triggered, and `isRestoredModelReady` returns **true**, so the camera confidently frames the line. Fifteen nodes in a row is not a laid-out graph, but nothing in the product disagrees.

## ⚠ Why the fix is NOT in the predicate

Loosening `graphNeedsInitialLayout` so a column counts as "needs layout" was considered and **rejected**: **a user can deliberately arrange nodes in a column**, and a geometric test cannot tell their column from ours. That fix would **destroy real work** to repair ours — this bug wastes a layout; that one would delete an arrangement.

⭐ **The predicate asks a GEOMETRIC question when the real one is PROVENANCE**: did *we* place these, or did the *user* arrange them? That answer is already in hand at the placement site — **`store.nodes.length === 0` means there was nothing to preserve.** No flag is recorded, because recording one would be a second source of truth for a fact the site can already see.

**So the branch is safe by construction**: it fires only when the canvas was empty, so there is no arrangement it can damage. The nodes keep the origin `mapDraftNodeToCanvas` gives them, which makes `graphNeedsInitialLayout` return **true on its own terms**, and `setPendingLayout(true)` rides the **same write** as the nodes it describes. `graphNeedsInitialLayout` is untouched.

## Evidence

**RED-first**: 2 failed / 4 passed / 6 collected. ⚠ The first run had a **vacuous pass of my own making** — I imported the placement constants from `mergeServerGraph` (which only re-uses them) instead of `mergeAppliedGraph`, so they were `undefined` and `Set.has(undefined)` was `false`. Its twin caught it by reporting `NaN`. The spec now asserts the constants are real numbers before relying on them.

**Mutation pair — this is what proves "safe by construction" in both directions:**

| mutant | expect | got |
|---|---|---|
| control (no mutation) | GREEN | GREEN 6/6 |
| **M1** remove the empty-canvas guard — the column returns | RED | RED (2) |
| **M2** fire for **every** hydration — user arrangements destroyed | RED | RED (2) |
| **M3** drop the `pendingLayout` request only | RED | RED (1) |
| trailing control | GREEN | GREEN 6/6 |

File restored to an identical sha256 (`eb061f02…7336`). **M1 and M2 together are the argument**: too narrow and the bug returns; too wide and it deletes user work.

- Merge + layout-guard suites: **15 files / 178 tests**, no regressions
- `scripts/ci/typecheck-gate.sh`: **PASSED**, exactly baseline (556 files / 2252 errors, **+0**)
- `eslint`: **0 errors**
- **Staging Gate: PASSED**, all four Full Test Suite shards green

**`Visual Regression (advisory)` discharged by measurement, not by label** — and not merely by matching totals, because a matching count can hide a swap:

```
HEAD aa33d587 : 13 failed / 21 passed · 12 unique failing specs
BASE 0ccfbc40 : 13 failed / 21 passed · 12 unique failing specs
diff of failing NAMES → IDENTICAL
```

The failure **set** is the same, not just its size. This change moved nothing visual.

## Relationship to #855

**#855 is not orthogonal to this — it is load-bearing for it.** #855 rescues the *throw* path; the reload path never throws, which is why #855 correctly did not change reload behaviour (predicted before the deploy, then witnessed). **This change routes fresh-browser reloads onto the layout path**, so if ELK throws there, #855's fallback — now live in staging — catches it and the user gets a readable grid plus a banner instead of a silent column.

## ⚠ OBSERVABILITY POSTURE — read this before debugging any regression here

**This change deliberately increases traffic on the layout path.**

- **Failures on that path DO reach the user**: #855's fallback places a readable grid and the "Layout failed. Try again." banner fires. **Detection is covered.**
- ⚠ **Failures on that path reach NO OPERATOR SINK.** `VITE_SENTRY_DSN` is **unset on staging** — measured at the deployed bytes (`VITE_SENTRY_DSN:void 0`, with `MODE` already `"production"`, so the DSN is the only missing half, and the probe was contrast-controlled). `captureError` therefore falls to `logger.error('[Monitoring] Error (Sentry disabled): …')`, a console line. **Diagnosis is not covered.**

**So: a failure here surfaces to the user and is invisible to us.** That is a deliberate, recorded trade — strictly better than the status quo, where a returning user got a silent uniform column and *nobody* saw anything — but if a regression appears on this seam and you cannot find any trace of it, **this is why**.

**The outstanding ask is `VITE_SENTRY_DSN` on Netlify** (UI is Netlify, not Render). It is raised with the founder and is what turns an intermittent, still-unexplained ELK throw from undiagnosable into diagnosable — on a path we are now sending more traffic down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
