### PR TITLE
fix(canvas): the hydration's layout request invalidates one already in flight

### DIFF
--- a/src/canvas/utils/__tests__/mergeServerGraph.emptyCanvasLayout.spec.ts
+++ b/src/canvas/utils/__tests__/mergeServerGraph.emptyCanvasLayout.spec.ts
@@ -173,3 +173,43 @@ describe('a canvas the user has arranged is untouched — the guard that makes t
     expect(nodes.find((n) => n.id === 'n1')!.position).toEqual({ x: 40, y: 500 })
   })
 })
+
+/**
+ * ⭐⭐ THE LAYOUT REQUEST INVALIDATES ONE ALREADY IN FLIGHT.
+ *
+ * ⚠ THE HALF THAT WAS SILENTLY MISSING. `setPendingLayout(true)` is
+ * `set({ pendingLayout: true, layoutRequestId: get().layoutRequestId + 1 })` —
+ * the bump is half of what it does. The hydration wrote only the FIELD, which
+ * looked equivalent and was not: the raw write was the ONLY one in `src/`
+ * outside the setter's own body, against 7 producers that use the setter.
+ *
+ * Without the bump, a layout that started BEFORE this hydration still passes
+ * `applyLayout`'s post-await commit guard — its generation never moved — and
+ * commits its stale snapshot over the graph we just merged. Measured on the
+ * unfixed build: `nodeCount: 0, layoutVersion: 1` — AN EMPTY CANVAS REPORTED AS
+ * A SUCCESSFUL LAYOUT. The same defect class the rest of this file closes, one
+ * line over, and nothing would have gone red when it shipped.
+ */
+describe('the hydration invalidates a layout already in flight', () => {
+  it('⭐ bumps layoutRequestId in the same write as the nodes', () => {
+    emptyCanvas()
+    const before = useCanvasStore.getState().layoutRequestId
+    mergeServerGraphOnHydrate(serverGraph(15))
+    const after = useCanvasStore.getState()
+    expect(after.layoutRequestId).toBeGreaterThan(before)
+    // Both halves, together — a bump without the request, or a request without
+    // the bump, are each the defect this pins.
+    expect(after.pendingLayout).toBe(true)
+  })
+
+  it('⭐ DISCRIMINATING TWIN — a non-empty hydration does NOT bump it', () => {
+    // The bump must be as narrowly scoped as the placement branch itself.
+    // Bumping on every hydration would invalidate layouts the user's own
+    // arranged canvas legitimately has in flight — the same over-wide failure
+    // M2 catches for the placement.
+    canvasWithUserArrangement()
+    const before = useCanvasStore.getState().layoutRequestId
+    mergeServerGraphOnHydrate(serverGraph(4))
+    expect(useCanvasStore.getState().layoutRequestId).toBe(before)
+  })
+})

--- a/src/canvas/utils/mergeServerGraph.ts
+++ b/src/canvas/utils/mergeServerGraph.ts
@@ -369,9 +369,19 @@ export function mergeServerGraphOnHydrate(
   //
   // So this branch is safe BY CONSTRUCTION: it fires only when the canvas was
   // empty, so there is no arrangement it can damage. The nodes keep the origin
-  // `mapDraftNodeToCanvas` gives them, which makes `graphNeedsInitialLayout`
-  // return TRUE on its own terms, and `setPendingLayout(true)` is the same
-  // request `useInitialLayoutGuard` already makes — the designed path, unchanged.
+  // `mapDraftNodeToCanvas` gives them, and the layout is requested directly in
+  // the commit below — the same request `useInitialLayoutGuard` makes, on the
+  // designed path, unchanged.
+  //
+  // ⚠ AN EARLIER VERSION OF THIS SENTENCE SAID the origin placement "makes
+  // `graphNeedsInitialLayout` return TRUE on its own terms". THAT IS FALSE AT
+  // n = 1 — the predicate returns `false` for `unlocked.length <= 1`, so a
+  // single-node hydration is NOT self-describing as needing layout. Corrected
+  // in place rather than deleted, because the consequence is worth carrying:
+  // the request below is what makes this work, and `useInitialLayoutGuard` is
+  // therefore NOT a safety net for a one-node hydration — if that request were
+  // ever swallowed, nothing else would ask. At n >= 2 the predicate does agree,
+  // which is exactly why the false sentence read as true.
   const hydratingEmptyCanvas = store.nodes.length === 0 && addedNodes.length > 0
 
   // Deterministic placement, right of the existing bounding box — never a
@@ -502,7 +512,34 @@ export function mergeServerGraphOnHydrate(
       // `setPendingLayout` call would leave a frame in which the canvas holds an
       // origin stack that nothing has asked to lay out, and the camera's restore
       // trigger reads exactly that state.
-      ...(hydratingEmptyCanvas ? { pendingLayout: true } : {}),
+      //
+      // ⚠⚠ AND `layoutRequestId` MOVES WITH IT, WHICH THE RAW FIELD WRITE ALONE
+      // DID NOT. `setPendingLayout(true)` is `set({ pendingLayout: true,
+      // layoutRequestId: get().layoutRequestId + 1 })` — the bump is half of
+      // what it does, and writing only the field silently dropped it. Complete
+      // manifest, contrast-controlled: this was the ONLY raw `pendingLayout:
+      // true` in `src/` outside the setter's own body, against 7 producers that
+      // use the setter.
+      //
+      // The bump is what INVALIDATES A LAYOUT ALREADY IN FLIGHT. Without it,
+      // `applyLayout`'s post-await commit guard (`isCurrentGen()`) still passes
+      // — its generation never moved — so a layout that started BEFORE this
+      // hydration commits its stale snapshot over the graph we just merged.
+      // Measured: hold a layout open across the hydration and the final state
+      // is `nodeCount: 0, layoutVersion: 1` — AN EMPTY CANVAS REPORTED AS A
+      // SUCCESSFUL LAYOUT. That is the same defect class this whole branch
+      // exists to close, one line over.
+      //
+      // ⚠ NOT a separate `setPendingLayout()` call: that reintroduces exactly
+      // the intermediate frame the paragraph above exists to prevent. Read
+      // fresh at write time rather than from the `store` snapshot captured at
+      // entry, so a bump landing during the merge is not overwritten.
+      ...(hydratingEmptyCanvas
+        ? {
+            pendingLayout: true,
+            layoutRequestId: useCanvasStore.getState().layoutRequestId + 1,
+          }
+        : {}),
     })
   } finally {
     useCanvasStore.getState().endExternalGraphMutation?.()


### PR DESCRIPTION
Follow-up to #862, from its review. Two items, same file, same `setState`.

## MEDIUM — the raw write dropped half of what the setter does

`setPendingLayout(true)` is:

```js
set({ pendingLayout: true, layoutRequestId: get().layoutRequestId + 1 })
```

The hydration wrote **only the field**. That looked equivalent and was not.

**Complete manifest, contrast-controlled** — this was the **only** raw `pendingLayout: true` in `src/` outside the setter's own body, against **7** producers that use the setter:

```
TARGET   store.ts:5771            ← the setter itself
         mergeServerGraph.ts:505  ← the raw write
CONTROL  setPendingLayout(true) producers → 7   ✓ probe not blind
```

### Why the bump matters

**It is what invalidates a layout already in flight.** Without it, `applyLayout`'s post-await commit guard (`isCurrentGen()`) still passes — its generation never moved — so a layout that started **before** the hydration commits its stale snapshot over the graph we just merged.

**Measured:** `nodeCount: 0, layoutVersion: 1` — **an empty canvas reported as a SUCCESSFUL LAYOUT.** That is the same defect class #862 exists to close, one line over, and **nothing would have gone red when it shipped**.

⚠ **NOT a separate `setPendingLayout()` call.** That reintroduces exactly the intermediate frame the comment there exists to prevent — a canvas holding an origin stack that nothing has asked to lay out, which is precisely the state the camera's restore trigger reads. The bump rides the **same write**, read fresh at write time rather than from the entry snapshot so a bump landing mid-merge is not overwritten.

## LOW — an over-broad sentence, corrected in place

It claimed the origin placement *"makes `graphNeedsInitialLayout` return TRUE on its own terms"*. **False at n = 1**: the predicate returns `false` for `unlocked.length <= 1`.

Harmless in practice, because the request is written directly — but the consequence is worth carrying rather than deleting: **`useInitialLayoutGuard` is NOT a safety net for a single-node hydration if that request is ever swallowed.** At n ≥ 2 the predicate does agree, which is exactly why the false sentence read as true.

## Evidence

Both halves pinned, each with a discriminating twin:

| mutant | expect | got |
|---|---|---|
| control | GREEN | GREEN 8/8 |
| **M4** drop the `layoutRequestId` bump (the shipped defect) | RED | RED (1) |
| **M5** bump **unconditionally** — invalidates a user's in-flight layout | RED | RED (1) |
| trailing control | GREEN | GREEN 8/8 |

File restored to an identical sha256 (`2bb15fa9…f44b`). **M5 is the half that matters**: the bump must be as narrowly scoped as the placement branch itself, or it invalidates layouts an arranged canvas legitimately has running — the same over-wide failure #862's M2 catches for the placement.

- Merge + layout-lifecycle suites: **14 files / 137 tests**, no regressions
- `scripts/ci/typecheck-gate.sh`: **PASSED**, exactly baseline (556 files / 2252 errors, **+0**)
- `eslint`: **0 errors**

Per the standing ruling, no local full suite — CI is the authority.

## Observability posture — unchanged from #862

This does not alter traffic on the layout path. The posture recorded there still holds: **failures reach the user** via #855's fallback grid and banner, and **reach no operator sink** — `VITE_SENTRY_DSN` is unset on staging (`VITE_SENTRY_DSN:void 0` at the deployed bytes, `MODE` already `"production"`). **Detection is covered; diagnosis is not.** The ask is outstanding with the founder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
