### PR TITLE
style(canvas): the two toolbars match in feel, not just in look

### DIFF
--- a/src/components/layout/CanvasFloatingToolbar.module.css
+++ b/src/components/layout/CanvasFloatingToolbar.module.css
@@ -15,9 +15,8 @@
  * value changed here moves both toolbars, which is the only way they stay
  * members of the same UI system.
  *
- * What each consumer still owns: its EDGE ANCHOR (`top` vs `bottom`) and its
- * `pointer-events` posture — both behavioural, and both deliberately left as
- * they already were.
+ * What each consumer still owns: its EDGE ANCHOR (`top` vs `bottom`). Nothing
+ * else — the two toolbars are now identical in look AND in feel.
  */
 
 .surface {
@@ -31,6 +30,14 @@
   justify-content: flex-start;
   z-index: 1100;
   gap: 6px;
+  /* ⚠ THE SIDEBAR USED TO BE `none` HERE, AND THAT LEAKED CLICKS. A click on
+     its padding — the 8px either side of a button, and the gaps between them —
+     passed straight through the visible white panel to the canvas beneath, so a
+     drag begun on the toolbar's edge PANNED THE GRAPH. Witnessed with
+     elementFromPoint: the sidebar's padding strips returned the canvas element,
+     the lower toolbar's returned the toolbar. An opaque surface should not move
+     what is behind it, so both now absorb. */
+  pointer-events: auto;
   /* Floating panel style - fit content height */
   height: fit-content;
   background: rgba(255, 255, 255, 0.95);
@@ -44,16 +51,11 @@
   composes: surface;
   /* Position below topbar with some spacing */
   top: calc(var(--topbar-h) + 1rem);
-  /* Unchanged: the container lets clicks through, the buttons take them back. */
-  pointer-events: none;
 }
 
 .viewportControls {
   composes: surface;
   bottom: 12px;
-  /* Unchanged from the pre-alignment lower toolbar, which took pointer events
-     on the container. Not a visual property, so alignment does not touch it. */
-  pointer-events: auto;
 }
 
 .group {
@@ -117,8 +119,14 @@
   border-color: var(--info);
 }
 
+/**
+ * Disabled — undo and redo spend most of a fresh canvas here, so this opacity
+ * sets how the WHOLE upper toolbar reads, not just one button. At 0.35 it read
+ * as a faded panel next to the lower one rather than as two live controls among
+ * four; 0.5 still says "not available" without dimming the toolbar it sits in.
+ */
 .iconButton:disabled {
-  opacity: 0.35;
+  opacity: 0.5;
   cursor: not-allowed;
   pointer-events: none;
 }


### PR DESCRIPTION
Two things the alignment left behind — both found by the founder looking at the result, neither caught by any gate.

## 1. The sidebar leaked clicks

Its container was `pointer-events: none`, so a click on its padding — the 8px either side of a button, and the gaps between them — passed straight through the visible white panel to the canvas beneath. **A drag begun on the toolbar's edge panned the graph.** The lower toolbar has always absorbed those clicks, so the two looked identical and behaved differently.

Witnessed with `elementFromPoint`, before and after:

| click on | before | after |
|---|---|---|
| sidebar padding strip | `#canvas` — passed through | `nav[Canvas tools]` |
| lower toolbar padding strip | `nav[Viewport controls]` | `nav[Viewport controls]` |

An opaque surface should not move what is behind it. `pointer-events` now lives once on `.surface`, and neither consumer overrides it — the edge anchor (`top` vs `bottom`) is the only thing they still own separately.

## 2. Disabled was too faint to read as one system

Undo and Redo are disabled for the whole of a fresh canvas, so `opacity: 0.35` set how the **upper toolbar** reads, not how one button reads. Three of its four controls are off-default at rest (two disabled, one active-blue), and beside a lower toolbar where nothing is ever disabled it looked like a faded panel rather than a live one.

`0.5` still says "not available" without dimming the toolbar it sits in. Measured after: disabled Undo computes `opacity: 0.5`.

## What was NOT wrong

The founder asked whether the icon colours differed. They do not, and this was measured button by button before changing anything: **every enabled icon in both toolbars is `rgb(38,38,38)`, `stroke-width: 2`, 24×24 viewBox rendered at 16px.** The difference visible on a fresh canvas is *state* — two disabled buttons and one active-blue one — not style. Only (2) changes it.

## Verification

- `elementFromPoint` probes before and after, both toolbars, padding strips and inter-button gaps
- disabled opacity confirmed at `0.5` on the rendered button
- typecheck gate PASSED, ratchet unchanged at 2252
- 12 spec files collected, 100/100 pass
- CSS-only diff, 17/9 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)