### PR TITLE
fix(canvas): the options section names what can resolve the blocker it displays

### DIFF
--- a/src/canvas/model-tab-v2/ModelOutline.tsx
+++ b/src/canvas/model-tab-v2/ModelOutline.tsx
@@ -30,6 +30,12 @@ import { typography } from '../../styles/typography'
 import { ModelRowView } from './ModelRowView'
 import { ModelGroupActions } from './ModelGroupActions'
 import { GROUP_ACTIONS, type GroupAction, type GroupActionContext } from './groupActions'
+import {
+  discussActionFor,
+  rowsThisSectionCannotResolve,
+  sectionWriterNoticeText,
+  SECTION_WRITER_NOTICE_TESTID,
+} from './sectionWriterNotice'
 import { GROUP_TITLE } from './rowPresentation'
 import {
   MODEL_GROUP_IDS,
@@ -123,6 +129,54 @@ export function outlineLayout(
     })),
     unknownGroupRowIds,
   }
+}
+
+/**
+ * One sentence for a section that DISPLAYS a blocker it cannot clear.
+ *
+ * ⚠ SILENT BY DEFAULT, on the same reasoning as the unknown summary above: a
+ * notice that always renders is chrome, and chrome states nothing about the
+ * data. This appears only where there is genuinely a blocked row with no
+ * writer, and RETIRES ITSELF the moment one is connected — the predicate reads
+ * the same `editConnectedIds` the row's value cell reads, so the notice cannot
+ * outlive its cause or disagree with the control beside it.
+ */
+function SectionWriterNotice({
+  group,
+  rows,
+  editConnectedIds,
+  actionsWillRender,
+}: {
+  group: ModelGroupId
+  rows: readonly ModelRow[]
+  editConnectedIds?: ReadonlySet<string>
+  /**
+   * ⚠ WHETHER THE ACTION ROW ACTUALLY RENDERS — not whether an action is
+   * DEFINED. `ModelGroupActions` returns `null` when it has no `onAction`, so a
+   * host that omits the handler shows no buttons at all. Without this the
+   * notice would say *Use "Discuss the options with Olumi" below* with no such
+   * control below it — naming a control the user cannot find, which is exactly
+   * the circularity this notice exists to avoid, merely relocated.
+   *
+   * Found by a FIXTURE GAP, not by inspection: the first version of the spec
+   * omitted `onGroupAction`, the button did not render, and the assertion that
+   * the notice quotes the BUTTON's own text failed. The test was right.
+   */
+  actionsWillRender: boolean
+}) {
+  const blocked = rowsThisSectionCannotResolve(rows, editConnectedIds)
+  const discuss = discussActionFor(GROUP_ACTIONS[group])
+  // No blocked row, no affordance defined, or no affordance on screen: say
+  // nothing. A notice pointing at an absent control is worse than silence.
+  if (blocked.length === 0 || discuss === null || !actionsWillRender) return null
+  return (
+    <p
+      data-testid={SECTION_WRITER_NOTICE_TESTID(group)}
+      className={`${typography.caption} text-text-light px-4 py-1`}
+    >
+      {sectionWriterNoticeText(blocked.length, discuss.label)}
+    </p>
+  )
 }
 
 /**
@@ -253,6 +307,20 @@ export function ModelOutline({
                   ))}
                 </ul>
               )}
+              {/*
+                ⭐ THE SECTION NAMES WHAT CAN RESOLVE WHAT IT IS DISPLAYING.
+                Rendered immediately ABOVE the actions, so the sentence and the
+                control it names are in one glance — a notice that points at a
+                button the user has to go and find is a notice that arrives too
+                late. See `sectionWriterNotice.ts` for why this is a notice and
+                not an edit control: there is no writer to give it.
+              */}
+              <SectionWriterNotice
+                group={group.id}
+                rows={group.rows}
+                editConnectedIds={editConnectedIds}
+                actionsWillRender={typeof onGroupAction === 'function'}
+              />
               {/*
                 THE ACTIONS RENDER EVEN WHEN THE GROUP IS EMPTY, and that is the
                 point of putting them here. "Add a factor" is at its most useful

--- a/src/canvas/model-tab-v2/__tests__/sectionNamesItsWriter.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/sectionNamesItsWriter.spec.tsx
@@ -1,0 +1,227 @@
+/**
+ * A SECTION THAT DISPLAYS A BLOCKER MUST NAME WHAT CAN RESOLVE IT.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * THE DEFECT, DERIVED AT `0ccfbc40` AND DRIVEN ON THE DEPLOYED BUILD
+ * ═══════════════════════════════════════════════════════════════════════════
+ * The OPTIONS section renders `missing-intervention` attention markers and
+ * provides no control that can clear them. Matched pair from the drive, same
+ * session, same tab, same moment:
+ *
+ *   OPTION row  `-value` → an EMPTY, zero-height <span>. Real click REFUSED.
+ *   FACTOR row  `-value` → a <button> "Not set", 37×42. Real click SUCCEEDED.
+ *
+ * ⚠⚠ AND IT IS NOT AN OVERSIGHT — established before writing a line of this.
+ * `mutationAuthority.ts:20` declares `modelOptionIntervention: 'disabled'`, so
+ * `hasServerGraphAuthority` is false, `OPTION_INTERVENTION_CONNECTED` is false,
+ * and `editConnectedIds` (`ModelTabV2Panel.tsx:215-219`) contains FACTORS ONLY.
+ * ONE declaration produces BOTH the empty span here AND the option inspector's
+ * `<fieldset disabled>`. **There is no writer for an option intervention
+ * anywhere in the product except a typed sentence to Olumi.**
+ *
+ * So the fix is NOT a control. A control here would be a surface with no
+ * writer. The fix is that the section SAYS SO and points at what does work.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHAT THIS DOES NOT CHANGE — the NOT SET WALL stays intact
+ * ═══════════════════════════════════════════════════════════════════════════
+ * `ModelRowView`'s rule — *"'Not set' is printed only where it is ACTIONABLE;
+ * where nothing can be done from this cell, the cell is SILENT"* — is correct
+ * and is deliberately left alone. A per-row string would breach it and put back
+ * the wall of identical inert text that rule exists to remove. The notice is
+ * SECTION-level: one sentence for the group, not N for the rows. Pinned below.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { ModelOutline } from '../ModelOutline'
+import { GROUP_ACTIONS } from '../groupActions'
+import {
+  rowsThisSectionCannotResolve,
+  SECTION_WRITER_NOTICE_TESTID,
+} from '../sectionWriterNotice'
+import type { ModelGroupId, ModelRow } from '../types'
+
+function row(id: string, group: ModelGroupId, over: Partial<ModelRow> = {}): ModelRow {
+  return {
+    id,
+    kind: 'option',
+    group,
+    label: `Label ${id}`,
+    primaryValue: null,
+    attention: ['missing-intervention'],
+    editable: true,
+    ...over,
+  }
+}
+
+/** Two unmapped options and one factor — the shape the drive measured. */
+function rows(): ModelRow[] {
+  return [
+    row('opt-1', 'options'),
+    row('opt-2', 'options'),
+    row('fac-1', 'factors', {
+      kind: 'factor',
+      attention: [],
+      primaryValue: '12',
+    }),
+  ]
+}
+
+/**
+ * ⚠ `onBeginEdit` IS LOAD-BEARING HERE, and omitting it made two assertions in
+ * this file VACUOUS on the first run. `editorAvailable` is
+ * `row.editable && editConnected && typeof onBeginEdit === 'function'`
+ * (`ModelRowView`), so with no handler EVERY row renders as a span — the
+ * factor included. The option-vs-factor contrast this file rests on would then
+ * hold for the wrong reason, and "the blocked row is still empty" would pass
+ * against a host where nothing is editable at all. Supplying it reproduces the
+ * drive's matched pair: the factor becomes a real <button>, the unconnected
+ * option stays an empty <span>.
+ */
+function renderOutline(over: Partial<Parameters<typeof ModelOutline>[0]> = {}) {
+  return render(
+    <ModelOutline
+      rows={rows()}
+      tier="plain"
+      filter=""
+      selectedId={null}
+      onSelect={() => {}}
+      onBeginEdit={() => {}}
+      onGroupAction={() => {}}
+      {...(over as Record<string, unknown>)}
+    />,
+  )
+}
+
+/** The label the section already renders — DERIVED, never re-typed here. */
+const DISCUSS_LABEL = GROUP_ACTIONS.options.find(a => a.intent === 'discuss')!.label
+
+describe('the pure predicate — which rows can this section NOT resolve?', () => {
+  it('POSITIVE CONTROL — the fixture really does carry the blocker', () => {
+    // Without this the whole file is vacuous: rows with no `missing-intervention`
+    // would produce an empty result for the WRONG reason.
+    const optionRows = rows().filter(r => r.group === 'options')
+    expect(optionRows).toHaveLength(2)
+    expect(optionRows.every(r => r.attention.includes('missing-intervention'))).toBe(true)
+  })
+
+  it('⭐ names the rows that are blocked AND have no writer', () => {
+    const ids = rowsThisSectionCannotResolve(rows(), new Set(['fac-1']))
+    expect([...ids].sort()).toEqual(['opt-1', 'opt-2'])
+  })
+
+  it('⭐ SELF-RETIRING — a row that GAINS a writer is no longer unresolvable', () => {
+    // The load-bearing property. When `modelOptionIntervention` becomes
+    // `server_graph`, `editConnectedIds` will contain the option ids and this
+    // returns empty WITHOUT anyone remembering to delete the notice. Derived
+    // from the same set the row cell reads, so the two cannot disagree.
+    const ids = rowsThisSectionCannotResolve(rows(), new Set(['fac-1', 'opt-1', 'opt-2']))
+    expect(ids).toEqual([])
+  })
+
+  it('a row with no blocker is not named, even without a writer', () => {
+    const clean = [row('opt-1', 'options', { attention: [], primaryValue: '3 changes' })]
+    expect(rowsThisSectionCannotResolve(clean, new Set())).toEqual([])
+  })
+
+  it('an UNDEFINED writer set means "this host connects everything" — nothing is unresolvable', () => {
+    // Matches `ModelOutline`'s own convention at its row cell: `undefined`
+    // is treated as connected, so a host without the concept is unchanged.
+    expect(rowsThisSectionCannotResolve(rows(), undefined)).toEqual([])
+  })
+})
+
+describe('⭐ the rendered notice — the section names what can resolve the blocker', () => {
+  it('⭐ RED-FIRST — the OPTIONS section renders a notice naming the discuss action', () => {
+    renderOutline({ editConnectedIds: new Set(['fac-1']) })
+    const notice = screen.getByTestId(SECTION_WRITER_NOTICE_TESTID('options'))
+    expect(notice).toBeTruthy()
+    // Bound to the affordance ALREADY on screen, by its real label.
+    expect(notice.textContent).toContain(DISCUSS_LABEL)
+  })
+
+  it('⭐ it quotes the label DERIVED from GROUP_ACTIONS, not a re-typed copy', () => {
+    // Trap 12: a hand-typed duplicate of the button's label would drift the
+    // first time the button is renamed, and the notice would point at a
+    // control the user cannot find. Asserted against the source of truth.
+    renderOutline({ editConnectedIds: new Set(['fac-1']) })
+    const notice = screen.getByTestId(SECTION_WRITER_NOTICE_TESTID('options'))
+    const button = screen.getByTestId('model-action-v2-options-discuss')
+    expect(notice.textContent).toContain(button.textContent!)
+  })
+
+  it('it states HOW MANY rows are affected, derived from the same predicate', () => {
+    renderOutline({ editConnectedIds: new Set(['fac-1']) })
+    const notice = screen.getByTestId(SECTION_WRITER_NOTICE_TESTID('options'))
+    expect(notice.textContent).toContain('2')
+  })
+
+  it('⭐ SELF-RETIRING in the DOM — connect a writer and the notice is GONE', () => {
+    // The component is free to disobey a pure function it does not call, so
+    // the retirement is asserted against the rendered DOM as well.
+    renderOutline({ editConnectedIds: new Set(['fac-1', 'opt-1', 'opt-2']) })
+    expect(screen.queryByTestId(SECTION_WRITER_NOTICE_TESTID('options'))).toBeNull()
+  })
+
+  it('CONTRAST — a section with no blocked rows renders no notice', () => {
+    // The FACTORS group is in the same render and carries no
+    // `missing-intervention`, so it must stay silent. This is what makes the
+    // assertion above about OPTIONS rather than about "a notice renders".
+    renderOutline({ editConnectedIds: new Set(['fac-1']) })
+    expect(screen.queryByTestId(SECTION_WRITER_NOTICE_TESTID('factors'))).toBeNull()
+  })
+
+  it('no notice when the host connects everything (undefined set)', () => {
+    renderOutline()
+    expect(screen.queryByTestId(SECTION_WRITER_NOTICE_TESTID('options'))).toBeNull()
+  })
+
+  it('⭐ NO NOTICE when the action row does not render — never name an absent control', () => {
+    // FOUND BY A FIXTURE GAP, NOT BY INSPECTION. The first version of this file
+    // omitted `onGroupAction`; `ModelGroupActions` returns null without it, so
+    // the button was absent and the "quotes the button's own text" assertion
+    // failed. The test was right and the component was wrong: it would have
+    // said *Use "Discuss the options with Olumi" below* with no such control
+    // below it — the same circularity as reusing SHARED_MODEL_AUTHORITY_COPY,
+    // merely relocated one surface along.
+    render(
+      <ModelOutline
+        rows={rows()}
+        tier="plain"
+        filter=""
+        selectedId={null}
+            onSelect={() => {}}
+        onBeginEdit={() => {}}
+        editConnectedIds={new Set(['fac-1'])}
+      />,
+    )
+    // PRECONDITION PINNED IN-TEST: the action row really is absent, so this
+    // asserts the gate rather than passing for some unrelated reason.
+    expect(screen.queryByTestId('model-action-v2-options-discuss')).toBeNull()
+    expect(screen.queryByTestId(SECTION_WRITER_NOTICE_TESTID('options'))).toBeNull()
+  })
+})
+
+describe('⚠ the NOT SET WALL is untouched — this adds no per-row text', () => {
+  it('the blocked row`s value cell is STILL empty', () => {
+    // The whole point of a section-level notice. If this ever REDs, someone has
+    // put the wall back one row at a time.
+    renderOutline({ editConnectedIds: new Set(['fac-1']) })
+    expect(screen.getByTestId('model-row-v2-opt-1-value').textContent).toBe('')
+    expect(screen.getByTestId('model-row-v2-opt-2-value').textContent).toBe('')
+  })
+
+  it('exactly ONE notice for the section, not one per blocked row', () => {
+    renderOutline({ editConnectedIds: new Set(['fac-1']) })
+    expect(screen.getAllByTestId(SECTION_WRITER_NOTICE_TESTID('options'))).toHaveLength(1)
+  })
+
+  it('the factor row still renders its own editable control — unchanged', () => {
+    // Guards the other direction: this change must not touch the path that
+    // WORKS. `fac-1` is edit-connected, so its cell is still a button.
+    renderOutline({ editConnectedIds: new Set(['fac-1']) })
+    expect(screen.getByTestId('model-row-v2-fac-1-value').tagName).toBe('BUTTON')
+  })
+})

--- a/src/canvas/model-tab-v2/sectionWriterNotice.ts
+++ b/src/canvas/model-tab-v2/sectionWriterNotice.ts
@@ -1,0 +1,91 @@
+/**
+ * A SECTION THAT DISPLAYS A BLOCKER MUST NAME WHAT CAN RESOLVE IT.
+ *
+ * ═══════════════════════════════════════════════════════════════════════════
+ * WHY THIS EXISTS, AND WHY IT IS A NOTICE RATHER THAN A CONTROL
+ * ═══════════════════════════════════════════════════════════════════════════
+ * The OPTIONS section renders `missing-intervention` markers and offers no
+ * control that can clear them. Established before writing any of this, and it
+ * is NOT an oversight:
+ *
+ *   `mutationAuthority.ts` declares `modelOptionIntervention: 'disabled'`
+ *      → `hasServerGraphAuthority` false
+ *      → `OPTION_INTERVENTION_CONNECTED` false (`ModelTabV2Panel.tsx`)
+ *      → `editConnectedIds` contains FACTORS ONLY (`ModelTabV2Panel.tsx`)
+ *      → the row's value cell falls to `<span>{display ?? ''}</span>`
+ *
+ * ⭐ ONE DECLARATION, TWO SYMPTOMS: that same line is why the option INSPECTOR
+ * sits inside a `<fieldset disabled>`. Two separate investigations chased those
+ * as unrelated dead ends; they are the same fact.
+ *
+ * So there is no writer for an option intervention anywhere in the product
+ * except a typed sentence to Olumi. **A control here would be a surface with no
+ * writer** — the thing the standing direction forbids. The honest repair is for
+ * the section to say so and point at what does work.
+ *
+ * ⚠ IT DOES NOT REUSE `SHARED_MODEL_AUTHORITY_COPY`, AND THAT IS DELIBERATE.
+ * That constant reads *"Change this through the Model tab or ask Olumi…"* —
+ * correct on the canvas, CIRCULAR here, because the Model tab is precisely the
+ * surface that just failed the user. A notice that points back at itself is
+ * worse than silence.
+ *
+ * ⚠ SECTION-LEVEL, NEVER PER-ROW. `ModelRowView`'s NOT SET WALL rule — *"'Not
+ * set' is printed only where it is ACTIONABLE; where nothing can be done from
+ * this cell, the cell is SILENT"* — is correct and is left intact. A per-row
+ * string would rebuild the wall of identical inert text that rule removed. One
+ * sentence for the group; the rows stay silent.
+ */
+
+import type { GroupAction } from './groupActions'
+import type { ModelGroupId, ModelRow } from './types'
+
+/** The testid for one section's notice. ID-addressed, never label-derived. */
+export function SECTION_WRITER_NOTICE_TESTID(group: ModelGroupId): string {
+  return `model-group-v2-${group}-writer-notice`
+}
+
+/**
+ * The rows this section DISPLAYS a blocker for and CANNOT resolve.
+ *
+ * ⭐ SELF-RETIRING BY CONSTRUCTION, which is the property that matters most.
+ * The second conjunct reads the SAME `editConnectedIds` the row's value cell
+ * reads, so the notice and the control cannot disagree about what is editable.
+ * When `modelOptionIntervention` becomes `server_graph`, options enter that set
+ * and this returns empty — the notice disappears with no one remembering to
+ * delete it. A notice that outlives its cause is the defect it was written to
+ * fix, wearing the opposite sign.
+ *
+ * `undefined` means "this host connects everything" — the same convention
+ * `ModelOutline` already applies at the row cell, so a host without the concept
+ * behaves exactly as it does today.
+ */
+export function rowsThisSectionCannotResolve(
+  rows: readonly ModelRow[],
+  editConnectedIds: ReadonlySet<string> | undefined,
+): readonly string[] {
+  if (editConnectedIds === undefined) return []
+  return rows
+    .filter(
+      r =>
+        r.attention.includes('missing-intervention') && !editConnectedIds.has(r.id),
+    )
+    .map(r => r.id)
+}
+
+/**
+ * The sentence. It states the blocker, admits this section cannot clear it, and
+ * names the affordance ALREADY on screen — quoting the action's own label
+ * rather than a re-typed copy, so a rename cannot leave the notice pointing at
+ * a control the user can no longer find (trap 12).
+ */
+export function sectionWriterNoticeText(count: number, discussLabel: string): string {
+  const subject = count === 1 ? 'One of these has' : `${count} of these have`
+  return `${subject} no effect on any factor yet, and that cannot be set from this section. Use "${discussLabel}" below.`
+}
+
+/** The `discuss` action for a group, or `null` when it has none. */
+export function discussActionFor(
+  actions: readonly GroupAction[] | undefined,
+): GroupAction | null {
+  return actions?.find(a => a.intent === 'discuss') ?? null
+}


### PR DESCRIPTION
## The defect

The OPTIONS section renders `missing-intervention` markers and offers **no control that can clear them**. Matched pair from a drive on the deployed build — same session, same tab, same moment:

```
OPTION row  model-row-v2-<id>-value : <span>, EMPTY, height 0, no role/tabindex
                                      real click (actionability enforced) → REFUSED, 0 wire calls
FACTOR row  model-row-v2-<id>-value : <button>, "Not set", 37×42
                                      real click → SUCCEEDED, input appeared
```

The user path is: **blocked → a section that cannot fix it → a chip that returns prose → type a sentence.**

## ⚠ It is NOT an oversight — established before writing a line of this

```
mutationAuthority.ts:20   modelOptionIntervention: 'disabled'
  → hasServerGraphAuthority() false
  → OPTION_INTERVENTION_CONNECTED false          (ModelTabV2Panel.tsx:111)
  → editConnectedIds = FACTORS ONLY              (ModelTabV2Panel.tsx:215-219)
  → row cell falls to <span>{display ?? ''}</span>   (ModelRowView.tsx:450)
```

An unmapped option's `primaryValue` is `null`, so `display ?? ''` renders the **empty zero-height span**. The factor takes the `<button>` branch.

⭐ **That one declaration is also why the option INSPECTOR sits inside a `<fieldset disabled>`.** Two investigations chased those as unrelated dead ends; **they are the same fact.**

**Two corrections to the obvious hypotheses**, both of which would have sent a fix at the wrong thing:
- It is **not** `row.editable` — options are `editable: **true**`. The `editable: false` nearby is *risks and outcomes*, a different kind. The panel's own note draws the distinction: *"that flag states what the design **intends** to be editable; this set states what the frozen transaction path **can actually carry today**."*
- The empty cell is **deliberate**, under the documented NOT SET WALL: *"'Not set' is printed only where it is ACTIONABLE; where nothing can be done from this cell, the cell is SILENT"* — with the fact carried by the attention marker, the group heading's unknown summary, and the detail region. **The section is behaving as designed.**

## So this adds a notice, never a control

**There is no writer for an option intervention anywhere in the product except a typed sentence to Olumi.** A control here would be a surface with no writer. The honest repair is that the section **says so and points at what does work** — the `model-action-v2-options-discuss` button **already on screen**, which a drive confirmed works, naming all three missing option→factor mappings precisely.

Three deliberate constraints:

1. **It does NOT reuse `SHARED_MODEL_AUTHORITY_COPY.** That constant reads *"Change this through the Model tab or ask Olumi…"* — correct on the canvas, **circular here**, because the Model tab is precisely the surface that just failed the user.
2. **Section-level, never per-row.** A per-row string would breach the NOT SET WALL and rebuild the wall of identical inert text that rule removed. One sentence for the group; the rows stay silent — **pinned by a test**.
3. **It quotes the action's OWN label**, derived from `GROUP_ACTIONS`, never a re-typed copy that would drift on the first rename (trap 12).

⛔ **`mutationAuthority.ts` is untouched.** Changing the authority table would enable a dark surface *and* is semantically coupled to #857, which touches that table's spec.

## ⭐ Self-retiring by construction

The predicate's second conjunct reads the **same `editConnectedIds` the row's value cell reads**, so the notice and the control cannot disagree. When `modelOptionIntervention` becomes `server_graph`, options enter that set and the notice **disappears with nobody remembering to delete it**. A notice that outlives its cause is the same defect wearing the opposite sign.

## RED-first

`sectionNamesItsWriter.spec.tsx` — **15 collected, asserted by name**. At the RED-first baseline (module present, not wired): **4 RED / 10 green of 14**, the four being exactly the notice-rendering tests. After wiring: **15/15**.

## Discriminating mutants

Isolated worktree, isolation **proven by writing** a sentinel (inodes `723156763` vs `723274962`), applied-check scoped to `src/`, clean-tree assertions, trailing control, 15-collected asserted every run. **Re-verified against the amended commit** after the fixture changed.

| mutant | RED |
|---|---|
| CONTROL | none (15 green, applied=0) |
| **M1** drop the **blocker** conjunct | "a row with no blocker is not named" — **only** |
| **M2** drop the **writer** conjunct | both SELF-RETIRING tests (pure + DOM) — **the pair with M1** |
| **M3** `undefined` no longer means all-connected | both undefined-set tests |
| **M4** hardcode the label | both label tests |
| **M5** drop the actions-on-screen gate | "never name an absent control" — **only** |
| TRAILING | none, tree clean |

## A fixture gap that found a real defect

The first spec omitted `onGroupAction`. `ModelGroupActions` returns `null` without it, so the button never rendered and the "quotes the button's own text" assertion failed. **The test was right and the component was wrong**: it would have said *Use "Discuss the options with Olumi" below* with **no such control below it** — the same circularity as reusing the shared copy, merely relocated one surface along. Now gated on `actionsWillRender`, with M5 pinning it.

A second fixture gap in the same file: omitting `onBeginEdit` made **every** row render as a span, so the option-vs-factor contrast held for the wrong reason and "the blocked row is still empty" would have passed against a host where nothing was editable at all. Both are recorded in the spec.

## Named limits

- **jsdom.** This asserts the DOM, not visibility or layout. That the sentence is *legible where it sits* is not shown here.
- **No live witness.** Rung is TESTED. The defect it addresses was driven on the deployed build; the fix has not been.
- **It does not make an option intervention settable.** It makes the section honest about that. The underlying capability gap is the `'disabled'` authority, which is untouched and out of scope.
- The copy names one affordance. If a host renders the section without group actions, the notice correctly says nothing — but then the user gets **no** pointer at all, which is silence rather than a lie, and is the pre-existing state.

## Boundaries

Three files, all in `src/canvas/model-tab-v2/`. That directory is **entirely uncontended** across all open UI PRs (both inputs asserted non-empty; contrast control fired). No CEE files, no `components/results/**`, no `mutationAuthority.ts`.
