### PR TITLE
fix(canvas): a GraphV3 row that carries geometry must still be projected (P0)

### DIFF
--- a/src/canvas/hooks/__tests__/useAutosave.geometryBearingCeeRowDirtyGate.p0.spec.ts
+++ b/src/canvas/hooks/__tests__/useAutosave.geometryBearingCeeRowDirtyGate.p0.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * P0 — THE EDIT-LOSS CONSEQUENCE OF A GEOMETRY-BEARING CEE ROW.
+ *
+ * `useAutosave.computeGraphHash` is the autosave's DIRTY GATE: if an edit does
+ * not flip this hash, the debounced save is skipped and the edit is gone on
+ * reload (the #457 loss class).
+ *
+ * The hash covers `data.*` by default. It reaches a node's analytical payload
+ * only when that payload is under `data` — which is precisely what the
+ * hydration-boundary projector is for. `useAutosave`'s own header recorded the
+ * gap as a RESIDUAL:
+ *
+ *     ⚠ RESIDUAL, deliberately not closed here: for a CEE-shaped node the
+ *     analytical payload (`observed_state`, `display_value`, `category`,
+ *     `interventions`) lives at the TOP LEVEL, not under `data`, so it is not
+ *     covered by the `data.*` hash-by-default rule and an edit to it would not
+ *     flip this hash. […] the fix belongs at the hydration boundary.
+ *
+ * It was right about where the fix belonged. The boundary could not deliver it
+ * for the **geometry-bearing** class, because `isCanvasShapedNode` discriminated
+ * on `position` alone and waved those rows through unprojected — so on the 19
+ * live rows that carry geometry, a user's edit to a factor's observed value
+ * changed nothing the dirty gate could see, and was lost on reload.
+ *
+ * These tests pin the consequence end-to-end: hydrate the way `loadScenario`
+ * does, then assert the gate can SEE an analytical edit.
+ *
+ * ⚠ BOTH DIRECTIONS ARE PINNED, and the second one is the trap. `position` IS
+ * legitimately part of this hash — it is the one authority in the estate that
+ * should see geometry, because a node move is a real change that must be
+ * persisted to the layout sidecar. A "fix" that made this hash ignore geometry
+ * would stop layout being saved at all. Analysis staleness is a DIFFERENT
+ * question with a DIFFERENT owner (`hasAnalyticalGraphChange` /
+ * `analyticalNodeFields`, which classifies position as cosmetic). Two questions,
+ * two authorities — CLAUDE.md trap 21.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { computeGraphHash } from '../useAutosave'
+import { normalisePersistedGraph } from '../../utils/normalisePersistedGraph'
+import ceeRow from './fixtures/cee-persisted-graph-wire-2026-08-12.json'
+
+const REAL_CEE_NODES = ceeRow.nodes as unknown as any[]
+const REAL_CEE_EDGES = ceeRow.edges as unknown as any[]
+
+/** The live class: a real GraphV3 row that also carries geometry. */
+function geometryBearingRow() {
+  return {
+    nodes: REAL_CEE_NODES.map((n, i) => ({
+      ...n,
+      position: { x: 100 + i * 40, y: 200 + i * 25 },
+    })),
+    edges: REAL_CEE_EDGES,
+  }
+}
+
+/** Hydrate exactly the way `useScenario.loadScenario` does. */
+function hydrate(row: unknown) {
+  return normalisePersistedGraph(row)
+}
+
+/** A node the real capture gives an `observed_state`. Bound by IDENTITY. */
+const OBSERVED_NODE_ID = (
+  REAL_CEE_NODES.find((n) => n.observed_state !== undefined) ?? {}
+).id as string
+
+describe('corpus precondition', () => {
+  it('the capture really does carry an `observed_state` node to edit', () => {
+    // Without this the edit below would be a no-op and every assertion vacuous.
+    expect(OBSERVED_NODE_ID).toBeTypeOf('string')
+    const src = REAL_CEE_NODES.find((n) => n.id === OBSERVED_NODE_ID)
+    expect(src.observed_state).toBeDefined()
+  })
+})
+
+describe('P0: the dirty gate must SEE an analytical edit on a geometry-bearing CEE row', () => {
+  it('an edit to `observed_state` flips the autosave hash (otherwise it is lost on reload)', () => {
+    const before = hydrate(geometryBearingRow())
+    const baseline = computeGraphHash(before.nodes, before.edges)
+
+    // Edit the factor's observed value, as the Model tab does.
+    const edited = hydrate(geometryBearingRow())
+    const target = edited.nodes.find((n: any) => n.id === OBSERVED_NODE_ID) as any
+    expect(target, 'the node under test must survive hydration').toBeDefined()
+    target.data.observedState = {
+      ...(target.data.observedState ?? {}),
+      value: 0.4242,
+    }
+
+    const after = computeGraphHash(edited.nodes, edited.edges)
+    expect(after).not.toBe(baseline)
+  })
+
+  it('the analytical payload is actually reachable under `data` after hydration', () => {
+    // Binds the mechanism, not just the outcome: if this stops holding, the
+    // test above could still pass for an unrelated reason.
+    const { nodes } = hydrate(geometryBearingRow())
+    const target = nodes.find((n: any) => n.id === OBSERVED_NODE_ID) as any
+    expect(target.data.observedState).toBeDefined()
+  })
+})
+
+describe('the twin: a pure LAYOUT move must STILL dirty the autosave', () => {
+  it('moving a node flips the hash — geometry belongs to this authority', () => {
+    const before = hydrate(geometryBearingRow())
+    const baseline = computeGraphHash(before.nodes, before.edges)
+
+    const moved = hydrate(geometryBearingRow())
+    const target = moved.nodes.find((n: any) => n.id === OBSERVED_NODE_ID) as any
+    target.position = { x: target.position.x + 137, y: target.position.y + 91 }
+
+    const after = computeGraphHash(moved.nodes, moved.edges)
+    expect(
+      after,
+      'a layout move must still be saved — this hash is the layout sidecar’s gate',
+    ).not.toBe(baseline)
+  })
+
+  it('and an unchanged graph does NOT flip it (the gate is not simply always-dirty)', () => {
+    // Without this, both assertions above would pass on a hash that changes on
+    // every call — a gate that always fires is not a gate.
+    const a = hydrate(geometryBearingRow())
+    const b = hydrate(geometryBearingRow())
+    expect(computeGraphHash(a.nodes, a.edges)).toBe(
+      computeGraphHash(b.nodes, b.edges),
+    )
+  })
+})

--- a/src/canvas/hooks/useAutosave.ts
+++ b/src/canvas/hooks/useAutosave.ts
@@ -137,8 +137,13 @@ function mayPersistGraphNow(scenarioId: string | null): boolean {
  * `scenarios.graph` holds either React-Flow-shaped bytes (`position`, `data`,
  * edge `source`/`target`) or CEE/GraphV3 bytes (`kind`/`label` top-level, edge
  * `from`/`to`, and NO `position`, `data`, `id`, `source` or `target` on edges).
- * `useScenario.loadScenario` hydrates that column into the canvas store VERBATIM,
- * so BOTH shapes reach this function. Before the fix the edge half read only
+ * `useScenario.loadScenario` USED TO hydrate that column into the canvas store
+ * VERBATIM, so both shapes reached this function. It no longer does — it
+ * normalises through `normalisePersistedGraph` first (`useScenario.ts:699`), and
+ * this sentence read "hydrates … VERBATIM" in the present tense for a fortnight
+ * after that stopped being true. The dual-shape reads below are now DEFENCE IN
+ * DEPTH for a store that should hold one shape, not the primary mechanism; the
+ * primary mechanism is the boundary. Before that fix the edge half read only
  * `e.source`, so a CEE-written row projected `undefined` endpoints and the
  * comparator threw `undefined.localeCompare(...)` DURING RENDER — React's error
  * boundary then took the whole canvas (0 nodes) on every reload of a
@@ -157,14 +162,33 @@ function mayPersistGraphNow(scenarioId: string | null): boolean {
  * problem — `canvas/utils/mergeServerGraph.ts` already resolves endpoints as
  * `e.from ?? e.source` on the server-hydration path.
  *
- * ⚠ RESIDUAL, deliberately not closed here: for a CEE-shaped node the analytical
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE FORMER RESIDUAL — NOW CLOSED AT THE BOUNDARY, WHERE IT SAID IT BELONGED
+ * ─────────────────────────────────────────────────────────────────────────────
+ * This block used to record an open gap: for a CEE-shaped node the analytical
  * payload (`observed_state`, `display_value`, `category`, `interventions`) lives
- * at the TOP LEVEL, not under `data`, so it is not covered by the `data.*`
- * hash-by-default rule and an edit to it would not flip this hash. That is a
- * symptom of CEE-shaped objects being in the store at all; the fix belongs at the
- * hydration boundary (see the lane report / ROADMAP 2.1096), not in this
- * projector, which would otherwise become a fourth hand-mirrored copy of the
- * CEE→React-Flow mapping.
+ * at the TOP LEVEL, not under `data`, so it escaped the `data.*` hash-by-default
+ * rule — an edit would not flip this hash, the save would skip, and the edit was
+ * lost on reload. It correctly refused to patch that here (which would have
+ * minted a fourth hand-mirrored CEE→React-Flow mapping) and named the hydration
+ * boundary as the right home.
+ *
+ * The boundary now delivers it, for BOTH CEE classes. It could not before: the
+ * shape discriminator tested `'position' in n` alone, so the **19 staging rows
+ * that are GraphV3 AND carry geometry** (census 2026-08-26) were waved through
+ * unprojected and hit this function with no `data` at all — `label` collapsing
+ * to `''`, `kind` to `undefined`, and the entire analytical payload invisible to
+ * the dirty gate. `isCanvasShapedNode` now discriminates on the React Flow
+ * envelope (`data`), which is a property of the shape rather than an observation
+ * about what CEE currently emits.
+ *
+ * ⚠ `position` REMAINS IN THIS HASH ON PURPOSE. This is the one authority in the
+ * estate that SHOULD see geometry: a node move is a real change that must reach
+ * the layout sidecar. Do not "align" it with the analysis-staleness owner
+ * (`domain/analyticalChange.ts`), which classifies position as cosmetic — they
+ * answer different questions (CLAUDE.md trap 21) and a shared window would break
+ * one of them. Pinned both ways in
+ * `useAutosave.geometryBearingCeeRowDirtyGate.p0.spec.ts`.
  */
 export function computeGraphHash(nodes: any[], edges: any[]): string {
   const canonical = {

--- a/src/canvas/hooks/useAutosave.ts
+++ b/src/canvas/hooks/useAutosave.ts
@@ -178,9 +178,26 @@ function mayPersistGraphNow(scenarioId: string | null): boolean {
  * that are GraphV3 AND carry geometry** (census 2026-08-26) were waved through
  * unprojected and hit this function with no `data` at all — `label` collapsing
  * to `''`, `kind` to `undefined`, and the entire analytical payload invisible to
- * the dirty gate. `isCanvasShapedNode` now discriminates on the React Flow
- * envelope (`data`), which is a property of the shape rather than an observation
- * about what CEE currently emits.
+ * the dirty gate. `isCanvasShapedNode` no longer rests on `'position' in n`.
+ *
+ * ⚠ CORRECTED IN PLACE, NOT DELETED (2026-08-26). This sentence used to say the
+ * predicate "discriminates on the React Flow envelope (`data`), which is a
+ * property of the shape rather than an observation about what CEE currently
+ * emits". That was true of the FIRST commit of this fix and is now false: review
+ * found the envelope test is still a NEGATIVE test against a schema that permits
+ * the thing — `NodeV3Schema` is `.passthrough()`, so a CEE node carrying `data`
+ * is contract-PERMITTED, merely unobserved, which is the very admissibility that
+ * let `position` through and caused this P0. The predicate was re-pointed at the
+ * CONTRACT-REQUIRED CEE marker instead: a node with top-level `kind` AND `label`
+ * (neither is `.optional()` on `NodeV3Schema`) is CEE whatever else it carries,
+ * and the envelope test survives only as a stated-contingent second limb. The
+ * full derivation is in `canvas/utils/normalisePersistedGraph.ts`.
+ *
+ * The correction is left visible rather than quietly swapped out, because a
+ * stale mechanism sentence is exactly what this module's own history shows
+ * going unnoticed: nothing tests a comment, it reads as settled fact, and the
+ * next reader inherits it. This one was stale by a SINGLE COMMIT and was caught
+ * by a human reading it, not by any gate.
  *
  * ⚠ `position` REMAINS IN THIS HASH ON PURPOSE. This is the one authority in the
  * estate that SHOULD see geometry: a node move is a real change that must reach

--- a/src/canvas/utils/__tests__/hydrationRouteNormalisation.sourceScan.spec.ts
+++ b/src/canvas/utils/__tests__/hydrationRouteNormalisation.sourceScan.spec.ts
@@ -36,8 +36,57 @@ import { resolve } from 'node:path'
 
 const SRC = resolve(__dirname, '../../..')
 
-/** The store action that REPLACES the graph slice. */
-const HYDRATE_CALL = 'hydrateGraphSlice({'
+/**
+ * The store action that REPLACES the graph slice.
+ *
+ * ⚠ MATCHED AS A CALL, NOT AS A FIXED BIGRAM — and this was Gate 1 of the
+ * re-review. The first version of this scan tested for the literal
+ * `'hydrateGraphSlice({'`, which requires `(` and `{` to be ADJACENT. That is a
+ * formatting accident, not a property of a call site. Measured against a fake
+ * new unnormalised route, four semantically identical spellings:
+ *
+ *     hydrateGraphSlice({ … })         → CAUGHT
+ *     hydrateGraphSlice(slice)         → MISSED
+ *     hydrateGraphSlice(⏎  { … })      → MISSED
+ *     hydrateGraphSlice ({ … })        → MISSED
+ *
+ * So the guard could not distinguish *"no undeclared route exists"* from *"an
+ * undeclared route is spelled without `({`"*: an absence claim from a probe
+ * never shown it can see a presence (CLAUDE.md trap 13), which is this file's
+ * own subject matter turned on itself. It bit at all only because both of
+ * today's callers happen to use the adjacent form — the class it exists to
+ * catch is *tomorrow's* route, and three of four spellings walked past it.
+ *
+ * The detector below matches the IDENTIFIER, then optional whitespace
+ * (including a newline), then `(`, with import lines removed first. Pinned per
+ * spelling in the detector-contract block, because a wider needle with no
+ * contract is the same defect with more characters.
+ *
+ * ─── WHAT THIS DETECTOR CANNOT SEE (stated, not implied away) ────────────────
+ * It is a LEXICAL scan for one identifier, so it is blind to:
+ *   · a DESTRUCTURING RENAME — `const { hydrateGraphSlice: replace } = …`,
+ *     then `replace({ … })`. The call site reads `replace(`.
+ *   · DYNAMIC DISPATCH — `store['hydrateGraphSlice'](…)`, or the action being
+ *     put in a variable, passed as a prop, and invoked somewhere else.
+ *   · anything the walk excludes — non-`.ts`/`.tsx` files, and `.spec`/`.test`
+ *     files (excluded deliberately: a test may hydrate whatever it likes).
+ * The IMPORT-ALIAS form is the one blind spot that can be closed cheaply,
+ * because the alias is created somewhere this scan CAN read — so it is detected
+ * and RED separately below instead of being left on this list.
+ *
+ * ⚠ AND IT ERRS TOWARDS OVER-INCLUSION, ON PURPOSE. Comments are not stripped,
+ * so a comment containing `hydrateGraphSlice(` counts as a route and REDs until
+ * declared. Over-reporting fails LOUD and a human resolves it; under-reporting
+ * passes silently, which is the failure this file exists to prevent. Measured
+ * at this tip: nine other files mention the identifier and NONE is counted —
+ * they are prose, plus the store's own definition, which is a PROPERTY
+ * (`hydrateGraphSlice: (loaded) => …`) whose colon stops the match. If that
+ * definition is ever rewritten in method-shorthand form
+ * (`hydrateGraphSlice(loaded) {`), this scan will flag `store.ts` as an
+ * undeclared route. That is the loud direction: register it, do not weaken the
+ * detector to make it quiet.
+ */
+const HYDRATE_IDENTIFIER = 'hydrateGraphSlice'
 
 /**
  * The canonical projector every persisted-column route must go through.
@@ -92,16 +141,53 @@ function walk(dir: string, out: string[] = []): string[] {
 
 const FILES = walk(SRC)
 
-/** Files that actually invoke the graph-replacing store action. */
-function hydrationRoutes(): string[] {
-  return FILES.filter((f) => readFileSync(f, 'utf8').includes(HYDRATE_CALL)).map(
-    (f) => f.slice(SRC.length - 'src'.length + 1).replace(/^\/+/, ''),
-  )
-}
-
 function relative(file: string): string {
   const idx = file.indexOf('/src/')
   return idx >= 0 ? file.slice(idx + 1) : file
+}
+
+/** Source with `import …` lines removed, so an import cannot read as a call. */
+function withoutImportLines(src: string): string {
+  return src
+    .split('\n')
+    .filter((line) => !/^\s*import\b/.test(line))
+    .join('\n')
+}
+
+/**
+ * Count CALL SITES of the graph-replacing store action.
+ *
+ * Exported so the detector's own contract can be pinned on literals — the twin
+ * of `countNormaliserCalls`, and precisely what Gate 1 found missing. The regex
+ * is rebuilt per call rather than hoisted to a module constant: a `/g` regex
+ * carries `lastIndex`, and a shared one is a stateful instrument.
+ */
+export function countHydrationCalls(src: string): number {
+  const callRe = new RegExp(`\\b${HYDRATE_IDENTIFIER}\\s*\\(`, 'g')
+  return (withoutImportLines(src).match(callRe) ?? []).length
+}
+
+/**
+ * Count ALIASED imports of the action (`… as somethingElse`).
+ *
+ * An alias renames the call site and defeats a lexical scan. Rather than list
+ * that as an unfixable blind spot, the scan refuses to permit one: the alias is
+ * created in source this scan can read, so an undetectable class is converted
+ * into a detectable one at the single point where it comes into existence.
+ */
+export function countHydrationAliasImports(src: string): number {
+  const aliasRe = new RegExp(
+    `\\b${HYDRATE_IDENTIFIER}\\s+as\\s+[A-Za-z_$][\\w$]*`,
+    'g',
+  )
+  return (src.match(aliasRe) ?? []).length
+}
+
+/** Files that actually invoke the graph-replacing store action. */
+function hydrationRoutes(): string[] {
+  return FILES.filter((f) => countHydrationCalls(readFileSync(f, 'utf8')) > 0).map(
+    relative,
+  )
 }
 
 /**
@@ -118,7 +204,7 @@ export function countNormaliserCalls(src: string): number {
 }
 
 function routesWithNormalisation(): { route: string; normalises: boolean }[] {
-  return FILES.filter((f) => readFileSync(f, 'utf8').includes(HYDRATE_CALL)).map(
+  return FILES.filter((f) => countHydrationCalls(readFileSync(f, 'utf8')) > 0).map(
     (f) => ({
       route: relative(f),
       normalises: countNormaliserCalls(readFileSync(f, 'utf8')) > 0,
@@ -155,6 +241,88 @@ describe('detector contract — the scan distinguishes a CALL from an IMPORT', (
 
   it('still counts a call that sits on a line beginning with whitespace', () => {
     expect(countNormaliserCalls('      const g = normalisePersistedGraph(x)')).toBe(1)
+  })
+})
+
+describe('detector contract — the hydration scan matches a CALL, not a fixed bigram', () => {
+  // GATE 1. Every row below is the SAME call, differently formatted; the
+  // previous detector caught only the first. A positive control PER SPELLING is
+  // what turns "offenders: []" from a hope into a measurement — without them,
+  // an empty offender list is equally consistent with a clean tree and with a
+  // detector that cannot see.
+  it.each([
+    ['an adjacent brace', 'hydrateGraphSlice({ nodes, edges })'],
+    ['a bare identifier argument', 'hydrateGraphSlice(slice)'],
+    ['a newline before the brace', 'hydrateGraphSlice(\n  { nodes, edges },\n)'],
+    ['a space before the paren', 'hydrateGraphSlice ({ nodes, edges })'],
+    ['a newline before the paren', 'hydrateGraphSlice\n  ({ nodes, edges })'],
+    ['a member call', 'useCanvasStore.getState().hydrateGraphSlice({ nodes })'],
+    ['leading indentation', '      hydrateGraphSlice({ nodes })'],
+    ['no argument at all', 'hydrateGraphSlice()'],
+  ])('counts a call spelled with %s', (_label, src) => {
+    expect(countHydrationCalls(src)).toBe(1)
+  })
+
+  // The negatives matter as much: a detector that counts everything is not a
+  // detector. These are the real shapes present in this tree today — nine files
+  // mention the identifier without calling it, and none may be counted.
+  it.each([
+    ['an import line', "import { hydrateGraphSlice } from '../store'"],
+    ['the store\'s own property definition', 'hydrateGraphSlice: (loaded) => {'],
+    ['a type declaration', 'hydrateGraphSlice: (loaded: { nodes: any[] }) => void'],
+    ['prose in a comment', '// restored graphs arrive through `hydrateGraphSlice`'],
+    ['a mention followed by a comma', 'loadScenario, hydrateGraphSlice, resetCanvas,'],
+    ['a mention followed by a close paren', '// (useScenario → hydrateGraphSlice) did not'],
+  ])('does NOT count %s', (_label, src) => {
+    expect(countHydrationCalls(src)).toBe(0)
+  })
+
+  it('counts two distinct call sites in one file', () => {
+    // Guards against a detector that reports a boolean dressed as a count.
+    expect(
+      countHydrationCalls('hydrateGraphSlice({ a })\nhydrateGraphSlice(b)'),
+    ).toBe(2)
+  })
+
+  it('is not satisfied by a longer identifier that merely contains the name', () => {
+    expect(countHydrationCalls('notHydrateGraphSliceAtAll(x)')).toBe(0)
+  })
+})
+
+describe('the action may not be import-aliased (an alias blinds this scan)', () => {
+  it('detects an aliased import on a literal', () => {
+    expect(
+      countHydrationAliasImports(
+        "import { hydrateGraphSlice as replaceGraph } from '../store'",
+      ),
+    ).toBe(1)
+  })
+
+  it('does not fire on a plain import', () => {
+    expect(
+      countHydrationAliasImports("import { hydrateGraphSlice } from '../store'"),
+    ).toBe(0)
+  })
+
+  // ⚠ WHERE THE DISCRIMINATION ACTUALLY LIVES, measured rather than assumed.
+  // Killing the alias detector (making it always return 0) REDs the positive
+  // literal above and NOTHING ELSE: the negative literal expects 0 and a dead
+  // detector satisfies it, and the tree-level test below stays GREEN because
+  // there is no alias in the tree to find. So the tree test is TRUE-BUT-VACUOUS
+  // today — it is a regression tripwire for the day someone adds an alias, not
+  // evidence that the detector works. The positive literal is the only thing
+  // standing between this block and a guard agreeing with itself (trap 13b),
+  // which is why it is not merely decorative to keep it.
+  it('no source file aliases it', () => {
+    const aliasing = FILES.filter(
+      (f) => countHydrationAliasImports(readFileSync(f, 'utf8')) > 0,
+    ).map(relative)
+
+    expect(
+      aliasing,
+      'an aliased import renames the call site and hides it from this scan — ' +
+        'import `hydrateGraphSlice` under its own name',
+    ).toEqual([])
   })
 })
 
@@ -210,7 +378,7 @@ describe('every hydration route normalises, or is a registered known gap', () =>
     for (const gap of REGISTERED_KNOWN_GAPS) {
       expect(
         routes,
-        `registered gap ${gap.file} no longer calls ${HYDRATE_CALL} — remove it`,
+        `registered gap ${gap.file} no longer calls ${HYDRATE_IDENTIFIER} — remove it`,
       ).toContain(gap.file)
     }
   })

--- a/src/canvas/utils/__tests__/hydrationRouteNormalisation.sourceScan.spec.ts
+++ b/src/canvas/utils/__tests__/hydrationRouteNormalisation.sourceScan.spec.ts
@@ -1,0 +1,223 @@
+/**
+ * THE GUARD THAT WATCHES ROUTES.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY A SOURCE SCAN AND NOT A BEHAVIOURAL TEST
+ * ─────────────────────────────────────────────────────────────────────────────
+ * `normalisePersistedGraph.geometryBearingCeeRow.p0.spec.ts` proves the
+ * PROJECTOR PROJECTS. It is a post-condition over that function's return value,
+ * and it is structurally blind to ROUTES: review demonstrated this by severing
+ * the call at `useScenario.ts:699` — the spec stayed **15/15 GREEN**, because a
+ * caller that never invokes the function cannot be observed by a test of the
+ * function's output.
+ *
+ * The gap that leaves is the one that actually ships: a NEW graph-replacement
+ * path added later, hydrating the store without normalising, silently re-opening
+ * the P0 for whichever rows it touches. Nothing in a per-function test can see
+ * that arriving.
+ *
+ * So this scan derives the route list FROM SOURCE and requires every caller of
+ * `hydrateGraphSlice` either to normalise, or to be a REGISTERED KNOWN GAP with
+ * a stated reason. Hand-maintaining a list of "the safe routes" would be the
+ * mirror this estate keeps paying for (CLAUDE.md trap 12); deriving the callers
+ * and checking each one means a new route FAILS LOUD by default.
+ *
+ * ⚠ WHAT THIS PROVES, AND WHAT IT DOES NOT. It is a claim about the SOURCE TREE
+ * at your tip — that every route either normalises or is declared. It is NOT a
+ * claim about deployed behaviour, and NOT a claim about a store that was already
+ * populated before the shape fix shipped. Those are different questions with
+ * different instruments; naming them apart here is deliberate, because this
+ * whole change exists because a contingent claim was written as a settled one.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const SRC = resolve(__dirname, '../../..')
+
+/** The store action that REPLACES the graph slice. */
+const HYDRATE_CALL = 'hydrateGraphSlice({'
+
+/**
+ * The canonical projector every persisted-column route must go through.
+ *
+ * ⚠ MATCHED AS A CALL, NOT AS AN IDENTIFIER — and this cost a round. The first
+ * version of this scan tested `source.includes('normalisePersistedGraph')`,
+ * which is satisfied by the IMPORT LINE alone. Severing the actual call at
+ * `useScenario.ts:699` therefore left this scan **GREEN** (measured), because
+ * `import { normalisePersistedGraph } from …` still contains the identifier.
+ * A guard that cannot tell an import from a call is a guard agreeing with
+ * itself. The trailing `(` is what makes it a call site.
+ */
+const NORMALISER_CALL = 'normalisePersistedGraph('
+
+/**
+ * Routes that call `hydrateGraphSlice` WITHOUT normalising, each with the reason
+ * it is safe. A registered gap is a disclosure, not an exemption — if one of
+ * these ever starts carrying persisted-column bytes it must move.
+ *
+ * ⚠ APPEND ONLY AFTER DERIVING WHY. The point of the scan is that an
+ * undocumented new route REDs; adding an entry to silence a red without stating
+ * a reason defeats the guard entirely.
+ */
+const REGISTERED_KNOWN_GAPS: ReadonlyArray<{ file: string; reason: string }> = [
+  {
+    file: 'src/canvas/ReactFlowGraph.tsx',
+    reason:
+      'Hydrates from the localStorage AUTOSAVE and from run-history restores, ' +
+      'both of which are written FROM the canvas store and are therefore already ' +
+      'in React Flow shape. ⚠ RESIDUAL, disclosed not dismissed: a store polluted ' +
+      'BEFORE the shape fix shipped was autosaved in CEE shape and re-enters here ' +
+      'unnormalised. That is a data-migration question, not a routing one, and it ' +
+      'is why this is a registered gap rather than a clean pass.',
+  },
+]
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '.git') continue
+    const full = resolve(dir, entry)
+    if (statSync(full).isDirectory()) {
+      walk(full, out)
+      continue
+    }
+    if (!/\.(ts|tsx)$/.test(entry)) continue
+    if (/\.(spec|test)\.(ts|tsx)$/.test(entry)) continue
+    if (/\.d\.ts$/.test(entry)) continue
+    out.push(full)
+  }
+  return out
+}
+
+const FILES = walk(SRC)
+
+/** Files that actually invoke the graph-replacing store action. */
+function hydrationRoutes(): string[] {
+  return FILES.filter((f) => readFileSync(f, 'utf8').includes(HYDRATE_CALL)).map(
+    (f) => f.slice(SRC.length - 'src'.length + 1).replace(/^\/+/, ''),
+  )
+}
+
+function relative(file: string): string {
+  const idx = file.indexOf('/src/')
+  return idx >= 0 ? file.slice(idx + 1) : file
+}
+
+/**
+ * Count genuine CALL SITES of the normaliser in a source text, ignoring imports.
+ * Exported shape so the detector's own contract can be tested on literals —
+ * a scan whose detector is only ever exercised against the real tree cannot
+ * demonstrate WHAT it discriminates.
+ */
+export function countNormaliserCalls(src: string): number {
+  return src
+    .split('\n')
+    .filter((line) => !/^\s*import\b/.test(line))
+    .filter((line) => line.includes(NORMALISER_CALL)).length
+}
+
+function routesWithNormalisation(): { route: string; normalises: boolean }[] {
+  return FILES.filter((f) => readFileSync(f, 'utf8').includes(HYDRATE_CALL)).map(
+    (f) => ({
+      route: relative(f),
+      normalises: countNormaliserCalls(readFileSync(f, 'utf8')) > 0,
+    }),
+  )
+}
+
+describe('detector contract — the scan distinguishes a CALL from an IMPORT', () => {
+  // This is the distinction the first version of this scan got wrong, and it is
+  // why severing the fixed route left it green. Pinned on literals so the
+  // discrimination is demonstrated, not assumed.
+  it('counts a real call site', () => {
+    expect(
+      countNormaliserCalls('const g = normalisePersistedGraph(row.graph)'),
+    ).toBe(1)
+  })
+
+  it('does NOT count the import line alone', () => {
+    expect(
+      countNormaliserCalls(
+        "import { normalisePersistedGraph } from '../canvas/utils/normalisePersistedGraph'",
+      ),
+    ).toBe(0)
+  })
+
+  it('a file with the import but no call reads as NOT normalising', () => {
+    // The exact severed-route shape.
+    const severed = [
+      "import { normalisePersistedGraph } from '../x'",
+      'const normalised = { nodes: row.graph.nodes, edges: row.graph.edges }',
+    ].join('\n')
+    expect(countNormaliserCalls(severed)).toBe(0)
+  })
+
+  it('still counts a call that sits on a line beginning with whitespace', () => {
+    expect(countNormaliserCalls('      const g = normalisePersistedGraph(x)')).toBe(1)
+  })
+})
+
+describe('the scan can see (walk is not silently empty)', () => {
+  it('walks a non-trivial number of source files', () => {
+    // Positive control. A broken walk returns "no violations" and looks
+    // identical to a clean tree (CLAUDE.md trap 13).
+    expect(FILES.length).toBeGreaterThan(500)
+  })
+
+  it('finds the hydration routes it exists to police', () => {
+    // Contrast control: if this ever reads zero, the scan is measuring nothing
+    // and every assertion below passes vacuously.
+    const routes = hydrationRoutes()
+    expect(routes.length).toBeGreaterThan(0)
+  })
+
+  it('sees the route the P0 was fixed on', () => {
+    // Binds by IDENTITY, not by count — a different route could satisfy a count.
+    const routes = routesWithNormalisation().map((r) => r.route)
+    expect(routes).toContain('src/hooks/useScenario.ts')
+  })
+})
+
+describe('every hydration route normalises, or is a registered known gap', () => {
+  it('has no undeclared route that replaces the graph without normalising', () => {
+    const offenders = routesWithNormalisation()
+      .filter((r) => !r.normalises)
+      .filter((r) => !REGISTERED_KNOWN_GAPS.some((g) => g.file === r.route))
+      .map((r) => r.route)
+
+    expect(
+      offenders,
+      'a new graph-replacement route must normalise the persisted column, ' +
+        'or be added to REGISTERED_KNOWN_GAPS with a derived reason',
+    ).toEqual([])
+  })
+
+  it('the fixed route genuinely still normalises (REDs if the call is severed)', () => {
+    // This is the assertion that severing `useScenario.ts:699` must break —
+    // the one the per-function post-condition test could not make.
+    const useScenario = routesWithNormalisation().find(
+      (r) => r.route === 'src/hooks/useScenario.ts',
+    )
+    expect(useScenario).toBeDefined()
+    expect(useScenario!.normalises).toBe(true)
+  })
+
+  it('every registered gap is still a real route (no stale exemptions)', () => {
+    // A gap entry for a file that no longer hydrates is dead weight that would
+    // silently excuse a future file of the same name.
+    const routes = routesWithNormalisation().map((r) => r.route)
+    for (const gap of REGISTERED_KNOWN_GAPS) {
+      expect(
+        routes,
+        `registered gap ${gap.file} no longer calls ${HYDRATE_CALL} — remove it`,
+      ).toContain(gap.file)
+    }
+  })
+
+  it('every registered gap states a reason', () => {
+    for (const gap of REGISTERED_KNOWN_GAPS) {
+      expect(gap.reason.length, `${gap.file} has no reason`).toBeGreaterThan(40)
+    }
+  })
+})

--- a/src/canvas/utils/__tests__/normalisePersistedGraph.geometryBearingCeeRow.p0.spec.ts
+++ b/src/canvas/utils/__tests__/normalisePersistedGraph.geometryBearingCeeRow.p0.spec.ts
@@ -1,0 +1,247 @@
+/**
+ * P0 — A CEE-SHAPED ROW THAT CARRIES `position` DEFEATS THE SHAPE DISCRIMINATOR.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * THE DEFECT, AND WHY THE EXISTING SUITE CANNOT SEE IT
+ * ─────────────────────────────────────────────────────────────────────────────
+ * `isCanvasShapedNode` decided canvas-shape on ONE signal:
+ *
+ *     return typeof n === 'object' && n !== null && 'position' in n
+ *
+ * Its header justified that with *"`position` is the discriminator: React Flow
+ * requires it on every node and CEE's GraphV3 carries no geometry at all"* — a
+ * statement about the DATA, and the data refutes it. A census of staging
+ * `scenarios` (2026-08-26) found **19 GraphV3 rows carrying node `position`**,
+ * every one updated within the preceding 30 days.
+ *
+ * For those rows the predicate answers TRUE, the node is passed through
+ * UNPROJECTED, and a CEE-shaped object lands in a store whose every consumer
+ * assumes React Flow shape — the exact P0 `normalisePersistedGraph` was created
+ * to retire, walking back in through its own discriminator.
+ *
+ * ⚠ THE EXISTING CORPUS ASSERTS THE CLASS AWAY. `store.ceeShapedHydration.p0`'s
+ * fixture precondition is:
+ *
+ *     it('is a real CEE row: edges carry no id, nodes carry no position', …)
+ *     expect(CEE_NODES.filter((n) => 'position' in n)).toHaveLength(0)
+ *
+ * That is an honest precondition pin, and it is also CLAUDE.md trap 13d in its
+ * purest form: **a corpus that omits a value class the contract admits cannot
+ * certify the code over that class.** The contract admits it — the column is
+ * untyped JSONB with two writers — and the live data contains it. So the whole
+ * suite is green over a class that is 19 rows wide in production.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * WHY THE CORPUS IS DERIVED, NOT INVENTED
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The base row is the REAL captured wire fixture
+ * (`cee-persisted-graph-wire-2026-08-12.json`, 15 nodes / 28 edges). This spec
+ * DERIVES the geometry-bearing class from it by adding `position` — it never
+ * edits the capture, which is a dated historic record and append-only
+ * (CLAUDE.md trap 14b). A self-authored CEE node would encode my model of CEE
+ * rather than CEE (trap 16-inverse); every analytical field asserted below is
+ * one the real capture actually carries.
+ *
+ * The preconditions are pinned IN-TEST so this spec fails loud if it ever stops
+ * modelling the class it was written for (trap 13b: a discriminator must pin its
+ * own precondition, or it decays into a guard agreeing with itself).
+ */
+
+import { describe, it, expect } from 'vitest'
+import {
+  normalisePersistedGraph,
+  isCanvasShapedNode,
+} from '../normalisePersistedGraph'
+import ceeRow from '../../hooks/__tests__/fixtures/cee-persisted-graph-wire-2026-08-12.json'
+
+const REAL_CEE_NODES = ceeRow.nodes as unknown as any[]
+const REAL_CEE_EDGES = ceeRow.edges as unknown as any[]
+
+/**
+ * The live class: a GraphV3 node that ALSO carries geometry. Derived from the
+ * real capture by adding `position` and nothing else.
+ */
+const GEOMETRY_BEARING_CEE_NODES = REAL_CEE_NODES.map((n, i) => ({
+  ...n,
+  position: { x: 100 + i * 40, y: 200 + i * 25 },
+}))
+
+const GEOMETRY_BEARING_ROW = {
+  nodes: GEOMETRY_BEARING_CEE_NODES,
+  edges: REAL_CEE_EDGES,
+}
+
+/** The four analytical fields that live at TOP LEVEL on a CEE node. */
+const ANALYTICAL_FIELDS = [
+  'observed_state',
+  'display_value',
+  'category',
+  'interventions',
+] as const
+
+describe('corpus precondition — this spec really is modelling the live class', () => {
+  it('the base fixture is a real CEE row: no node carries `data`', () => {
+    expect(REAL_CEE_NODES).toHaveLength(15)
+    expect(REAL_CEE_NODES.filter((n) => 'data' in n)).toHaveLength(0)
+  })
+
+  it('the base fixture carries no geometry (so the derivation below is the ONLY source of it)', () => {
+    expect(REAL_CEE_NODES.filter((n) => 'position' in n)).toHaveLength(0)
+  })
+
+  it('the derived class is CEE-shaped AND geometry-bearing — both, on every node', () => {
+    expect(GEOMETRY_BEARING_CEE_NODES).toHaveLength(15)
+    // still CEE-shaped: payload at top level, no React Flow envelope
+    expect(GEOMETRY_BEARING_CEE_NODES.filter((n) => 'data' in n)).toHaveLength(0)
+    expect(
+      GEOMETRY_BEARING_CEE_NODES.filter((n) => typeof n.kind === 'string'),
+    ).toHaveLength(15)
+    // …and carrying geometry, which is what defeats the old discriminator
+    expect(
+      GEOMETRY_BEARING_CEE_NODES.filter(
+        (n) => typeof n.position?.x === 'number',
+      ),
+    ).toHaveLength(15)
+  })
+
+  it('the real capture actually carries every analytical field this spec asserts', () => {
+    // Guards against asserting preservation of a field the corpus never had —
+    // which would pass vacuously for ever.
+    for (const field of ANALYTICAL_FIELDS) {
+      expect(
+        REAL_CEE_NODES.some((n) => n[field] !== undefined),
+        `real capture carries no \`${field}\` — this spec's preservation assertion would be vacuous`,
+      ).toBe(true)
+    }
+  })
+})
+
+describe('P0: a geometry-bearing CEE row must still be projected to canvas shape', () => {
+  it('does NOT classify a geometry-bearing CEE node as canvas-shaped', () => {
+    // The whole defect in one assertion. `position` alone is not the envelope.
+    const offenders = GEOMETRY_BEARING_CEE_NODES.filter((n) =>
+      isCanvasShapedNode(n),
+    )
+    expect(offenders).toHaveLength(0)
+  })
+
+  it('projects every node into the React Flow envelope (label/kind reach `data`)', () => {
+    const { nodes } = normalisePersistedGraph(GEOMETRY_BEARING_ROW)
+
+    expect(nodes).toHaveLength(15)
+    expect(
+      nodes.filter((n: any) => typeof n.data?.label === 'string'),
+    ).toHaveLength(15)
+    expect(
+      nodes.filter((n: any) => typeof n.data?.kind === 'string'),
+    ).toHaveLength(15)
+  })
+
+  it('POST-CONDITION: no node in the output is still in the un-projected shape', () => {
+    // Assert the invariant rather than narrate it (Finding A). This REDs if a
+    // SECOND shape ever reaches the store, whatever route it arrives by.
+    const { nodes } = normalisePersistedGraph(GEOMETRY_BEARING_ROW)
+
+    const unProjected = nodes.filter(
+      (n: any) => n.data == null || typeof n.data !== 'object',
+    )
+    expect(unProjected).toHaveLength(0)
+  })
+
+  it('binds by IDENTITY: the specific factor node keeps its own label and kind', () => {
+    // Not a value predicate another node could satisfy (CLAUDE.md trap 19).
+    const { nodes } = normalisePersistedGraph(GEOMETRY_BEARING_ROW)
+    const adoption = nodes.find((n: any) => n.id === 'fac_adoption_speed')
+
+    expect(adoption).toBeDefined()
+    expect(adoption!.data.label).toBe('Sales Team Adoption Speed')
+    expect(adoption!.data.kind).toBe('factor')
+  })
+})
+
+describe('the mandatory opposite-direction twin: projecting must not LOSE anything', () => {
+  it('preserves every top-level analytical field into `data` on the geometry-bearing row', () => {
+    const { nodes } = normalisePersistedGraph(GEOMETRY_BEARING_ROW)
+    const byId = new Map(nodes.map((n: any) => [n.id, n]))
+
+    for (const field of ANALYTICAL_FIELDS) {
+      const sources = REAL_CEE_NODES.filter((n) => n[field] !== undefined)
+      expect(sources.length).toBeGreaterThan(0)
+
+      for (const src of sources) {
+        const out: any = byId.get(src.id)
+        expect(out, `node ${src.id} vanished during normalisation`).toBeDefined()
+
+        // `observed_state` is deliberately renamed to `observedState` by the
+        // canonical mapper; the rest ride through under their own names.
+        const landed =
+          field === 'observed_state'
+            ? out.data.observedState
+            : out.data[field]
+
+        expect(
+          landed,
+          `\`${field}\` was dropped for node ${src.id} — a shape fix must never become a data loss`,
+        ).toEqual(src[field])
+      }
+    }
+  })
+
+  it('preserves the same fields on the position-LESS row too (both input shapes)', () => {
+    const { nodes } = normalisePersistedGraph({
+      nodes: REAL_CEE_NODES,
+      edges: REAL_CEE_EDGES,
+    })
+    const byId = new Map(nodes.map((n: any) => [n.id, n]))
+
+    for (const field of ANALYTICAL_FIELDS) {
+      for (const src of REAL_CEE_NODES.filter((n) => n[field] !== undefined)) {
+        const out: any = byId.get(src.id)
+        const landed =
+          field === 'observed_state' ? out.data.observedState : out.data[field]
+        expect(landed, `\`${field}\` dropped for ${src.id}`).toEqual(src[field])
+      }
+    }
+  })
+
+  it('KEEPS the persisted geometry rather than resetting it to {0,0}', () => {
+    // The naive fix — route these through the mapper — would scramble the
+    // user's canvas, because `mapDraftNodeToCanvas` hardcodes {x:0,y:0}.
+    // Shape is normalised; layout is preserved.
+    const { nodes } = normalisePersistedGraph(GEOMETRY_BEARING_ROW)
+    const byId = new Map(nodes.map((n: any) => [n.id, n]))
+
+    for (const src of GEOMETRY_BEARING_CEE_NODES) {
+      const out: any = byId.get(src.id)
+      expect(out.position).toEqual(src.position)
+    }
+  })
+
+  it('does not leave geometry loose inside `data` (it is not an analytical field)', () => {
+    const { nodes } = normalisePersistedGraph(GEOMETRY_BEARING_ROW)
+    expect(nodes.filter((n: any) => 'position' in n.data)).toHaveLength(0)
+  })
+})
+
+describe('the other direction: a genuine React Flow row must not be touched', () => {
+  const RF_NODES = [
+    { id: 'n1', type: 'factor', position: { x: 5, y: 6 }, data: { kind: 'factor', label: 'A' } },
+    { id: 'n2', type: 'goal', position: { x: 7, y: 8 }, data: { kind: 'goal', label: 'B' } },
+  ]
+
+  it('still classifies a real canvas node as canvas-shaped', () => {
+    expect(RF_NODES.filter((n) => isCanvasShapedNode(n))).toHaveLength(2)
+  })
+
+  it('returns the SAME node objects by reference (no re-projection, no layout churn)', () => {
+    const { nodes } = normalisePersistedGraph({ nodes: RF_NODES, edges: [] })
+    expect(nodes[0]).toBe(RF_NODES[0])
+    expect(nodes[1]).toBe(RF_NODES[1])
+  })
+
+  it('keeps the persisted positions exactly', () => {
+    const { nodes } = normalisePersistedGraph({ nodes: RF_NODES, edges: [] })
+    expect((nodes[0] as any).position).toEqual({ x: 5, y: 6 })
+    expect((nodes[1] as any).position).toEqual({ x: 7, y: 8 })
+  })
+})

--- a/src/canvas/utils/__tests__/normalisePersistedGraph.geometryBearingCeeRow.p0.spec.ts
+++ b/src/canvas/utils/__tests__/normalisePersistedGraph.geometryBearingCeeRow.p0.spec.ts
@@ -137,9 +137,19 @@ describe('P0: a geometry-bearing CEE row must still be projected to canvas shape
     ).toHaveLength(15)
   })
 
-  it('POST-CONDITION: no node in the output is still in the un-projected shape', () => {
-    // Assert the invariant rather than narrate it (Finding A). This REDs if a
-    // SECOND shape ever reaches the store, whatever route it arrives by.
+  it('POST-CONDITION: no node in THIS FUNCTION’S OUTPUT is still un-projected', () => {
+    // ⚠ SCOPE, stated exactly. This asserts a post-condition over the RETURN
+    // VALUE of `normalisePersistedGraph` for the fixtures under test. It proves
+    // the projector projects.
+    //
+    // It CANNOT observe ROUTES. Review measured that directly: severing the
+    // call at `useScenario.ts:699` left this spec 15/15 GREEN, because a caller
+    // that never invokes this function is invisible to a test of this
+    // function's output. An earlier version of this comment claimed it REDs
+    // "whatever route it arrives by" — false, and false in the same way as the
+    // docstring this whole PR exists to correct.
+    //
+    // Routes are watched by `hydrationRouteNormalisation.sourceScan.spec.ts`.
     const { nodes } = normalisePersistedGraph(GEOMETRY_BEARING_ROW)
 
     const unProjected = nodes.filter(
@@ -220,6 +230,53 @@ describe('the mandatory opposite-direction twin: projecting must not LOSE anythi
   it('does not leave geometry loose inside `data` (it is not an analytical field)', () => {
     const { nodes } = normalisePersistedGraph(GEOMETRY_BEARING_ROW)
     expect(nodes.filter((n: any) => 'position' in n.data)).toHaveLength(0)
+  })
+})
+
+describe('the discriminator rests on a CONTRACT-REQUIRED marker, not an observed absence', () => {
+  it('every node in the real capture carries the required `kind` and `label`', () => {
+    // `NodeV3Schema` declares both without `.optional()`, so any node that
+    // validates as GraphV3 must have them. This pins that the corpus agrees
+    // with the contract the predicate now relies on.
+    expect(
+      REAL_CEE_NODES.filter(
+        (n) => typeof n.kind === 'string' && typeof n.label === 'string',
+      ),
+    ).toHaveLength(15)
+  })
+
+  it('a CEE node carrying `data` is still NOT canvas-shaped (NodeV3 is .passthrough())', () => {
+    // The class the previous envelope-only test would have mis-classified.
+    // Contract-PERMITTED, merely unobserved — exactly how `position` arrived.
+    const passthroughCeeNode = {
+      id: 'fac_x',
+      kind: 'factor',
+      label: 'Passthrough factor',
+      position: { x: 10, y: 20 },
+      data: { label: 'stale canvas copy', someCanvasField: 1 },
+    }
+    expect(isCanvasShapedNode(passthroughCeeNode)).toBe(false)
+  })
+
+  it('projects that hybrid without nesting the canvas payload as `data.data`', () => {
+    const hybrid = {
+      id: 'fac_x',
+      kind: 'factor',
+      label: 'Contract label',
+      category: 'external',
+      position: { x: 10, y: 20 },
+      data: { someCanvasField: 1, label: 'stale canvas copy' },
+    }
+    const { nodes } = normalisePersistedGraph({ nodes: [hybrid], edges: [] })
+    const out: any = nodes[0]
+
+    expect(out.data.data).toBeUndefined()
+    // the canvas payload survives…
+    expect(out.data.someCanvasField).toBe(1)
+    // …but the CONTRACT-REQUIRED top-level value wins the collision
+    expect(out.data.label).toBe('Contract label')
+    expect(out.data.kind).toBe('factor')
+    expect(out.position).toEqual({ x: 10, y: 20 })
   })
 })
 

--- a/src/canvas/utils/__tests__/normalisePersistedGraph.geometryBearingCeeRow.p0.spec.ts
+++ b/src/canvas/utils/__tests__/normalisePersistedGraph.geometryBearingCeeRow.p0.spec.ts
@@ -302,3 +302,99 @@ describe('the other direction: a genuine React Flow row must not be touched', ()
     expect((nodes[1] as any).position).toEqual({ x: 7, y: 8 })
   })
 })
+
+describe('the EDGE of the identity guarantee — pinned, because it was stated too wide', () => {
+  // GATE 3 of the re-review. The module header promised byte-identity for "a row
+  // already in React Flow shape", unqualified. That is a claim about every canvas
+  // node this estate could write — structurally the same kind of claim as the
+  // "`scenarios.graph` carries no geometry" sentence that produced this P0.
+  //
+  // These are the two classes the corpus lacked. NEITHER has a writer today
+  // (measured: no `src/` writer mints top-level `kind`+`label` on a canvas node;
+  // the client write to `scenarios.graph` is gated shut at
+  // `clientGraphWritePolicy.ts:55-57`), which is precisely why nothing had ever
+  // measured them. They are pinned so the behaviour is RECORDED rather than
+  // described — a header sentence is not a measurement, and this PR exists
+  // because one was read as though it were.
+
+  const HYBRID_CANVAS_NODE = {
+    id: 'n1',
+    type: 'factor',
+    kind: 'factor',
+    label: 'A',
+    position: { x: 5, y: 6 },
+    data: { kind: 'factor', label: 'A', userEditedValue: 42 },
+  }
+
+  it('a canvas node carrying the CEE markers is classified CEE by limb (1)', () => {
+    expect(isCanvasShapedNode(HYBRID_CANVAS_NODE)).toBe(false)
+  })
+
+  it('LOSES object identity — so a reference-equality pin would move', () => {
+    const { nodes } = normalisePersistedGraph({
+      nodes: [HYBRID_CANVAS_NODE],
+      edges: [],
+    })
+    expect(nodes[0]).not.toBe(HYBRID_CANVAS_NODE)
+  })
+
+  // ⚠ Which of these carries the classification discrimination, measured: a
+  // mutant disabling limb (1) for ALL nodes REDs the two tests above and leaves
+  // the two below GREEN — content survives whether or not the node is
+  // re-projected, so only the IDENTITY assertion can observe the classification.
+  // The content tests are pinning that projection is not LOSSY, a different
+  // question, and they are kept for that and not mistaken for the other.
+  it('PRESERVES content: geometry, the canvas payload, and no `data.data` nesting', () => {
+    const { nodes } = normalisePersistedGraph({
+      nodes: [HYBRID_CANVAS_NODE],
+      edges: [],
+    })
+    const out = nodes[0] as any
+    // Geometry kept rather than reset to the mapper's hardcoded {0, 0}.
+    expect(out.position).toEqual({ x: 5, y: 6 })
+    // An arbitrary canvas-only payload survives the round trip.
+    expect(out.data.userEditedValue).toBe(42)
+    expect(out.data.label).toBe('A')
+    expect(out.data.kind).toBe('factor')
+    // The canvas payload is flattened, not hidden one level down.
+    expect(out.data.data).toBeUndefined()
+  })
+
+  it('binds by IDENTITY: it is THIS node that survives, not merely some node', () => {
+    // A value predicate ('some node has userEditedValue 42') could be satisfied
+    // by a different node; find by id first, then assert on it (CLAUDE.md 19).
+    const { nodes } = normalisePersistedGraph({
+      nodes: [
+        HYBRID_CANVAS_NODE,
+        { id: 'other', type: 'goal', position: { x: 0, y: 0 }, data: { kind: 'goal', label: 'B' } },
+      ],
+      edges: [],
+    })
+    const mine = (nodes as any[]).find((n) => n.id === 'n1')
+    expect(mine).toBeDefined()
+    expect(mine.data.userEditedValue).toBe(42)
+    expect(mine.position).toEqual({ x: 5, y: 6 })
+  })
+
+  it("limb (2)'s stated contingency: a canvas node with NO `data` projects conservatively", () => {
+    // The header claims this failure mode is "conservative rather than lossy".
+    // It was true and unmeasured; this is the measurement.
+    const NO_DATA_CANVAS_NODE = { id: 'n2', type: 'goal', position: { x: 7, y: 8 } }
+    expect(isCanvasShapedNode(NO_DATA_CANVAS_NODE)).toBe(false)
+
+    const { nodes } = normalisePersistedGraph({
+      nodes: [NO_DATA_CANVAS_NODE],
+      edges: [],
+    })
+    const out = nodes[0] as any
+    expect(out.id).toBe('n2')
+    expect(out.position).toEqual({ x: 7, y: 8 }) // geometry preserved
+    expect(out.data).toBeTruthy() // envelope added
+    expect(out.data.kind).toBe('goal')
+    // ⚠ The one lossy-looking detail, pinned so it is not discovered as a
+    // surprise: the mapper leaves a `label` KEY present and undefined, because
+    // the source node had no label to carry. Present-and-undefined, not absent.
+    expect('label' in out.data).toBe(true)
+    expect(out.data.label).toBeUndefined()
+  })
+})

--- a/src/canvas/utils/graphHash.ts
+++ b/src/canvas/utils/graphHash.ts
@@ -9,8 +9,32 @@ import type { Node, Edge } from '@xyflow/react'
 import { getEdgeKey } from '../domain/edgeUtils'
 
 /**
- * Generate a stable hash for the current graph state
- * Includes node IDs, types, labels, positions and edge connections
+ * Generate a stable hash for the current graph state.
+ *
+ * COVERS, exactly: node ids · node `type` · `data.label` · `data.probability` ·
+ * `data.confidence` · edge keys · edge `data.confidence` / `weight` / `belief`.
+ *
+ * ⚠ IT DOES NOT COVER `position`, AND THAT IS DELIBERATE. This docstring
+ * previously read *"Includes node IDs, types, labels, positions and edge
+ * connections"* — false since at least the current history, and false in the
+ * dangerous direction. This hash answers *"has the ANALYTICAL content changed?"*:
+ * it is written to `p_hashes.graph_hash` and compared against CEE's own graph
+ * hash, so it must describe the model, not the picture. Identity is analytical;
+ * geometry is presentation.
+ *
+ * A reader who trusted the old sentence had two ways to go wrong, and both were
+ * live: conclude that moving a node already invalidates an analysis (it does
+ * not, and nothing here would tell them otherwise), or "correct" the code to
+ * match the comment — which would make every drag re-hash the model, fork this
+ * definition from CEE's, and make every scenario read as changed. A stale
+ * comment that invites a harmful fix is worse than no comment.
+ *
+ * The authority for *"is the autosave dirty?"* is a DIFFERENT hash with a
+ * different answer — `useAutosave.computeGraphHash` — and it SHOULD see
+ * geometry, because a node move must be persisted to the layout sidecar. The
+ * authority for *"does this change invalidate an analysis?"* is
+ * `domain/analyticalChange.ts`, whose registry classifies `position` as
+ * cosmetic. Three questions, three owners; do not collapse them.
  *
  * Used for:
  * - Deduplicating graph readiness fetches

--- a/src/canvas/utils/normalisePersistedGraph.ts
+++ b/src/canvas/utils/normalisePersistedGraph.ts
@@ -87,12 +87,38 @@
  * shape defect by discarding the user's layout would swap one silent loss for
  * another.
  *
- * ⚠ IDENTITY FOR ALREADY-CANVAS-SHAPED INPUT. A row already in React Flow shape
- * must come through byte-identical — those rows reload correctly today
- * (witnessed 2/2) and every existing autosave/history pin depends on their
- * projection not moving. `normalisePersistedGraph` returns the SAME node objects
- * by reference in that case; only the documented `DEFAULT_EDGE_DATA` backfill,
- * which `loadScenario` already performed, is applied to edges.
+ * ⚠ IDENTITY FOR ALREADY-CANVAS-SHAPED INPUT — AND THE EXACT EDGE OF THE CLAIM.
+ * A node that `isCanvasShapedNode` classifies as canvas-shaped comes through by
+ * reference: `normalisePersistedGraph` returns the SAME object, so every
+ * existing autosave/history pin sees an unmoved projection. Those rows reload
+ * correctly today (witnessed 2/2). Only the documented `DEFAULT_EDGE_DATA`
+ * backfill, which `loadScenario` already performed, is applied to edges.
+ *
+ * ⚠⚠ THE GUARANTEE IS ABOUT THE PREDICATE, NOT ABOUT "ANY REACT FLOW ROW"
+ * (narrowed 2026-08-26). This paragraph used to promise byte-identity for *"a
+ * row already in React Flow shape"*, unqualified — a claim about every canvas
+ * node this estate could ever write, which is structurally the SAME KIND of
+ * claim as the *"`scenarios.graph` carries no geometry"* sentence above: the one
+ * the data refuted, and the one that produced this P0. Wider margin, same shape.
+ * Measured rather than assumed:
+ *   · A canvas node that ALSO carries top-level `kind` + `label` is classified
+ *     CEE by limb (1) and is RE-PROJECTED. **Identity is lost; content is not**
+ *     — geometry kept, arbitrary `data` payload kept, nothing nested as
+ *     `data.data`.
+ *   · A canvas node with NO `data` is likewise projected: geometry kept, an
+ *     envelope added, a `label` key left present-and-undefined.
+ * BOUND ON THE RESIDUAL: neither class exists today. Two independent sweeps of
+ * `src/` (with firing contrast controls) find no writer that mints a canvas node
+ * with both top-level markers — every canvas-node origin puts them inside
+ * `data`, `mapDraftNodeToCanvas` destructures them OUT of the top level, and the
+ * client write to `scenarios.graph` is gated shut unconditionally at
+ * `clientGraphWritePolicy.ts:55-57`. WHAT WOULD CREATE ONE: any new writer that
+ * spreads a node's `data` up to the top level, or a CEE→canvas merge that keeps
+ * both copies. If you are writing that, the projection is content-preserving,
+ * but object identity — and therefore any pin resting on reference equality —
+ * will move. Both classes are pinned by fixture in
+ * `normalisePersistedGraph.geometryBearingCeeRow.p0.spec.ts`, so this is a
+ * recorded measurement rather than another description.
  */
 
 import type { Edge } from '@xyflow/react'
@@ -133,6 +159,21 @@ import { DEFAULT_EDGE_DATA, type EdgeData } from '../domain/edges'
  * A canvas node keeps `kind`/`label` inside `data`; the top level is React
  * Flow's own `{id, type, position, data}`. So the two shapes are separated by a
  * marker each one is REQUIRED to carry, in opposite places.
+ *
+ * ⚠ THOSE TWO HALVES ARE NOT THE SAME STRENGTH, and were previously written as
+ * if they were. *"A CEE node carries top-level `kind`+`label`"* is GUARANTEED —
+ * `NodeV3Schema` marks neither `.optional()`. *"A canvas node keeps them inside
+ * `data`"* is an OBSERVATION ABOUT THIS ESTATE'S WRITERS: React Flow's node type
+ * does not forbid extra top-level keys, exactly as `.passthrough()` does not
+ * forbid `data` on a CEE node. Stating the observation in the same flat voice as
+ * the contract fact is how the `'position' in n` rule came to look safe — the
+ * asymmetry is the whole lesson of this change, so it is spelled out rather than
+ * left for the next reader to notice. It holds today (measured: no writer in
+ * `src/` mints both markers at the top level), and the consequence if it ever
+ * lapses is stated under IDENTITY FOR ALREADY-CANVAS-SHAPED INPUT above:
+ * re-projection, content-preserving, identity not preserved. The limb resting on
+ * the contract can be relied on; the limb resting on an observation must be
+ * re-derived whenever a canvas writer changes.
  *
  * ⚠ THE ENVELOPE TEST IS KEPT AS THE SECOND LIMB, and its contingency is stated
  * rather than implied away: it is what a node must present once it is NOT

--- a/src/canvas/utils/normalisePersistedGraph.ts
+++ b/src/canvas/utils/normalisePersistedGraph.ts
@@ -45,6 +45,33 @@
  * correctly rather than being classified by whichever element happens to be
  * first.
  *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * ⚠⚠ THE SHAPE TEST IS A PROPERTY OF THE ENVELOPE, NEVER AN OBSERVATION ABOUT
+ * WHAT CEE CURRENTLY EMITS (P0, 2026-08-26)
+ * ─────────────────────────────────────────────────────────────────────────────
+ * This header used to state, as a fact about the data, that *"`scenarios.graph`
+ * carries no geometry at all"* — and `isCanvasShapedNode` was built on it,
+ * discriminating purely on `'position' in n`. A census of staging `scenarios`
+ * then found **19 GraphV3 rows carrying node `position`**, all written within
+ * the preceding 30 days. Every one of them defeated the discriminator and
+ * hydrated UNPROJECTED: the P0 walked back in through this module's own front
+ * door, and the whole suite stayed green because the fixture precondition in
+ * `store.ceeShapedHydration.p0` explicitly asserts CEE nodes carry no position
+ * (CLAUDE.md trap 13d — a corpus that omits a class the contract admits cannot
+ * certify the code over that class).
+ *
+ * A shape predicate must therefore test what makes a node THAT SHAPE — the
+ * React Flow `data` envelope — not a field one writer happens not to send yet.
+ * The invariant is now ASSERTED rather than narrated: see the POST-CONDITION
+ * test in `normalisePersistedGraph.geometryBearingCeeRow.p0.spec.ts`, which REDs
+ * if any second shape reaches the store by any route.
+ *
+ * ⚠ SHAPE IS NORMALISED; LAYOUT IS PRESERVED. A projected node keeps whatever
+ * geometry the row carried (`mapDraftNodeToCanvas` hardcodes `{x: 0, y: 0}`,
+ * which is right for its WIRE callers and wrong for a persisted row). Fixing a
+ * shape defect by discarding the user's layout would swap one silent loss for
+ * another.
+ *
  * ⚠ IDENTITY FOR ALREADY-CANVAS-SHAPED INPUT. A row already in React Flow shape
  * must come through byte-identical — those rows reload correctly today
  * (witnessed 2/2) and every existing autosave/history pin depends on their
@@ -60,14 +87,56 @@ import { DEFAULT_EDGE_DATA, type EdgeData } from '../domain/edges'
 /**
  * Is this persisted node already in canvas shape?
  *
- * `position` is the discriminator: React Flow requires it on every node and
- * CEE's GraphV3 carries no geometry at all — `mergeServerGraph`'s header states
- * that CEE measures `layout_present` as false for every real graph. Testing for
- * the field's PRESENCE (not its truthiness) keeps a legitimately-persisted
- * `{x: 0, y: 0}` on the canvas-shaped side.
+ * ⚠ `position` ALONE IS NOT THE DISCRIMINATOR, AND USING IT AS ONE WAS A P0
+ * (measured 2026-08-26). The original rule here was `'position' in n`, justified
+ * by *"React Flow requires it on every node and CEE's GraphV3 carries no
+ * geometry at all"*. That is a claim about the DATA, and the data refutes it: a
+ * census of staging `scenarios` found **19 GraphV3 rows carrying node
+ * `position`**, all updated within the preceding 30 days. For every one of them
+ * this predicate answered TRUE, the node was passed through UNPROJECTED, and a
+ * CEE-shaped object reached a store whose every consumer assumes React Flow —
+ * the exact P0 this module exists to retire, re-entering through its own front
+ * door.
+ *
+ * The discriminator is now the REACT FLOW ENVELOPE — `data` — because that is a
+ * property of the SHAPE rather than an observation about what CEE happens to
+ * emit. Derived, not asserted: the captured wire row
+ * (`cee-persisted-graph-wire-2026-08-12.json`, 15 nodes) carries `data` on
+ * **0/15** nodes, while a canvas node keeps its entire payload there. A writer
+ * that starts emitting geometry cannot silently defeat this the way it defeated
+ * the geometry test.
+ *
+ * `position` is still REQUIRED, so a payload-bearing object that is not a
+ * canvas node cannot slip through on `data` alone. Both must hold. Presence
+ * (not truthiness) keeps a legitimate `{x: 0, y: 0}` on the canvas-shaped side.
  */
 export function isCanvasShapedNode(n: unknown): boolean {
-  return typeof n === 'object' && n !== null && 'position' in (n as object)
+  if (typeof n !== 'object' || n === null) return false
+  const node = n as { position?: unknown; data?: unknown }
+  if (!('position' in node)) return false
+  return typeof node.data === 'object' && node.data !== null
+}
+
+/**
+ * Geometry keys that must never end up inside `data`.
+ *
+ * `mapDraftNodeToCanvas` destructures only `{id, kind, type, label,
+ * observed_state}` and spreads the REST onto `data`, so a persisted node that
+ * carries geometry would deposit `position` into `data` while the mapper's
+ * hardcoded `{x: 0, y: 0}` took the real top-level slot. Layout is presentation
+ * and belongs at the root of a React Flow node or nowhere.
+ */
+const CANVAS_GEOMETRY_KEYS = ['position', 'positionAbsolute', 'measured'] as const
+
+/** A usable `{x, y}`, or null. Guards against a malformed persisted value. */
+function readPersistedPosition(n: unknown): { x: number; y: number } | null {
+  if (typeof n !== 'object' || n === null) return null
+  const pos = (n as { position?: unknown }).position
+  if (typeof pos !== 'object' || pos === null) return null
+  const { x, y } = pos as { x?: unknown; y?: unknown }
+  if (typeof x !== 'number' || !Number.isFinite(x)) return null
+  if (typeof y !== 'number' || !Number.isFinite(y)) return null
+  return { x, y }
 }
 
 /**
@@ -102,7 +171,30 @@ export function normalisePersistedGraph(graph: unknown): NormalisedGraph {
   const rawNodes = Array.isArray(g.nodes) ? g.nodes : []
   const rawEdges = Array.isArray(g.edges) ? g.edges : []
 
-  const nodes = rawNodes.map((n) => (isCanvasShapedNode(n) ? n : mapDraftNodeToCanvas(n)))
+  const nodes = rawNodes.map((n) => {
+    if (isCanvasShapedNode(n)) return n
+
+    // Project the shape — then put the LAYOUT back. `mapDraftNodeToCanvas`
+    // hardcodes `{x: 0, y: 0}` because its other three callers convert WIRE
+    // nodes, which genuinely have no geometry. A persisted row can have some,
+    // and normalising the shape must not scramble the user's canvas: fixing a
+    // shape defect by silently discarding layout would trade one silent loss
+    // for another. The mapper stays byte-unchanged for its other callers; the
+    // salvage lives here, at the boundary that owns the persisted column.
+    const mapped = mapDraftNodeToCanvas(n)
+    const persistedPosition = readPersistedPosition(n)
+
+    if (persistedPosition) mapped.position = persistedPosition
+
+    // `...rest` deposits any geometry the row carried into `data`. Strip it:
+    // layout is presentation, and a duplicate copy inside `data` would ride
+    // into the autosave hash and every `data.*` consumer as if it were content.
+    for (const key of CANVAS_GEOMETRY_KEYS) {
+      if (mapped.data && key in mapped.data) delete mapped.data[key]
+    }
+
+    return mapped
+  })
 
   const edges = rawEdges.map((e, i) => {
     const canvasEdge: any = isCanvasShapedEdge(e) ? e : mapDraftEdgeToCanvas(e, i)

--- a/src/canvas/utils/normalisePersistedGraph.ts
+++ b/src/canvas/utils/normalisePersistedGraph.ts
@@ -60,11 +60,26 @@
  * (CLAUDE.md trap 13d — a corpus that omits a class the contract admits cannot
  * certify the code over that class).
  *
- * A shape predicate must therefore test what makes a node THAT SHAPE — the
- * React Flow `data` envelope — not a field one writer happens not to send yet.
- * The invariant is now ASSERTED rather than narrated: see the POST-CONDITION
- * test in `normalisePersistedGraph.geometryBearingCeeRow.p0.spec.ts`, which REDs
- * if any second shape reaches the store by any route.
+ * A shape predicate must therefore test what makes a node THAT SHAPE, not a
+ * field one writer happens not to send yet — see `isCanvasShapedNode` for the
+ * contract-required marker it uses instead.
+ *
+ * ⚠ WHAT THE GUARDS DO AND DO NOT COVER — stated exactly, because an earlier
+ * draft of this header claimed the post-condition test *"REDs if any second
+ * shape reaches the store by ANY ROUTE"*, and review MEASURED that false: it
+ * severed the call at `useScenario.ts:699` and the spec stayed 15/15 green.
+ * **That sentence was a contingent claim stated as settled fact — the precise
+ * defect this module exists to close, re-armed in the header of its own fix.**
+ *   · `normalisePersistedGraph.geometryBearingCeeRow.p0.spec.ts` asserts a
+ *     post-condition over THIS FUNCTION'S OUTPUT for the fixtures under test.
+ *     It proves the projector projects. It cannot see ROUTES at all: a caller
+ *     that never calls this function is invisible to it.
+ *   · `hydrationRouteNormalisation.sourceScan.spec.ts` is what watches routes.
+ *     It derives every `hydrateGraphSlice` caller from source and requires each
+ *     to normalise or be a REGISTERED KNOWN GAP.
+ * Neither is a claim about deployed data. Together they cover "the projector is
+ * correct" and "every route reaches it"; they do not cover a store already
+ * populated before this change shipped.
  *
  * ⚠ SHAPE IS NORMALISED; LAYOUT IS PRESERVED. A projected node keeps whatever
  * geometry the row carried (`mapDraftNodeToCanvas` hardcodes `{x: 0, y: 0}`,
@@ -98,21 +113,53 @@ import { DEFAULT_EDGE_DATA, type EdgeData } from '../domain/edges'
  * the exact P0 this module exists to retire, re-entering through its own front
  * door.
  *
- * The discriminator is now the REACT FLOW ENVELOPE — `data` — because that is a
- * property of the SHAPE rather than an observation about what CEE happens to
- * emit. Derived, not asserted: the captured wire row
- * (`cee-persisted-graph-wire-2026-08-12.json`, 15 nodes) carries `data` on
- * **0/15** nodes, while a canvas node keeps its entire payload there. A writer
- * that starts emitting geometry cannot silently defeat this the way it defeated
- * the geometry test.
+ * ── THE TEST IS A POSITIVE, CONTRACT-GUARANTEED CEE MARKER ─────────────────
+ * The first version of this fix discriminated on the React Flow ENVELOPE
+ * (`data`). That is a real improvement on `'position' in n` — it is a property
+ * of the shape rather than a claim about a producer — but review found it is
+ * still a NEGATIVE test against a contract that does not forbid the thing:
+ * `NodeV3Schema` is **`.passthrough()`** (`@talchain/schemas/dist/graph.js:256`,
+ * `.passthrough()` at :273), so a CEE node carrying `data` is contract-
+ * PERMITTED, merely unobserved — **the very same admissibility that let
+ * `position` through.** Shipping that would have re-armed this defect's own
+ * mechanism one level along.
  *
- * `position` is still REQUIRED, so a payload-bearing object that is not a
- * canvas node cannot slip through on `data` alone. Both must hold. Presence
- * (not truthiness) keeps a legitimate `{x: 0, y: 0}` on the canvas-shaped side.
+ * So the CEE side is now identified by what the contract REQUIRES. On
+ * `NodeV3Schema`, `id`, `kind` and `label` carry no `.optional()`: any node that
+ * validates as GraphV3 **must** have `kind` and `label` at the top level. That
+ * is guaranteed by the schema, not observed in a sample — the difference
+ * between *"the data has not done this yet"* and *"the data cannot."*
+ *
+ * A canvas node keeps `kind`/`label` inside `data`; the top level is React
+ * Flow's own `{id, type, position, data}`. So the two shapes are separated by a
+ * marker each one is REQUIRED to carry, in opposite places.
+ *
+ * ⚠ THE ENVELOPE TEST IS KEPT AS THE SECOND LIMB, and its contingency is stated
+ * rather than implied away: it is what a node must present once it is NOT
+ * CEE-marked, and `position` presence (not truthiness) keeps a legitimate
+ * `{x: 0, y: 0}` on the canvas side. It is a sufficient test for the shapes this
+ * estate writes today; it is not a contract guarantee, because React Flow does
+ * not require `data`. If a canvas writer ever emits a node without `data`, this
+ * limb sends it through the projector — which preserves its geometry and gives
+ * it an envelope, so the failure mode is conservative rather than lossy.
  */
 export function isCanvasShapedNode(n: unknown): boolean {
   if (typeof n !== 'object' || n === null) return false
-  const node = n as { position?: unknown; data?: unknown }
+  const node = n as {
+    position?: unknown
+    data?: unknown
+    kind?: unknown
+    label?: unknown
+  }
+
+  // (1) POSITIVE, CONTRACT-REQUIRED CEE MARKER. `NodeV3Schema` requires BOTH,
+  // so this cannot be defeated by a producer starting to emit an extra field —
+  // it can only be defeated by CEE ceasing to emit a REQUIRED one.
+  if (typeof node.kind === 'string' && typeof node.label === 'string') {
+    return false
+  }
+
+  // (2) Otherwise the node must present the React Flow envelope.
   if (!('position' in node)) return false
   return typeof node.data === 'object' && node.data !== null
 }
@@ -185,6 +232,19 @@ export function normalisePersistedGraph(graph: unknown): NormalisedGraph {
     const persistedPosition = readPersistedPosition(n)
 
     if (persistedPosition) mapped.position = persistedPosition
+
+    // A CEE-MARKED NODE THAT ALSO CARRIES `data`. `NodeV3Schema` is
+    // `.passthrough()`, so this is contract-PERMITTED — and the lesson of this
+    // whole change is that "permitted but unobserved" is exactly the class that
+    // eventually arrives (trap 13d). The mapper's `...rest` would nest it as
+    // `data.data`, hiding the canvas payload from every `data.*` consumer.
+    // Flatten it UNDERNEATH the CEE values: the top-level fields are the ones
+    // the contract requires, so they win a collision.
+    const nested = mapped.data?.data
+    if (nested && typeof nested === 'object' && !Array.isArray(nested)) {
+      mapped.data = { ...nested, ...mapped.data }
+      delete mapped.data.data
+    }
 
     // `...rest` deposits any geometry the row carried into `data`. Strip it:
     // layout is presentation, and a duplicate copy inside `data` would ride

--- a/src/hooks/useScenario.ts
+++ b/src/hooks/useScenario.ts
@@ -693,9 +693,14 @@ export function useScenario(): UseScenarioReturn {
       // CEE-shaped objects into a store whose every consumer assumes React Flow,
       // crashing `reseedIds` inside `hydrateGraphSlice` and then `computeGraphHash`
       // during render — a blank canvas on every reload of a CEE-drafted decision.
-      // A React-Flow-shaped row is passed through unchanged (same objects by
-      // reference); the DEFAULT_EDGE_DATA backfill this path always applied is
-      // preserved inside the normaliser.
+      // A row whose nodes classify as canvas-shaped is passed through unchanged
+      // (same objects by reference); the DEFAULT_EDGE_DATA backfill this path
+      // always applied is preserved inside the normaliser.
+      // ⚠ "Canvas-shaped" is the predicate's ANSWER, not a synonym for "React
+      // Flow shaped" (narrowed 2026-08-26): a canvas node that also carries
+      // top-level `kind`+`label`, or none at all, is re-projected — content
+      // preserved, object identity not. No writer produces either today; see
+      // `normalisePersistedGraph`'s header for the bound and what would break it.
       const normalised = normalisePersistedGraph(row.graph)
       const graphNodes = normalised.nodes as Parameters<
         ReturnType<typeof useCanvasStore.getState>['hydrateGraphSlice']


### PR DESCRIPTION
## The defect, in one line

`isCanvasShapedNode` discriminated React Flow shape on **`'position' in n` alone**, so the **19 staging rows that are GraphV3 *and* carry geometry** were classified canvas-shaped and hydrated **unprojected** — the exact P0 `normalisePersistedGraph` exists to retire, walking back in through its own front door.

**The root shape of it:** the predicate was justified by an *observation about what a writer currently emits* — *"CEE's GraphV3 carries no geometry at all"* — rather than by a *property of the shape*. The data moved; the predicate could not follow. That is the hand-maintained mirror at the level of a type discriminator.

## Why it mattered: silent edit loss

`useAutosave.computeGraphHash` is the autosave's dirty gate and covers `data.*`. An unprojected node has **no `data` at all**, so:

- `label` collapsed to `''`, `kind` to `undefined`
- the entire analytical payload (`observed_state`, `display_value`, `category`, `interventions`) was **invisible to the gate**
- the debounced save skipped, and **the user's edit was gone on reload** — the #457 loss class, on the CEE-shaped half

## ⭐ Why the suite was green — the most instructive part of this PR

`store.ceeShapedHydration.p0`'s fixture precondition:

```js
it('is a real CEE row: edges carry no id, nodes carry no position', () => {
  expect(CEE_NODES.filter((n) => 'position' in n)).toHaveLength(0)
})
```

**An honest precondition pin that asserts away the exact class the live data contains.** Not a weak test, not an oversight — a deliberate, correct-looking assertion that made the defect structurally unobservable. This is CLAUDE.md trap 13d in its purest form: *a corpus that omits a value class the contract admits cannot certify the code over that class.* The column is untyped JSONB with two writers; the class is 19 rows wide in staging.

The lesson generalises past this fix: **check what your corpus EXCLUDES, not what it covers** — and treat a precondition that narrows the input space as a claim requiring the same scrutiny as the code.

## The fix — two halves, and the second is the opposite-direction twin

**1. Discriminate on the React Flow envelope (`data`).** A property of the *shape*, not a claim about a producer. Derived, not asserted: the captured wire row carries `data` on **0/15** nodes. `position` is still required, so a payload-bearing non-node cannot slip through on `data` alone.

**2. Preserve persisted geometry when projecting.** `mapDraftNodeToCanvas` hardcodes `{x: 0, y: 0}` — **correct for its wire callers, wrong for a persisted row.** Routing these rows through it naively would have normalised the shape while scrambling the user's canvas: **fixing shape by discarding layout swaps one silent loss for another.** So the salvage lives at the *boundary*, and geometry is stripped out of `data` (`...rest` had deposited it there).

### The reviewer check that matters, in one command

The salvage is at the boundary **specifically so the shared mapper stays byte-unchanged for its other callers.** Verify it:

```bash
git diff --name-only origin/staging...HEAD | grep -c applyDraftResult   # => 0
```

`mapDraftNodeToCanvas` has **4 other call sites across 3 modules** — `mergeServerGraph.ts:336`, `mergeAppliedGraph.ts:293`, `mergeAppliedGraph.ts:531`, `applyDraftResult.ts:209` — and **none of them changes behaviour in this PR.** A fix inside the shared mapper would have altered the draft path, the applied-edit receipt path and the server-hydration path at the same time; this one does not.

**Invariant asserted, not narrated — and scoped to what it proves.** The spec pins a POST-CONDITION over **this function's output** for the fixtures under test: no returned node is still un-projected. It proves the projector projects.

⚠ **It cannot observe ROUTES, and an earlier version of this PR claimed it could.** Review severed the call at `useScenario.ts:699` and the spec stayed **15/15 green**; I reproduced that as MR1 (route severed → projector spec **GREEN (18)**). That sentence was a contingent claim stated as settled fact — **the precise defect this PR exists to close, re-armed in the header of its own fix.** Routes are watched by a separate guard, below.

## G3 — the guard that watches routes

`hydrationRouteNormalisation.sourceScan.spec.ts` derives **every `hydrateGraphSlice` caller from source** and requires each to normalise or be a **registered known gap with a stated reason**. Deriving the list means a new graph-replacement route **fails loud by default** rather than depending on someone remembering to update a list (trap 12).

⚠ **My first version of this scan did not bite, and the mutation kit caught it, not inspection.** It tested `source.includes('normalisePersistedGraph')` — which the **import line alone satisfies** — so a severed route read as safe and the scan was GREEN. It now counts **call sites with import lines excluded**, and a detector-contract block pins the import-vs-call discrimination on literals.

`ReactFlowGraph.tsx` is a registered gap: it hydrates from the localStorage autosave and run-history restores, both written *from* the store. Its residual is **disclosed, not dismissed** — a store polluted before this fix shipped was autosaved in CEE shape and re-enters unnormalised. That is a data-migration question, not a routing one.

## The predicate rests on a contract-REQUIRED marker

Discriminating on the React Flow envelope (`data`) was a real improvement on `'position' in n` — a property of the shape rather than a claim about a producer — and **still a negative test against a schema that does not forbid the thing.** `NodeV3Schema` is **`.passthrough()`** (`@talchain/schemas/dist/graph.js:256-273`), so a CEE node carrying `data` is contract-**permitted**, merely unobserved — *the same admissibility that let `position` through.*

Derived at the contract bytes: `id`, `kind` and `label` carry no `.optional()`, so **any node that validates as GraphV3 must carry `kind` and `label` at the top level.** The CEE side is now identified by what the contract *requires* — the difference between *"the data has not done this yet"* and *"the data cannot."*

The envelope test is kept as the second limb **with its contingency stated rather than implied away**: React Flow does not require `data`, so it is sufficient for the shapes this estate writes today and is not a contract guarantee. Its failure mode is conservative — a canvas node lacking `data` is projected, keeping its geometry.

**New class handled:** a CEE-marked node that *also* carries `data` would have nested as `data.data` via the mapper's `...rest`. It is flattened, with the contract-required top-level values winning collisions.

## Evidence

| Check | Result |
|---|---|
| RED-first at pristine | **6 of 15 failed by name** |
| M1 revert discriminator to `'position' in n` | applied=1 → **RED** |
| M2 drop the position salvage | applied=1 → **RED** |
| M3 drop the geometry strip | applied=1 → **RED** |
| M4 discriminating partner (mutates the **edge** branch) | applied=1 → node spec **GREEN (15)**, edge spec **RED** — mutant is real (non-equivalent) *and* node assertions bind to nodes |
| Leading + trailing controls | applied=0, **GREEN** both |
| Isolation | proven by **writing a sentinel** into the mutation tree and asserting the source SHA unchanged; inodes compared (APFS hard-link hazard) |
| Typecheck gate | **PASSED**, ratchet **exactly at baseline (2251 = 2251)** |
| Affected specs (symbol sweep, not directory) | **38 files / 443 tests, all pass** |
| M5 drop the contract-marker limb | applied=1 → **RED (2)** |
| M1' revert whole discriminator to `'position' in n` | applied=1 → **RED (8)** |
| M6 drop the `data.data` flatten | applied=1 → **RED (1)** |
| **Route scan** MR1 sever the fixed route | **RED (2)** — while the projector spec stays **GREEN (18)**, which is G1 reproduced |
| **Route scan** MR2 new unregistered route | **RED** |
| **Route scan** MR3 stale exemption | **RED** |
| Lint | 0 errors (2 pre-existing warnings at `useAutosave.ts:344`, outside this diff) |

## ⚠ Status rung — stated honestly

Both harms are **DERIVED AND PINNED, not journey-witnessed on this build.**

- The original P0 signature (`undefined.localeCompare` → error boundary → 0 nodes) was witnessed on deployed `978d073c` (3/3 CEE rows, 0/2 React Flow rows) — that is a **prior** witness, for the position-*less* class.
- The **geometry-bearing** class, and the edit-loss consequence, are established here by derivation at the bytes plus RED-first tests and a mutation kit. **No fresh-journey witness has been taken on this build**, and the 19 rows have not been driven through a browser reload.
- What would raise the rung: a fresh-session journey on a scenario whose row is GraphV3-with-geometry — edit a factor value, reload, confirm it survives.

## Two comments corrected — both false in the *harmful* direction

- **`graphHash.ts`** claimed the analytical hash *"includes … positions"*. It does not, and must not — it is compared against CEE's own hash. A reader "making the comment true" would have **created** the very defect this PR closes.
- **`useAutosave.ts`** still said `loadScenario` hydrates **VERBATIM** (untrue since 2026-08-13) and carried the RESIDUAL note for this gap. The boundary now closes it, exactly where that note said it belonged. **`position` stays in that hash on purpose** — it is the layout sidecar's gate, a different question from analysis staleness (trap 21); both directions are pinned.

## Scope, and one deliberate non-completion

Collision intersection with all open UI PRs: **EMPTY**, with three controls (theirs∩theirs = |theirs|, mine∩mine = |mine|, an injected known-theirs file appears). Does not touch `DecisionOverviewCard.tsx`, `PreAnalysisGuidance.tsx`, `canRunAnalysis.ts`, `applyV5State.ts`.

**Dual-shape reads are NOT converged in this PR, and that is a sequencing decision, not a completed job.** The family splits in two:

- **KEEP — these read the WIRE, where the CEE shape is genuine and permanent:** `adapters/cee/client.ts:165-166`, `v5/consumeStreamedDraftTurn.ts:143-144`, `mergeAppliedGraph.ts:568-569`, `mergeServerGraph.ts:416-417`, `graphIdentity.ts:47-48`. That last one is the pattern the rest should follow — it lives inside `wireEdgePairKey`, scoped to the wire, with `canvasEdgePairKey` as its canvas twin: **not one shape everywhere, but two questions named apart.**
- **ROUTE THROUGH CANONICAL (follow-up) — read the store, false branch now unreachable:** `useAutosave.ts:208-209, 230, 243-244`, `graphNeedsInitialLayout.ts:46-47`, `useResultsSectionData.ts:834, 841`.
- **NOT dual-shape — a different question sharing a similar spelling, deliberately excluded:** every `label ?? edge.source` site, `RunSelector.tsx:85,102`, `AppPoC.tsx:461`.

**FOLLOW-UP WITH AN EXPLICIT TRIGGER — re-pointed.** Delete the store-side dual reads **once `hydrationRouteNormalisation.sourceScan.spec.ts` has held across one full release.** The trigger previously named the post-condition test; since that test cannot watch routes (G1), it would have authorised deleting live dual-shape reads on evidence that never watched them. The route scan is what actually watches them.

They are left in place here because **deleting the net on the same commit that changes what it catches is how an unenumerated hydration path ships unguarded.**

`applyPatchAndLog` (dead: zero non-test callers, the only raw `p_graph` pass-through) is **rowed, not deleted here** — unrelated surface.

## CI — polled to conclusion, `running = 0`

**13 of 14 checks pass**, including `Staging Gate`, all four `Full Test Suite` shards, `TypeScript + Lint`, `Typecheck Gate Self-Test` and `Production Build`.

One failure: **`Visual Regression (advisory)`**.

**I am still not calling it pre-existing** — visreg is PR-triggered, so no base-commit control exists for this branch. What I can offer instead is a **contrast control across the same instrument**, which is stronger than an assertion:

- it fails identically on **#878** (`fbecbc95`) and **#868** (`f36ce4a0`) — two unrelated branches from other lanes;
- **#879** is open specifically to *"retire the stale linux references so CI can regenerate them"*, and documents causes (Compare's tab leaving the presented row, `MAX_PRESENTED_SURFACES` 4 → 3) that **predate all three branches**;
- this diff contains **zero non-spec `.tsx` files** — `git diff --name-only origin/staging...HEAD | grep -E '\.tsx$' | grep -v spec` returns **0**.

So: the failure is **not specific to this branch**, and the check is marked *advisory*. That is an observation with a control behind it, not a verdict that it is harmless — #879 is the PR that settles it.

Rebased onto `323b195a` (#881 merged since this branch was cut).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
