### PR TITLE
D — a blocked refusal is not restored into a session where nothing was refused [IN-class]

### DIFF
--- a/src/canvas/store.ts
+++ b/src/canvas/store.ts
@@ -4947,9 +4947,27 @@ export const useCanvasStore = create<CanvasState>((originalSet, get) => {
         )
       }
       // Persist to sessionStorage for tab-refresh survival (with node IDs for validation)
+      //
+      // ⛔ EXCEPT A BLOCKED REFUSAL, which is not a readiness verdict and must
+      // not survive a reload. `setAnalysisRefusalNotice` below states the rule
+      // for its sibling in as many words — persisting it "would restore a
+      // refusal into a session where no analysis was refused" — and after CEE
+      // began carrying model identity on refusals, this payload is exactly that
+      // shape. Restoring it hands the user the refusal's EVIDENCE on a fresh tab
+      // while its EXPLANATION is deliberately withheld.
+      //
+      // `validateCeeAnalysisReady` rejects the same condition on the way back
+      // in, so this is belt-and-braces: not writing it is cheaper than relying
+      // on every restore path to check.
+      const isBlockedRefusal = analysisReady.status === 'blocked'
       try {
-        sessionStorage.setItem('olumi-cee-analysis-ready', JSON.stringify(analysisReady))
-        sessionStorage.setItem('olumi-cee-analysis-ready-node-ids', JSON.stringify(nodeIds))
+        if (isBlockedRefusal) {
+          sessionStorage.removeItem('olumi-cee-analysis-ready')
+          sessionStorage.removeItem('olumi-cee-analysis-ready-node-ids')
+        } else {
+          sessionStorage.setItem('olumi-cee-analysis-ready', JSON.stringify(analysisReady))
+          sessionStorage.setItem('olumi-cee-analysis-ready-node-ids', JSON.stringify(nodeIds))
+        }
       } catch {}
     } else {
       logConstraintClearIfPresent(get, 'setCeeAnalysisReady(null)')

--- a/src/canvas/utils/__tests__/blockedRefusalIsNotRestored.spec.ts
+++ b/src/canvas/utils/__tests__/blockedRefusalIsNotRestored.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * A BLOCKED REFUSAL MUST NOT SURVIVE A RELOAD.
+ *
+ * ── THE MECHANISM, and it is the third instance of one shape today ────────
+ * `validateCeeAnalysisReady` gates every restore of `ceeAnalysisReady` —
+ * sessionStorage, the autosave projection, and the graph-load path. It rejected
+ * blocked refusals ONLY BY ACCIDENT: a refusal used to carry `options: []`, so
+ * the `empty_options` check caught it and nothing was ever restored.
+ *
+ * CEE now carries model identity on refusals — correctly, since a refusal that
+ * cannot name the model is one a user cannot act on. The payload therefore has
+ * non-empty options and the validator ADMITS it. The accident has stopped
+ * happening, and nothing replaced it: `validateCeeAnalysisReady` reads `.status`
+ * zero times.
+ *
+ * ⭐ THE ARGUMENT IS ALREADY IN THIS CODEBASE, ABOUT THE SIBLING FIELD.
+ * `store.ts`'s `setAnalysisRefusalNotice` is deliberately a bare `set` with no
+ * sessionStorage write, and says why: doing so "would restore a refusal into a
+ * session where no analysis was refused."
+ *
+ * So after the producer change the refusal's PAYLOAD gets exactly the treatment
+ * its EXPLANATION is denied. Reload the tab and the user holds the evidence of a
+ * refusal with no account of it — on a session where nothing was refused.
+ *
+ * ── BOTH DIRECTIONS ──────────────────────────────────────────────────────
+ * The opposite harm is worse: a genuine readiness verdict that stops surviving a
+ * refresh would silently lose real state on every reload. Every case below is
+ * paired against a non-blocked payload built from the same fixture.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { validateCeeAnalysisReady } from '../ceeAnalysisReadyValidation'
+import type { CEEAnalysisReady } from '../../../adapters/cee/types'
+import type { Node } from '@xyflow/react'
+
+const GOAL_ID = 'goal_1'
+const OPTION_ID = 'opt_rebuild'
+
+const NODES = [
+  { id: GOAL_ID, type: 'goal', position: { x: 0, y: 0 }, data: {} },
+  { id: OPTION_ID, type: 'option', position: { x: 0, y: 0 }, data: {} },
+] as unknown as Node[]
+
+/** The shape CEE now sends on a refusal: identity present, status blocked. */
+const payload = (status?: string): CEEAnalysisReady =>
+  ({
+    goal_node_id: GOAL_ID,
+    options: [{ id: OPTION_ID, label: 'Rebuild', interventions: {} }],
+    ...(status === undefined ? {} : { status }),
+  }) as unknown as CEEAnalysisReady
+
+describe('a blocked refusal is not restored', () => {
+  it('PRECONDITION — the fixture would OTHERWISE validate, so a rejection is the status doing it', () => {
+    // Without this, `blocked` could be rejected for a missing goal or absent
+    // option and the case would pass for the wrong reason (trap 13).
+    expect(validateCeeAnalysisReady(payload(undefined), null, NODES).isValid).toBe(true)
+  })
+
+  it('⛔ a BLOCKED payload is rejected, and named as such', () => {
+    const result = validateCeeAnalysisReady(payload('blocked'), null, NODES)
+    expect(result.isValid).toBe(false)
+    expect(result.reason).toBe('blocked_refusal')
+  })
+
+  it('⛔ OPPOSITE DIRECTION — a genuine readiness verdict still restores', () => {
+    // The harm this must not cause: silently losing real state on every reload.
+    for (const status of ['ready', 'needs_encoding', 'needs_user_mapping', 'needs_user_input']) {
+      expect(
+        validateCeeAnalysisReady(payload(status), null, NODES).isValid,
+        `status ${status} must still restore`,
+      ).toBe(true)
+    }
+  })
+
+  it('DISCRIMINATING — the rejection is not swallowing the other reasons', () => {
+    // A gate that rejected everything would satisfy the blocked case while
+    // destroying the validator's real work.
+    const missingGoal = validateCeeAnalysisReady(payload('ready'), null, [])
+    expect(missingGoal.isValid).toBe(false)
+    expect(missingGoal.reason).toBe('missing_goal')
+
+    const noOptions = { ...payload('ready'), options: [] } as unknown as CEEAnalysisReady
+    expect(validateCeeAnalysisReady(noOptions, null, NODES).reason).toBe('empty_options')
+  })
+})
+
+/**
+ * BELT AND BRACES: it is not WRITTEN in the first place.
+ *
+ * The validator gates the way back in; this gates the way out. Not writing a
+ * refusal is cheaper than relying on every restore path to check for one — and
+ * `setCeeAnalysisReady` is the single writer of both sessionStorage keys, so it
+ * is the one place that can be sure.
+ *
+ * ⚠ It also CLEARS any prior entry. A session that stored a genuine verdict and
+ * then received a refusal would otherwise keep the stale verdict on disk and
+ * restore THAT on reload — a different wrong answer, and a quieter one.
+ */
+describe('a blocked refusal is not written to sessionStorage', () => {
+  const KEY = 'olumi-cee-analysis-ready'
+  const IDS = 'olumi-cee-analysis-ready-node-ids'
+
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('⛔ BLOCKED — nothing is written, and any prior entry is cleared', async () => {
+    const { useCanvasStore } = await import('../../store')
+    // PRECONDITION: a genuine verdict really does persist, so the absence below
+    // is this status's doing and not a broken writer.
+    useCanvasStore.getState().setCeeAnalysisReady(payload('ready') as never)
+    expect(sessionStorage.getItem(KEY), 'precondition: a ready verdict persists').not.toBeNull()
+
+    useCanvasStore.getState().setCeeAnalysisReady(payload('blocked') as never)
+    expect(sessionStorage.getItem(KEY)).toBeNull()
+    expect(sessionStorage.getItem(IDS)).toBeNull()
+  })
+
+  it('⛔ OPPOSITE DIRECTION — a genuine verdict is still written', async () => {
+    const { useCanvasStore } = await import('../../store')
+    useCanvasStore.getState().setCeeAnalysisReady(payload('ready') as never)
+    expect(sessionStorage.getItem(KEY)).not.toBeNull()
+    expect(sessionStorage.getItem(IDS)).not.toBeNull()
+  })
+})

--- a/src/canvas/utils/__tests__/blockedRefusalIsNotRestored.spec.ts
+++ b/src/canvas/utils/__tests__/blockedRefusalIsNotRestored.spec.ts
@@ -46,7 +46,7 @@ const payload = (status?: string): CEEAnalysisReady =>
     goal_node_id: GOAL_ID,
     options: [{ id: OPTION_ID, label: 'Rebuild', interventions: {} }],
     ...(status === undefined ? {} : { status }),
-  }) as unknown as CEEAnalysisReady
+  }) as CEEAnalysisReady
 
 describe('a blocked refusal is not restored', () => {
   it('PRECONDITION — the fixture would OTHERWISE validate, so a rejection is the status doing it', () => {
@@ -113,6 +113,38 @@ describe('a blocked refusal is not written to sessionStorage', () => {
     useCanvasStore.getState().setCeeAnalysisReady(payload('blocked') as never)
     expect(sessionStorage.getItem(KEY)).toBeNull()
     expect(sessionStorage.getItem(IDS)).toBeNull()
+  })
+
+  /*
+   * ⛔ THE OPPOSITE-DIRECTION QUESTION ON THE CLEAR, asked and answered.
+   *
+   * Clearing a PRIOR entry is surface nobody specified — it was added because a
+   * session that stored a genuine verdict and then received a refusal would
+   * otherwise restore the stale verdict on reload. Good additions are where
+   * unreviewed surface enters, so it gets the same scrutiny as the part that
+   * was asked for: IS THERE ANY ARM WHERE A PRIOR VERDICT SHOULD SURVIVE?
+   *
+   * The answer rests on blast radius, and it is narrow: this touches
+   * sessionStorage ONLY. The live store value is still set — a blocked payload
+   * remains readable in-session, which is what consumers gate on — and analysis
+   * RESULTS live in separate fields the setter never reaches. So nothing a user
+   * is currently looking at is lost.
+   *
+   * What changes is only what survives a RELOAD, and there the alternative is
+   * restoring a readiness verdict that CEE has explicitly superseded with a
+   * refusal. That is the same class as the sibling precedent, not a new
+   * judgement.
+   */
+  it('⛔ IN-SESSION NOTHING IS LOST — the live value is still set on a refusal', async () => {
+    const { useCanvasStore } = await import('../../store')
+    useCanvasStore.getState().setCeeAnalysisReady(payload('blocked') as never)
+
+    // The store value is PRESENT (consumers gate on `status`, per #871) …
+    const live = useCanvasStore.getState().ceeAnalysisReady
+    expect(live, 'the live value must survive — only persistence is withheld').not.toBeNull()
+    expect(live?.status).toBe('blocked')
+    // … while the persisted copy is not.
+    expect(sessionStorage.getItem(KEY)).toBeNull()
   })
 
   it('⛔ OPPOSITE DIRECTION — a genuine verdict is still written', async () => {

--- a/src/canvas/utils/ceeAnalysisReadyValidation.ts
+++ b/src/canvas/utils/ceeAnalysisReadyValidation.ts
@@ -10,7 +10,13 @@ import type { Node } from '@xyflow/react'
 
 export interface ValidationResult {
   isValid: boolean
-  reason?: 'missing_goal' | 'missing_option_nodes' | 'node_ids_changed' | 'empty_options'
+  reason?:
+    | 'missing_goal'
+    | 'missing_option_nodes'
+    | 'node_ids_changed'
+    | 'empty_options'
+    /** A blocked refusal: identity-bearing, but not a readiness verdict to restore. */
+    | 'blocked_refusal'
   details?: string
 }
 
@@ -35,6 +41,28 @@ export function validateCeeAnalysisReady(
 ): ValidationResult {
   if (!ceeAnalysisReady || !ceeAnalysisReady.options?.length) {
     return { isValid: false, reason: 'empty_options' }
+  }
+
+  // ⛔ A BLOCKED REFUSAL IS NOT A RESTORABLE READINESS VERDICT.
+  //
+  // The check above USED to cover this by accident: a blocked refusal carried
+  // `options: []`, so `empty_options` rejected it and nothing was ever
+  // restored. CEE now carries model identity on refusals — correctly, because a
+  // refusal that cannot name the model is one a user cannot act on — so the
+  // payload has non-empty options and this validator ADMITS it.
+  //
+  // ⭐ THE ARGUMENT IS ALREADY IN THIS CODEBASE, ABOUT ITS SIBLING.
+  // `store.ts`'s `setAnalysisRefusalNotice` is deliberately a bare `set` with no
+  // sessionStorage write, and says why: doing so "would restore a refusal into a
+  // session where no analysis was refused". The refusal's EXPLANATION is
+  // withheld from persistence for exactly this reason — so restoring the
+  // refusal's PAYLOAD leaves a user holding the evidence of a refusal with no
+  // account of it, on a fresh tab where nothing was refused.
+  //
+  // One seam, three sources: this validator gates the sessionStorage restore,
+  // the autosave projection and the graph-load path alike.
+  if (ceeAnalysisReady.status === 'blocked') {
+    return { isValid: false, reason: 'blocked_refusal' }
   }
 
   // Check goal node exists


### PR DESCRIPTION
## A blocked refusal was about to survive a reload

**CEE #1128 is held behind this.**

`validateCeeAnalysisReady` gates **every** restore of `ceeAnalysisReady` — sessionStorage, the autosave projection, and the graph-load path. It rejected blocked refusals **only by accident**: a refusal used to carry `options: []`, so the `empty_options` check caught it. **The validator reads `.status` zero times.**

Once CEE carries model identity on refusals — correctly, since a refusal that cannot name the model is one a user cannot act on — the payload has non-empty options, the accident stops happening, and nothing replaces it.

> **A guard that rejects degenerate payloads becomes an implicit status check, and loosening it removes a check nobody knew they were relying on.**

That is the **third instance of this one shape today**.

## ⭐ The argument is already in this codebase, about the sibling field

`setAnalysisRefusalNotice` is deliberately a bare `set` with no sessionStorage write, and says why:

> *"would restore a refusal into a session where no analysis was refused."*

So after the producer change, the refusal's **payload** gets exactly the treatment its **explanation** is denied. **Reload the tab and the user holds the evidence of a refusal with no account of it.**

## Two seams, deliberately

- **`ceeAnalysisReadyValidation.ts`** rejects `status === 'blocked'` with its own named reason — **one seam covering all three restore sources.**
- **`store.ts`'s `setCeeAnalysisReady`** does not *write* it in the first place, and **clears any prior entry**. A session that stored a genuine verdict and then received a refusal would otherwise keep the stale verdict on disk and restore *that* — a different wrong answer, and a quieter one.

Not writing is cheaper than relying on every restore path to check, and the setter is the single writer of both keys.

## Both directions pinned

**The opposite harm is worse**: a genuine readiness verdict that stopped surviving a refresh would silently lose real state on every reload. Every case is paired against a non-blocked payload built from the same fixture — and the **precondition** case asserts that fixture *would otherwise validate*, so a rejection is the status doing it rather than a missing goal.

| mutant | result |
|---|---|
| remove the validator gate | **RED** 1/6 |
| reject **everything** | **RED** 3/6 (the true case, silenced) |
| write it anyway | **RED** 1/6 |
| never write anything | **RED** 2/6 (the true case, silenced) |

2491 passed across three directories. Typecheck gate **PASSED at exactly baseline 2252 / 556**.

## ⚠ And I invented a signature, caught by the gate

The spec called `setCeeAnalysisReady(payload, nodeIds)` because `nodeIds` appears in the surrounding store code. **It takes one argument.** No test could see it; the typecheck gate did.
