### PR TITLE
C+D: render the producer's blocked-reason sentences one per line

### DIFF
--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -1228,7 +1228,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   const runBlockedTooltip = getRunButtonTooltip(runGateResult)
   // The producer's sentences BEHIND that tooltip, from the same filter the gate
   // decided on (`actionableBlockers`), so the footer can render them one per
-  // line instead of ~1,425 characters joined into a single meta paragraph.
+  // line instead of the join is UNBOUNDED and nothing truncates it.
   //
   // ⚠ NOT ASSUMED TO MATCH. `runBlockedTooltip` is `blockingReasons[0]`, which
   // is not necessarily this composition — another blocker can come first.

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -120,13 +120,14 @@ import { useConversation } from '../conversation/useConversation'
 import {
   canRunAnalysis as canRunAnalysisUtil,
   getRunButtonTooltip,
+  actionableBlockers,
   readinessObjectsToRun,
   verdictLicenceSuperseded,
   RUN_LICENCE_SUPERSEDED_REFUSAL,
   type ReadinessVerdictLicence,
 } from '../utils/canRunAnalysis'
 import { analysisHeldOn } from '../utils/analysisHeldOnInjectedModel'
-import { selectOptionsNeedingValues } from '../utils/composeBlockedReason'
+import { selectOptionsNeedingValues, analysisBlockedSentences } from '../utils/composeBlockedReason'
 import { WarningBanner } from './WarningBanner'
 import { DegradedStateBanner } from './DegradedStateBanner'
 import { mapConfidenceToReadiness } from '../utils/mapConfidenceToReadiness'
@@ -1225,6 +1226,22 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
   )
   const canRunAnalysis = runGateResult.allowed
   const runBlockedTooltip = getRunButtonTooltip(runGateResult)
+  // The producer's sentences BEHIND that tooltip, from the same filter the gate
+  // decided on (`actionableBlockers`), so the footer can render them one per
+  // line instead of ~1,425 characters joined into a single meta paragraph.
+  //
+  // ⚠ NOT ASSUMED TO MATCH. `runBlockedTooltip` is `blockingReasons[0]`, which
+  // is not necessarily this composition — another blocker can come first.
+  // `deriveReadinessDisplay` therefore uses this array ONLY when it joins byte
+  // for byte to the vetted string it is rendering beside, and withholds it
+  // otherwise. Supplying a non-matching array here is safe by construction.
+  const runBlockedSentences = useMemo(
+    () =>
+      analysisReadiness
+        ? analysisBlockedSentences(actionableBlockers(analysisReadiness.blockers))
+        : undefined,
+    [analysisReadiness],
+  )
   // ── INPUTS FOR THE SHELL-HOSTED READINESS BAR ──────────────────────────────
   // Both are DERIVED THROUGH THE PANEL'S OWN OWNER (`readinessDisplay.ts`), not
   // restated here. `usePreAnalysisModel` builds the identical two values from
@@ -3045,6 +3062,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                           isAnalysing={isRunning}
                           canRun={canRunAnalysis}
                           blockedReason={runBlockedTooltip}
+                          blockedSentences={runBlockedSentences}
                         />
                       </Suspense>
                     </div>

--- a/src/canvas/components/__tests__/OutputsDock.readinessSurvivesTabChange.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.readinessSurvivesTabChange.spec.tsx
@@ -119,7 +119,7 @@ import { useReadinessStore } from '../../stores/readinessStore'
 import { useUIStore } from '../../../stores/uiStore'
 import { useFloatingPanelState } from '../../hooks/useFloatingPanelState'
 import { clearInflightCache } from '../../hooks/useGraphReadiness'
-import { composeAnalysisBlockedReason } from '../../utils/composeBlockedReason'
+import { composeAnalysisBlockedReason, analysisBlockedSentences } from '../../utils/composeBlockedReason'
 import { actionableBlockers } from '../../utils/canRunAnalysis'
 import { FOOTER_COPY } from '../pre-analysis-v3/constants'
 import { WORKSPACE_SURFACES, presentedSurfaces } from '../workspaceShell/shellContract'
@@ -205,6 +205,38 @@ function fourBlockers(): AnalysisStateV1['readiness'] {
  * evaluates, filter included.
  */
 const WITNESSED_REASON = composeAnalysisBlockedReason(actionableBlockers(FOUR_BLOCKERS))
+
+/**
+ * The SAME producer sentences, unjoined — one `<li>` each in the footer.
+ *
+ * ⚠ `expect(footer).toHaveTextContent(WITNESSED_REASON)` NO LONGER WORKS AND
+ * MUST NOT BE RESTORED. The footer renders the producer's sentences one per
+ * line, and sibling `<li>` elements concatenate with NO SEPARATOR — so the
+ * container's `textContent` is `"A.B."` where the joined string is `"A. B."`.
+ *
+ * ⛔ AND BE PRECISE ABOUT WHAT THE BYTE-IDENTITY GUARANTEE COVERS, because the
+ * PR that split this rendering stated it too broadly. It holds for the ARRAY
+ * and the JOINED STRING —
+ *   `analysisBlockedSentences(b).join(' ') === composeAnalysisBlockedReason(b)`
+ * — true by construction. **It was never a claim about rendered `textContent`.**
+ * The Analyse button's `title` is still the joined string (it is built from
+ * `gateBlockedSubline`, not from the DOM), which is why `:382` below is
+ * unaffected.
+ *
+ * ⭐ Asserting each sentence INDIVIDUALLY is stronger than substring-containment
+ * on one blob: a render that dropped a sentence and joined the rest would
+ * satisfy the old assertion for the sentences it kept, and REDs here.
+ */
+const WITNESSED_SENTENCES = analysisBlockedSentences(actionableBlockers(FOUR_BLOCKERS))
+
+function expectFooterCarriesEveryProducerSentence(footer: HTMLElement): void {
+  // Pin the fixture's own discriminating power: a one-sentence corpus could not
+  // observe a dropped sentence at all.
+  expect(WITNESSED_SENTENCES.length).toBeGreaterThan(1)
+  for (const sentence of WITNESSED_SENTENCES) {
+    expect(footer).toHaveTextContent(sentence)
+  }
+}
 
 function ensureMatchMedia() {
   if (typeof window.matchMedia !== 'function') {
@@ -380,7 +412,7 @@ describe('the witnessed defect — following the advice removes the control', ()
     const analyse = await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
     expect(analyse).toBeDisabled()
     expect(analyse).toHaveAttribute('title', WITNESSED_REASON)
-    expect(screen.getByTestId('pre-analysis-v3-footer')).toHaveTextContent(WITNESSED_REASON)
+    expectFooterCarriesEveryProducerSentence(screen.getByTestId('pre-analysis-v3-footer'))
 
     clickOlumiTab()
 
@@ -397,8 +429,7 @@ describe('the witnessed defect — following the advice removes the control', ()
     render(<Wrapper><OutputsDock /></Wrapper>)
 
     await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
-    const beforeText = screen.getByTestId('pre-analysis-v3-footer').textContent ?? ''
-    expect(beforeText).toContain(WITNESSED_REASON)
+    expectFooterCarriesEveryProducerSentence(screen.getByTestId('pre-analysis-v3-footer'))
 
     clickOlumiTab()
     expect(olumiIsFronted()).toBe(true)
@@ -412,7 +443,15 @@ describe('the witnessed defect — following the advice removes the control', ()
     const reason = screen.getByTestId('analysis-readiness-bar-reason').textContent ?? ''
     expect(reason.length).toBeGreaterThan(20)
     expect(reason).toBe(WITNESSED_REASON)
-    expect(beforeText).toContain(reason)
+    // ⭐ CROSS-SURFACE IDENTITY, at the granularity the two surfaces now use.
+    // The footer renders the producer's sentences one per line and the bar
+    // renders their JOIN, so `beforeText.toContain(reason)` can no longer hold
+    // — sibling `<li>` textContent has no separator. The property it was
+    // guarding is unchanged and is asserted here directly: the bar's string IS
+    // the join of exactly the sentences the Analysis surface was showing, in
+    // that order. That is a stronger claim than substring-containment, because
+    // it pins the SET and the ORDER rather than mere presence.
+    expect(reason).toBe(WITNESSED_SENTENCES.join(' '))
 
     // …and a run control the user can see the state of, still honest.
     const barAnalyse = screen.getByTestId('analysis-readiness-bar-analyse')

--- a/src/canvas/components/__tests__/OutputsDock.readinessSurvivesTabChange.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.readinessSurvivesTabChange.spec.tsx
@@ -429,7 +429,17 @@ describe('the witnessed defect — following the advice removes the control', ()
     render(<Wrapper><OutputsDock /></Wrapper>)
 
     await screen.findByTestId('pre-analysis-v3-analyse', {}, { timeout: 20_000 })
-    expectFooterCarriesEveryProducerSentence(screen.getByTestId('pre-analysis-v3-footer'))
+    const beforeFooter = screen.getByTestId('pre-analysis-v3-footer')
+    expectFooterCarriesEveryProducerSentence(beforeFooter)
+    // ⛔ READ THE DOM, NOT THE FIXTURE. An earlier version asserted
+    // `reason === WITNESSED_SENTENCES.join(' ')` — but
+    // `composeAnalysisBlockedReason` IS `analysisBlockedSentences(b).join(' ')`,
+    // so BOTH SIDES were fixture constants and the footer was never read. It
+    // passed with NO producer at all, and a wrong-ORDER render left it green.
+    const renderedSentences = Array.from(beforeFooter.querySelectorAll('li')).map(
+      li => li.textContent ?? '',
+    )
+    expect(renderedSentences.length).toBeGreaterThan(1)
 
     clickOlumiTab()
     expect(olumiIsFronted()).toBe(true)
@@ -451,7 +461,7 @@ describe('the witnessed defect — following the advice removes the control', ()
     // the join of exactly the sentences the Analysis surface was showing, in
     // that order. That is a stronger claim than substring-containment, because
     // it pins the SET and the ORDER rather than mere presence.
-    expect(reason).toBe(WITNESSED_SENTENCES.join(' '))
+    expect(reason).toBe(renderedSentences.join(' '))
 
     // …and a run control the user can see the state of, still honest.
     const barAnalyse = screen.getByTestId('analysis-readiness-bar-analyse')

--- a/src/canvas/components/pre-analysis-v3/PreAnalysisPanelV3.tsx
+++ b/src/canvas/components/pre-analysis-v3/PreAnalysisPanelV3.tsx
@@ -40,9 +40,11 @@ export interface PreAnalysisPanelV3Props {
    * gating); the blocked explanation when canRun is false.
    */
   blockedReason?: string
+  /** The producer's sentences behind `blockedReason` — see `ReadinessDisplay.sublineSentences`. */
+  blockedSentences?: readonly string[]
 }
 
-function PanelBody({ onAnalyse, isAnalysing, canRun, blockedReason }: PreAnalysisPanelV3Props) {
+function PanelBody({ onAnalyse, isAnalysing, canRun, blockedReason, blockedSentences }: PreAnalysisPanelV3Props) {
   const model = usePreAnalysisModel()
   const { sendPrompt } = useConversationActions()
   const showToast = useShowToast()
@@ -178,6 +180,7 @@ function PanelBody({ onAnalyse, isAnalysing, canRun, blockedReason }: PreAnalysi
         isAnalysing={isAnalysing}
         canRun={canRun}
         blockedReason={blockedReason}
+        blockedSentences={blockedSentences}
         // ROADMAP 2.332 / 2.339 — when the readiness CHECK failed, this footer
         // is the surface that used to claim "Analysis available" about a model
         // nothing had assessed. It says so instead. Run authority is unchanged.

--- a/src/canvas/components/pre-analysis-v3/footer/PanelFooter.tsx
+++ b/src/canvas/components/pre-analysis-v3/footer/PanelFooter.tsx
@@ -107,7 +107,7 @@ export const PanelFooter = memo(function PanelFooter({
         </p>
         {/* THE PRODUCER'S SENTENCES ARE A LIST, NOT A PARAGRAPH. Every blocker
             CEE names arrived here joined by spaces into one `panelMeta` line —
-            ten of them is ~1,425 characters of unbroken small text. Nothing is
+            the join is UNBOUNDED and nothing truncates it. Nothing is
             truncated or summarised (the contract forbids both, so we never put
             our words in the producer's mouth); the SAME bytes render one per
             line, and `display.subline` stays their exact join for the tooltip.

--- a/src/canvas/components/pre-analysis-v3/footer/PanelFooter.tsx
+++ b/src/canvas/components/pre-analysis-v3/footer/PanelFooter.tsx
@@ -38,6 +38,8 @@ interface PanelFooterProps {
   canRun: boolean
   /** Advisory tooltip when canRun; the blocked explanation when not. */
   blockedReason?: string
+  /** The producer's sentences behind `blockedReason` — see `ReadinessDisplay.sublineSentences`. */
+  blockedSentences?: readonly string[]
   /**
    * ROADMAP 2.332 / 2.339 — non-null only when the readiness CHECK failed.
    * Never gates the run; it replaces the footer's claim about the check.
@@ -58,6 +60,7 @@ export const PanelFooter = memo(function PanelFooter({
   isAnalysing,
   canRun,
   blockedReason,
+  blockedSentences,
   readinessCheck = null,
   nothingHasAnswered = false,
 }: PanelFooterProps) {
@@ -74,6 +77,7 @@ export const PanelFooter = memo(function PanelFooter({
     isAnalysing,
     canRun,
     blockedReason,
+    blockedSentences,
     nothingHasAnswered,
     resting: footer,
   })
@@ -101,7 +105,27 @@ export const PanelFooter = memo(function PanelFooter({
         >
           {display.headline}
         </p>
-        <p className={`${typography.panelMeta} text-text-light`}>{display.subline}</p>
+        {/* THE PRODUCER'S SENTENCES ARE A LIST, NOT A PARAGRAPH. Every blocker
+            CEE names arrived here joined by spaces into one `panelMeta` line —
+            ten of them is ~1,425 characters of unbroken small text. Nothing is
+            truncated or summarised (the contract forbids both, so we never put
+            our words in the producer's mouth); the SAME bytes render one per
+            line, and `display.subline` stays their exact join for the tooltip.
+            ⚠ ONE sentence stays a sentence: a list of one renders a bullet
+            where prose belonged, which would be a regression in the common
+            small case bought with a fix for the large one. */}
+        {display.sublineSentences !== undefined && display.sublineSentences.length > 1 ? (
+          <ul
+            className={`${typography.panelMeta} text-text-light list-disc space-y-0.5 pl-4`}
+            data-testid="pre-analysis-v3-footer-subline-list"
+          >
+            {display.sublineSentences.map((sentence, index) => (
+              <li key={`${index}:${sentence}`}>{sentence}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className={`${typography.panelMeta} text-text-light`}>{display.subline}</p>
+        )}
       </div>
       {/* The check can be retried without touching the run. Deliberately NOT a
           gate: the verdict is the server's, and this asks it again — it never

--- a/src/canvas/components/pre-analysis-v3/footer/__tests__/PanelFooter.sentenceList.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/footer/__tests__/PanelFooter.sentenceList.spec.tsx
@@ -2,7 +2,7 @@
  * THE FOOTER RENDERS THE PRODUCER'S SENTENCES ONE PER LINE.
  *
  * Every blocker CEE names arrived joined by spaces into one `panelMeta` line —
- * ten of them is ~1,425 characters of unbroken small text. Nothing is truncated
+ * the join is UNBOUNDED and nothing truncates it. Nothing is truncated
  * or summarised: the SAME bytes render one per line.
  *
  * ⚠ THE ONE-BLOCKER TWIN IS PART OF THE CONTRACT. A list of one renders a

--- a/src/canvas/components/pre-analysis-v3/footer/__tests__/PanelFooter.sentenceList.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/footer/__tests__/PanelFooter.sentenceList.spec.tsx
@@ -22,6 +22,10 @@ const REAL = [
 const renderShut = (sentences?: readonly string[]) =>
   render(
     <PanelFooter
+      // The RESTING value only. `deriveReadinessDisplay` overrides it entirely
+      // while the gate is shut, which is the state under test — so this must not
+      // be mistaken for the source of the subline being asserted below.
+      footer={{ dot: 'success', headline: 'Ready', subline: 'resting' }}
       onAnalyse={() => {}}
       isAnalysing={false}
       canRun={false}

--- a/src/canvas/components/pre-analysis-v3/footer/__tests__/PanelFooter.sentenceList.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/footer/__tests__/PanelFooter.sentenceList.spec.tsx
@@ -1,0 +1,71 @@
+/**
+ * THE FOOTER RENDERS THE PRODUCER'S SENTENCES ONE PER LINE.
+ *
+ * Every blocker CEE names arrived joined by spaces into one `panelMeta` line —
+ * ten of them is ~1,425 characters of unbroken small text. Nothing is truncated
+ * or summarised: the SAME bytes render one per line.
+ *
+ * ⚠ THE ONE-BLOCKER TWIN IS PART OF THE CONTRACT. A list of one renders a
+ * bullet where prose belonged — a regression in the common small case bought
+ * with a fix for the rare large one. It is asserted here, not assumed.
+ */
+import { describe, it, expect } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen } from '@testing-library/react'
+import { PanelFooter } from '../PanelFooter'
+
+const REAL = [
+  'Choose the missing effect value for "keep what we have" on "Current CRM Capability Gap".',
+  'Choose the missing effect value for "migrate to Salesforce instead" on "Salesforce Switching Cost".',
+]
+
+const renderShut = (sentences?: readonly string[]) =>
+  render(
+    <PanelFooter
+      onAnalyse={() => {}}
+      isAnalysing={false}
+      canRun={false}
+      blockedReason={(sentences ?? REAL).join(' ')}
+      blockedSentences={sentences}
+    />,
+  )
+
+describe('PanelFooter — producer sentences render as a list', () => {
+  it('PRECONDITION: the fixture is multi-sentence, so a list is the right shape', () => {
+    expect(REAL.length).toBeGreaterThan(1)
+  })
+
+  it('renders ONE LIST ITEM PER PRODUCER SENTENCE', () => {
+    renderShut(REAL)
+    const list = screen.getByTestId('pre-analysis-v3-footer-subline-list')
+    expect(list.querySelectorAll('li')).toHaveLength(REAL.length)
+  })
+
+  it('EVERY ITEM IS BYTE-IDENTICAL to a sentence the producer wrote', () => {
+    renderShut(REAL)
+    const items = Array.from(
+      screen.getByTestId('pre-analysis-v3-footer-subline-list').querySelectorAll('li'),
+    ).map(li => li.textContent)
+    expect(items).toEqual([...REAL])
+  })
+
+  it('THE UNION IS EXACT — joining the rendered items reproduces the joined string', () => {
+    renderShut(REAL)
+    const items = Array.from(
+      screen.getByTestId('pre-analysis-v3-footer-subline-list').querySelectorAll('li'),
+    ).map(li => li.textContent ?? '')
+    expect(items.join(' ')).toBe(REAL.join(' '))
+  })
+
+  it('THE ONE-BLOCKER TWIN: a single sentence renders as prose, NOT a list of one', () => {
+    renderShut([REAL[0]])
+    expect(screen.queryByTestId('pre-analysis-v3-footer-subline-list')).toBeNull()
+    expect(screen.getByText(REAL[0])).toBeInTheDocument()
+  })
+
+  it('NO SENTENCES SUPPLIED: today’s single paragraph, unchanged', () => {
+    renderShut(undefined)
+    expect(screen.queryByTestId('pre-analysis-v3-footer-subline-list')).toBeNull()
+    expect(screen.getByText(REAL.join(' '))).toBeInTheDocument()
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/footer/__tests__/readinessDisplaySentences.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/footer/__tests__/readinessDisplaySentences.spec.ts
@@ -1,0 +1,87 @@
+/**
+ * THE LIST AND THE STRING CANNOT DISAGREE.
+ *
+ * `deriveReadinessDisplay` is "the one owner" of this verdict — the pre-analysis
+ * footer AND `AnalysisReadinessBar` both call it. So the array that renders as a
+ * list and the string that renders in the bar and the Analyse tooltip come from
+ * ONE derivation in ONE call.
+ *
+ * ⚠ THE SUBTLETY THAT MAKES THIS MORE THAN A PASS-THROUGH. `gateBlockedSubline`
+ * runs `vetBlockedReason`, which does not merely accept or reject — it can
+ * SUBSTITUTE a UI-composed fallback for the producer's text. Handing the array
+ * through blindly would then render the fallback in the bar and the producer's
+ * sentences in the footer: two surfaces telling different stories about one
+ * state, which is the defect this seam exists to end.
+ *
+ * So the list is used ONLY when the vetted string is byte-identical to the
+ * list's own join. Byte-identity is ENFORCED AT THE POINT OF USE, never assumed.
+ */
+import { describe, it, expect } from 'vitest'
+import { deriveReadinessDisplay } from '../readinessDisplay'
+
+const REAL = [
+  'Choose the missing effect value for "keep what we have" on "Current CRM Capability Gap".',
+  'Choose the missing effect value for "migrate to Salesforce instead" on "Salesforce Switching Cost".',
+]
+
+const shutGate = (sentences?: readonly string[], reason?: string) =>
+  deriveReadinessDisplay({
+    readinessCheck: null,
+    isAnalysing: false,
+    canRun: false,
+    blockedReason: reason ?? sentences?.join(' '),
+    blockedSentences: sentences,
+    nothingHasAnswered: false,
+    resting: { dot: 'success', headline: 'x', subline: '' },
+  })
+
+describe('deriveReadinessDisplay — producer sentences survive as a list', () => {
+  it('PRECONDITION: the fixture is multi-sentence, so a join defect is observable', () => {
+    expect(REAL.length).toBeGreaterThan(1)
+    expect(REAL.join(' ')).toContain('. ')
+  })
+
+  it('carries the sentences when the vetted string IS their join', () => {
+    expect(shutGate(REAL).sublineSentences).toEqual(REAL)
+  })
+
+  it('THE INVARIANT: whenever sentences are present, subline is exactly their join', () => {
+    const d = shutGate(REAL)
+    expect(d.sublineSentences).toBeDefined()
+    expect(d.sublineSentences!.join(' ')).toBe(d.subline)
+  })
+
+  it('WITHHOLDS the list when the string and the array disagree — a mismatch is never trusted', () => {
+    const d = shutGate(REAL, 'A completely different sentence.')
+    expect(d.sublineSentences).toBeUndefined()
+    expect(d.subline).not.toBe(REAL.join(' '))
+  })
+
+  it('WITHHOLDS the list whenever the vet SUBSTITUTED — never UI copy beside producer bullets', () => {
+    const unsafe = ['The graph is fine.', 'Nothing to do.']
+    const d = shutGate(unsafe)
+    if (d.subline !== unsafe.join(' ')) expect(d.sublineSentences).toBeUndefined()
+    if (d.sublineSentences) expect(d.sublineSentences.join(' ')).toBe(d.subline)
+  })
+
+  it('THE ONE-BLOCKER TWIN: one sentence carries as one item', () => {
+    const d = shutGate([REAL[0]])
+    expect(d.sublineSentences).toEqual([REAL[0]])
+    expect(d.sublineSentences!.join(' ')).toBe(d.subline)
+  })
+
+  it('no sentences supplied → no list, and the string is unchanged from today', () => {
+    const d = shutGate(undefined, REAL.join(' '))
+    expect(d.sublineSentences).toBeUndefined()
+    expect(d.subline).toBe(REAL.join(' '))
+  })
+
+  it('an OPEN gate carries no sentences — this is the blocked arm only', () => {
+    const d = deriveReadinessDisplay({
+      readinessCheck: null, isAnalysing: false, canRun: true,
+      nothingHasAnswered: false,
+      resting: { dot: 'success', headline: 'Ready', subline: 'all set' },
+    })
+    expect(d.sublineSentences).toBeUndefined()
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/footer/readinessDisplay.ts
+++ b/src/canvas/components/pre-analysis-v3/footer/readinessDisplay.ts
@@ -103,6 +103,20 @@ export interface ReadinessDisplay {
   readonly dot: ReadinessDot
   readonly headline: string
   readonly subline: string
+  /**
+   * The SAME text as `subline`, unjoined — one entry per producer sentence.
+   *
+   * Present only on the gate-shut arm, and only when the vetted string is
+   * BYTE-IDENTICAL to this array's own join. A surface may render these as a
+   * list; every other surface keeps reading `subline`. Because both come from
+   * one derivation in one call, the bar and the footer cannot tell different
+   * stories about one state.
+   *
+   * ⚠ ABSENT is the safe default and means "render `subline`". It is absent
+   * whenever the vet substituted UI copy for the producer's text — see the
+   * equality guard in `deriveReadinessDisplay`.
+   */
+  readonly sublineSentences?: readonly string[]
 }
 
 /** The resting value for a surface that has no `PreAnalysisModel`. See the
@@ -224,6 +238,17 @@ export interface ReadinessDisplayInput {
   readonly canRun: boolean
   /** The gate's own reason. Read only while the gate is shut. */
   readonly blockedReason?: string
+  /**
+   * The producer's sentences BEHIND `blockedReason` — `analysisBlockedSentences`,
+   * from the same call that produced the string.
+   *
+   * Optional and additive: a caller that supplies nothing gets exactly today's
+   * behaviour. Supplying an array that does not join to `blockedReason` is not
+   * an error — it is simply not used (the guard below), because a mismatch means
+   * something composed one of them separately and neither can be trusted to
+   * speak for the other.
+   */
+  readonly blockedSentences?: readonly string[]
   /** `readinessNothingHasAnswered(...)`, from the same two authorities the gate reads. */
   readonly nothingHasAnswered: boolean
   /** What this surface says when none of the arms above fire. */
@@ -240,10 +265,24 @@ export function deriveReadinessDisplay(input: ReadinessDisplayInput): ReadinessD
     return { dot: 'success', headline: FOOTER_COPY.running, subline: FOOTER_COPY.runningSub }
   }
   if (!input.canRun) {
+    const subline = gateBlockedSubline(input.blockedReason)
+    // ⛔ BYTE-IDENTITY ENFORCED AT THE POINT OF USE, NEVER ASSUMED.
+    // `gateBlockedSubline` runs `vetBlockedReason`, which does not merely accept
+    // or reject — it SUBSTITUTES a composed fallback for producer text it will
+    // not pass. Handing the array through regardless would render our fallback
+    // in the bar and the producer's sentences in the footer: two surfaces
+    // telling different stories about one state. So the list is carried only
+    // when the vetted string IS its join, and withheld otherwise.
+    const sentences =
+      input.blockedSentences !== undefined &&
+      input.blockedSentences.join(' ') === subline
+        ? input.blockedSentences
+        : undefined
     return {
       dot: 'muted',
       headline: FOOTER_COPY.notReady,
-      subline: gateBlockedSubline(input.blockedReason),
+      subline,
+      ...(sentences !== undefined ? { sublineSentences: sentences } : {}),
     }
   }
   if (input.nothingHasAnswered) {

--- a/src/canvas/utils/__tests__/producerSentencesAreAList.spec.ts
+++ b/src/canvas/utils/__tests__/producerSentencesAreAList.spec.ts
@@ -3,7 +3,7 @@
  *
  * `composeAnalysisBlockedReason` joined every producer sentence with a space
  * into ONE string, rendered in a `panelMeta` line and a `title` attribute. On a
- * ten-blocker graph that is ~1,425 characters in a single meta paragraph.
+ * the join is UNBOUNDED and nothing truncates it.
  *
  * ⛔ THE FIX IS NOT TRUNCATION. The no-truncation contract
  * (`composeBlockedReason.ts`) exists so we never attribute our words to the


### PR DESCRIPTION
## Render the producer's blocked-reason sentences one per line

**Stacked on [#881](https://github.com/Talchain/DecisionGuideAI/pull/881)** (base is that branch, not `staging`). #881 made the string a derivation of an array; this renders it.

The pre-analysis footer showed **every** blocker CEE names joined by spaces into a single `typography.panelMeta text-text-light` paragraph — **~1,425 characters of unbroken small text** on a ten-blocker graph, and the same string in the Analyse tooltip. The same bytes now render one per line.

⛔ **Nothing is truncated, summarised or reordered.** That contract exists so we never put our words in the producer's mouth, and it is untouched. **The remedy is presentation.**

### It extends the ONE owner, it does not add a second path

Threaded through `deriveReadinessDisplay` — the module's own header calls it *"the one owner"*, and `AnalysisReadinessBar` calls it too. So this is convergence on an existing authority rather than a second render path.

### ⛔ Byte-identity is enforced at the point of use, never assumed

The subtlety that makes this more than a pass-through: `gateBlockedSubline` runs `vetBlockedReason`, which does **not** merely accept or reject — it **substitutes** a composed fallback for producer text it will not pass. Handing the array through regardless would render *our* fallback in the readiness bar and the *producer's* sentences in the footer — two surfaces telling different stories about one state, which is the defect this seam exists to end.

So the list is used **only** when the vetted string is byte-identical to its own join, and withheld otherwise.

`OutputsDock` supplies the array beside the string it already computes, from the same `actionableBlockers` filter the gate decided on. It is **not assumed to match** — `runBlockedTooltip` is `blockingReasons[0]`, which need not be this composition — so a non-matching array is simply not used. Safe by construction.

### ⚠ One sentence stays a sentence

A list of one renders a bullet where prose belonged — a regression in the common small case bought with a fix for the rare large one. **Asserted, not assumed.**

### Scope

Only the **live v3** call site is wired. The legacy flag-off panel and the readiness bar are deliberately untouched: the bar renders the string and cannot diverge, because both are bound to the same vetted value. (My first pass blanket-replaced and hit all three parents; the gate caught it and I reverted to the one that matters.)

### Evidence

- **Typecheck gate exit 0**, `556 file(s) / 2251 error(s)` — exactly baseline, asserted by exit code.
- **RED first**, by name, on both new specs.
- **Regression**: `pre-analysis-v3` + `workspaceShell` + `canvas/utils` → **123 files / 2295 passed**, exit 0.
- **Mutants** — throwaway worktree at an absolute path outside the repo root, write-isolation proven by sentinel, HEAD-relative restores, applied-check scoped to `src/`. Failing **names** compared, not counts:

| | result | |
|---|---|---|
| pristine | exit 0, 23 passed | applied 0 |
| **M1** byte-identity guard removed | exit 1 — the two *withholding* tests | bites |
| **M2** footer derives its own list (splits the string) | exit 1 — byte-identity + union | **a second derivation is the defect** |
| **M3** drop the last producer sentence | exit 1 — 5 named | bites |
| **C1** styling changed | **exit 0, 23 passed** | styling is not the contract |
| trailing control | exit 0, clean | |

Three mutants, three **different** named failure sets — the tests bind to the contract, not merely to change.

Fixtures use **real producer wording from the 26 Aug wire capture**, and both specs **pin their own precondition** (that the fixture is genuinely multi-sentence), so a one-item fixture cannot make the union assertions hold vacuously.

### Not verified here
How 1,425 characters actually reflow is a browser question — jsdom cannot prove layout. This changes the DOM shape from one `<p>` to an `<ul>`; the visual result wants a live look.



---

## ⚠ SCOPE OF THE SCALE EVIDENCE — corrected before review, by the author

The `~1,425 characters` figure above is from a **measured ten-blocker fixture**. It is not what a live journey currently produces.

**A plain `fresh` drive against deployed CEE `d80e813` (run `20260826T181147Z-fresh-7922ca`) carries TWO blockers per payload**, parsed from the payloads rather than grepped:
```
step-T1_DRAFT     status='needs_user_input'  options=2  blockers=2
step-T2_FOLLOWUP  status='needs_user_input'  options=2  blockers=2
step-T3_ANALYSE   status='needs_user_input'  options=2  blockers=2
```

⛔ **I earlier reported "twelve blockers" and said the wall-of-text case was "not hypothetical any more". That was wrong and is withdrawn.** The 12 was a `grep -c` **sum across three files and both blocker arrays** — a corpus total read as one payload's fan-out. **Two sentences is not a wall of text.**

**What this does NOT change:** the join is **unbounded** — `analysisBlockedSentences(...).join(' ')` grows with the blocker count and nothing truncates it (deliberately: the contract forbids truncation). A ten-blocker graph is a real shape, measured. **The fix is justified by the unbounded join, not by the live count.**

**What it does change:** this PR does not have a live witness of the large case, and no claim here should be read as though it does.
