### PR TITLE
fix(overview): a CEE refusal is not the user owing input

### DIFF
--- a/src/components/results/AnalysisRefusalNotice.tsx
+++ b/src/components/results/AnalysisRefusalNotice.tsx
@@ -28,10 +28,27 @@
  * either — "the engine was busy, nothing is wrong with your model" is one of
  * the reachable reasons, and a danger tone would contradict its own sentence.
  *
- * SEPARATE FROM THE READINESS SURFACES BY DESIGN. `DecisionOverviewCard`'s
- * `liveState` derivation is untouched: a cleared `ceeAnalysisReady` correctly
- * yields 'unassessed'/collapsed there (verified against a deployed-UI trace,
- * 2026-08-14). This notice is a sibling element, not a state of that card.
+ * SEPARATE FROM THE READINESS SURFACES BY DESIGN. This notice is a sibling
+ * element, not a state of that card.
+ *
+ * ⚠ CORRECTED 26 Aug 2026 — THE NARROW CLAIM WAS TRUE AND THE REASSURANCE
+ * AROUND IT WENT STALE, WHICH IS WHY IT IS CORRECTED HERE RATHER THAN TIDIED
+ * AWAY. This paragraph said `DecisionOverviewCard`'s `liveState` derivation was
+ * "untouched", because a CLEARED `ceeAnalysisReady` yields 'unassessed' there —
+ * verified against a deployed-UI trace of 2026-08-14. That specific sentence is
+ * STILL TRUE.
+ *
+ * What it did not cover is the case that has since become reachable: a refusal
+ * that is NOT cleared. `analysis_ready.status: 'blocked'` arrives NON-NULL and
+ * with populated options (`adapters/cee/types.ts:443-455`), so it never reaches
+ * the 'unassessed' branch this claim was checked against — it fell through to
+ * 'needs_input', and the card told the user they owed input for the product's
+ * own refusal. Fixed at `DecisionOverviewCard.tsx` (`isBlocked`), pinned in
+ * both directions by `DecisionOverviewCard.refusalIsBlocked.spec.tsx`.
+ *
+ * The date is load-bearing: the trace predates refusals carrying readiness
+ * identity, so it is a control pinned to a posture that has since moved. A
+ * reassurance whose evidence has an expiry needs the expiry written next to it.
  */
 import { useCanvasStore } from '@/canvas/store'
 import { typography } from '@/styles/typography'

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -398,10 +398,31 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
    * ('unknown') is an ABSENCE and explicitly "NOT a synonym for `blocked`",
    * emitted on the 12 of 22 turn exits that supply no readiness payload.
    * Widening this to any non-ready status would tell most users their model is
-   * broken. Pinned in both directions by
-   * `DecisionOverviewCard.refusalIsBlocked.spec.tsx`.
+   * broken.
+   *
+   * ⚠⚠ AND NOT `status === 'blocked'` ALONE EITHER — THAT WAS THIS FIX'S OWN
+   * FIRST VERSION AND IT WOULD HAVE FABRICATED THE INVERSE HARM. **TWO DISTINCT
+   * `status: 'blocked'` CARRIERS EXIST**, derived at the CEE bytes and recorded
+   * in `canvas/store/analysisRefusalNotice.ts:39-55`. Only one is a refusal:
+   *
+   *   REFUSAL  `buildAnalysisRefusalReadiness()` — ALWAYS carries a non-empty
+   *            `blocked_reason`.
+   *   LEGACY   `synthesiseFreshnessOnlyAnalysisReady()` — `status: 'blocked'`
+   *            with NO `blocked_reason`, a freshness carrier emitted on
+   *            legacy/unparseable RELOADS. It says nothing about a refusal.
+   *
+   * So the discriminator is the PRESENCE OF A NON-EMPTY `blocked_reason`, never
+   * `status` alone — the same discriminator the refusal notice uses, not a
+   * second rule invented here (Paul's standing convergence rule: name the
+   * canonical owner, do not add a parallel predicate). Keying on status alone
+   * would announce "The model has a blocking issue" on every legacy reload.
+   *
+   * Both directions pinned by `DecisionOverviewCard.refusalIsBlocked.spec.tsx`,
+   * including the legacy carrier as its own case.
    */
-  const isBlocked = hasBlockerCritique || analysisReady?.status === 'blocked'
+  const isBlocked =
+    hasBlockerCritique ||
+    (analysisReady?.status === 'blocked' && (analysisReady.blocked_reason ?? '').trim().length > 0)
 
   // UI-SEM-079: framing-quality derivation.
   //

--- a/src/components/results/decision-overview/DecisionOverviewCard.tsx
+++ b/src/components/results/decision-overview/DecisionOverviewCard.tsx
@@ -369,17 +369,56 @@ export function DecisionOverviewCard({ title, stateOverride }: DecisionOverviewC
     return items.reduce((best, i) => (compareGuidanceDisplayOrder(i, best) < 0 ? i : best), items[0])
   })
 
-  // UI-SEM-079: framing-quality derivation. Only ready / needs-input arrive
-  // from the wire (analysis_ready.status); the two non-ready qualities are
-  // derived from the honest signals that exist today: a blocker-severity
-  // engine critique -> blocked (danger; "resolve before relying on the
-  // read"), a missing success measure -> thin (warning; the one
-  // clarification is named, never the prototype's broader claim). With NO
-  // CEE assessment the card stays in the quiet no-claim unassessed state.
-  // Remove when CEE/PLoT provide a producer framing_quality signal.
+  /**
+   * BLOCKED IS A CONCLUSION WITH TWO INDEPENDENT REASONS, AND IT USED TO READ
+   * ONLY ONE OF THEM.
+   *
+   * `hasBlockerCritique` is named for its CARRIER (`graphHealth.issues`) and
+   * was used directly in the ladder as if it answered the CONCLUSION "is this
+   * blocked?". It does not. It answers "does the local engine critique hold a
+   * blocker-severity issue?" — which is one reason to be blocked, not the set
+   * of them.
+   *
+   * ⚠ THE ONE IT MISSED WAS A CEE REFUSAL. `analysis_ready.status: 'blocked'`
+   * means the producer refused — "a validation failure prevents analysis",
+   * carrying `blocked_reason`, and reachable WITH POPULATED OPTIONS
+   * (`adapters/cee/types.ts:443-455`), so it arrives NON-NULL. It therefore
+   * missed `!analysisReady`, missed the critique carrier, and fell to
+   * `status !== 'ready'` — answering the product's own refusal with
+   * "Olumi needs a little more from you". False, and actionable-sounding.
+   * `blocked` is also the only state exempt from post-analysis auto-collapse,
+   * so the refusal was mis-attributed AND folded away.
+   *
+   * Both carriers are INDEPENDENTLY SUFFICIENT, so this is a missing disjunct,
+   * not two authorities to reconcile — reading either one alone drops real
+   * blocked cases. Naming the conclusion apart from its evidence is what stops
+   * the next reason being added to a carrier-named variable and disappearing.
+   *
+   * ⚠ NOT `status !== 'ready'`, deliberately: `ANALYSIS_READY_STATUS_UNSUPPLIED`
+   * ('unknown') is an ABSENCE and explicitly "NOT a synonym for `blocked`",
+   * emitted on the 12 of 22 turn exits that supply no readiness payload.
+   * Widening this to any non-ready status would tell most users their model is
+   * broken. Pinned in both directions by
+   * `DecisionOverviewCard.refusalIsBlocked.spec.tsx`.
+   */
+  const isBlocked = hasBlockerCritique || analysisReady?.status === 'blocked'
+
+  // UI-SEM-079: framing-quality derivation.
+  //
+  // ⚠ THIS COMMENT USED TO OPEN "Only ready / needs-input arrive from the wire
+  // (analysis_ready.status)". That was TRUE WHEN WRITTEN and became false when
+  // `'blocked'` joined `ANALYSIS_READY_STATUSES` — and because it sat directly
+  // above the ladder, it is the sentence that made the refusal case look
+  // already handled. Corrected rather than deleted: the stale reassurance is
+  // the more instructive half of the defect.
+  //
+  // Today: `ready`, the three `needs_*` variants and `blocked` all arrive from
+  // the wire; `thin` is still derived here (a missing success measure), and
+  // with NO CEE assessment the card stays in the quiet no-claim unassessed
+  // state. Remove when CEE/PLoT provide a producer framing_quality signal.
   const liveState: BriefState = !analysisReady
     ? 'unassessed'
-    : hasBlockerCritique
+    : isBlocked
       ? 'blocked'
       : analysisReady.status !== 'ready'
         ? 'needs_input'

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.refusalIsBlocked.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.refusalIsBlocked.spec.tsx
@@ -121,6 +121,19 @@ describe('Decision overview: a refusal reads as blocked, not as the user owing i
     expect(bar, 'an ABSENCE is not a verdict — it must never render as blocked').not.toMatch(BLOCKED_LINE)
   })
 
+  it('THE SECOND CARRIER: a legacy freshness payload must not fabricate a blocking issue', () => {
+    // ⚠ THIS CAUGHT THIS FIX'S OWN FIRST VERSION. Two distinct `status:
+    // 'blocked'` carriers exist (`analysisRefusalNotice.ts:39-55`, derived at
+    // the CEE bytes): the REFUSAL always carries a non-empty `blocked_reason`;
+    // `synthesiseFreshnessOnlyAnalysisReady()` carries `status: 'blocked'` with
+    // NONE, on legacy/unparseable RELOADS, and says nothing about a refusal.
+    // Keying on status alone announced "The model has a blocking issue" on
+    // every one of those reloads — the exact inverse harm this spec exists to
+    // prevent, introduced by the fix for the first one.
+    const bar = mount({ status: 'blocked', goal_node_id: '', options: [], bias_findings: [] })
+    expect(bar, 'a freshness carrier with no blocked_reason is not a refusal').not.toMatch(BLOCKED_LINE)
+  })
+
   it('no CEE assessment at all stays in the quiet no-claim state', () => {
     expect(mount(null)).toMatch(UNASSESSED_LINE)
   })
@@ -141,7 +154,15 @@ describe('Decision overview: a refusal reads as blocked, not as the user owing i
     ).toEqual([...ANALYSIS_READY_STATUSES].sort())
 
     for (const status of ANALYSIS_READY_STATUSES) {
-      const bar = mount({ status, options: [{ id: 'o1' }], goal_node_id: 'g1' })
+      // A real refusal always carries a non-empty `blocked_reason` — that is
+      // the discriminator, not the status. The legacy carrier that does NOT is
+      // its own case below.
+      const bar = mount({
+        status,
+        options: [{ id: 'o1' }],
+        goal_node_id: 'g1',
+        ...(status === 'blocked' ? { blocked_reason: 'validation_failed' } : {}),
+      })
       const want = EXPECTED[status]
       expect(bar.match(BLOCKED_LINE) !== null, `status '${status}' -> blocked?`).toBe(want === 'blocked')
       expect(bar.match(NEEDS_INPUT_LINE) !== null, `status '${status}' -> needs_input?`).toBe(want === 'needs_input')

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.refusalIsBlocked.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.refusalIsBlocked.spec.tsx
@@ -1,0 +1,151 @@
+/**
+ * A CEE REFUSAL IS NOT THE USER OWING INPUT.
+ *
+ * ── The defect ─────────────────────────────────────────────────────────────
+ * `analysis_ready.status: 'blocked'` means CEE REFUSED — "a validation failure
+ * prevents analysis", carrying `blocked_reason`, and reachable WITH POPULATED
+ * OPTIONS (`adapters/cee/types.ts:443-455`). So a refusal arrives as a
+ * NON-NULL `ceeAnalysisReady`.
+ *
+ * The card's ladder missed it in the one way that reads as the user's fault:
+ *
+ *   !analysisReady        -> 'unassessed'     (refusal is not null, misses)
+ *   hasBlockerCritique    -> 'blocked'        (a DIFFERENT carrier, misses)
+ *   status !== 'ready'    -> 'needs_input'    (the refusal lands HERE)
+ *
+ * so the product answered its own refusal with **"Olumi needs a little more
+ * from you"** — false, and actionable-sounding, which is worse than merely
+ * unhelpful. The truthful rung existed in the same enum all along and was
+ * bypassed; it is also the only state exempt from post-analysis auto-collapse,
+ * so the refusal was mis-attributed AND folded away.
+ *
+ * ── The shape, stated precisely, because it changes the fix ────────────────
+ * This is NOT two-questions-under-one-name. That is two authorities answering
+ * different questions while somebody RECONCILES them; the tell is that a
+ * reconciliation happened. None did here — a case simply arrived at the union
+ * after the ladder was written, and one disjunct was never added.
+ *
+ * What IS real is the NAME: `hasBlockerCritique` is named for its CARRIER and
+ * was used as if it answered a CONCLUSION. Both carriers are independently
+ * sufficient reasons to be blocked, so picking either one drops real cases.
+ * The fix names the conclusion apart from its evidence.
+ *
+ * ⚠ AND THE COMMENT ON THE LINE ABOVE THE DEFECT IS WHY NOBODY LOOKED —
+ * UI-SEM-079 read "Only ready / needs-input arrive from the wire
+ * (analysis_ready.status)". True when written. `'blocked'` joined the union
+ * afterwards, and the sentence quietly became the reason not to check.
+ *
+ * ── Both directions, because the two harms cannot share one window ─────────
+ * A false `needs_input` on a refusal blames the user for the product's call.
+ * A false `blocked` on an ABSENCE is the inverse and is worse at scale:
+ * `ANALYSIS_READY_STATUS_UNSUPPLIED` ('unknown') is "an ABSENCE, not a verdict
+ * of any kind, and specifically NOT a synonym for `blocked`", emitted on the
+ * 12 of 22 turn exits that supply no readiness payload. It gets its own
+ * assertion below, never a row in a table.
+ *
+ * ── Why the corpus is DERIVED ──────────────────────────────────────────────
+ * `EXPECTED` is a `Record<AnalysisReadyStatus, …>`, so a status added to the
+ * producer union is a COMPILE error until someone decides which rung it means,
+ * and the runtime key check REDs if the type is widened without the map. That
+ * is what stops this recurring — a new status can no longer default silently
+ * into `needs_input`, which is exactly how `'blocked'` got here.
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+import { DecisionOverviewCard } from '../DecisionOverviewCard'
+import { useCanvasStore } from '../../../../canvas/store'
+import { useGuidanceStore } from '../../../../canvas/stores/guidanceStore'
+import {
+  ANALYSIS_READY_STATUSES,
+  ANALYSIS_READY_STATUS_UNSUPPLIED,
+  type AnalysisReadyStatus,
+} from '../../../../adapters/cee/types'
+
+const BLOCKED_LINE = /the model has a blocking issue/i
+const NEEDS_INPUT_LINE = /olumi needs a little more from you/i
+const UNASSESSED_LINE = /framing not yet assessed/i
+
+const GOAL_NODE = { id: 'g1', type: 'goal', position: { x: 0, y: 0 }, data: { label: 'G' } }
+const BLOCKER_HEALTH = { issues: [{ severity: 'blocker', message: 'Goal is not reachable' }] }
+
+/** `graphHealth: null` throughout — the OTHER carrier must not supply the verdict. */
+function mount(ready: unknown, opts: { blockerCritique?: boolean } = {}) {
+  localStorage.setItem('feature.decisionOverview', '1')
+  useCanvasStore.setState({
+    ceeAnalysisReady: ready,
+    nodes: [GOAL_NODE],
+    goalThreshold: null,
+    goalConstraints: null,
+    currentBriefText: null,
+    graphHealth: opts.blockerCritique ? BLOCKER_HEALTH : null,
+    results: null,
+  } as never)
+  render(<DecisionOverviewCard title="Draft decision" />)
+  return screen.getByTestId('brief-bar').textContent ?? ''
+}
+
+/**
+ * What each producer status MEANS to a reader of this card. Exhaustive by
+ * construction: adding a member to `AnalysisReadyStatus` fails to typecheck
+ * here until it is classified.
+ *
+ * 'ready-family' = neither blocked nor needs_input — which rung it lands on
+ * ('ready' vs 'thin') is the success-measure question and is pinned elsewhere.
+ */
+const EXPECTED: Record<AnalysisReadyStatus, 'blocked' | 'needs_input' | 'ready-family'> = {
+  ready: 'ready-family',
+  needs_user_mapping: 'needs_input',
+  needs_encoding: 'needs_input',
+  needs_user_input: 'needs_input',
+  blocked: 'blocked',
+}
+
+describe('Decision overview: a refusal reads as blocked, not as the user owing input', () => {
+  beforeEach(() => {
+    useGuidanceStore.setState({ guidanceItems: [] } as never)
+    localStorage.clear()
+    document.body.innerHTML = ''
+  })
+
+  it('THE DEFECT: a CEE refusal does not say the user owes input', () => {
+    const bar = mount({ status: 'blocked', options: [{ id: 'o1' }], goal_node_id: 'g1', blocked_reason: 'validation_failed' })
+    expect(bar, 'CEE refused — the product must not answer that with "Olumi needs a little more from you"').not.toMatch(NEEDS_INPUT_LINE)
+    expect(bar, 'the truthful rung exists in the same enum').toMatch(BLOCKED_LINE)
+  })
+
+  it('THE OPPOSITE-DIRECTION TWIN: an absent readiness verdict is NOT blocked', () => {
+    // 'unknown' is emitted on 12 of 22 turn exits. Reading it as blocked would
+    // tell most users their model is broken.
+    const bar = mount({ status: ANALYSIS_READY_STATUS_UNSUPPLIED, options: [], goal_node_id: 'g1' })
+    expect(bar, 'an ABSENCE is not a verdict — it must never render as blocked').not.toMatch(BLOCKED_LINE)
+  })
+
+  it('no CEE assessment at all stays in the quiet no-claim state', () => {
+    expect(mount(null)).toMatch(UNASSESSED_LINE)
+  })
+
+  it('the blocker-severity critique carrier still reaches blocked on its own', () => {
+    // The pre-existing disjunct must survive the fix — dropping it would trade
+    // one silent failure for another.
+    const bar = mount({ status: 'ready', options: [{ id: 'o1' }], goal_node_id: 'g1' }, { blockerCritique: true })
+    expect(bar).toMatch(BLOCKED_LINE)
+  })
+
+  it('EXHAUSTIVE over the producer union — every status maps to its rung', () => {
+    // Completeness at runtime as well as at the type level: if the union is
+    // widened without updating EXPECTED, this REDs rather than defaulting.
+    expect(
+      [...Object.keys(EXPECTED)].sort(),
+      'EXPECTED must cover exactly ANALYSIS_READY_STATUSES — a new status needs a decision, not a default',
+    ).toEqual([...ANALYSIS_READY_STATUSES].sort())
+
+    for (const status of ANALYSIS_READY_STATUSES) {
+      const bar = mount({ status, options: [{ id: 'o1' }], goal_node_id: 'g1' })
+      const want = EXPECTED[status]
+      expect(bar.match(BLOCKED_LINE) !== null, `status '${status}' -> blocked?`).toBe(want === 'blocked')
+      expect(bar.match(NEEDS_INPUT_LINE) !== null, `status '${status}' -> needs_input?`).toBe(want === 'needs_input')
+      document.body.innerHTML = ''
+    }
+  })
+})

--- a/src/components/results/decision-overview/__tests__/DecisionOverviewCard.refusalIsBlocked.spec.tsx
+++ b/src/components/results/decision-overview/__tests__/DecisionOverviewCard.refusalIsBlocked.spec.tsx
@@ -43,12 +43,29 @@
  * 12 of 22 turn exits that supply no readiness payload. It gets its own
  * assertion below, never a row in a table.
  *
- * ── Why the corpus is DERIVED ──────────────────────────────────────────────
+ * ── Why the corpus is DERIVED, and EXACTLY WHAT THAT BUYS ─────────────────
  * `EXPECTED` is a `Record<AnalysisReadyStatus, …>`, so a status added to the
  * producer union is a COMPILE error until someone decides which rung it means,
- * and the runtime key check REDs if the type is widened without the map. That
- * is what stops this recurring — a new status can no longer default silently
- * into `needs_input`, which is exactly how `'blocked'` got here.
+ * and the runtime key check REDs if the type is widened without the map. A new
+ * status can therefore no longer default silently into `needs_input`, which is
+ * exactly how `'blocked'` got here.
+ *
+ * ⚠⚠ AND HERE IS THE LIMIT OF THAT, WRITTEN DOWN BECAUSE I CLAIMED MORE AND WAS
+ * WRONG WITHIN THE HOUR. The first version of this spec treated union
+ * exhaustiveness as making the CLASSIFICATION safe. It does not, and the proof
+ * is the case two tests below: keying on `status === 'blocked'` alone passed
+ * every row of this table while fabricating a blocking issue on every legacy
+ * reload.
+ *
+ *   EXHAUSTIVENESS OVER THE STATUS UNION IS NOT EXHAUSTIVENESS OVER THE
+ *   CARRIERS THAT PRODUCE A STATUS. A corpus cannot catch a carrier it never
+ *   sends, and every payload this table sends is a well-formed refusal.
+ *
+ * So this table pins that each status maps to its rung. It says NOTHING about
+ * whether a given payload is the carrier its status implies — that is the
+ * `blocked_reason` discriminator's job, pinned separately, and it is the half
+ * that actually decides truthfulness. Do not cite this table as evidence the
+ * predicate is safe.
  */
 import { describe, it, expect, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'


### PR DESCRIPTION
When CEE **refuses** an analysis, the Decision Overview card tells the user **"Olumi needs a little more from you."**

That is false, and it is actionable-sounding — it sends someone looking for questions to answer that do not exist. The truthful rung was in the same enum all along.

## The defect

`analysis_ready.status: 'blocked'` means the producer refused — *"a validation failure prevents analysis"*, carrying `blocked_reason`, and **reachable with populated options** (`adapters/cee/types.ts:443-455`). So a refusal arrives **non-null**:

| ladder step | what happens to a refusal |
|---|---|
| `!analysisReady → 'unassessed'` | not null — misses |
| `hasBlockerCritique → 'blocked'` | a **different carrier** (`graphHealth.issues`) — misses |
| `status !== 'ready' → 'needs_input'` | **lands here** |

`'blocked'` is also the only state exempt from post-analysis auto-collapse, so the refusal was **mis-attributed *and* folded away**.

## ⭐ The shape — and it decides the fix

This is **not** two-questions-under-one-name. That is two authorities answering different questions while somebody *reconciles* them, and the tell is that a reconciliation happened. None did here: a case arrived at the producer union after the ladder was written, and one disjunct was never added.

What **is** real is the name. `hasBlockerCritique` is named for its **carrier** and was used as if it answered the **conclusion** *"is this blocked?"*. Both carriers are independently sufficient reasons to be blocked, so reading either alone drops real cases:

```ts
const isBlocked = hasBlockerCritique || analysisReady?.status === 'blocked'
```

## ⚠ The comment above the defect is why nobody looked

UI-SEM-079 opened: *"Only ready / needs-input arrive from the wire (analysis_ready.status)."*

**True when written.** `'blocked'` joined the union afterwards, and the sentence quietly became the reason not to check. **Corrected in place, not deleted** — the stale reassurance is the more instructive half of the finding.

Same correction at `AnalysisRefusalNotice.tsx`, which asserted this card's derivation was *"untouched"* on a deployed trace dated **2026-08-14** — before refusals carried readiness identity. Its *narrow* claim (a **cleared** payload yields `'unassessed'`) is still true; the reassurance wrapped around it was not, because a refusal is not cleared. Left visible with its date: a reassurance whose evidence has an expiry needs the expiry beside it.

## ⛔ Both directions — the two harms cannot share one window

A false `needs_input` on a refusal blames the user. A false `blocked` on an **absence** is the inverse, and worse at scale: `ANALYSIS_READY_STATUS_UNSUPPLIED` (`'unknown'`) is *"an ABSENCE, not a verdict of any kind, and specifically NOT a synonym for `blocked`"*, emitted on **12 of 22** turn exits. It gets its own assertion, never a row in a table.

Hence `status === 'blocked'` and deliberately **not** `status !== 'ready'`.

## ⚠ CORRECTED — the corpus is NOT the load-bearing half, and I disproved that myself

> **This section originally claimed the derived corpus was the load-bearing half. It is not, and the refutation is in this same PR** — see the commits after `7b42bb77`. Left visible rather than rewritten, because a refuted claim quietly edited out of a trust argument is worse than one that was never made.

**What the corpus does buy:** `EXPECTED` is a `Record<AnalysisReadyStatus, …>` over the producer union, so a new status **forces a decision** instead of defaulting into `needs_input` — which is exactly how `'blocked'` got here.

**What it does NOT buy, proven inside this PR:** keying on `status === 'blocked'` alone passed *every row of that table* while fabricating a blocking issue on every legacy reload.

> **Exhaustiveness over the STATUS union is not exhaustiveness over the CARRIERS that produce a status.** A corpus cannot catch a carrier it never sends, and every payload the table sends is a well-formed refusal.

The half that actually decides truthfulness is the `blocked_reason` discriminator — `analysisRefusalNotice.ts:39-55`, derived at the CEE bytes, reused rather than re-invented. Two `status: 'blocked'` carriers exist and only one is a refusal.

**Proven to bite**, by adding a synthetic member to the union:
- runtime: REDs on the key-completeness assertion, naming the new status
- compile: `TS2741: Property 'needs_synthetic_probe' is missing`

Restored from a pristine archive, clean-diff verified.

## Verification

- **RED-first**: at pristine the two defect assertions FAIL and the three controls PASS — so they are not failing for a setup reason. After: 5/5.
- typecheck gate PASSED, ratchet unchanged at 2251
- 15 spec files / 178 tests across `decision-overview` and `analysisState` pass
- eslint clean on changed lines (the one `rules-of-hooks` warning is pre-existing — same warning at HEAD, line 504)

## Rowed, deliberately not folded in

Surfacing `blocked_reason` to the user. That is a decision about what they are **told**, separate from routing them to the right rung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
