### PR TITLE
fix(visreg): the completeness guard measures coverage, not correctness

### DIFF
--- a/e2e/visual/globalTeardown.ts
+++ b/e2e/visual/globalTeardown.ts
@@ -48,7 +48,10 @@ export default function globalTeardown(): void {
       `[visreg] COMPLETENESS GUARD FAILED: ZERO screenshots were captured.\n` +
         `  Expected ${expected.length}: ${expected.join(', ')}\n` +
         `  This run measured nothing. It must not be reported as a pass — the most likely\n` +
-        `  causes are that the app failed to boot, or that no test matched.`,
+        `  causes are that the app failed to boot, or that no test matched.\n` +
+        `  NOTE: a stale-reference cascade no longer lands here. captureState records\n` +
+        `  coverage in a \`finally\`, so a state that ran and FAILED its comparison still\n` +
+        `  counts as captured. If you are reading this, the states genuinely did not run.`,
     )
   }
 

--- a/e2e/visual/harness.ts
+++ b/e2e/visual/harness.ts
@@ -386,6 +386,22 @@ export async function clearNotifications(page: Page): Promise<void> {
 export async function minimiseFloatingOlumiPanel(page: Page): Promise<void> {
   const panel = page.getByTestId('floating-olumi-panel')
   if ((await panel.count()) === 0) return
+
+  // ⚠ ALREADY-MINIMISED IS NOT A FAILURE, AND THIS TOOK OUT TWO STATES.
+  // The absent-panel guard above tests `count() === 0`, i.e. not in the DOM at
+  // all. It does not cover the case that actually happened: the panel's default
+  // changed to start minimised, so the panel AND its minimise control are both
+  // in the DOM and both hidden. `activateByKeyboard` then waited 20s for a
+  // control that resolves 23 times and is hidden every time, and `graph at
+  // default zoom` failed at BOTH viewports without ever reaching a capture.
+  //
+  // The postcondition this function exists for is the one asserted below — the
+  // panel is not covering the graph. When it is already hidden that is already
+  // true, so there is nothing to do and nothing to assert that is not already
+  // asserted. Note this returns ONLY on a genuinely hidden panel: a VISIBLE
+  // panel still takes the full path, so a broken minimise control still REDs.
+  if (await panel.isHidden()) return
+
   await activateByKeyboard(page, 'floating-olumi-panel-minimise')
   await expect(panel, 'floating Olumi panel did not minimise — it would occlude the graph').toBeHidden({ timeout: 10_000 })
 }
@@ -663,22 +679,41 @@ export async function captureState(
     })
   }
 
-  await expect(target).toHaveScreenshot(`${name}.png`, {
-    maxDiffPixelRatio: MAX_DIFF_PIXEL_RATIO,
-    threshold: PIXEL_THRESHOLD,
-    animations: 'disabled',
-    caret: 'hide',
-    scale: 'css',
-    ...(opts.clip ? {} : { fullPage: false }),
-  })
+  // ⚠ THE MANIFEST RECORDS COVERAGE, NOT CORRECTNESS, AND THE `finally` IS THE
+  // WHOLE POINT. This state has now mounted, been stabilised and been
+  // photographed; whether the photograph MATCHES is the assertion's business,
+  // not the completeness guard's.
+  //
+  // It used to record only on the happy path, one line below the assertion, and
+  // that conflated the two questions with a cascading consequence: when the
+  // references went stale, all ten comparisons failed, not one `recordCapture`
+  // ran, the manifest was empty, and the guard reported
+  // "ZERO screenshots were captured — the app failed to boot, or no test
+  // matched". Neither was true. The app booted perfectly and every test matched.
+  //
+  // That message sent two separate readers hunting a boot failure that did not
+  // exist, and the real diagnosis — ten stale references — was invisible behind
+  // it. Recorded here instead, the same run reports "10/10 captured" with ten
+  // failed comparisons, which is what actually happened and points straight at
+  // the references.
+  try {
+    await expect(target).toHaveScreenshot(`${name}.png`, {
+      maxDiffPixelRatio: MAX_DIFF_PIXEL_RATIO,
+      threshold: PIXEL_THRESHOLD,
+      animations: 'disabled',
+      caret: 'hide',
+      scale: 'css',
+      ...(opts.clip ? {} : { fullPage: false }),
+    })
+  } finally {
+    recordCapture(name)
+  }
 
   if (blessing) {
     const ref = assertReferenceIsSubstantive(name, expectedSize)
     // eslint-disable-next-line no-console
     console.log(`[visreg] blessed ${name}: ${ref.bytes}B, ${ref.distinctColours} quantised colours`)
   }
-
-  recordCapture(name)
 }
 
 /** Everything the artefact should say about how a run was configured. */


### PR DESCRIPTION
The visual gate has been red on every commit for some time, reporting:

```
[visreg] COMPLETENESS GUARD FAILED: ZERO screenshots were captured.
  ... the most likely causes are that the app failed to boot, or that no test matched.
```

**Neither was true.** The app booted perfectly and every test matched. Two separate readers — the orchestrator discharging this advisory daily, and me — took the message at face value and went looking for a boot failure that does not exist. The real cause was **ten stale references**, and it was invisible behind the message.

## The defect: one line answering two questions

`recordCapture(name)` sat one line *below* the screenshot assertion, so it only ran when the comparison **passed**. "Did this state run?" and "does it still look right?" were the same flag.

When the references went stale, all ten comparisons threw, not one `recordCapture` ran, the manifest was empty — and a guard whose entire job is to notice that nothing was measured concluded that nothing was measured. It had been measured ten times.

Recording in a `finally` separates them. **Measured on this branch, same tree, same stale references:**

| | captured | guard says |
|---|---|---|
| before | 0 of 10 | "ZERO … the app failed to boot" |
| **after** | **10 of 10** | ten failed comparisons — what actually happened |

The guard keeps all its protective value: a state that is skipped, filtered or renamed still never calls `captureState`, so it still never records. What it loses is the ability to blame a boot failure for a comparison failure.

## ⭐ It immediately found a second, unrelated defect

With coverage recorded honestly, 8 of 10 states recorded and **two did not** — `graph at default zoom` at both viewports. Those two were not failing their comparison; **they never reached one.** The old flag could not express that difference at all.

`minimiseFloatingOlumiPanel` guards on `count() === 0` — the panel not being in the DOM. It does not cover what actually happened: **the panel's default changed to start minimised**, so the panel and its minimise control are both present and both hidden. `activateByKeyboard` then waited its full 20s for a control that resolves 23 times and is hidden every time.

An already-minimised panel already satisfies the postcondition the function exists to establish, so it now returns early — **only on a genuinely hidden panel.** A visible panel still takes the full path, so a broken minimise control still REDs.

## What this PR does NOT do

**It does not re-bless.** After both fixes, 10/10 states capture and **all ten still fail their comparisons**, because the references are genuinely stale — the app's default panel state and its tab set have both moved. That is the *correct* red.

Re-blessing is a separate, reviewable commit, and it lands **after** the CSS work (#873, #874, #876) so the references are blessed once against the intended final state rather than twice. `scripts/visual/rebless.sh` says references are committed on their own, and they will be.

## Verification

By execution, not by reading:
- run locally against the committed references at both viewports
- manifest inspected directly (`test-results/visual-manifest.txt`): 0 → 10
- the two-state regression reproduced, fixed, and re-run to a capture
- typecheck gate PASSED, ratchet unchanged at 2252

🤖 Generated with [Claude Code](https://claude.com/claude-code)