### PR TITLE
D — the Model tab names the axis it counts, instead of the other one [IN-class]

### DIFF
--- a/src/canvas/model-tab-v2/ModelOutline.tsx
+++ b/src/canvas/model-tab-v2/ModelOutline.tsx
@@ -224,58 +224,62 @@ function unsetSummary(rows: readonly ModelRow[]): string | null {
   // Read from the SHARED predicate (`factorIsConfirmable`, surfaced as this
   // attention reason) — never a second local answer to "has Olumi estimated
   // this?", which is how the confirm chip went wrong.
-  const estimated = unset.filter(
-    r => Array.isArray(r.attention) && r.attention.includes('unconfirmed-estimate'),
-  ).length
 
-  // ⛔ AUTHORSHIP IS A THIRD QUESTION, AND THE COUNT CANNOT ANSWER IT.
+  // ⛔⛔ NO UMBRELLA CLAIM — THE FOURTH ATTEMPT, AND THE FIRST THAT IS NOT AN
+  // ADJECTIVE. Three previous heads each characterised the whole `unset`
+  // population, and each was FALSE for a class the corpus behind it excluded:
   //
-  // The first cut of this said "not set by your team", attributing the whole
-  // `unset` population to authorship. `unset` is `raw_value === undefined`, and
-  // that does NOT imply the team did not set the value. Measured end-to-end on
-  // a real edit: `buildFactorValueEditEvent` attaches `raw_value` only
-  // `if (inUserUnits)`, which is false for a factor carrying `value` with no
-  // `raw_value` — so typing 0.8 into such a factor persists
-  // `{value: 0.8, source: 'user'}` and the row comes back
-  // `{primaryValue: null, provenanceSource: 'user'}`.
+  //   "have no value yet"        FALSE for a band  (cell shows "Olumi: 0.25 to 0.75")
+  //   "not set by your team"     FALSE for a user-set factor with no `raw_value`
+  //                              (measured: typing 0.8 persists {value, source:'user'})
+  //   "without a figure"         FALSE for a numeric estimate — `estimateText` is
+  //                              CEE's `display_value` with only an EMPTINESS check,
+  //                              and the estate's fixtures carry '£20,000' (11×),
+  //                              '£30k', '£49', '3 months', '20%', '0.7'. A row can
+  //                              render "Olumi: £20,000" under a heading calling it
+  //                              figureless.
   //
-  // The heading therefore told the user that the factor they had JUST TYPED was
-  // not set by them — an untruth directly contradicting the action the surface
-  // exists to invite. Not a regression (the old string was false for that class
-  // too) but a more specific one.
+  // ⚠ THE POPULATION IS HETEROGENEOUS, SO NO ADJECTIVE CAN BE TRUE OF IT. Three
+  // rounds is past the point where one more wording is a fix rather than the
+  // next refutation, so this states the COMPOSITION instead of characterising it:
+  // three DISJOINT buckets, each clause independently true, and nothing asserted
+  // about the whole.
   //
-  // So authorship is DERIVED from the shared taxonomy rather than asserted, and
-  // it is a THIRD independently-owned axis: `unset` keeps `getPrimaryValue`, the
-  // estimate clause keeps `factorIsConfirmable`, and this reads
-  // `classifyValueProvenance().userOwned`. Three questions, three predicates,
-  // none aligned (`valueProvenance.ts:389` — "named apart on purpose").
+  // ⚠ AND THE BUCKETS READ WHAT THE CELL READS. "Olumi has something here" is
+  // answered by `estimateText` — the very field `ModelRowView` renders — NOT by a
+  // second predicate over the same question. `factorIsConfirmable` answers a
+  // different one ("is there a value to RATIFY?"), which is why a band satisfies
+  // this and not that. The heading's job is to be consistent with the cell beside
+  // it, so it reads the cell's own field.
   const yours = unset.filter(
     r => classifyValueProvenance(r.provenanceSource)?.userOwned === true,
   ).length
+  // ⚠ TWO FACTS, ONE QUESTION — NOT TWO PREDICATES OVER IT. Olumi can have
+  // something here in two independently-owned ways, and a row may carry either
+  // without the other:
+  //   · `estimateText`         — CEE sent display text, and the CELL RENDERS IT.
+  //   · `unconfirmed-estimate` — `factorIsConfirmable`: a numeric value to
+  //                              RATIFY, which a band does not satisfy and a
+  //                              text-less numeric estimate does.
+  // Bucketing on only the first calls a ratifiable estimate "no value yet";
+  // only the second calls a band that. Neither fact is re-derived here — both
+  // are read from their existing owners, and their union is the one question
+  // this clause asks.
+  const fromOlumi = unset.filter(
+    r =>
+      classifyValueProvenance(r.provenanceSource)?.userOwned !== true &&
+      (r.estimateText !== undefined ||
+        (Array.isArray(r.attention) && r.attention.includes('unconfirmed-estimate'))),
+  ).length
+  const nothing = unset.length - yours - fromOlumi
 
-  // ⭐ "WITHOUT A FIGURE" — and this head is what makes the sentence true beside
-  // the value cell rather than in spite of it.
-  //
-  // `raw_value` is the value in the USER'S OWN UNITS — a figure. The old head,
-  // "have no value yet", was false in two directions at once: a factor Olumi had
-  // estimated HAS a value, and a factor carrying a producer BAND
-  // ("0.25 to 0.75") has one too. Since the row cell now renders that band
-  // verbatim ("Olumi: 0.25 to 0.75"), "have no value yet" would sit directly
-  // above a visible value — the exact untruth this function's own header exists
-  // to abolish, re-created one element up.
-  //
-  // A band is not a figure. A normalised level on a frame is not a figure
-  // either. "Without a figure" is true of every member of `unset`, so the
-  // heading and the cell can both be right at once — and it needs NO second
-  // answer to "has Olumi estimated this?", which would have been a fourth
-  // predicate over the same question.
-  const head = `${unset.length} of ${rows.length} without a figure`
   const clauses = [
-    estimated > 0 ? `Olumi estimated ${estimated}` : null,
+    nothing > 0 ? `${nothing} with no value yet` : null,
+    fromOlumi > 0 ? `${fromOlumi} estimated by Olumi` : null,
     yours > 0 ? `you set ${yours}` : null,
   ].filter((c): c is string => c !== null)
 
-  return clauses.length === 0 ? head : `${head} · ${clauses.join(' · ')}`
+  return clauses.join(' · ')
 }
 
 export function ModelOutline({

--- a/src/canvas/model-tab-v2/ModelOutline.tsx
+++ b/src/canvas/model-tab-v2/ModelOutline.tsx
@@ -26,6 +26,7 @@
  */
 
 import { useCallback, useMemo, useState } from 'react'
+import { classifyValueProvenance } from '../domain/valueProvenance'
 import { typography } from '../../styles/typography'
 import { ModelRowView } from './ModelRowView'
 import { ModelGroupActions } from './ModelGroupActions'
@@ -227,10 +228,54 @@ function unsetSummary(rows: readonly ModelRow[]): string | null {
     r => Array.isArray(r.attention) && r.attention.includes('unconfirmed-estimate'),
   ).length
 
-  const head = `${unset.length} of ${rows.length}`
-  return estimated === 0
-    ? `${head} have no value yet`
-    : `${head} not set by your team · Olumi estimated ${estimated}`
+  // ⛔ AUTHORSHIP IS A THIRD QUESTION, AND THE COUNT CANNOT ANSWER IT.
+  //
+  // The first cut of this said "not set by your team", attributing the whole
+  // `unset` population to authorship. `unset` is `raw_value === undefined`, and
+  // that does NOT imply the team did not set the value. Measured end-to-end on
+  // a real edit: `buildFactorValueEditEvent` attaches `raw_value` only
+  // `if (inUserUnits)`, which is false for a factor carrying `value` with no
+  // `raw_value` — so typing 0.8 into such a factor persists
+  // `{value: 0.8, source: 'user'}` and the row comes back
+  // `{primaryValue: null, provenanceSource: 'user'}`.
+  //
+  // The heading therefore told the user that the factor they had JUST TYPED was
+  // not set by them — an untruth directly contradicting the action the surface
+  // exists to invite. Not a regression (the old string was false for that class
+  // too) but a more specific one.
+  //
+  // So authorship is DERIVED from the shared taxonomy rather than asserted, and
+  // it is a THIRD independently-owned axis: `unset` keeps `getPrimaryValue`, the
+  // estimate clause keeps `factorIsConfirmable`, and this reads
+  // `classifyValueProvenance().userOwned`. Three questions, three predicates,
+  // none aligned (`valueProvenance.ts:389` — "named apart on purpose").
+  const yours = unset.filter(
+    r => classifyValueProvenance(r.provenanceSource)?.userOwned === true,
+  ).length
+
+  // ⭐ "WITHOUT A FIGURE" — and this head is what makes the sentence true beside
+  // the value cell rather than in spite of it.
+  //
+  // `raw_value` is the value in the USER'S OWN UNITS — a figure. The old head,
+  // "have no value yet", was false in two directions at once: a factor Olumi had
+  // estimated HAS a value, and a factor carrying a producer BAND
+  // ("0.25 to 0.75") has one too. Since the row cell now renders that band
+  // verbatim ("Olumi: 0.25 to 0.75"), "have no value yet" would sit directly
+  // above a visible value — the exact untruth this function's own header exists
+  // to abolish, re-created one element up.
+  //
+  // A band is not a figure. A normalised level on a frame is not a figure
+  // either. "Without a figure" is true of every member of `unset`, so the
+  // heading and the cell can both be right at once — and it needs NO second
+  // answer to "has Olumi estimated this?", which would have been a fourth
+  // predicate over the same question.
+  const head = `${unset.length} of ${rows.length} without a figure`
+  const clauses = [
+    estimated > 0 ? `Olumi estimated ${estimated}` : null,
+    yours > 0 ? `you set ${yours}` : null,
+  ].filter((c): c is string => c !== null)
+
+  return clauses.length === 0 ? head : `${head} · ${clauses.join(' · ')}`
 }
 
 export function ModelOutline({

--- a/src/canvas/model-tab-v2/ModelOutline.tsx
+++ b/src/canvas/model-tab-v2/ModelOutline.tsx
@@ -180,15 +180,57 @@ function SectionWriterNotice({
 }
 
 /**
- * How many of these rows state no value.
+ * ⭐ THE COUNT WAS RIGHT AND THE SENTENCE NAMED THE OTHER AXIS.
  *
- * `primaryValue === null` is the projection's OWN definition of "nothing is
- * stated" (`types.ts`: *"`null` means nothing is stated — which is a fact to
- * render, never a zero to invent"*). Reading that same field is what keeps the
- * group heading and the value cells from drifting apart.
+ * The COUNT is `primaryValue === null`, i.e. `getPrimaryValue`, i.e.
+ * **`raw_value` is undefined** — "nobody has SUPPLIED a number". That is a
+ * useful, honest count and it is unchanged here.
+ *
+ * The sentence it carried — *"N of M have no value yet"* — is the OTHER
+ * question, and it was false. Measured on a live signed-in journey
+ * (`20260826T082826Z-fresh-extended-17c4a0`, quartet UI `d0e24ccc` /
+ * CEE `c24bfe3`), the persisted graph held:
+ *
+ *   Sales Rep Adoption Rate   value 0.6   raw_value —      display "High (0.6)"
+ *   CRM Feature Fit           value —     raw_value —      display "0.25 to 0.75"
+ *
+ * Both counted as "have no value yet". The first HAS a value — Olumi estimated
+ * it — and the product had already computed the words for it. Four inches away
+ * the context pack said "one factor has no value", because CEE's `has_value`
+ * reads `value`. Neither surface was lying; together they were incoherent, and
+ * that incoherence sent an expert lane chasing a regression that did not exist.
+ *
+ * ⚠ THE TWO PREDICATES ARE DELIBERATELY SEPARATE AND STAY SEPARATE.
+ * `valueProvenance.ts:389` says so in as many words — *"NOT THE SAME QUESTION AS
+ * `no-value` (trap 21) … named apart on purpose rather than aligned."* This is
+ * not a call to align them. It is the copy finally naming the one it counts,
+ * and reading the OTHER from the predicate that already exists rather than
+ * re-deriving half of it — the exact correction `ModelRowView`'s confirm chip
+ * received when it read `primaryValue !== null` to answer a `value` question.
+ *
+ * `null` renders nothing: a group where every row is set states nothing rather
+ * than announcing a zero.
  */
-function unknownCount(rows: readonly ModelRow[]): number {
-  return rows.reduce((n, r) => (r.primaryValue === null ? n + 1 : n), 0)
+function unsetSummary(rows: readonly ModelRow[]): string | null {
+  // `primaryValue === null` is the projection's OWN definition of "nothing is
+  // stated" (`types.ts`: *"`null` means nothing is stated — which is a fact to
+  // render, never a zero to invent"*). Reading that same field is what keeps
+  // this heading and the value cells from drifting apart — the reason the count
+  // itself is untouched.
+  const unset = rows.filter(r => r.primaryValue === null)
+  if (unset.length === 0) return null
+
+  // Read from the SHARED predicate (`factorIsConfirmable`, surfaced as this
+  // attention reason) — never a second local answer to "has Olumi estimated
+  // this?", which is how the confirm chip went wrong.
+  const estimated = unset.filter(
+    r => Array.isArray(r.attention) && r.attention.includes('unconfirmed-estimate'),
+  ).length
+
+  const head = `${unset.length} of ${rows.length}`
+  return estimated === 0
+    ? `${head} have no value yet`
+    : `${head} not set by your team · Olumi estimated ${estimated}`
 }
 
 export function ModelOutline({
@@ -262,12 +304,12 @@ export function ModelOutline({
               would be its own wall — chrome that always renders states nothing
               about the data.
             */}
-            {unknownCount(group.rows) > 0 && (
+            {unsetSummary(group.rows) !== null && (
               <span
                 data-testid={`model-group-v2-${group.id}-unknown-summary`}
                 className={`${typography.panelMeta} text-text-light ml-2`}
               >
-                {unknownCount(group.rows)} of {group.rows.length} have no value yet
+                {unsetSummary(group.rows)}
               </span>
             )}
           </button>

--- a/src/canvas/model-tab-v2/__tests__/ModelOutline.unknownsAreSummarised.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/ModelOutline.unknownsAreSummarised.spec.tsx
@@ -92,6 +92,16 @@ describe('B4 · unknown values are summarised at the group, not repeated down th
    * they had just typed was not theirs. The head is now "without a figure" for
    * EVERY case, so this string changes here too.
    *
+   * ⛔⛔ AND A THIRD TIME, WHICH IS THE POINT AT WHICH THE APPROACH CHANGED.
+   * "Without a figure" was itself refuted: `estimateText` is CEE's
+   * `display_value` gated only on emptiness, and the estate's fixtures carry
+   * '£20,000' (11×), '£30k', '3 months', '20%'. A row can render
+   * "Olumi: £20,000" beneath a heading calling it figureless.
+   *
+   * Three heads, three classes each corpus excluded. The population is
+   * HETEROGENEOUS, so no adjective is true of it — the summary now states its
+   * COMPOSITION in disjoint buckets and asserts nothing about the whole.
+   *
    * Rewritten rather than deleted: what this case guards — that the heading
    * counts and states the unset population at all — is unchanged and still worth
    * pinning. Only the expected wording moved.
@@ -101,7 +111,7 @@ describe('B4 · unknown values are summarised at the group, not repeated down th
     // Bound by identity to the FACTORS group's own summary node, not by
     // searching the document for a number another group could also render.
     const summary = screen.getByTestId('model-group-v2-factors-unknown-summary')
-    expect(summary).toHaveTextContent('3 of 4 without a figure')
+    expect(summary).toHaveTextContent('3 with no value yet')
   })
 
   it('a row that is NOT EDITABLE AT ALL prints nothing either', () => {
@@ -159,6 +169,6 @@ describe('B4 · unknown values are summarised at the group, not repeated down th
     const outline = screen.getByTestId('model-outline-v2')
     expect(
       within(outline).getByTestId('model-group-v2-factors-unknown-summary'),
-    ).toHaveTextContent('3 of 4 without a figure')
+    ).toHaveTextContent('3 with no value yet')
   })
 })

--- a/src/canvas/model-tab-v2/__tests__/ModelOutline.unknownsAreSummarised.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/ModelOutline.unknownsAreSummarised.spec.tsx
@@ -77,12 +77,31 @@ function renderOutline(rows: readonly ModelRow[], editConnectedIds?: ReadonlySet
 }
 
 describe('B4 · unknown values are summarised at the group, not repeated down the list', () => {
+  /*
+   * ⚠ PREMISE UPDATED TWICE, AND THE SECOND TIME MATTERS MORE THAN THE FIRST.
+   *
+   * The first change named the axis the count measures. It deliberately left
+   * this string byte-identical, and this spec passing unchanged was offered as
+   * proof the honest case had not been swallowed.
+   *
+   * ⛔ THAT PROOF NO LONGER HOLDS, and saying so is the point. Independent review
+   * found the head clause made an AUTHORSHIP claim the count cannot support:
+   * `raw_value === undefined` does not mean the team did not set the value, and
+   * measured end-to-end, a user typing into a factor with no `raw_value`
+   * persists `{value, source: 'user'}` — so the heading told them the factor
+   * they had just typed was not theirs. The head is now "without a figure" for
+   * EVERY case, so this string changes here too.
+   *
+   * Rewritten rather than deleted: what this case guards — that the heading
+   * counts and states the unset population at all — is unchanged and still worth
+   * pinning. Only the expected wording moved.
+   */
   it('the group heading states how many rows have no value yet', () => {
     renderOutline(FACTORS, new Set<string>())
     // Bound by identity to the FACTORS group's own summary node, not by
     // searching the document for a number another group could also render.
     const summary = screen.getByTestId('model-group-v2-factors-unknown-summary')
-    expect(summary).toHaveTextContent('3 of 4 have no value yet')
+    expect(summary).toHaveTextContent('3 of 4 without a figure')
   })
 
   it('a row that is NOT EDITABLE AT ALL prints nothing either', () => {
@@ -140,6 +159,6 @@ describe('B4 · unknown values are summarised at the group, not repeated down th
     const outline = screen.getByTestId('model-outline-v2')
     expect(
       within(outline).getByTestId('model-group-v2-factors-unknown-summary'),
-    ).toHaveTextContent('3 of 4 have no value yet')
+    ).toHaveTextContent('3 of 4 without a figure')
   })
 })

--- a/src/canvas/model-tab-v2/__tests__/modelOutlineNamesTheRightAxis.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/modelOutlineNamesTheRightAxis.spec.tsx
@@ -1,0 +1,102 @@
+/**
+ * THE GROUP HEADING COUNTED ONE AXIS AND NAMED THE OTHER.
+ *
+ * The count is `primaryValue === null` — `getPrimaryValue`, i.e. **`raw_value`
+ * is undefined** — "nobody has SUPPLIED a number". Honest and useful, and
+ * unchanged by this spec. The SENTENCE said *"N of M have no value yet"*, which
+ * is the other question, and it was false.
+ *
+ * ── MEASURED, NOT IMAGINED ────────────────────────────────────────────────
+ * Live signed-in journey `20260826T082826Z-fresh-extended-17c4a0`
+ * (UI `d0e24ccc` / CEE `c24bfe3`), persisted graph at the cold re-read:
+ *
+ *   One-Off Migration and Setup Cost  value 1.3  raw_value 65000  user_set
+ *   Sales Rep Adoption Rate           value 0.6  raw_value —      ai_inferred
+ *   CRM Annual Licence Cost           value 0.5  raw_value 50000  ai_inferred
+ *   CRM Feature Fit for B2B Sales     value —    raw_value —      ai_inferred
+ *
+ * Two rows had no `raw_value`, so the heading said "2 of 4 have no value yet".
+ * **One of them HAS a value — Olumi estimated it at 0.6** and the product had
+ * already computed the words (`display_value: "High (0.6)"`). Four inches away
+ * the context pack said "one factor has no value", because CEE's `has_value`
+ * reads `value`. Neither surface lying; together incoherent — and that
+ * incoherence sent an expert lane chasing a regression that did not exist.
+ *
+ * ⚠ THE TWO PREDICATES STAY SEPARATE. `valueProvenance.ts:389` is explicit:
+ * *"NOT THE SAME QUESTION AS `no-value` (trap 21) … named apart on purpose
+ * rather than aligned."* This is not an alignment. It is the copy naming the
+ * axis it counts, and reading the other from the predicate that already exists.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ModelOutline } from '../ModelOutline'
+import type { ModelRow } from '../types'
+
+const row = (over: Partial<ModelRow>): ModelRow =>
+  ({
+    id: 'n1',
+    kind: 'factor',
+    group: 'factors',
+    label: 'A factor',
+    primaryValue: null,
+    attention: [],
+    editable: true,
+    ...over,
+  }) as ModelRow
+
+/** Set by the user — has a `raw_value`, so it is NOT counted. */
+const setRow = (id: string) =>
+  row({ id, label: `Set ${id}`, primaryValue: '£65k', attention: [] })
+
+/** Olumi estimated it: no `raw_value`, but a value the user can confirm. */
+const estimatedRow = (id: string) =>
+  row({ id, label: `Estimated ${id}`, primaryValue: null, attention: ['no-value', 'unconfirmed-estimate'] })
+
+/** Genuinely nothing: no value on either axis. */
+const emptyRow = (id: string) =>
+  row({ id, label: `Empty ${id}`, primaryValue: null, attention: ['no-value'] })
+
+function summaryText(rows: ModelRow[]): string | null {
+  render(<ModelOutline rows={rows} tier="plain" />)
+  const el = screen.queryByTestId('model-group-v2-factors-unknown-summary')
+  return el === null ? null : (el.textContent ?? '')
+}
+
+describe('the group heading names the axis it counts', () => {
+  it('PRECONDITION — the fixture really does reproduce the measured mix', () => {
+    // Without this the cases below could pass over rows that are not the shape
+    // the live journey found (trap 13b — pin your own precondition).
+    const e = estimatedRow('a')
+    expect(e.primaryValue).toBeNull()
+    expect(e.attention).toContain('unconfirmed-estimate')
+    expect(setRow('b').primaryValue).not.toBeNull()
+  })
+
+  it('⭐ never says "no value" about a factor Olumi has estimated', () => {
+    const out = summaryText([setRow('a'), estimatedRow('b'), setRow('c'), emptyRow('d')])
+    expect(out).not.toContain('have no value yet')
+    // Exact: the sentence is the whole claim, so containment would miss anything ADDED.
+    expect(out).toBe('2 of 4 not set by your team · Olumi estimated 1')
+  })
+
+  it('still says "no value yet" when NOTHING has been estimated — the honest case is preserved', () => {
+    const out = summaryText([setRow('a'), emptyRow('b'), emptyRow('c')])
+    expect(out).toBe('2 of 3 have no value yet')
+  })
+
+  it('counts every estimate, not just the first', () => {
+    const out = summaryText([estimatedRow('a'), estimatedRow('b'), emptyRow('c')])
+    expect(out).toBe('3 of 3 not set by your team · Olumi estimated 2')
+  })
+
+  it('THE COUNT IS UNCHANGED — this fix is the sentence, never the arithmetic', () => {
+    // The measured shape: 2 of 4 unset. If a later edit "fixes" the count by
+    // folding in estimates, this REDs — which is the whole point of the split.
+    const out = summaryText([setRow('a'), estimatedRow('b'), setRow('c'), emptyRow('d')])
+    expect(out).toMatch(/^2 of 4 /)
+  })
+
+  it('renders NOTHING when every row is set — a group states no zero', () => {
+    expect(summaryText([setRow('a'), setRow('b')])).toBeNull()
+  })
+})

--- a/src/canvas/model-tab-v2/__tests__/modelOutlineNamesTheRightAxis.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/modelOutlineNamesTheRightAxis.spec.tsx
@@ -30,6 +30,7 @@
 import { describe, it, expect } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { ModelOutline } from '../ModelOutline'
+import { toModelRows } from '../adapters'
 import type { ModelRow } from '../types'
 
 const row = (over: Partial<ModelRow>): ModelRow =>
@@ -40,6 +41,7 @@ const row = (over: Partial<ModelRow>): ModelRow =>
     label: 'A factor',
     primaryValue: null,
     attention: [],
+    provenanceSource: undefined,
     editable: true,
     ...over,
   }) as ModelRow
@@ -76,17 +78,17 @@ describe('the group heading names the axis it counts', () => {
     const out = summaryText([setRow('a'), estimatedRow('b'), setRow('c'), emptyRow('d')])
     expect(out).not.toContain('have no value yet')
     // Exact: the sentence is the whole claim, so containment would miss anything ADDED.
-    expect(out).toBe('2 of 4 not set by your team · Olumi estimated 1')
+    expect(out).toBe('2 of 4 without a figure · Olumi estimated 1')
   })
 
   it('still says "no value yet" when NOTHING has been estimated — the honest case is preserved', () => {
     const out = summaryText([setRow('a'), emptyRow('b'), emptyRow('c')])
-    expect(out).toBe('2 of 3 have no value yet')
+    expect(out).toBe('2 of 3 without a figure')
   })
 
   it('counts every estimate, not just the first', () => {
     const out = summaryText([estimatedRow('a'), estimatedRow('b'), emptyRow('c')])
-    expect(out).toBe('3 of 3 not set by your team · Olumi estimated 2')
+    expect(out).toBe('3 of 3 without a figure · Olumi estimated 2')
   })
 
   it('THE COUNT IS UNCHANGED — this fix is the sentence, never the arithmetic', () => {
@@ -94,6 +96,120 @@ describe('the group heading names the axis it counts', () => {
     // folding in estimates, this REDs — which is the whole point of the split.
     const out = summaryText([setRow('a'), estimatedRow('b'), setRow('c'), emptyRow('d')])
     expect(out).toMatch(/^2 of 4 /)
+  })
+
+  /*
+   * ⛔ THE AUTHORSHIP GATE. The first cut said "not set by your team" about the
+   * whole `unset` population. Measured end-to-end: editing a factor that carries
+   * `value` with no `raw_value` persists `{value: 0.8, source: 'user'}` — the row
+   * comes back `{primaryValue: null, provenanceSource: 'user'}`, so the heading
+   * told the user the factor they had JUST TYPED was not set by them.
+   *
+   * Authorship is now DERIVED from the shared taxonomy, never asserted over the
+   * count. A third axis, deliberately not aligned with the other two.
+   */
+  it('⛔ NEVER tells the user a value THEY set is not theirs', () => {
+    const userSet = row({
+      id: 'u',
+      label: 'User typed this',
+      primaryValue: null,
+      attention: ['no-value'],
+      provenanceSource: 'user',
+    })
+    const out = summaryText([userSet, emptyRow('b')])
+    // ⚠ ASSERTS ONLY THE AUTHORSHIP AXIS. An exact full-string match here would
+    // also fail on any head-wording change, making this case indistinguishable
+    // from the head guard — measured: two different mutants failed the identical
+    // six cases, so the kit proved sensitivity without specificity.
+    expect(out).not.toMatch(/not set by your team/i)
+    expect(out).toMatch(/\byou set 1\b/)
+  })
+
+  it('DISCRIMINATING — a producer value is NOT credited to the user', () => {
+    // Without this, "userOwned everything" satisfies the case above while
+    // inventing authorship the taxonomy does not support.
+    const inferred = row({
+      id: 'i',
+      label: 'Olumi inferred this',
+      primaryValue: null,
+      attention: ['no-value'],
+      provenanceSource: 'cee_inference',
+    })
+    const out = summaryText([inferred, emptyRow('b')])
+    // Authorship axis only — see the note above.
+    expect(out).not.toMatch(/you set/i)
+  })
+
+  /*
+   * ⭐ THE CROSS-PR GAP (#867 × #866), closed by the HEAD WORDING rather than by
+   * widening the count.
+   *
+   * #867 renders a producer BAND in the value cell ("Olumi: 0.25 to 0.75") for a
+   * factor with no numeric `observedState.value`. `factorIsConfirmable` requires
+   * a finite value, so such a row is NOT `unconfirmed-estimate` and the estimate
+   * clause does not fire. Under the old head that produced "1 of 1 have no value
+   * yet" DIRECTLY ABOVE a visible value.
+   *
+   * Widening the count to `|| estimateText !== undefined` would have been a
+   * SECOND answer to "has Olumi estimated this?" — the shape this file refused
+   * in the first place. A band is simply not a figure, so the head is true and
+   * the cell is true, together.
+   */
+  it('⭐ a producer BAND does not make the heading claim there is no value', () => {
+    const band = row({
+      id: 'band',
+      label: 'CRM Feature Fit',
+      primaryValue: null,
+      attention: ['no-value'],
+      estimateText: '0.25 to 0.75',
+    })
+    const out = summaryText([band])
+    // HEAD axis only, so this case discriminates a head-wording regression from
+    // an authorship one.
+    expect(out).not.toMatch(/no value/i)
+    expect(out).not.toMatch(/you set/i)
+  })
+
+  /*
+   * ⭐⭐ THE CROSS-PR INTERACTION, PROVEN AS ONE RENDER RATHER THAN TWO CLAIMS.
+   *
+   * The heading and the value cell were built in separate PRs and each was
+   * reviewed against base in isolation, so neither review could see the pair.
+   * Independent adjudication found the gap: the cell renders a producer band for
+   * a factor with no numeric value, while the heading's estimate clause requires
+   * `factorIsConfirmable`, which needs a finite one — so the old head said
+   * "have no value yet" DIRECTLY ABOVE a visible value.
+   *
+   * This drives the REAL adapter, so it fails if either side regresses, and it
+   * asserts the two elements are consistent WITH EACH OTHER rather than each
+   * being separately defensible.
+   */
+  it('⭐⭐ heading and cell do not contradict each other on a band-only factor', () => {
+    const rows = toModelRows({
+      nodes: [
+        {
+          id: 'band',
+          type: 'factor',
+          data: { label: 'CRM Feature Fit', kind: 'factor', display_value: '0.25 to 0.75' },
+        },
+      ],
+      edges: [],
+    } as never)
+
+    // PRECONDITION — the real adapter really did produce the shape the gap needs:
+    // a band in the cell and NO confirmable estimate for the heading.
+    expect(rows[0].estimateText).toBe('0.25 to 0.75')
+    expect(rows[0].attention).not.toContain('unconfirmed-estimate')
+
+    render(<ModelOutline rows={rows} tier="plain" />)
+    const heading = screen.getByTestId('model-group-v2-factors-unknown-summary').textContent ?? ''
+    const cell = screen.getByTestId('model-row-v2-band-value-estimate').textContent ?? ''
+
+    // The cell shows Olumi's band …
+    expect(cell).toBe('Olumi: 0.25 to 0.75')
+    // … and the heading above it does not deny that a value exists.
+    expect(heading).not.toMatch(/no value/i)
+    expect(heading).toContain('without a figure')
   })
 
   it('renders NOTHING when every row is set — a group states no zero', () => {

--- a/src/canvas/model-tab-v2/__tests__/modelOutlineNamesTheRightAxis.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/modelOutlineNamesTheRightAxis.spec.tsx
@@ -78,24 +78,28 @@ describe('the group heading names the axis it counts', () => {
     const out = summaryText([setRow('a'), estimatedRow('b'), setRow('c'), emptyRow('d')])
     expect(out).not.toContain('have no value yet')
     // Exact: the sentence is the whole claim, so containment would miss anything ADDED.
-    expect(out).toBe('2 of 4 without a figure · Olumi estimated 1')
+    expect(out).toBe('1 with no value yet · 1 estimated by Olumi')
   })
 
   it('still says "no value yet" when NOTHING has been estimated — the honest case is preserved', () => {
     const out = summaryText([setRow('a'), emptyRow('b'), emptyRow('c')])
-    expect(out).toBe('2 of 3 without a figure')
+    expect(out).toBe('2 with no value yet')
   })
 
   it('counts every estimate, not just the first', () => {
     const out = summaryText([estimatedRow('a'), estimatedRow('b'), emptyRow('c')])
-    expect(out).toBe('3 of 3 without a figure · Olumi estimated 2')
+    expect(out).toBe('1 with no value yet · 2 estimated by Olumi')
   })
 
   it('THE COUNT IS UNCHANGED — this fix is the sentence, never the arithmetic', () => {
     // The measured shape: 2 of 4 unset. If a later edit "fixes" the count by
     // folding in estimates, this REDs — which is the whole point of the split.
     const out = summaryText([setRow('a'), estimatedRow('b'), setRow('c'), emptyRow('d')])
-    expect(out).toMatch(/^2 of 4 /)
+    // The COUNT is now expressed as a disjoint decomposition, so the guard is
+    // that the buckets still SUM to the unset population — folding estimates
+    // into `unset` would change that total.
+    const nums = [...(out ?? '').matchAll(/(\d+)/g)].map(m => Number(m[1]))
+    expect(nums.reduce((a, b) => a + b, 0)).toBe(2)
   })
 
   /*
@@ -209,7 +213,75 @@ describe('the group heading names the axis it counts', () => {
     expect(cell).toBe('Olumi: 0.25 to 0.75')
     // … and the heading above it does not deny that a value exists.
     expect(heading).not.toMatch(/no value/i)
-    expect(heading).toContain('without a figure')
+    expect(heading).toBe('1 estimated by Olumi')
+  })
+
+  /*
+   * ⛔⛔ THE THIRD REFUTED HEAD, AND WHY THERE IS NO LONGER A HEAD.
+   *
+   * `estimateText` is CEE's `display_value` through `readFactorDisplayValue`,
+   * gated only on EMPTINESS — it is NOT restricted to bands and qualitative
+   * text. The estate's own fixtures carry '£20,000' (11 occurrences), '£30k',
+   * '£49', '3 months', '20%', '0.7'. So "without a figure" was false the moment
+   * a row rendered "Olumi: £20,000" beneath it.
+   *
+   * Three heads, three classes each corpus excluded. The population is
+   * HETEROGENEOUS, so no adjective can be true of it — which is why this states
+   * the composition rather than characterising it.
+   */
+  it('⛔ a NUMERIC estimate is never called figureless — the third refutation, pinned', () => {
+    const numeric = row({
+      id: 'n',
+      label: 'Annual CRM Licence Cost',
+      primaryValue: null,
+      attention: ['no-value'],
+      estimateText: '£20,000',
+    })
+    const out = summaryText([numeric])
+    expect(out).not.toMatch(/without a figure/i)
+    expect(out).not.toMatch(/no value/i)
+    expect(out).toBe('1 estimated by Olumi')
+  })
+
+  /*
+   * ⚠ THE OVERLAP CASE, ADDED AFTER A MUTANT SURVIVED. The first disjointness
+   * test used three rows that each satisfied exactly ONE bucket condition, so
+   * removing the `userOwned !== true` exclusion from Olumi's bucket — which
+   * makes the buckets overlap — changed nothing and passed. A disjointness test
+   * whose fixture cannot produce an overlap asserts nothing about disjointness.
+   *
+   * This row is BOTH user-owned AND carries `estimateText`, which is a real
+   * shape: a user can set a value on a factor CEE has also sent display text
+   * for. It must be counted ONCE, as theirs.
+   */
+  it('DISJOINT — a row that satisfies TWO conditions is counted once, as the user\'s', () => {
+    const both = row({
+      id: 'both',
+      label: 'User set, Olumi also has text',
+      primaryValue: null,
+      attention: ['no-value', 'unconfirmed-estimate'],
+      provenanceSource: 'user',
+      estimateText: '£20,000',
+    })
+    const out = summaryText([both, emptyRow('x')])
+    expect(out).toBe('1 with no value yet · you set 1')
+    // and the buckets still sum to the unset population — not 3 from 2 rows.
+    const nums = [...(out ?? '').matchAll(/(\d+)/g)].map(m => Number(m[1]))
+    expect(nums.reduce((a, b) => a + b, 0)).toBe(2)
+  })
+
+  it('DISJOINT — every unset row lands in exactly one bucket, and they sum', () => {
+    // Without this, a row could be counted twice (or dropped) and each clause
+    // would still read as true on its own.
+    const out = summaryText([
+      emptyRow('a'),
+      row({ id: 'b', primaryValue: null, attention: ['no-value'], estimateText: '£20,000' }),
+      row({ id: 'c', primaryValue: null, attention: ['no-value'], provenanceSource: 'user' }),
+      setRow('d'),
+    ])
+    const nums = [...(out ?? '').matchAll(/(\d+)/g)].map(m => Number(m[1]))
+    expect(nums.reduce((a, b) => a + b, 0)).toBe(3)
+    expect(out).toBe('1 with no value yet · 1 estimated by Olumi · you set 1')
   })
 
   it('renders NOTHING when every row is set — a group states no zero', () => {

--- a/src/canvas/model-tab-v2/__tests__/rowShowsOlumisEstimate.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/rowShowsOlumisEstimate.spec.tsx
@@ -135,8 +135,14 @@ describe('the row shows what Olumi computed for a value nobody has set', () => {
     expect(screen.getByTestId('model-row-v2-f1-value-estimate').textContent).toBe(
       `Olumi: ${RANGE}`,
     )
-    expect(screen.getByTestId('model-group-v2-factors-unknown-summary').textContent).toContain(
-      '1 of 1',
+    // ⚠ PREMISE UPDATED — and this case is why the heading changed at all.
+    // It asserted the heading's "N of M" prefix. Adjudication found this exact
+    // pairing was the cross-PR defect: the cell renders Olumi's band while the
+    // heading called the row valueless. The heading now states its composition
+    // in disjoint buckets, so it names this row as Olumi's rather than as empty
+    // — which is the consistency this case was always really about.
+    expect(screen.getByTestId('model-group-v2-factors-unknown-summary').textContent).toBe(
+      '1 estimated by Olumi',
     )
   })
 


### PR DESCRIPTION
## Two surfaces, four inches apart, disagreeing about the same model

Measured on a **live signed-in journey** — run `20260826T082826Z-fresh-extended-17c4a0`, quartet UI `d0e24ccc` / CEE `c24bfe3` / PLoT `3a3bee5` / ISL `28fe0c95`. Persisted graph at the cold re-read:

| factor | `value` | `raw_value` | provenance | `display_value` |
|---|---|---|---|---|
| One-Off Migration and Setup Cost | 1.3 | 65000 | user_set | £65k |
| Sales Rep Adoption Rate | 0.6 | **—** | ai_inferred | **High (0.6)** |
| CRM Annual Licence Cost | 0.5 | 50000 | ai_inferred | 50,000 |
| CRM Feature Fit for B2B Sales | **—** | **—** | ai_inferred | **0.25 to 0.75** |

Two rows carry no `raw_value`, so the heading said **"2 of 4 have no value yet"**.

**One of those two has a value.** Olumi estimated it at 0.6, and the product had already computed the words for it. Four inches away the context pack said *"one factor has no value"*, because CEE's `has_value` reads `value`.

**Neither surface was lying.** Together they were incoherent — and that incoherence sent an expert lane chasing a regression that did not exist, with the persisted state one command away. It will do worse to a user who has no such option.

## The count is unchanged, and that is the point

`primaryValue === null` is `getPrimaryValue`, i.e. **`raw_value` is undefined** — *"nobody has supplied a number"*. That is a useful, honest question and the tab was answering it correctly.

**The defect was never the arithmetic; it was the sentence naming the other question.** A guard pins the count so that a later "fix" folding estimates into it goes red.

## The two predicates stay separate

`valueProvenance.ts:389` is explicit:

> *"NOT THE SAME QUESTION AS `no-value` (trap 21) … named apart on purpose rather than aligned."*

So this is **not** an alignment. The copy now names the axis it counts, and reads the other from `factorIsConfirmable` — surfaced as the `unconfirmed-estimate` attention reason — rather than deriving half of it locally.

That is the same correction `ModelRowView`'s confirm chip already received. Its own header records it: it read `primaryValue !== null` to answer a `value` question and *"hid on rows the authority would have accepted"*. **This is that defect's twin, living in the copy.**

## Evidence

Pristine archive outside the tree, isolation proven by **sentinel write**, inodes compared, applied-check 1 per mutation, trailing control 6/6.

| mutant | result | proves |
|---|---|---|
| revert to the old sentence | **RED** 2/6 | the fix is load-bearing |
| fold estimates **into the count** | **RED** 3/6 | a **different** assertion — the count guard bites |

⭐ **The pre-existing sibling spec `ModelOutline.unknownsAreSummarised.spec.tsx` asserts `"3 of 4 have no value yet"` verbatim and still passes 7/7** — its fixture carries no estimates, so the honest case is preserved byte-for-byte. An independent, pre-existing guard proving this did not swallow the old behaviour while changing it.

Typecheck gate **PASSED at exactly baseline 2252 errors / 556 files**.

## Rowed, not taken here

The factor **row** ignores `display_value` while the option-intervention path *in the same file* honours it — `adapters.ts:782`, *"a CEE-authored `display_value` wins the DISPLAY"*. So the product computes **"High (0.6)"** and **"0.25 to 0.75"** and shows neither. That is a larger change touching the ACT affordance and belongs in its own PR.
