### PR TITLE
D2 — remove the duplicate Inspector authority; keep the policy in its enforced form

### DIFF
--- a/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
+++ b/src/canvas/model-tab-v2/ModelTabV2Panel.tsx
@@ -145,16 +145,34 @@ export function ModelTabV2Panel({
    * the branch above is structurally exclusive and the spec pins the outline rows
    * absent in queue mode, with a before-click contrast control.
    *
-   * What is NOT yet true is the SURFACE. `ModelTabBody.tsx` renders
-   * `FactorsSection` unconditionally, outside this panel, in the same scroll — so
-   * a queued factor appears in the queue AND in its v1 factor card. The
-   * consolidation's invariant *"there is only ever one rendering of a row"* is a
-   * goal at this tip, not an achieved state, and it stays that way until the
-   * duplicate section stack is deleted.
+   * ⚠⚠ THE PARAGRAPH THAT USED TO SIT HERE IS FALSE AND IS CORRECTED BELOW
+   * (26 Aug 2026). It read: *"`ModelTabBody.tsx` renders `FactorsSection`
+   * unconditionally, outside this panel, in the same scroll — so a queued
+   * factor appears in the queue AND in its v1 factor card."* **It does not.**
    *
-   * A spec that renders THIS COMPONENT can never see that (trap 3b — bound to a
-   * component, not to the surface the deployed tab mounts), which is exactly how
-   * the overstatement passed a green suite.
+   * `ModelTabBody.tsx:120` declares `const LEGACY_DETAILED_EDITOR_MOUNTED =
+   * false`, and `:917` gates the ENTIRE v1 section stack behind it
+   * (`{LEGACY_DETAILED_EDITOR_MOUNTED && (<section data-testid="model-tab-v1-stack">…)}`).
+   * esbuild folds the constant, so Goal/Options/Factors/Relationships/Risks are
+   * dead-code-eliminated — they are not merely hidden, they are not shipped.
+   * Verified at the DEPLOYED bundle (staging `f287c012`, 81 chunks crawled):
+   * `factor-card-`, `factors-add-cta`, `attribution-stability-pill` and
+   * `range-derivation-badge` all read ZERO, while positive controls in the same
+   * sweep fired (`option-card-` ×2 — both from live RESULTS components —
+   * `model-scientific-transparency`, `model-tab-v2-panel`). So this panel IS
+   * the sole rendering of a row, and the consolidation invariant HOLDS.
+   *
+   * ⚠ HOW THE FALSE VERSION SURVIVED, because that is the reusable part: the
+   * JSX for those sections really does sit at `ModelTabBody.tsx:972`/`:981`
+   * with no local condition. Reading the call site WITHOUT its enclosing guard
+   * at `:917` produces exactly the sentence above — and a later reader who
+   * greps for `<FactorsSection` reproduces the same mistake. A comment that
+   * describes a mount MUST name the guard, not just the call site.
+   *
+   * A spec that renders THIS COMPONENT can never settle either version (trap 3b
+   * — bound to a component, not to the surface the deployed tab mounts), which
+   * is why the deployed-bundle sweep above, not a green suite, is the evidence
+   * cited here. Re-derive it rather than inheriting this paragraph.
    */
   const [activeQueue, setActiveQueue] = useState<MountedQueueId | null>(null)
   /**

--- a/src/canvas/mutations/__tests__/mutationAuthority.spec.ts
+++ b/src/canvas/mutations/__tests__/mutationAuthority.spec.ts
@@ -146,9 +146,15 @@ describe('mutation authority is exhaustive and fail-closed', () => {
    * They asserted over `NODE_SETTER_AUTHORITY` / `EDGE_SETTER_AUTHORITY` —
    * that every Inspector setter was classified, and that none was classified
    * `'server_graph'`. Those two tables were the only readers of themselves:
-   * outside this file and their own definition, every reference was a COMMENT.
-   * So the tests proved a hand-maintained list agreed with itself, which is
-   * not the same as proving the Inspector is read-only.
+   * outside this file and their own definition, every reference was a comment
+   * or a documentation string, and none was a consumer. So the tests proved a
+   * hand-maintained list agreed with itself, which is not the same as proving
+   * the Inspector is read-only.
+   *
+   * ⚠ This read "every reference was a COMMENT" until 27 Aug 2026. That was
+   * false — `canvas/domain/analyticalNodeFields.ts:158` names the table in a
+   * runtime string literal that ships to browsers. The claim the deletion
+   * rests on is the narrow one: zero code CONSUMERS.
    *
    * What actually keeps it read-only is `InspectorRouter`'s unconditional
    * `<fieldset disabled>` around every panel. That is now pinned, per region

--- a/src/canvas/mutations/__tests__/mutationAuthority.spec.ts
+++ b/src/canvas/mutations/__tests__/mutationAuthority.spec.ts
@@ -5,12 +5,6 @@ import {
   hasServerGraphAuthority,
   type MutationAuthority,
 } from '../mutationAuthority'
-import {
-  EDGE_SETTER_AUTHORITY,
-  EDGE_SETTER_FIELDS,
-  NODE_SETTER_AUTHORITY,
-  NODE_SETTER_FIELDS,
-} from '../../ui/inspector-v2/useInspectorMutations'
 
 /**
  * Frozen, independently-written audit contract from Brief B3. This is
@@ -145,21 +139,26 @@ describe('mutation authority is exhaustive and fail-closed', () => {
     }
   })
 
-  it('classifies every Inspector setter, with no unowned write surface', () => {
-    expect(Object.keys(NODE_SETTER_AUTHORITY).sort()).toEqual(Object.keys(NODE_SETTER_FIELDS).sort())
-    expect(Object.keys(EDGE_SETTER_AUTHORITY).sort()).toEqual(Object.keys(EDGE_SETTER_FIELDS).sort())
-  })
-
-  it('mounts no Inspector semantic setter as a GraphV3 edit', () => {
-    expect(Object.values(NODE_SETTER_AUTHORITY)).not.toContain('server_graph')
-    expect(Object.values(NODE_SETTER_AUTHORITY)).toEqual(
-      expect.arrayContaining(Array(Object.keys(NODE_SETTER_AUTHORITY).length).fill('disabled')),
-    )
-    expect(Object.values(EDGE_SETTER_AUTHORITY)).toEqual(
-      expect.arrayContaining(Array(Object.keys(EDGE_SETTER_AUTHORITY).length).fill('disabled')),
-    )
-    expect(NODE_SETTER_AUTHORITY.setPriorRange).toBe('disabled')
-  })
+  /**
+   * ⭐ TWO TESTS WERE REMOVED HERE ON 26 Aug 2026, AND THE PROPERTY THEY NAMED
+   * DID NOT GO WITH THEM.
+   *
+   * They asserted over `NODE_SETTER_AUTHORITY` / `EDGE_SETTER_AUTHORITY` —
+   * that every Inspector setter was classified, and that none was classified
+   * `'server_graph'`. Those two tables were the only readers of themselves:
+   * outside this file and their own definition, every reference was a COMMENT.
+   * So the tests proved a hand-maintained list agreed with itself, which is
+   * not the same as proving the Inspector is read-only.
+   *
+   * What actually keeps it read-only is `InspectorRouter`'s unconditional
+   * `<fieldset disabled>` around every panel. That is now pinned, per region
+   * and by identity, in
+   * `canvas/ui/inspector-v2/__tests__/inspectorAuthorityBinding.spec.tsx`:
+   * the boundary exists, the notice renders `INSPECTOR_READ_ONLY_REASON`
+   * (the CONSTANT, not a substring of it), `aria-describedby` resolves to that
+   * notice, and no editing control inside the boundary is effectively enabled.
+   * Those hold however many setters exist, so no key list can fall behind.
+   */
 
   it('preserves only the receipt-bearing model actions as shared-model edits', () => {
     const graphEdits = Object.entries(CANONICAL_EDIT_AUTHORITY)

--- a/src/canvas/mutations/mutationAuthority.ts
+++ b/src/canvas/mutations/mutationAuthority.ts
@@ -5,6 +5,41 @@
  * receipt-bearing GraphV3 carrier. Keeping this policy independent of any
  * particular editor prevents the Model tab, Inspector and post-run surfaces
  * from inventing different definitions of "saved".
+ *
+ * ⭐⭐ THE QUESTION THIS TABLE ANSWERS, IN ONE SENTENCE, BECAUSE GETTING IT
+ * WRONG NEARLY COST US TWO WORKING FEATURES (26 Aug 2026):
+ *
+ *     "MAY THIS CONTROL **LOOK LIKE** A SHARED-MODEL EDIT?"
+ *
+ * It does NOT answer *"may this write happen?"*. Those are two different
+ * questions, and this is a PRESENTATION authority: every one of its consumers
+ * reads it into a `*_CONNECTED` boolean and uses that to decide what to RENDER
+ * — whether to show an affordance, disable it, or show honest copy instead.
+ * Not one consumer gates a store write with it.
+ *
+ * ⚠⚠ SO DO NOT WIRE IT INTO A WRITER. A proposal to make
+ * `useModelEditAuthority` consult this table was withdrawn after measurement:
+ * it would have used the answer to the first question to gate the second, and
+ * turned OFF `proposeOptionIntervention` and `proposeFactorConfirmation`.
+ * Both are marked `'disabled'` here — correctly, because neither has a
+ * receipt-bearing wire carrier — and BOTH ARE GENUINELY WORKING WRITES:
+ * `interventions` and `observedState` are `purposes: ['stale']` in
+ * `canvas/domain/analyticalNodeFields.ts`, "persisted by hash-by-default",
+ * absent from the three-field ephemeral denylist, and read by
+ * `hasAnalyticalNodeChange` (live in `store.ts`, `analyticalChange.ts`,
+ * `graphChangeDiff.ts`, `applyPatch.ts`). They persist, survive reload and are
+ * analysis-affecting. Disabling them would have removed the only way to say
+ * what an option does and the only way to confirm a factor value.
+ *
+ * `'disabled'` here therefore means *"this control must not present itself as
+ * a saved shared-model edit"* — never *"this write is fake"*. When a key has
+ * no consumer, that is UNENFORCED POLICY, not dead policy; the two need
+ * opposite treatments, so check which one you are looking at before deleting.
+ *
+ * ⭐ A DIFFERENT AUTHORITY GOVERNS THE INSPECTOR. Whether the Inspector's
+ * controls are reachable at all is decided structurally by
+ * `InspectorRouter`'s unconditional `<fieldset disabled>`, not by this table
+ * or by any manifest — see `ui/inspector-v2/useInspectorMutations.ts`.
  */
 export type MutationAuthority =
   | 'server_graph'

--- a/src/canvas/ui/inspector-v2/__tests__/FactorExternalPanel.priorRangeHonesty.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/FactorExternalPanel.priorRangeHonesty.spec.tsx
@@ -73,8 +73,12 @@
  *   · `InspectorRouter` wraps EVERY panel in an unconditional
  *     `<fieldset disabled data-authority="disabled">`
  *     (InspectorRouter.tsx:334-340), beneath INSPECTOR_READ_ONLY_REASON.
- *   · `NODE_SETTER_AUTHORITY.setPriorRange` is `'disabled'`
- *     (useInspectorMutations.ts:127) — the repo's own authority manifest.
+ *   ⚠ A second bullet stood here: "`NODE_SETTER_AUTHORITY.setPriorRange` is
+ *     `'disabled'` (useInspectorMutations.ts:127) — the repo's own authority
+ *     manifest". That manifest was DELETED on 27 Aug 2026 (PR #886) — zero
+ *     code consumers, an unenforced mirror — and the line number it cited now
+ *     points at unrelated code. Q2 rests on the fieldset bullet above, which
+ *     is the enforcement and was always the half doing the work.
  *   · Even the write would not settle it: `setPriorRange` updates the store and
  *     emits `prior_range_edit`, which CEE persists as a typed turn FACT and
  *     which writes no graph (useInspectorMutations.ts:293-295).

--- a/src/canvas/ui/inspector-v2/__tests__/inspectorAuthorityBinding.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/inspectorAuthorityBinding.spec.tsx
@@ -48,9 +48,13 @@
  *      ⚠ THAT IS NOT "STRONGER", AND THE FIRST VERSION OF THIS NOTE INVITED
  *      EXACTLY THAT READING (corrected 27 Aug 2026, measured). The two guards
  *      catch DIFFERENT things and NEITHER supersedes the other:
- *        · Gut the constant and the two PRE-EXISTING substring guards RED.
+ *        · Gut the constant and exactly two guards RED, and BOTH are
+ *          PRE-EXISTING — `InspectorRouter.spec.tsx:347` and
+ *          `FactorExternalPanel.priorRangeHonesty.spec.tsx:705`. This file's
+ *          17 stay GREEN. (Measured at this tip, applied-check 1, controls 0.)
  *        · Reword the constant to INVERT its meaning — "You may freely edit
- *          anything here" — and all 53 cases stay GREEN, this file's included,
+ *          anything here" — and every one of the 68 cases across the six specs
+ *          that reference the constant stays GREEN, this file's 17 included,
  *          because an equality-to-the-constant check moves WITH the constant.
  *      An identity check pins the WIRING; a substring check pins a fragment of
  *      the MEANING, and this file is the weaker of the two on meaning.

--- a/src/canvas/ui/inspector-v2/__tests__/inspectorAuthorityBinding.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/inspectorAuthorityBinding.spec.tsx
@@ -1,0 +1,328 @@
+/**
+ * The Inspector's read-only policy, pinned IN ITS ENFORCED FORM.
+ *
+ * ⭐ WHY THIS FILE EXISTS — the unenforced mirror is gone (26 Aug 2026).
+ * `useInspectorMutations.ts` used to carry two authority manifests,
+ * `NODE_SETTER_AUTHORITY` (21 keys) and `EDGE_SETTER_AUTHORITY` (5), every
+ * value `'disabled'`. They were DELETED because they had **zero code
+ * consumers**: every reference to either, outside their own definition and
+ * `mutationAuthority.spec.ts`, was a COMMENT. Nothing branched on them, so
+ * nothing could drift from them — and a table that cannot drift also cannot
+ * enforce. Contrast control at the time of deletion: `useNodeMutations` /
+ * `useEdgeMutations` were imported by 30+ files, so the sweep that returned
+ * zero for the tables was demonstrably able to see consumers.
+ *
+ * The ACTUAL enforcement was, and remains, structural: `InspectorRouter` wraps
+ * every panel — node and edge — in an unconditional
+ * `<fieldset disabled data-authority="disabled">`, beneath a note carrying
+ * `INSPECTOR_READ_ONLY_REASON`. That is strictly STRONGER than the manifests
+ * were: a fieldset disables every descendant control, so a NEW setter added
+ * tomorrow is inert without anyone remembering to classify it. The manifests
+ * could only ever record a decision; the fieldset makes it.
+ *
+ * ⚠ WHAT THE PRE-EXISTING GUARD DID NOT COVER, and why deleting the tables
+ * without this file would have left the fieldset UNEXPLAINED — an unexplained
+ * enforcement being the next thing someone tidies away:
+ *
+ *   1. `InspectorRouter.spec.tsx` asserts the notice contains the SUBSTRING
+ *      `'cannot yet be saved to the shared model'`. That is a hand-copied
+ *      mirror of the copy: inline the constant as a literal, or reword the
+ *      constant around that fragment, and it still passes. Here the expectation
+ *      IS the imported constant, so the copy and its guard cannot diverge.
+ *   2. NOTHING asserted the ARIA BINDING. Delete `aria-describedby` from the
+ *      fieldset and every pre-existing test stays green while the boundary
+ *      stops being announced to a screen reader — the control is inert and the
+ *      user is never told why. The binding is the half that makes the policy
+ *      legible, so it is pinned here by IDENTITY: the fieldset's
+ *      `aria-describedby` must resolve to the element that renders the reason.
+ *   3. The old tests asserted the FIELDSET element `toBeDisabled()`. That is a
+ *      property of the wrapper, not of anything a user can touch. A per-element
+ *      check is not an actionability check (an ancestor `<fieldset disabled>`
+ *      has defeated one before), so each case below finds a real focusable
+ *      control INSIDE the boundary and asserts the DOM reports it disabled.
+ *
+ * ── BINDING BY IDENTITY, AND THE DISCRIMINATING PAIR ────────────────────────
+ * `InspectorRouter` has TWO independent boundary regions — the edge branch
+ * (`InspectorRouter.tsx:221`) and the node branch (`:334`). Every assertion
+ * below names WHICH region it is about and resolves it through that region's
+ * own rendered panel, never through a bare
+ * `document.querySelector('fieldset')` that either region could satisfy.
+ * That is what makes the mutant pair discriminating: breaking ONE region must
+ * RED only that region's cases and leave the other GREEN. A single biting
+ * mutant would prove only sensitivity to *something*; the pair proves
+ * sensitivity to the named region.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, cleanup } from '@testing-library/react'
+
+import { InspectorRouter } from '../InspectorRouter'
+import { INSPECTOR_READ_ONLY_REASON } from '../useInspectorMutations'
+import { useCanvasStore } from '../../../store'
+
+vi.mock('@xyflow/react', () => ({
+  useViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+}))
+
+function setStoreState(nodes: unknown[], edges: unknown[] = []) {
+  useCanvasStore.setState({
+    nodes: nodes as never[],
+    edges: edges as never[],
+    results: { status: 'idle' },
+    selection: { nodeIds: new Set(), edgeIds: new Set(), anchorPosition: null },
+    goalThreshold: null,
+    confirmedNodeIds: new Set(),
+    _internal: {},
+  } as never)
+}
+
+const NODE_FIXTURE = [
+  {
+    id: 'r1',
+    type: 'risk',
+    data: { label: 'Operational risk', kind: 'risk', probability: 0.4, impact: 'medium' },
+    position: { x: 0, y: 0 },
+  },
+]
+
+/** A node kind whose panel renders a real editing INPUT (not only buttons). */
+const CONTROLLABLE_FACTOR_FIXTURE = [
+  {
+    id: 'f1',
+    type: 'factor',
+    data: {
+      label: 'Price',
+      kind: 'factor',
+      category: 'controllable',
+      observedState: { raw_value: 49, value: 0.49, unit: '£' },
+    },
+    position: { x: 0, y: 0 },
+  },
+]
+
+const EDGE_FIXTURE_NODES = [
+  { id: 'f1', type: 'factor', data: { label: 'Marketing' }, position: { x: 0, y: 0 } },
+  { id: 'g1', type: 'goal', data: { label: 'Revenue' }, position: { x: 0, y: 0 } },
+]
+const EDGE_FIXTURE_EDGES = [
+  { id: 'e1', source: 'f1', target: 'g1', data: { weight: 0.5, direction: 'positive' } },
+]
+
+/**
+ * Resolve the boundary and its explanation together.
+ *
+ * ⚠ PINS ITS OWN PRECONDITION. If the router rendered no boundary at all, a
+ * test asserting "everything inside is disabled" would pass VACUOUSLY over an
+ * empty set. So this throws unless the region exists AND contains at least one
+ * focusable control — the thing the policy is actually about.
+ */
+function readBoundary() {
+  const fieldset = document.querySelector<HTMLFieldSetElement>(
+    'fieldset[data-authority="disabled"]',
+  )
+  if (!fieldset) throw new Error('PRECONDITION FAILED: no authority boundary rendered')
+
+  const controls = Array.from(
+    fieldset.querySelectorAll<HTMLElement>('input, select, textarea, button'),
+  )
+  return { fieldset, controls }
+}
+
+describe('Inspector read-only policy — enforced form, node region', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cleanup()
+    setStoreState(NODE_FIXTURE)
+  })
+
+  it('renders the boundary around at least one real control (precondition, not a claim)', () => {
+    render(<InspectorRouter nodeId="r1" edgeId={null} onClose={vi.fn()} />)
+    const { controls } = readBoundary()
+    // If this ever reads zero, every disabled-ness assertion below is vacuous.
+    expect(controls.length).toBeGreaterThan(0)
+  })
+
+  it('explains the boundary with INSPECTOR_READ_ONLY_REASON — the constant, not a copy', () => {
+    render(<InspectorRouter nodeId="r1" edgeId={null} onClose={vi.fn()} />)
+    expect(screen.getByTestId('inspector-authority-notice')).toHaveTextContent(
+      INSPECTOR_READ_ONLY_REASON,
+    )
+  })
+
+  it('BINDS the boundary to that explanation via aria-describedby, by identity', () => {
+    render(<InspectorRouter nodeId="r1" edgeId={null} onClose={vi.fn()} />)
+    const { fieldset } = readBoundary()
+    const describedBy = fieldset.getAttribute('aria-describedby')
+    expect(describedBy).toBeTruthy()
+
+    // Resolve the id to the element it names, and require THAT element to be
+    // the one carrying the reason. An `aria-describedby` pointing at nothing,
+    // or at some other node, is a boundary the user is never told about.
+    const explanation = document.getElementById(describedBy as string)
+    expect(explanation).not.toBeNull()
+    expect(explanation).toHaveTextContent(INSPECTOR_READ_ONLY_REASON)
+    expect(explanation).toBe(screen.getByTestId('inspector-authority-notice'))
+  })
+
+  it('makes every control inside the boundary genuinely inert', () => {
+    render(<InspectorRouter nodeId="r1" edgeId={null} onClose={vi.fn()} />)
+    const { controls } = readBoundary()
+    for (const control of controls) {
+      expect(control).toBeDisabled()
+    }
+  })
+
+  it('POSITIVE CONTROL: the close affordance sits OUTSIDE the boundary and stays usable', () => {
+    render(<InspectorRouter nodeId="r1" edgeId={null} onClose={vi.fn()} />)
+    const { fieldset } = readBoundary()
+    const close = screen.getByRole('button', { name: /close/i })
+    // Proves the boundary is scoped, not a blanket "everything is disabled"
+    // reading that would pass even if the panel rendered nothing at all.
+    expect(fieldset.contains(close)).toBe(false)
+    expect(close).toBeEnabled()
+  })
+})
+
+describe('Inspector read-only policy — enforced form, edge region', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cleanup()
+    setStoreState(EDGE_FIXTURE_NODES, EDGE_FIXTURE_EDGES)
+  })
+
+  it('renders the boundary around at least one real control (precondition, not a claim)', () => {
+    render(<InspectorRouter nodeId={null} edgeId="e1" onClose={vi.fn()} />)
+    const { controls } = readBoundary()
+    expect(controls.length).toBeGreaterThan(0)
+  })
+
+  it('explains the boundary with INSPECTOR_READ_ONLY_REASON — the constant, not a copy', () => {
+    render(<InspectorRouter nodeId={null} edgeId="e1" onClose={vi.fn()} />)
+    expect(screen.getByTestId('inspector-authority-notice')).toHaveTextContent(
+      INSPECTOR_READ_ONLY_REASON,
+    )
+  })
+
+  it('BINDS the boundary to that explanation via aria-describedby, by identity', () => {
+    render(<InspectorRouter nodeId={null} edgeId="e1" onClose={vi.fn()} />)
+    const { fieldset } = readBoundary()
+    const describedBy = fieldset.getAttribute('aria-describedby')
+    expect(describedBy).toBeTruthy()
+
+    const explanation = document.getElementById(describedBy as string)
+    expect(explanation).not.toBeNull()
+    expect(explanation).toHaveTextContent(INSPECTOR_READ_ONLY_REASON)
+    expect(explanation).toBe(screen.getByTestId('inspector-authority-notice'))
+  })
+
+  it('makes every control inside the boundary genuinely inert', () => {
+    render(<InspectorRouter nodeId={null} edgeId="e1" onClose={vi.fn()} />)
+    const { controls } = readBoundary()
+    for (const control of controls) {
+      expect(control).toBeDisabled()
+    }
+  })
+})
+
+/**
+ * ⭐ THE REPLACEMENT FOR THE DELETED COMPLETENESS GUARD.
+ *
+ * `mutationAuthority.spec.ts` used to assert that every key of
+ * `NODE_SETTER_FIELDS` / `EDGE_SETTER_FIELDS` appeared in the corresponding
+ * manifest — a completeness check over the PROSE. What actually matters is
+ * that no Inspector control escapes the boundary, and that is a property of
+ * the DOM, not of a table: the assertions below hold no matter how many
+ * setters exist, which is precisely why they cannot go stale the way a
+ * hand-maintained key list did.
+ *
+ * ⚠⚠ AND THE INSTRUMENT TRAP THIS FILE HIT WHILE BEING WRITTEN, KEPT BECAUSE
+ * THE NEXT PERSON WILL HIT IT TOO. The first version of these two cases
+ * filtered on the RAW DOM PROPERTY `(el as HTMLInputElement).disabled`. It
+ * FAILED, reporting two enabled `<input type="range">` inside a fieldset that
+ * is unambiguously `disabled` — because **jsdom reflects the `disabled`
+ * ATTRIBUTE and does not propagate a `<fieldset disabled>` to its
+ * descendants' property.** In a real browser those inputs are inert; in jsdom
+ * the property says otherwise.
+ *
+ * So the raw property is not an actionability check — it is a check on where
+ * the attribute happens to be written. `expect(el).toBeDisabled()` IS
+ * ancestor-aware (jest-dom walks up for a disabled fieldset), which is why the
+ * per-region cases above passed while this block failed on the same DOM. The
+ * helper below derives effective disabled-ness explicitly rather than trusting
+ * either reflection, so the assertion means what it says.
+ *
+ * Had it been left as written, the "fix" would have looked like removing the
+ * assertion or narrowing it past the sliders — weakening a guard to match a
+ * broken probe.
+ */
+function isEffectivelyDisabled(el: HTMLElement): boolean {
+  if ((el as HTMLInputElement).disabled) return true
+  // Walk ancestors for a disabled <fieldset>, which natively disables every
+  // descendant control (outside its first <legend>).
+  let ancestor: HTMLElement | null = el.parentElement
+  while (ancestor) {
+    if (ancestor.tagName === 'FIELDSET' && ancestor.hasAttribute('disabled')) return true
+    ancestor = ancestor.parentElement
+  }
+  return false
+}
+
+describe('Inspector read-only policy — no control escapes the boundary', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    cleanup()
+  })
+
+  it('leaves no effectively-enabled editing control anywhere in the node panel', () => {
+    // ⚠ NOT the risk fixture used above. The risk panel renders only <button>
+    // controls, so this completeness claim over input/select/textarea was
+    // VACUOUS against it — caught by the precondition below, which is the
+    // whole reason the precondition is written as an assertion rather than a
+    // comment. A controllable factor renders a real number input, so the
+    // claim has something to be true ABOUT.
+    setStoreState(CONTROLLABLE_FACTOR_FIXTURE)
+    render(<InspectorRouter nodeId="f1" edgeId={null} onClose={vi.fn()} />)
+
+    const { fieldset } = readBoundary()
+    const editing = Array.from(
+      fieldset.querySelectorAll<HTMLElement>('input, select, textarea'),
+    )
+    // Precondition: a completeness claim over an empty set is vacuous.
+    expect(editing.length).toBeGreaterThan(0)
+
+    const escaped = editing.filter(el => !isEffectivelyDisabled(el))
+    expect(escaped.map(el => el.getAttribute('aria-label') ?? el.tagName)).toEqual([])
+  })
+
+  it('leaves no effectively-enabled editing control anywhere in the edge panel', () => {
+    setStoreState(EDGE_FIXTURE_NODES, EDGE_FIXTURE_EDGES)
+    render(<InspectorRouter nodeId={null} edgeId="e1" onClose={vi.fn()} />)
+
+    const { fieldset } = readBoundary()
+    const editing = Array.from(
+      fieldset.querySelectorAll<HTMLElement>('input, select, textarea'),
+    )
+    expect(editing.length).toBeGreaterThan(0)
+
+    const escaped = editing.filter(el => !isEffectivelyDisabled(el))
+    expect(escaped.map(el => el.getAttribute('aria-label') ?? el.tagName)).toEqual([])
+  })
+
+  it('POSITIVE CONTROL: the helper reports an ungoverned control as NOT disabled', () => {
+    // Without this, `isEffectivelyDisabled` returning `true` unconditionally
+    // would make both cases above pass while observing nothing (trap 13 — an
+    // absence probe needs to be shown capable of detecting a presence).
+    const loose = document.createElement('input')
+    document.body.appendChild(loose)
+    expect(isEffectivelyDisabled(loose)).toBe(false)
+
+    const guarded = document.createElement('fieldset')
+    guarded.setAttribute('disabled', '')
+    const inner = document.createElement('input')
+    guarded.appendChild(inner)
+    document.body.appendChild(guarded)
+    expect(isEffectivelyDisabled(inner)).toBe(true)
+
+    loose.remove()
+    guarded.remove()
+  })
+})

--- a/src/canvas/ui/inspector-v2/__tests__/inspectorAuthorityBinding.spec.tsx
+++ b/src/canvas/ui/inspector-v2/__tests__/inspectorAuthorityBinding.spec.tsx
@@ -6,29 +6,56 @@
  * `NODE_SETTER_AUTHORITY` (21 keys) and `EDGE_SETTER_AUTHORITY` (5), every
  * value `'disabled'`. They were DELETED because they had **zero code
  * consumers**: every reference to either, outside their own definition and
- * `mutationAuthority.spec.ts`, was a COMMENT. Nothing branched on them, so
- * nothing could drift from them — and a table that cannot drift also cannot
- * enforce. Contrast control at the time of deletion: `useNodeMutations` /
- * `useEdgeMutations` were imported by 30+ files, so the sweep that returned
- * zero for the tables was demonstrably able to see consumers.
+ * `mutationAuthority.spec.ts`, was a comment or a documentation string, and
+ * NONE WAS A CONSUMER. Nothing branched on them, so nothing could drift from
+ * them — and a table that cannot drift also cannot enforce. Contrast control
+ * at the time of deletion: `useNodeMutations` / `useEdgeMutations` were
+ * imported by 30+ files, so the sweep that returned zero for the tables was
+ * demonstrably able to see consumers.
+ *
+ * ⚠ "was a COMMENT" is what this said until 27 Aug 2026, and it was false:
+ * `canvas/domain/analyticalNodeFields.ts:158` names the table in a RUNTIME
+ * STRING LITERAL that ships to browsers. The narrow claim — zero code
+ * CONSUMERS — is true and is the one the deletion rests on. See
+ * `useInspectorMutations.ts` for the full correction.
  *
  * The ACTUAL enforcement was, and remains, structural: `InspectorRouter` wraps
  * every panel — node and edge — in an unconditional
  * `<fieldset disabled data-authority="disabled">`, beneath a note carrying
- * `INSPECTOR_READ_ONLY_REASON`. That is strictly STRONGER than the manifests
- * were: a fieldset disables every descendant control, so a NEW setter added
- * tomorrow is inert without anyone remembering to classify it. The manifests
- * could only ever record a decision; the fieldset makes it.
+ * `INSPECTOR_READ_ONLY_REASON`. That is STRUCTURAL where the manifests were
+ * clerical: a fieldset disables every descendant FORM CONTROL, so a NEW setter
+ * added tomorrow is inert without anyone remembering to classify it — provided
+ * it is a form control. The manifests could only ever record a decision; the
+ * fieldset makes it.
+ *
+ * ⚠ THIS SAID "strictly STRONGER … every descendant control" UNTIL
+ * 27 Aug 2026, AND EXECUTION REFUTED IT. `<fieldset disabled>` inerts
+ * form-associated descendants only — not a `[role="button"]` div, not a
+ * `[contenteditable]`, not an `a[href]`. The exact scope, the measured
+ * counter-example, and the BOUND on it (**no write escapes**, and user
+ * reachability was explicitly NOT claimed) are in `useInspectorMutations.ts`
+ * and pinned below as `NOT_INERTED_BY_THE_FIELDSET_NODE`.
  *
  * ⚠ WHAT THE PRE-EXISTING GUARD DID NOT COVER, and why deleting the tables
  * without this file would have left the fieldset UNEXPLAINED — an unexplained
  * enforcement being the next thing someone tidies away:
  *
  *   1. `InspectorRouter.spec.tsx` asserts the notice contains the SUBSTRING
- *      `'cannot yet be saved to the shared model'`. That is a hand-copied
- *      mirror of the copy: inline the constant as a literal, or reword the
- *      constant around that fragment, and it still passes. Here the expectation
- *      IS the imported constant, so the copy and its guard cannot diverge.
+ *      `'cannot yet be saved to the shared model'` — a hand-copied mirror of
+ *      the copy. Here the expectation IS the imported constant, so the copy
+ *      and its guard cannot diverge by hand-copying.
+ *
+ *      ⚠ THAT IS NOT "STRONGER", AND THE FIRST VERSION OF THIS NOTE INVITED
+ *      EXACTLY THAT READING (corrected 27 Aug 2026, measured). The two guards
+ *      catch DIFFERENT things and NEITHER supersedes the other:
+ *        · Gut the constant and the two PRE-EXISTING substring guards RED.
+ *        · Reword the constant to INVERT its meaning — "You may freely edit
+ *          anything here" — and all 53 cases stay GREEN, this file's included,
+ *          because an equality-to-the-constant check moves WITH the constant.
+ *      An identity check pins the WIRING; a substring check pins a fragment of
+ *      the MEANING, and this file is the weaker of the two on meaning.
+ *      **Keep both. Do not delete the substring guards on the strength of this
+ *      file** — that is precisely the tidy-up this note exists to prevent.
  *   2. NOTHING asserted the ARIA BINDING. Delete `aria-describedby` from the
  *      fieldset and every pre-existing test stays green while the boundary
  *      stops being announced to a screen reader — the control is inert and the
@@ -41,16 +68,28 @@
  *      has defeated one before), so each case below finds a real focusable
  *      control INSIDE the boundary and asserts the DOM reports it disabled.
  *
- * ── BINDING BY IDENTITY, AND THE DISCRIMINATING PAIR ────────────────────────
+ * ── WHAT MAKES THE MUTANT PAIR DISCRIMINATING ───────────────────────────────
  * `InspectorRouter` has TWO independent boundary regions — the edge branch
- * (`InspectorRouter.tsx:221`) and the node branch (`:334`). Every assertion
- * below names WHICH region it is about and resolves it through that region's
- * own rendered panel, never through a bare
- * `document.querySelector('fieldset')` that either region could satisfy.
- * That is what makes the mutant pair discriminating: breaking ONE region must
+ * (`InspectorRouter.tsx:221`) and the node branch (`:334`). Breaking ONE must
  * RED only that region's cases and leave the other GREEN. A single biting
- * mutant would prove only sensitivity to *something*; the pair proves
- * sensitivity to the named region.
+ * mutant proves only sensitivity to *something*; the pair proves sensitivity
+ * to the named region, and the pair has been run.
+ *
+ * ⚠ BUT NOT BY THE MECHANISM THIS COMMENT ORIGINALLY CLAIMED (corrected
+ * 27 Aug 2026). It said each assertion resolves its region "never through a
+ * bare `document.querySelector('fieldset')` that either region could satisfy"
+ * — and `readBoundary()` below is exactly a bare document-level query. The
+ * discrimination is REAL, and it comes from the FIXTURE, not from the
+ * selector: each `describe` seeds the store with only nodes or only an edge
+ * and renders `InspectorRouter` with only `nodeId` or only `edgeId`, so
+ * exactly one branch is ever mounted and the document holds exactly one
+ * boundary. `readBoundary()` throws if there is none, which is what stops the
+ * query being vacuous rather than any scoping in the selector.
+ *
+ * State the real mechanism, because it is what a future edit will get wrong:
+ * the discrimination lives in the PER-`describe` FIXTURE and would be LOST by
+ * a refactor that rendered both regions in one test. If you ever do that,
+ * scope the queries to the rendered region instead of to `document`.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, cleanup } from '@testing-library/react'
@@ -230,34 +269,140 @@ describe('Inspector read-only policy — enforced form, edge region', () => {
  * `NODE_SETTER_FIELDS` / `EDGE_SETTER_FIELDS` appeared in the corresponding
  * manifest — a completeness check over the PROSE. What actually matters is
  * that no Inspector control escapes the boundary, and that is a property of
- * the DOM, not of a table: the assertions below hold no matter how many
- * setters exist, which is precisely why they cannot go stale the way a
- * hand-maintained key list did.
+ * the DOM, not of a table.
  *
- * ⚠⚠ AND THE INSTRUMENT TRAP THIS FILE HIT WHILE BEING WRITTEN, KEPT BECAUSE
- * THE NEXT PERSON WILL HIT IT TOO. The first version of these two cases
- * filtered on the RAW DOM PROPERTY `(el as HTMLInputElement).disabled`. It
- * FAILED, reporting two enabled `<input type="range">` inside a fieldset that
- * is unambiguously `disabled` — because **jsdom reflects the `disabled`
- * ATTRIBUTE and does not propagate a `<fieldset disabled>` to its
- * descendants' property.** In a real browser those inputs are inert; in jsdom
- * the property says otherwise.
+ * ⚠⚠ AND THE FIRST VERSION OF THIS BLOCK COULD NOT OBSERVE THAT PROPERTY AT
+ * ALL. Corrected 27 Aug 2026 after an independent review MEASURED it, and the
+ * measurement is kept here because it is the whole reason the shape below is
+ * what it is:
  *
- * So the raw property is not an actionability check — it is a check on where
- * the attribute happens to be written. `expect(el).toBeDisabled()` IS
- * ancestor-aware (jest-dom walks up for a disabled fieldset), which is why the
- * per-region cases above passed while this block failed on the same DOM. The
- * helper below derives effective disabled-ness explicitly rather than trusting
- * either reflection, so the assertion means what it says.
+ *   Mutant M5 added an enabled `<input aria-label="ESCAPED_EDITOR" />` to the
+ *   `InspectorShell` HEADER — inside the Inspector, OUTSIDE the fieldset.
+ *   Applied-check scoped to `src/`: exactly 1 file, 1 insertion.
+ *   The suite stayed **12/12 GREEN**.
  *
- * Had it been left as written, the "fix" would have looked like removing the
- * assertion or narrowing it past the sliders — weakening a guard to match a
- * broken probe.
+ * The mechanism: both cases built their candidate set from
+ * `fieldset.querySelectorAll(...)`, so every member had the disabled fieldset
+ * as an ancestor and `isEffectivelyDisabled` was true BY CONSTRUCTION.
+ * `escaped` could only be non-empty if the fieldset itself lost `disabled` —
+ * which the sibling case "makes every control inside the boundary genuinely
+ * inert" already measures. It was a DUPLICATE of its sibling wearing the name
+ * of the guard it replaced. **A guard that cannot fail in the way its name
+ * claims is worse than no guard, because it retires the question.**
+ *
+ * ── WHAT THE CASES BELOW ACTUALLY ASSERT ────────────────────────────────────
+ * The escape question is a claim about the WHOLE Inspector, so it is asked of
+ * the whole rendered region and not of the boundary's own subtree:
+ *
+ *   escaped = (every control in the Inspector region)
+ *           − (everything inside the boundary)
+ *           − (the deliberately-outside set, pinned by identity below)
+ *
+ * and `escaped` must be empty. That REDs on M5, and on the realistic version
+ * of M5: `InspectorRouter` passes no `onLabelChange`, so `EditableLabel`
+ * renders a bare `<span>` (`EditableLabel.tsx:124-130`). Wire that prop and a
+ * `<button data-testid="inspector-rename-trigger">` appears in the header,
+ * outside the fieldset, opening an `<input>` that writes the label — i.e.
+ * `setLabel`, which was a key of the deleted `NODE_SETTER_AUTHORITY`. That is
+ * the escape class the manifest was nominally about, and this is the guard
+ * that would catch it.
+ *
+ * The selector is widened past form controls on purpose — `[role="button"]`,
+ * `[contenteditable]` and `a[href]` are how a write surface arrives WITHOUT
+ * being a form control, and the section below records why that distinction is
+ * load-bearing here.
  */
+
+/** The Inspector's outermost rendered element — `InspectorShell.tsx:88-94`. */
+const INSPECTOR_REGION = '[role="region"][aria-label="Inspector panel"]'
+
+/**
+ * Anything a user can press, type into, or follow. Deliberately wider than
+ * `input, select, textarea` — see `NOT_INERTED_BY_THE_FIELDSET` below.
+ */
+const EDITING_SELECTOR =
+  'input, select, textarea, button, [role="button"], [contenteditable], a[href]'
+
+/** The four element types `<fieldset disabled>` actually inerts, per the HTML spec. */
+const NATIVELY_DISABLEABLE = 'button, input, select, textarea'
+
+/**
+ * Chrome that sits OUTSIDE the boundary ON PURPOSE. None of these writes the
+ * model: they navigate, dismiss, or toggle presentation.
+ *
+ * ⚠ A SUBTRACTION LIST IS A HAND-MAINTAINED MIRROR (trap 12), so it is fenced
+ * two ways: every entry MUST match at least one element (a renamed or removed
+ * affordance REDs here instead of silently widening the guard), and every
+ * match MUST resolve outside the boundary (so an allowlisted identity cannot
+ * be reused INSIDE the fieldset to launder a control past the escape check).
+ * Identity only — a value predicate another element could satisfy is trap 19.
+ */
+const DELIBERATELY_OUTSIDE: ReadonlyArray<{ selector: string; why: string }> = [
+  { selector: '[data-testid="inspector-back-to-results"]', why: 'navigation' },
+  { selector: '[aria-label="Show technical detail"]', why: 'presentation toggle' },
+  { selector: '[aria-label="Close inspector"]', why: 'dismissal' },
+  { selector: '[data-testid="inspector-quick-analysis"]', why: 'navigation' },
+]
+
+function describeControl(el: Element): string {
+  const id =
+    el.getAttribute('data-testid') ??
+    el.getAttribute('aria-label') ??
+    (el.textContent ?? '').trim().slice(0, 40)
+  return `<${el.tagName.toLowerCase()}> ${id}`
+}
+
+/**
+ * Every control in the Inspector that is neither inside the boundary nor
+ * deliberately outside it. Non-empty means a write surface has escaped.
+ */
+function escapedControls(): string[] {
+  const region = document.querySelector<HTMLElement>(INSPECTOR_REGION)
+  if (!region) throw new Error('PRECONDITION FAILED: no Inspector region rendered')
+  const fieldset = document.querySelector<HTMLElement>('fieldset[data-authority="disabled"]')
+  if (!fieldset) throw new Error('PRECONDITION FAILED: no authority boundary rendered')
+
+  const allowed = new Set<Element>()
+  for (const { selector } of DELIBERATELY_OUTSIDE) {
+    const matches = Array.from(region.querySelectorAll(selector))
+    // Fails loud rather than quietly excusing one control fewer.
+    expect(matches.length, `deliberately-outside entry matched nothing: ${selector}`)
+      .toBeGreaterThan(0)
+    for (const match of matches) {
+      expect(
+        fieldset.contains(match),
+        `deliberately-outside entry resolved INSIDE the boundary: ${selector}`,
+      ).toBe(false)
+      allowed.add(match)
+    }
+  }
+
+  return Array.from(region.querySelectorAll<HTMLElement>(EDITING_SELECTOR))
+    .filter(el => !fieldset.contains(el) && !allowed.has(el))
+    .map(describeControl)
+}
+
 function isEffectivelyDisabled(el: HTMLElement): boolean {
   if ((el as HTMLInputElement).disabled) return true
   // Walk ancestors for a disabled <fieldset>, which natively disables every
-  // descendant control (outside its first <legend>).
+  // descendant FORM CONTROL (outside its first <legend>).
+  //
+  // ⚠ THE INSTRUMENT TRAP THIS FILE HIT WHILE BEING WRITTEN, kept because the
+  // next person will hit it too. The first version filtered on the RAW DOM
+  // PROPERTY `(el as HTMLInputElement).disabled` alone. It FAILED, reporting
+  // two enabled `<input type="range">` inside a fieldset that is unambiguously
+  // `disabled` — because jsdom reflects the `disabled` ATTRIBUTE and does not
+  // propagate a `<fieldset disabled>` to its descendants' property. In a real
+  // browser those inputs are inert; in jsdom the property says otherwise. So
+  // the raw property is not an actionability check, it is a check on where the
+  // attribute happens to be written. Had it been left as written, the "fix"
+  // would have looked like removing the assertion or narrowing it past the
+  // sliders — weakening a guard to match a broken probe.
+  //
+  // ⚠ AND THE LIMIT OF THIS HELPER, WHICH IS A FACT ABOUT THE PLATFORM AND NOT
+  // A BUG IN THE HELPER: it is only sound for `NATIVELY_DISABLEABLE` elements.
+  // Callers must not hand it a `[role="button"]` div — see the pinned set
+  // below, which is where that case is recorded instead.
   let ancestor: HTMLElement | null = el.parentElement
   while (ancestor) {
     if (ancestor.tagName === 'FIELDSET' && ancestor.hasAttribute('disabled')) return true
@@ -266,51 +411,120 @@ function isEffectivelyDisabled(el: HTMLElement): boolean {
   return false
 }
 
+/** Controls inside the boundary that `<fieldset disabled>` does NOT inert. */
+function notInertedInsideBoundary(): string[] {
+  const fieldset = document.querySelector<HTMLElement>('fieldset[data-authority="disabled"]')
+  if (!fieldset) throw new Error('PRECONDITION FAILED: no authority boundary rendered')
+  return Array.from(fieldset.querySelectorAll<HTMLElement>(EDITING_SELECTOR))
+    .filter(el => !el.matches(NATIVELY_DISABLEABLE))
+    .map(describeControl)
+}
+
 describe('Inspector read-only policy — no control escapes the boundary', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     cleanup()
   })
 
-  it('leaves no effectively-enabled editing control anywhere in the node panel', () => {
-    // ⚠ NOT the risk fixture used above. The risk panel renders only <button>
-    // controls, so this completeness claim over input/select/textarea was
-    // VACUOUS against it — caught by the precondition below, which is the
-    // whole reason the precondition is written as an assertion rather than a
-    // comment. A controllable factor renders a real number input, so the
-    // claim has something to be true ABOUT.
+  it('leaves no editing control outside the boundary in the node panel', () => {
+    // ⚠ NOT the risk fixture used above. A controllable factor renders a real
+    // number input inside the boundary, so the boundary has something to be
+    // true ABOUT rather than only buttons.
     setStoreState(CONTROLLABLE_FACTOR_FIXTURE)
     render(<InspectorRouter nodeId="f1" edgeId={null} onClose={vi.fn()} />)
-
-    const { fieldset } = readBoundary()
-    const editing = Array.from(
-      fieldset.querySelectorAll<HTMLElement>('input, select, textarea'),
-    )
-    // Precondition: a completeness claim over an empty set is vacuous.
-    expect(editing.length).toBeGreaterThan(0)
-
-    const escaped = editing.filter(el => !isEffectivelyDisabled(el))
-    expect(escaped.map(el => el.getAttribute('aria-label') ?? el.tagName)).toEqual([])
+    expect(escapedControls()).toEqual([])
   })
 
-  it('leaves no effectively-enabled editing control anywhere in the edge panel', () => {
+  it('leaves no editing control outside the boundary in the edge panel', () => {
     setStoreState(EDGE_FIXTURE_NODES, EDGE_FIXTURE_EDGES)
     render(<InspectorRouter nodeId={null} edgeId="e1" onClose={vi.fn()} />)
+    expect(escapedControls()).toEqual([])
+  })
 
+  it('leaves no effectively-enabled FORM CONTROL inside the node boundary', () => {
+    setStoreState(CONTROLLABLE_FACTOR_FIXTURE)
+    render(<InspectorRouter nodeId="f1" edgeId={null} onClose={vi.fn()} />)
     const { fieldset } = readBoundary()
-    const editing = Array.from(
-      fieldset.querySelectorAll<HTMLElement>('input, select, textarea'),
+    const formControls = Array.from(
+      fieldset.querySelectorAll<HTMLElement>(NATIVELY_DISABLEABLE),
     )
-    expect(editing.length).toBeGreaterThan(0)
+    // Precondition: a completeness claim over an empty set is vacuous.
+    expect(formControls.length).toBeGreaterThan(0)
+    expect(formControls.filter(el => !isEffectivelyDisabled(el)).map(describeControl)).toEqual([])
+  })
 
-    const escaped = editing.filter(el => !isEffectivelyDisabled(el))
-    expect(escaped.map(el => el.getAttribute('aria-label') ?? el.tagName)).toEqual([])
+  it('leaves no effectively-enabled FORM CONTROL inside the edge boundary', () => {
+    setStoreState(EDGE_FIXTURE_NODES, EDGE_FIXTURE_EDGES)
+    render(<InspectorRouter nodeId={null} edgeId="e1" onClose={vi.fn()} />)
+    const { fieldset } = readBoundary()
+    const formControls = Array.from(
+      fieldset.querySelectorAll<HTMLElement>(NATIVELY_DISABLEABLE),
+    )
+    expect(formControls.length).toBeGreaterThan(0)
+    expect(formControls.filter(el => !isEffectivelyDisabled(el)).map(describeControl)).toEqual([])
+  })
+
+  /**
+   * ⭐ THE KNOWN SCOPE LIMIT OF `<fieldset disabled>`, PINNED SO THE SUITE CAN
+   * SEE IT RATHER THAN ONLY THIS COMMENT.
+   *
+   * A fieldset inerts FORM CONTROLS. It does not inert a `[role="button"]`
+   * div, a `[contenteditable]`, or an `a[href]`. An independent review
+   * measured one such div inside this boundary — `EmptyDescriptionPrompt`,
+   * `tabindex=0` — taking focus, firing its handler and opening an editor,
+   * while the two real `<button>`s beside it were disabled in the same run.
+   *
+   * ⚠ THE BOUND ON THAT FINDING, CARRIED EXACTLY AND NOT UPGRADED: **NO WRITE
+   * ESCAPES.** The `<textarea>` that opens is itself inside the fieldset and
+   * natively disabled. The review explicitly DECLINED to claim user
+   * reachability, because the store write it exercised came from a synthetic
+   * `fireEvent.change` that bypasses the browser's own gating. So this is a
+   * recorded scope limit of the MECHANISM, not a known user-facing defect —
+   * do not cite it as one, and do not widen it without measuring it yourself.
+   *
+   * The set is pinned EXACTLY, so it REDs if it GROWS (a new non-form control
+   * appears inside the boundary and needs adjudicating) or SHRINKS (someone
+   * made one inert, and this note plus the sentence in
+   * `useInspectorMutations.ts` should be updated to say so). A gap recorded in
+   * the suite is honest; a gap visible only to a comment is how it gets lost.
+   */
+  const NOT_INERTED_BY_THE_FIELDSET_NODE = [
+    '<div> What is this factor and why does it matter?',
+  ]
+
+  it('pins EXACTLY which controls the fieldset does not inert (node panel)', () => {
+    setStoreState(CONTROLLABLE_FACTOR_FIXTURE)
+    render(<InspectorRouter nodeId="f1" edgeId={null} onClose={vi.fn()} />)
+    expect(notInertedInsideBoundary()).toEqual(NOT_INERTED_BY_THE_FIELDSET_NODE)
+  })
+
+  it('pins EXACTLY which controls the fieldset does not inert (edge panel)', () => {
+    setStoreState(EDGE_FIXTURE_NODES, EDGE_FIXTURE_EDGES)
+    render(<InspectorRouter nodeId={null} edgeId="e1" onClose={vi.fn()} />)
+    expect(notInertedInsideBoundary()).toEqual([])
+  })
+
+  it('POSITIVE CONTROL: the escape check can SEE an escape', () => {
+    // Without this, `escapedControls()` returning `[]` unconditionally would
+    // make both escape cases pass while observing nothing (trap 13 — an
+    // absence probe must be shown capable of detecting a presence). This is
+    // the M5 shape, injected directly: an enabled control inside the Inspector
+    // region and outside the boundary.
+    setStoreState(CONTROLLABLE_FACTOR_FIXTURE)
+    render(<InspectorRouter nodeId="f1" edgeId={null} onClose={vi.fn()} />)
+    expect(escapedControls()).toEqual([])
+
+    const region = document.querySelector<HTMLElement>(INSPECTOR_REGION)!
+    const escapee = document.createElement('input')
+    escapee.setAttribute('aria-label', 'ESCAPED_EDITOR')
+    region.appendChild(escapee)
+    expect(escapedControls()).toEqual(['<input> ESCAPED_EDITOR'])
+
+    escapee.remove()
+    expect(escapedControls()).toEqual([])
   })
 
   it('POSITIVE CONTROL: the helper reports an ungoverned control as NOT disabled', () => {
-    // Without this, `isEffectivelyDisabled` returning `true` unconditionally
-    // would make both cases above pass while observing nothing (trap 13 — an
-    // absence probe needs to be shown capable of detecting a presence).
     const loose = document.createElement('input')
     document.body.appendChild(loose)
     expect(isEffectivelyDisabled(loose)).toBe(false)

--- a/src/canvas/ui/inspector-v2/coachingConfig.ts
+++ b/src/canvas/ui/inspector-v2/coachingConfig.ts
@@ -74,9 +74,11 @@ export const COACHING = {
    * What is entitled here, per this file's own header: the factor's declared
    * TYPE supports "source of uncertainty"; the field's declared role supports
    * "analysis input". What is NOT entitled is any advice to go and set it —
-   * `NODE_SETTER_AUTHORITY.setPriorRange` is `'disabled'` and the Inspector is
-   * wrapped in a disabled fieldset, so the only action this card's button
-   * performs is `handleAsk`. The nudge therefore points at asking, which is
+   * the Inspector is wrapped in an unconditional disabled fieldset, so the
+   * only action this card's button performs is `handleAsk`. (This sentence
+   * also cited `NODE_SETTER_AUTHORITY.setPriorRange`; that manifest was
+   * deleted on 27 Aug 2026, PR #886, as an unenforced mirror with zero code
+   * consumers. The fieldset is the enforcement.) The nudge therefore points at asking, which is
    * exactly what the button does.
    */
   factorExternalUncertainty: 'This is a source of uncertainty. Its recorded range is an analysis input, so it is worth asking whether that range reflects what you know.',

--- a/src/canvas/ui/inspector-v2/panels/FactorExternalPanel.tsx
+++ b/src/canvas/ui/inspector-v2/panels/FactorExternalPanel.tsx
@@ -196,8 +196,13 @@ export const FactorExternalPanel = memo(function FactorExternalPanel({
    * panel in an unconditional `<fieldset disabled>` beneath
    * INSPECTOR_READ_ONLY_REASON (`InspectorRouter.tsx:334-340`, pinned by
    * `InspectorRouter.spec.tsx` "semantic controls fail closed without GraphV3
-   * authority"), and `NODE_SETTER_AUTHORITY.setPriorRange` is `'disabled'`. On
-   * the deployed build this control is mounted and INERT. These tiers state
+   * authority"). On the deployed build this control is mounted and INERT.
+   *
+   * ⚠ THIS ALSO CITED `NODE_SETTER_AUTHORITY.setPriorRange` AS A SECOND
+   * AUTHORITY. That manifest was DELETED on 27 Aug 2026 (PR #886) because it
+   * had zero code consumers — it RECORDED the verdict, it never MADE it. The
+   * fieldset above is the whole enforcement and always was, so nothing about
+   * this control's inertness changed with the deletion. These tiers state
    * what is true of the FACTOR; the role note states what the RANGE is and
    * that it cannot be set here; neither tells anyone to act.
    */
@@ -416,10 +421,14 @@ export const FactorExternalPanel = memo(function FactorExternalPanel({
             Q2 is a fact about this SURFACE, and it is why the sentence is not
             simply "It affects analysis." The inspector is read-only:
             `InspectorRouter` wraps every panel in an unconditional `<fieldset
-            disabled>` (InspectorRouter.tsx:334-340), and this repo's own
-            authority manifest records the verdict directly —
-            `NODE_SETTER_AUTHORITY.setPriorRange: 'disabled'`. No affordance on
-            this panel can write the field. Even the local write would not
+            disabled>` (InspectorRouter.tsx:334-340). No affordance on
+            this panel can write the field.
+
+            ⚠ A second clause here cited "this repo's own authority manifest"
+            (`NODE_SETTER_AUTHORITY.setPriorRange: 'disabled'`). It was deleted
+            on 27 Aug 2026 (PR #886) as an unenforced mirror — zero code
+            consumers — so the fieldset is now the only citation, which is what
+            it always was in fact. Q2's claim is unchanged. Even the local write would not
             settle it: `setPriorRange` updates the store and emits
             `prior_range_edit`, which CEE persists as a typed turn FACT and
             which writes no graph.

--- a/src/canvas/ui/inspector-v2/useInspectorMutations.ts
+++ b/src/canvas/ui/inspector-v2/useInspectorMutations.ts
@@ -103,22 +103,60 @@ export const EDITOR_WRITTEN_FIELDS = {
  * and `EDGE_SETTER_AUTHORITY` (5), every value `'disabled'`. They were DELETED
  * on 26 Aug 2026 because they had **zero code consumers**: outside their own
  * definition and `mutationAuthority.spec.ts`, every reference to either was a
- * COMMENT. Nothing branched on them. A table nothing reads cannot drift — and
- * cannot enforce either; it was a hand-maintained mirror of a decision that is
- * actually made somewhere else.
+ * comment or a documentation string, and NONE WAS A CONSUMER. Nothing branched
+ * on them. A table nothing reads cannot drift — and cannot enforce either; it
+ * was a hand-maintained mirror of a decision that is actually made somewhere
+ * else.
+ *
+ * ⚠ THAT SENTENCE SAID "every reference … was a COMMENT" UNTIL 27 Aug 2026,
+ * AND THAT WAS FALSE — corrected after an independent review found the
+ * counter-example. `canvas/domain/analyticalNodeFields.ts:158` names
+ * `NODE_SETTER_AUTHORITY.setPriorRange` inside a RUNTIME STRING LITERAL, in a
+ * file imported by `useAutosave`, `graphChangeDiff`, `analyticalChange` and
+ * `useGraphEditEvents` — so it ships to browsers. The narrow claim the
+ * deletion actually rests on ("zero code CONSUMERS": nothing branches on
+ * either table) is true and was always the load-bearing one; "a COMMENT" was a
+ * careless widening of it. **The distinction matters because a string that
+ * ships is prose the PRODUCT carries, not prose the repo carries** — this
+ * deletion converts that literal from true to false, and repairing it is a
+ * separate owned follow-up, deliberately not done here because you cannot
+ * write "the table was deleted" before it is.
  *
  * WHERE IT IS ACTUALLY MADE: `InspectorRouter` wraps every panel — node
  * (`InspectorRouter.tsx:334`) and edge (`:221`) — in an unconditional
  * `<fieldset disabled data-authority="disabled">`, beneath a note rendering
  * `INSPECTOR_READ_ONLY_REASON` and bound to it by `aria-describedby`.
  *
- * ⭐ THE FIELDSET IS STRICTLY STRONGER THAN THE MANIFESTS WERE. It disables
- * every descendant control structurally, so a setter added tomorrow is inert
+ * ⭐ THE FIELDSET IS STRUCTURAL WHERE THE MANIFESTS WERE CLERICAL. It disables
+ * every descendant FORM CONTROL — `button`, `input`, `select`, `textarea` —
  * without anyone remembering to classify it. The manifests could only record a
  * decision after the fact; the fieldset makes it. Their one real contribution —
  * a completeness check that every setter was classified — is replaced by a
  * DOM-level claim that no control escapes the boundary, which holds however
  * many setters exist.
+ *
+ * ⚠ THIS PARAGRAPH SAID "STRICTLY STRONGER … a setter added tomorrow is inert"
+ * UNTIL 27 Aug 2026. AN INDEPENDENT REVIEW REFUTED IT BY EXECUTION, so the
+ * scope is now stated exactly. `<fieldset disabled>` inerts form-associated
+ * descendants ONLY. It does NOT inert a `[role="button"]` div, a
+ * `[contenteditable]`, or an `a[href]`. Measured inside this very boundary:
+ * one such div (`EmptyDescriptionPrompt`, `tabindex=0`) takes focus, fires its
+ * handler and opens an editor, while the two real `<button>`s beside it are
+ * disabled in the same run. "A setter added tomorrow is inert" is therefore
+ * true of a form control and false of a div with a click handler — which is
+ * exactly the kind of control someone adds without thinking of it as a setter.
+ *
+ * ⭐ THE BOUND ON THAT FINDING, CARRIED EXACTLY AND NOT UPGRADED: **NO WRITE
+ * ESCAPES.** The `<textarea>` that opens is itself inside the fieldset and
+ * natively disabled, and the review explicitly DECLINED to claim user
+ * reachability, because the store write it exercised came from a synthetic
+ * `fireEvent.change` that bypasses the browser's own gating. So this is a
+ * recorded SCOPE LIMIT of the mechanism, not a known user-facing defect. Do
+ * not cite it as one; do not widen it without measuring it yourself. The exact
+ * set of non-inerted controls is pinned in
+ * `__tests__/inspectorAuthorityBinding.spec.tsx`
+ * (`NOT_INERTED_BY_THE_FIELDSET_NODE`), so it REDs if it grows or shrinks
+ * rather than living only in this comment.
  *
  * The setters below remain exported because producer/reconciliation code uses
  * them; being callable in code has never been what made a control reachable to

--- a/src/canvas/ui/inspector-v2/useInspectorMutations.ts
+++ b/src/canvas/ui/inspector-v2/useInspectorMutations.ts
@@ -9,7 +9,6 @@ import { useCallback } from 'react'
 import { useCanvasStore } from '../../store'
 import type { RiskImpact } from '../../domain/nodes'
 import { useOptionalConversationContext } from '../../conversation/ConversationContext'
-import type { MutationAuthority } from '../../mutations/mutationAuthority'
 
 // ─── Editor-written-field manifest (single source of truth) ────────────
 //
@@ -98,55 +97,44 @@ export const EDITOR_WRITTEN_FIELDS = {
 } as const
 
 /**
- * Product authority for a user-visible mutation.
+ * ⭐ THE INSPECTOR'S READ-ONLY POLICY LIVES IN ITS ENFORCEMENT, NOT IN A TABLE.
  *
- * `server_graph` is the only class allowed to look like a model edit. A
- * `server_fact` records a judgement without changing GraphV3 or analysis;
- * `local_presentation` may change selection/layout only; `disabled` has no
- * honest mounted write path yet.
- */
-/**
- * Exhaustive authority manifest for the Inspector's sanctioned setters.
+ * Two authority manifests used to sit here — `NODE_SETTER_AUTHORITY` (21 keys)
+ * and `EDGE_SETTER_AUTHORITY` (5), every value `'disabled'`. They were DELETED
+ * on 26 Aug 2026 because they had **zero code consumers**: outside their own
+ * definition and `mutationAuthority.spec.ts`, every reference to either was a
+ * COMMENT. Nothing branched on them. A table nothing reads cannot drift — and
+ * cannot enforce either; it was a hand-maintained mirror of a decision that is
+ * actually made somewhere else.
  *
- * The setters themselves remain useful to producer/reconciliation code, but
- * this table decides whether an Inspector control may expose them. Only the
- * prior-range event has a server carrier here, and that carrier is a FACT — it
- * deliberately does not update canonical GraphV3 or simulation inputs. The
- * mounted emergency policy therefore keeps the Inspector read-only until a
- * field has a receipt-bearing graph transaction (or a deliberately designed,
- * explicitly fact-only UI).
+ * WHERE IT IS ACTUALLY MADE: `InspectorRouter` wraps every panel — node
+ * (`InspectorRouter.tsx:334`) and edge (`:221`) — in an unconditional
+ * `<fieldset disabled data-authority="disabled">`, beneath a note rendering
+ * `INSPECTOR_READ_ONLY_REASON` and bound to it by `aria-describedby`.
+ *
+ * ⭐ THE FIELDSET IS STRICTLY STRONGER THAN THE MANIFESTS WERE. It disables
+ * every descendant control structurally, so a setter added tomorrow is inert
+ * without anyone remembering to classify it. The manifests could only record a
+ * decision after the fact; the fieldset makes it. Their one real contribution —
+ * a completeness check that every setter was classified — is replaced by a
+ * DOM-level claim that no control escapes the boundary, which holds however
+ * many setters exist.
+ *
+ * The setters below remain exported because producer/reconciliation code uses
+ * them; being callable in code has never been what made a control reachable to
+ * a user, and the fieldset is what decides that.
+ *
+ * ⚠ DO NOT REINTRODUCE A CLASSIFICATION TABLE HERE. If you want to know why a
+ * control is inert, read the fieldset and the notice; both are pinned by
+ * `__tests__/inspectorAuthorityBinding.spec.tsx`, which fails if the boundary,
+ * the copy, or the aria binding between them is removed — per region, so a
+ * break in one is not masked by the other.
+ *
+ * ⚠ AND NOTE WHICH QUESTION THIS IS. `CANONICAL_EDIT_AUTHORITY`
+ * (`canvas/mutations/mutationAuthority.ts`) answers a DIFFERENT one — see its
+ * header. It governs whether a control may LOOK like a shared-model edit. This
+ * file governs whether the Inspector's controls are reachable at all.
  */
-export const NODE_SETTER_AUTHORITY = {
-  setLabel: 'disabled',
-  setDescription: 'disabled',
-  setThreshold: 'disabled',
-  setObservedValue: 'disabled',
-  setIntervention: 'disabled',
-  removeIntervention: 'disabled',
-  setPriorRange: 'disabled',
-  setObservedRawValue: 'disabled',
-  setObservedUnit: 'disabled',
-  setObservedCap: 'disabled',
-  setObservedBaseline: 'disabled',
-  setObservedStd: 'disabled',
-  setObservedSource: 'disabled',
-  setCategory: 'disabled',
-  setExtractionType: 'disabled',
-  setFactorType: 'disabled',
-  setStateSpaceRange: 'disabled',
-  setUncertaintyDrivers: 'disabled',
-  setGoalCap: 'disabled',
-  setProbability: 'disabled',
-  setImpact: 'disabled',
-} as const satisfies Record<keyof typeof NODE_SETTER_FIELDS, MutationAuthority>
-
-export const EDGE_SETTER_AUTHORITY = {
-  setStrength: 'disabled',
-  setStd: 'disabled',
-  setExistsProbability: 'disabled',
-  setLabel: 'disabled',
-  setDirection: 'disabled',
-} as const satisfies Record<keyof typeof EDGE_SETTER_FIELDS, MutationAuthority>
 
 /** Receipt-bearing actions mounted elsewhere and intentionally preserved. */
 export const INSPECTOR_READ_ONLY_REASON =

--- a/src/components/results/TriageActionCardsBody.tsx
+++ b/src/components/results/TriageActionCardsBody.tsx
@@ -279,10 +279,18 @@ const POST_RUN_FACTOR_CONFIRMATION_CONNECTED = hasServerGraphAuthority(
  * ⭐ THE "EDIT" ACT — RE-POINTED FROM THE INSPECTOR TO THE ONE SURFACE THAT WRITES.
  *
  * It used to call `openNodeInspector`, which selects the node and raises
- * `InspectorModal`. The Inspector CANNOT SAVE. `inspector-v2/useInspectorMutations.ts`
- * carries its own authority manifest — `NODE_SETTER_AUTHORITY` (:119) and
- * `EDGE_SETTER_AUTHORITY` (:143) — and EVERY setter in both is `'disabled'`,
- * `setObservedValue` included. The module says so in a mounted constant:
+ * `InspectorModal`. The Inspector CANNOT SAVE: `InspectorRouter` wraps every
+ * panel — node and edge — in an unconditional `<fieldset disabled>`, so
+ * `setObservedValue` is inert along with every other setter.
+ *
+ * ⚠ THIS PARAGRAPH USED TO REST ON TWO AUTHORITY MANIFESTS INSTEAD —
+ * `NODE_SETTER_AUTHORITY` (:119) and `EDGE_SETTER_AUTHORITY` (:143) in
+ * `inspector-v2/useInspectorMutations.ts`. Both were DELETED on 27 Aug 2026
+ * (PR #886): they had zero code consumers, so they RECORDED a decision the
+ * fieldset MAKES. Those two line numbers now point at unrelated code. The
+ * conclusion below is unchanged; only the citation is.
+ *
+ * The module says so in a mounted constant:
  *
  *   INSPECTOR_READ_ONLY_REASON = 'This inspector is read-only because these
  *   changes cannot yet be saved to the shared model. Use the Model tab for

--- a/src/components/results/__tests__/ResultsBody.editValueOpensEditor.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.editValueOpensEditor.spec.tsx
@@ -250,11 +250,16 @@ describe('ResultsBody — local-only value actions fail closed', () => {
    *
    * This case asserted the pencil was WITHHELD, on the correct premise that its
    * destination could not save: it called `openNodeInspector`, and the Inspector
-   * is read-only by its own policy — `inspector-v2/useInspectorMutations.ts`
-   * `NODE_SETTER_AUTHORITY` (:119) and `EDGE_SETTER_AUTHORITY` (:143) are every
-   * setter `'disabled'`, and `INSPECTOR_READ_ONLY_REASON` says so in user-facing
-   * copy: "these changes cannot yet be saved to the shared model. Use the Model
-   * tab for supported factor values."
+   * is read-only by its own policy — `InspectorRouter` wraps every panel in an
+   * unconditional `<fieldset disabled>`, and `INSPECTOR_READ_ONLY_REASON` says
+   * so in user-facing copy: "these changes cannot yet be saved to the shared
+   * model. Use the Model tab for supported factor values."
+   *
+   * ⚠ THE PREMISE WAS ORIGINALLY CITED TO TWO MANIFESTS —
+   * `inspector-v2/useInspectorMutations.ts` `NODE_SETTER_AUTHORITY` (:119) and
+   * `EDGE_SETTER_AUTHORITY` (:143). Both were deleted on 27 Aug 2026 (PR #886)
+   * as unenforced mirrors with zero code consumers, and those line numbers now
+   * point at unrelated code. The premise itself is unchanged and still true.
    *
    * The act now goes where that copy points. Withholding it was right while it
    * dead-ended; it is wrong now that it reaches the one path that writes.

--- a/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
+++ b/src/components/results/analysis-hero/AnalysisHeroPanel.tsx
@@ -569,9 +569,13 @@ export function AnalysisHeroPanel({
         collapse — and says the most specific thing Olumi produces. Its button was
         gated on `analysisAssumedEdgeStrength` and pointed at
         `openEdgeStrengthEditor`, which raises the Inspector. The Inspector CANNOT
-        SAVE: `inspector-v2/useInspectorMutations.ts` EDGE_SETTER_AUTHORITY (:143)
-        is every setter `'disabled'`, and its own mounted copy says these changes
-        "cannot yet be saved to the shared model".
+        SAVE: `InspectorRouter` wraps every panel in an unconditional
+        `<fieldset disabled>`, and its own mounted copy says these changes
+        "cannot yet be saved to the shared model". (This cited
+        `inspector-v2/useInspectorMutations.ts` EDGE_SETTER_AUTHORITY (:143);
+        that manifest was deleted 27 Aug 2026, PR #886, as an unenforced mirror
+        with zero code consumers, and the line number now points at unrelated
+        code. The claim itself is unchanged.)
 
         ⚠ THE FLAG IS UNCHANGED AND STILL HONEST. `analysisAssumedEdgeStrength`
         stays `'disabled'` because the DIRECT-manipulation route genuinely is dead.

--- a/src/components/results/analysis-hero/__tests__/AssumedStrengthCard.mountPath.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/AssumedStrengthCard.mountPath.spec.tsx
@@ -123,8 +123,11 @@ describe('§0 the elicitation is on the DEFAULT Analysis tab', () => {
    * ⭐ THE ACT IS NOW OFFERED, AND THAT IS THE CHANGE.
    *
    * This case asserted the button was WITHHELD, on the correct premise that its
-   * destination could not save: it opened the Inspector, whose EDGE_SETTER_AUTHORITY
-   * is every setter `'disabled'`. The product's most prominent intervention — panel
+   * destination could not save: it opened the Inspector, which `InspectorRouter`
+   * wraps in an unconditional `<fieldset disabled>`. (The premise was originally
+   * cited to `EDGE_SETTER_AUTHORITY`; that manifest was deleted 27 Aug 2026,
+   * PR #886, as an unenforced mirror with zero code consumers. The premise is
+   * unchanged.) The product's most prominent intervention — panel
    * top level, zero clicks — therefore ended in nothing, which is why it was hidden.
    *
    * It now asks Olumi, who CAN change an edge (`update_edge` is first-class in the

--- a/src/components/results/strengthElicitation/AssumedStrengthCard.tsx
+++ b/src/components/results/strengthElicitation/AssumedStrengthCard.tsx
@@ -28,10 +28,13 @@
  *
  * ⚠ IT USED TO CALL `openEdgeStrengthEditor`, AND THAT IS WHY THIS PARAGRAPH
  * CHANGED. That seam selects the edge, stands the dock down, centres the canvas
- * and raises the Inspector — and every Inspector EDGE setter is `'disabled'`
- * (`inspector-v2/useInspectorMutations.ts` EDGE_SETTER_AUTHORITY), with the
+ * and raises the Inspector — which is read-only, because `InspectorRouter`
+ * wraps every panel in an unconditional `<fieldset disabled>`, with the
  * panel's own mounted copy saying the value "cannot yet be saved to the shared
- * model". So the product's most prominent intervention arrived at a read-only
+ * model". (This cited the `EDGE_SETTER_AUTHORITY` manifest in
+ * `inspector-v2/useInspectorMutations.ts`; deleted 27 Aug 2026, PR #886, as an
+ * unenforced mirror. The re-point stands on the fieldset, which is what
+ * actually enforces it.) So the product's most prominent intervention arrived at a read-only
  * panel. There is no user-facing edge editor to route to.
  *
  * But OLUMI can change an edge: `update_edge` is a first-class op in the

--- a/src/components/results/strengthElicitation/__tests__/elicitationChain.spec.ts
+++ b/src/components/results/strengthElicitation/__tests__/elicitationChain.spec.ts
@@ -201,7 +201,10 @@ describe('P4 chain: elicitation → resolve → stale → rerun → loop closed'
 
     // ⚠ THE PRODUCT NO LONGER WIRES THIS CARD TO THIS HANDLER. The panel now routes
     // the act to the Ask-Olumi drawer, because the Inspector cannot save an edge
-    // strength (EDGE_SETTER_AUTHORITY: every setter 'disabled'). The adapter below
+    // strength — `InspectorRouter` wraps every panel in an unconditional
+    // `<fieldset disabled>`. (This cited `EDGE_SETTER_AUTHORITY: every setter
+    // 'disabled'`; that manifest was deleted 27 Aug 2026, PR #886, as an
+    // unenforced mirror with zero code consumers.) The adapter below
     // keeps this spec exercising `openEdgeStrengthEditor` itself — which retains
     // other callers (`ConnRow`, `NodeQuickActions`) — rather than deleting
     // coverage of a helper that is still live elsewhere.
@@ -295,7 +298,10 @@ describe('P4 chain: elicitation → resolve → stale → rerun → loop closed'
 
     // ⚠ THE PRODUCT NO LONGER WIRES THIS CARD TO THIS HANDLER. The panel now routes
     // the act to the Ask-Olumi drawer, because the Inspector cannot save an edge
-    // strength (EDGE_SETTER_AUTHORITY: every setter 'disabled'). The adapter below
+    // strength — `InspectorRouter` wraps every panel in an unconditional
+    // `<fieldset disabled>`. (This cited `EDGE_SETTER_AUTHORITY: every setter
+    // 'disabled'`; that manifest was deleted 27 Aug 2026, PR #886, as an
+    // unenforced mirror with zero code consumers.) The adapter below
     // keeps this spec exercising `openEdgeStrengthEditor` itself — which retains
     // other callers (`ConnRow`, `NodeQuickActions`) — rather than deleting
     // coverage of a helper that is still live elsewhere.

--- a/src/components/results/strengthElicitation/assumedStrengthCopy.ts
+++ b/src/components/results/strengthElicitation/assumedStrengthCopy.ts
@@ -110,9 +110,12 @@ export function assumedStrengthOthers(assumedFragileCount: number): string | nul
  */
 /**
  * ⭐ "ASK OLUMI TO", NOT "SET". The button used to read "Set this strength" and
- * pointed at `openEdgeStrengthEditor` -> the Inspector, whose every edge setter
- * is `'disabled'` (`inspector-v2/useInspectorMutations.ts` EDGE_SETTER_AUTHORITY)
- * and whose own mounted copy says it "cannot yet be saved to the shared model".
+ * pointed at `openEdgeStrengthEditor` -> the Inspector, which is read-only
+ * because `InspectorRouter` wraps every panel in an unconditional
+ * `<fieldset disabled>`, and whose own mounted copy says it "cannot yet be
+ * saved to the shared model". (This cited the `EDGE_SETTER_AUTHORITY` manifest
+ * in `inspector-v2/useInspectorMutations.ts`; deleted 27 Aug 2026, PR #886 —
+ * zero code consumers. The reason the button was re-pointed is unchanged.)
  * So the product's MOST PROMINENT intervention — zero clicks, panel top level,
  * carrying the most specific sentence Olumi produces — terminated in nothing.
  *


### PR DESCRIPTION
## What disappears, what survives

**DISAPPEARS:** `NODE_SETTER_AUTHORITY` (21 keys) + `EDGE_SETTER_AUTHORITY` (5) — 26 keys of prose with **zero code consumers**. Outside their own definition and `mutationAuthority.spec.ts`, every reference to either was a *comment*. Nothing branched on them, so they could neither drift nor enforce.

**SURVIVES:** the policy in its **enforced** form — `InspectorRouter`'s unconditional `<fieldset disabled>` around every panel, node (`:334`) and edge (`:221`), beneath `INSPECTOR_READ_ONLY_REASON`. Strictly stronger than the manifests: it disables descendants structurally, so a setter added tomorrow is inert without anyone remembering to classify it.

Contrast control at time of deletion: `useNodeMutations`/`useEdgeMutations` were imported by 30+ files — the sweep that returned zero for the tables was demonstrably able to see consumers.

## Scope — 5 files, deliberately

| File | Why it is here |
|---|---|
| `useInspectorMutations.ts` | the deletion itself |
| `mutationAuthority.spec.ts` | **forced** — it *imports* all four deleted symbols; without this edit the tree does not compile. The single real code consumer, and the exception the sweep above names in advance. |
| `inspectorAuthorityBinding.spec.tsx` | the replacement guard |
| `mutationAuthority.ts` | docstring names the question it answers |
| `ModelTabV2Panel.tsx` | corrects a false mount claim |

An earlier revision of this PR also redirected 11 files' worth of prose citations of the deleted symbols. Those were prose-only, not forced by the deletion, and have been **reverted** — an authority removal should be reviewable as one thing. One of them is a genuine finding and is rowed separately: `analyticalNodeFields.ts` has a `note:` **runtime string** that ships to browsers naming `NODE_SETTER_AUTHORITY` (measured: one occurrence in the deployed bundle at `assets/store-*.js`, commit `f287c012`; `EDGE_SETTER_AUTHORITY` zero).

## The guard that makes the deletion safe

`inspector-v2/__tests__/inspectorAuthorityBinding.spec.tsx` — 12 tests. It pins what nothing covered:

1. the notice renders the **constant**, not a substring of it;
2. `aria-describedby` **resolves to that notice by identity** — nothing asserted the binding, so it could be deleted silently, leaving the control inert and the user never told why;
3. no editing control inside the boundary is **effectively** enabled (the deleted completeness check, replaced by a DOM claim that holds however many setters exist).

### Discriminating mutant matrix
Worktree outside the repo root; isolation proven by a sentinel whose landing was asserted (worktree=1, source=0, inodes differ); pristine-archive restore; applied-check scoped to `src/` = 1 per mutant, control = 0, trailing control clean.

| Mutant | New guard | Other region | Pre-existing guard |
|---|---|---|---|
| A node `aria-describedby` removed | node BINDS **RED** | edge GREEN | — |
| B edge `aria-describedby` removed | edge BINDS **RED** | node GREEN | — |
| C node `disabled` removed | node inert + escapes **RED** | edge GREEN | — |
| D node copy gutted, **old substring kept** | **RED** | edge GREEN | **GREEN — blind** |
| E edge copy gutted, **old substring kept** | **RED** | node GREEN | **GREEN — blind** |

D and E are the added-value demonstration: the pre-existing substring assertion stays fully green while the copy is gutted.

## A ruling was inverted by measurement — read this before reviewing

The original plan was to wire `CANONICAL_EDIT_AUTHORITY` into `useModelEditAuthority`. **That is withdrawn**, and the docstring now records why.

`CANONICAL_EDIT_AUTHORITY` is a **presentation** authority. 14 of its 21 keys have production consumers and *every one* reads it into a `*_CONNECTED` boolean that decides what to **render**. It answers *"may this control **look like** a shared-model edit?"* — not *"may this write happen?"* Wiring it into the writer would use the first answer to gate the second, and would have turned off `proposeOptionIntervention` and `proposeFactorConfirmation`.

Both are **genuinely working writes**: `interventions` and `observedState` are `purposes: ['stale']`, *"persisted by hash-by-default"*, absent from the three-field ephemeral denylist, and read by `hasAnalyticalNodeChange` (live in `store.ts`, `analyticalChange.ts`, `graphChangeDiff.ts`, `applyPatch.ts`). Disabling them would have removed the only way to say what an option does and the only way to confirm a factor value.

**Scope limit, stated because it bounds the claim:** there is **no wire witness** of `interventions` reaching PLoT. `islRequestAdapter`'s only callers are `useISLConformal.ts` and a debug tab — the conformal path, not the main run. The persistence and staleness findings stand on their own and do not depend on it.

## A false comment corrected

`ModelTabV2Panel.tsx` asserted that `ModelTabBody` *"renders `FactorsSection` unconditionally"*. **It does not** — `LEGACY_DETAILED_EDITOR_MOUNTED = false` (`ModelTabBody.tsx:120`) gates the whole v1 stack at `:917` and esbuild folds it out.

Verified at the **deployed bundle** (staging `f287c012`, 81 chunks crawled): `factor-card-`, `factors-add-cta`, `attribution-stability-pill`, `range-derivation-badge` all **zero**, while positive controls fired in the same sweep (`option-card-` ×2 — both from live *results* components — `model-scientific-transparency`, `model-tab-v2-panel`) and a fabricated control read zero.

The comment described the call site (`:972`/`:981`) without its enclosing guard, which is exactly how it read as true. It now names the guard.

## Gate — the required check's real step sequence, all of it

`TypeScript + Lint` is **seven** steps, not two. All run locally at this head, plus the separate self-test on a clean tree:

| Step | Result |
|---|---|
| `pnpm run lint` (eslint + hooks-ratchet) | exit 0 |
| `pnpm run typecheck` | exit 0 — 2251 diagnostics = baseline exactly |
| `pnpm run ci:guard:zustand` | exit 0 |
| `pnpm run ci:guard:starters` | exit 0 |
| `pnpm run check:vendor` | exit 0 |
| `pnpm run ci:guard:schemas-version` | exit 0 |
| `pnpm run ci:guard:ds:enforce` | exit 0 |
| `pnpm run typecheck:selftest` | exit 0 |

Tests over every touched area: **132 spec files, 1892 passed / 0 failed**, with the new spec's collected count asserted **by name** (12). No stray `.only`/`.skip` in the changed specs, detector's own positive control firing.

## Review notes

Please check the **breadth** of the new guard's claims rather than only that they pass. Instrument defects caught and disclosed during this work: a grep that ate leading-dash strings as flags (false zero on every item at once), a `sed` that stripped the vitest pass/fail marker, a single-byte capture of a multibyte marker, and un-anchored mutation patterns that silently hit the wrong region — only the final matrix is trustworthy, and it is the one above.

---

## Review remedies R1–R6 applied at `2168b51e` (27 Aug 2026)

**R1 — the guard that could not fail.** Reproduced the reviewer's mutant M5 (an enabled `<input aria-label="ESCAPED_EDITOR">` in the `InspectorShell` header, inside the Inspector and outside the fieldset, applied-check 1 file / 1 insertion) **before** replacing anything: the shipped suite stayed **12/12 GREEN**. Both cases built their candidate set from `fieldset.querySelectorAll(...)`, so `isEffectivelyDisabled` was true **by construction**. Replaced with a query over the whole Inspector region minus the boundary minus an identity-pinned deliberately-outside set, widened to `[role="button"], [contenteditable], a[href]`. The exemption list is fenced **both ways** — every entry must match something, and every match must resolve outside the boundary — so it cannot quietly become the answer. New guard: **17/17 GREEN clean, 3 RED under M5**, naming `<input> ESCAPED_EDITOR`. Node/edge discriminating pair re-run and still clean.

**R2 — "strictly stronger" withdrawn.** `<fieldset disabled>` inerts form-associated descendants only. Reworded to "every descendant **form control**" and dropped "a setter added tomorrow is inert", in both places that carried it. The reviewer's bound is carried exactly and **not** upgraded: **no write escapes**, and user reachability was explicitly not claimed (its store write used a synthetic `fireEvent.change`). The non-inerted set is now pinned in the suite as `NOT_INERTED_BY_THE_FIELDSET_NODE`, so it REDs if it grows **or** shrinks — the bound lives in the tests, not in a comment.

**R3 — "every reference … was a COMMENT" was false** and is corrected in all three places that carried it (not only the one flagged). `analyticalNodeFields.ts:158` names the table in a runtime string literal; verified it is a `note:` property value and that all four named importers exist. The narrow claim — zero code **consumers** — is true and is what the deletion rests on.

**R4 —** the docstring disavowed "a bare `document.querySelector('fieldset')`" while `readBoundary()` is exactly that. Corrected to the real mechanism (one region mounted per `describe`) and named the refactor that would destroy it.

**R5 — framing only; nothing deleted.** Both mutants re-run here: inverting the constant's meaning while keeping the guarded substring leaves **68/68 GREEN**; gutting the constant REDs **exactly two, both pre-existing** (`InspectorRouter.spec.tsx:347`, `FactorExternalPanel.priorRangeHonesty.spec.tsx:705`). This file is the weaker of the two on meaning and now says so, and says keep both.

**R6 — 12 sites, not 11.** Every line number re-derived at this tip. The extra site is `FactorExternalPanel.priorRangeHonesty.spec.tsx:76`, which also carried a third dead citation (`useInspectorMutations.ts:127`). `analyticalNodeFields.ts` deliberately untouched — owned follow-up.

### Shape of the delta, proven rather than asserted
13 files, +415 / −106. Transpiling base and head with comments stripped, **12 of 13 files emit byte-identical code**: the only executable change in the whole delta is the spec this remedy was about. No shipped behaviour or copy changed.

### ⚠ Instrument disclosure — the part worth keeping
Two independent attempts at that comment-only proof returned a **uniform IDENTICAL across all seven files** while measuring nothing: both sides hashed the empty string (`da39a3ee5e6b4b0d3255bfef95601890afd80709`, byte counts 0/0) because esbuild's CLI was never installed, and a second attempt did the same after `node` left `PATH`. Each was caught only by a contrast control required to DIFFER. **Uniformity across items that ought to differ is evidence about the instrument, not the world — and an absence proof that flatters its author is the one nobody re-checks.**

### Gate at this tip
`typecheck` PASSED (556 files / 2251 errors, baseline 2251, Δ0) · `typecheck:selftest` PASSED (18/0) · `lint` PASSED (0 errors; hooks ratchet 229/13 exactly at baseline) · targeted vitest 9 files / **120 passed**, target spec collected **by name** (17). Full suite left to CI by instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
