### PR TITLE
style(canvas): the zoom read-out wears the toolbar's own circle

### DIFF
--- a/src/components/layout/CanvasFloatingToolbar.module.css
+++ b/src/components/layout/CanvasFloatingToolbar.module.css
@@ -130,29 +130,25 @@
 }
 
 /**
- * The zoom read-out — a text control with no counterpart on the upper toolbar,
- * so it takes the shared button's BOX (32px tall, full content width, same
- * transition and focus ring) without the chrome that would box in a number.
- * Deliberately not given `.iconButton`'s border/background: it is a label you
- * can click, and drawing a 32px circle around "400%" would clip it.
+ * The zoom read-out — the toolbar's one text control, and the only element that
+ * displays state rather than performing an action. It takes the shared circle
+ * anyway, because it IS a control: clicking it resets to 100%, and a bare
+ * number was the one thing here that did not look clickable.
+ *
+ * ⚠ THE UNIT IS DELIBERATELY NOT ON THE FACE. Measured in Inter at the shipped
+ * size, "400%" — the widest value the canvas can reach at maxZoom 4 — is 33.8px
+ * against the circle's 30px of usable width, and still 31.2px at 11px. A
+ * legible circle and the "%" are mutually exclusive at this column width;
+ * widening the column would break alignment with the sidebar. "400" is 22.7px.
+ * The unit is carried by the tooltip and the accessible name instead, so it is
+ * available on hover and to assistive technology, just not painted twice.
+ *
+ * Tabular figures so the number holds still as it changes.
  */
-.textButton {
-  width: 100%;
-  height: 32px;
-  border: 0;
-  background: none;
-  border-radius: 999px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: color 120ms ease;
-  pointer-events: auto;
-}
-
-.textButton:focus-visible {
-  outline: 2px solid var(--info);
-  outline-offset: 2px;
+.readout {
+  composes: iconButton;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
 }
 
 .icon {

--- a/src/components/layout/CanvasViewportControls.tsx
+++ b/src/components/layout/CanvasViewportControls.tsx
@@ -43,7 +43,10 @@ export const CanvasViewportControls = memo(function CanvasViewportControls({
   onAutoArrange,
 }: CanvasViewportControlsProps) {
   const zoom = useStore(s => s.transform[2])
-  const zoomPct = `${Math.round(zoom * 100)}%`
+  // The face shows the number; the unit rides the tooltip and the accessible
+  // name (see `.readout` — "400%" does not fit the shared circle legibly).
+  const zoomWhole = String(Math.round(zoom * 100))
+  const zoomPct = `${zoomWhole}%`
 
   // D4: comfortable/compact density is derived from the persisted tier spacing.
   const layerSpacing = useLayoutStore(s => s.layerSpacing)
@@ -61,15 +64,17 @@ export const CanvasViewportControls = memo(function CanvasViewportControls({
       <div className={styles.group}>
         {/* Zoom read-out — click resets to 100%. Leads the group rather than
             sitting between the two zoom buttons: it is a state display you can
-            act on, not a third step in a -/+ sequence. */}
+            act on, not a third step in a -/+ sequence. It wears the shared
+            circle for the same reason — it is a control, and a bare number
+            was the one thing here that did not look like one. */}
         <Tooltip content="Reset to 100%">
           <button
             type="button"
-            className={`${styles.textButton} text-xs text-text-light hover:text-text-body hover:underline`}
+            className={styles.readout}
             aria-label={`Zoom level ${zoomPct}. Click to reset to 100%`}
             onClick={onZoomReset}
           >
-            {zoomPct}
+            {zoomWhole}
           </button>
         </Tooltip>
 


### PR DESCRIPTION
Third and last step of the lower-toolbar alignment, on founder approval. Follows #852 (the surface) and #854 (the read-out leads its group).

The zoom read-out was the one element in the toolbar that did not look like a control — which is exactly what it is; clicking it resets the canvas to 100%. Every other control is a 32px circle. Moving it to the top in #854 made that *more* obvious, not less: a bare number at the top of a stack starts to read as a heading.

It now takes `.readout`, which `composes: iconButton` — same circle, border, fill, hover, focus ring and disabled grammar as its neighbours. Verified in a browser that its box is identical to the icon buttons beside it.

### The cost, stated plainly: the `%` comes off the face

The circle has **30px** of usable width. Measured in Inter:

| | 10px | 11px | 12px (shipped) |
|---|---|---|---|
| `400%` — widest value at `maxZoom 4` | 28.6px | 31.2px ✗ | 33.8px ✗ |
| `400` | 19.3px | 21.0px | **22.7px** ✓ |

So the unit only fits at 10px with 0.7px to spare — too small for the one element here carrying information. **A legible circle and the `%` are mutually exclusive at this column width**, and widening the column would undo the sidebar alignment that #852 just established.

The unit therefore *moves* rather than disappears:
- tooltip: `Reset to 100%`
- accessible name: `Zoom level 100%. Click to reset to 100%`

Both unchanged. On the face, a number directly above a magnifier-minus and a magnifier-plus is not ambiguous.

Also **tabular figures**, so the number holds still rather than shifting as it moves between 90 and 100.

### Also ruled out

A filled/tonal circle. A filled circle is already this toolbar's **pressed** state (`iconButtonActive`), so a filled read-out would read as permanently switched on.

### Verification

- **Measured no-overflow at every reachable value**: `scrollWidth 30 == clientWidth 30` at 10, 100 and 400
- Read-out box confirmed identical to the icon buttons beside it (width, height, radius, background, border colour)
- Typecheck gate PASSED, ratchet unchanged at 2252
- ESLint clean
- 6 bound spec files, all collected, 48/48 pass. No test binds to the read-out's rendered text (checked)
- Dead `.textButton` rule removed with its only caller

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ⛔ Minimum-viewport disclosure (requested before merge)

**The aligned toolbars overlap below a viewport height of 596px.** Measured at this PR's head, 1280px wide:

| viewport height | gap between the two toolbars | overlap |
|---|---|---|
| 600px | 4px | no |
| **596px** | **0px** | no — this is the exact boundary |
| 590px | −6px | **yes** |

Above that height the layout is unaffected. Below it, the lower toolbar's top edge runs under the sidebar's bottom edge.

### ⚠ But this PR is not what raised the floor — correcting the attribution

**#870's height delta is zero.** Measured in a browser, staging's toolbar and this PR's toolbar are **both 320px tall**, and the sidebar is untouched, so the derived floor is **596px on both sides of this diff**. The read-out was already a 32px-tall box (`.textButton { height: 32px }`); `.readout` composes `.iconButton`, also 32px. Same height, different chrome.

The floor moved from ~527px to 596px in **#852**, when the toolbar adopted the sidebar's 32px buttons and 6px rhythm — and **#852 is already merged and deployed to staging**. So the raised minimum is live now, and holding this PR does not lower it. If the trade is rejected, the change required is to the geometry #852 shipped, not to this PR.

### Is it avoidable within scope?

**In this PR: there is nothing to avoid** — it costs no height.

**In the lane as a whole: no, not without inventing a third standard.** The height comes from the 32px buttons and 6px rhythm, which is what "matching the upper toolbar" means and what the brief asked for. Keeping the old 28px buttons would centre them at x=22 against the sidebar's x=20, so the button edges — the most visible line in a vertical toolbar — would still be misaligned; closing that needs a 10px container padding that exists on neither toolbar.

**So it is a genuine product trade, not an implementation defect:** 596px is above some real laptop and split-screen heights. That call belongs to the founder, and this PR is not the lever that decides it.
