### PR TITLE
C+D: the producer's blocked-reason sentences are a list, not a paragraph

### DIFF
--- a/src/canvas/utils/__tests__/producerSentencesAreAList.spec.ts
+++ b/src/canvas/utils/__tests__/producerSentencesAreAList.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * THE PRODUCER'S SENTENCES ARE A LIST, NOT A PARAGRAPH.
+ *
+ * `composeAnalysisBlockedReason` joined every producer sentence with a space
+ * into ONE string, rendered in a `panelMeta` line and a `title` attribute. On a
+ * ten-blocker graph that is ~1,425 characters in a single meta paragraph.
+ *
+ * ⛔ THE FIX IS NOT TRUNCATION. The no-truncation contract
+ * (`composeBlockedReason.ts`) exists so we never attribute our words to the
+ * producer, and it is honoured: nothing here cuts, summarises or reorders.
+ * The change is PRESENTATION — the same bytes, rendered as a list.
+ *
+ * ⭐ THE STRING IS NOW A DERIVATION OF THE ARRAY. `composeAnalysisBlockedReason`
+ * is defined as `analysisBlockedSentences(...).join(' ')`. Byte-identity of the
+ * union is therefore true BY CONSTRUCTION, not by a test that could drift — and
+ * the gate's tooltip and the panel's list cannot disagree about what the
+ * producer said, because there is one array behind both.
+ */
+import { describe, it, expect } from 'vitest'
+import {
+  analysisBlockedSentences,
+  composeAnalysisBlockedReason,
+} from '../composeBlockedReason'
+import type { AnalysisBlocker } from '@talchain/schemas/boundary'
+
+const blocker = (message: string, i: number): AnalysisBlocker =>
+  ({ code: `MISSING_OPTION_VALUE`, category: 'inputs', repairability: 'user', message,
+     factor_id: `fac-${i}`, option_id: `opt-${i}` }) as unknown as AnalysisBlocker
+
+// Real producer wording, from the 26 Aug wire capture.
+const REAL = [
+  'Choose the missing effect value for "keep what we have" on "Current CRM Capability Gap".',
+  'Choose the missing effect value for "migrate to Salesforce instead" on "Salesforce Switching Cost".',
+]
+
+describe('analysisBlockedSentences — the union is byte-identical to the joined string', () => {
+  it('PRECONDITION: the fixture is genuinely multi-sentence and producer-authored', () => {
+    // Pins the fixture's discriminating power: a one-item fixture could not
+    // observe a join defect at all, and the assertions below would hold vacuously.
+    expect(REAL.length).toBeGreaterThan(1)
+    const out = analysisBlockedSentences(REAL.map(blocker))
+    expect(out.length).toBe(REAL.length)
+  })
+
+  it('THE UNION IS EXACT — joining the list reproduces the string byte for byte', () => {
+    const blockers = REAL.map(blocker)
+    expect(analysisBlockedSentences(blockers).join(' ')).toBe(
+      composeAnalysisBlockedReason(blockers),
+    )
+  })
+
+  it('every item is byte-identical to a sentence the producer wrote — nothing altered', () => {
+    const out = analysisBlockedSentences(REAL.map(blocker))
+    for (const item of out) expect(REAL).toContain(item)
+  })
+
+  it('NOTHING IS DROPPED — every producer sentence appears', () => {
+    const out = analysisBlockedSentences(REAL.map(blocker))
+    for (const sentence of REAL) expect(out).toContain(sentence)
+  })
+
+  it('ORDER IS THE PRODUCER’S — not ours to choose', () => {
+    expect(analysisBlockedSentences(REAL.map(blocker))).toEqual(REAL)
+  })
+
+  it('THE ONE-BLOCKER TWIN: a single sentence stays a single item, not a list of one', () => {
+    const out = analysisBlockedSentences([blocker(REAL[0], 0)])
+    expect(out).toEqual([REAL[0]])
+    expect(out).toHaveLength(1)
+  })
+
+  it('exact duplicates are de-duplicated once, as before', () => {
+    const out = analysisBlockedSentences([blocker(REAL[0], 0), blocker(REAL[0], 1)])
+    expect(out).toEqual([REAL[0]])
+  })
+
+  it('NO BLOCKERS: falls back to the composed copy as one item — never an empty list', () => {
+    const out = analysisBlockedSentences([])
+    expect(out).toHaveLength(1)
+    expect(out[0].length).toBeGreaterThan(0)
+    expect(out.join(' ')).toBe(composeAnalysisBlockedReason([]))
+  })
+
+  it('THE JOIN IS STILL WHAT IS VETTED — an unsafe join withholds the WHOLE list, not part', () => {
+    // The contract vets the JOIN because a phrase can form ACROSS the seam
+    // between two individually-safe sentences. Rendering parts must not weaken
+    // that: if the join is rejected, no producer text ships at all.
+    const unsafe = [blocker('The graph is fine.', 0), blocker('Nothing to do.', 1)]
+    const out = analysisBlockedSentences(unsafe)
+    const joined = out.join(' ')
+    expect(joined).toBe(composeAnalysisBlockedReason(unsafe))
+    // Either all producer sentences survive, or none do — never a mixture.
+    const anyProducer = out.some(s => s === 'The graph is fine.' || s === 'Nothing to do.')
+    const allProducer = out.length === 2
+    expect(anyProducer === allProducer || out.length === 1).toBe(true)
+  })
+})

--- a/src/canvas/utils/composeBlockedReason.ts
+++ b/src/canvas/utils/composeBlockedReason.ts
@@ -604,9 +604,9 @@ export function composeReadinessBlockedReason(
  *  · INVENT NOTHING — the return value is the producer's own text and nothing
  *    else. No prefix, no framing, no connective of ours.
  */
-function composeProducerAuthoredSentences(
+function composeProducerAuthoredSentenceList(
   values: readonly (string | undefined)[],
-): string | null {
+): readonly string[] | null {
   const sentences: string[] = []
   for (const value of values) {
     const text = typeof value === 'string' ? value.trim() : ''
@@ -615,14 +615,28 @@ function composeProducerAuthoredSentences(
   }
   if (sentences.length === 0) return null
 
+  // STILL VET THE JOIN, even though the LIST is what ships to the panel. A
+  // phrase can form across the seam between two individually-safe sentences,
+  // so the join remains the vetted string and a rejection withholds the WHOLE
+  // list — never a subset. Rendering the parts is strictly safer than
+  // rendering the join: the cross-seam adjacency never reaches the reader.
   const joined = sentences.join(' ')
-  return isSafeCeeText(joined) ? joined : null
+  return isSafeCeeText(joined) ? sentences : null
 }
 
-function producerAuthoredReason(blockers: readonly AnalysisBlocker[]): string | null {
+/** The joined form. Derived from the list, so the two cannot disagree. */
+function composeProducerAuthoredSentences(
+  values: readonly (string | undefined)[],
+): string | null {
+  return composeProducerAuthoredSentenceList(values)?.join(' ') ?? null
+}
+
+function producerAuthoredSentences(
+  blockers: readonly AnalysisBlocker[],
+): readonly string[] | null {
   // The TYPE says `string` and the schema says `.min(1)`; the shared body still
   // re-checks at runtime, because a type is not a runtime guarantee here.
-  return composeProducerAuthoredSentences(blockers.map(blocker => blocker.message))
+  return composeProducerAuthoredSentenceList(blockers.map(blocker => blocker.message))
 }
 
 /**
@@ -645,12 +659,12 @@ function producerAuthoredReason(blockers: readonly AnalysisBlocker[]): string | 
  * only when those sentences cannot ship as written. See `producerAuthoredReason`
  * for the vet, and the rung docs above for why the old order was a defect.
  */
-export function composeAnalysisBlockedReason(
+export function analysisBlockedSentences(
   blockers: readonly AnalysisBlocker[],
-): string {
-  if (blockers.length === 0) return BLOCKED_REASON_COPY.unspecified
+): readonly string[] {
+  if (blockers.length === 0) return [BLOCKED_REASON_COPY.unspecified]
 
-  const authored = producerAuthoredReason(blockers)
+  const authored = producerAuthoredSentences(blockers)
   if (authored !== null) return authored
 
   // `option_label` and `factor_label` are the two scopes the contract carries.
@@ -663,16 +677,32 @@ export function composeAnalysisBlockedReason(
     .filter((label): label is string => label !== null)
 
   if (blockers.length === 1 && labelled.length === 1) {
-    return BLOCKED_REASON_COPY.canonicalOneBlocker(labelled[0])
+    return [BLOCKED_REASON_COPY.canonicalOneBlocker(labelled[0])]
   }
   if (blockers.length === 2 && labelled.length === 2) {
-    return BLOCKED_REASON_COPY.canonicalTwoBlockers(labelled[0], labelled[1])
+    return [BLOCKED_REASON_COPY.canonicalTwoBlockers(labelled[0], labelled[1])]
   }
   // A2's rule, inherited: the count published is the VERDICT's own list length,
   // never the length of the sub-list we managed to quote. Publishing the latter
   // would understate the work outstanding by exactly the number of entries we
   // could not name.
-  return BLOCKED_REASON_COPY.canonicalManyBlockers(blockers.length)
+  return [BLOCKED_REASON_COPY.canonicalManyBlockers(blockers.length)]
+}
+
+/**
+ * The joined form — DERIVED from `analysisBlockedSentences`, never composed
+ * separately.
+ *
+ * ⭐ THAT DERIVATION IS THE POINT. The Analyse button's tooltip and readiness
+ * bar consume this string while the pre-analysis panel renders the list; if the
+ * two were composed independently they could disagree about what the producer
+ * said, and one surface would be quietly wrong. One array behind both makes the
+ * union byte-identical BY CONSTRUCTION rather than by a test that can drift.
+ */
+export function composeAnalysisBlockedReason(
+  blockers: readonly AnalysisBlocker[],
+): string {
+  return analysisBlockedSentences(blockers).join(' ')
 }
 
 // ══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## The producer's blocked-reason sentences are a list, not a paragraph

`composeAnalysisBlockedReason` joined **every** blocker CEE names with a space into one string, rendered in a `typography.panelMeta text-text-light` paragraph (`PanelFooter.tsx:104`) and in the Analyse button's `title`. On a ten-blocker graph that is **~1,425 characters of unbroken small text**.

**This PR is the ENABLING half only.** It carries no render change — see *Scope boundary* below.

### The string is now derived from the array

```ts
analysisBlockedSentences(blockers)  // readonly string[]   (new, exported)
composeAnalysisBlockedReason(b)     // = analysisBlockedSentences(b).join(' ')
```

**Byte-identity of the union is true BY CONSTRUCTION, not by a test that can drift.** The Analyse tooltip and readiness bar keep consuming one string; a list-rendering surface can consume the array; the two cannot disagree about what the producer said, because there is one array behind both. That property is the whole point — two surfaces quietly disagreeing about the producer's words is the defect this file exists to end.

### ⛔ The no-truncation contract is untouched

`composeBlockedReason.ts:571-575` forbids truncating and summarising, so we never put our words in the producer's mouth. Nothing here cuts, summarises or reorders. **The remedy is presentation, not truncation** — the same bytes, one per line.

### ⚠ The join is still what is vetted

A phrase can form **across the seam** between two individually-safe sentences, so `isSafeCeeText` still runs on the join and a rejection withholds the **whole** list, never a subset. Pinned by a test. Rendering the parts is strictly *safer* than rendering the join: the cross-seam adjacency never reaches the reader.

### Evidence

- **Typecheck gate exit 0**, `556 file(s) / 2251 error(s)` — exactly baseline, asserted by exit code.
- **RED first**: 9 failing by name before the change.
- **Regression**: `canvas/utils` + `pre-analysis-v3` + `workspaceShell` → **97 files / 1812 passed**, exit 0.
- **No behaviour change**: every existing consumer receives the identical string.
- Fixtures use **real producer wording from the 26 Aug wire capture**, not invented text.
- The spec **pins its own precondition** — that the fixture is genuinely multi-sentence, so a one-item fixture cannot make the union assertions hold vacuously.

### Scope boundary — why the render is not here

The footer's blocked subline comes from `deriveReadinessDisplay`'s `input.blockedReason` (**the gate's string**, from `OutputsDock`), not from `usePreAnalysisModel`'s display, which feeds only the *resting* arm when the gate is open. Rendering a list therefore needs the array carried through `OutputsDock` → `ReadinessDisplayInput` → `ReadinessDisplay` — **files outside this lane's clearance**.

The array cannot be recovered by splitting the string: sentences contain spaces, and splitting on `'. '` would re-derive the producer's segmentation, which is inventing structure. So the seam is real, and it is being re-briefed rather than taken unilaterally.
