### PR TITLE
style(topbar): the header is made of the same material as the toolbars

### DIFF
--- a/src/components/layout/TopBar.module.css
+++ b/src/components/layout/TopBar.module.css
@@ -11,10 +11,26 @@
   padding: 0 8px 0 12px;
   gap: 2px;
 
-  background: var(--bg-panel, #FEFEFE);
+  /**
+   * The canvas toolbars' surface, value for value — see
+   * `CanvasFloatingToolbar.module.css`. All three of these float over the same
+   * canvas, and the header was the only one made of different material: 12px
+   * corners against 16px, opaque against translucent, and a flatter shadow that
+   * sat it lower than the panels beside it.
+   *
+   * ⚠ THE BLUR IS TAKEN KNOWINGLY AND IS NOT VISIBLE TODAY. Rendered against
+   * the real canvas, 95%-white over a near-white background and white node
+   * cards is imperceptible — the visible half of this change is the radius and
+   * the shadow. It is here so the header states the SAME surface as the
+   * toolbars rather than a fourth near-copy of it, and so it stays right if the
+   * canvas background ever stops being near-white. Do not "tidy" it away as a
+   * no-op: that is the drift this file has already been through once.
+   */
+  background: rgba(255, 255, 255, 0.95);
+  backdrop-filter: blur(8px);
   border: 1px solid var(--border-default, #EEE6D8);
-  border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
+  border-radius: 16px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08), 0 1px 3px rgba(0, 0, 0, 0.04);
 }
 
 .topBarLeft {


### PR DESCRIPTION
Item 3 of the header consistency assessment, on founder approval. Follows #874 (the mechanical items).

All three floating surfaces sit over the same canvas, and the header was the only one made of something else.

| | header (before) | header (now) | canvas toolbars |
|---|---|---|---|
| corner radius | 12px | **16px** | 16px |
| background | opaque `--bg-panel` | **`rgba(255,255,255,.95)`** | `rgba(255,255,255,.95)` |
| backdrop | none | **`blur(8px)`** | `blur(8px)` |
| shadow | `0 2px 8px/.08` + `0 1px 2px/.04` | **`0 4px 20px/.08` + `0 1px 3px/.04`** | same |

## ⚠ The blur is taken knowingly and is not visible today

Rendered against the real canvas before committing: **95%-white over a near-white background and white node cards is imperceptible.** The visible half of this change is the radius and the shadow.

It is included anyway, for two stated reasons: so the header declares the *same* surface as the toolbars rather than a fourth near-copy of it, and so it stays correct if the canvas background ever stops being near-white. The rule carries a comment saying this, so nobody later "tidies away" an apparent no-op — which is exactly the drift this file has already been through once.

## Still open, deliberately not folded in

This file has **seven distinct `border-radius` values** (6, 10, 12, 16, 50%, 999px, 4, 2px). Collapsing them changes how the metadata chips, the stage pill and the dropdown look, so it wants the founder's eye rather than a mechanical sweep.

## Gate

Typecheck PASSED (ratchet unchanged at 2252), 10 layout spec files collected, 72/72 pass. CSS-only, one rule changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)