### PR TITLE
Disclose Olumi authorship on invented options (67% of drafts contain one)

### DIFF
--- a/src/canvas/components/pre-analysis-v3/constants.ts
+++ b/src/canvas/components/pre-analysis-v3/constants.ts
@@ -239,6 +239,15 @@ export const CONTESTED_COPY = {
 } as const
 
 export const ATTRIBUTION_COPY = {
+  /**
+   * The authorship marker on a named entity Olumi put in the model (an option
+   * or a risk stamped `provenance: 'ai_inferred'`). One string for both
+   * groups, because one row component renders both — see `EntityRow`.
+   *
+   * ⚠ This is the string ALREADY ON THE DEPLOYED BUILD for risks; it is lifted
+   * here verbatim, not reworded. Changing it changes a live surface.
+   */
+  olumiAuthored: 'Olumi',
   olumiNoticed: 'Olumi noticed',
   olumiPrefix: 'Olumi:',
   olumiEstimate: 'Olumi estimate',

--- a/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
+++ b/src/canvas/components/pre-analysis-v3/hooks/usePreAnalysisModel.ts
@@ -26,6 +26,10 @@ import { computeContestedRows, type ContestedRowModel } from '../selectors/compu
 import { computeEstimateRanking } from '../selectors/computeEstimateRanking'
 import { computeGraphFacts, computeProvenanceCounts } from '../selectors/graphFacts'
 import { computeInfluenceCoverage } from '../selectors/computeInfluenceCoverage'
+import {
+  projectAuthoredEntities,
+  type AuthoredEntity,
+} from '../selectors/projectAuthoredEntities'
 import { computeLadder } from '../selectors/computeLadder'
 import { computeStructuralAbsence } from '../selectors/computeStructuralAbsence'
 import { computeSuccessState, type SuccessState } from '../selectors/computeSuccessState'
@@ -69,8 +73,22 @@ export interface PreAnalysisModel {
     checkableCount: number
     needsValueCount: number
   }
-  options: Array<{ nodeId: string; label: string }>
-  risks: Array<{ nodeId: string; label: string; attribution: Attribution }>
+  /**
+   * ⭐ ONE PROJECTION FOR BOTH NAMED-ENTITY SLICES (`projectAuthoredEntities`).
+   *
+   * `options` used to be `{nodeId, label}` while `risks` beside it carried an
+   * attribution — two adjacent memos over the same node array, one reading
+   * CEE's `provenance` stamp and one not. An option Olumi invented therefore
+   * rendered identically to one the user named, on a product whose premise is
+   * that the humans are the authors.
+   *
+   * Both are now `AuthoredEntity`, whose `attribution` is NON-OPTIONAL: a slice
+   * that adopts the type cannot omit the field. That is a strong convention,
+   * not a structural guarantee — a future slice declining the type compiles
+   * clean (measured). Reach for `AuthoredEntity` for any named-entity slice.
+   */
+  options: AuthoredEntity[]
+  risks: AuthoredEntity[]
   /**
    * ROADMAP 2.376 — connections CEE's two validation passes disagreed about, as words.
    *
@@ -371,42 +389,12 @@ export function usePreAnalysisModel(): PreAnalysisModel {
     }
   }, [draftCoaching, analysisReady])
 
-  const options = useMemo(
-    () =>
-      nodes
-        .filter(n => {
-          const kind = (n.data as Record<string, unknown> | undefined)?.kind ?? n.type
-          return kind === 'option'
-        })
-        .map(n => ({
-          nodeId: n.id,
-          label:
-            typeof (n.data as Record<string, unknown>)?.label === 'string'
-              ? ((n.data as Record<string, unknown>).label as string)
-              : n.id,
-        })),
-    [nodes],
-  )
+  // Both slices, one projection. The authorship question is asked ONCE, in
+  // `projectAuthoredEntities` — not restated per slice, which is how options
+  // came to be silent about it while risks directly below were not.
+  const options = useMemo(() => projectAuthoredEntities(nodes, 'option'), [nodes])
 
-  const risks = useMemo(
-    () =>
-      nodes
-        .filter(n => {
-          const kind = (n.data as Record<string, unknown> | undefined)?.kind ?? n.type
-          return kind === 'risk'
-        })
-        .map(n => {
-          const data = n.data as Record<string, unknown>
-          return {
-            nodeId: n.id,
-            label: typeof data?.label === 'string' ? (data.label as string) : n.id,
-            attribution: (data?.provenance === 'ai_inferred'
-              ? { kind: 'olumi' }
-              : { kind: 'person', displayName: 'You' }) as Attribution,
-          }
-        }),
-    [nodes],
-  )
+  const risks = useMemo(() => projectAuthoredEntities(nodes, 'risk'), [nodes])
 
   // ROADMAP 2.376 — contested connections. Keyed on the store's own nodes/edges so one
   // commit (a resolve in the Model tab, a re-draft) updates this section in the same pass as

--- a/src/canvas/components/pre-analysis-v3/model/YourDecisionSection.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/YourDecisionSection.tsx
@@ -28,6 +28,7 @@ import { EstimateRow } from './EstimateRow'
 import { SUCCESS_INPUT_ID } from '../hero/HeroSection'
 import type { NodeType } from '../../../domain/nodes'
 import type { PreAnalysisModel } from '../hooks/usePreAnalysisModel'
+import type { AuthoredEntity } from '../selectors/projectAuthoredEntities'
 import type { SparkPrompt } from '../types'
 import { CANONICAL_EDIT_AUTHORITY, hasServerGraphAuthority } from '../../../mutations/mutationAuthority'
 
@@ -113,6 +114,35 @@ const Group = memo(function Group({
           {children}
         </>
       )}
+    </div>
+  )
+})
+
+/**
+ * EntityRow — one named entity (an option or a risk) and WHO AUTHORED IT.
+ *
+ * ⭐ ONE ROW FOR BOTH GROUPS. The Options group used to render a bare label
+ * while the Risks group directly below rendered the same shape PLUS an
+ * authorship pill, so an option Olumi invented was visually indistinguishable
+ * from one the user named. Both groups now render through here, which is what
+ * stops the asymmetry returning: the pill is no longer a per-group decision,
+ * and a group added later gets it by using this row.
+ *
+ * The person case renders NO pill on purpose. Disclosure marks what Olumi
+ * authored; badging the user's own words back at them is noise, not honesty.
+ */
+const EntityRow = memo(function EntityRow({ entity }: { entity: AuthoredEntity }) {
+  return (
+    <div
+      data-testid={`pre-analysis-v3-entity-${entity.nodeId}`}
+      className="ml-6 grid min-h-7 grid-cols-[1fr_auto] items-center gap-2 py-0.5"
+    >
+      <span className="flex min-w-0 items-center gap-2">
+        <span className={`${typography.panelBody} truncate text-text-body`}>{entity.label}</span>
+        {entity.attribution.kind === 'olumi' && (
+          <Pill variant="default" size="small">{ATTRIBUTION_COPY.olumiAuthored}</Pill>
+        )}
+      </span>
     </div>
   )
 })
@@ -304,11 +334,7 @@ export const YourDecisionSection = memo(function YourDecisionSection({
         onToggle={toggleGroup}
       >
         {model.options.map(option => (
-          <div key={option.nodeId} className="ml-6 grid min-h-7 grid-cols-[1fr_auto] items-center gap-2 py-0.5">
-            <span className="flex min-w-0 items-center gap-2">
-              <span className={`${typography.panelBody} truncate text-text-body`}>{option.label}</span>
-            </span>
-          </div>
+          <EntityRow key={option.nodeId} entity={option} />
         ))}
         {V3_STRUCTURAL_ADD_CONNECTED ? (
           <AddRow
@@ -342,14 +368,7 @@ export const YourDecisionSection = memo(function YourDecisionSection({
         onToggle={toggleGroup}
       >
         {model.risks.map(risk => (
-          <div key={risk.nodeId} className="ml-6 grid min-h-7 grid-cols-[1fr_auto] items-center gap-2 py-0.5">
-            <span className="flex min-w-0 items-center gap-2">
-              <span className={`${typography.panelBody} truncate text-text-body`}>{risk.label}</span>
-              {risk.attribution.kind === 'olumi' && (
-                <Pill variant="default" size="small">Olumi</Pill>
-              )}
-            </span>
-          </div>
+          <EntityRow key={risk.nodeId} entity={risk} />
         ))}
         {V3_STRUCTURAL_ADD_CONNECTED ? (
           <AddRow

--- a/src/canvas/components/pre-analysis-v3/model/__tests__/optionAuthorshipDisclosure.spec.tsx
+++ b/src/canvas/components/pre-analysis-v3/model/__tests__/optionAuthorshipDisclosure.spec.tsx
@@ -1,0 +1,170 @@
+/**
+ * Option authorship disclosure — an option Olumi invented must not render
+ * identically to one the user named.
+ *
+ * MEASURED DEFECT. Across 18 drafts on 7 frozen briefs, 12 (67%) contained at
+ * least one option the brief never mentions. CEE's stamp is perfectly
+ * discriminating (15/15 invented options `provenance: 'ai_inferred'` with no
+ * `source_quote`; 36/36 user-stated options `provenance: 'from_brief'` WITH
+ * one) — the panel was simply silent about it for options while disclosing it
+ * for risks in the group directly below.
+ *
+ * The product tells the user, verbatim: "Olumi doesn't invent options on its
+ * own… You stay in control of the set." Control that is uninformed is not
+ * control, so this is a truthfulness contract, not a styling one.
+ *
+ * ⚠ WHAT THIS SPEC IS BUILT TO SURVIVE:
+ *  - It binds by IDENTITY (the row's own `nodeId` test id), never "some element
+ *    has a pill" — a value predicate a different row could satisfy.
+ *  - It PINS ITS OWN PRECONDITION: the fixture is asserted to contain BOTH an
+ *    `ai_inferred` option AND a `from_brief` option, read back off the store.
+ *    An all-invented fixture would make the disclosure assertion pass for the
+ *    wrong reason, and a fixture that silently lost a class would too.
+ *  - It asserts the two render DIFFERENTLY, which is the actual user-visible
+ *    claim; a fix that marks every option is as wrong as one that marks none.
+ *  - It carries the RISKS path as a contrast object, so a mutation aimed at
+ *    the risks slice leaves it green while one aimed at options REDs it.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import '@testing-library/jest-dom/vitest'
+import { render, screen, fireEvent, within } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { PreAnalysisPanelV3 } from '../../PreAnalysisPanelV3'
+import { ATTRIBUTION_COPY } from '../../constants'
+import { ToastProvider } from '../../../../ToastContext'
+import { useCanvasStore } from '../../../../store'
+import { useReadinessStore } from '../../../../stores/readinessStore'
+
+function node(id: string, kind: string, label: string, data: Record<string, unknown> = {}): Node {
+  return { id, type: kind, position: { x: 0, y: 0 }, data: { kind, label, ...data } } as Node
+}
+
+/** The user named this one — CEE stamps it `from_brief` and quotes the brief. */
+const USER_OPTION = node('o_user', 'option', 'Hire a tech lead', {
+  provenance: 'from_brief',
+  source_quote: 'should we hire a tech lead',
+})
+/** Olumi invented this one — a synthesis of the stated poles, the largest class. */
+const OLUMI_OPTION = node('o_olumi', 'option', 'Hire one senior contractor and one junior', {
+  provenance: 'ai_inferred',
+})
+const USER_RISK = node('r_user', 'risk', 'Budget overrun', { provenance: 'from_brief' })
+const OLUMI_RISK = node('r_olumi', 'risk', 'Onboarding drag', { provenance: 'ai_inferred' })
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true, status: 200, json: async () => ({}) })))
+  useReadinessStore.setState({
+    readiness: {
+      readiness_score: 60,
+      readiness_level: 'fair',
+      can_run_analysis: true,
+      confidence_explanation: '',
+      improvements: [],
+    },
+    loading: false,
+    error: null,
+  })
+  useCanvasStore.setState({
+    nodes: [
+      node('d1', 'decision', 'Hire a tech lead or two developers?'),
+      node('g1', 'goal', 'Increase delivery output', { goal_threshold: 0.8 }),
+      USER_OPTION,
+      OLUMI_OPTION,
+      USER_RISK,
+      OLUMI_RISK,
+      node('f1', 'factor', 'Tech lead impact', {
+        provenance: 'ai_inferred',
+        observedState: { raw_value: 30, value: 0.3, unit: '%', source: 'cee_inference' },
+      }),
+    ],
+    edges: [],
+    preAnalysisSensitivity: null,
+    draftCoaching: null,
+    currentBriefText: null,
+    goalThreshold: 0.8,
+  })
+})
+
+/** Render the panel and reveal the model view + every group. */
+function renderModelView() {
+  render(
+    <ToastProvider>
+      <PreAnalysisPanelV3 onAnalyse={vi.fn()} isAnalysing={false} canRun blockedReason={undefined} />
+    </ToastProvider>,
+  )
+  fireEvent.click(screen.getByTestId('pre-analysis-v3-your-decision').querySelector('button')!)
+  fireEvent.click(screen.getByTestId('pre-analysis-v3-groups-toggle-all'))
+}
+
+/** The authorship marker inside ONE named row, or null. Identity-bound. */
+function markerIn(nodeId: string): HTMLElement | null {
+  const row = screen.getByTestId(`pre-analysis-v3-entity-${nodeId}`)
+  return within(row).queryByText(ATTRIBUTION_COPY.olumiAuthored)
+}
+
+describe('precondition — the fixture can actually discriminate', () => {
+  it('holds BOTH an ai_inferred option AND a from_brief option', () => {
+    const options = useCanvasStore
+      .getState()
+      .nodes.filter(n => (n.data as Record<string, unknown>).kind === 'option')
+    const provenances = options.map(n => (n.data as Record<string, unknown>).provenance)
+    // Not "at least one of each somewhere" — exactly this pair, or the
+    // disclosure assertions below could pass without discriminating anything.
+    expect(provenances).toEqual(['from_brief', 'ai_inferred'])
+    expect(options.map(n => n.id)).toEqual(['o_user', 'o_olumi'])
+  })
+
+  it('pins the deployed marker copy (derived from the shipped risks pill)', () => {
+    expect(ATTRIBUTION_COPY.olumiAuthored).toBe('Olumi')
+  })
+})
+
+describe('an option Olumi invented is disclosed as Olumi authored', () => {
+  it('marks the ai_inferred option and leaves the user-named one unmarked', () => {
+    renderModelView()
+
+    // Both rows exist and carry their own labels — the rows really are the
+    // objects named, not two lookups that happened to resolve to one element.
+    expect(screen.getByTestId('pre-analysis-v3-entity-o_olumi')).toHaveTextContent(
+      'Hire one senior contractor and one junior',
+    )
+    expect(screen.getByTestId('pre-analysis-v3-entity-o_user')).toHaveTextContent(
+      'Hire a tech lead',
+    )
+
+    // THE CLAIM: they render differently, and in the right direction.
+    expect(markerIn('o_olumi')).not.toBeNull()
+    expect(markerIn('o_user')).toBeNull()
+  })
+
+  it('marks exactly one of the two option rows (disclosure, not a blanket pill)', () => {
+    renderModelView()
+    const marked = ['o_user', 'o_olumi'].filter(id => markerIn(id) !== null)
+    expect(marked).toEqual(['o_olumi'])
+  })
+})
+
+describe('the same claim, probed with PRISTINE affordances only', () => {
+  it('the invented option row carries the marker; the user-named one does not', () => {
+    renderModelView()
+    // ⭐ This test deliberately uses NOTHING this fix introduces: no row test
+    // id, no new copy constant — only the option's own label text and the
+    // literal marker string the risks pill has rendered on the deployed build
+    // all along. So its RED at pristine is about the missing DISCLOSURE, not
+    // about an affordance that simply did not exist yet.
+    const rowOf = (label: string) => screen.getByText(label).closest('div') as HTMLElement
+    expect(
+      within(rowOf('Hire one senior contractor and one junior')).queryByText('Olumi'),
+    ).not.toBeNull()
+    expect(within(rowOf('Hire a tech lead')).queryByText('Olumi')).toBeNull()
+  })
+})
+
+describe('contrast object — the risks slice keeps its existing disclosure', () => {
+  it('marks the ai_inferred risk and leaves the from_brief risk unmarked', () => {
+    renderModelView()
+    expect(markerIn('r_olumi')).not.toBeNull()
+    expect(markerIn('r_user')).toBeNull()
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/selectors/__tests__/projectAuthoredEntities.spec.ts
+++ b/src/canvas/components/pre-analysis-v3/selectors/__tests__/projectAuthoredEntities.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * projectAuthoredEntities ↔ computeGraphFacts — the two authorities that count
+ * the same entities must agree.
+ *
+ * ⭐ WHY THIS FILE EXISTS. The projection replaced two memos that asked
+ * `(n.data)?.kind ?? n.type` with one that asks `kindOf` — the predicate
+ * `computeGraphFacts` already uses. That convergence was shipped UNPINNED:
+ * reverting it turned nothing red across all 41 spec files in this directory
+ * (measured: 40 passed / 651 tests, the single failure an unrelated
+ * pre-existing one). The only pre-existing `kindOf` test asserts it "prefers
+ * data.kind over node.type" and never exercises the class where the two
+ * predicates actually diverge.
+ *
+ * That gap mattered because the convergence is this change's own thesis: the
+ * type makes a slice declare authorship, and this makes the two counts agree.
+ * An unpinned half of the argument is the half that silently comes back.
+ *
+ * ⚠ THE INVARIANT IS WRITTEN AGAINST THE SPEC, NOT AGAINST THE FAILURE MODE.
+ * The claim is not "the code calls `kindOf`" — that is an implementation
+ * detail a refactor may legitimately change. The claim is that for any node
+ * set, the number of entities the panel LISTS equals the number the panel
+ * COUNTS. Those two numbers are rendered as near-identical sentences on one
+ * screen: the Options group header says "N included" from the projection,
+ * while the HealthBars tooltip says "N options included" from
+ * `computeGraphFacts.optionCount` (`computeBars.ts`), and the option-breadth
+ * signal (`signals/registry.ts`) reads the same count. Two authorities, one
+ * user-visible claim.
+ */
+
+import { describe, it, expect } from 'vitest'
+import type { Node } from '@xyflow/react'
+import { projectAuthoredEntities } from '../projectAuthoredEntities'
+import { computeGraphFacts } from '../graphFacts'
+
+/**
+ * `data.kind` is deliberately typed loose here: these are the representations
+ * that actually arrive on the store, not a tidy subset of them.
+ */
+function node(id: string, type: string, dataKind: unknown, label: string): Node {
+  return {
+    id,
+    type,
+    position: { x: 0, y: 0 },
+    data: dataKind === undefined ? { label } : { kind: dataKind, label },
+  } as Node
+}
+
+/**
+ * The kind-representation classes a node can arrive in. The last two are the
+ * DIVERGENT class — `?? ` accepts them as the kind (they are not nullish) while
+ * `kindOf` falls through to `node.type`. `null` is deliberately NOT here: it is
+ * nullish, so both predicates already agree on it.
+ */
+const OPTIONS: Node[] = [
+  node('o_normal', 'option', 'option', 'Hire a tech lead'),
+  node('o_typeonly', 'option', undefined, 'Hire two developers'),
+  node('o_emptykind', 'option', '', 'Keep the current team'),
+  node('o_numerickind', 'option', 123, 'Hire one senior and one junior'),
+]
+
+const RISKS: Node[] = [
+  node('r_normal', 'risk', 'risk', 'Budget overrun'),
+  node('r_emptykind', 'risk', '', 'Onboarding drag'),
+]
+
+describe('the two counting authorities agree, across every kind representation', () => {
+  it('lists exactly as many options as computeGraphFacts counts', () => {
+    const listed = projectAuthoredEntities(OPTIONS, 'option')
+    const counted = computeGraphFacts(OPTIONS).optionCount
+
+    // Bound by identity, not just by length: a projection that dropped
+    // `o_emptykind` and gained some other node would keep the length.
+    expect(listed.map(e => e.nodeId)).toEqual([
+      'o_normal',
+      'o_typeonly',
+      'o_emptykind',
+      'o_numerickind',
+    ])
+    expect(counted).toBe(OPTIONS.length)
+    // The invariant itself, stated as agreement between the two authorities.
+    expect(listed).toHaveLength(counted)
+  })
+
+  it('lists exactly as many risks as computeGraphFacts counts', () => {
+    const listed = projectAuthoredEntities(RISKS, 'risk')
+    const counted = computeGraphFacts(RISKS).riskCount
+    expect(listed.map(e => e.nodeId)).toEqual(['r_normal', 'r_emptykind'])
+    expect(counted).toBe(RISKS.length)
+    expect(listed).toHaveLength(counted)
+  })
+
+  it('still agrees on a mixed graph, and does not bleed across kinds', () => {
+    const mixed = [...OPTIONS, ...RISKS, node('g1', 'goal', 'goal', 'Increase output')]
+    const facts = computeGraphFacts(mixed)
+    expect(projectAuthoredEntities(mixed, 'option')).toHaveLength(facts.optionCount)
+    expect(projectAuthoredEntities(mixed, 'risk')).toHaveLength(facts.riskCount)
+    // A goal is neither, under either authority.
+    expect(projectAuthoredEntities(mixed, 'option').map(e => e.nodeId)).not.toContain('g1')
+    expect(projectAuthoredEntities(mixed, 'risk').map(e => e.nodeId)).not.toContain('g1')
+  })
+})

--- a/src/canvas/components/pre-analysis-v3/selectors/projectAuthoredEntities.ts
+++ b/src/canvas/components/pre-analysis-v3/selectors/projectAuthoredEntities.ts
@@ -1,0 +1,105 @@
+/**
+ * projectAuthoredEntities — ONE projection for every named-entity slice of the
+ * panel (options, risks, and any slice added after this one).
+ *
+ * ⭐ WHY THIS EXISTS, AND WHY IT IS ONE FUNCTION RATHER THAN TWO.
+ *
+ * Options and risks were built by two ADJACENT `useMemo`s over the same node
+ * array in `usePreAnalysisModel`. The risks memo read `provenance` and produced
+ * an `Attribution`; the options memo mapped to `{nodeId, label}` and never read
+ * it. The panel therefore rendered an option Olumi invented and an option the
+ * user named as the same row — while doing the opposite for risks one group
+ * below, and while `EstimateRowModel` had carried `attribution` all along.
+ *
+ * That was measured, not assumed: across 18 drafts on 7 frozen briefs, 12 (67%)
+ * contained at least one option the brief never mentions. The PRODUCER is
+ * correct and perfectly discriminating — 15/15 invented options carry
+ * `provenance: 'ai_inferred'` with no `source_quote`, 36/36 user-stated options
+ * carry `provenance: 'from_brief'` WITH one. Only the consumer was silent.
+ *
+ * The fix is DISCLOSURE, never suppression: those inventions are 10 syntheses,
+ * 3 status-quo baselines and 2 novel moves — textbook decision analysis, and
+ * real value. Marking them is what keeps the user the author of the set.
+ *
+ * So the shape of the fix matters as much as the fix. A second attribution
+ * expression next to the first would be the same hand-maintained mirror one
+ * slice wider. Instead BOTH slices now come out of this function, and
+ * `AuthoredEntity` makes `attribution` NON-OPTIONAL.
+ *
+ * ⚠ BE PRECISE ABOUT WHAT THAT BUYS, because the obvious stronger claim is
+ * false and was measured: anything TYPED `AuthoredEntity` cannot omit the
+ * field (dropping it is a compile error, +1 diagnostic against a 1923
+ * baseline). But a future slice that declines the type — say
+ * `assumptions: Array<{nodeId, label}>` — compiles perfectly clean (measured:
+ * delta 0). So this is a strong CONVENTION with a type that enforces it once
+ * adopted, plus one shared row component, NOT a structural guarantee that a
+ * new slice must disclose. Anyone adding a named-entity slice should reach for
+ * `AuthoredEntity`; nothing in the compiler will make them.
+ *
+ * ⚠ ONE DELIBERATE BEHAVIOURAL CONVERGENCE. The two memos this replaces asked
+ * `(n.data)?.kind ?? n.type`, which differs from `kindOf` — the predicate
+ * `computeGraphFacts` already uses to produce `optionCount` / `riskCount` — on
+ * a node whose `data.kind` is present but not a non-empty string (`''`, or a
+ * non-string). `null` is NOT in that class: it is nullish, so `??` falls
+ * through and both predicates already agree.
+ *
+ * The two answers reach the user as near-identical sentences on ONE panel:
+ * the Options group header renders "N included" from this projection, while
+ * the HealthBars tooltip renders "N options included" from
+ * `computeGraphFacts.optionCount` (`computeBars.ts`), and the option-breadth
+ * signal (`signals/registry.ts`) reads that same count. This function asks
+ * `kindOf`, so those numbers cannot disagree — pinned by
+ * `__tests__/projectAuthoredEntities.spec.ts`, because reverting the
+ * convergence turned nothing red across all 41 specs in this directory.
+ */
+
+import type { Node } from '@xyflow/react'
+import { kindOf } from './graphFacts'
+import type { Attribution } from '../types'
+
+/**
+ * A named entity in the model, with WHO PUT IT THERE.
+ *
+ * `attribution` is required on purpose. It is the whole point of this type:
+ * the field is what a new slice cannot forget.
+ */
+export interface AuthoredEntity {
+  nodeId: string
+  label: string
+  attribution: Attribution
+}
+
+/** The kinds this projection serves. Widen it here, never by re-deriving. */
+export type AuthoredEntityKind = 'option' | 'risk'
+
+/**
+ * The ONE reading of CEE's authorship stamp for a named entity.
+ *
+ * `ai_inferred` is Olumi's own; everything else — `from_brief`, a user-created
+ * node with no stamp at all — is the person's, and renders unmarked. The
+ * asymmetry is the design: we mark what Olumi authored, we do not badge the
+ * user's own words back at them.
+ */
+export function attributionOfNode(data: unknown): Attribution {
+  const provenance = (data as Record<string, unknown> | undefined)?.provenance
+  return provenance === 'ai_inferred'
+    ? { kind: 'olumi' }
+    : { kind: 'person', displayName: 'You' }
+}
+
+export function projectAuthoredEntities(
+  nodes: ReadonlyArray<Node>,
+  kind: AuthoredEntityKind,
+): AuthoredEntity[] {
+  const out: AuthoredEntity[] = []
+  for (const node of nodes) {
+    if (kindOf(node) !== kind) continue
+    const data = node.data as Record<string, unknown> | undefined
+    out.push({
+      nodeId: node.id,
+      label: typeof data?.label === 'string' ? data.label : node.id,
+      attribution: attributionOfNode(data),
+    })
+  }
+  return out
+}


### PR DESCRIPTION
## The defect

**An option Olumi invented rendered visually identical to one the user named.**

Measured, not assumed — 18 drafts across 7 frozen briefs: **12 (67%) contain at least one option the brief never mentions.** The producer is correct and perfectly discriminating:

| | stamp | `source_quote` |
|---|---|---|
| 15/15 invented options | `provenance: 'ai_inferred'` | absent |
| 36/36 user-stated options | `provenance: 'from_brief'` | present |

Only the consumer was silent, and asymmetrically so — two **adjacent** `useMemo`s over the same node array in `usePreAnalysisModel.ts`, the risks one reading `provenance` and the options one not, rendering into two groups one above the other.

That matters because the deployed build tells the user, verbatim: *"Olumi doesn't invent options on its own, it works from the ones you name or confirm… **You stay in control of the set.**"* Control that is uninformed is not control.

## The fix is disclosure, not suppression

Classified across all 15, the inventions are **10 syntheses**, **3 status-quo baselines**, **2 genuinely novel moves** — zero noise, zero unclassifiable. That is textbook decision analysis and real value. This marks them; it does not hide them.

## Converged, not patched

- **`selectors/projectAuthoredEntities.ts`** — the ONE projection for both named-entity slices.
- **`EntityRow`** — one row component for both groups, so the pill is no longer a per-group decision. The person case renders **no** pill on purpose: disclosure marks what Olumi authored, it does not badge the user's own words back at them.
- **`ATTRIBUTION_COPY.olumiAuthored`** — the marker string lifted **verbatim** from the shipped risks pill, not reworded.

### What the type actually buys — ⚠ corrected

> ~~"`AuthoredEntity.attribution` is non-optional, so a slice added later cannot silently opt out."~~ **Refuted by measurement, and the source comments have been corrected to match.**

- A slice that **adopts** `AuthoredEntity` cannot omit the field: dropping it is `error TS2345`, **+1 diagnostic against a 1923 baseline**. No `as`, no `Partial<>`, no `attribution?:` escape.
- A slice that **declines** the type — e.g. `assumptions: Array<{nodeId, label}>` — **compiles clean (delta 0)**.

So this is a **strong convention that the type enforces once adopted, plus one shared row component — not a structural guarantee.** Both the interface docblock and the projection docblock now state the accurate version.

### The `kindOf` convergence — ⚠ corrected, and now pinned

> ~~"the count in the group header sits directly above the rows it counts — so they could disagree."~~ **False as written**: at pristine both the header meta and the rows came from the *same* `options` memo, so they could never disagree with *each other*.

The divergence is real and user-visible, but it is between **two different authorities** rendering near-identical sentences on one panel:

| surface | source | renders |
|---|---|---|
| Options group header | the projection | `"N included"` |
| HealthBars tooltip (`computeBars.ts`) | `computeGraphFacts.optionCount` | `"N options included"` |
| option-breadth signal (`signals/registry.ts`) | `computeGraphFacts.optionCount` | breadth copy |

They diverge when `data.kind` is present but not a non-empty string (`''` or a non-string). `null` is **not** in that class — it is nullish, so `??` falls through and both predicates already agree.

**This shipped unpinned, and that is now fixed.** Reverting the convergence turned **nothing** red across all 41 spec files in this directory (measured: 40 passed / 651 tests; the single failure unrelated and pre-existing). `selectors/__tests__/projectAuthoredEntities.spec.ts` closes it — reverting now **REDs 3/3**, naming the dropped nodes (`o_emptykind`, `o_numerickind`, `r_emptykind`) rather than merely mismatching a length.

The invariant is written **against the spec** — *the number of entities listed equals the number counted* — not against the failure mode, and deliberately **not** against "the code calls `kindOf`", which a refactor may legitimately change.

## Evidence

**RED-first at pristine** (separate clone, isolation proven by sentinel *write* + differing inodes, only the spec added): **5 failed / 1 passed of 6 collected by name.** One test uses **only pristine affordances** — the option's own label text and the literal `Olumi` the risks pill has always rendered — and fails `expected null not to be null`. That is the defect on its own terms; the other four fail on *missing affordance*, which is weaker evidence.

**Discriminating mutant pair** (applied-checked, restored from a pristine archive, never `git checkout -- <path>`):

| mutant | applied | result |
|---|---|---|
| control (leading) | 0 | 6 passed |
| disclosure removed for ALL entities | 1 | 4 failed — option **and** risk |
| **risks ONLY (different object)** | 1 | **1 failed / 5 passed — all 3 option tests GREEN** |
| **options ONLY** | 1 | **3 failed / 3 passed — all 3 option tests RED, risks contrast GREEN** |
| renderer pill deleted | 1 | 4 failed — the render half is load-bearing |
| a DIFFERENT attribution object (goal "Set" pill) | 1 | **6 passed** |
| control (trailing) | 0 | 6 passed |

The middle two fail on **different assertions** in each direction — that is the pair, not one biting mutant.

**Binding.** Assertions bind by **identity**, never "some element has a pill". The spec **pins its own precondition**: the fixture is asserted to hold BOTH an `ai_inferred` and a `from_brief` option, so it cannot pass for the wrong reason on an all-invented fixture. It also asserts they render **differently**.

**Gate.** All seven `Staging Gate` → `TypeScript + Lint` steps exit 0 on this rebase. DS ratchet `panel-typography-scoped` 15 vs baseline 15, Δ0.

**Suite.** My two specs: **9 tests collected by name**, all pass. Full `pre-analysis-v3` on the rebased base: 41 files / 654 tests pass; the one failure is `useSensitivityRanking.plotBearer.spec.tsx`, **proven pre-existing** (reproduced at pristine with an empty working tree) and a local `.env.local` artefact — it passes in CI's Full Test Suite.

## Size — ⚠ corrected

> ~~"Net effect in the hook is −50 lines."~~ **False.** Measured `--numstat`: the hook is **+25 / −37 = net −12**. The −50 was *total deletions across all five files*.

## Scope

- Rebased onto `7c2cb3e2` (**#888**, "eleven lists, eleven treatments"). Its new `panel-list-conformance` guard scans `src/canvas/conversation` plus two named files — **not** `pre-analysis-v3`. Verified green (4/4) against this branch.
- No intersection with **#886**: disjoint file sets, and its `mutationAuthority.ts` diff touches neither symbol this file imports.
- `model.options` had exactly **one** consumer file, so the type widening is additive.

## Not in this PR

- **`currentUser` threading** (rowed as a follow-on). The three sibling sites in this directory take a `currentUser` parameter; `attributionOfNode` hardcodes `{kind:'person', displayName:'You'}`. **Blast radius today is exactly zero** — the only `buildEstimateRows` call site passes `null`, and `EntityRow` reads only `.kind`. It matters solely because this file is nominated as what future slices inherit.
- ⚠ **A claim withdrawn from the original body**: I wrote that `EstimateRowModel` "already carried `attribution`", implying options was missing from a shared standard. That implication is wrong — `EstimateRowModel.attribution` derives from `reviewed` (`buildEstimateRows.ts:90-92`), **not** from `provenance`. It is a **third rule answering a different question**, not a standard this slice was absent from. The convergence is still right; the argument for it is different.

🤖 Generated with [Claude Code](https://claude.com/claude-code)