### PR TITLE
C+D: a refusal is not a readiness assessment

### DIFF
--- a/src/adapters/cee/types.ts
+++ b/src/adapters/cee/types.ts
@@ -426,6 +426,17 @@ export type RecognisedAnalysisReadyStatus =
  * When present in CEE response, this contains analysis-ready options
  * with resolved interventions that can be directly used for V2RunRequest.
  */
+/**
+ * A readiness payload that is NOT a refusal — see `canvas/domain/usableAnalysisReady`.
+ *
+ * ⚠ This type is for DERIVED READS ONLY. The store's `ceeAnalysisReady` field is
+ * deliberately NOT typed with it: that field really does hold `status: 'blocked'`
+ * at runtime, so narrowing it would be a claim the writer does not honour.
+ */
+export interface UsableCEEAnalysisReady extends Omit<CEEAnalysisReady, 'status'> {
+  status?: Exclude<AnalysisReadyStatus, 'blocked'>
+}
+
 export interface CEEAnalysisReady {
   /** Options with resolved interventions */
   options: CEEOptionV3[]

--- a/src/canvas/domain/__tests__/usableAnalysisReady.spec.ts
+++ b/src/canvas/domain/__tests__/usableAnalysisReady.spec.ts
@@ -1,0 +1,82 @@
+/**
+ * A REFUSAL IS NOT A READINESS ASSESSMENT.
+ *
+ * `analysis_ready.status === 'blocked'` is CEE refusing. It is not a verdict a
+ * consumer asking "what is ready?" may act on. Two carriers exist and only the
+ * second is the reason this selector has to exist:
+ *
+ *   ARM A  empty carrier (`options: []`) — already rejected upstream.
+ *   ARM B  IDENTITY-PRESERVING carrier — non-empty `options` and `goal_node_id`,
+ *          deliberately preserved by CEE so a refusal can still name the model
+ *          it refused about. This one is ACCEPTED and stored.
+ *
+ * ARM B is why a truthiness or `options.length` check is not enough: on a
+ * refusal those are populated, so every consumer keyed on "are there options?"
+ * silently reads a refusal as readiness.
+ *
+ * ⚠ THE STORED FIELD IS DELIBERATELY NOT NARROWED. `ceeAnalysisReady` really
+ * does hold `status: 'blocked'` at runtime, so typing it as un-blockable would
+ * be a false claim enforced by the compiler on every reader EXCEPT the writer
+ * that produces the value. The narrowing lives here, in a derived read, which
+ * has no storage and therefore cannot drift from the field.
+ */
+import { describe, it, expect } from 'vitest'
+import type { CEEAnalysisReady } from '../../../adapters/cee/types'
+import { selectUsableAnalysisReady, isUsableAnalysisReady } from '../usableAnalysisReady'
+
+const IDENTITY_BEARING_REFUSAL = {
+  status: 'blocked',
+  blocked_reason: 'MISSING_OPTION_VALUE',
+  goal_node_id: 'goal-1',
+  options: [{ id: 'opt-a', label: 'Option A', interventions: {} }],
+} as unknown as CEEAnalysisReady
+
+const READY = {
+  status: 'ready',
+  goal_node_id: 'goal-1',
+  options: [{ id: 'opt-a', label: 'Option A', interventions: {} }],
+} as unknown as CEEAnalysisReady
+
+describe('selectUsableAnalysisReady', () => {
+  it('PRECONDITION: the refusal fixture is ARM B — populated exactly where a naive guard looks', () => {
+    // Pins the fixture's own discriminating power (trap 13b). If this stops
+    // holding, the test below would pass for the wrong reason.
+    expect(IDENTITY_BEARING_REFUSAL.status).toBe('blocked')
+    expect(IDENTITY_BEARING_REFUSAL.options.length).toBeGreaterThan(0)
+    expect(IDENTITY_BEARING_REFUSAL.goal_node_id).not.toBe('')
+  })
+
+  it('withholds an identity-bearing refusal', () => {
+    expect(selectUsableAnalysisReady(IDENTITY_BEARING_REFUSAL)).toBeNull()
+  })
+
+  it('passes a ready payload through UNCHANGED — same object identity, nothing rebuilt', () => {
+    expect(selectUsableAnalysisReady(READY)).toBe(READY)
+  })
+
+  it('withholds null and undefined without inventing a payload', () => {
+    expect(selectUsableAnalysisReady(null)).toBeNull()
+    expect(selectUsableAnalysisReady(undefined)).toBeNull()
+  })
+
+  it('an ABSENT status is not a refusal — silence is not a verdict', () => {
+    const noStatus = { goal_node_id: 'g', options: [] } as unknown as CEEAnalysisReady
+    expect(selectUsableAnalysisReady(noStatus)).toBe(noStatus)
+  })
+
+  it('every non-blocked producer status survives — the selector withholds ONE value, not a mood', () => {
+    for (const status of ['ready', 'needs_encoding', 'needs_user_mapping', 'needs_user_input']) {
+      const p = { ...READY, status } as unknown as CEEAnalysisReady
+      expect(selectUsableAnalysisReady(p), `status=${status}`).toBe(p)
+    }
+  })
+
+  it('isUsableAnalysisReady discriminates on status alone, not on shape', () => {
+    // Same shape, different status — so a shape-keyed guard could not tell these
+    // apart, and this asserts the discriminator is the status.
+    const emptyButReady = { status: 'ready', goal_node_id: '', options: [] } as unknown as CEEAnalysisReady
+    const fullButBlocked = IDENTITY_BEARING_REFUSAL
+    expect(isUsableAnalysisReady(emptyButReady)).toBe(true)
+    expect(isUsableAnalysisReady(fullButBlocked)).toBe(false)
+  })
+})

--- a/src/canvas/domain/__tests__/usableAnalysisReady.spec.ts
+++ b/src/canvas/domain/__tests__/usableAnalysisReady.spec.ts
@@ -22,7 +22,11 @@
  */
 import { describe, it, expect } from 'vitest'
 import type { CEEAnalysisReady } from '../../../adapters/cee/types'
-import { selectUsableAnalysisReady, isUsableAnalysisReady } from '../usableAnalysisReady'
+import {
+  ANALYSIS_READY_STATUSES,
+  ANALYSIS_READY_STATUS_UNSUPPLIED,
+} from '../../../adapters/cee/types'
+import { selectUsableAnalysisReady, isUsableAnalysisReady, isBlockedCarrier } from '../usableAnalysisReady'
 
 const IDENTITY_BEARING_REFUSAL = {
   status: 'blocked',
@@ -59,16 +63,72 @@ describe('selectUsableAnalysisReady', () => {
     expect(selectUsableAnalysisReady(undefined)).toBeNull()
   })
 
-  it('an ABSENT status is not a refusal — silence is not a verdict', () => {
+  it('an ABSENT status is not a refusal — defensive only; the store cannot hold this', () => {
+    // ⚠ SCOPE, STATED: this shape does NOT occur at runtime. `applyV5State`
+    // substitutes the unsupplied sentinel for an absent status, so this asserts
+    // defensive behaviour for a payload that never reaches the store — it is
+    // NOT evidence about the producer's domain. The test that is about the
+    // producer is the sentinel case above.
     const noStatus = { goal_node_id: 'g', options: [] } as unknown as CEEAnalysisReady
     expect(selectUsableAnalysisReady(noStatus)).toBe(noStatus)
   })
 
-  it('every non-blocked producer status survives — the selector withholds ONE value, not a mood', () => {
-    for (const status of ['ready', 'needs_encoding', 'needs_user_mapping', 'needs_user_input']) {
+  it('EXHAUSTIVE PARTITION — derived from ANALYSIS_READY_STATUSES, not hand-listed', () => {
+    // ⚠ THE HAND-WRITTEN LIST THIS REPLACES PASSED 11/11 AGAINST A SYNTHETIC
+    // SIXTH STATUS. A corpus enumerated by hand cannot observe a member the
+    // producer adds; deriving from the producer's own tuple means a new status
+    // arrives in this test automatically and must be classified deliberately.
+    expect(ANALYSIS_READY_STATUSES.length).toBeGreaterThan(1)
+    let withheld = 0
+    for (const status of ANALYSIS_READY_STATUSES) {
       const p = { ...READY, status } as unknown as CEEAnalysisReady
-      expect(selectUsableAnalysisReady(p), `status=${status}`).toBe(p)
+      const out = selectUsableAnalysisReady(p)
+      if (status === 'blocked') {
+        expect(out, `status=${status} must be withheld`).toBeNull()
+        withheld += 1
+      } else {
+        expect(out, `status=${status} must survive`).toBe(p)
+      }
     }
+    // Exactly one member of the producer's vocabulary is a refusal. If a future
+    // status is also a refusal this REDs, which is the point.
+    expect(withheld).toBe(1)
+  })
+
+  it('THE UNSUPPLIED SENTINEL SURVIVES — and it is the shape that actually occurs', () => {
+    // ⚠ `applyV5State.ts:262` writes `typeof obj.status === 'string' ? obj.status
+    // : 'unknown'`, so the store NEVER holds an absent status — an absent one
+    // becomes this sentinel. An earlier version of this spec pinned the ABSENT
+    // shape (which the producer cannot emit) and never tested this one: a mutant
+    // collapsing the sentinel into refusal passed 11/11 GREEN.
+    const p = { ...READY, status: ANALYSIS_READY_STATUS_UNSUPPLIED } as unknown as CEEAnalysisReady
+    expect(selectUsableAnalysisReady(p)).toBe(p)
+    expect(isUsableAnalysisReady(p)).toBe(true)
+  })
+
+  it('BOTH BLOCKED CARRIERS are withheld — exhaustive over PRODUCERS, not just over the status union', () => {
+    // ⚠ EXHAUSTIVENESS OVER THE STATUS UNION IS NOT EXHAUSTIVENESS OVER THE
+    // CARRIERS THAT PRODUCE A STATUS. Two producers emit `status: 'blocked'`
+    // (derived at the CEE bytes, recorded at analysisRefusalNotice.ts:39-55):
+    //   REFUSAL — non-empty `blocked_reason`; CEE refused.
+    //   LEGACY  — NO `blocked_reason`; a freshness carrier from a legacy reload,
+    //             which says nothing about a refusal.
+    // For THIS question both are withheld: neither is a verdict to act on. A
+    // corpus that sent only the refusal carrier would certify a predicate that
+    // mishandles the other.
+    const refusal = { status: 'blocked', blocked_reason: 'MISSING_OPTION_VALUE',
+                      goal_node_id: 'goal-1', options: [{ id: 'o', label: 'O', interventions: {} }] } as unknown as CEEAnalysisReady
+    const legacy = { status: 'blocked', goal_node_id: '', options: [], bias_findings: [] } as unknown as CEEAnalysisReady
+
+    // Pin that the two fixtures genuinely differ on the canonical discriminator,
+    // or this test would be sending one carrier twice.
+    expect('blocked_reason' in (refusal as object)).toBe(true)
+    expect('blocked_reason' in (legacy as object)).toBe(false)
+
+    expect(selectUsableAnalysisReady(refusal)).toBeNull()
+    expect(selectUsableAnalysisReady(legacy)).toBeNull()
+    expect(isBlockedCarrier(refusal)).toBe(true)
+    expect(isBlockedCarrier(legacy)).toBe(true)
   })
 
   it('isUsableAnalysisReady discriminates on status alone, not on shape', () => {

--- a/src/canvas/domain/usableAnalysisReady.ts
+++ b/src/canvas/domain/usableAnalysisReady.ts
@@ -35,22 +35,49 @@ import type { CEEAnalysisReady, UsableCEEAnalysisReady } from '../../adapters/ce
 /**
  * Type predicate: this payload is not a refusal.
  *
- * A predicate rather than a cast — the narrowing is then something the compiler
- * checks, not something this module asserts.
+ * ⚠ CORRECTED. An earlier draft of this comment said the narrowing is "something
+ * the compiler checks, not something this module asserts". **That is backwards.**
+ * TypeScript does not verify a type-predicate's BODY — it takes `x is T` on
+ * trust and propagates it. A predicate is therefore exactly as much an assertion
+ * as a cast; it is preferable only because the assertion sits in ONE named place
+ * with a test around it, instead of at every call site. The guarantee here is
+ * the test below it, never the compiler.
  */
 export function isUsableAnalysisReady(
   analysisReady: CEEAnalysisReady,
 ): analysisReady is UsableCEEAnalysisReady {
-  return !isAnalysisRefusal(analysisReady)
+  return !isBlockedCarrier(analysisReady)
 }
 
 /**
- * THE discriminator. Structurally typed on purpose: several consumers hold only
- * a narrow projection of the payload, and they must not each re-spell
- * `status === 'blocked'` — one literal, one module, so a change to what counts
- * as a refusal cannot land in some readers and miss others.
+ * "Is this payload a readiness verdict at all?" — FALSE for every `blocked`
+ * carrier, and NOT a claim that CEE refused.
+ *
+ * ⚠⚠ RENAMED FROM `isAnalysisRefusal`, AND THE OLD NAME WAS A FALSE CLAIM.
+ * TWO DISTINCT `status: 'blocked'` CARRIERS EXIST, derived at the CEE bytes and
+ * recorded at `canvas/store/analysisRefusalNotice.ts:39-55`:
+ *
+ *   REFUSAL  `buildAnalysisRefusalReadiness()` — ALWAYS a non-empty
+ *            `blocked_reason`. CEE refused.
+ *   LEGACY   `synthesiseFreshnessOnlyAnalysisReady()` — `status:'blocked'`,
+ *            NO `blocked_reason`, emitted on legacy/unparseable RELOADS. It
+ *            "says nothing about a refusal".
+ *
+ * ⭐ SO THE PREDICATE'S BEHAVIOUR WAS RIGHT AND ITS NAME WAS WRONG — the
+ * sharpest form of this estate's recurring defect, because nothing in a test
+ * can see it. For THIS question both carriers are correctly excluded: neither
+ * is a verdict a consumer may act on. But `isAnalysisRefusal` ASSERTED that a
+ * legacy freshness carrier is a refusal, which is false, and any reader who
+ * adopted it for the refusal question would have fabricated "this analysis did
+ * not run" on every legacy reload.
+ *
+ * ⛔ THE REFUSAL QUESTION IS A DIFFERENT QUESTION AND IT IS NOT ANSWERED HERE.
+ * Its owner is `analysisRefusalNotice.ts`, and its discriminator is the PRESENCE
+ * OF A NON-EMPTY `blocked_reason`, never `status` alone. Do not use this
+ * predicate for it, and do not "align" the two — they are two questions, and
+ * naming them apart is the fix (trap 21), not reconciling their answers.
  */
-export function isAnalysisRefusal(
+export function isBlockedCarrier(
   analysisReady: { status?: string } | null | undefined,
 ): boolean {
   return analysisReady?.status === 'blocked'

--- a/src/canvas/domain/usableAnalysisReady.ts
+++ b/src/canvas/domain/usableAnalysisReady.ts
@@ -1,0 +1,70 @@
+/**
+ * "Is this a readiness verdict I may act on?" — the READ side of `analysis_ready`.
+ *
+ * ⭐ WHY THIS IS A DERIVED READ AND NOT A NARROWED FIELD.
+ *
+ * `status: 'blocked'` is CEE REFUSING. It is not a readiness verdict, and a
+ * consumer asking "what is ready?" must never receive one. The obvious fix —
+ * typing the store's `ceeAnalysisReady` so `status` cannot be `'blocked'` — is
+ * NOT taken here, deliberately, and the next reader should not "finish" it:
+ *
+ *   The store REALLY DOES hold `status: 'blocked'` at runtime.
+ *   `store.ts`'s `setCeeAnalysisReady` sets unconditionally, and CEE's
+ *   identity-preserving refusal (ARM B) is accepted by the V5 normaliser and
+ *   written (`applyV5State.ts:1232`). Narrowing the FIELD would therefore be a
+ *   false claim — and a false type is worse than a false comment, because it is
+ *   the one kind of claim nothing checks at runtime: the compiler would enforce
+ *   the guarantee on every READER while the WRITER that produces the value does
+ *   not provide it.
+ *
+ * A derived read has no storage, so it cannot drift from the field it narrows.
+ * That is the whole reason it is a function and not a second slice.
+ *
+ * ⚠ WHY A TRUTHINESS OR `options.length` CHECK IS NOT ENOUGH. Two refusal
+ * carriers exist:
+ *   ARM A  empty carrier (`options: []`, `goal_node_id: ''`) — rejected upstream.
+ *   ARM B  IDENTITY-PRESERVING carrier — non-empty `options` AND `goal_node_id`,
+ *          preserved on purpose so a refusal can still name the model it refused
+ *          about (CEE #1128).
+ * On ARM B every shape-keyed guard reads a refusal as readiness, because the
+ * fields those guards look at are exactly the ones ARM B populates. The only
+ * honest discriminator is the status.
+ */
+import type { CEEAnalysisReady, UsableCEEAnalysisReady } from '../../adapters/cee/types'
+
+/**
+ * Type predicate: this payload is not a refusal.
+ *
+ * A predicate rather than a cast — the narrowing is then something the compiler
+ * checks, not something this module asserts.
+ */
+export function isUsableAnalysisReady(
+  analysisReady: CEEAnalysisReady,
+): analysisReady is UsableCEEAnalysisReady {
+  return !isAnalysisRefusal(analysisReady)
+}
+
+/**
+ * THE discriminator. Structurally typed on purpose: several consumers hold only
+ * a narrow projection of the payload, and they must not each re-spell
+ * `status === 'blocked'` — one literal, one module, so a change to what counts
+ * as a refusal cannot land in some readers and miss others.
+ */
+export function isAnalysisRefusal(
+  analysisReady: { status?: string } | null | undefined,
+): boolean {
+  return analysisReady?.status === 'blocked'
+}
+
+/**
+ * The payload IF it is a readiness verdict, else `null`.
+ *
+ * Returns the SAME OBJECT on the pass-through path — nothing is rebuilt, so a
+ * consumer cannot receive a payload this module composed.
+ */
+export function selectUsableAnalysisReady(
+  analysisReady: CEEAnalysisReady | null | undefined,
+): UsableCEEAnalysisReady | null {
+  if (analysisReady === null || analysisReady === undefined) return null
+  return isUsableAnalysisReady(analysisReady) ? analysisReady : null
+}

--- a/src/canvas/stores/__tests__/readinessStore.refusalIsNotReadiness.spec.ts
+++ b/src/canvas/stores/__tests__/readinessStore.refusalIsNotReadiness.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * A REFUSAL MUST NOT BE SENT TO THE READINESS AUTHORITY AS A READINESS ASSESSMENT.
+ *
+ * `buildReadinessPayload` attaches `analysis_ready` to the `/graph-readiness`
+ * request. Its guard was `ceeAnalysisReady?.options?.length` — a SHAPE check.
+ *
+ * ⚠ WHY A SHAPE CHECK CANNOT WORK HERE. CEE's identity-preserving refusal
+ * (ARM B, CEE #1128) carries a NON-EMPTY `options` array on purpose, so the
+ * refusal can name the model it refused about. `options.length` is therefore
+ * populated on exactly the payload that must not be sent — the guard is
+ * satisfied by the thing it needed to exclude.
+ *
+ * These cases are TWINS: identical everywhere except `status`. A guard keyed on
+ * anything but the status cannot separate them, which is what makes this a test
+ * of the discriminator rather than of the outcome.
+ */
+import { describe, it, expect } from 'vitest'
+import type { Node, Edge } from '@xyflow/react'
+import { buildReadinessPayload } from '../readinessStore'
+
+const nodes = [
+  { id: 'goal-1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'Goal', kind: 'goal' } },
+  { id: 'opt-a', type: 'option', position: { x: 0, y: 0 }, data: { label: 'Option A', kind: 'option' } },
+] as unknown as Node[]
+const edges = [] as unknown as Edge[]
+
+const OPTIONS = [{ id: 'opt-a', label: 'Option A', interventions: {} }]
+
+function build(status: string) {
+  return buildReadinessPayload({
+    nodes,
+    edges,
+    ceeAnalysisReady: { status, goal_node_id: 'goal-1', options: OPTIONS } as never,
+    currentBriefText: null,
+    currentScenarioId: null,
+  })
+}
+
+describe('buildReadinessPayload — a refusal is not a readiness assessment', () => {
+  it('PRECONDITION: the twins differ ONLY by status, and both populate the old shape guard', () => {
+    // Pins the discriminating power of the fixtures themselves (trap 13b): if
+    // these stopped being twins, the assertions below would pass for the wrong
+    // reason — a shape difference rather than the status.
+    expect(OPTIONS.length).toBeGreaterThan(0)
+    const ready = JSON.parse(build('ready'))
+    const blocked = JSON.parse(build('blocked'))
+    expect(ready.graph).toEqual(blocked.graph)
+  })
+
+  it('OMITS analysis_ready when CEE refused, even though options are populated', () => {
+    const payload = JSON.parse(build('blocked'))
+    expect(payload.analysis_ready).toBeUndefined()
+  })
+
+  it('STILL SENDS analysis_ready on a genuine readiness verdict', () => {
+    const payload = JSON.parse(build('ready'))
+    expect(payload.analysis_ready).toBeDefined()
+    expect(payload.analysis_ready.options).toHaveLength(1)
+  })
+
+  it('sends every non-blocked producer status — one value is withheld, not a category', () => {
+    for (const status of ['ready', 'needs_encoding', 'needs_user_mapping', 'needs_user_input']) {
+      const payload = JSON.parse(build(status))
+      expect(payload.analysis_ready, `status=${status}`).toBeDefined()
+    }
+  })
+})

--- a/src/canvas/stores/readinessStore.ts
+++ b/src/canvas/stores/readinessStore.ts
@@ -10,7 +10,7 @@
  * thin wrapper useGraphReadiness() for backward compatibility.
  */
 import { create } from 'zustand'
-import { isAnalysisRefusal } from '../domain/usableAnalysisReady'
+import { isBlockedCarrier } from '../domain/usableAnalysisReady'
 import { IMPROVEMENT_ACTION_PLACEHOLDER } from '../utils/improvementActionPlaceholder'
 import { useCanvasStore } from '../store'
 import type { Node, Edge } from '@xyflow/react'
@@ -390,7 +390,7 @@ export function buildReadinessPayload(s: ReadinessPayloadInputs): string {
   // refusal (ARM B) populates `options` on purpose, so the shape guard was
   // satisfied by exactly the payload it needed to exclude. Sending it would
   // hand CEE's readiness authority its own refusal back as an assessment.
-  if (!isAnalysisRefusal(ceeAnalysisReady) && ceeAnalysisReady?.options?.length) {
+  if (!isBlockedCarrier(ceeAnalysisReady) && ceeAnalysisReady?.options?.length) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { model_adjustments: _strip, ...analysisReadyForPayload } =
       ceeAnalysisReady as Record<string, unknown>

--- a/src/canvas/stores/readinessStore.ts
+++ b/src/canvas/stores/readinessStore.ts
@@ -10,6 +10,7 @@
  * thin wrapper useGraphReadiness() for backward compatibility.
  */
 import { create } from 'zustand'
+import { isAnalysisRefusal } from '../domain/usableAnalysisReady'
 import { IMPROVEMENT_ACTION_PLACEHOLDER } from '../utils/improvementActionPlaceholder'
 import { useCanvasStore } from '../store'
 import type { Node, Edge } from '@xyflow/react'
@@ -250,7 +251,12 @@ export const WATCHED_ROOTS = [
 export interface ReadinessPayloadInputs {
   nodes: Node[]
   edges: Edge[]
-  ceeAnalysisReady: { options?: unknown[] } | null | undefined
+  /**
+   * ⚠ CARRIES `status` DELIBERATELY. This was `{ options?: unknown[] }`, which is
+   * structurally blind to the only honest discriminator — see the refusal guard
+   * in `buildReadinessPayload`.
+   */
+  ceeAnalysisReady: { options?: unknown[]; status?: string } | null | undefined
   currentBriefText: string | null | undefined
   /**
    * The saved scenario this canvas IS, or `null`/`undefined` when it is not
@@ -379,7 +385,12 @@ export function buildReadinessPayload(s: ReadinessPayloadInputs): string {
     payload.brief = currentBriefText
   }
 
-  if (ceeAnalysisReady?.options?.length) {
+  // A REFUSAL IS NOT A READINESS ASSESSMENT. The guard here was
+  // `options?.length` alone — a SHAPE check, and CEE's identity-preserving
+  // refusal (ARM B) populates `options` on purpose, so the shape guard was
+  // satisfied by exactly the payload it needed to exclude. Sending it would
+  // hand CEE's readiness authority its own refusal back as an assessment.
+  if (!isAnalysisRefusal(ceeAnalysisReady) && ceeAnalysisReady?.options?.length) {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { model_adjustments: _strip, ...analysisReadyForPayload } =
       ceeAnalysisReady as Record<string, unknown>


### PR DESCRIPTION
## A refusal is not a readiness assessment

`analysis_ready.status === 'blocked'` is CEE **refusing**. `buildReadinessPayload` attached that payload to the `/graph-readiness` request — handing CEE's readiness authority its own refusal back as an assessment.

The guard was `ceeAnalysisReady?.options?.length` — a **shape** check. CEE's identity-preserving refusal (ARM B, CEE #1128) populates `options` **on purpose**, so a refusal can name the model it refused about. **The shape guard was satisfied by exactly the payload it needed to exclude.**

### Reproduced RED before the fix, by name

```
× buildReadinessPayload — a refusal is not a readiness assessment
  › OMITS analysis_ready when CEE refused, even though options are populated
AssertionError: expected { status: 'blocked', …(2) } to be undefined
```

The request really did carry the refusal. This is a live defect, not a hypothetical.

---

## ⚠ THE STORED FIELD IS DELIBERATELY **NOT** NARROWED — do not "finish" this

The obvious version of this change is to type the store's `ceeAnalysisReady` so `status` cannot be `'blocked'`. **That was measured, considered, and rejected as a false claim.**

`store.ts`'s `setCeeAnalysisReady` sets **unconditionally** (`store.ts:4859`), and the V5 normaliser **accepts** ARM B and writes it (`applyV5State.ts:1232`). So the field genuinely holds `status: 'blocked'` at runtime. Narrowing it would be a guarantee **the compiler enforces on every reader except the writer that produces the value** — the one kind of claim nothing checks at runtime.

The narrowing therefore lives in a **derived read**, which has no storage and so cannot drift from the field it narrows.

### The compile-error manifest (measured, not asserted)

Narrowing the field instead, at `06c616c5`, `tsconfig.app.json`:

```
pristine 1924 errors → narrowed 1938      TRUE NEW = 14, all TS2322
  6  conversation/__tests__/analysisInputsWiring.spec.ts
  3  conversation/__tests__/analysisInputsReconciliation.spec.ts
  2  pre-analysis-v3/__tests__/PreAnalysisPanelV3.spec.tsx
  1  store/__tests__/analysisReady.invalidation.spec.ts
  1  conversation/__tests__/goldenFixture.spec.ts
  1  canvas/store.ts   ← the ONLY source file
```
`store.ts(4860,13): TS2322: Type 'CEEAnalysisReady' is not assignable to type 'UsableCEEAnalysisReady'.`

**One source error, at the one writer — the seam is already single-writer.** And only **two** sites in the whole estate discriminate on `'blocked'`. The value is at the **write** boundary, not across a spread of read sites. Deltas were keyed on `file(line,col)+TScode`, never on message text: a message that merely reflows scores as one gone plus one new and inflates the manifest in the direction that flatters the hypothesis.

---

## Evidence

**Gates** — exit codes asserted explicitly, not inferred from output:
- `scripts/ci/typecheck-gate.sh` → **exit 0**, `556 file(s) / 2252 error(s)` — exactly baseline.
- `eslint` on changed files → **exit 0** (2 pre-existing warnings at `readinessStore.ts:471,1014`, untouched).

**Mutants** — throwaway worktree at an absolute path outside the repo root, write-isolation proven by sentinel, HEAD-relative restores, applied-check scoped to `src/` reading exactly 1, controls reading exactly 0. Failing **names** compared, not counts:

| | result | |
|---|---|---|
| pristine control | exit 0, 11 passed | applied 0 |
| **M1** guard removed | exit 1, **3** named failures | bites |
| **M2** keyed on `'ready'` instead | exit 1, **7** named failures — **a different set**, incl. *"STILL SENDS analysis_ready on a genuine readiness verdict"*, which M1 does **not** fail | discriminates |
| **C1** a *different* type narrowed | **exit 0, 11 passed** | tests bind to the discriminator, not the type |
| trailing control | exit 0, 11 passed | clean |

M1 and M2 fail on **different named tests** — the pair proves the tests bind to *this* discriminator, not merely that they are sensitive to something.

**Regression:** `canvas/stores/__tests__/` → 33 files / **389 passed**, exit 0.

**Both new specs pin their own precondition in-test** — that the refusal fixture is genuinely ARM B (populated exactly where the old shape guard looked), and that the payload twins differ *only* by status. Without that, a fixture that quietly stopped reproducing ARM B would leave the tests passing for the wrong reason.

## Not in scope
The store split / two-field version is **deferred, not planned** — a derived read needs no "one writer produces both" discipline, so it may never be needed. If it ever is, that is a new decision with new evidence.

## One consequence a reviewer should weigh

`buildReadinessPayload`'s output doubles as the change-detection key (*"a hash derived from the payload cannot drift from the payload, because it IS the payload"*). Omitting `analysis_ready` on a refusal therefore changes that key for refused states.

I believe this is correct rather than merely tolerable — the readiness input genuinely differs — and it does not churn, because the payload is stable while the state is. **But it is a behavioural consequence outside the stated fix, so it should be looked at rather than taken on my word.** No test here pins it, and I have not measured how CEE handles receiving a refusal as `analysis_ready` today; the change is justified by the semantics of what we send, not by a witnessed downstream harm.


---

## ⚠ CORRECTIONS AFTER INDEPENDENT REVIEW — two claims above are REFUTED

Leaving a refuted premise in a PR body is how it becomes the next session's inherited fact. Both are corrected here rather than quietly edited away.

### ❌ REFUTED — the causal claim about CEE

The body says this "hands CEE's readiness authority its own refusal back as an assessment." **That is wrong.** Measured at CEE `45cf25e1`: `input.analysis_ready` appears exactly twice in `assist.v1.graph-readiness.ts` — a comment stating it is **"deliberately NOT read"**, and a telemetry boolean. **CEE fixed this on its own side.**

The request *did* carry the refusal — that part stands and was reproduced RED. But it never reached the readiness authority as an assessment. **The real effect is on the `analysis_ready_present` telemetry signal plus the change-detection key**, not on CEE's verdict.

I had flagged in this body that I had not measured CEE's handling. The reviewer measured it; this is the answer. The change remains correct hygiene — we should not send a refusal as `analysis_ready` regardless — but it is a smaller claim than the one I made.

### ❌ REFUTED — "only two sites in the whole estate discriminate on `'blocked'`"

**There are at least four**, and the miscount has a reusable cause:

```
ceeAnalysisReadyValidation.ts:64   status === 'blocked'
store.ts:4962                      status === 'blocked'
analysisRefusalNotice.ts:283       status !== 'blocked'              ← NEGATED
canRunAnalysis.ts:611              === ANALYSIS_READINESS_BLOCKED    ← NAMED CONSTANT
```

**My sweep grepped the field-qualified literal, so it was structurally blind to the negated form and to the named constant** — two whole spellings a contrast control would not have caught, because the control would have used the same spelling. Sweep for the **concept across its spellings**, not for the string you happened to write.

⚠ **This matters because the count was load-bearing**: it was part of the argument for rejecting the field-narrowing design. The design conclusion still holds — the narrowing would be a false claim at runtime, which is an independent argument — but the site count that supported it was understated by at least 2×.

### Also corrected in the code itself
- The module claimed a type predicate is "something the compiler checks". **Backwards** — TypeScript does not verify a predicate's body; it takes `x is T` on trust. A predicate is exactly as much an assertion as a cast, better only because the assertion sits in one named place with a test around it.
- The module claimed "one literal, one module". **It migrated none.** The four unmigrated sites are now named in the module.
- `isAnalysisRefusal` → **`isBlockedCarrier`**. Its behaviour was right; its **name** asserted that the LEGACY freshness carrier is a refusal, which is false. Two questions under one name — and no test can see it, because the predicate returns the right booleans.
