### PR TITLE
D — the first thing a user reads invites a challenge, not only a decision [IN-class]

### DIFF
--- a/src/canvas/components/FirstUseComposer.tsx
+++ b/src/canvas/components/FirstUseComposer.tsx
@@ -1,4 +1,8 @@
 import { memo, useCallback, useEffect, useRef } from 'react'
+
+/** The first-use hero's own entry copy — exported so its guard reads the real string. */
+export const FIRST_USE_PLACEHOLDER =
+  "Describe the decision or challenge you’re working through, any options you’re weighing, and what a good outcome looks like."
 import { createPortal } from 'react-dom'
 import { AlertCircle } from 'lucide-react'
 import { useCanvasStore } from '../store'
@@ -340,8 +344,16 @@ export const FirstUseComposer = memo(function FirstUseComposer({ onCogClick, blu
           variant="welcome"
           onCogClick={onCogClick}
           hideChevron
-          placeholder="Describe your decision, goal, options, and any assumptions, risks or constraints you’re aware of."
-          ariaLabel="Describe your decision"
+          /*
+           * ⭐ THIS SURFACE PASSES ITS OWN COPY, SO THE HOOK CHANGE NEVER REACHED IT.
+           * `AIInputBar` resolves `placeholder ?? stagePlaceholder` — an explicit
+           * prop WINS — so widening `useStageAwarePlaceholder` left the FIRST-USE
+           * screen, the most prominent entry surface there is, still demanding a
+           * decision. Correcting only the claim about it would have made the
+           * change accurate and left the defect where it matters most.
+           */
+          placeholder={FIRST_USE_PLACEHOLDER}
+          ariaLabel="Describe your decision or challenge"
           testId="first-use-input-bar"
           onAfterSend={handleAfterSend}
         />

--- a/src/canvas/components/FirstUseComposer.tsx
+++ b/src/canvas/components/FirstUseComposer.tsx
@@ -1,8 +1,7 @@
 import { memo, useCallback, useEffect, useRef } from 'react'
+import { FIRST_USE_PLACEHOLDER } from './firstUsePlaceholder'
 
-/** The first-use hero's own entry copy — exported so its guard reads the real string. */
-export const FIRST_USE_PLACEHOLDER =
-  "Describe the decision or challenge you’re working through, any options you’re weighing, and what a good outcome looks like."
+
 import { createPortal } from 'react-dom'
 import { AlertCircle } from 'lucide-react'
 import { useCanvasStore } from '../store'

--- a/src/canvas/components/OlumiTabBody.tsx
+++ b/src/canvas/components/OlumiTabBody.tsx
@@ -4,7 +4,7 @@ import { memo, useCallback, useEffect } from 'react'
 // while `FirstUseComposer` passes it as a placeholder ATTRIBUTE, so a grep for
 // one shape does not find the other. Bound to the shared constant so the two
 // cannot drift apart again.
-import { FIRST_USE_PLACEHOLDER } from './FirstUseComposer'
+import { FIRST_USE_PLACEHOLDER } from './firstUsePlaceholder'
 import { ExternalLink } from 'lucide-react'
 import { typo } from '../../styles/typography'
 import { useConversationContext } from '../conversation/ConversationContext'

--- a/src/canvas/components/OlumiTabBody.tsx
+++ b/src/canvas/components/OlumiTabBody.tsx
@@ -1,4 +1,10 @@
 import { memo, useCallback, useEffect } from 'react'
+// ⭐ THE FIFTH ENTRY SURFACE, and it had its OWN copy of the string.
+// Found by a spec, not by the sweep: this renders the first-use line as TEXT
+// while `FirstUseComposer` passes it as a placeholder ATTRIBUTE, so a grep for
+// one shape does not find the other. Bound to the shared constant so the two
+// cannot drift apart again.
+import { FIRST_USE_PLACEHOLDER } from './FirstUseComposer'
 import { ExternalLink } from 'lucide-react'
 import { typo } from '../../styles/typography'
 import { useConversationContext } from '../conversation/ConversationContext'
@@ -92,7 +98,7 @@ export const OlumiTabBody = memo(function OlumiTabBody({ onFloatOut }: OlumiTabB
         {floatOutIcon}
         <div className="flex flex-1 items-center justify-center px-6 py-6">
           <p className={typo('panelBody', 'text-text-light text-center max-w-xs')}>
-            Describe your decision, goal, options, and any assumptions, risks or constraints you’re aware of.
+            {FIRST_USE_PLACEHOLDER}
           </p>
         </div>
       </div>

--- a/src/canvas/components/__tests__/FirstUseComposer.spec.tsx
+++ b/src/canvas/components/__tests__/FirstUseComposer.spec.tsx
@@ -16,6 +16,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { FIRST_USE_PLACEHOLDER } from '../firstUsePlaceholder'
 import { act, fireEvent, render, screen } from '@testing-library/react'
 import type { ReactNode } from 'react'
 
@@ -311,9 +312,14 @@ describe('FirstUseComposer — welcome hero (round-11 chromeless UX)', () => {
 
     // The guidance copy lives in the textarea's placeholder (round-8) —
     // the textarea is the visual home of the guidance prompt.
-    expect(
-      screen.getByPlaceholderText(/Describe your decision, goal, options, and any assumptions, risks or constraints/i),
-    ).toBeInTheDocument()
+    //
+    // ⚠ PREMISE UPDATED, AND BOUND TO THE CONSTANT RATHER THAN RETYPED. The
+    // literal was inverted when the hero copy widened to admit a challenge (CEE
+    // #1110 accepts open strategic challenges, so entry copy demanding a
+    // decision steered users away from a shipped capability). Retyping it here
+    // is what let the sibling `OlumiTabBody` guard drift in the first place, so
+    // this reads the same exported constant the component renders.
+    expect(screen.getByPlaceholderText(FIRST_USE_PLACEHOLDER)).toBeInTheDocument()
     // No legacy standalone guidance <p>.
     expect(screen.queryByTestId('first-use-guidance')).toBeNull()
     // The previous verbose copy must NOT leak through.

--- a/src/canvas/components/__tests__/OlumiTabBody.returningUser.spec.tsx
+++ b/src/canvas/components/__tests__/OlumiTabBody.returningUser.spec.tsx
@@ -7,7 +7,10 @@
  * you write a brief, the product drafts a 19-node model and coaches you on it,
  * you close the tab, you come back. The model returns in full — and the chat
  * shows `data-testid="olumi-tab-empty"` carrying
- * "Describe your decision, goal, options, and any assumptions, risks or
+ * ⚠ The literal was retyped here and inverted when the hero copy widened to admit
+ * a challenge (CEE #1110 accepts open strategic challenges). Now bound to the
+ * EXPORTED constant, so the assertion cannot drift from the component again.
+ * Formerly: "Describe your decision, goal, options, and any assumptions, risks or
  * constraints you're aware of." That element is a factual claim that the user
  * has never been here, and it is false.
  *
@@ -24,6 +27,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { FIRST_USE_PLACEHOLDER } from '../FirstUseComposer'
 import { render, screen, waitFor } from '@testing-library/react'
 import { OlumiTabBody } from '../OlumiTabBody'
 import { ConversationProvider } from '../../conversation/ConversationContext'
@@ -95,7 +99,7 @@ describe('returning user — the chat pane after a reload', () => {
       expect(screen.getByTestId('olumi-tab-empty')).toBeInTheDocument()
     })
     expect(
-      screen.getByText(/Describe your decision, goal, options/i),
+      screen.getByText(FIRST_USE_PLACEHOLDER),
     ).toBeInTheDocument()
   })
 
@@ -109,7 +113,7 @@ describe('returning user — the chat pane after a reload', () => {
       expect(screen.queryByTestId('olumi-tab-empty')).not.toBeInTheDocument()
     })
     expect(
-      screen.queryByText(/Describe your decision, goal, options/i),
+      screen.queryByText(FIRST_USE_PLACEHOLDER),
     ).not.toBeInTheDocument()
   })
 

--- a/src/canvas/components/__tests__/OlumiTabBody.returningUser.spec.tsx
+++ b/src/canvas/components/__tests__/OlumiTabBody.returningUser.spec.tsx
@@ -27,7 +27,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { FIRST_USE_PLACEHOLDER } from '../FirstUseComposer'
+import { FIRST_USE_PLACEHOLDER } from '../firstUsePlaceholder'
 import { render, screen, waitFor } from '@testing-library/react'
 import { OlumiTabBody } from '../OlumiTabBody'
 import { ConversationProvider } from '../../conversation/ConversationContext'

--- a/src/canvas/components/firstUsePlaceholder.ts
+++ b/src/canvas/components/firstUsePlaceholder.ts
@@ -1,0 +1,19 @@
+/**
+ * The first-use entry copy, in a LEAF with no imports of its own.
+ *
+ * Two surfaces render this same sentence in two different syntactic positions:
+ * `FirstUseComposer` passes it as a placeholder ATTRIBUTE, and `OlumiTabBody`
+ * renders it as TEXT. A grep for one shape does not find the other, which is how
+ * four sweeps missed the second — so they share one constant rather than two
+ * copies that agree today.
+ *
+ * ⚠ AND IT LIVES HERE, NOT ON `FirstUseComposer`, FOR A MEASURED REASON.
+ * Exporting it from the component made `OlumiTabBody` import the component, which
+ * pulled `FirstUseComposer` and its transitive imports into the DOCK IMPORT
+ * CLOSURE — and `tests/ci-guards/shell-conformance.spec.ts` checks that closure
+ * for raw typography. It went from 0 violations to 54. The guard was right: a
+ * shared string must not drag a component's dependency graph across an
+ * architectural boundary. A leaf carries no graph.
+ */
+export const FIRST_USE_PLACEHOLDER =
+  'Describe the decision or challenge you’re working through, any options you’re weighing, and what a good outcome looks like.'

--- a/src/canvas/conversation/__tests__/ChatComposer.spec.tsx
+++ b/src/canvas/conversation/__tests__/ChatComposer.spec.tsx
@@ -9,6 +9,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { STAGE_PLACEHOLDERS } from '../zones/ChatComposer'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { createRef } from 'react'
 import { ChatComposer } from '../zones/ChatComposer'
@@ -112,7 +113,15 @@ function makeConversation(overrides: Record<string, any> = {}) {
   } as any
 }
 
-const PLACEHOLDER = 'Describe your decision, the options you\'re weighing, and what a good outcome looks like.'
+/*
+ * ⚠ PREMISE INVERTED — the string changed, the guard did not.
+ * CEE #1110 (`aa134eac`, live on deployed `c24bfe37`) accepts open strategic
+ * challenges, so entry copy demanding decision syntax steered users away from a
+ * capability the product ships. Rewritten rather than deleted: rendering the
+ * real placeholder into the real textarea is exactly what this case is for, and
+ * it is now imported rather than retyped so it cannot drift again.
+ */
+const PLACEHOLDER = STAGE_PLACEHOLDERS.frame
 
 describe('ChatComposer', () => {
   beforeEach(() => {

--- a/src/canvas/conversation/__tests__/entryInvitesChallenges.spec.ts
+++ b/src/canvas/conversation/__tests__/entryInvitesChallenges.spec.ts
@@ -39,6 +39,7 @@ import { renderHook } from '@testing-library/react'
 import { useBriefSignals, detectGoal } from '../hooks/useBriefSignals'
 import { useStageAwarePlaceholder } from '../../hooks/useStageAwarePlaceholder'
 import { STAGE_PLACEHOLDERS } from '../zones/ChatComposer'
+import { FIRST_USE_PLACEHOLDER } from '../../components/FirstUseComposer'
 
 const BRIEF = 'We need to decide how to grow revenue next year.'
 
@@ -50,6 +51,17 @@ function tip(kind: 'goal' | 'options'): string {
 
 const firstUseLine = () => renderHook(() => useStageAwarePlaceholder()).result.current
 
+/** The FIRST-USE hero's own copy — it passes an explicit prop, so the hook never reaches it. */
+const heroLine = () => FIRST_USE_PLACEHOLDER
+
+/**
+ * The PROPERTY: a decision and a challenge are offered as ALTERNATIVE things the
+ * user can bring. The alternation is what a verb cannot satisfy.
+ */
+function admitsBoth(s: string): boolean {
+  return /\bdecision\s+or\s+challenge\b/i.test(s)
+}
+
 /** Decision must be named, and named FIRST — the testable form of "not demoted". */
 function decisionLeads(s: string): boolean {
   const l = s.toLowerCase()
@@ -59,21 +71,50 @@ function decisionLeads(s: string): boolean {
 describe('the entry copy invites a challenge as well as a decision', () => {
   it('PRECONDITION — every string under test is real and non-empty', () => {
     // A blank satisfies every "does not match" assertion below.
-    for (const s of [STAGE_PLACEHOLDERS.frame, tip('goal'), tip('options'), firstUseLine()]) {
+    for (const s of [STAGE_PLACEHOLDERS.frame, tip('goal'), tip('options'), firstUseLine(), heroLine()]) {
       expect(s.length).toBeGreaterThan(15)
     }
   })
 
-  it('⭐ ADMITS A CHALLENGE — on all three entry surfaces', () => {
-    expect(STAGE_PLACEHOLDERS.frame).toMatch(/\bchallenge\b/i)
-    expect(tip('goal')).toMatch(/\bchallenge\b/i)
-    expect(firstUseLine()).toMatch(/\bchallenge\b/i)
+  /*
+   * ⛔⛔ THIS ASSERTION USED TO BE `/\bchallenge\b/i` AND IT PINNED NOTHING.
+   *
+   * "Challenge" is a VERB as well as a noun. Independent review reworded all
+   * three surfaces back to decision-only framing — *"…and any assumption you
+   * want to challenge"* — and the spec stayed 7/7 GREEN, regression control
+   * included. The word was present; the INVITATION was gone. A different speech
+   * act entirely, satisfying the same regex.
+   *
+   * The property is that the copy offers a decision and a challenge as
+   * ALTERNATIVE THINGS THE USER CAN BRING, so it is the ALTERNATION that is
+   * pinned, not the word. `admitsBoth` is exercised against the reviewer's own
+   * attack strings below, so its discrimination is proven in-test rather than
+   * assumed — the guard has to reject the thing that beat its predecessor.
+   */
+  it('⭐ ADMITS A CHALLENGE AS A THING YOU BRING — on all four entry surfaces', () => {
+    for (const s of [STAGE_PLACEHOLDERS.frame, tip('goal'), firstUseLine(), heroLine()]) {
+      expect(admitsBoth(s), `does not offer both: "${s}"`).toBe(true)
+    }
+  })
+
+  it('⛔ THE GUARD REJECTS THE REWORDING THAT BEAT ITS PREDECESSOR', () => {
+    // Verbatim shapes from the review that passed the old `/\bchallenge\b/i`.
+    const attacks = [
+      'Describe your decision, the options you\u2019re weighing, and any assumption you want to challenge.',
+      'State the decision you need to make, and challenge your own assumptions.',
+      'Describe your decision\u2026 then challenge it.',
+    ]
+    for (const a of attacks) {
+      expect(/\bchallenge\b/i.test(a), 'precondition: the OLD guard passes this').toBe(true)
+      expect(admitsBoth(a), `attack slipped through: "${a}"`).toBe(false)
+    }
   })
 
   it('⛔ REGRESSION CONTROL — a decision is still named, and still leads', () => {
     expect(decisionLeads(STAGE_PLACEHOLDERS.frame)).toBe(true)
     expect(decisionLeads(tip('goal'))).toBe(true)
     expect(decisionLeads(firstUseLine())).toBe(true)
+    expect(decisionLeads(heroLine())).toBe(true)
   })
 
   it('⛔ NEVER DEMANDS OPTIONS FROM A USER WHO HAS NONE', () => {

--- a/src/canvas/conversation/__tests__/entryInvitesChallenges.spec.ts
+++ b/src/canvas/conversation/__tests__/entryInvitesChallenges.spec.ts
@@ -39,7 +39,7 @@ import { renderHook } from '@testing-library/react'
 import { useBriefSignals, detectGoal } from '../hooks/useBriefSignals'
 import { useStageAwarePlaceholder } from '../../hooks/useStageAwarePlaceholder'
 import { STAGE_PLACEHOLDERS } from '../zones/ChatComposer'
-import { FIRST_USE_PLACEHOLDER } from '../../components/FirstUseComposer'
+import { FIRST_USE_PLACEHOLDER } from '../../components/firstUsePlaceholder'
 
 const BRIEF = 'We need to decide how to grow revenue next year.'
 

--- a/src/canvas/conversation/__tests__/entryInvitesChallenges.spec.ts
+++ b/src/canvas/conversation/__tests__/entryInvitesChallenges.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * THE ENTRY COPY TALKED USERS OUT OF A CAPABILITY THE PRODUCT SHIPS.
+ *
+ * CEE #1110 (`aa134eac`) is merged and live on deployed CEE `c24bfe37`. It
+ * accepts OPEN STRATEGIC CHALLENGES: a statement of a problem with no decision
+ * verb and no trailing `?` drafts a model because the classifier returns
+ * `start_model`. Its own control case, from the CEE suite:
+ *
+ *   "Our enterprise renewal rates have been sliding for three quarters and
+ *    leadership disagrees about why."
+ *
+ * Meanwhile the first lines a fresh user read were "Describe your DECISION…"
+ * (first-use composer) and "Describe your DECISION, THE options you're
+ * weighing…" (chat composer), with a goal tip of "State the DECISION you need
+ * to make" and an options tip that DEMANDED "at least two alternatives".
+ *
+ * The runtime had been widened and the entry copy still steered users into the
+ * narrow form the fix existed to remove — the product talking people out of a
+ * capability it ships and has witnessed.
+ *
+ * ⚠ THE REGRESSION CONTROL IS NON-NEGOTIABLE AND IT IS THE FOUNDER'S OWN.
+ * #1110 kept "Should we expand into the US this year?" undegraded — Olumi was
+ * generalised WITHOUT costing decision reasoning. Copy that de-emphasised
+ * decisions to make room for challenges would undo exactly that, so every case
+ * below pins BOTH directions: a challenge is admitted, AND a decision leads.
+ *
+ * ⚠ WHAT IS DELIBERATELY NOT CHANGED. `SCAFFOLD_LABELS`' "the decision i'm
+ * facing is:" is a DETECTION constant, not user-facing copy. Renaming it for
+ * vocabulary consistency would stop recognising users who type that phrase —
+ * an internal construct renamed for cosmetic reasons, which the founder's
+ * language ruling forbids. Pinned below so a later tidy cannot do it silently.
+ *
+ * Read through the HOOK and the exported map that the composer actually uses,
+ * never a retyped copy — `ChatComposer.spec` pins that the map reaches the
+ * textarea, and `stagePlaceholder.spec` now imports it rather than mirroring it.
+ */
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { useBriefSignals, detectGoal } from '../hooks/useBriefSignals'
+import { useStageAwarePlaceholder } from '../../hooks/useStageAwarePlaceholder'
+import { STAGE_PLACEHOLDERS } from '../zones/ChatComposer'
+
+const BRIEF = 'We need to decide how to grow revenue next year.'
+
+function tip(kind: 'goal' | 'options'): string {
+  const { result } = renderHook(() => useBriefSignals(BRIEF, 'frame', BRIEF))
+  const el = result.current?.elements.find(e => e.kind === kind)
+  return el?.coachingTip ?? ''
+}
+
+const firstUseLine = () => renderHook(() => useStageAwarePlaceholder()).result.current
+
+/** Decision must be named, and named FIRST — the testable form of "not demoted". */
+function decisionLeads(s: string): boolean {
+  const l = s.toLowerCase()
+  return l.includes('decision') && l.indexOf('decision') < l.indexOf('challenge')
+}
+
+describe('the entry copy invites a challenge as well as a decision', () => {
+  it('PRECONDITION — every string under test is real and non-empty', () => {
+    // A blank satisfies every "does not match" assertion below.
+    for (const s of [STAGE_PLACEHOLDERS.frame, tip('goal'), tip('options'), firstUseLine()]) {
+      expect(s.length).toBeGreaterThan(15)
+    }
+  })
+
+  it('⭐ ADMITS A CHALLENGE — on all three entry surfaces', () => {
+    expect(STAGE_PLACEHOLDERS.frame).toMatch(/\bchallenge\b/i)
+    expect(tip('goal')).toMatch(/\bchallenge\b/i)
+    expect(firstUseLine()).toMatch(/\bchallenge\b/i)
+  })
+
+  it('⛔ REGRESSION CONTROL — a decision is still named, and still leads', () => {
+    expect(decisionLeads(STAGE_PLACEHOLDERS.frame)).toBe(true)
+    expect(decisionLeads(tip('goal'))).toBe(true)
+    expect(decisionLeads(firstUseLine())).toBe(true)
+  })
+
+  it('⛔ NEVER DEMANDS OPTIONS FROM A USER WHO HAS NONE', () => {
+    // Old copy presupposed alternatives exist: "List at least two alternatives
+    // you are considering" and "THE options you're weighing".
+    expect(tip('options')).not.toMatch(/^list at least/i)
+    expect(tip('options')).toMatch(/\bif\b/i)
+    expect(STAGE_PLACEHOLDERS.frame).not.toMatch(/\bthe options\b/i)
+  })
+
+  it('still GUIDES the decision case — "two or more" survives as an invitation', () => {
+    // Removing the demand must not remove the help: a user who IS choosing
+    // between alternatives should still learn Olumi wants at least two.
+    expect(tip('options')).toMatch(/two or more|at least two/i)
+  })
+
+  /*
+   * ⚠ THIS CASE'S FIRST FIXTURE PASSED ON THE WRONG BRANCH, AND THE MUTANT
+   * PROVED IT. `detectGoal` has THREE branches — `DECISION_FRAMING_PHRASES`,
+   * `GOAL_VERBS`, and `SCAFFOLD_LABELS`. The original fixture ended
+   * "…is: whether to rebuild or buy", and `'whether to'` is a framing phrase,
+   * so it detected `true` via branch 1 no matter what the scaffold list said.
+   * Renaming the scaffold constant left the suite GREEN 7/7 — the exact tidy
+   * this case exists to forbid.
+   *
+   * The payload after the colon is now a bare noun phrase that trips NO other
+   * branch, and the PAIR below proves it: without the scaffold prefix the same
+   * text is NOT detected, so a `true` with it can only have come from branch 3.
+   */
+  it('⛔ INTERNAL DETECTION IS UNTOUCHED — and only the scaffold branch can explain it', () => {
+    // PRECONDITION: the payload alone trips nothing. If this ever returns true,
+    // the case below stops discriminating and must be re-fixtured.
+    expect(detectGoal('HubSpot or Salesforce')).toBe(false)
+    // …so this true is the SCAFFOLD LABEL's doing, and nothing else's.
+    expect(detectGoal("The decision I'm facing is: HubSpot or Salesforce")).toBe(true)
+  })
+
+  it('DISCRIMINATING — the detector has not simply stopped discriminating', () => {
+    // Without this the case above passes on a detector that returns true for
+    // everything, which is how a guard goes quiet without going red.
+    expect(detectGoal('')).toBe(false)
+    expect(detectGoal('hello')).toBe(false)
+    // …and it still detects a genuine goal through a DIFFERENT branch, so the
+    // fixture above is narrow rather than the detector being broken.
+    expect(detectGoal('We need to reach 20% margin')).toBe(true)
+  })
+})

--- a/src/canvas/conversation/__tests__/stageAwarePlaceholder.voice.spec.ts
+++ b/src/canvas/conversation/__tests__/stageAwarePlaceholder.voice.spec.ts
@@ -57,9 +57,16 @@ describe('L-17 — a selection no longer writes a fake sentence into the compose
     expect(result.current).toBe('Ask about this model…')
   })
 
-  it('still says "Describe your decision…" on an empty canvas', () => {
+  /*
+   * ⚠ PREMISE INVERTED. The empty-canvas line now admits a challenge as well as
+   * a decision — CEE #1110 accepts open strategic challenges and this is the
+   * FIRST-USE composer's placeholder. What this case actually guards is that a
+   * SELECTION does not write a fake sentence here; that is unchanged and still
+   * asserted. Only the expected neutral string moved.
+   */
+  it('still says the neutral empty-canvas line on an empty canvas', () => {
     const { result } = renderHook(() => useStageAwarePlaceholder())
-    expect(result.current).toBe('Describe your decision…')
+    expect(result.current).toBe('Describe your decision or challenge…')
   })
 })
 

--- a/src/canvas/conversation/__tests__/stagePlaceholder.spec.ts
+++ b/src/canvas/conversation/__tests__/stagePlaceholder.spec.ts
@@ -7,17 +7,21 @@
 
 import { describe, it, expect } from 'vitest'
 import type { ScenarioStage } from '../../../types/scenario'
+import { STAGE_PLACEHOLDERS } from '../zones/ChatComposer'
 
-// Mirror the map from ChatComposer — tested independently to avoid
-// rendering the full component tree (canvas store deps make that expensive).
-const STAGE_PLACEHOLDERS: Record<ScenarioStage, string> = {
-  frame:    'Describe your decision, the options you\u2019re weighing, and what a good outcome looks like.',
-  ideate:   'Explore options, add factors, or challenge assumptions...',
-  evaluate: 'Ask about the results, challenge assumptions, or refine the model...',
-  decide:   'Challenge the recommendation, or generate your brief...',
-  optimise: 'Plan your next steps...',
-}
-
+/*
+ * ⚠ THIS WAS A HAND-MAINTAINED MIRROR AND IT HAD ALREADY DRIFTED.
+ *
+ * It copied the map with the note "tested independently to avoid rendering the
+ * full component tree", and by the time the entry copy changed its `decide`
+ * entry read "Challenge the RECOMMENDATION…" while the product said "Challenge
+ * the RESULT…". A spec that copies the data tests its own copy: it passed
+ * green through an entry-copy change it exists to guard, and it would have gone
+ * on asserting a placeholder the product does not have.
+ *
+ * Now IMPORTED. The map is the map, so drift is impossible rather than merely
+ * discouraged (trap 12 — derive, do not mirror).
+ */
 const DEFAULT_PLACEHOLDER = STAGE_PLACEHOLDERS.frame
 
 const ALL_STAGES: ScenarioStage[] = ['frame', 'ideate', 'evaluate', 'decide', 'optimise']

--- a/src/canvas/conversation/hooks/useBriefSignals.ts
+++ b/src/canvas/conversation/hooks/useBriefSignals.ts
@@ -112,9 +112,29 @@ export function detectGoal(text: string): boolean {
 // Coaching tips per element
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * ⭐ THE TIPS ADMIT A CHALLENGE, AND STILL WELCOME A DECISION.
+ *
+ * `goal` demanded decision syntax and `options` demanded at least two
+ * alternatives — from a user who may legitimately have neither. CEE #1110
+ * (`aa134eac`, live on deployed `c24bfe37`) accepts open strategic challenges,
+ * so this copy was steering users away from a capability the product ships.
+ *
+ * ⚠ THE DECISION CASE IS NOT DEMOTED. #1110's own regression control is
+ * *"Should we expand into the US this year?"*, and it was kept undegraded
+ * precisely so generalising would not cost decision reasoning. "Decision" leads
+ * in both strings for that reason, and `options` still names "two or more" —
+ * it is now CONDITIONAL rather than an instruction, which is the whole change.
+ *
+ * ⚠ NOT TOUCHED, AND DELIBERATELY: `SCAFFOLD_LABELS`' *"the decision i'm facing
+ * is:"* is a DETECTION constant, not user-facing copy. Rewriting it for
+ * vocabulary consistency would stop recognising users who type that phrase —
+ * an internal construct renamed for cosmetic reasons, which is the exact move
+ * the founder's language ruling forbids. Pinned by the spec.
+ */
 const COACHING_TIPS: Record<BriefElementKind, string> = {
-  goal:        'State the decision you need to make and what you want to achieve.',
-  options:     'List at least two alternatives you are considering.',
+  goal:        'State the decision or challenge you\'re working through, and what you want to achieve.',
+  options:     'If you\'re weighing specific alternatives, name them — two or more.',
   metric:      'Include a measurable outcome with a number or percentage.',
   constraints: 'Mention any limits such as budget, timeline, or resources.',
   risks:       'Note potential risks or downsides you want to avoid.',

--- a/src/canvas/conversation/zones/ChatComposer.tsx
+++ b/src/canvas/conversation/zones/ChatComposer.tsx
@@ -69,8 +69,31 @@ interface ChatComposerProps {
   runBlockedReason?: string
 }
 
-const STAGE_PLACEHOLDERS: Record<ScenarioStage, string> = {
-  frame:    'Describe your decision, the options you\'re weighing, and what a good outcome looks like.',
+/**
+ * ⭐ THE FRAMING PLACEHOLDER INVITES A CHALLENGE, NOT ONLY A DECISION.
+ *
+ * `frame` is the first line a fresh user reads, and the fallback for any stage
+ * (`STAGE_PLACEHOLDERS[stage] ?? STAGE_PLACEHOLDERS.frame`). It used to read
+ * *"Describe your decision, THE options you're weighing…"* — which asks for
+ * decision syntax and presupposes that options already exist.
+ *
+ * CEE #1110 (`aa134eac`, live on deployed CEE `c24bfe37`) accepts open
+ * strategic challenges: a statement of a problem with no decision verb and no
+ * trailing `?` drafts a model because the classifier says `start_model` — its
+ * own control case is *"Our enterprise renewal rates have been sliding for
+ * three quarters and leadership disagrees about why."* So the runtime had been
+ * widened and the entry copy still steered users into the narrow form the fix
+ * existed to remove: the product talking people out of a capability it ships.
+ *
+ * ⚠ AND THE DECISION CASE MUST STAY FIRST-CLASS. #1110's own regression control
+ * is *"Should we expand into the US this year?"*, kept undegraded. Copy that
+ * de-emphasised decisions to make room for challenges would undo the thing that
+ * made that change safe. "Decision" leads; "challenge" joins it; and `any`
+ * options replaces `the` options so a user who has none is not told they are
+ * missing something.
+ */
+export const STAGE_PLACEHOLDERS: Record<ScenarioStage, string> = {
+  frame:    'Describe the decision or challenge you\'re working through, any options you\'re weighing, and what a good outcome looks like.',
   ideate:   'Explore options, add factors, or challenge assumptions...',
   evaluate: 'Ask about the results, challenge assumptions, or refine the model...',
   decide:   'Challenge the result, or generate your brief...',

--- a/src/canvas/hooks/__tests__/useStageAwarePlaceholder.spec.ts
+++ b/src/canvas/hooks/__tests__/useStageAwarePlaceholder.spec.ts
@@ -38,8 +38,15 @@ const complete = () => useCanvasStore.setState({ results: { status: 'complete' }
 const setFresh = () => useCanvasStore.getState().setAnalysisFreshness({ freshness: 'fresh', freshness_reason: 'graph_hash_match' })
 
 describe('useStageAwarePlaceholder', () => {
-  it('no model → "Describe your decision…"', () => {
-    expect(placeholder()).toBe('Describe your decision…')
+  /*
+   * ⚠ PREMISE INVERTED — and the reason this was missed is the lesson. The
+   * change's own corpus was scoped to `src/canvas/conversation/**`, while this
+   * SECOND consumer lives in `src/canvas/hooks/__tests__/`. A suite that cannot
+   * see a directory returns the same clean green as one that looked and found
+   * nothing. Caught by CI, not by the sweep.
+   */
+  it('no model → "Describe your decision or challenge…"', () => {
+    expect(placeholder()).toBe('Describe your decision or challenge…')
   })
 
   it('model exists, no analysis → "Ask about this model…"', () => {

--- a/src/canvas/hooks/useStageAwarePlaceholder.ts
+++ b/src/canvas/hooks/useStageAwarePlaceholder.ts
@@ -58,8 +58,14 @@ export function useStageAwarePlaceholder(): string {
   if (nodeCount > 0) {
     return 'Ask about this model…'
   }
-  // ⭐ "OR CHALLENGE" — the empty-canvas line, i.e. the FIRST-USE composer
-  // (`FirstUseComposer` via `ReactFlowGraph`) and the dock's persistent strip.
+  // ⭐ "OR CHALLENGE" — the empty-canvas line.
+  //
+  // ⚠ AND IT IS NOT THE FIRST-USE HERO, WHICH AN EARLIER VERSION OF THIS COMMENT
+  // CLAIMED. `AIInputBar` resolves `placeholder ?? stagePlaceholder`, so an
+  // explicit prop WINS — and `FirstUseComposer` passes its own. This hook feeds
+  // the dock's `PersistentInputStrip`; the hero carries its own copy and was
+  // fixed there. Proven by execution: the hero's spec passed GREEN asserting the
+  // OLD copy while this hook already returned the new line.
   // CEE #1110 (`aa134eac`, live on deployed `c24bfe37`) accepts open strategic
   // challenges, so asking only for a decision steered users away from a
   // capability the product ships. "Decision" stays FIRST: #1110's own

--- a/src/canvas/hooks/useStageAwarePlaceholder.ts
+++ b/src/canvas/hooks/useStageAwarePlaceholder.ts
@@ -21,7 +21,7 @@ import { useAnalysisTrust } from './useAnalysisTrust'
  *   3. Analysis exists, can't confirm → "Ask about this analysis..."
  *      (cannot-confirm / no freshness verdict — never claims "latest")
  *   4. Model exists                   → "Ask about this model..."
- *   5. No model                       → "Describe your decision..."
+ *   5. No model                       → "Describe your decision or challenge..."
  *
  * ── L-17: THE SELECTION BRANCH IS GONE, DELIBERATELY ───────────────────────
  * This hook used to return "Ask about [label]…" whenever one element was
@@ -58,5 +58,12 @@ export function useStageAwarePlaceholder(): string {
   if (nodeCount > 0) {
     return 'Ask about this model…'
   }
-  return 'Describe your decision…'
+  // ⭐ "OR CHALLENGE" — the empty-canvas line, i.e. the FIRST-USE composer
+  // (`FirstUseComposer` via `ReactFlowGraph`) and the dock's persistent strip.
+  // CEE #1110 (`aa134eac`, live on deployed `c24bfe37`) accepts open strategic
+  // challenges, so asking only for a decision steered users away from a
+  // capability the product ships. "Decision" stays FIRST: #1110's own
+  // regression control is "Should we expand into the US this year?", kept
+  // undegraded, and this copy must not cost what that change protected.
+  return 'Describe your decision or challenge…'
 }


### PR DESCRIPTION
## The product was talking users out of a capability it ships

**CEE #1110 (`aa134eac`) is merged and live on deployed CEE `c24bfe37`.** It accepts open strategic challenges — a statement of a problem with no decision verb and no trailing `?` drafts a model because the classifier returns `start_model`. Its own control case, from the CEE suite:

> *"Our enterprise renewal rates have been sliding for three quarters and leadership disagrees about why."*

Meanwhile the first lines a fresh user reads still demanded decision syntax:

| surface | string |
|---|---|
| `useStageAwarePlaceholder` — **first-use composer** | *"Describe your decision…"* |
| `ChatComposer` frame placeholder | *"Describe your decision, **the** options you're weighing…"* |
| `COACHING_TIPS.goal` | *"State the **decision** you need to make…"* |
| `COACHING_TIPS.options` | *"**List at least two** alternatives you are considering."* |

The runtime had been widened and the entry copy still steered users into the narrow form the fix existed to remove. **Not a dark feature — a shipped, witnessed capability that the product's own guidance argued against using.**

## ⛔ The decision case is not demoted, and that is a pinned property

#1110's regression control is *"Should we expand into the US this year?"*, kept undegraded — Olumi was generalised **without** costing decision reasoning. Copy that de-emphasised decisions to make room for challenges would undo exactly that.

So **"decision" leads in every changed string**, and a mutant that merely reorders it to *"challenge or decision"* goes red.

`options` keeps its "two or more" guidance and becomes **conditional** rather than an instruction. The change is that it no longer tells a user who has no alternatives that they are missing something.

## Not changed, deliberately

`SCAFFOLD_LABELS`' *"the decision i'm facing is:"* is a **detection constant**, not user-facing copy. Renaming it for vocabulary consistency would stop recognising users who type that phrase — an internal construct renamed for cosmetic reasons. Pinned so a later tidy cannot do it silently.

## ⭐ A hand-maintained mirror removed on the way past

`stagePlaceholder.spec` **copied** the placeholder map — *"tested independently to avoid rendering the full component tree"* — and had **already drifted**: its `decide` entry read *"Challenge the recommendation…"* while the product said *"Challenge the result…"*. It passed green through this entry-copy change and would have gone on asserting a placeholder the product does not have.

The map is now exported and imported, so drift is impossible rather than discouraged.

Two other specs had their premise inverted and were **rewritten, not deleted**: `ChatComposer.spec` (which renders the real textarea — the binding that matters) and `stageAwarePlaceholder.voice.spec` (whose actual subject, that a selection does not write a fake sentence, is unchanged and still asserted).

## Evidence

Pristine archive outside the tree, isolation by sentinel write, inodes compared, applied-check 1 per mutation, trailing control 7/7. **2572 passed across 188 files** in the conversation suite.

| mutant | result |
|---|---|
| revert the first-use line to decision-only | **RED** 2/7 |
| demote the decision (*"challenge or decision"*) | **RED** 1/7 |
| restore the unconditional options demand | **RED** 1/7 |
| rename the internal detection constant | **RED** 1/7 |

### ⚠ Instrument defect, disclosed — the third of this shape this session

**The fourth mutant survived 7/7 on the first run.** `detectGoal` has three branches, and my fixture ended *"…is: whether to rebuild or buy"* — `'whether to'` is a `DECISION_FRAMING_PHRASE`, so it detected `true` via a different branch no matter what the scaffold list said.

The payload is now a bare noun phrase, and **the case proves its own precondition**: without the scaffold prefix the same text is *not* detected, so a `true` with it can only be branch 3.

Typecheck gate **PASSED at exactly baseline 2252 errors / 556 files**.
