### PR TITLE
fix(panel): the type census measured a directory and was read as measuring the panel

### DIFF
--- a/scripts/conversation-type-census.mjs
+++ b/scripts/conversation-type-census.mjs
@@ -35,7 +35,39 @@ import { fileURLToPath } from 'node:url'
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 
-const SCOPE_DIRS = ['src/canvas/conversation', 'src/v5/blocks']
+/*
+ * ⚠⚠ THIS SCOPE WAS TWO DIRECTORIES AND THE PANEL RENDERS FROM MANY MORE — the
+ * census reported "4 distinct sizes, zero raw hits" while SEVEN sizes rendered
+ * in the panel column. Derived 26 Aug 2026 by walking the import closure from
+ * the panel's own roots (`FloatingOlumiPanel`, `OlumiTabBody`,
+ * `ConversationPanel`, `ChatThread`): 698 rendering files, of which 92 were in
+ * scope. The guard was not wrong about what it measured; it measured a
+ * DIRECTORY and was read as measuring the PANEL.
+ *
+ * Added below: the panel's own hosts and the surfaces that render in the same
+ * dock column and were governed by neither this census nor
+ * `check-ds-compliance`'s `panel-typography-scoped` class.
+ *
+ * ⛔ WHAT IS STILL NOT GOVERNED, STATED SO THE NEXT READER DOES NOT INHERIT MY
+ * ERROR: `src/canvas/components` at large — 315 files carrying 232 off-scale
+ * hits (16px x199, 20px x11, 18px x10, 10px x8, plus 28/30/36). That is the
+ * canvas and its modals, not the panel column, and it needs its own scale
+ * decision before it can be brought under an absolute-list census. Do not read
+ * a green census as "the app has three type sizes".
+ */
+const SCOPE_DIRS = [
+  'src/canvas/conversation',
+  'src/v5/blocks',
+  'src/canvas/components/pre-analysis',
+  'src/canvas/shared',
+  'src/canvas/model-tab-v2',
+]
+/** Panel/dock hosts that are single files rather than directories. */
+const SCOPE_FILES = [
+  'src/canvas/components/FloatingOlumiPanel.tsx',
+  'src/canvas/components/OlumiTabBody.tsx',
+  'src/canvas/components/OutputsDock.tsx',
+]
 const TYPOGRAPHY_TS = 'src/styles/typography.ts'
 const EXCLUDE_DIR_NAMES = new Set(['__tests__', 'tests', '__fixtures__'])
 
@@ -141,8 +173,27 @@ function classesToTraits(classString, context) {
 // ---------------------------------------------------------------------------
 // Mechanism 1 + 2 + 4: TS/TSX files
 // ---------------------------------------------------------------------------
+/**
+ * ⚠ COMMENTS ARE NOT USAGE, AND THIS COUNTED THEM. `FloatingOlumiPanel.tsx:1352`
+ * is a JSX comment explaining that compact mode swaps `typography.body` (16px)
+ * for `typography.panelBody` — prose ABOUT a token, not a use of one. The census
+ * reported a 16px size the panel does not render, which is the same class of
+ * false positive `check-ds-compliance` already strips for (see its
+ * `stripComments` note: a class written in a JSDoc block ships nothing).
+ *
+ * Deliberately line-preserving: the census reports file:line, so blanking must
+ * not shift them.
+ */
+function stripComments(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .split('\n')
+    .map((l) => l.replace(/(^|[^:])\/\/.*$/, (mm, p1) => p1 + ' '.repeat(mm.length - p1.length)))
+    .join('\n')
+}
+
 function scanTsx(file, tokens) {
-  const src = readFileSync(file, 'utf8')
+  const src = stripComments(readFileSync(file, 'utf8'))
 
   // Fail loud on dynamically-composed size classes.
   for (const m of src.matchAll(/text-\$\{/g)) {
@@ -279,7 +330,10 @@ function scanCss(file) {
 // Run
 // ---------------------------------------------------------------------------
 const tokens = parseTypographyTokens()
-const files = SCOPE_DIRS.flatMap((d) => walk(path.join(ROOT, d)))
+const files = [
+  ...SCOPE_DIRS.flatMap((d) => walk(path.join(ROOT, d))),
+  ...SCOPE_FILES.map((f) => path.join(ROOT, f)),
+]
 for (const f of files) {
   if (f.endsWith('.css')) scanCss(f)
   else scanTsx(f, tokens)
@@ -318,6 +372,15 @@ const summary = {
   sizes: [...sizes.keys()].map(Number).sort((a, b) => a - b),
   weights: [...weights.keys()].map(Number).sort((a, b) => a - b),
   lineHeights: [...lineHeights.keys()].sort(),
+  /*
+   * Which MECHANISM produced each line-height. Exposed because the guard admits
+   * `leading-none` for buttons and must refuse it for prose — an assertion that
+   * only saw the VALUE could not tell those apart, and would have to widen the
+   * whole rule to let one control through.
+   */
+  lineHeightMechanisms: Object.fromEntries(
+    [...lineHeights.entries()].map(([lh, hs]) => [lh, [...new Set(hs.map((h) => h.mechanism))].sort()]),
+  ),
   counts: { sizes: sizes.size, weights: weights.size, lineHeights: lineHeights.size },
   rawMechanismHits: {
     // raw = not token-/var-mediated; the sweep drives these to the pinned floor

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -2821,7 +2821,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                             <summary className={`${typography.code} text-text-light cursor-pointer`}>
                               Debug info
                             </summary>
-                            <div className={`${typography.code} text-text-light mt-1 text-xs`}>
+                            <div className={`${typography.code} text-text-light mt-1`}>
                               Code: {error.code} | Request ID: {error.request_id || 'n/a'}
                             </div>
                           </details>
@@ -2882,7 +2882,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                       aria-live="polite"
                       data-testid="outputs-error-banner"
                     >
-                      <div className={`${typography.body} font-medium ${
+                      <div className={`${typography.panelHeader} ${
                         friendlyError.severity === 'error'
                           ? 'text-danger'
                           : friendlyError.severity === 'warning'
@@ -2967,7 +2967,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                           <summary className={`${typography.code} text-text-light cursor-pointer`}>
                             Debug info
                           </summary>
-                          <div className={`${typography.code} text-text-light mt-1 text-xs`}>
+                          <div className={`${typography.code} text-text-light mt-1`}>
                             Code: {error.code} | Request ID: {error.request_id || 'n/a'}
                           </div>
                         </details>
@@ -3584,7 +3584,7 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
           >
             <div className="bg-white px-6 py-4 rounded-lg shadow-3 flex items-center gap-3">
               <div className="w-5 h-5 border-2 border-info border-t-transparent rounded-full animate-spin" />
-              <span className={`${typography.body} text-text-header`}>Generating comparison...</span>
+              <span className={`${typography.panelBody} text-text-header`}>Generating comparison...</span>
             </div>
           </div>
         )}

--- a/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
+++ b/src/canvas/components/pre-analysis/PreAnalysisPanel.tsx
@@ -862,7 +862,7 @@ const T1DecisionReadinessCard = memo(function T1DecisionReadinessCard({
         <>
           <div className="border-t border-panel-border" role="separator" aria-hidden="true" />
           <div className="flex flex-col gap-1" data-testid="t1-also-consider">
-            <p className={`text-[10px] font-semibold text-text-light`}>Also consider</p>
+            <p className={`${typography.panelMeta} font-semibold text-text-light`}>Also consider</p>
             <div className="flex flex-col">
               {alsoConsider.map((entry) => {
                 const subtitle = entry.overlay?.detail ?? entry.card.subtitle

--- a/src/canvas/components/pre-analysis/SharpenYourThinking.tsx
+++ b/src/canvas/components/pre-analysis/SharpenYourThinking.tsx
@@ -204,7 +204,7 @@ export function SharpenYourThinking(props: SharpenYourThinkingProps) {
             className="flex flex-col gap-1 p-2.5 border border-panel-border rounded-[10px]"
             data-testid={card.testId}
           >
-            <span className={`text-[10px] text-text-light`}>{card.label}</span>
+            <span className={`${typography.panelMeta} text-text-light`}>{card.label}</span>
             <p className={`${typography.panelBody} text-text-body leading-snug`}>
               {card.question}
             </p>

--- a/src/canvas/model-tab-v2/ModelDetailRegion.tsx
+++ b/src/canvas/model-tab-v2/ModelDetailRegion.tsx
@@ -205,7 +205,7 @@ export function ModelDetailRegion({
     >
       {/* 1 — What this is */}
       <section data-testid="model-detail-v2-what">
-        <h3 className={`${typography.h5} text-text-header`}>{row.label}</h3>
+        <h3 className={`${typography.panelHeader} text-text-header`}>{row.label}</h3>
         <p className={`${typography.caption} text-text-light`}>{KIND_LABEL[row.kind]}</p>
         {detail.description !== null && (
           <p

--- a/src/canvas/model-tab-v2/ModelRowView.tsx
+++ b/src/canvas/model-tab-v2/ModelRowView.tsx
@@ -182,7 +182,7 @@ export function ModelRowView({
         <span
           data-testid={GOAL_LABEL_FROM_BRIEF_TESTID}
           title={GOAL_LABEL_FROM_BRIEF_COPY.notice}
-          className={`${typography.edgeLabel} text-text-light whitespace-nowrap`}
+          className={`${typography.panelMeta} text-text-light whitespace-nowrap`}
         >
           {GOAL_LABEL_FROM_BRIEF_COPY.pill}
         </span>

--- a/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
+++ b/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
@@ -459,7 +459,7 @@ export function ModelTabV2Panel({
       className="flex flex-col gap-2 border border-panel-border rounded-lg p-2"
     >
       <header className="flex items-center gap-2 flex-wrap">
-        <h3 className={`${typography.h5} text-text-header`}>Model outline</h3>
+        <h3 className={`${typography.panelHeader} text-text-header`}>Model outline</h3>
         <input
           data-testid="model-tab-v2-filter"
           type="search"

--- a/src/canvas/model-tab-v2/RepairQueueList.tsx
+++ b/src/canvas/model-tab-v2/RepairQueueList.tsx
@@ -226,7 +226,7 @@ export function RepairQueueList({
   return (
     <section data-testid={`repair-queue-v2-${q}`} className="flex flex-col gap-2 p-2">
       <header>
-        <h3 className={`${typography.h5} text-text-header`}>{queue.title}</h3>
+        <h3 className={`${typography.panelHeader} text-text-header`}>{queue.title}</h3>
         {/*
           The two counts are reported SEPARATELY and deliberately. Deferring does
           not reduce the number of real gaps in the model — only the number

--- a/src/canvas/shared/AnalysisFooter.tsx
+++ b/src/canvas/shared/AnalysisFooter.tsx
@@ -81,7 +81,7 @@ export function AnalysisFooter({
                 stays verbatim. Pinned by AnalysisFooter.metaWrap.spec.tsx. */}
             {metaText ? (
               <span
-                className="text-[10px] text-text-light leading-snug whitespace-normal break-words"
+                className={`${typography.panelMeta} text-text-light whitespace-normal break-words`}
                 data-testid="sticky-footer-meta"
               >
                 {metaText}

--- a/tests/ci-guards/conversation-type-census.spec.ts
+++ b/tests/ci-guards/conversation-type-census.spec.ts
@@ -28,6 +28,8 @@ interface CensusSummary {
   sizes: number[]
   weights: number[]
   lineHeights: string[]
+  /** line-height -> the mechanisms that produced it, so buttons can be told from prose. */
+  lineHeightMechanisms: Record<string, string[]>
   counts: { sizes: number; weights: number; lineHeights: number }
   rawMechanismHits: {
     tailwindSize: number
@@ -64,9 +66,33 @@ describe('conversation-panel type-scale census (F3)', () => {
     expect(census.weights).toEqual([400, 500, 600])
   })
 
-  it('line-heights collapse to 1.375 / 1.5 / 1.625', () => {
+  /**
+   * ⚠ `1` IS ADMITTED, AND ONLY FROM THE BUTTON TOKENS — the scope widening
+   * (26 Aug 2026) brought `typography.button` / `buttonSmall` into the census,
+   * and both carry `leading-none`. That is correct for a button: the rule
+   * exists to keep PROSE rhythm consistent, and a single-line control is not
+   * prose.
+   *
+   * ⛔ SO IT IS NOT ENOUGH TO ADD '1' TO THE LIST. A bare widening would also
+   * admit `leading-none` on a paragraph, which is the harm this case exists to
+   * prevent — the inverse defect, bought by fixing the first one. The prose
+   * line-heights stay closed, and `1` must arrive via a button token or the
+   * assertion fails naming the mechanism that produced it.
+   */
+  it('line-heights collapse to 1.375 / 1.5 / 1.625 — plus leading-none on BUTTONS only', () => {
+    const PROSE = ['1.375', '1.5', '1.625']
+    const BUTTON_TOKENS = ['button', 'buttonSmall']
     for (const lh of census.lineHeights) {
-      expect(['1.375', '1.5', '1.625']).toContain(lh)
+      if (PROSE.includes(lh)) continue
+      expect(lh, `unexpected line-height ${lh} — prose must use ${PROSE.join(' / ')}`).toBe('1')
+      const mechanisms = census.lineHeightMechanisms[lh] ?? []
+      const nonButton = mechanisms.filter(
+        (m: string) => !BUTTON_TOKENS.some((t) => m === `token(${t})`),
+      )
+      expect(
+        nonButton,
+        `line-height 1 is admitted for buttons only; these are not buttons: ${nonButton.join(', ')}`,
+      ).toEqual([])
     }
   })
 

--- a/tests/ci-guards/shell-conformance.spec.ts
+++ b/tests/ci-guards/shell-conformance.spec.ts
@@ -347,7 +347,7 @@ describe('workspace shell — OutputsDock burn-down pins (exact, both directions
   const PINNED: Record<string, number> = {
     'dock-width-literal': 0,
     'off-scale-spacing': 6,
-    'raw-typography': 9,
+    'raw-typography': 6,
     'sticky-bottom-in-body': 0,
     'viewport-breakpoint': 0,
   }
@@ -515,13 +515,13 @@ describe('workspace shell — child surfaces: raw typography, pinned per file', 
     'src/canvas/components/EvidenceCoverage.tsx': 2,
     'src/canvas/components/GraphTextView.tsx': 8,
     'src/canvas/components/IdentifiabilityBadge.tsx': 1,
-    'src/canvas/components/OutputsDock.tsx': 9,
+    'src/canvas/components/OutputsDock.tsx': 6,
     'src/canvas/components/SectionErrorBoundary.tsx': 7,
     'src/canvas/components/ValidationPanel.tsx': 4,
     'src/canvas/components/WarningBanner.tsx': 1,
     'src/canvas/components/WhatChangedChip.tsx': 1,
-    'src/canvas/components/pre-analysis/PreAnalysisPanel.tsx': 5,
-    'src/canvas/components/pre-analysis/SharpenYourThinking.tsx': 3,
+    'src/canvas/components/pre-analysis/PreAnalysisPanel.tsx': 4,
+    'src/canvas/components/pre-analysis/SharpenYourThinking.tsx': 2,
     'src/canvas/conversation/InlineBlocks.tsx': 1,
     'src/canvas/conversation/ModelReceiptBlock.tsx': 1,
     'src/canvas/conversation/zones/BriefGuidanceStrip.tsx': 1,
@@ -529,7 +529,7 @@ describe('workspace shell — child surfaces: raw typography, pinned per file', 
     'src/canvas/conversation/zones/ChatComposer.tsx': 1,
     'src/canvas/conversation/zones/ChatThread.tsx': 1,
     'src/canvas/conversation/zones/ComposerTools.tsx': 1,
-    'src/canvas/shared/AnalysisFooter.tsx': 2,
+    'src/canvas/shared/AnalysisFooter.tsx': 1,
     'src/canvas/ui/inspector/StrengthBar.tsx': 1,
     'src/components/Tooltip.tsx': 1,
     'src/styles/typography.ts': 38,
@@ -588,6 +588,8 @@ describe('workspace shell — child surfaces: raw typography, pinned per file', 
     // measuring almost nothing, which is how this kind of ratchet dies.
     const files = Object.keys(RAW_TYPOGRAPHY_BY_FILE).length
     const total = Object.values(RAW_TYPOGRAPHY_BY_FILE).reduce((a, b) => a + b, 0)
+    // 26 Aug 2026 (AI-panel type scale): 113 -> 107, as six off-scale sizes in
+    // four dock-column files became panel tokens. See the census scope widening.
     // 18 Aug 2026 (B4): 37 -> 30 files, 134 -> 113 occurrences, as the seven
     // `model-tab/**` entries above burned to zero. These two numbers are a
     // hand-maintained mirror OF THE MAP and must be lowered in the same PR as
@@ -595,7 +597,7 @@ describe('workspace shell — child surfaces: raw typography, pinned per file', 
     // entries turned the ratchet green and turned THIS assertion red, so the
     // pair cannot be quietly hollowed out from either end.
     expect(files).toBe(30)
-    expect(total).toBe(113)
+    expect(total).toBe(107)
   })
 })
 


### PR DESCRIPTION
The founder said the AI panel's font sizes were "all over the shop". I ran the census, reported **"4 distinct sizes, zero raw hits"**, and told him it was clean.

**He was right and the measurement was wrong.**

`SCOPE_DIRS` held two directories. Walking the import closure from the panel's own roots (`FloatingOlumiPanel`, `OlumiTabBody`, `ConversationPanel`, `ChatThread`) gives **698 rendering files, of which 92 were in scope**. Seven sizes rendered in the panel column against a declared scale of three plus a named hero.

The guard was not wrong about what it measured. **It measured a directory and was read as measuring the panel.**

## Widened, and the sizes brought back to the scale

Scope now covers the panel's hosts and the dock-column surfaces governed by neither this census nor `check-ds-compliance`'s `panel-typography-scoped` class — **109 → 179 files**. Sizes are back to the declared `[11, 12, 14, 24]`.

**8 off-scale hits retired, all on live surfaces:**

| was | → | where |
|---|---|---|
| `text-[10px]` | `panelMeta` | SharpenYourThinking, PreAnalysisPanel, AnalysisFooter |
| `typography.h5` (18px) | `panelHeader` | RepairQueueList, ModelTabV2Panel, ModelDetailRegion |
| `typography.body` (16px) | `panelBody` / `panelHeader` | OutputsDock ×2 |
| `typography.edgeLabel` (10px) | `panelMeta` | ModelRowView — a **canvas** token in a panel row |

Plus two redundant raw `text-xs` sitting beside `typography.code`, which is already 12px.

## ⭐ The census counted comments

`FloatingOlumiPanel.tsx:1352` is JSX prose explaining that compact mode swaps `typography.body` for `panelBody` — a token **named**, never used. It was reported as a rendered 16px. `check-ds-compliance` already strips comments for exactly this false-positive class and documents why; this census did not. Now comment-blanked, line-preserving so `file:line` still resolves.

## ⛔ `leading-none` admitted for buttons, still refused for prose

Widening brought `typography.button` / `buttonSmall` into scope, both `leading-none`. **A bare widening of the allowed list would also have admitted `leading-none` on a paragraph** — the inverse defect, bought by fixing the first one.

The census now exposes `lineHeightMechanisms` so the assertion can tell a button from prose. **Proven:** applying `leading-none` to `chatProse` REDs, naming the offending token.

## Ratchet lowered, not suppressed

`shell-conformance` pins raw typography **exactly, in both directions**, so a burn-down fails until it is recorded — the guard working as designed. 9→6 (OutputsDock), 5→4, 3→2, 2→1; total **113 → 107**.

## ⛔ What is still NOT governed

`src/canvas/components` at large — **315 files, 232 off-scale hits** (16px ×199, 20px ×11, 18px ×10, 10px ×8, plus 28/30/36). That is the canvas and its modals, not the panel column, and it needs its own scale decision before an absolute-list census can hold there. Recorded in the scope comment so nobody inherits my error: **a green census is not "the app has three sizes".**

## Two dead components found, deliberately not polished

- **`DegeneracyWarning`** — the component is never rendered (only its hook is imported), and all 13 of its legacy `carrot`/`banana` colour classes **generate no CSS**, control-checked against the built bundle (`text-carrot-500` generates, `text-carrot-800` does not, `banana` appears zero times).
- **`GrowingInput`** — zero importers, still carrying the retired `"Describe your decision..."` copy.

Both rowed, neither edited — polishing dead code is churn.

## Gate

typecheck ratchet unchanged (2251) · **1372 tests pass** across `ci-guards`, `pre-analysis`, `model-tab-v2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)