### PR TITLE
fix(panel): eleven lists, eleven treatments — one spelling each, enforced

### DIFF
--- a/src/canvas/conversation/AddOptionPanel.tsx
+++ b/src/canvas/conversation/AddOptionPanel.tsx
@@ -21,6 +21,7 @@ import { formatValueWithUnit } from '../utils/formatValueWithUnit'
 import { MAX_ADD_OPTION_INTERVENTIONS } from '../../v5/chipParameters'
 import { ADD_OPTION_REFUSAL_COPY } from './addOptionRequest'
 import type { AddOptionChange, AddOptionFactorTarget } from './addOptionRequest'
+import { PANEL_LIST_CONTROLS } from './panelLists'
 
 export interface AddOptionPanelProps {
   /** Label extracted from the user's message — a prefill, always editable. */
@@ -178,7 +179,7 @@ export function AddOptionPanel({
               Optional. Tick a factor and give it the value this option would produce — up to{' '}
               {MAX_ADD_OPTION_INTERVENTIONS}.
             </p>
-            <ul className="mb-5 space-y-2" data-testid="add-option-factor-list">
+            <ul className={`mb-5 ${PANEL_LIST_CONTROLS}`} data-testid="add-option-factor-list">
               {factors.map((factor) => {
                 const row = rows[factor.id] ?? { checked: false, text: '' }
                 const invalid = row.checked && invalidIds.includes(factor.id)

--- a/src/canvas/conversation/AnswerBody.tsx
+++ b/src/canvas/conversation/AnswerBody.tsx
@@ -24,6 +24,7 @@ import { safeRichText } from '../utils/safeRichText'
 import styles from './Conversation.module.css'
 import { dedupeRenderedText } from './messageComposition'
 import type { AnswerShape } from './answerShape'
+import { PANEL_LIST_BULLET } from './panelLists'
 
 /**
  * UI-SEM-090: clamp the producer's bullet list to at most MAX_BULLETS at the
@@ -138,7 +139,7 @@ export const AnswerBody = memo(function AnswerBody({
         />
       )}
       {bulletHtml.length > 0 && (
-        <ul className={`${bodyType} ${styles.answerBullets}`} data-testid="answer-bullets">
+        <ul className={`${bodyType} ${PANEL_LIST_BULLET}`} data-testid="answer-bullets">
           {bulletHtml.map((html, i) => (
             <li
               key={i}

--- a/src/canvas/conversation/Conversation.module.css
+++ b/src/canvas/conversation/Conversation.module.css
@@ -762,9 +762,6 @@
   margin: 0 0 8px;
   color: var(--text-body, #4A4642);
 }
-.answerBullets {
-  margin: 4px 0 6px;
-}
 .answerDetail {
   margin-top: 8px;
   color: var(--text-body, #4A4642);

--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -91,6 +91,7 @@ import { V5UnsupportedBlock } from '../../v5/blocks/V5UnsupportedBlock'
 import { safeRichText, plainTextPreview } from '../utils/safeRichText'
 import { isOrchestratorRenderingV2Enabled } from '../../flags'
 import styles from './Conversation.module.css'
+import { PANEL_LIST_BULLET } from './panelLists'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1506,9 +1507,9 @@ function CommentarySections({ sections }: { sections: import('./types').Commenta
             </p>
           )}
           {section.items && section.items.length > 0 && (
-            <ul style={{ margin: '4px 0 0', paddingLeft: 20 }}>
+            <ul className={`mt-1 ${PANEL_LIST_BULLET}`}>
               {section.items.map((item, j) => (
-                <li key={j} className={typography.panelBody} style={{ color: 'var(--text-body)', marginBottom: 2 }}>
+                <li key={j} className={typography.panelBody} style={{ color: 'var(--text-body)' }}>
                   {item}
                 </li>
               ))}

--- a/src/canvas/conversation/ModelBuildingNoticesNotice.tsx
+++ b/src/canvas/conversation/ModelBuildingNoticesNotice.tsx
@@ -47,6 +47,7 @@ import {
   modelBuildingNoticesSummary,
   type ModelBuildingNoticesView,
 } from './modelBuildingNotices'
+import { PANEL_LIST_STACK } from './panelLists'
 
 export interface ModelBuildingNoticesNoticeProps {
   notices: ModelBuildingNoticesView
@@ -86,7 +87,7 @@ export const ModelBuildingNoticesNotice = memo(function ModelBuildingNoticesNoti
 
       {expanded && (
         <div id="model-building-notices-detail" className="mt-1 pl-4 space-y-1">
-          <ul className="space-y-1" role="list">
+          <ul className={PANEL_LIST_STACK} role="list">
             {notices.rows.map((row) => (
               <li
                 key={row.kind}

--- a/src/canvas/conversation/ModelReceiptBlock.tsx
+++ b/src/canvas/conversation/ModelReceiptBlock.tsx
@@ -17,6 +17,7 @@ import { memo, useState } from 'react'
 import { ChevronDown, ChevronRight, ClipboardCheck, Wrench } from 'lucide-react'
 import { typography } from '../../styles/typography'
 import type { ModelReceiptData } from '../adapters/modelCardAdapter'
+import { PANEL_LIST_STACK } from './panelLists'
 
 // ---------------------------------------------------------------------------
 // § 1 — Readiness label (neutral; demoted to the "Model details" disclosure)
@@ -134,7 +135,7 @@ export const ModelReceiptBlock = memo(function ModelReceiptBlock({ data }: Model
           {adjustmentsExpanded && (
             <ul
               id="receipt-adjustments"
-              className="mt-1 space-y-0.5 pl-4"
+              className={`mt-1 ${PANEL_LIST_STACK}`}
               role="list"
             >
               {data.adjustments.map((a, i) => (

--- a/src/canvas/conversation/panelLists.ts
+++ b/src/canvas/conversation/panelLists.ts
@@ -1,0 +1,45 @@
+/**
+ * panelLists — the ONE spelling for every `<ul>` the AI panel renders.
+ * British English: standardise, colour, behaviour.
+ *
+ * ── WHY THIS EXISTS ──────────────────────────────────────────────────────────
+ * Ten lists in the panel surface were styled ten different ways. Measured on
+ * `16c55158`: three carried a marker (`list-disc`) and seven did not; indents ran
+ * `pl-4`, `pl-5` and an inline `paddingLeft: 20`; vertical rhythm ran `space-y-1`,
+ * `space-y-2`, a CSS-module `margin: 4px 0 6px`, and nothing at all. A reader
+ * scrolling one answer met several different ideas of what a list is.
+ *
+ * ⚠ DS v5 does not settle this. Its only statement about lists is that bullets
+ * take `panelBody` (12px) — §6.1. There is no list rule to derive, so these three
+ * constants ARE the rule, and they are chosen from what the panel already had
+ * rather than invented: `list-disc pl-4` was the most common marker treatment,
+ * and `space-y-1` the most common rhythm.
+ *
+ * ── WHY THREE AND NOT ONE ────────────────────────────────────────────────────
+ * "Make every list identical" is the wrong target, because two of these are not
+ * bullet lists at all. Collapsing them would put a disc in front of a checkbox
+ * row. The split is by WHAT THE ITEMS ARE, not by how they were styled:
+ *
+ *   BULLET   — short prose items. A marker helps the eye separate them.
+ *              (answer bullets, driver factors, consent lines, warning signs)
+ *   STACK    — composed text rows carrying their own label, id or separator.
+ *              A marker would compete with the row's own structure.
+ *              (story headlines, scenario contexts, notice rows, flip scenarios)
+ *   CONTROLS — stacked INTERACTIVE rows (checkbox + input). Same absence of a
+ *              marker as STACK, but roomier: 4px between 44px-tall controls reads
+ *              as a single block. This is the one density exception and it is
+ *              named rather than left as a stray `space-y-2`.
+ *
+ * Every `<ul>` in the panel surface must use exactly one of these, and
+ * `tests/ci-guards/panel-list-conformance.spec.ts` REDs if one does not — so a
+ * new list cannot quietly become an eleventh treatment.
+ */
+
+/** Short prose items, disc marker. The default for anything the AI writes. */
+export const PANEL_LIST_BULLET = 'list-disc pl-4 space-y-1'
+
+/** Composed text rows that carry their own structure. No marker, no indent. */
+export const PANEL_LIST_STACK = 'list-none p-0 m-0 space-y-1'
+
+/** Stacked interactive rows. As STACK, with room for 44px controls. */
+export const PANEL_LIST_CONTROLS = 'list-none p-0 m-0 space-y-2'

--- a/src/v5/blocks/V5AnalysisResultBlock.tsx
+++ b/src/v5/blocks/V5AnalysisResultBlock.tsx
@@ -61,6 +61,7 @@ import { deriveDecisionVerdict } from '../../lib/decisionVerdict'
 import { isRecord } from '../../lib/guards'
 import { formatProbabilityWithResolution } from '../../utils/formatPercent'
 import { calibrateUncertaintyCopy } from '../../components/results/utils/uncertaintyCalibration'
+import { PANEL_LIST_BULLET, PANEL_LIST_STACK } from '../../canvas/conversation/panelLists'
 
 export interface V5AnalysisResultBlockProps {
   block: V5AnalysisResultBlockType
@@ -150,7 +151,7 @@ function FactorList({
   return (
     <div data-testid={sectionTestId}>
       <p className={`${typography.panelMeta} text-text-light font-medium`}>{title}</p>
-      <ul className="list-disc pl-4">
+      <ul className={PANEL_LIST_BULLET}>
         {factors.map((f, i) => (
           <li
             // Index key: the LLM can legitimately repeat a factor string, and
@@ -449,7 +450,7 @@ function V5AnalysisResultBlockImpl({
           )}
 
           {review030.story_headlines.length > 0 && (
-            <ul className="space-y-1" data-testid="v5-analysis-result-story-headlines">
+            <ul className={PANEL_LIST_STACK} data-testid="v5-analysis-result-story-headlines">
               {review030.story_headlines.map((h) => {
                 // R-4: the shared null-refusing policy. `null` means no honest
                 // label exists for this id — the label and its separator are
@@ -524,7 +525,7 @@ function V5AnalysisResultBlockImpl({
           )}
 
           {review030.scenario_contexts.length > 0 && (
-            <ul className="space-y-1" data-testid="v5-analysis-result-scenario-contexts">
+            <ul className={PANEL_LIST_STACK} data-testid="v5-analysis-result-scenario-contexts">
               {review030.scenario_contexts.map((s) => (
                 <li
                   key={s.id}

--- a/src/v5/blocks/V5ExerciseBlock.tsx
+++ b/src/v5/blocks/V5ExerciseBlock.tsx
@@ -38,6 +38,7 @@ import type {
   V5BlockTargetRef,
   V5ExerciseBlock as V5ExerciseBlockType,
 } from '../../canvas/conversation/types'
+import { PANEL_LIST_BULLET } from '../../canvas/conversation/panelLists'
 
 export interface V5ExerciseBlockProps {
   block: V5ExerciseBlockType
@@ -114,7 +115,7 @@ export function V5ExerciseBlock({ block }: V5ExerciseBlockProps): ReactElement {
           )}
           {block.warning_signs && block.warning_signs.length > 0 && (
             <ul
-              className={`${typography.panelBody} list-disc pl-5 space-y-1`}
+              className={`${typography.panelBody} ${PANEL_LIST_BULLET}`}
               data-testid="v5-exercise-warning-signs"
             >
               {block.warning_signs.map((sign, i) => (

--- a/src/v5/blocks/V5FlipAnalysisBlock.tsx
+++ b/src/v5/blocks/V5FlipAnalysisBlock.tsx
@@ -21,6 +21,7 @@ import { typography } from '../../styles/typography'
 import type { V5FlipAnalysisBlock as V5FlipAnalysisBlockType } from '../../canvas/conversation/types'
 import { useCanvasNodeLabels } from './useCanvasLabels'
 import { resolveCanvasLabel } from '../../canvas/domain/canvasLabels'
+import { PANEL_LIST_STACK } from '../../canvas/conversation/panelLists'
 
 export interface V5FlipAnalysisBlockProps {
   block: V5FlipAnalysisBlockType
@@ -54,7 +55,7 @@ export function V5FlipAnalysisBlock({ block }: V5FlipAnalysisBlockProps): ReactE
       <h3 className={typography.panelHeader}>Flip analysis</h3>
       <p className={typography.panelBody}>{block.narrative}</p>
       {block.flip_scenarios.length > 0 && (
-        <ul className={`${typography.panelMeta} space-y-1`} role="list">
+        <ul className={`${typography.panelMeta} ${PANEL_LIST_STACK}`} role="list">
           {scenarios.map(({ scenario: s, label }, i) => (
             <li
               // The id remains the React key and the test id — a machine

--- a/src/v5/blocks/V5HeldProposalBlock.tsx
+++ b/src/v5/blocks/V5HeldProposalBlock.tsx
@@ -67,6 +67,7 @@ import {
   HELD_PROPOSAL_CONFIRMED_ACK,
   HELD_PROPOSAL_DISMISSED_ACK,
 } from './heldProposalReasonCopy'
+import { PANEL_LIST_BULLET } from '../../canvas/conversation/panelLists'
 
 /** How this card is settled, if it is. `null` ⇒ still pending. */
 export type HeldProposalSettlement = 'accepted' | 'dismissed'
@@ -334,7 +335,7 @@ export function V5HeldProposalBlock({
           already on screen, so a tooltip would be a second copy of it. */}
       {consentLines.length > 1 ? (
         <ul
-          className={`${typography.panelBody} list-disc pl-4 space-y-1 break-words`}
+          className={`${typography.panelBody} ${PANEL_LIST_BULLET} break-words`}
           data-testid="v5-held-proposal-summary"
           data-consent-line-count={consentLines.length}
         >

--- a/tests/ci-guards/panel-list-conformance.spec.ts
+++ b/tests/ci-guards/panel-list-conformance.spec.ts
@@ -1,0 +1,117 @@
+// tests/ci-guards/panel-list-conformance.spec.ts
+//
+// Every `<ul>` the AI panel renders must take its styling from `panelLists.ts`.
+//
+// ── WHY ──────────────────────────────────────────────────────────────────────
+// Ten lists, ten treatments, measured on `16c55158`: markers on three and absent
+// from seven; indents `pl-4` / `pl-5` / inline `paddingLeft: 20`; rhythm
+// `space-y-1` / `space-y-2` / a CSS-module margin / nothing. None of it was a
+// decision — each list was styled by whoever wrote it, and the drift was
+// invisible because no two sat on screen together.
+//
+// This guard is DERIVED: it finds the `<ul>` opening tags itself rather than
+// carrying a list of files someone must remember to update. A new list in a new
+// file is caught the day it lands.
+//
+// ⚠ IT ASSERTS THE MECHANISM, NOT THE VALUES. It does not check for `list-disc`
+// or `space-y-1` — that would pass a hand-copied duplicate of the constant and
+// re-open exactly the drift it exists to close. It requires the CONSTANT, so the
+// values live in one place and changing them is one edit.
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { resolve, join } from 'node:path'
+
+const root = resolve(__dirname, '../..')
+
+/** The AI panel's render surface — the dirs and files that compose the panel. */
+const SURFACE = [
+  'src/canvas/conversation',
+  'src/v5/blocks',
+  'src/canvas/components/FloatingOlumiPanel.tsx',
+  'src/canvas/components/OlumiTabBody.tsx',
+]
+
+function walk(rel: string): string[] {
+  const abs = resolve(root, rel)
+  if (statSync(abs).isFile()) return abs.endsWith('.tsx') ? [rel] : []
+  const out: string[] = []
+  for (const entry of readdirSync(abs)) {
+    if (entry === '__tests__' || entry === '__fixtures__') continue
+    const childRel = join(rel, entry)
+    const childAbs = resolve(root, childRel)
+    if (statSync(childAbs).isDirectory()) out.push(...walk(childRel))
+    else if (entry.endsWith('.tsx') && !/\.(spec|test)\.tsx$/.test(entry)) out.push(childRel)
+  }
+  return out
+}
+
+/** Every `<ul …>` opening tag in the surface, as `{ file, line, tag }`. */
+function panelLists(): Array<{ file: string; line: number; tag: string }> {
+  const found: Array<{ file: string; line: number; tag: string }> = []
+  for (const rel of SURFACE.flatMap(walk)) {
+    const src = readFileSync(resolve(root, rel), 'utf8')
+    const lines = src.split('\n')
+    for (let i = 0; i < lines.length; i++) {
+      // `\b`, not `(\s|>)`: a multi-line JSX tag puts `<ul` at END of line with
+      // nothing after it, and `(\s|>)` silently skipped every one of those —
+      // which is the form the most complex lists happen to use. Caught by the
+      // scan returning 8 when a hand audit found 10.
+      if (!/<ul\b/.test(lines[i])) continue
+      // A JSX opening tag may wrap over several lines; take until the closing `>`.
+      let tag = ''
+      for (let j = i; j < Math.min(i + 8, lines.length); j++) {
+        tag += lines[j]
+        if (lines[j].includes('>')) break
+      }
+      found.push({ file: rel, line: i + 1, tag })
+    }
+  }
+  return found
+}
+
+const CONSTANTS = ['PANEL_LIST_BULLET', 'PANEL_LIST_STACK', 'PANEL_LIST_CONTROLS']
+
+describe('AI panel list conformance', () => {
+  it('PRECONDITION — the surface is walkable and actually contains lists', () => {
+    // Without this, every assertion below passes vacuously on an empty scan —
+    // a renamed directory would read as "all lists conform".
+    const files = SURFACE.flatMap(walk)
+    expect(files.length, 'no .tsx files found in the panel surface').toBeGreaterThan(40)
+    expect(panelLists().length, 'no <ul> found — the scanner is blind').toBeGreaterThan(5)
+  })
+
+  it('every <ul> in the panel takes its styling from panelLists.ts', () => {
+    const offenders = panelLists()
+      .filter((l) => !CONSTANTS.some((c) => l.tag.includes(c)))
+      .map((l) => `${l.file}:${l.line}`)
+    expect(offenders, 'these lists style themselves instead of using a PANEL_LIST_* constant').toEqual([])
+  })
+
+  it('no <ul> hand-rolls a marker, indent or rhythm alongside the constant', () => {
+    // Catches the half-migration: importing the constant and then appending
+    // `pl-5` or `space-y-2` next to it, which re-opens the drift one class at a
+    // time while the guard above still passes.
+    const strays = panelLists()
+      .filter((l) => CONSTANTS.some((c) => l.tag.includes(c)))
+      .filter((l) => /\b(list-disc|list-none|list-decimal|pl-\d|pt-\d|space-y-\d|paddingLeft)\b/.test(
+        // Look only at what sits OUTSIDE the constant reference itself.
+        CONSTANTS.reduce((acc, c) => acc.split(c).join(''), l.tag),
+      ))
+      .map((l) => `${l.file}:${l.line}`)
+    expect(strays, 'list styling appended beside the constant — put it in panelLists.ts instead').toEqual([])
+  })
+
+  it('the three constants remain distinct — two names for one spelling is not a scale', () => {
+    const mod = readFileSync(resolve(root, 'src/canvas/conversation/panelLists.ts'), 'utf8')
+    const values = CONSTANTS.map((c) => {
+      const m = mod.match(new RegExp(`export const ${c} =\\s*'([^']+)'`))
+      expect(m, `${c} is not exported as a string literal`).toBeTruthy()
+      return m![1]
+    })
+    expect(new Set(values).size, `duplicate spellings: ${values.join(' | ')}`).toBe(3)
+    // BULLET is the only one that carries a marker; the other two must not.
+    expect(values[0]).toContain('list-disc')
+    expect(values[1]).not.toContain('list-disc')
+    expect(values[2]).not.toContain('list-disc')
+  })
+})


### PR DESCRIPTION
## Paul asked whether bullets always render the same. They did not.

**Eleven `<ul>` in the AI panel, styled eleven ways** (measured on `16c55158`):

| Where | Marker | Indent | Rhythm |
|---|---|---|---|
| `AnswerBody:141` | — | — | CSS-module `margin: 4px 0 6px` |
| `InlineBlocks:1509` | — | inline `paddingLeft: 20` | inline `marginBottom: 2` |
| `V5AnalysisResultBlock:153` | `list-disc` | `pl-4` | — |
| `V5ExerciseBlock:116` | `list-disc` | **`pl-5`** | `space-y-1` |
| `V5HeldProposalBlock:336` | `list-disc` | `pl-4` | `space-y-1` |
| `V5AnalysisResultBlock:452, :527` | — | — | `space-y-1` |
| `ModelBuildingNoticesNotice:89` · `V5FlipAnalysisBlock:57` | — | — | `space-y-1` |
| `AddOptionPanel:181` | — | — | **`space-y-2`** |
| `ModelReceiptBlock:135` | — | `pl-4` | **`space-y-0.5`** |

Markers on three, absent from eight. Three indents. Four rhythms. **None of it was a decision** — the drift stayed invisible because no two of these sit on screen together.

## ⚠ DS v5 does not settle this

Its only statement about lists is that bullets take `panelBody` (12px), §6.1. There was **no rule to derive**, so `panelLists.ts` *is* the rule — chosen from what the panel already had (`list-disc pl-4` was the commonest marker treatment, `space-y-1` the commonest rhythm), not invented.

## Three constants, not one

Collapsing all eleven would put a disc in front of a checkbox. The split is by **what the items are**:

- **`BULLET`** — short prose items; a marker separates them.
- **`STACK`** — composed text rows carrying their own label/id/separator; a marker would compete with the row's own structure.
- **`CONTROLS`** — stacked *interactive* rows; as STACK, with room for 44px controls. The one density exception, **named** rather than left as a stray `space-y-2`.

The guard is **derived** (it finds `<ul>` itself, no file list to maintain) and asserts the **mechanism, not the values** — requiring `list-disc` would pass a hand-copied duplicate and re-open the drift it exists to close.

Also removed `.answerBullets`, dead after the migration.

## ⭐ Two instrument failures caught, either of which would have shipped a false result

**1. The scanner was blind to multi-line tags.** `/<ul(\s|>)/` never matches when `<ul` ends the line — the form the most complex lists use. It reported **8** offenders; a hand audit found **10**; the fixed `/<ul\b/` found **11**, including `ModelReceiptBlock.tsx`, which **my own grep had missed for exactly the same reason**.

**2. A green-looking total hiding 856 tests that never ran.** Splicing imports after `^import .*$` landed three of them *inside* multi-line import statements. The first suite run read **`2183 passed | 0 failed`** — with **68 test files failing at collect**. Files went **68 → 36 → 0**; passing tests **2183 → 2741 → 3039**.

## Evidence

- **RED-first at pristine**, naming all 11 offenders by `file:line`.
- **Three discriminating mutants, each biting a DIFFERENT named assertion**: reverting one list → conformance test REDs; appending `pl-5` beside the constant → stray test REDs; collapsing two constants → distinctness test REDs.
- Leading **and** trailing controls green, applied-check per mutation, clean tree after, **isolation proven by writing a sentinel**.
- Affected suites: **221/221 files, 3039 passed, 0 transform errors.**
- `eslint` exit 0. Its three warnings are **pre-existing** — verified by diffing the import region against `origin/staging`, which is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)