### PR TITLE
C+D — the row shows the band Olumi computed, instead of a blank cell [IN-class]

### DIFF
--- a/src/canvas/model-tab-v2/ModelRowView.tsx
+++ b/src/canvas/model-tab-v2/ModelRowView.tsx
@@ -447,10 +447,40 @@ function ValueCell({
    * plus one marker, which is the difference between stating a fact and
    * shouting it.
    */
+  /*
+   * ⭐ OLUMI'S OWN TEXT, BESIDE THE AFFORDANCE — NEVER INSTEAD OF IT.
+   *
+   * `estimateText` is present only on rows nobody has SET, and it carries what
+   * CEE computed for them — including, on the row that matters most, a RANGE
+   * ("0.25 to 0.75"). The product was holding that band and showing nothing.
+   *
+   * ⚠ THE INVERSE HARM IS THE ONE TO PRICE, AND IT DECIDES THIS SHAPE. If the
+   * cell rendered the estimate ALONE, a user would read it as a value that IS
+   * set — while the affordance correctly still asks them to set one, and the
+   * row would contradict its own button. So both axes render together: the
+   * control keeps saying "Not set" and does what it always did, and Olumi's
+   * text sits beside it, attributed, in secondary type. Nothing here re-derives
+   * a value; this component still renders what the projection handed it.
+   *
+   * It is NOT a "Not set" wall: that rule exists because N identical inert
+   * strings drown the outline. These strings are distinct per row and each one
+   * is a fact the product computed.
+   */
+  const estimate =
+    display === null && row.estimateText !== undefined ? (
+      <span
+        data-testid={`${testid}-estimate`}
+        className={`${typography.caption} text-text-light ml-2`}
+      >
+        Olumi: {row.estimateText}
+      </span>
+    ) : null
+
   if (!row.editable || !editorAvailable) {
     return (
       <span data-testid={testid} className={typography.tabular}>
         {display ?? ''}
+        {estimate}
       </span>
     )
   }
@@ -468,6 +498,7 @@ function ValueCell({
       }}
     >
       {display ?? 'Not set'}
+      {estimate}
     </button>
   )
 }

--- a/src/canvas/model-tab-v2/__tests__/rowShowsOlumisEstimate.spec.tsx
+++ b/src/canvas/model-tab-v2/__tests__/rowShowsOlumisEstimate.spec.tsx
@@ -1,0 +1,151 @@
+/**
+ * THE PRODUCT COMPUTED A RANGE AND SHOWED THE USER NOTHING.
+ *
+ * Measured on a live signed-in journey `20260826T082826Z-fresh-extended-17c4a0`
+ * (UI `d0e24ccc` / CEE `c24bfe3`). The persisted graph, at the cold re-read:
+ *
+ *   Sales Rep Adoption Rate   value 0.6  raw_value —  display_value "High (0.6)"
+ *   CRM Feature Fit for B2B   value —    raw_value —  display_value "0.25 to 0.75"
+ *
+ * `getPrimaryValue` returns null when `raw_value` is undefined, so BOTH rows
+ * rendered blank. The second is a BAND OF UNCERTAINTY the product computed,
+ * holds, and discarded at the last inch.
+ *
+ * ⚠ AND IT WAS NEVER A MISSING CAPABILITY. `readFactorDisplayValue` already
+ * exists and is already shared by `FactorNode`, the inspector-v2 panels and the
+ * debug bundle, "so every consumer shares one priority rule instead of
+ * re-implementing it". The Model tab was the one surface not on it — and the
+ * option-intervention path IN THE SAME FILE already honoured the field
+ * (`adapters.ts`: "a CEE-authored display_value wins the DISPLAY").
+ *
+ * ── THE CONSTRAINT THIS SPEC EXISTS TO HOLD ───────────────────────────────
+ * DISPLAY reads `display_value`. AFFORDANCE keeps reading `raw_value`.
+ * Two questions, not one (trap 21, third time on this seam).
+ *
+ * The inverse harm is the reason: an estimate rendered ALONE reads as a value
+ * that IS set, while the affordance correctly still asks the user to set one —
+ * the row would contradict its own button. So the cases below pin BOTH axes on
+ * the same row, and a mutant that lets the estimate stand in for the value
+ * must RED.
+ */
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { toModelRows } from '../adapters'
+import { ModelOutline } from '../ModelOutline'
+
+/** The live shapes, reproduced exactly — including TOP-LEVEL `display_value`. */
+const node = (id: string, label: string, obs: unknown, displayValue?: string) => ({
+  id,
+  type: 'factor',
+  data: {
+    label,
+    kind: 'factor',
+    ...(obs === undefined ? {} : { observedState: obs }),
+    ...(displayValue === undefined ? {} : { display_value: displayValue }),
+  },
+})
+
+const RANGE = '0.25 to 0.75'
+const ESTIMATE = 'High (0.6)'
+
+function rowsFor(nodes: unknown[]) {
+  return toModelRows({ nodes, edges: [] } as never)
+}
+
+describe('the row shows what Olumi computed for a value nobody has set', () => {
+  it('PRECONDITION — the fixture reproduces the live shape (top-level display_value, no raw_value)', () => {
+    // Pin the precondition in-test: measured on the wire, `display_value` was
+    // TOP-LEVEL in 11 of 11 occurrences and nested in ZERO. A fixture that
+    // nested it would pass against a reader this one does not exercise.
+    const n = node('f1', 'CRM Feature Fit', undefined, RANGE)
+    expect((n.data as Record<string, unknown>).display_value).toBe(RANGE)
+    expect((n.data as Record<string, unknown>).observedState).toBeUndefined()
+  })
+
+  it('⭐ ROW 4 — a computed RANGE reaches the user instead of a blank cell', () => {
+    const rows = rowsFor([node('f1', 'CRM Feature Fit', undefined, RANGE)])
+    expect(rows[0].primaryValue).toBeNull()
+    expect(rows[0].estimateText).toBe(RANGE)
+  })
+
+  it('an estimated point value reaches the user too', () => {
+    const rows = rowsFor([node('f2', 'Sales Rep Adoption', { value: 0.6 }, ESTIMATE)])
+    expect(rows[0].estimateText).toBe(ESTIMATE)
+  })
+
+  it('⛔ A SUPPLIED VALUE IS NEVER MASKED — estimateText is absent when the user set one', () => {
+    // Structural, not incidental: a CEE string must never stand where a person's
+    // own number belongs. Same direction as the canonical priority chain.
+    const rows = rowsFor([
+      node('f3', 'One-Off Migration', { raw_value: 65000, unit: '£' }, '£65k'),
+    ])
+    expect(rows[0].primaryValue).not.toBeNull()
+    expect(rows[0].estimateText).toBeUndefined()
+  })
+
+  it('⛔ THE AFFORDANCE AXIS IS UNTOUCHED — an estimated row still asks to be set', () => {
+    // The whole constraint in one assertion. If a later change lets the estimate
+    // satisfy the affordance, this REDs.
+    const rows = rowsFor([node('f1', 'CRM Feature Fit', undefined, RANGE)])
+    expect(rows[0].primaryValue).toBeNull()
+    expect(rows[0].attention).toContain('no-value')
+  })
+
+  /*
+   * ⚠ THIS CASE EXISTS BECAUSE ITS FIRST VERSION EXERCISED THE WRONG ARM.
+   *
+   * `ModelRowView` has TWO value-cell arms — a silent `<span>` when no editor is
+   * connected, and the `Not set` BUTTON when one is
+   * (`editorAvailable = row.editable && editConnected && typeof onBeginEdit === 'function'`).
+   * A render with no callbacks takes the span. So the mutant that matters —
+   * rendering the estimate INSTEAD of "Not set", the inverse harm this whole
+   * design exists to prevent — mutated the BUTTON arm and my assertions never
+   * reached it: 7/7 GREEN on a mutant that shipped the exact defect.
+   *
+   * A passing test proves nothing until you know which path it took. Both arms
+   * are now pinned, and the button arm asserts the two axes are SEPARATE
+   * elements rather than one merged string.
+   */
+  it('BOTH AXES, EDITOR ARM — the estimate sits beside "Not set", never instead of it', () => {
+    const rows = rowsFor([node('f1', 'CRM Feature Fit', undefined, RANGE)])
+    render(
+      <ModelOutline
+        rows={rows}
+        tier="plain"
+        editConnectedIds={new Set(['f1'])}
+        onBeginEdit={() => {}}
+      />,
+    )
+    // PRECONDITION: we really are on the button arm, not the silent span.
+    const control = screen.getByTestId('model-row-v2-f1-value')
+    expect(control.tagName).toBe('BUTTON')
+
+    // The affordance still states the row is not set …
+    expect(control.textContent).toContain('Not set')
+    // … and Olumi's text is a SEPARATE element beside it, not a substitute.
+    expect(screen.getByTestId('model-row-v2-f1-value-estimate').textContent).toBe(
+      `Olumi: ${RANGE}`,
+    )
+  })
+
+  it('BOTH AXES, READ-ONLY ARM — the estimate still reaches the user', () => {
+    const rows = rowsFor([node('f1', 'CRM Feature Fit', undefined, RANGE)])
+    render(<ModelOutline rows={rows} tier="plain" />)
+    expect(screen.getByTestId('model-row-v2-f1-value').tagName).not.toBe('BUTTON')
+    expect(screen.getByTestId('model-row-v2-f1-value-estimate').textContent).toBe(
+      `Olumi: ${RANGE}`,
+    )
+    expect(screen.getByTestId('model-group-v2-factors-unknown-summary').textContent).toContain(
+      '1 of 1',
+    )
+  })
+
+  it('DISCRIMINATING — no estimate element at all when CEE supplied no text', () => {
+    // Without this, "always render something" would satisfy every case above
+    // while inventing a value on a row that genuinely has none.
+    const rows = rowsFor([node('f4', 'Bare factor', undefined, undefined)])
+    expect(rows[0].estimateText).toBeUndefined()
+    render(<ModelOutline rows={rows} tier="plain" />)
+    expect(screen.queryByTestId('model-row-v2-f4-value-estimate')).toBeNull()
+  })
+})

--- a/src/canvas/model-tab-v2/adapters.ts
+++ b/src/canvas/model-tab-v2/adapters.ts
@@ -115,6 +115,7 @@
  */
 
 import type { Edge, Node } from '@xyflow/react'
+import { readFactorDisplayValue } from '../../utils/formatFactorDisplayValue'
 import { goalLabelIsUnconfirmedBriefExtract } from '../domain/goalLabelProvenance'
 import type { EdgeData } from '../domain/edges'
 import type { ObservedState } from '../domain/nodes'
@@ -443,7 +444,24 @@ export function toModelRows(input: ModelProjectionInput): ModelRow[] {
         group: KIND_GROUP[kind],
         label,
         primaryValue: value,
+        // ⭐ ONLY WHEN NOBODY SUPPLIED A VALUE — see `ModelRow.estimateText`.
+        // Read through `readFactorDisplayValue`, the SHARED reader that already
+        // honours CEE's wire shape (top-level `display_value` first, then
+        // `observedState.display_value`). Measured on the live journey: 11 of 11
+        // occurrences are TOP-LEVEL and zero are nested, so a nested-only read
+        // would have found nothing. Not re-implemented here — `FactorNode`, the
+        // inspector-v2 panels and the debug bundle already share it, and the
+        // Model tab was the one surface not on it.
+        ...(value === null
+          ? (() => {
+              const text = readFactorDisplayValue(data)
+              return text === undefined ? {} : { estimateText: text }
+            })()
+          : {}),
         provenanceSource: typeof obs?.source === 'string' ? obs.source : undefined,
+        // ⚠ UNCHANGED, DELIBERATELY. `attention` is the AFFORDANCE axis and it
+        // still reads `value` (i.e. `raw_value`). A row with an estimate and no
+        // supplied value must still ask for one.
         attention: attentionForFactor(data, value),
         editable: true,
       })

--- a/src/canvas/model-tab-v2/types.ts
+++ b/src/canvas/model-tab-v2/types.ts
@@ -156,6 +156,34 @@ export interface ModelRow {
    */
   primaryValue: string | null
   /**
+   * ⭐ CEE'S OWN DISPLAY TEXT, FOR A ROW THE USER HAS NOT SET — and ONLY then.
+   *
+   * `primaryValue` is `raw_value`: what a person SUPPLIED. When nobody has,
+   * Olumi has often still computed something and written the words for it. On a
+   * live signed-in journey (`20260826T082826Z-fresh-extended-17c4a0`) the
+   * persisted graph carried, on rows the outline rendered as blank:
+   *
+   *   Sales Rep Adoption Rate   display_value "High (0.6)"     value 0.6
+   *   CRM Feature Fit for B2B   display_value "0.25 to 0.75"   value —
+   *
+   * The second is a RANGE — the product computed a band of uncertainty, holds
+   * it, and showed the user neither the band nor anything else.
+   *
+   * ⚠ THIS SITS BESIDE `primaryValue` AND NEVER REPLACES IT (trap 21, the third
+   * time on this seam). Two questions: *what should this row SHOW?* and *what
+   * does this row still NEED from the user?* They have different answers on a
+   * row with an estimate and no `raw_value`, which is exactly the row that
+   * matters. So DISPLAY reads this; the AFFORDANCE — `attention`, the editor
+   * button, `valueAffordance` — keeps reading `primaryValue`, untouched.
+   *
+   * Populated ONLY when `primaryValue === null`, so a CEE string can never mask
+   * a value the user actually set. That is the same direction as the canonical
+   * priority chain (`FactorDisplayInput.display_value`: a fresh `raw_value` with
+   * a meaningful unit outranks `display_value`), enforced structurally here
+   * rather than re-implemented.
+   */
+  estimateText?: string
+  /**
    * The RAW provenance stamp as the model recorded it (`'brief_extraction'`,
    * `'cee_inference'`, `'user_confirmed'`, …) — NOT a classified kind.
    *


### PR DESCRIPTION
## The product computed uncertainty and threw it away at the last inch

Measured on a **live signed-in journey** — `20260826T082826Z-fresh-extended-17c4a0`, UI `d0e24ccc` / CEE `c24bfe3`. Persisted graph at the cold re-read:

| factor | `value` | `raw_value` | `display_value` | rendered |
|---|---|---|---|---|
| Sales Rep Adoption Rate | 0.6 | — | **High (0.6)** | *blank* |
| CRM Feature Fit for B2B | — | — | **0.25 to 0.75** | *blank* |

`getPrimaryValue` returns null when `raw_value` is undefined, so both rendered as an empty cell.

**The second is a band.** The product worked out a range of uncertainty for a factor nobody has pinned down, holds it on the node, and showed the user neither the band nor anything else. Surfacing uncertainty that matters is the reasoning capability — and it was already built.

## It was never a missing capability, which is why this is small

`readFactorDisplayValue` already exists and is already shared by `FactorNode`, the inspector-v2 panels and the debug bundle —

> *"single source of truth so every consumer shares one priority rule instead of re-implementing it"*

**The Model tab was the one surface not on it.** And the option-intervention path *in the same file* already honoured the field (*"a CEE-authored `display_value` wins the DISPLAY"*). Nothing is invented here; a second consumer converges on the authority that already exists.

## ⚠ The container matters — a nested-only read would have found nothing

On the wire, `display_value` is **top-level in 11 of 11 occurrences and nested in zero** (contrast control `observed_state` = 3, negative control = 0) — while the UI's own `ObservedStateData` type declares it *inside* `observed_state`. `readFactorDisplayValue` honours both, top-level first. Using it rather than reaching for the field directly is what makes this correct.

## Display reads `display_value`. Affordance keeps reading `raw_value`.

Two questions, not one — **the third time this seam has produced that defect** (`ModelRowView`'s confirm chip, then the group heading, now this).

- `estimateText` is populated **only** when `primaryValue === null`, so a CEE string can never mask a number a person supplied.
- `attention` is untouched, so a row with an estimate **still asks to be set**.
- The cell renders **both**: the control still says "Not set" and does what it always did, with Olumi's text beside it, attributed, in secondary type.

**The inverse harm is why.** An estimate rendered alone reads as a value that *is* set, while the affordance correctly still asks for one — and the row would contradict its own button.

## Evidence

Pristine archive outside the tree, isolation proven by sentinel write, inodes compared, applied-check 1 per mutation, trailing control 8/8. **286/286 green** across the directory's 18 sibling specs.

| mutant | result |
|---|---|
| never populate `estimateText` | **RED** 3/8 |
| mask a supplied value | **RED** 1/8 |
| collapse the axes (estimate satisfies the affordance) | **RED** 1/8 |
| render the estimate **instead of** "Not set" | **RED** 1/8 |
| drop the estimate from the read-only arm only | **RED** 1/8 (different assertion) |

### ⚠ Instrument defect in my own kit, disclosed

**The fourth mutant — the exact inverse harm this design exists to prevent — survived 7/7 on the first run.**

`ModelRowView` has two value-cell arms, and a render with no callbacks takes the silent one. The mutant changed the **button** arm, which my assertions never reached. A passing test proves nothing until you know which path it took. The spec now **pins the arm it is on before asserting**, and covers both.
