### PR TITLE
D — a blocked analysis makes no claim about the user's options [IN-class]

### DIFF
--- a/src/canvas/domain/__tests__/optionAssessment.spec.ts
+++ b/src/canvas/domain/__tests__/optionAssessment.spec.ts
@@ -1,0 +1,78 @@
+/**
+ * A BLOCKED ANALYSIS MAKES NO CLAIM ABOUT THE USER'S OPTIONS.
+ *
+ * ── THE REGRESSION, MEASURED AND LIVE ─────────────────────────────────────
+ * `normaliseV5AnalysisReady` rejects a payload whose `goal_node_id` is empty or
+ * whose `options` array is empty. A blocked refusal used to be exactly that —
+ * witnessed on an authenticated journey:
+ *
+ *   { options: [], goal_node_id: "", status: "blocked",
+ *     blocked_reason: "MISSING_OPTION_VALUE" }
+ *
+ * So the guard WAS the status check: nothing downstream ever saw a blocked
+ * payload, and `BaseNode` could treat mere PRESENCE as a licence to mark an
+ * option incomplete.
+ *
+ * CEE now carries model identity on refusals — correctly, because a refusal
+ * that cannot name the model is one a user cannot act on. The composer returns
+ * `{ ...refusal, goal_node_id, options }`, each unvalued option carrying
+ * `interventions: {}`. The guard ADMITS, and every unvalued option on a blocked
+ * run rendered a dashed "incomplete" border: a claim about the user's model
+ * that nothing established.
+ *
+ * ⚠ THE FIX IS THE READER, NOT THE WRITER. Withholding identity is the defect
+ * the CEE change exists to close.
+ *
+ * ── BOTH DIRECTIONS, and the second is the one that matters more ──────────
+ * Silencing the TRUE case would be worse than the false one: an option that
+ * genuinely has no interventions on an analysis that DID assess it must still
+ * render uncertain. Every case below is paired.
+ */
+import { describe, it, expect } from 'vitest'
+import { optionsWereAssessed } from '../optionAssessment'
+import {
+  RECOGNISED_ANALYSIS_READY_STATUSES,
+  type RecognisedAnalysisReadyStatus,
+} from '../../../adapters/cee/types'
+
+describe('optionsWereAssessed — did the analysis project these options?', () => {
+  it('PRECONDITION — the status union is populated (a guard over an empty set is vacuous)', () => {
+    expect(RECOGNISED_ANALYSIS_READY_STATUSES.length).toBeGreaterThanOrEqual(5)
+    expect(RECOGNISED_ANALYSIS_READY_STATUSES).toContain('blocked')
+  })
+
+  it('⛔ a BLOCKED refusal licenses no claim — CEE refused before projecting', () => {
+    expect(optionsWereAssessed('blocked')).toBe(false)
+  })
+
+  it('⛔ OPPOSITE DIRECTION — every other recognised status still licenses the claim', () => {
+    // The harm this must not cause: silencing a TRUE incompleteness finding.
+    const others = RECOGNISED_ANALYSIS_READY_STATUSES.filter(
+      (s: RecognisedAnalysisReadyStatus) => s !== 'blocked',
+    )
+    expect(others.length).toBeGreaterThan(0)
+    for (const status of others) {
+      expect(optionsWereAssessed(status), `status ${status} must still assess`).toBe(true)
+    }
+  })
+
+  it('FAIL-SAFE — absent or unrecognised status keeps the pre-existing behaviour', () => {
+    // Narrowing here would withdraw a true claim on every payload that predates
+    // refusals carrying identity — the opposite-direction harm, at scale.
+    for (const s of [undefined, null, '', 'some_future_status']) {
+      expect(optionsWereAssessed(s as never), `input ${String(s)}`).toBe(true)
+    }
+  })
+
+  it('⭐ TOTALITY — the map decides EVERY recognised status, so a new one cannot slip through', () => {
+    // The typecheck enforces this at build time; this asserts it at runtime too,
+    // so a cast or a loosened type cannot quietly reopen the gap.
+    for (const status of RECOGNISED_ANALYSIS_READY_STATUSES) {
+      expect(typeof optionsWereAssessed(status)).toBe('boolean')
+    }
+    // …and the two answers are BOTH represented, so the map has not collapsed
+    // to a constant — which would pass every case above.
+    const answers = new Set(RECOGNISED_ANALYSIS_READY_STATUSES.map(optionsWereAssessed))
+    expect(answers.size, 'the map must discriminate, not return one answer').toBe(2)
+  })
+})

--- a/src/canvas/domain/optionAssessment.ts
+++ b/src/canvas/domain/optionAssessment.ts
@@ -1,0 +1,78 @@
+import type { RecognisedAnalysisReadyStatus } from '../../adapters/cee/types'
+
+/**
+ * ⭐ DID THE ANALYSIS ASSESS THESE OPTIONS? — the question that decides whether
+ * an option's EMPTY `interventions` is a FINDING or an ABSENCE.
+ *
+ * ── THE SEMANTIC COLLAPSE THIS EXISTS TO NAME APART ────────────────────────
+ * `interventions: {}` on an option now means one of two opposite things, and
+ * nothing in the shape distinguishes them:
+ *
+ *   ASSESSED     CEE projected this option's interventions and there are none.
+ *                "This option changes nothing" is a real finding about the
+ *                user's model, and the canvas should say so.
+ *   NOT ASSESSED CEE refused before projecting. The empty object is the
+ *                absence of an answer, not an answer. Rendering it as
+ *                incompleteness states a fact about the model that nobody
+ *                established.
+ *
+ * ── WHY IT BECAME REACHABLE (measured, deployed) ───────────────────────────
+ * `applyV5State.ts`'s `normaliseV5AnalysisReady` rejects a payload whose
+ * `goal_node_id` is empty or whose `options` array is empty — and a blocked
+ * refusal used to be exactly that shape (witnessed: `{ options: [],
+ * goal_node_id: "", status: "blocked", blocked_reason: "MISSING_OPTION_VALUE" }`).
+ * So the guard was, in effect, the status check: nothing downstream ever saw a
+ * blocked payload.
+ *
+ * CEE now carries model identity on refusals — correctly, since a refusal that
+ * cannot name the model is one a user cannot act on. The refusal composer
+ * returns `{ ...refusal, goal_node_id, options }` with `options` passed through
+ * from the readiness projection, each unvalued option carrying
+ * `interventions: {}`. The guard therefore ADMITS, and consumers behind it
+ * inherit a payload whose status they never had to consider.
+ *
+ * ⚠ THE DURABLE LESSON, AND IT IS WHY THIS FILE IS NAMED FOR THE QUESTION
+ * RATHER THAN THE FIX: **a guard that rejects degenerate payloads becomes an
+ * implicit status check, and loosening it removes a check nobody knew they were
+ * relying on.** The producer's own comment reasoned about the guard's ACCEPT
+ * PREDICATE and never asked what the consumers behind it relied upon. Gating on
+ * `status` alone would fix today's caller and leave the next one to walk into
+ * the same collapse; naming the question gives them something to read.
+ *
+ * ── THE MAP IS A DRIFT GUARD, NOT A CONVENIENCE ────────────────────────────
+ * Typed `Record<RecognisedAnalysisReadyStatus, …>` deliberately: adding a
+ * status to the union without deciding whether it licenses an assessment claim
+ * is a TYPECHECK FAILURE, and removing one orphans a key — also a failure. The
+ * same mechanism `STATUS_DISPOSITION` uses, for a DIFFERENT question (that one
+ * asks what the RUN GATE does; this asks whether an assessment happened). Two
+ * questions, two maps, deliberately not shared.
+ */
+type OptionAssessment = 'assessed' | 'not_assessed'
+
+const OPTION_ASSESSMENT: Record<RecognisedAnalysisReadyStatus, OptionAssessment> = {
+  // CEE projected the options; an empty `interventions` is its answer.
+  ready: 'assessed',
+  needs_user_mapping: 'assessed',
+  needs_encoding: 'assessed',
+  needs_user_input: 'assessed',
+  // CEE REFUSED. `options` is an identity passthrough, not a projection.
+  blocked: 'not_assessed',
+  // No status supplied. Kept 'assessed' because that is the behaviour every
+  // payload had before refusals carried identity — narrowing it here would
+  // silence the true case on every pre-existing shape, which is the
+  // opposite-direction harm this change must not cause.
+  unknown: 'assessed',
+}
+
+/**
+ * True when the analysis actually projected these options, so an empty
+ * `interventions` is a finding the surface may render.
+ *
+ * Fail-safe on an unrecognised status: treated as assessed, matching the
+ * pre-existing behaviour rather than silently withdrawing a true claim.
+ */
+export function optionsWereAssessed(status: string | undefined | null): boolean {
+  if (typeof status !== 'string' || status.length === 0) return true
+  const known = (OPTION_ASSESSMENT as Record<string, OptionAssessment | undefined>)[status]
+  return known === undefined ? true : known === 'assessed'
+}

--- a/src/canvas/nodes/BaseNode.tsx
+++ b/src/canvas/nodes/BaseNode.tsx
@@ -10,6 +10,7 @@
  */
 
 import { memo, useState, useCallback, type ReactNode } from 'react'
+import { optionsWereAssessed } from '../domain/optionAssessment'
 import { Handle, Position, type NodeProps, useUpdateNodeInternals } from '@xyflow/react'
 import type { NodeType, Controllability } from '../domain/nodes'
 import { ChevronDown, ChevronUp, Flag as FlagIcon, ArrowUp, ArrowDown, Minus, type LucideIcon } from 'lucide-react'
@@ -167,6 +168,27 @@ export const BaseNode = memo(({ id, nodeType, icon: _icon, data, selected, child
       // Only mark incomplete if analysisReady exists AND contains this option with empty interventions.
       // When analysisReady is null (cleared as stale), don't flag options as incomplete.
       if (!ceeAnalysisReady) return false
+
+      // ⛔ AND ONLY WHEN THE ANALYSIS ACTUALLY ASSESSED THEM.
+      //
+      // PRESENCE of `ceeAnalysisReady` used to be a sufficient licence for this
+      // claim, because `normaliseV5AnalysisReady` rejected any payload with an
+      // empty `goal_node_id` or empty `options` — and a blocked refusal was
+      // exactly that shape. The guard WAS the status check.
+      //
+      // CEE now carries model identity on refusals, so a blocked payload
+      // ADMITS: non-empty `options`, each unvalued one carrying
+      // `interventions: {}`, with `status: 'blocked'`. Without this line every
+      // unvalued option on a blocked run renders a dashed "incomplete" border —
+      // a claim about the user's model that nothing established, because CEE
+      // refused BEFORE projecting interventions.
+      //
+      // `optionsWereAssessed` is named for the QUESTION rather than this fix:
+      // empty `interventions` means "assessed, changes nothing" OR "never
+      // assessed", and the next consumer needs something to read rather than a
+      // bare `status !== 'blocked'` here.
+      if (!optionsWereAssessed(ceeAnalysisReady.status)) return false
+
       const ceeOption = ceeAnalysisReady.options?.find(opt => opt.id === id)
       if (!ceeOption) return false // Option not in analysisReady — not necessarily incomplete
       return !ceeOption.interventions || Object.keys(ceeOption.interventions).length === 0

--- a/src/canvas/nodes/__tests__/BaseNode.blockedAnalysisMakesNoClaim.spec.tsx
+++ b/src/canvas/nodes/__tests__/BaseNode.blockedAnalysisMakesNoClaim.spec.tsx
@@ -1,0 +1,127 @@
+/**
+ * A BLOCKED ANALYSIS MAY NOT MARK THE USER'S OPTIONS INCOMPLETE.
+ *
+ * `isIncomplete` renders `data-testid="overlay-missing-value"` and a warning
+ * dashed border — a factual claim that this option is missing something.
+ *
+ * ── WHY IT BECAME FALSE (measured, deployed) ──────────────────────────────
+ * The licence for that claim was mere PRESENCE of `ceeAnalysisReady`, and that
+ * was safe only because `normaliseV5AnalysisReady` rejected any payload with an
+ * empty `goal_node_id` or empty `options`. A blocked refusal was exactly that —
+ * witnessed on an authenticated journey:
+ *
+ *   { options: [], goal_node_id: "", status: "blocked",
+ *     blocked_reason: "MISSING_OPTION_VALUE" }
+ *
+ * So the guard WAS the status check; nothing downstream ever saw a blocked
+ * payload. CEE now carries model identity on refusals — correctly, since a
+ * refusal that cannot name the model is one a user cannot act on — so the
+ * composer returns `{ ...refusal, goal_node_id, options }` with each unvalued
+ * option carrying `interventions: {}`. The guard ADMITS, and every unvalued
+ * option on a blocked run was marked incomplete.
+ *
+ * ⚠ THE WIRING WAS UNPINNED, WHICH IS WHY THIS FILE EXISTS. Deleting the status
+ * gate from `BaseNode` left 842 tests across 46 files GREEN. The predicate had
+ * its own unit spec; the LINE THAT USES IT had nothing. A guard that is correct
+ * and unreached is not a guard.
+ *
+ * ── BOTH DIRECTIONS, and the second matters more ─────────────────────────
+ * Silencing the TRUE case would be worse than the false one, so the paired case
+ * asserts that an option genuinely without interventions on an analysis that
+ * DID assess it still renders the marker.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ReactFlowProvider } from '@xyflow/react'
+
+vi.mock('@xyflow/react', async () => {
+  const actual = await vi.importActual('@xyflow/react')
+  return { ...actual, Handle: () => null }
+})
+vi.mock('../../store', () => ({ useCanvasStore: vi.fn() }))
+vi.mock('../../layoutStore', () => ({
+  useLayoutStore: vi.fn(((s: (x: { layoutNodeWidth: number | null }) => unknown) =>
+    s({ layoutNodeWidth: null })) as unknown as (...a: never[]) => unknown),
+}))
+vi.mock('../../hooks/useNodeDisplayMetadata', () => ({
+  useNodeDisplayMetadata: vi.fn(() => ({
+    sensitivityRank: null,
+    influence: null,
+    confidence: null,
+    inSensitivityAnalysis: false,
+    achievementProbability: null,
+    stabilityPercentage: null,
+  })),
+}))
+
+import { useCanvasStore } from '../../store'
+import { OptionNode } from '../OptionNode'
+
+const OPTION_ID = 'opt_rebuild'
+
+/* eslint-disable @typescript-eslint/no-explicit-any -- mirrors the sibling
+   OptionNode specs: ReactFlow's NodeProps requires a dozen fields no assertion
+   here depends on. */
+const baseProps = {
+  selected: false,
+  dragging: false,
+  zIndex: 0,
+  isConnectable: false,
+  positionAbsoluteX: 0,
+  positionAbsoluteY: 0,
+  type: 'option',
+  deletable: true,
+  selectable: true,
+  draggable: true,
+}
+
+/** An option CEE listed with NO interventions — the shape at issue. */
+const UNVALUED_OPTION = { id: OPTION_ID, label: 'Rebuild', interventions: {} }
+
+function withStatus(status: string | undefined) {
+  vi.mocked(useCanvasStore).mockImplementation((selector) =>
+    selector({
+      hoveredOptionId: null,
+      nodes: [{ id: OPTION_ID, type: 'option', data: { type: 'option', label: 'Rebuild' } }],
+      edges: [],
+      ceeAnalysisReady: { options: [UNVALUED_OPTION], goal_node_id: 'goal_1', status },
+      results: { status: 'idle', report: null },
+      highlightedNodes: new Set(),
+      dimmedNodeIds: new Set(),
+      lens: { _dimmedNodeIds: new Set() },
+      goalThreshold: null,
+      goalConstraints: [],
+      setHoveredOption: vi.fn(),
+      viewMode: 'expert',
+    } as never),
+  )
+  return render(
+    <ReactFlowProvider>
+      <OptionNode {...(baseProps as any)} id={OPTION_ID} data={{ label: 'Rebuild', type: 'option' }} />
+    </ReactFlowProvider>,
+  )
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('a blocked analysis makes no claim about the options', () => {
+  it('⛔ BLOCKED — the option is NOT marked incomplete', () => {
+    withStatus('blocked')
+    expect(screen.queryByTestId('overlay-missing-value')).toBeNull()
+  })
+
+  it('⛔ OPPOSITE DIRECTION — an assessed analysis STILL marks it incomplete', () => {
+    // The harm this fix must not cause. Same fixture, same empty
+    // `interventions`; only the status differs — so a pass here cannot be
+    // explained by the option shape, only by the status being consulted.
+    withStatus('ready')
+    expect(screen.getByTestId('overlay-missing-value')).toBeTruthy()
+  })
+
+  it('FAIL-SAFE — an absent status keeps the pre-existing behaviour', () => {
+    withStatus(undefined)
+    expect(screen.getByTestId('overlay-missing-value')).toBeTruthy()
+  })
+})


### PR DESCRIPTION
## A blocked analysis was marking the user's options incomplete

**Live regression on deployed staging**, and the cause is a check nobody knew they were relying on.

`isIncomplete` renders `data-testid="overlay-missing-value"` and a warning dashed border on an option node — **a factual claim that the option is missing something.** Its licence was mere *presence* of `ceeAnalysisReady`.

That was safe only because `normaliseV5AnalysisReady` rejects a payload whose `goal_node_id` is empty or whose `options` array is empty — and a blocked refusal used to be **exactly that shape**. Witnessed on an authenticated journey:

```json
{ "options": [], "goal_node_id": "", "status": "blocked",
  "blocked_reason": "MISSING_OPTION_VALUE" }
```

**So the guard *was* the status check.** Nothing downstream ever saw a blocked payload, and presence was a sound proxy for *"an analysis assessed this"*.

CEE now carries model identity on refusals — **correctly**, since a refusal that cannot name the model is one a user cannot act on. Its composer returns `{ ...refusal, goal_node_id, options }`, each unvalued option carrying `interventions: {}`. **The guard admits, and every unvalued option on a blocked run was marked incomplete.**

⚠ **The fix is the reader, not the writer.** Asking CEE to withhold identity would reinstate the defect its change exists to close.

## ⭐ The deliverable is the name, not the gate

`interventions: {}` now means one of two opposite things:

| | |
|---|---|
| **assessed** | CEE projected this option and there are none — a real finding about the model |
| **not assessed** | CEE refused before projecting — the absence of an answer |

Gating on `status !== 'blocked'` inline would fix this caller and leave the next one to walk into the same collapse. `canvas/domain/optionAssessment.ts` is named for the **question**, so the next consumer has something to read.

The map is typed `Record<RecognisedAnalysisReadyStatus, …>` deliberately: **adding a status without deciding whether it licenses an assessment claim is a typecheck failure.** Same mechanism as `STATUS_DISPOSITION`, for a **different question** — that one asks what the *run gate* does; this asks whether an *assessment happened*. Two questions, two maps, deliberately not shared.

## ⚠ The wiring was unpinned, which is why there is a render spec

**Deleting the status gate from `BaseNode` left 842 tests across 46 files green.** A predicate would have had its own unit spec; the line that *uses* it had nothing. **A guard that is correct and unreached is not a guard.**

## Evidence

Pristine archive outside the tree, applied-check 1 per mutation, trailing control clean. **301 passed** across the two suites; **2393 across four directories** including `tests/ci-guards/`.

| mutant | result |
|---|---|
| delete the gate from `BaseNode` | **RED** (render spec) — previously **green 842/842** |
| collapse the map (silence the true case) | **RED at both levels** |
| `blocked` → `assessed` (reopen it) | **RED at both levels** |

**Both directions pinned.** Silencing a true finding would be worse than the false one, so the paired case asserts an option with the **same** empty `interventions` still renders the marker when the status says the analysis assessed it — only the status differs, so a pass cannot be explained by the option shape.

**Fail-safe** on an absent or unrecognised status: treated as assessed, matching the behaviour every payload had before refusals carried identity. Narrowing there would withdraw a true claim on every pre-existing shape.

Typecheck gate **PASSED at exactly baseline 2252 errors / 556 files**.
