### PR TITLE
fix(canvas): RecoveryBanner actually validates the restore its comment claimed

### DIFF
--- a/scripts/ci/typecheck-baseline-identities.txt
+++ b/scripts/ci/typecheck-baseline-identities.txt
@@ -13,7 +13,7 @@
 # Messages here are canonicalised (union members sorted) for that reason.
 #
 # Format: <count><TAB><path><TAB><TS-code><TAB><canonicalised message>.
-# count=2252
+# count=2251
 1	e2e/_helpers.ts	TS6133	'expect' is declared but its value is never read.
 1	e2e/a11y.spec.ts	TS6133	'resultsPanel' is declared but its value is never read.
 9	e2e/canvas-inspector.spec.ts	TS6133	'page' is declared but its value is never read.
@@ -340,7 +340,6 @@
 1	src/canvas/components/RangeDisplay.tsx	TS6133	'formatOutcomeValue' is declared but its value is never read.
 1	src/canvas/components/RangeDisplay.tsx	TS6133	'formatOutcomeValueCompact' is declared but its value is never read.
 1	src/canvas/components/RecoveryBanner.tsx	TS2322	Type 'Edge[]' is not assignable to type 'Edge<EdgeData>[]'.
-1	src/canvas/components/RecoveryBanner.tsx	TS2322	Type '{ options: { id: string; label: string; status: "needs_encoding" | "needs_user_mapping" | "ready"; interventions: Record<string, unknown>; user_questions?: string[] | undefined; unresolved_targets?: string[] | undefined; }[]; goal_node_id: string; suggested_seed?: string | undefined; status?: string | undefined; use...' is not assignable to type 'CEEAnalysisReady | null | undefined'.
 1	src/canvas/components/RecoveryBanner.tsx	TS2741	Property 'anchorPosition' is missing in type '{ nodeIds: Set<string>; edgeIds: Set<string>; }' but required in type '{ nodeIds: Set<string>; edgeIds: Set<string>; anchorPosition: { x: number; y: number; } | null; }'.
 1	src/canvas/components/RiskAdjustedDisplay.tsx	TS2305	Module '"../../adapters/plot/types"' has no exported member 'RiskProfile'.
 1	src/canvas/components/RiskAdjustedDisplay.tsx	TS2305	Module '"../../adapters/plot/types"' has no exported member 'RiskProfilePreset'.

--- a/scripts/ci/typecheck-baseline.txt
+++ b/scripts/ci/typecheck-baseline.txt
@@ -10,7 +10,7 @@
 # this file and phase 2.
 #
 # Format: <error-count><TAB><path>, sorted by path.
-# count=2252
+# count=2251
 1	e2e/_helpers.ts
 1	e2e/a11y.spec.ts
 9	e2e/canvas-inspector.spec.ts
@@ -141,7 +141,7 @@
 1	src/canvas/components/OutputsDock.stories.tsx
 27	src/canvas/components/PreAnalysisGuidance.tsx
 2	src/canvas/components/RangeDisplay.tsx
-3	src/canvas/components/RecoveryBanner.tsx
+2	src/canvas/components/RecoveryBanner.tsx
 2	src/canvas/components/RiskAdjustedDisplay.tsx
 2	src/canvas/components/RiskProfileBadge.tsx
 6	src/canvas/components/RiskProfileSelector.tsx

--- a/src/canvas/components/RecoveryBanner.tsx
+++ b/src/canvas/components/RecoveryBanner.tsx
@@ -10,6 +10,8 @@ import { useState, useEffect } from 'react'
 import { AlertCircle, X } from 'lucide-react'
 import { loadAutosave, clearAutosave, hasUnsavedWork } from '../store/scenarios'
 import { useCanvasStore } from '../store'
+import { validateCeeAnalysisReady } from '../utils/ceeAnalysisReadyValidation'
+import type { CEEAnalysisReady } from '../../adapters/cee/types'
 import { typography } from '../../styles/typography'
 
 const DISMISSED_KEY = 'autosave-recovery-dismissed'
@@ -58,6 +60,43 @@ export function RecoveryBanner() {
       }
     }
 
+    // ⛔ THE RESTORE IS GATED, NOT PASSED THROUGH.
+    //
+    // `validateCeeAnalysisReady` is the one seam that decides whether a
+    // persisted readiness verdict may re-enter a session. Its own header names
+    // three sources it gates; this component was a FOURTH, and it wrote
+    // `autosaveData.ceeAnalysisReady` straight into the store. The sharpest
+    // thing that walked through was a BLOCKED REFUSAL: CEE now carries model
+    // identity on refusals, so the payload has non-empty options and the old
+    // `empty_options` check no longer rejects it by accident — a user would be
+    // handed the evidence of a refusal with no account of it, in a session
+    // where nothing was refused.
+    //
+    // ⚠ This component is currently UNMOUNTED (`ReactFlowGraph.tsx:2344`
+    // `{/* RecoveryBanner removed */}`); boot auto-recovers instead and routes
+    // readiness through `restoreCeeAnalysisReady`, which validates. The gate is
+    // here so that REMOUNTING it cannot silently reopen the bypass — the
+    // failure mode is a component coming back without its guard, and a comment
+    // elsewhere asserting the guard runs is not one.
+    //
+    // Boundary cast at the call: AutosaveData's inline shape declares
+    // `status?: string` where `CEEAnalysisReady` narrows it. Node ids are
+    // derived from the recovered graph itself, at parity with
+    // `ReactFlowGraph.restoreCeeAnalysisReady`'s `loadSource === 'autosave'`
+    // branch, which snapshots `autosave.nodes.map(n => n.id)` the same way.
+    const restoredReady = (autosaveData.ceeAnalysisReady ?? null) as CEEAnalysisReady | null
+    const readyValidation = validateCeeAnalysisReady(
+      restoredReady,
+      autosaveData.nodes.map((n) => n.id),
+      autosaveData.nodes
+    )
+    if (!readyValidation.isValid && import.meta.env.DEV) {
+      console.warn(
+        '[RecoveryBanner] Dropped ceeAnalysisReady on restore:',
+        readyValidation.reason
+      )
+    }
+
     // ⚠ NOT A USER EDIT — RECOVERING THE USER'S OWN UNSAVED WORK. Without this
     // window `useGuidanceInvalidationOnEdit` reads the restore as the user
     // rebuilding their model from nothing and destroys the coaching that
@@ -76,8 +115,11 @@ export function RecoveryBanner() {
       isDirty: true, // Mark as dirty since recovered work is unsaved
       history: { past: [], future: [] },
       selection: { nodeIds: new Set(), edgeIds: new Set() },
-      // V3: Restore analysis_ready and goal selection from autosave
-      ceeAnalysisReady: autosaveData.ceeAnalysisReady ?? null,
+      // V3: Restore analysis_ready and goal selection from autosave — only when
+      // the gate above admits it. An invalid verdict CLEARS rather than
+      // inheriting: a stale or refused readiness left in place would be read as
+      // belonging to the graph the user is being handed back.
+      ceeAnalysisReady: readyValidation.isValid ? restoredReady : null,
       selectedGoalNode: goalNodeId,
     })
     useCanvasStore.setState({ _externalMutationActive: Math.max(0, suppressed - 1) })

--- a/src/canvas/components/__tests__/RecoveryBanner.spec.tsx
+++ b/src/canvas/components/__tests__/RecoveryBanner.spec.tsx
@@ -303,4 +303,85 @@ describe('RecoveryBanner (P0-2)', () => {
     // Banner SHOULD re-appear in new session
     expect(screen.getByTestId('autosave-recovery-banner')).toBeInTheDocument()
   })
+
+  // -------------------------------------------------------------------------
+  // THE RESTORE IS GATED BY validateCeeAnalysisReady
+  //
+  // `handleRecover` used to write `autosaveData.ceeAnalysisReady` straight into
+  // the store while `autosaveProjection.ts` asserted the opposite in a comment
+  // ("RecoveryBanner → validateCeeAnalysisReady validates before use"). The
+  // component is unmounted today, so the claim was true of the mounted product
+  // and false of the repo — remounting it would have reopened the bypass.
+  //
+  // ⭐ THE PAIR IS THE POINT. Test 1 alone passes against a fix that drops
+  // EVERYTHING; test 2 alone passes against no fix at all. Only both together
+  // bind to the validator's DECISION rather than to the field's presence.
+  // -------------------------------------------------------------------------
+  describe('ceeAnalysisReady restore is gated by validateCeeAnalysisReady', () => {
+    const GOAL = { id: 'goal_1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal' } }
+    const OPTION = { id: 'opt_1', type: 'option', position: { x: 0, y: 0 }, data: { label: 'A' } }
+
+    /** A readiness verdict the validator ADMITS: options present, goal + option nodes present. */
+    const validReady = (status?: string) => ({
+      options: [
+        { id: 'opt_1', label: 'A', status: 'ready' as const, interventions: {} },
+      ],
+      goal_node_id: 'goal_1',
+      ...(status ? { status } : {}),
+    })
+
+    const restoreWith = (ceeAnalysisReady: unknown) => {
+      vi.mocked(scenarios.hasUnsavedWork).mockReturnValue(true)
+      vi.mocked(scenarios.loadAutosave).mockReturnValue({
+        timestamp: Date.now(),
+        scenarioId: 'test-scenario',
+        nodes: [GOAL, OPTION],
+        edges: [],
+        ceeAnalysisReady,
+      } as never)
+
+      render(<RecoveryBanner />)
+      fireEvent.click(screen.getByTestId('btn-recover-autosave'))
+
+      const calls = (useCanvasStore as any).setState.mock.calls
+      // Precondition (trap 13): the handler really ran and really wrote the graph.
+      // Without this, both assertions below would pass against a no-op handler.
+      expect(calls.length, 'precondition: handleRecover wrote to the store').toBeGreaterThan(0)
+      const payload = calls[0][0]
+      expect(payload.nodes, 'precondition: the restore carried the graph').toEqual([GOAL, OPTION])
+      return payload
+    }
+
+    it('DROPS a blocked refusal instead of restoring it into the session', () => {
+      // A refusal is identity-bearing but is not a readiness verdict. CEE now
+      // puts model identity on refusals, so `options` is non-empty and the old
+      // `empty_options` check no longer rejects it by accident.
+      const payload = restoreWith(validReady('blocked'))
+
+      expect(
+        payload.ceeAnalysisReady,
+        'a blocked refusal must not be restored into a session where nothing was refused',
+      ).toBeNull()
+    })
+
+    it('TWIN — still restores a readiness verdict the validator admits', () => {
+      // The opposite-direction twin. A fix that simply stopped restoring
+      // `ceeAnalysisReady` would satisfy the test above and silently destroy the
+      // feature; this is what makes that fix RED.
+      const admitted = validReady('ready')
+      const payload = restoreWith(admitted)
+
+      expect(
+        payload.ceeAnalysisReady,
+        'a valid verdict must survive the gate — dropping everything is not the fix',
+      ).toEqual(admitted)
+    })
+
+    it('DROPS a verdict whose goal node is absent from the recovered graph', () => {
+      const orphaned = { ...validReady('ready'), goal_node_id: 'goal_missing' }
+      const payload = restoreWith(orphaned)
+
+      expect(payload.ceeAnalysisReady, 'missing_goal must not restore').toBeNull()
+    })
+  })
 })

--- a/src/canvas/store/autosaveProjection.ts
+++ b/src/canvas/store/autosaveProjection.ts
@@ -96,9 +96,22 @@ export interface AutosaveStoreSlice {
   currentScenarioId: string | null
   /**
    * The store's `CEEAnalysisReady` is a WIDER union than AutosaveData's inline
-   * shape. Kept opaque here and cast at the boundary: the restore path
-   * (RecoveryBanner → validateCeeAnalysisReady) validates before use, so the
-   * cast is safe by construction. Same justification as crashFlush's.
+   * shape. Kept opaque here and cast at the boundary: every restore path
+   * validates before use, so the cast is safe by construction. Same
+   * justification as crashFlush's.
+   *
+   * The MOUNTED reader is `ReactFlowGraph.restoreCeeAnalysisReady`
+   * (`ReactFlowGraph.tsx:234`, called on boot at `:1689`), which runs
+   * `validateCeeAnalysisReady`. `RecoveryBanner` is a second reader that is
+   * currently unmounted (`ReactFlowGraph.tsx:2344`) and now runs the same
+   * validator in its own click handler.
+   *
+   * ⚠ This sentence used to name `RecoveryBanner → validateCeeAnalysisReady` as
+   * the justification while RecoveryBanner called NEITHER seam — true of the
+   * mounted product (the banner was unmounted) and false of the repo, so
+   * remounting the component would have walked around the guard by way of a
+   * comment saying it did not. Name the path you mean and check it still calls
+   * what you say it calls.
    */
   ceeAnalysisReady: unknown
   /**


### PR DESCRIPTION
## Verdict

`autosaveProjection.ts:100` asserted that `RecoveryBanner` validates a restored
`ceeAnalysisReady` before use. **It did not call the validator at all.** The claim was true of
the *mounted product* — the banner is unmounted — and false of the *repo*, so remounting the
component would have walked around `validateCeeAnalysisReady` by way of a comment saying it
did not.

**Disposition: (b) route it through the validator.** The comment is now true, and the bypass is
closed permanently rather than documented.

## ⚠ Premise correction — only ONE of the two comments was false

The brief that commissioned this named two files making the same claim. They do not:

| site | names | verdict |
|---|---|---|
| `store/autosaveProjection.ts:100` | `RecoveryBanner → validateCeeAnalysisReady` | **FALSE** — called neither seam |
| `persist/crashFlush.ts:99` | `restoreCeeAnalysisReady → validateCeeAnalysisReady` | **TRUE** — verified at the bytes |

`restoreCeeAnalysisReady` exists at `ReactFlowGraph.tsx:234`, calls the validator at `:288`,
and is called live on boot at `:1689`. **`crashFlush.ts` is deliberately untouched by this PR.**

## Why (b) and not (a) delete

The component is genuinely dead *and* genuinely superseded — boot auto-recovers from autosave
(`ReactFlowGraph.tsx:1562-1592`), routes readiness through the validating
`restoreCeeAnalysisReady`, and even writes the banner's own dismissal key
(`// auto-recovery already happened`). Deletion was the first choice and is **blocked at a
boundary I may not cross**:

- **`src/canvas/store.ts:6271` is held by another writer.** Its crash-flush `selectedGoalNode`
  index-cast is justified *by* "RecoveryBanner writes it via a bare setState". Deleting the
  component makes `selectedGoalNode` writer-less and that justification false — replacing the
  stale comment this PR removes with a new stale comment in a file I cannot reach.
- `coachingSurvivesReload.acceptance.spec.tsx` §F `readFileSync`s
  `canvas/components/RecoveryBanner.tsx` and asserts its suppression window. Deletion = ENOENT
  throw. That manifest was authored **yesterday** by #783 — the same PR that last edited
  RecoveryBanner. Deleting a component another lane guarded one day earlier is a collision, not
  a tidy-up.
- `scripts/ci/typecheck-baseline*.txt` carry 3 baselined diagnostics for the file.

(c) comment-only was rejected: leaving a correctly-labelled trap is weaker than removing it, and
(b) was not blocked.

**Recommended follow-up:** delete the component in a lane that holds `store.ts`, and resolve
`selectedGoalNode` (a phantom field not declared on `CanvasState`) at the same time. Out of scope
here per the scope-expansion rule.

## The change

`handleRecover` now runs `validateCeeAnalysisReady` over the persisted verdict and writes `null`
when it is rejected — at parity with `restoreCeeAnalysisReady`'s `loadSource === 'autosave'`
branch, which snapshots `autosave.nodes.map(n => n.id)` the same way.

The sharpest thing that walked through was a **blocked refusal**. CEE now carries model identity
on refusals, so `options` is non-empty and the validator's older `empty_options` check no longer
rejects them by accident — `blocked_refusal` is the guard that does, and it was being bypassed.

## Evidence

**RED-first, by name**, at pristine source with the new spec in place:

```
× DROPS a blocked refusal instead of restoring it into the session
  → expected { …(3) } to be null
× DROPS a verdict whose goal node is absent from the recovered graph
  → expected { …(3) } to be null
✓ TWIN — still restores a readiness verdict the validator admits   (correctly passes: no gate = pass-through)
Tests  2 failed | 15 passed (17)
```

After the fix: `Tests 17 passed (17)` — **same collected count**, so nothing vanished at collect.

**Discriminating mutant pair** (`applied=1` each, trailing control `applied=0`, archive-isolation
write-test passed, target asserted pristine after each):

| mutant | blocked-drop | TWIN | missing-goal |
|---|---|---|---|
| baseline (fix) | ✓ | ✓ | ✓ |
| M1 — gate always DROPS | ✓ | **×** | ✓ |
| M2 — gate REMOVED | **×** | ✓ | **×** |
| control — unmutated | ✓ | ✓ | ✓ |

M1 and M2 RED on **different** assertions. Neither alone shows binding; the pair proves the tests
bind to the validator's *decision*, not to the field's presence. Collected count 17 in all four runs.

`autosaveProjection.ts` is **comment-only, verified in both directions**: 0 non-comment lines added
*and* 0 removed, with a positive control on `RecoveryBanner.tsx` reading 15 added / 1 removed —
proving the detector sees real code.

**Gate** (pnpm 10.18.0 / node from `.nvmrc`, matching CI):
- `pnpm run typecheck` — **PASSED**. The boundary cast *fixed* one baselined diagnostic
  (2252 → 2251); the baseline is banked and its diff touches **only** `RecoveryBanner.tsx`.
- `pnpm run lint` — 0 errors; hooks ratchet exactly matches baseline.

**What this evidence excludes:** these are jsdom unit tests against a mocked store. They prove the
gate's decision, not that any user reaches it — the component is unmounted, so there is no journey
or wire witness available and none is claimed. The rung here is TESTED, not MOUNTED.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
