### PR TITLE
D — the landing card names the artefact, not a decision the user may not have [IN-class]

### DIFF
--- a/src/pages/ScenarioListPage.tsx
+++ b/src/pages/ScenarioListPage.tsx
@@ -115,7 +115,34 @@ function formatLastActivity(events: ScenarioEvent[] | null | undefined, updatedA
     case 'graph_drafted':
       return `Model drafted with ${details.node_count ?? '?'} factors`
     case 'brief_generated':
-      return 'Decision brief generated'
+      /*
+       * ⭐ "BRIEF", NOT "DECISION BRIEF" — AND THIS IS A TRUTHFULNESS FIX, NOT A
+       * VOCABULARY ONE.
+       *
+       * The event kind is `brief_generated`. The word "Decision" was added HERE,
+       * by this surface, to an artefact whose own name does not carry it.
+       *
+       * ⚠ AND SINCE CEE #1110 (`aa134eac`, live on deployed `c24bfe37`) IT IS
+       * SOMETIMES FALSE. That change made the runtime accept OPEN STRATEGIC
+       * CHALLENGES — a statement of a problem with no decision verb drafts a
+       * model. A user who brought one has no decision, so a card telling them
+       * their "Decision brief" is ready names something they never had. Before
+       * #1110 every scenario was a decision and this string was merely
+       * inconsistent; it is now capable of being wrong.
+       *
+       * Its own siblings already agree: this switch's `graph_drafted` and
+       * `patch_accepted` arms say "Model …", and `renderTimeline`'s neighbouring
+       * `brief_shared` says plain "Brief shared" — the same artefact, two lines
+       * apart, without the word.
+       *
+       * ⚠ SCOPE. One user-facing string on a mounted landing page. NOT a rename
+       * of the internal `decision_brief` carrier, which is the producer's name
+       * for its own payload and must keep it; and NOT `renderTimeline.ts`'s
+       * identical line, which serves the Journey surface — derived dark at this
+       * tip (`VITE_FEATURE_JOURNEY_TAB` absent from the build config, contrast:
+       * 41 other `VITE_` keys present), so changing it would be invisible work.
+       */
+      return 'Brief generated'
     case 'patch_accepted':
       return `Model updated — ${details.summary ?? 'changes applied'}`
     case 'stage_changed':

--- a/src/pages/__tests__/landingCardSaysBrief.spec.tsx
+++ b/src/pages/__tests__/landingCardSaysBrief.spec.tsx
@@ -1,0 +1,121 @@
+/**
+ * THE LANDING CARD NAMED SOMETHING THE USER MAY NEVER HAVE HAD.
+ *
+ * `ScenarioListPage` is mounted at the ROOT ROUTE (`AppPoC.tsx:949-950`, `/` and
+ * `/scenarios`), so this card is the first thing a returning user reads. Its
+ * `brief_generated` arm said **"Decision brief generated"**.
+ *
+ * The event kind is `brief_generated`. The word "Decision" is added HERE, by
+ * this surface, to an artefact whose own name does not carry it.
+ *
+ * ⚠ AND SINCE CEE #1110 (`aa134eac`, live on deployed CEE `c24bfe37`) IT IS
+ * SOMETIMES FALSE — which is what makes this a truthfulness fix rather than a
+ * vocabulary one. #1110 made the runtime accept OPEN STRATEGIC CHALLENGES: a
+ * statement of a problem, no decision verb, no trailing `?`, drafts a model.
+ * A user who brought one has NO DECISION, so a card announcing their "Decision
+ * brief" names something they never had. Before #1110 every scenario was a
+ * decision and the string was merely inconsistent; it is now capable of being
+ * wrong, and it was not yesterday.
+ *
+ * Its own siblings already agree — this switch's `graph_drafted` and
+ * `patch_accepted` arms say "Model …", and `renderTimeline`'s neighbouring
+ * `brief_shared` says plain "Brief shared": the same artefact, two lines apart,
+ * without the word.
+ *
+ * ⚠ SCOPE, and it is deliberately narrow. One user-facing string on one mounted
+ * page. NOT the internal `decision_brief` carrier (the producer's name for its
+ * own payload, which must keep it). NOT `renderTimeline.ts:162`'s identical
+ * line, which serves the Journey surface — derived DARK at this tip
+ * (`VITE_FEATURE_JOURNEY_TAB` absent from the build config; contrast: 41 other
+ * `VITE_` keys present), so changing it would be invisible work.
+ *
+ * Driven through the RENDERED PAGE rather than the module-private function, so
+ * what is asserted is what a user reads.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom')
+  return { ...actual, useNavigate: () => vi.fn() }
+})
+
+const mockAuthValue = { user: { id: '550e8400-e29b-41d4-a716-446655440000' }, authenticated: true }
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: () => mockAuthValue }))
+vi.mock('../../hooks/useScenario', () => ({
+  useScenario: () => ({
+    createScenario: vi.fn(),
+    deleteScenario: vi.fn(),
+    isPersistenceActive: true,
+  }),
+}))
+
+const mockListScenarios = vi.fn()
+vi.mock('../../services/scenarioService', () => ({
+  listScenarios: (...args: unknown[]) => mockListScenarios(...args),
+}))
+
+import ScenarioListPage from '../ScenarioListPage'
+
+function withEvent(eventType: string, details: Record<string, unknown> = {}) {
+  mockListScenarios.mockResolvedValue([
+    {
+      id: 's1',
+      title: 'Test',
+      stage: 'evaluate',
+      analysis_status: 'ready',
+      updated_at: new Date().toISOString(),
+      events: [
+        { event_id: 'e1', seq: 1, event_type: eventType, timestamp: new Date().toISOString(), details },
+      ],
+    },
+  ])
+  render(
+    <MemoryRouter>
+      <ScenarioListPage />
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  mockListScenarios.mockReset()
+})
+
+describe('the landing card names the artefact, not a decision the user may not have', () => {
+  it('⭐ a generated brief is a BRIEF — never a "decision brief"', async () => {
+    withEvent('brief_generated')
+    await waitFor(() => {
+      expect(screen.getByText('Brief generated')).toBeTruthy()
+    })
+    expect(screen.queryByText('Decision brief generated')).toBeNull()
+  })
+
+  it('PRECONDITION — the assertion is reading the brief_generated ARM, not a fallback', async () => {
+    // `formatLastActivity` has six arms and two of them are generic ("Updated
+    // X ago"). A card that fell through to one of those would satisfy a
+    // `not.toBeNull()` on the old string while proving nothing about this arm.
+    // The exact-text match above can only come from the arm under test, and
+    // this pins that the generic fallback is NOT what rendered.
+    withEvent('brief_generated')
+    await waitFor(() => expect(screen.getByText('Brief generated')).toBeTruthy())
+    expect(screen.queryByText(/^Updated /)).toBeNull()
+  })
+
+  it('DISCRIMINATING — a DIFFERENT arm is untouched, so this was not a blanket rewrite', async () => {
+    // Without this, deleting the word "Decision" everywhere — or collapsing the
+    // switch to one string — would satisfy the cases above.
+    withEvent('graph_drafted', { node_count: 12 })
+    await waitFor(() => {
+      expect(screen.getByText(/^Model drafted with 12 /)).toBeTruthy()
+    })
+  })
+
+  it('DISCRIMINATING — the analysis arm still makes no leader claim', async () => {
+    // A prior lane DELETED a `winner`-based claim from this arm. The fixture
+    // keeps `winner` on purpose: it proves the subtitle ignores it.
+    withEvent('analysis_run', { winner: 'Option A', probability: 0.73 })
+    await waitFor(() => expect(screen.getByText('Analysis run')).toBeTruthy())
+    expect(screen.queryByText(/Option A/)).toBeNull()
+  })
+})


### PR DESCRIPTION
## A merged capability made previously-true copy false, and nothing detected it

`ScenarioListPage` is mounted at the **root route** (`AppPoC.tsx:949-950`, `/` and `/scenarios`), so this card is the first thing a returning user reads. Its `brief_generated` arm said **"Decision brief generated"**.

The event kind is `brief_generated`. **The word "Decision" is added here, by this surface**, to an artefact whose own name does not carry it.

### ⚠ And since CEE #1110 it is sometimes false

**#1110 (`aa134eac`) is live on deployed CEE `c24bfe37`.** It made the runtime accept **open strategic challenges**: a statement of a problem, no decision verb, no trailing `?`, drafts a model.

**A user who brought one has no decision** — so a card announcing their *"Decision brief"* names something they never had.

Before #1110 every scenario was a decision and this string was merely *inconsistent*. **It is now capable of being wrong, and it was not yesterday.** That is what makes this a truthfulness fix rather than a vocabulary preference — and it is the generalisable half:

> We widened what the product accepts. The landing page still describes the old class. **No gate anywhere notices when a merged capability invalidates copy elsewhere.**

Its own siblings already agree: this switch's `graph_drafted` and `patch_accepted` arms say **"Model …"**, and `renderTimeline`'s neighbouring `brief_shared` says plain **"Brief shared"** — the same artefact, two lines apart, without the word.

## Scope, deliberately narrow

One user-facing string, one mounted page.

- **Not** the internal `decision_brief` carrier — the producer's name for its own payload, which must keep it.
- **Not** `renderTimeline.ts:162`'s identical line. That serves the Journey surface, derived **dark** at this tip: `VITE_FEATURE_JOURNEY_TAB` is absent from the build config (contrast control: **41** other `VITE_` keys present). Changing it would be invisible work, and its existing spec stays green.

## ⚠ Rowed, not fixed — a second defect in the same six-arm function

`graph_drafted` renders **"Model drafted with `${node_count}` factors"**. `node_count` is a **graph-size** measure, not a node **kind**: CEE reads it alongside `edge_count` (`context/event-log.ts:54`) and writes it literally as `graph.nodes.length` (`buffer-optimization.ts:139`).

On a captured live graph — **12 nodes, of which 4 are factors** — that card reads *"Model drafted with 12 factors"*.

**Not fixed here because the writer of the persisted event is not located**: no UI code creates it, and `scenario_event` returns zero non-test files in CEE. The **semantic** is derived; the **producer** is not. The fix depends on what that writer actually sends, so this is rowed with both halves rather than guessed at.

### An over-read caught before it was reported

I first took `OutputsDock:1353`'s `node_count: storeState.nodes.length` as that writer. **It is `trackRunStarted` — telemetry for a run, not this event.** Same field name, adjacent subsystem, and it would have "confirmed" the story. The dangerous false result is the one that agrees with you.

## Evidence

Pristine archive outside the tree, isolation by sentinel write, inodes compared, applied-check 1 per mutation, trailing control 4/4. **67/67 green** across the page specs *and* the Journey spec this deliberately does not touch.

| mutant | result |
|---|---|
| restore *"Decision brief generated"* | **RED** 2/4 |
| blanket rewrite — collapse `graph_drafted` to the same string | **RED** 1/4 (different assertion) |
| reinstate the deleted leader claim on the analysis arm | **RED** 1/4 |

Driven through the **rendered page** rather than the module-private function, and the `brief_generated` case pins that it is reading **that arm** rather than falling through to one of the two generic ones.

Typecheck gate **PASSED at exactly baseline 2252 errors / 556 files**.
