### PR TITLE
style(topbar): the header gets a focus ring, and stops saying its button three times

### DIFF
--- a/src/components/layout/TopBar.module.css
+++ b/src/components/layout/TopBar.module.css
@@ -35,7 +35,7 @@
   align-items: center;
 }
 
-.logoLink:focus {
+.logoLink:focus-visible {
   outline: 2px solid var(--info);
   outline-offset: 2px;
   border-radius: 4px;
@@ -76,7 +76,16 @@
   flex-shrink: 0;
 }
 
-/* Compact icon buttons for pill design */
+/**
+ * THE header button. Share and menu below are the same control and now say so
+ * rather than repeating it — three byte-identical copies of one button is how
+ * the two canvas toolbars drifted apart, and this file had the same shape.
+ *
+ * Deliberately NOT the canvas toolbars' bordered circle: 6px rounded squares
+ * are right for a dense 45px horizontal bar, where circles would read heavy.
+ * What IS shared with them is the part a user feels — the 32px box, the 16px
+ * icon, and the focus/disabled grammar below.
+ */
 .iconButton {
   display: flex;
   align-items: center;
@@ -91,7 +100,9 @@
   background: transparent;
   color: var(--text-body, #3F3F3E);
   cursor: pointer;
-  transition: all 150ms;
+  /* Was `all 150ms`, which animates layout properties too. Enumerated, at the
+     canvas toolbars' 120ms. */
+  transition: background 120ms ease, color 120ms ease;
 }
 
 .iconButton:hover:not(:disabled) {
@@ -99,8 +110,22 @@
   color: var(--text-header, #262626);
 }
 
+/**
+ * ⚠ THIS FILE HAD NO `:focus-visible` RULE AT ALL — the only focus style was
+ * `.logoLink:focus`. Every control in the header therefore fell back to the
+ * browser default ring while the canvas toolbars draw an explicit one. That is
+ * an accessibility gap, not a styling preference. Same rule as
+ * `CanvasFloatingToolbar.module.css`.
+ */
+.iconButton:focus-visible {
+  outline: 2px solid var(--info);
+  outline-offset: 2px;
+}
+
+/* 0.5, matching the canvas toolbars — 0.4 read fainter than the same state
+   does twelve pixels below it. */
 .iconButton:disabled {
-  opacity: 0.4;
+  opacity: 0.5;
   cursor: not-allowed;
 }
 
@@ -131,57 +156,14 @@
   text-decoration: underline;
 }
 
-/* Share button - icon only in pill */
+/* Share and menu ARE the header button. Both class names are kept so no call
+   site moves; they now inherit every rule above, focus and disabled included. */
 .shareButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  border: none;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-body, #3F3F3E);
-  cursor: pointer;
-  transition: all 150ms;
+  composes: iconButton;
 }
 
-.shareButton:hover {
-  background: var(--bg-panel-hover, #FEF9F3);
-  color: var(--text-header, #262626);
-}
-
-.shareButton svg {
-  width: 16px;
-  height: 16px;
-}
-
-
-/* Menu button */
 .menuButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  border: none;
-  border-radius: 6px;
-  background: transparent;
-  color: var(--text-body, #3F3F3E);
-  cursor: pointer;
-  transition: all 150ms;
-}
-
-.menuButton:hover {
-  background: var(--bg-panel-hover, #FEF9F3);
-  color: var(--text-header, #262626);
-}
-
-.menuButton svg {
-  width: 16px;
-  height: 16px;
+  composes: iconButton;
 }
 
 .menuDropdown {
@@ -193,7 +175,7 @@
   top: calc(100% + 8px);
   right: 0;
   min-width: 220px;
-  background: white;
+  background: var(--bg-panel, #FEFEFE);
   border: 1px solid var(--border-default, #EEE6D8);
   border-radius: 10px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12), 0 2px 4px rgba(0, 0, 0, 0.06);
@@ -213,12 +195,17 @@
   background: transparent;
   border-radius: 6px;
   cursor: pointer;
-  transition: background 150ms;
+  transition: background 120ms ease;
   color: var(--text-body, #3F3F3E);
 }
 
 .dropdownMenuButton:hover {
   background: var(--bg-panel-hover, #FEF9F3);
+}
+
+.dropdownMenuButton:focus-visible {
+  outline: 2px solid var(--info);
+  outline-offset: -2px;
 }
 
 .dropdownMenuButton svg {


### PR DESCRIPTION
Consistency pass on the floating header, alongside the canvas toolbar work (#852, #854, #870, #873). **Five mechanical items. The header's own visual language is deliberately untouched.**

## ⚠ 1. The header had no `:focus-visible` rule at all

The only focus style in the file was `.logoLink:focus`. Every control in the header — the icon buttons, share, the kebab, and every item in the kebab's dropdown — fell back to the browser default ring, while the canvas toolbars twelve pixels below draw an explicit 2px one.

**This is an accessibility gap, not a styling preference.** The toolbars' rule now applies to the header button and the dropdown's items, and `.logoLink:focus` becomes `:focus-visible` so the ring stops appearing on mouse clicks too.

## 2. One button, said three times

`.iconButton`, `.shareButton` and `.menuButton` were byte-identical copies, each with its own `:hover` and `svg` rules. Copies of one visual standard is exactly how the two canvas toolbars drifted apart, and this file had the same shape.

Share and menu now `composes: iconButton`. **Both class names are kept, so no call site moves** — and they inherit the new focus and disabled rules, which three copies would each have needed separately.

## 3–5. Small alignments

| | before | after |
|---|---|---|
| disabled opacity | `0.4` | `0.5` — the toolbars' value |
| transition | `all 150ms` | `background 120ms ease, color 120ms ease` |
| `.dropdownMenu` background | literal `white` | `var(--bg-panel)` |

`transition: all` animates layout properties too; 120ms matches the toolbars.

## Deliberately NOT done

**The header's buttons stay 6px rounded squares** rather than becoming the toolbars' bordered circles. A dense 45px horizontal bar is not a 48px vertical rail, and circles would read heavy there. What is now shared is the part a user feels: the 32px box, the 16px icon, and the focus/disabled grammar.

**The header's surface treatment** — 12px radius vs 16px, opaque vs translucent, flatter shadow, no backdrop blur — is a separate question with a visible consequence. It goes to the founder with a rendering rather than being decided in a mechanical PR. Same for the seven distinct `border-radius` values in this file.

## Verification

Checked at the **built bytes**, not just the source:
- the bundle emits `_shareButton_… _iconButton_…` and `_menuButton_… _iconButton_…`, so `composes` resolves in production
- `:focus-visible` rules present in the built CSS for the header button and the dropdown items

Plus: typecheck gate PASSED (ratchet unchanged at 2252), production build clean, 10 layout spec files collected, 72/72 pass. CSS-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)