### PR TITLE
Analysis (New): a second Analysis tab for a reasoning-led IA comparison (experiment, not for merge yet)

### DIFF
--- a/e2e/visual/shellLayout.visual.spec.ts
+++ b/e2e/visual/shellLayout.visual.spec.ts
@@ -38,6 +38,16 @@ import {
   seedStarterDraft,
   waitForVisualQuiescence,
 } from './harness'
+// ⚠ DERIVED, NOT RE-STATED. The tab count below used to be a hardcoded `4`
+// with the comment "Olumi, Analysis, Compare, Model". Compare left the strip
+// by contract on 18 Aug 2026 and this pin was never re-recorded, so it has
+// been asserting 4 against a strip of 3 ever since — a stale pin on an
+// advisory job, which is the quietest place for one to rot. Worse, the NEXT
+// surface added would have made it pass again for entirely the wrong reason: a
+// broken alarm going green is harder to notice than one going red.
+// `MAX_PRESENTED_SURFACES` is the recorded budget, and `compareDeTab.contract
+// .spec.tsx` DT-4 is what holds it honest against the Record.
+import { MAX_PRESENTED_SURFACES } from '../../src/canvas/components/workspaceShell/shellContract'
 
 const STARTER = 'build-vs-buy' as const
 
@@ -211,8 +221,13 @@ test.describe('workspace shell — layout, measured', () => {
       const navBox = await boxOf(page, 'nav[aria-label="Outputs sections"]')
       const tabs = nav.locator('button')
       const tabCount = await tabs.count()
-      // Journey is hidden by contract, so four surfaces are presented.
-      expect(tabCount, 'four presented surfaces: Olumi, Analysis, Compare, Model').toBe(4)
+      // Journey and Compare are hidden by contract; the presented set is
+      // whatever the shell contract records, and this asserts the strip lays
+      // out exactly that many.
+      expect(
+        tabCount,
+        `the strip must lay out exactly the recorded budget (${MAX_PRESENTED_SURFACES} presented surfaces)`,
+      ).toBe(MAX_PRESENTED_SURFACES)
       for (let i = 0; i < tabCount; i++) {
         const t = await tabs.nth(i).boundingBox()
         expect(t, `tab ${i} is not laid out`).not.toBeNull()

--- a/src/canvas/components/OutputsDock.tsx
+++ b/src/canvas/components/OutputsDock.tsx
@@ -24,7 +24,7 @@
  */
 
 import { useEffect, useState, useRef, useMemo, useCallback, lazy, Suspense } from 'react'
-import { BarChart3, Shuffle, Activity, Clock, AlertTriangle, HelpCircle, MessageCircle, MessageSquare, CheckCircle } from 'lucide-react'
+import { BarChart3, Shuffle, Activity, Clock, AlertTriangle, HelpCircle, MessageCircle, MessageSquare, CheckCircle, FlaskConical } from 'lucide-react'
 import { useShallow } from 'zustand/react/shallow'
 import { useUIStore, type OutputTab } from '../../stores/uiStore'
 import { useDockState } from '../hooks/useDockState'
@@ -151,6 +151,7 @@ import { useResultsSectionData } from '../../components/results/useResultsSectio
 import type { TornadoRow } from '../../components/results/TornadoChart'
 import { useCanvasResultsSync } from '../../components/results/useCanvasResultsSync'
 import { ResultsBody } from '../../components/results/ResultsBody'
+import { AnalysisNewTabBody } from '../../components/results/analysisNew/AnalysisNewTabBody'
 import { useGuidanceStore } from '../stores/guidanceStore'
 import { useDraftStore, draftStreamPhaseFor } from '../stores/draftStore'
 import { executeAutoFix, determineFixType, type AutoFixParams } from '../utils/autoFix'
@@ -247,7 +248,7 @@ export function readPersistedActiveDockTab(): OutputsDockTab | null {
     // 'altview' is deliberately absent: the retired V7 comparison tab must not
     // rehydrate from a session persisted before its retirement — an unknown id
     // falls through to null and the dock opens on its default tab.
-    if (tab === 'results' || tab === 'compare' || tab === 'diagnostics' || tab === 'journey' || tab === 'olumi') {
+    if (tab === 'results' || tab === 'analysisNew' || tab === 'compare' || tab === 'diagnostics' || tab === 'journey' || tab === 'olumi') {
       return tab
     }
     return null
@@ -2627,6 +2628,8 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
             const Icon =
               tab.id === 'results'
                 ? BarChart3
+                : tab.id === 'analysisNew'
+                ? FlaskConical
                 : tab.id === 'compare'
                 ? Shuffle
                 : tab.id === 'journey'
@@ -3441,6 +3444,29 @@ function OutputsDockBody({ sendMessage }: OutputsDockBodyProps) {
                   />
                 )}
               </div>
+            )}
+            {effectiveActiveTab === 'analysisNew' && (
+              // ⭐ TEMPORARY comparison surface (Paul, 27 Aug 2026): the SAME
+              // analysis run, laid out around the reasoning. The existing
+              // Analysis branch above is untouched.
+              //
+              // SINGLE DATA AUTHORITY, AND IT IS THE POINT OF THE EXPERIMENT:
+              // every expression below is the SAME one `ResultsBody` receives
+              // in the `results` branch — the same `resultsSectionData`
+              // instance, the same sample/seed/hash reads, the same focus
+              // handler, the same freshness derivation. Never a re-derivation.
+              // If these two lists ever diverge, the two tabs stop being a
+              // presentation comparison and the whole experiment is void.
+              <AnalysisNewTabBody
+                resultsSectionData={resultsSectionData}
+                isPreRun={isPreRun}
+                isRunning={isRunning}
+                nSamples={(report as any)?.summary?.n_samples_used ?? (report as any)?.meta?.n_samples}
+                seedUsed={(report as any)?.meta?.seed}
+                responseHash={results?.hash}
+                onFocusNode={handleFocusResultNode}
+                isStale={analysisNotConfirmedFresh}
+              />
             )}
             {effectiveActiveTab === 'compare' && (
               // 2.581 — ONE expert mode for the product. The Compare pill used

--- a/src/canvas/components/__tests__/OutputsDock.analysisNewTab.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.analysisNewTab.spec.tsx
@@ -1,0 +1,354 @@
+/**
+ * ANALYSIS (NEW) — THE COMPARISON TAB, AND THE PROOF THE OLD ONE DID NOT MOVE.
+ *
+ * The experiment (Paul, 27 Aug 2026) adds a SECOND Analysis surface beside the
+ * existing one so the two information architectures can be compared on one
+ * scenario. Its hard constraint is that the existing Analysis tab is untouched.
+ *
+ * ── WHY THE PRESERVATION CASE IS NOT "THE NEW TAB EXISTS" ──────────────────
+ * The brief asks for a DISCRIMINATING regression test, and it is right to: a
+ * spec that asserts the new tab mounted would pass just as happily on a change
+ * that reordered, restyled or silently re-propped the old one. So the
+ * preservation case captures the Analysis surface's rendered TESTID SEQUENCE
+ * and its TEXT, drives a full round trip through the new tab, and asserts both
+ * come back identical.
+ *
+ * That pins exactly what §8 forbids moving — render tree, ordering, copy,
+ * component removal — and it is immune to `useId` churn across the remount,
+ * which a raw innerHTML diff is not (the results branch is a bare conditional
+ * render, so switching tabs genuinely unmounts and remounts it, and React's id
+ * counter advances). Attribute-level identity is deliberately NOT claimed here;
+ * the advisory visual-regression harness owns pixels.
+ *
+ * ⚠ AND ITS POSITIVE CONTROL. A sequence comparison passes trivially when both
+ * sides are empty (CLAUDE.md trap 13 — an absence probe with no positive
+ * control proves nothing). `RESULTS_TESTID_FLOOR` asserts the captured sequence
+ * is substantial BEFORE it is compared, so a harness that stubbed the Analysis
+ * surface into nothing fails loudly instead of certifying it unchanged. This is
+ * also why the pre-analysis panels are NOT mocked out in this file.
+ *
+ * ── MOUNT PATH IS ASSERTED, NOT ASSUMED (trap 3b) ──────────────────────────
+ * This estate has twice shipped a feature dark because its tests targeted a
+ * component the deployed flag posture does not render. MOUNT PATH below asserts
+ * the contract declarations themselves, with contrast controls, so a moved
+ * declaration REDs here rather than silently retargeting every case.
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { fireEvent, render, screen, cleanup } from '@testing-library/react'
+
+// ── heavy-import stubs: only what genuinely breaks under jsdom ──────────────
+vi.mock('../../../lib/supabase', () => ({
+  supabase: { from: () => ({ select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: null }) }) }) }) },
+  isSupabaseAvailable: () => false,
+}))
+vi.mock('dompurify', () => ({ default: { sanitize: (s: string) => s } }))
+vi.mock('../../utils/markdown', () => ({
+  renderMarkdown: (s: string) => s,
+  sanitiseMarkdown: (s: string) => s,
+}))
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>()
+  return { ...actual, useNavigate: vi.fn(() => vi.fn()) }
+})
+// The real readiness hook fetches a relative URL on mount, which jsdom rejects
+// as an unhandled rejection. Stubbed so the fetch spy below measures only what
+// a TAB SWITCH causes — the question this file exists to answer.
+vi.mock('../../hooks/useGraphReadiness', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../hooks/useGraphReadiness')>()
+  return {
+    ...actual,
+    useGraphReadiness: () => ({ readiness: null, loading: false, error: null, refresh: vi.fn() }),
+  }
+})
+
+// Flags: spread the real module — a hand-listed factory REPLACES it and
+// silently drops every flag added later (trap 12; it killed 51 tests here once).
+vi.mock('../../../flags', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../flags')>()
+  return {
+    ...actual,
+    isAiPanelV2Enabled: () => true,
+    isTelemetryEnabled: () => false,
+    isCompareTabEnabled: () => false,
+    isJourneyTabEnabled: () => false,
+  }
+})
+
+import { ConversationProvider } from '../../conversation/ConversationContext'
+import { ToastProvider } from '../../ToastContext'
+import { OutputsDock, OUTPUTS_DOCK_STORAGE_KEY } from '../OutputsDock'
+import { useCanvasStore } from '../../store'
+import { useUIStore } from '../../../stores/uiStore'
+import { useFloatingPanelState } from '../../hooks/useFloatingPanelState'
+import {
+  MAX_PRESENTED_SURFACES,
+  WORKSPACE_SURFACES,
+  WORKSPACE_SURFACE_ORDER,
+  presentedSurfaces,
+} from '../workspaceShell/shellContract'
+import { ANALYSIS_NEW_COPY } from '../../../components/results/analysisNew/analysisNewCopy'
+
+const NEW_TAB = 'outputs-dock-tab-analysisNew'
+const OLD_TAB = 'outputs-dock-tab-results'
+const BODY = 'outputs-dock-body'
+
+/**
+ * The Analysis surface must render at least this many testid-bearing elements
+ * for the preservation comparison to mean anything. Measured at the tip this
+ * spec was written against; a floor, not a pin, so ADDING to the Analysis tab
+ * in a later change does not RED this file — only stubbing it into nothing does.
+ */
+const RESULTS_TESTID_FLOOR = 5
+
+/**
+ * Render the dock AND expand it.
+ *
+ * ⚠ THE DOCK MOUNTS COLLAPSED IN THIS HARNESS, and the collapsed rail renders a
+ * DIFFERENT set of testids (`outputs-dock-rail-tab-*`). Every case below is
+ * about the expanded strip and the body, so expansion is a precondition, not a
+ * step under test. Tolerant of both starting states — the dock's open flag is
+ * module-level and survives `cleanup()` — and asserts only its POSTCONDITION.
+ */
+function renderDock() {
+  const result = render(
+    <ToastProvider>
+      <ConversationProvider>
+        <OutputsDock />
+      </ConversationProvider>
+    </ToastProvider>,
+  )
+  const control = screen.getByTestId('dock-collapse-control')
+  if (control.getAttribute('aria-label') === 'Expand outputs dock') {
+    fireEvent.click(control)
+  }
+  expect(screen.getByTestId(OLD_TAB), 'the dock did not expand').toBeInTheDocument()
+  return result
+}
+
+function ensureMatchMedia() {
+  if (typeof window.matchMedia !== 'function') {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: query === '(prefers-reduced-motion: reduce)',
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => true,
+      }),
+    })
+  }
+}
+function ensureScrollIntoView() {
+  if (!Element.prototype.scrollIntoView) Element.prototype.scrollIntoView = () => {}
+}
+
+/** The ordered testid sequence + text of whatever the dock body is showing. */
+function captureBody() {
+  const body = screen.getByTestId(BODY)
+  return {
+    testIds: Array.from(body.querySelectorAll('[data-testid]')).map((el) =>
+      el.getAttribute('data-testid'),
+    ),
+    text: body.textContent ?? '',
+  }
+}
+
+beforeEach(() => {
+  ensureMatchMedia()
+  ensureScrollIntoView()
+  try {
+    sessionStorage.removeItem(OUTPUTS_DOCK_STORAGE_KEY)
+    sessionStorage.clear()
+  } catch {
+    /* jsdom quirk */
+  }
+  // ⚠ The URL is a singleton across the whole FILE in jsdom, and `handleTabClick`
+  // writes a `?tab=` deep link. Without this reset the first case's click leaks
+  // into every later mount and misattributes their failures.
+  window.history.replaceState({}, '', '/')
+  useUIStore.setState({ activeOutputTab: 'results', activeOutputTabVersion: 0 } as never)
+  useFloatingPanelState.setState({ isOpen: false, isMinimised: false, source: 'user' } as never)
+})
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('MOUNT PATH — the declarations this experiment depends on', () => {
+  it('declares Analysis (New) as a presented surface, adjacent to Analysis', () => {
+    expect(WORKSPACE_SURFACES.analysisNew.presentedAsTab).toBe(true)
+    expect(WORKSPACE_SURFACES.analysisNew.label).toBe('Analysis (New)')
+    const order = WORKSPACE_SURFACE_ORDER
+    expect(order.indexOf('analysisNew')).toBe(order.indexOf('results') + 1)
+    // CONTRAST CONTROL: not every declared surface is presented, so "some
+    // surface is presented" cannot satisfy the assertion above.
+    expect(WORKSPACE_SURFACES.compare.presentedAsTab).toBe(false)
+    expect(WORKSPACE_SURFACES.journey.presentedAsTab).toBe(false)
+  })
+
+  it('the recorded strip budget matches the presented set', () => {
+    // The budget is a RECORDED literal by design — deriving it would make the
+    // conformance guard a tautology. This asserts the record was updated.
+    expect(presentedSurfaces()).toHaveLength(MAX_PRESENTED_SURFACES)
+  })
+
+  it('asks the shell for the reanalyse footer, so no second run authority exists', () => {
+    expect(WORKSPACE_SURFACES.analysisNew.footerBar).toBe('reanalyse')
+    // CONTRAST CONTROL: the three footer arms are genuinely different.
+    expect(WORKSPACE_SURFACES.results.footerBar).toBe('none')
+    expect(WORKSPACE_SURFACES.olumi.footerBar).toBe('readiness')
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('A · THE EXISTING ANALYSIS TAB IS UNCHANGED', () => {
+  it('its own contract declaration is byte-for-byte what it was', () => {
+    // The cheapest discriminating guard there is: if anyone re-declares the
+    // Analysis surface while adding to this experiment, this REDs by name.
+    expect(WORKSPACE_SURFACES.results).toEqual({
+      id: 'results',
+      label: 'Analysis',
+      footerBar: 'none',
+      scroll: 'self',
+      padding: 'self',
+      presentedAsTab: true,
+      hiddenReason: '',
+    })
+  })
+
+  it('survives a full round trip through Analysis (New) with an identical render tree, ordering and copy', () => {
+    renderDock()
+
+    const before = captureBody()
+    // POSITIVE CONTROL — without this, two empty captures would "match" and
+    // this case would certify a surface it never saw.
+    expect(
+      before.testIds.length,
+      'the Analysis surface rendered almost nothing — this comparison would be vacuous',
+    ).toBeGreaterThanOrEqual(RESULTS_TESTID_FLOOR)
+    expect(before.text.trim().length).toBeGreaterThan(0)
+
+    fireEvent.click(screen.getByTestId(NEW_TAB))
+    expect(screen.getByTestId('analysis-new-tab-body')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId(OLD_TAB))
+    const after = captureBody()
+
+    // Render tree AND ordering.
+    expect(after.testIds).toEqual(before.testIds)
+    // Copy.
+    expect(after.text).toBe(before.text)
+  })
+
+  it('does not render any Analysis (New) element while Analysis is fronted', () => {
+    renderDock()
+    // Binds to the new surface's own root testid — a leak of the experimental
+    // IA into the old tab is exactly what §8 forbids.
+    expect(screen.queryByTestId('analysis-new-tab-body')).toBeNull()
+    expect(screen.queryByTestId('analysis-new-key-insights')).toBeNull()
+    expect(screen.queryByTestId('analysis-new-strengthen')).toBeNull()
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('B · THE NEW TAB IS MOUNTED, AND IS NOT THE DEFAULT', () => {
+  it('appears in the strip under its exact label', () => {
+    renderDock()
+    const tab = screen.getByTestId(NEW_TAB)
+    expect(tab).toBeInTheDocument()
+    expect(tab).toHaveTextContent('Analysis (New)')
+  })
+
+  it('Analysis, not Analysis (New), is what the dock opens on', () => {
+    renderDock()
+    expect(screen.getByTestId(BODY)).toBeInTheDocument()
+    expect(screen.queryByTestId('analysis-new-tab-body')).toBeNull()
+    expect(useUIStore.getState().activeOutputTab).toBe('results')
+  })
+
+  it('switching tabs issues NO network request and mutates NO canonical state', () => {
+    // ⭐ THE PROPERTY THE WHOLE COMPARISON RESTS ON. If a tab switch re-ran
+    // analysis, produced a second result, or moved canonical state, the two
+    // surfaces would no longer be showing the same run and Paul's side-by-side
+    // would be measuring different data, not different layouts.
+    const fetchSpy = vi.fn(() => Promise.resolve(new Response('{}')))
+    vi.stubGlobal('fetch', fetchSpy)
+
+    renderDock()
+    const before = useCanvasStore.getState()
+    const resultsBefore = before.results
+    const callsAfterMount = fetchSpy.mock.calls.length
+
+    fireEvent.click(screen.getByTestId(NEW_TAB))
+    fireEvent.click(screen.getByTestId(OLD_TAB))
+    fireEvent.click(screen.getByTestId(NEW_TAB))
+
+    const after = useCanvasStore.getState()
+    expect(fetchSpy.mock.calls.length, 'a tab switch issued a network request').toBe(callsAfterMount)
+    // Referential identity, not deep equality: a re-derivation that produced an
+    // equal-but-new object would still be a second computation, and deep
+    // equality would wave it through.
+    expect(after.results).toBe(resultsBefore)
+    expect(after.nodes).toBe(before.nodes)
+    expect(after.edges).toBe(before.edges)
+    expect(after.analysisStateV1).toBe(before.analysisStateV1)
+  })
+})
+
+// ═══════════════════════════════════════════════════════════════════════════
+
+describe('C · THE FOUR-SECTION STRUCTURE', () => {
+  it('renders Key insights, Strengthen the reasoning, Drivers and dynamics, Uncertainty and gaps — in that order', () => {
+    renderDock()
+    fireEvent.click(screen.getByTestId(NEW_TAB))
+
+    const body = screen.getByTestId('analysis-new-tab-body')
+    const headings = Array.from(body.querySelectorAll('h3')).map((h) => h.textContent)
+    expect(headings).toEqual([
+      ANALYSIS_NEW_COPY.sections.keyInsights,
+      ANALYSIS_NEW_COPY.sections.strengthen,
+      ANALYSIS_NEW_COPY.sections.drivers,
+      ANALYSIS_NEW_COPY.sections.uncertainty,
+    ])
+  })
+
+  it('puts Strengthen the reasoning near the TOP, not at the end', () => {
+    // The placement IS the experiment. On the existing Analysis tab the same
+    // material sits roughly eleventh, below the option comparison.
+    renderDock()
+    fireEvent.click(screen.getByTestId(NEW_TAB))
+    const body = screen.getByTestId('analysis-new-tab-body')
+    const headings = Array.from(body.querySelectorAll('h3')).map((h) => h.textContent)
+    expect(headings.indexOf(ANALYSIS_NEW_COPY.sections.strengthen)).toBe(1)
+    expect(headings.indexOf(ANALYSIS_NEW_COPY.sections.strengthen)).toBeLessThan(
+      headings.indexOf(ANALYSIS_NEW_COPY.sections.uncertainty),
+    )
+  })
+
+  it('every section is a labelled landmark with a real heading', () => {
+    renderDock()
+    fireEvent.click(screen.getByTestId(NEW_TAB))
+    for (const testId of [
+      'analysis-new-key-insights',
+      'analysis-new-strengthen',
+      'analysis-new-drivers',
+      'analysis-new-uncertainty',
+    ]) {
+      const section = screen.getByTestId(testId)
+      expect(section.tagName).toBe('SECTION')
+      expect(section.getAttribute('aria-labelledby')).toBe(`${testId}-heading`)
+      expect(document.getElementById(`${testId}-heading`)).not.toBeNull()
+    }
+  })
+})

--- a/src/canvas/components/__tests__/OutputsDock.analysisNewTab.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.analysisNewTab.spec.tsx
@@ -325,7 +325,9 @@ describe('C · THE FOUR-SECTION STRUCTURE', () => {
 
   it('puts Strengthen the reasoning near the TOP, not at the end', () => {
     // The placement IS the experiment. On the existing Analysis tab the same
-    // material sits roughly eleventh, below the option comparison.
+    // material is the FIFTH of eleven named sections in `ResultsBody` (below
+    // Decision brief, Analysis hero, Key question and What I was given), plus
+    // the warning strips and status furniture above it. Here it is second.
     renderDock()
     fireEvent.click(screen.getByTestId(NEW_TAB))
     const body = screen.getByTestId('analysis-new-tab-body')

--- a/src/canvas/components/__tests__/OutputsDock.assistantOpenedAttribution.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.assistantOpenedAttribution.spec.tsx
@@ -348,7 +348,7 @@ describe('ROADMAP 2.1132 — the assistant attributes the panel gestures it actu
     // before anything below asserts a presence or an absence inside it.
     const strip = screen.getByRole('navigation', { name: 'Outputs sections' })
     expect(strip).toBeInTheDocument()
-    expect(tabLabels(strip)).toEqual(['Olumi', 'Analysis', 'Model'])
+    expect(tabLabels(strip)).toEqual(['Olumi', 'Analysis', 'Analysis (New)', 'Model'])
 
     // Absent before any gesture — so the presence below is the gesture's doing.
     expect(notice()).not.toBeInTheDocument()
@@ -372,7 +372,7 @@ describe('ROADMAP 2.1132 — the assistant attributes the panel gestures it actu
     mockIsAiPanelV2Enabled.mockReturnValue(false)
     renderDock()
     const strip = screen.getByRole('navigation', { name: 'Outputs sections' })
-    expect(tabLabels(strip)).toEqual(['Analysis', 'Model'])
+    expect(tabLabels(strip)).toEqual(['Analysis', 'Analysis (New)', 'Model'])
 
     driveDirective(openPanelEnvelope('results'))
     expect(screen.getByTestId('outputs-dock')).toContainElement(

--- a/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
+++ b/src/canvas/components/__tests__/OutputsDock.dom.spec.tsx
@@ -208,6 +208,13 @@ describe('OutputsDock DOM', () => {
     expect(tabs.map(tab => tab.textContent)).toEqual([
       'Olumi',
       'Analysis',
+      // TEMPORARY comparison surface (Paul, 27 Aug 2026) — a second Analysis
+      // tab rendering the SAME run through a reasoning-led IA, placed directly
+      // after Analysis so the two are adjacent. Added to this EXACT list rather
+      // than the list being loosened: an exact, ordered list is what catches a
+      // surface silently appearing OR disappearing, and loosening it to make
+      // room for the experiment would retire the guard along with it.
+      'Analysis (New)',
       'Model',
     ])
   })
@@ -1196,6 +1203,13 @@ describe('I.2a: Secondary action button interaction', () => {
     expect(tabs.map(tab => tab.textContent)).toEqual([
       'Olumi',
       'Analysis',
+      // TEMPORARY comparison surface (Paul, 27 Aug 2026) — a second Analysis
+      // tab rendering the SAME run through a reasoning-led IA, placed directly
+      // after Analysis so the two are adjacent. Added to this EXACT list rather
+      // than the list being loosened: an exact, ordered list is what catches a
+      // surface silently appearing OR disappearing, and loosening it to make
+      // room for the experiment would retire the guard along with it.
+      'Analysis (New)',
       'Model',
     ])
     // ⭐ 18 Aug 2026: 'Compare' left this list the same way Journey did, and

--- a/src/canvas/components/__tests__/compareDeTab.contract.spec.tsx
+++ b/src/canvas/components/__tests__/compareDeTab.contract.spec.tsx
@@ -96,7 +96,7 @@ describe('Compare is de-tabbed by contract (Fable, 18 Aug 2026)', () => {
     expect(ids).not.toContain('compare')
     // CONTRAST CONTROL in the same run — absence is only evidence when the
     // things that must be present read present (trap 13e).
-    expect(ids).toEqual(['olumi', 'results', 'diagnostics'])
+    expect(ids).toEqual(['olumi', 'results', 'analysisNew', 'diagnostics'])
     // ⚠ 120s, and the number is deliberate, not padding. Importing OutputsDock
     // cold through `resetModules` + `doMock` pulls a very large module graph:
     // measured 27.1s on this machine, and the 5s default fired BEFORE any
@@ -113,7 +113,7 @@ describe('Compare is de-tabbed by contract (Fable, 18 Aug 2026)', () => {
   }, 120_000)
 
   it('DT-3: presentedSurfaces() drops compare and keeps the other three, in strip order', () => {
-    expect(presentedSurfaces().map(s => s.id)).toEqual(['olumi', 'results', 'diagnostics'])
+    expect(presentedSurfaces().map(s => s.id)).toEqual(['olumi', 'results', 'analysisNew', 'diagnostics'])
   })
 
   it('DT-4: the strip budget moved WITH the Record, not independently of it', () => {
@@ -126,7 +126,10 @@ describe('Compare is de-tabbed by contract (Fable, 18 Aug 2026)', () => {
     // this pins it in both directions: it REDs if a surface is presented AND
     // if one is hidden without the budget being re-recorded.
     expect(MAX_PRESENTED_SURFACES).toBe(presentedSurfaces().length)
-    expect(MAX_PRESENTED_SURFACES).toBe(3)
+    // 3 while Compare was hidden and nothing replaced it; 4 since the
+    // temporary 'Analysis (New)' comparison surface joined the strip
+    // (27 Aug 2026). Re-record deliberately when that experiment retires.
+    expect(MAX_PRESENTED_SURFACES).toBe(4)
   })
 
   it('DT-5: compare keeps its ORDER slot and its Record row — hidden, not retired', () => {

--- a/src/canvas/components/workspaceShell/shellContract.ts
+++ b/src/canvas/components/workspaceShell/shellContract.ts
@@ -352,6 +352,42 @@ export const WORKSPACE_SURFACES: Record<OutputTab, WorkspaceSurfaceDescriptor> =
     presentedAsTab: true,
     hiddenReason: '',
   },
+  /**
+   * TEMPORARY comparison surface (Paul, 27 Aug 2026) — "Analysis (New)".
+   *
+   * A SECOND, SEPARATE Analysis tab rendering the SAME analysis run through a
+   * reasoning-led IA (Key insights · Strengthen the reasoning · Drivers and
+   * dynamics · Uncertainty and gaps), so the existing Analysis surface and this
+   * one can be compared directly on one scenario. `results` above is UNCHANGED
+   * and stays the default tab; this row is purely additive.
+   *
+   * Sits directly after `results` so the two surfaces under comparison are
+   * adjacent in the strip — the same placement rule the retired 'Alt view'
+   * comparison tab used (PR #673). Unflagged, per the standing no-dark-launch
+   * ruling: a flag here would add a second posture to reason about for a
+   * surface whose whole purpose is to be looked at.
+   *
+   * `footerBar: 'reanalyse'` DELIBERATELY. The Rerun control and the stale
+   * warning are then rendered BY THE SHELL, from the SAME `handleRunAnalysis`
+   * the Model surface uses — so this experiment introduces no second run
+   * authority and no second staleness owner. `AnalysisFooter` mounts on the
+   * `results` branch only, so without this declaration the surface would have
+   * no re-run control at all, which is the exact defect this field exists to
+   * fix.
+   *
+   * `scroll`/`padding: 'self'` because the surface owns a narrower inner
+   * content measure than the shell gutter provides (the dock's outer width is
+   * unchanged — see the width note in `AnalysisNewTabBody.tsx`).
+   */
+  analysisNew: {
+    id: 'analysisNew',
+    label: 'Analysis (New)',
+    footerBar: 'reanalyse',
+    scroll: 'self',
+    padding: 'self',
+    presentedAsTab: true,
+    hiddenReason: '',
+  },
   compare: {
     id: 'compare',
     label: 'Compare',
@@ -439,6 +475,10 @@ export const WORKSPACE_SURFACES: Record<OutputTab, WorkspaceSurfaceDescriptor> =
 export const WORKSPACE_SURFACE_ORDER: readonly OutputTab[] = [
   'olumi',
   'results',
+  // Directly after 'results' so the two surfaces under comparison are adjacent
+  // in the strip (Paul, 27 Aug 2026 — the same placement rule the retired
+  // 'Alt view' comparison tab used).
+  'analysisNew',
   'compare',
   'diagnostics',
   'journey',
@@ -461,9 +501,12 @@ export const WORKSPACE_SURFACE_ORDER: readonly OutputTab[] = [
  * it was written when five surfaces were presented and was never re-read. Do
  * not restate the count in words. Derive it: `presentedSurfaces().length`.
  *
- * Was 4 until 18 Aug 2026; 3 since Compare's row was hidden by contract.
+ * Was 4 until 18 Aug 2026; 3 since Compare's row was hidden by contract; 4
+ * again since 27 Aug 2026, when the temporary 'Analysis (New)' comparison
+ * surface was added beside Analysis. It returns to 3 when that experiment
+ * retires — re-record it here in the same change, deliberately.
  */
-export const MAX_PRESENTED_SURFACES = 3
+export const MAX_PRESENTED_SURFACES = 4
 
 /**
  * The surfaces offered as tabs, in strip order.

--- a/src/components/results/analysisNew/AnalysisNewTabBody.tsx
+++ b/src/components/results/analysisNew/AnalysisNewTabBody.tsx
@@ -1,0 +1,218 @@
+/**
+ * Analysis (New) — the experimental Analysis surface (Paul, 27 Aug 2026).
+ *
+ * A SECOND, SEPARATE tab beside the existing Analysis tab, rendering THE SAME
+ * analysis run through a reasoning-led information architecture so the two can
+ * be compared directly on one scenario. The existing Analysis tab is untouched.
+ *
+ *   What should we notice?            → Key insights
+ *   How can we strengthen this?       → Strengthen the reasoning
+ *   What is shaping the situation?    → Drivers and dynamics
+ *   What is still uncertain?          → Uncertainty and gaps
+ *   (everything deeper)               → one collapsed region
+ *
+ * ⭐ SINGLE DATA AUTHORITY. `resultsSectionData` arrives as a PROP — the same
+ * instance `OutputsDock` hands `ResultsBody`. This surface calls no analysis
+ * hook of its own, issues no request, and writes to no store. Switching tabs
+ * therefore cannot re-run analysis, produce a second result, change canonical
+ * state, change readiness or change staleness. That is what makes this a
+ * presentation comparison rather than an A/B test on different data, and it is
+ * the property `canvas/components/__tests__/OutputsDock.analysisNewTab.spec.tsx`
+ * pins ("switching tabs issues NO network request and mutates NO canonical state").
+ *
+ * ⚠ ON WIDTH (§11), STATED AS A LIMITATION RATHER THAN SOLVED. The dock's outer
+ * width is 416px, fixed by the workspace shell and asserted at every viewport by
+ * `e2e/visual/shellLayout.visual.spec.ts`. Varying it per surface is a
+ * shell-level change that would alter the existing Analysis tab's container, so
+ * it is deliberately NOT done. The narrower, calmer treatment is scoped to this
+ * tab's INNER content measure — wider gutters, a capped measure, and far fewer
+ * elements per screen. The outer panel is unchanged.
+ */
+
+import { typography } from '../../../styles/typography'
+import { focusModelTarget } from '../../../canvas/utils/focusHelpers'
+import { openAskOlumi } from '../coaching/askOlumiStore'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import { ANALYSIS_NEW_COPY as COPY } from './analysisNewCopy'
+import { ANALYSIS_NEW_LIMITS } from './buildAnalysisNewViewModel'
+import { useAnalysisNewViewModel } from './useAnalysisNewViewModel'
+import { AnalysisNewSection } from './sections/AnalysisNewSection'
+import { StrengthenTheReasoning } from './sections/StrengthenTheReasoning'
+import { DeeperAnalysis } from './sections/DeeperAnalysis'
+
+export interface AnalysisNewTabBodyProps {
+  /** THE SAME instance OutputsDock hands ResultsBody. Never re-derived here. */
+  resultsSectionData: ResultsSectionDataReturn
+  isPreRun: boolean
+  isRunning: boolean
+  /** The displayed report predates the current model. Freshness only. */
+  isStale: boolean
+  nSamples?: number
+  seedUsed?: number | string
+  responseHash?: string
+  /** OutputsDock's canvas-focus handler, shared with the existing tab. */
+  onFocusNode?: (nodeId: string) => void
+}
+
+export function AnalysisNewTabBody({
+  resultsSectionData,
+  isPreRun,
+  isRunning,
+  isStale,
+  nSamples,
+  seedUsed,
+  responseHash,
+  onFocusNode,
+}: AnalysisNewTabBodyProps) {
+  const vm = useAnalysisNewViewModel({
+    data: resultsSectionData,
+    isPreRun,
+    isRunning,
+    isStale,
+    nSamples,
+    seedUsed,
+    responseHash,
+  })
+
+  // Canvas focus prefers the dock's own handler (shared with the existing tab);
+  // `focusModelTarget` is the fail-closed fallback for edge ids the node-scoped
+  // handler cannot resolve.
+  const focusTarget = (targetId: string) => {
+    if (onFocusNode) onFocusNode(targetId)
+    else focusModelTarget(targetId)
+  }
+
+  /**
+   * A contextual intervention runs through the SAME non-mutating route as the
+   * Strengthen section's primary CTA — the Ask-Olumi drawer, prefilled and
+   * never auto-sent. The recommendation is found by id, so the drawer is
+   * seeded with the ENGINE's own words, not with a paraphrase of the row.
+   */
+  const runIntervention = (recommendationId: string) => {
+    const rec = vm.strengthen.interventions.find((r) => r.id === recommendationId)
+    if (!rec) return
+    openAskOlumi({
+      context: rec.whyNow || rec.signal,
+      draft: rec.action.prompt ?? rec.tryThis,
+      label: rec.action.label,
+      ...(rec.targetId ? { targetId: rec.targetId } : {}),
+    })
+  }
+
+  return (
+    <div
+      className="flex-1 min-h-0 olumi-scrollbar overflow-y-auto"
+      data-testid="analysis-new-tab-body"
+      data-run-identity={responseHash ?? ''}
+    >
+      {/* The narrower measure (§11): wider gutters and a capped line length
+          inside the unchanged 416px dock. */}
+      <div className="px-5 py-4 space-y-5 max-w-[360px] mx-auto">
+        <p className={`${typography.panelMeta} text-text-light`} data-testid="analysis-new-intro">
+          {COPY.tabIntro}
+        </p>
+
+        {/* ── STATUS ────────────────────────────────────────────────────────
+            Contextualises the content; never dominates it (§20). One line,
+            not a banner stack. The Rerun control is the shell's footer bar,
+            declared by this surface's `footerBar: 'reanalyse'` in the shell
+            contract — the SAME control and the SAME handler the Model tab
+            uses, so no second run authority exists. */}
+        {vm.status.isPreRun ? (
+          <p className={`${typography.panelBody} text-text-light`} data-testid="analysis-new-status-pre-run">
+            {COPY.status.preRun}
+          </p>
+        ) : null}
+        {vm.status.isStale ? (
+          <p
+            className={`${typography.panelMeta} text-warning`}
+            role="status"
+            data-testid="analysis-new-status-stale"
+          >
+            {COPY.status.stale}
+          </p>
+        ) : null}
+        {vm.status.statusNote ? (
+          <p className={`${typography.panelMeta} text-text-light`} data-testid="analysis-new-status-note">
+            {vm.status.statusNote}
+          </p>
+        ) : null}
+
+        {/* ── 1. KEY INSIGHTS ─────────────────────────────────────────────── */}
+        <AnalysisNewSection
+          title={COPY.sections.keyInsights}
+          findings={vm.keyInsights.insights}
+          emptyMessage={vm.status.isPreRun ? null : COPY.empty.keyInsights}
+          onFocusTarget={focusTarget}
+          onRunIntervention={runIntervention}
+          testId="analysis-new-key-insights"
+        />
+
+        {/* ── 2. STRENGTHEN THE REASONING ──────────────────────────────────
+            Second from the top by design. This is the placement the
+            experiment is testing. */}
+        <StrengthenTheReasoning
+          interventions={vm.strengthen.interventions}
+          scienceGrounding={vm.strengthen.scienceGrounding}
+        />
+
+        {/* ── 3. DRIVERS AND DYNAMICS ─────────────────────────────────────── */}
+        <AnalysisNewSection
+          title={COPY.sections.drivers}
+          findings={vm.drivers.findings}
+          preview={ANALYSIS_NEW_LIMITS.DRIVER_PREVIEW}
+          // ⚠ The caveat is a function of the PRODUCER's provenance token, not
+          // of taste: a set-relative influence is "largest in this set", never
+          // a causal share of the outcome.
+          caveat={
+            vm.drivers.influenceIsSetRelative
+              ? COPY.coverage.setRelativeInfluence
+              : vm.drivers.referenceOptionLabel
+                ? `${COPY.coverage.referencePrefix} ${vm.drivers.referenceOptionLabel}.`
+                : null
+          }
+          emptyMessage={vm.status.isPreRun ? null : COPY.empty.drivers}
+          onFocusTarget={focusTarget}
+          onRunIntervention={runIntervention}
+          testId="analysis-new-drivers"
+        />
+
+        {/* ── 4. UNCERTAINTY AND GAPS ─────────────────────────────────────── */}
+        <AnalysisNewSection
+          title={COPY.sections.uncertainty}
+          findings={vm.uncertainty.findings}
+          preview={ANALYSIS_NEW_LIMITS.UNCERTAINTY_PREVIEW}
+          // ⚠⚠ THE EMPTY STATE HERE IS A TRUTH CLAIM AND IT SPLITS TWO WAYS.
+          // "Nothing was flagged" is licensed ONLY when the producer actually
+          // assessed evidence on this run; otherwise the honest sentence is
+          // that it was not assessed. An empty list cannot tell them apart —
+          // `evidenceGapsAssessed` can.
+          emptyMessage={
+            vm.status.isPreRun
+              ? null
+              : vm.uncertainty.evidenceAssessed
+                ? COPY.empty.uncertaintyAssessed
+                : COPY.empty.uncertaintyUnassessed
+          }
+          onFocusTarget={focusTarget}
+          onRunIntervention={runIntervention}
+          testId="analysis-new-uncertainty"
+        />
+
+        {/* Whole-decision value of information — a VERDICT, never the number.
+            'not_computed' renders nothing: it is a distinct state from a
+            measured zero and must not be collapsed into one. */}
+        {vm.uncertainty.decisionVoi !== 'not_computed' ? (
+          <p className={`${typography.panelMeta} text-text-light`} data-testid="analysis-new-decision-voi">
+            {vm.uncertainty.decisionVoi === 'measured_non_zero'
+              ? COPY.decisionVoi.measuredNonZero
+              : COPY.decisionVoi.measuredZero}
+          </p>
+        ) : null}
+
+        {/* ── LEVEL 3 ─────────────────────────────────────────────────────── */}
+        <DeeperAnalysis deeper={vm.deeper} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/results/analysisNew/DisclosureRow.tsx
+++ b/src/components/results/analysisNew/DisclosureRow.tsx
@@ -1,0 +1,179 @@
+/**
+ * Analysis (New) — the one progressive-disclosure primitive every section uses.
+ *
+ * Three levels, per the brief §12:
+ *   L1 scan     — headline + one implication sentence. Always visible.
+ *   L2 understand — detail, grounding, and the row's own reasoning intervention.
+ *   L3 inspect  — provenance/calculation rows, nested inside L2.
+ *
+ * ⚠ ACCESSIBILITY IS NOT OPTIONAL HERE AND PROGRESSIVE DISCLOSURE IS WHERE IT
+ * USUALLY BREAKS. The whole L1 row is ONE button (so the target is large and
+ * the keyboard reaches it once, not three times), it carries `aria-expanded`
+ * and `aria-controls`, and the region it controls carries the matching id. A
+ * collapsed region is UNMOUNTED rather than CSS-hidden, so a screen reader
+ * never walks content the sighted user cannot see.
+ *
+ * ⚠ NO CARD INSIDE A CARD (§10). This renders a row with a hairline separator,
+ * not a container. Depth is expressed with typography and space.
+ */
+
+import { useId, useState } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { typography } from '../../../styles/typography'
+import { ANALYSIS_NEW_COPY as COPY } from './analysisNewCopy'
+import type { AnalysisNewFinding } from './analysisNewTypes'
+
+const MARKER_LABEL: Record<NonNullable<AnalysisNewFinding['marker']>, string> = {
+  provisional: COPY.markers.provisional,
+  stale: COPY.markers.stale,
+  not_assessed: COPY.markers.notAssessed,
+}
+
+export interface DisclosureRowProps {
+  finding: AnalysisNewFinding
+  /** Canvas focus. Absent when the producer named no target. */
+  onFocusTarget?: (targetId: string) => void
+  /** Runs the row's reasoning intervention through an EXISTING action route. */
+  onRunIntervention?: (recommendationId: string) => void
+  /** Stable prefix so two sections cannot mint the same testid. */
+  testIdPrefix: string
+}
+
+export function DisclosureRow({
+  finding,
+  onFocusTarget,
+  onRunIntervention,
+  testIdPrefix,
+}: DisclosureRowProps) {
+  const [open, setOpen] = useState(false)
+  const [inspectOpen, setInspectOpen] = useState(false)
+  const regionId = useId()
+  const inspectId = useId()
+
+  const hasLevel2 =
+    Boolean(finding.detail) || Boolean(finding.intervention) || finding.inspect.length > 0
+  const marker = finding.marker ? MARKER_LABEL[finding.marker] : null
+
+  return (
+    <div
+      className="border-b border-panel-border last:border-b-0 py-2.5"
+      data-testid={`${testIdPrefix}-row`}
+      data-finding-id={finding.id}
+    >
+      <button
+        type="button"
+        // A row with nothing beneath it is not a disclosure control. It stays a
+        // plain block so the keyboard is not offered an expander that expands
+        // nothing — an affordance that does nothing is the same class of lie as
+        // a claim nobody measured.
+        onClick={hasLevel2 ? () => setOpen((v) => !v) : undefined}
+        disabled={!hasLevel2}
+        aria-expanded={hasLevel2 ? open : undefined}
+        aria-controls={hasLevel2 && open ? regionId : undefined}
+        className={`w-full text-left flex items-start gap-2 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-info ${
+          hasLevel2 ? 'hover:opacity-80' : 'cursor-default'
+        }`}
+        data-testid={`${testIdPrefix}-toggle`}
+      >
+        {hasLevel2 ? (
+          open ? (
+            <ChevronDown className="w-3.5 h-3.5 mt-0.5 shrink-0 text-text-light" aria-hidden="true" />
+          ) : (
+            <ChevronRight className="w-3.5 h-3.5 mt-0.5 shrink-0 text-text-light" aria-hidden="true" />
+          )
+        ) : (
+          <span className="w-3.5 shrink-0" aria-hidden="true" />
+        )}
+        <span className="min-w-0 flex-1">
+          <span className={`${typography.panelHeader} text-text-header block`}>
+            {finding.headline}
+            {marker ? (
+              <span
+                className={`${typography.panelMeta} text-text-light ml-2`}
+                data-testid={`${testIdPrefix}-marker`}
+              >
+                {marker}
+              </span>
+            ) : null}
+          </span>
+          {finding.implication ? (
+            <span className={`${typography.panelBody} text-text-body block mt-0.5`}>
+              {finding.implication}
+            </span>
+          ) : null}
+        </span>
+      </button>
+
+      {hasLevel2 && open ? (
+        <div id={regionId} className="pl-6 mt-2 space-y-2" data-testid={`${testIdPrefix}-detail`}>
+          {finding.detail ? (
+            <p className={`${typography.panelBody} text-text-body`}>{finding.detail}</p>
+          ) : null}
+
+          {/* The grounding line. Every row can say what put it here. */}
+          <p className={`${typography.panelMeta} text-text-light`} data-testid={`${testIdPrefix}-grounding`}>
+            {COPY.disclosure.groundedIn} {finding.groundedIn}.
+          </p>
+
+          <div className="flex flex-wrap gap-3">
+            {finding.targetId && onFocusTarget ? (
+              <button
+                type="button"
+                onClick={() => onFocusTarget(finding.targetId!)}
+                className={`${typography.panelMeta} text-info underline rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+                data-testid={`${testIdPrefix}-focus`}
+              >
+                Show on canvas
+              </button>
+            ) : null}
+
+            {/* ⚠ CONTEXTUAL INTERVENTION — stays visibly attached to the finding
+                that triggered it (§3B). It is never a generic tip: it exists
+                only because the strengthen ENGINE emitted a recommendation for
+                THIS row's target id. */}
+            {finding.intervention && onRunIntervention ? (
+              <button
+                type="button"
+                onClick={() => onRunIntervention(finding.intervention!.recommendationId)}
+                className={`${typography.panelMeta} text-info underline rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+                data-testid={`${testIdPrefix}-intervention`}
+                data-recommendation-id={finding.intervention.recommendationId}
+              >
+                {finding.intervention.label} →
+              </button>
+            ) : null}
+          </div>
+
+          {finding.inspect.length > 0 ? (
+            <div>
+              <button
+                type="button"
+                onClick={() => setInspectOpen((v) => !v)}
+                aria-expanded={inspectOpen}
+                aria-controls={inspectOpen ? inspectId : undefined}
+                className={`${typography.panelMeta} text-text-light underline rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+                data-testid={`${testIdPrefix}-inspect-toggle`}
+              >
+                {COPY.disclosure.inspect}
+              </button>
+              {inspectOpen ? (
+                <dl
+                  id={inspectId}
+                  className="mt-1.5 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1"
+                  data-testid={`${testIdPrefix}-inspect`}
+                >
+                  {finding.inspect.map((r) => (
+                    <div key={r.label} className="contents">
+                      <dt className={`${typography.panelMeta} text-text-light`}>{r.label}</dt>
+                      <dd className={`${typography.panelMeta} text-text-body`}>{r.value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/results/analysisNew/__tests__/AnalysisNewTabBody.spec.tsx
+++ b/src/components/results/analysisNew/__tests__/AnalysisNewTabBody.spec.tsx
@@ -1,0 +1,195 @@
+/**
+ * Analysis (New) — the surface END TO END on a completed analysis.
+ *
+ * ⚠ WHY THIS FILE EXISTS SEPARATELY FROM THE OTHERS. The adapter suite proves
+ * the view model is honest; the dock suite proves the tab mounts and costs
+ * nothing to switch to. Neither proves the surface actually SHOWS anything when
+ * a run has completed — the dock cases all run pre-run, and a view model full
+ * of findings that no component renders is precisely this estate's most
+ * expensive defect class ("we build more than we plug in").
+ *
+ * So this drives the real `AnalysisNewTabBody` with post-run fixtures and
+ * asserts rendered content, not shape.
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+
+vi.mock('../../coaching/askOlumiStore', () => ({ openAskOlumi: vi.fn() }))
+vi.mock('../../../../canvas/utils/focusHelpers', () => ({ focusModelTarget: vi.fn() }))
+
+import { AnalysisNewTabBody } from '../AnalysisNewTabBody'
+import { ANALYSIS_NEW_COPY as COPY } from '../analysisNewCopy'
+import { useStrengthenStore } from '../../../../canvas/stores/strengthenStore'
+import {
+  decisionWithLeaderWithheld,
+  genuineDecision,
+  highUncertainty,
+  openStrategicChallenge,
+} from './analysisNewFixtures'
+import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
+
+const renderBody = (
+  data: ResultsSectionDataReturn,
+  over: Partial<Parameters<typeof AnalysisNewTabBody>[0]> = {},
+) =>
+  render(
+    <AnalysisNewTabBody
+      resultsSectionData={data}
+      isPreRun={false}
+      isRunning={false}
+      isStale={false}
+      responseHash="run_abc123"
+      {...over}
+    />,
+  )
+
+beforeEach(() => {
+  useStrengthenStore.setState({ records: {}, priorityOrder: [] } as never)
+})
+afterEach(() => cleanup())
+
+describe('the surface renders real content on a completed run', () => {
+  it('shows all four sections with findings, not just headings', () => {
+    renderBody(openStrategicChallenge())
+
+    const insights = screen.getByTestId('analysis-new-key-insights')
+    expect(within(insights).getAllByTestId('analysis-new-key-insights-row').length).toBeGreaterThan(0)
+    expect(insights).toHaveTextContent('Supplier lead time dominates the model')
+
+    const drivers = screen.getByTestId('analysis-new-drivers')
+    expect(within(drivers).getAllByTestId('analysis-new-drivers-row').length).toBeGreaterThan(0)
+    expect(drivers).toHaveTextContent('Supplier lead time')
+  })
+
+  it('carries the run identity both tabs share, so the comparison is checkable on screen', () => {
+    renderBody(genuineDecision())
+    expect(screen.getByTestId('analysis-new-tab-body')).toHaveAttribute('data-run-identity', 'run_abc123')
+  })
+})
+
+describe('F · the three scenario classes (§24F)', () => {
+  it('OPEN STRATEGIC CHALLENGE — no forced winner or option framing', () => {
+    renderBody(openStrategicChallenge())
+    const body = screen.getByTestId('analysis-new-tab-body')
+    expect(body.textContent).not.toMatch(/\bwins\b|\bwinner\b|scores higher/i)
+    // …and it is NOT empty: a decision-first IA would have nothing to say here.
+    expect(within(screen.getByTestId('analysis-new-key-insights')).getAllByTestId('analysis-new-key-insights-row').length)
+      .toBeGreaterThan(0)
+  })
+
+  it('GENUINE DECISION — comparative material appears, phrased as "currently scores higher"', () => {
+    renderBody(genuineDecision())
+    expect(screen.getByTestId('analysis-new-key-insights')).toHaveTextContent(
+      'Raise price currently scores higher',
+    )
+  })
+
+  it('LEADER WITHHELD — the same fixture with one boolean flipped says nothing about a leader', () => {
+    // The discriminating twin of the case above.
+    renderBody(decisionWithLeaderWithheld())
+    const body = screen.getByTestId('analysis-new-tab-body')
+    expect(body.textContent).not.toContain('currently scores higher')
+    expect(body.textContent).not.toContain('Raise price')
+  })
+
+  it('HIGH UNCERTAINTY — uncertainty is prominent and the analysis is NOT presented as blocked', () => {
+    renderBody(highUncertainty())
+    const uncertainty = screen.getByTestId('analysis-new-uncertainty')
+    expect(within(uncertainty).getAllByTestId('analysis-new-uncertainty-row').length).toBeGreaterThan(0)
+    expect(uncertainty).toHaveTextContent('Customer adoption')
+
+    const body = screen.getByTestId('analysis-new-tab-body')
+    // Nothing may read as a readiness refusal — RunAdmission owns that.
+    expect(body.textContent).not.toMatch(/not ready|cannot run|blocked/i)
+    // The producer's own partial-run reason is carried verbatim, not dramatised.
+    expect(screen.getByTestId('analysis-new-status-note')).toHaveTextContent(
+      'Two factors could not be sampled to the requested precision.',
+    )
+    // The set-relative caveat fires, so no absolute causal-share claim stands.
+    expect(screen.getByTestId('analysis-new-drivers-caveat')).toHaveTextContent(
+      COPY.coverage.setRelativeInfluence,
+    )
+  })
+})
+
+describe('empty states say what was NOT established (§19)', () => {
+  it('distinguishes "assessed, none found" from "never assessed"', () => {
+    // High-uncertainty fixture has evidenceGapsAssessed:false but DOES have
+    // uncertainties, so use a fixture with neither to reach the empty arm.
+    const unassessed = {
+      ...openStrategicChallenge(),
+      confidence: { ...openStrategicChallenge().confidence, evidenceGapsAssessed: false },
+    } as ResultsSectionDataReturn
+    renderBody(unassessed)
+    expect(screen.getByTestId('analysis-new-uncertainty-empty')).toHaveTextContent(
+      COPY.empty.uncertaintyUnassessed,
+    )
+
+    cleanup()
+    renderBody(openStrategicChallenge())
+    expect(screen.getByTestId('analysis-new-uncertainty-empty')).toHaveTextContent(
+      COPY.empty.uncertaintyAssessed,
+    )
+  })
+
+  // ⚠ THE EMPTY-STRENGTHEN CASE LIVES IN `StrengthenTheReasoning.spec.tsx`, NOT
+  // HERE, AND THAT IS A CORRECTION. This file first wrapped it in `if (empty)`
+  // — and a probe showed the engine DOES emit an intervention for this fixture,
+  // so the branch never ran and the case asserted nothing at all. A conditional
+  // assertion is a test that cannot fail (CLAUDE.md trap 13b). The empty arm is
+  // driven directly, with `interventions={[]}`, in the component's own spec;
+  // what belongs HERE is the opposite proof — that a grounded intervention
+  // reaches the screen through the real hook and the real engine.
+  it('a grounded intervention reaches the screen through the real engine', () => {
+    renderBody(openStrategicChallenge())
+    const items = screen.getAllByTestId('analysis-new-strengthen-item')
+    expect(items.length).toBeGreaterThan(0)
+    expect(items.length).toBeLessThanOrEqual(3)
+    const first = items[0]
+    // What / why / do-it are all present, and all come from the engine.
+    expect(within(first).getByTestId('analysis-new-strengthen-why')).toBeInTheDocument()
+    expect(within(first).getByTestId('analysis-new-strengthen-action')).toBeInTheDocument()
+    // Bound by the ENGINE's id, so a row cannot be satisfied by a lookalike.
+    expect(first.getAttribute('data-recommendation-id')).toMatch(/^strengthen:/)
+  })
+})
+
+describe('staleness contextualises without dominating (§20)', () => {
+  it('states the MODEL changed — not that the result is wrong — and keeps the content', () => {
+    renderBody(genuineDecision(), { isStale: true })
+    expect(screen.getByTestId('analysis-new-status-stale')).toHaveTextContent(
+      'The model has changed since this analysis ran.',
+    )
+    // One line, not a banner stack: the findings are still on screen.
+    expect(
+      within(screen.getByTestId('analysis-new-key-insights')).getAllByTestId('analysis-new-key-insights-row').length,
+    ).toBeGreaterThan(0)
+  })
+})
+
+describe('progressive disclosure on the real surface (§24E)', () => {
+  it('holds grounding and inspect behind two levels, and reveals them on request', () => {
+    renderBody(openStrategicChallenge())
+    expect(screen.queryByTestId('analysis-new-drivers-grounding')).toBeNull()
+
+    fireEvent.click(within(screen.getByTestId('analysis-new-drivers')).getAllByTestId('analysis-new-drivers-toggle')[0])
+    expect(screen.getByTestId('analysis-new-drivers-grounding')).toBeInTheDocument()
+    expect(screen.queryByTestId('analysis-new-drivers-inspect')).toBeNull()
+
+    fireEvent.click(screen.getAllByTestId('analysis-new-drivers-inspect-toggle')[0])
+    expect(screen.getByTestId('analysis-new-drivers-inspect')).toBeInTheDocument()
+  })
+
+  it('keeps deeper technical material out of the first screen', () => {
+    renderBody(genuineDecision())
+    // Unconditional: the run-identity group always exists when a hash is
+    // supplied, so a `if (deeper)` wrapper here would only ever hide a
+    // regression that removed the section entirely.
+    expect(screen.getByTestId('analysis-new-deeper')).toBeInTheDocument()
+    expect(screen.queryByTestId('analysis-new-deeper-group')).toBeNull()
+    fireEvent.click(screen.getByTestId('analysis-new-deeper-toggle'))
+    expect(screen.getAllByTestId('analysis-new-deeper-group').length).toBeGreaterThan(0)
+  })
+})

--- a/src/components/results/analysisNew/__tests__/DisclosureRow.spec.tsx
+++ b/src/components/results/analysisNew/__tests__/DisclosureRow.spec.tsx
@@ -1,0 +1,156 @@
+/**
+ * Analysis (New) — progressive disclosure (brief §12, §21, §24E).
+ *
+ * Three levels, and the properties that make them honest:
+ *   · a collapsed region is UNMOUNTED, not CSS-hidden, so a screen reader never
+ *     walks content the sighted user cannot see;
+ *   · a row with nothing beneath it is NOT an expander — an affordance that
+ *     expands nothing is the same class of lie as a claim nobody measured;
+ *   · `aria-expanded` / `aria-controls` are wired to the region that exists.
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { DisclosureRow } from '../DisclosureRow'
+import type { AnalysisNewFinding } from '../analysisNewTypes'
+
+const rich: AnalysisNewFinding = {
+  id: 'driver:f_adopt',
+  headline: 'Customer adoption',
+  implication: 'Among the strongest influences in this run; raises the outcome.',
+  detail: 'This relationship is one the result is sensitive to.',
+  groundedIn: 'factor sensitivity, ranked within this run',
+  marker: 'not_assessed',
+  targetId: 'f_adopt',
+  inspect: [
+    { label: 'Rank', value: '1' },
+    { label: 'Basis', value: 'ranked within this run' },
+  ],
+  intervention: { recommendationId: 'strengthen:voi', label: 'Gather evidence', targetId: 'f_adopt' },
+}
+
+const bare: AnalysisNewFinding = {
+  id: 'uncertainty:PLAIN',
+  headline: 'A finding with nothing beneath it',
+  implication: 'One sentence and no more.',
+  groundedIn: 'the critique analysis',
+  inspect: [],
+}
+
+const renderRow = (finding: AnalysisNewFinding, over: Partial<Parameters<typeof DisclosureRow>[0]> = {}) =>
+  render(
+    <DisclosureRow
+      finding={finding}
+      testIdPrefix="row"
+      onFocusTarget={vi.fn()}
+      onRunIntervention={vi.fn()}
+      {...over}
+    />,
+  )
+
+describe('level 1 — scan', () => {
+  it('shows the headline and implication, and nothing deeper', () => {
+    renderRow(rich)
+    expect(screen.getByText('Customer adoption')).toBeInTheDocument()
+    expect(screen.getByText(rich.implication)).toBeInTheDocument()
+    // Level 2 is UNMOUNTED, not hidden.
+    expect(screen.queryByTestId('row-detail')).toBeNull()
+    expect(screen.queryByTestId('row-grounding')).toBeNull()
+    expect(screen.queryByTestId('row-inspect')).toBeNull()
+  })
+
+  it('renders the provisional/not-assessed marker at level 1 where it can be seen', () => {
+    renderRow(rich)
+    expect(screen.getByTestId('row-marker')).toHaveTextContent('Not assessed')
+  })
+})
+
+describe('level 2 — understand', () => {
+  it('expands to reveal detail, grounding and the contextual intervention', () => {
+    renderRow(rich)
+    const toggle = screen.getByTestId('row-toggle')
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+
+    fireEvent.click(toggle)
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+    expect(screen.getByTestId('row-detail')).toBeInTheDocument()
+    expect(screen.getByTestId('row-grounding')).toHaveTextContent(
+      'Grounded in factor sensitivity, ranked within this run.',
+    )
+    // The intervention stays visibly attached to the finding that triggered it,
+    // and carries the engine recommendation id that justifies it.
+    expect(screen.getByTestId('row-intervention')).toHaveAttribute(
+      'data-recommendation-id',
+      'strengthen:voi',
+    )
+  })
+
+  it('wires aria-controls to the region that actually exists', () => {
+    renderRow(rich)
+    const toggle = screen.getByTestId('row-toggle')
+    expect(toggle).not.toHaveAttribute('aria-controls')
+    fireEvent.click(toggle)
+    const id = toggle.getAttribute('aria-controls')
+    expect(id).toBeTruthy()
+    expect(document.getElementById(id!)).toBe(screen.getByTestId('row-detail'))
+  })
+
+  it('collapses back, unmounting the region', () => {
+    renderRow(rich)
+    fireEvent.click(screen.getByTestId('row-toggle'))
+    fireEvent.click(screen.getByTestId('row-toggle'))
+    expect(screen.queryByTestId('row-detail')).toBeNull()
+  })
+})
+
+describe('level 3 — inspect', () => {
+  it('nests inside level 2 and is collapsed until asked for', () => {
+    renderRow(rich)
+    fireEvent.click(screen.getByTestId('row-toggle'))
+    expect(screen.queryByTestId('row-inspect')).toBeNull()
+
+    fireEvent.click(screen.getByTestId('row-inspect-toggle'))
+    const inspect = screen.getByTestId('row-inspect')
+    expect(inspect).toHaveTextContent('Rank')
+    expect(inspect).toHaveTextContent('Basis')
+  })
+})
+
+describe('a row with nothing beneath it is not an expander', () => {
+  it('offers no toggle, no aria-expanded, and is not focusable as a control', () => {
+    // The discriminating half: the SAME component, given a finding with no
+    // detail / intervention / inspect rows, must not advertise a disclosure.
+    renderRow(bare)
+    const toggle = screen.getByTestId('row-toggle')
+    expect(toggle).toBeDisabled()
+    expect(toggle).not.toHaveAttribute('aria-expanded')
+    fireEvent.click(toggle)
+    expect(screen.queryByTestId('row-detail')).toBeNull()
+  })
+})
+
+describe('actions', () => {
+  it('routes canvas focus by the producer-named target id', () => {
+    const onFocusTarget = vi.fn()
+    renderRow(rich, { onFocusTarget })
+    fireEvent.click(screen.getByTestId('row-toggle'))
+    fireEvent.click(screen.getByTestId('row-focus'))
+    expect(onFocusTarget).toHaveBeenCalledWith('f_adopt')
+  })
+
+  it('runs the intervention by its engine recommendation id, not by its label', () => {
+    const onRunIntervention = vi.fn()
+    renderRow(rich, { onRunIntervention })
+    fireEvent.click(screen.getByTestId('row-toggle'))
+    fireEvent.click(screen.getByTestId('row-intervention'))
+    expect(onRunIntervention).toHaveBeenCalledWith('strengthen:voi')
+  })
+
+  it('offers no focus affordance when the producer named no target', () => {
+    renderRow({ ...rich, targetId: undefined })
+    fireEvent.click(screen.getByTestId('row-toggle'))
+    expect(screen.queryByTestId('row-focus')).toBeNull()
+  })
+})

--- a/src/components/results/analysisNew/__tests__/StrengthenTheReasoning.spec.tsx
+++ b/src/components/results/analysisNew/__tests__/StrengthenTheReasoning.spec.tsx
@@ -1,0 +1,132 @@
+/**
+ * Analysis (New) — "Strengthen the reasoning" presentation, and the science-
+ * grounding rule that governs it (brief §14, §15).
+ *
+ * The rule under test is the one most easily broken by good intentions: a
+ * recommendation is NOT scientifically grounded because it sounds like a
+ * recognised technique. Only the producer's own DSK attestation licenses the
+ * grounding line, presence IS the attestation, and the ids ride as `data-*`
+ * rather than as sentences.
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { StrengthenTheReasoning } from '../sections/StrengthenTheReasoning'
+import type { Recommendation } from '../../strengthen/strengthenTypes'
+
+vi.mock('../../coaching/askOlumiStore', () => ({ openAskOlumi: vi.fn() }))
+vi.mock('../../../../canvas/utils/focusHelpers', () => ({ focusModelTarget: vi.fn() }))
+
+import { openAskOlumi } from '../../coaching/askOlumiStore'
+import { focusModelTarget } from '../../../../canvas/utils/focusHelpers'
+
+const rec = (over: Partial<Recommendation> & { id: string }): Recommendation =>
+  ({
+    helpType: 'challenge',
+    title: 'Run a premortem on this plan',
+    signal: 'One factor carries most of the influence.',
+    whyNow: 'The conclusion rests almost entirely on it.',
+    tryThis: 'Imagine it is six months on and this failed. Write down why.',
+    sourceLine: 'From the influence concentration check.',
+    action: { kind: 'ai-dialogue', label: 'Work through a premortem', prompt: 'Run a premortem' },
+    targetId: 'f_leadtime',
+    priority: 1,
+    ...over,
+  }) as Recommendation
+
+describe('what / why / do it (§14)', () => {
+  it('renders all three, from the engine’s own fields', () => {
+    render(<StrengthenTheReasoning interventions={[rec({ id: 'strengthen:phase3:g1' })]} />)
+    expect(screen.getByText('Run a premortem on this plan')).toBeInTheDocument()
+    expect(screen.getByTestId('analysis-new-strengthen-why')).toHaveTextContent(
+      'One factor carries most of the influence. The conclusion rests almost entirely on it.',
+    )
+    expect(screen.getByTestId('analysis-new-strengthen-try')).toHaveTextContent(
+      'Imagine it is six months on and this failed.',
+    )
+    expect(screen.getByTestId('analysis-new-strengthen-action')).toHaveTextContent(
+      'Work through a premortem',
+    )
+  })
+
+  it('routes the primary action through the existing Ask-Olumi drawer, prefilled and NOT auto-sent', () => {
+    render(<StrengthenTheReasoning interventions={[rec({ id: 'strengthen:phase3:g1' })]} />)
+    fireEvent.click(screen.getByTestId('analysis-new-strengthen-action'))
+    expect(openAskOlumi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // The ENGINE's strings, so what the user sends is what the engine
+        // recommended — not a paraphrase composed here.
+        draft: 'Run a premortem',
+        label: 'Work through a premortem',
+        targetId: 'f_leadtime',
+      }),
+    )
+  })
+
+  it('routes canvas focus through the existing fail-closed helper', () => {
+    render(<StrengthenTheReasoning interventions={[rec({ id: 'strengthen:phase3:g1' })]} />)
+    fireEvent.click(screen.getByTestId('analysis-new-strengthen-focus'))
+    expect(focusModelTarget).toHaveBeenCalledWith('f_leadtime')
+  })
+})
+
+describe('science grounding (§15) — the producer attests, or nothing does', () => {
+  const item = rec({ id: 'strengthen:phase3:g1' })
+
+  it('renders the grounding line ONLY when the producer attested a claim for THIS row', () => {
+    render(
+      <StrengthenTheReasoning
+        interventions={[item]}
+        scienceGrounding={{
+          'strengthen:phase3:g1': { claimId: 'DSK-B-003', protocolId: 'DSK-P-002', strength: 'strong' },
+        }}
+      />,
+    )
+    const line = screen.getByTestId('analysis-new-strengthen-science-grounding')
+    expect(line).toHaveTextContent('Grounded in the decision-science knowledge base · Strong evidence.')
+    // Ids are PROVENANCE FOR AN AUDITOR, not copy for a reader.
+    expect(line).toHaveAttribute('data-dsk-claim-id', 'DSK-B-003')
+    expect(line).toHaveAttribute('data-dsk-protocol-id', 'DSK-P-002')
+    expect(line.textContent).not.toContain('DSK-B-003')
+  })
+
+  it('renders NOTHING when the producer attested nothing — no default, no inferred strength', () => {
+    // The discriminating half. The row's title literally says "premortem", so a
+    // surface that labelled grounding from the WORDING rather than from the
+    // attestation would pass the case above and fail this one.
+    render(<StrengthenTheReasoning interventions={[item]} scienceGrounding={{}} />)
+    expect(screen.queryByTestId('analysis-new-strengthen-science-grounding')).toBeNull()
+  })
+
+  it('does not borrow another row’s attestation', () => {
+    render(
+      <StrengthenTheReasoning
+        interventions={[item]}
+        scienceGrounding={{ 'strengthen:phase3:SOMEONE_ELSE': { claimId: 'DSK-B-999' } }}
+      />,
+    )
+    expect(screen.queryByTestId('analysis-new-strengthen-science-grounding')).toBeNull()
+  })
+
+  it('drops an unrecognised strength token rather than passing it through as copy', () => {
+    render(
+      <StrengthenTheReasoning
+        interventions={[item]}
+        scienceGrounding={{ 'strengthen:phase3:g1': { claimId: 'DSK-B-003', strength: 'wildly_conclusive' } }}
+      />,
+    )
+    const line = screen.getByTestId('analysis-new-strengthen-science-grounding')
+    expect(line).toHaveTextContent('Grounded in the decision-science knowledge base.')
+    expect(line.textContent).not.toContain('wildly_conclusive')
+  })
+})
+
+describe('the empty state (§19)', () => {
+  it('states what was not found, and makes no claim that the reasoning is sound', () => {
+    render(<StrengthenTheReasoning interventions={[]} />)
+    const empty = screen.getByTestId('analysis-new-strengthen-empty')
+    expect(empty).toHaveTextContent('No high-priority reasoning intervention identified yet.')
+    expect(empty.textContent).not.toMatch(/solid|healthy|good|no issues|looks fine/i)
+  })
+})

--- a/src/components/results/analysisNew/__tests__/analysisNewFixtures.ts
+++ b/src/components/results/analysisNew/__tests__/analysisNewFixtures.ts
@@ -1,0 +1,251 @@
+/**
+ * Analysis (New) — fixtures for the three scenario CLASSES the experiment must
+ * behave correctly across (brief §24F).
+ *
+ *   1. OPEN STRATEGIC CHALLENGE — no decision exists. The surface must not
+ *      manufacture a winner or an option frame.
+ *   2. GENUINE DECISION — a leader the single verdict entitles naming.
+ *      Comparative material may appear, phrased as "currently scores higher".
+ *   3. HIGH UNCERTAINTY — uncertainty becomes prominent WITHOUT the surface
+ *      falsely blocking the analysis or equating coverage with readiness.
+ *
+ * ⚠ THESE ARE HAND-BUILT AND THAT IS A KNOWN LIMIT (CLAUDE.md trap 22): a
+ * corpus from the author's head cannot see the class the author did not
+ * imagine. They are therefore used to pin SEMANTIC RULES that are checkable
+ * from the producer's own declared field semantics (leader entitlement,
+ * absence-is-not-zero, set-relative influence, assessed-vs-unassessed), NOT to
+ * certify that the IA is right. The IA question is what Paul's side-by-side
+ * comparison answers, and no fixture can stand in for it.
+ */
+
+import type {
+  ConfidenceSectionData,
+  DecisionResultData,
+  DriverItem,
+  DriversSectionData,
+  ImprovementsSectionData,
+  OptionResult,
+} from '../../types'
+import type { ResultCompleteness } from '../../useResultCompleteness'
+import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
+
+export function makeOption(
+  overrides: Partial<OptionResult> & { id: string; label: string },
+): OptionResult {
+  return {
+    expected: null,
+    outcome: { mean: null, p10: null, p50: null, p90: null },
+    p10: null,
+    p50: null,
+    p90: null,
+    isRecommended: false,
+    ...overrides,
+  } as OptionResult
+}
+
+export function makeDriver(overrides: Partial<DriverItem> & { factorKey: string; factorLabel: string }): DriverItem {
+  return {
+    rawElasticity: 0.4,
+    normalisedInfluence: 0.6,
+    rank: 1,
+    semanticLabel: 'primary',
+    canFocus: true,
+    displayInfluence: 0.6,
+    displayProvenance: 'influence_score',
+    ...overrides,
+  } as DriverItem
+}
+
+const EMPTY_COMPLETENESS: ResultCompleteness = { status: 'full', missing: [], reasons: [] }
+
+export interface MakeDataOptions {
+  recommendation?: Partial<DecisionResultData>
+  drivers?: Partial<DriversSectionData>
+  confidence?: Partial<ConfidenceSectionData>
+  completeness?: ResultCompleteness
+  decisionVoi?: ResultsSectionDataReturn['decisionVoi']
+  sensitivityReference?: ResultsSectionDataReturn['sensitivityReference']
+  voiRanking?: ResultsSectionDataReturn['voiRanking']
+}
+
+export function makeData(opts: MakeDataOptions = {}): ResultsSectionDataReturn {
+  const recommendation: DecisionResultData = {
+    recommendedOption: null,
+    allOptions: [],
+    goalLabel: 'Sustained margin',
+    isSingleOption: false,
+    analysisStatus: 'computed',
+    ...opts.recommendation,
+  } as DecisionResultData
+
+  const drivers: DriversSectionData = {
+    drivers: [],
+    driversStatus: 'computed',
+    topDrivers: [],
+    totalCount: 0,
+    hasMagnitudeData: true,
+    ...opts.drivers,
+  } as DriversSectionData
+
+  const confidence: ConfidenceSectionData = {
+    // The vocabulary is strong | fair | needs_work | unknown — not a
+    // high/medium/low scale. Using an invented token here would have made every
+    // case below assert against a tier the producer can never send.
+    tier: { tier: 'fair', icon: '', label: 'Fair', description: '' },
+    qualityScore: 60,
+    uncertainties: [],
+    topUncertainties: [],
+    improvements: [],
+    topImprovements: [],
+    ...opts.confidence,
+  } as ConfidenceSectionData
+
+  const improvements: ImprovementsSectionData = {
+    improvements: [],
+    count: 0,
+    hasHighPriority: false,
+  }
+
+  return {
+    recommendation,
+    drivers,
+    confidence,
+    improvements,
+    isLoading: false,
+    isError: false,
+    goalLabel: recommendation.goalLabel,
+    completeness: opts.completeness ?? EMPTY_COMPLETENESS,
+    autoNoiseProvenance: null,
+    sensitivityReference: opts.sensitivityReference ?? null,
+    voiRanking: opts.voiRanking ?? null,
+    decisionVoi: opts.decisionVoi ?? 'not_computed',
+    assumedStrength: { selected: null, refusalReason: null, assumedFragileCount: 0 },
+  } as ResultsSectionDataReturn
+}
+
+// ── 1. OPEN STRATEGIC CHALLENGE ─────────────────────────────────────────────
+// No options, no leader, no verdict entitlement. A well-analysed problem that
+// simply is not a decision.
+export function openStrategicChallenge(): ResultsSectionDataReturn {
+  return makeData({
+    recommendation: {
+      allOptions: [],
+      recommendedOption: null,
+      isSingleOption: true,
+      // No `verdict` at all — the producer never named one.
+      robustnessVerdict: 'fragile',
+      robustnessVerdictReason:
+        'Small changes in supplier lead time change which direction looks better.',
+      dominantFactorId: 'f_leadtime',
+      dominantFactorLabel: 'Supplier lead time',
+    },
+    drivers: {
+      drivers: [
+        makeDriver({ factorKey: 'f_leadtime', factorLabel: 'Supplier lead time', direction: 'negative' }),
+        makeDriver({ factorKey: 'f_demand', factorLabel: 'Demand volatility', rank: 2, displayInfluence: 0.35, direction: 'mixed' }),
+      ],
+    },
+    confidence: { evidenceGapsAssessed: true, robustnessStatus: 'computed' },
+  })
+}
+
+// ── 2. GENUINE DECISION ─────────────────────────────────────────────────────
+export function genuineDecision(): ResultsSectionDataReturn {
+  const a = makeOption({ id: 'opt_a', label: 'Hold price', winProbability: 0.31 })
+  const b = makeOption({ id: 'opt_b', label: 'Raise price', isRecommended: true, winProbability: 0.69 })
+  return makeData({
+    recommendation: {
+      allOptions: [a, b],
+      recommendedOption: b,
+      isSingleOption: false,
+      winProbability: 0.69,
+      determinedBy: 'win_probability',
+      // The ONE boolean that entitles naming a leader.
+      verdict: { leaderId: 'opt_b', hasLeadingOption: true } as DecisionResultData['verdict'],
+      robustnessVerdict: 'robust',
+      robustnessVerdictReason: 'The ordering held across the simulated range.',
+    },
+    drivers: {
+      drivers: [makeDriver({ factorKey: 'f_elasticity', factorLabel: 'Price elasticity', direction: 'negative' })],
+    },
+    confidence: { evidenceGapsAssessed: true },
+  })
+}
+
+/** The same decision, but the producer WITHHELD the leader entitlement. */
+export function decisionWithLeaderWithheld(): ResultsSectionDataReturn {
+  const data = genuineDecision()
+  return {
+    ...data,
+    recommendation: {
+      ...data.recommendation,
+      verdict: { leaderId: 'opt_b', hasLeadingOption: false } as DecisionResultData['verdict'],
+    },
+  }
+}
+
+// ── 3. HIGH UNCERTAINTY ─────────────────────────────────────────────────────
+// Consequential uncertainty everywhere, incomplete coverage — and STILL a valid
+// analysis. Nothing here may read as "the analysis is blocked".
+export function highUncertainty(): ResultsSectionDataReturn {
+  return makeData({
+    recommendation: {
+      analysisStatus: 'partial',
+      statusReason: 'Two factors could not be sampled to the requested precision.',
+      robustnessVerdict: 'fragile',
+      robustnessVerdictReason: 'The ordering changed in a substantial share of the simulated range.',
+    },
+    drivers: {
+      drivers: [
+        // Set-relative basis — the caveat must fire.
+        makeDriver({
+          factorKey: 'f_adopt',
+          factorLabel: 'Customer adoption',
+          displayProvenance: 'normalised_elasticity',
+          isDefaultedConfidence: true,
+          confidence: 0.25,
+          direction: 'positive',
+        }),
+      ],
+    },
+    confidence: {
+      // Producer NEVER assessed evidence on this run — distinct from "assessed,
+      // none found". The empty-state copy must differ.
+      evidenceGapsAssessed: false,
+      evidenceGaps: [],
+      uncertainties: [
+        {
+          code: 'SENSITIVE_ASSUMPTION',
+          message: 'RAW_TOKEN_SHOULD_NOT_RENDER',
+          userMessage: 'Customer adoption is the assumption the result is most sensitive to.',
+          displayText: 'Customer adoption is the assumption the result is most sensitive to.',
+          suggestion: 'Test the adoption assumption before committing.',
+          severity: 'critical',
+          affectedNodes: ['f_adopt'],
+          eValue: 1.8,
+        },
+      ],
+      robustnessStatus: 'computed',
+    },
+    completeness: { status: 'partial', missing: ['robustness'], reasons: [] } as unknown as ResultCompleteness,
+    decisionVoi: 'measured_non_zero',
+  })
+}
+
+/** Evidence gaps present, but with a NULL confidence — absence, not zero. */
+export function evidenceGapWithNullConfidence(): ResultsSectionDataReturn {
+  return makeData({
+    confidence: {
+      evidenceGapsAssessed: true,
+      evidenceGaps: [
+        {
+          factorId: 'f_churn',
+          factorLabel: 'Churn rate',
+          confidence: null,
+          voi: null,
+          suggestion: 'Pull the last four quarters of churn before relying on this.',
+        },
+      ],
+    },
+  })
+}

--- a/src/components/results/analysisNew/__tests__/buildAnalysisNewViewModel.spec.ts
+++ b/src/components/results/analysisNew/__tests__/buildAnalysisNewViewModel.spec.ts
@@ -281,6 +281,32 @@ describe('staleness (§20)', () => {
   })
 })
 
+describe('withheld fields (ROADMAP 2.1273) — never read, never rendered', () => {
+  it('renders neither recommendation stability nor ranking stability, on any fixture', () => {
+    // ⛔ PLoT WITHHOLDS `recommendation_stability`: ISL derives it as the
+    // leader's win probability RELABELLED, carrying "zero independent
+    // information". `ranking_stability` was never emitted. Printing either
+    // beside the honest win probability is the same quantity twice, the second
+    // time under a name implying an independent robustness measurement.
+    //
+    // An earlier draft of the comparative insight printed BOTH. The estate-wide
+    // `withheldFieldReadBan.spec.ts` caught it; this case makes the surface
+    // answerable for it in its own suite too.
+    for (const fixture of [genuineDecision(), highUncertainty(), openStrategicChallenge()]) {
+      const text = JSON.stringify(build(fixture))
+      expect(text).not.toMatch(/stability/i)
+    }
+  })
+
+  it('still renders the HONEST statistic it was standing beside', () => {
+    // The discriminating half: without this, deleting the whole comparative
+    // insight would satisfy the case above and prove nothing.
+    const vm = build(genuineDecision())
+    const comparative = vm.keyInsights.insights.find((i) => i.id === 'insight:comparative')!
+    expect(comparative.inspect.map((r) => r.label)).toContain('Win probability')
+  })
+})
+
 describe('the refuted EVPI-in-percentage-points display', () => {
   it('is absent from every rendered row', () => {
     const vm = build(highUncertainty())

--- a/src/components/results/analysisNew/__tests__/buildAnalysisNewViewModel.spec.ts
+++ b/src/components/results/analysisNew/__tests__/buildAnalysisNewViewModel.spec.ts
@@ -1,0 +1,290 @@
+/**
+ * Analysis (New) — the adapter's SEMANTIC contract.
+ *
+ * These cases pin the rules that make this surface honest, not the rules that
+ * make it pretty. Each one is derived from the PRODUCER's declared field
+ * semantics (CLAUDE.md trap 13c — an expectation written from the author's own
+ * reading of what a field ought to mean is a perfect score on the wrong exam),
+ * and each names the field it is answerable to.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { buildAnalysisNewViewModel } from '../buildAnalysisNewViewModel'
+import { ANALYSIS_NEW_COPY as COPY } from '../analysisNewCopy'
+import type { Recommendation } from '../../strengthen/strengthenTypes'
+import {
+  decisionWithLeaderWithheld,
+  evidenceGapWithNullConfidence,
+  genuineDecision,
+  highUncertainty,
+  makeData,
+  openStrategicChallenge,
+} from './analysisNewFixtures'
+
+const rec = (over: Partial<Recommendation> & { id: string }): Recommendation =>
+  ({
+    helpType: 'challenge',
+    title: 'Challenge this assumption',
+    signal: 'One factor carries most of the influence.',
+    whyNow: 'The conclusion rests on it.',
+    tryThis: 'State what would have to be true for it to be wrong.',
+    sourceLine: 'From the influence concentration check.',
+    action: { kind: 'ai-dialogue', label: 'Challenge this assumption' },
+    targetId: null,
+    priority: 1,
+    ...over,
+  }) as Recommendation
+
+const build = (
+  data: ReturnType<typeof makeData>,
+  recommendations: Recommendation[] = [],
+  over: Partial<Parameters<typeof buildAnalysisNewViewModel>[0]> = {},
+) =>
+  buildAnalysisNewViewModel({
+    data,
+    recommendations,
+    recommendationCandidateCount: recommendations.length,
+    isPreRun: false,
+    isRunning: false,
+    isStale: false,
+    ...over,
+  })
+
+describe('leader entitlement (§13) — recommendation.verdict.hasLeadingOption', () => {
+  it('names a leader ONLY when the verdict entitles it, and never says "wins"', () => {
+    const vm = build(genuineDecision())
+    const comparative = vm.keyInsights.insights.find((i) => i.id === 'insight:comparative')
+    expect(comparative, 'a genuine decision with an entitled verdict must offer the comparative insight').toBeDefined()
+    expect(comparative!.headline).toBe('Raise price currently scores higher')
+    // The forbidden vocabulary, checked across the WHOLE surface rather than
+    // just this row — a leader claim leaking through another section would be
+    // the same defect in a different place.
+    const allText = JSON.stringify(vm)
+    expect(allText).not.toMatch(/\bwins\b/i)
+    expect(allText).not.toMatch(/\bwinner\b/i)
+    expect(allText).not.toMatch(/\bbest option\b/i)
+  })
+
+  it('WITHHOLDS the comparative insight when the producer withheld the entitlement', () => {
+    // Identical data, one boolean flipped. This is the discriminating pair: if
+    // the surface gated on `analysisStatus === "computed"` (a lifecycle fact)
+    // instead of the verdict (an entitlement), this case would still name a
+    // leader — which is exactly the conflation the single verdict exists to
+    // prevent.
+    const vm = build(decisionWithLeaderWithheld())
+    expect(vm.keyInsights.insights.map((i) => i.id)).not.toContain('insight:comparative')
+  })
+
+  it('an open strategic challenge produces insights WITHOUT any option framing', () => {
+    const vm = build(openStrategicChallenge())
+    expect(vm.keyInsights.insights.length).toBeGreaterThan(0)
+    expect(vm.keyInsights.insights.map((i) => i.id)).not.toContain('insight:comparative')
+    // The section is NOT empty just because there is no decision — that is the
+    // failure mode a decision-first ladder produces.
+    expect(vm.keyInsights.insights.map((i) => i.id)).toContain('insight:robustness')
+    expect(vm.keyInsights.insights.map((i) => i.id)).toContain('insight:dominant-factor')
+  })
+})
+
+describe('robustness (§4) — display-safe verdict only', () => {
+  it("renders the producer's own reason verbatim and never authors robustness prose", () => {
+    const vm = build(openStrategicChallenge())
+    const r = vm.keyInsights.insights.find((i) => i.id === 'insight:robustness')!
+    expect(r.implication).toBe(
+      'Small changes in supplier lead time change which direction looks better.',
+    )
+  })
+
+  it('omits the robustness insight entirely when no display-safe verdict arrived', () => {
+    // `robustnessLevel` alone must NOT produce a headline — it is structured
+    // data, not a display-safe verdict.
+    const vm = build(makeData({ recommendation: { robustnessLevel: 'low' } }))
+    expect(vm.keyInsights.insights.map((i) => i.id)).not.toContain('insight:robustness')
+  })
+
+  it('covers ALL FOUR vocabulary members distinctly, and turns none of them into a claim it did not receive', () => {
+    // ⭐ THE BREADTH CASE. `RobustnessDisplayVerdict` has four members and an
+    // earlier draft split them binary — so 'moderate' read as "sensitive" and
+    // 'not_assessed', the producer's own stated absence, read as a measurement.
+    // Turning "we did not measure this" into a verdict is the single worst
+    // thing this surface could do, so it gets its own case.
+    const headlineFor = (verdict: string) =>
+      build(
+        makeData({
+          recommendation: {
+            robustnessVerdict: verdict as never,
+            robustnessVerdictReason: 'Producer reason.',
+          },
+        }),
+      ).keyInsights.insights.find((i) => i.id === 'insight:robustness')?.headline
+
+    expect(headlineFor('robust')).toBe('This result holds up under uncertainty')
+    expect(headlineFor('moderate')).toBe('This result holds up, but not strongly')
+    expect(headlineFor('fragile')).toBe('This result is sensitive to uncertainty')
+    // Absence renders NOTHING — not a fourth headline, and certainly not the
+    // fragile one.
+    expect(headlineFor('not_assessed')).toBeUndefined()
+    // …and the three that do render are genuinely distinct, so a future
+    // collapse back to a binary split REDs here.
+    expect(new Set([headlineFor('robust'), headlineFor('moderate'), headlineFor('fragile')]).size).toBe(3)
+  })
+})
+
+describe('influence basis (§16) — displayProvenance decides, not taste', () => {
+  it('flags a set-relative basis and makes NO absolute causal-share claim', () => {
+    const vm = build(highUncertainty())
+    expect(vm.drivers.influenceIsSetRelative).toBe(true)
+    const d = vm.drivers.findings[0]
+    expect(d.implication).toContain('Among the strongest influences in this run')
+    // The absolute claim must be absent. A percentage here would assert a share
+    // of the outcome the normalised basis does not license.
+    expect(d.implication).not.toMatch(/\d+%/)
+    expect(d.groundedIn).toBe('factor sensitivity, ranked within this run')
+  })
+
+  it('states structural influence numerically ONLY on the producer influence scale', () => {
+    const vm = build(openStrategicChallenge())
+    expect(vm.drivers.influenceIsSetRelative).toBe(false)
+    expect(vm.drivers.findings[0].implication).toContain('Structural influence 60%')
+  })
+})
+
+describe('absence is not zero (§4)', () => {
+  it('a null evidence-gap confidence renders NO confidence row and marks it unassessed', () => {
+    const vm = build(evidenceGapWithNullConfidence())
+    const gap = vm.uncertainty.findings.find((f) => f.id === 'gap:f_churn')!
+    expect(gap.marker).toBe('not_assessed')
+    expect(gap.inspect.map((r) => r.label)).not.toContain('Confidence')
+    // The specific fabrication this guards: a rendered 0 the user cannot tell
+    // apart from a measured zero.
+    expect(JSON.stringify(gap.inspect)).not.toContain('0%')
+  })
+
+  it('a defaulted factor confidence is suppressed rather than shown as evidence', () => {
+    const vm = build(highUncertainty())
+    const d = vm.drivers.findings[0]
+    expect(d.marker).toBe('not_assessed')
+    expect(d.inspect.find((r) => r.label === 'Confidence')).toBeUndefined()
+  })
+})
+
+describe('assessed vs never-assessed (§17, §19)', () => {
+  it('carries the producer distinction so the empty state can differ', () => {
+    expect(build(highUncertainty()).uncertainty.evidenceAssessed).toBe(false)
+    expect(build(evidenceGapWithNullConfidence()).uncertainty.evidenceAssessed).toBe(true)
+    // The two empty-state strings must actually be different, or carrying the
+    // distinction buys nothing.
+    expect(COPY.empty.uncertaintyAssessed).not.toBe(COPY.empty.uncertaintyUnassessed)
+  })
+})
+
+describe('coverage is not readiness (§17)', () => {
+  it('discloses partial completeness as provenance without any readiness claim', () => {
+    const vm = build(highUncertainty())
+    expect(vm.status.isProvisional).toBe(true)
+    const text = JSON.stringify(vm)
+    // Nothing on this surface may assert or deny that analysis may run —
+    // `RunAdmission` owns that and this adapter never reads it.
+    expect(text).not.toMatch(/not ready|cannot run|blocked from running|readiness/i)
+  })
+
+  it('never blocks or empties the analysis just because uncertainty is high', () => {
+    const vm = build(highUncertainty())
+    expect(vm.uncertainty.findings.length).toBeGreaterThan(0)
+    expect(vm.drivers.findings.length).toBeGreaterThan(0)
+    expect(vm.keyInsights.insights.length).toBeGreaterThan(0)
+  })
+})
+
+describe('humanised producer text (§4)', () => {
+  it('prefers the sanitised display text and never reaches past it to the raw message', () => {
+    const vm = build(highUncertainty())
+    expect(JSON.stringify(vm)).not.toContain('RAW_TOKEN_SHOULD_NOT_RENDER')
+    expect(
+      vm.uncertainty.findings.some((f) => f.implication.includes('Test the adoption assumption')),
+    ).toBe(true)
+  })
+})
+
+describe('whole-decision VOI (§4) — verdict only, never the number', () => {
+  it("passes 'not_computed' through as its own state, distinct from a measured zero", () => {
+    expect(build(makeData()).uncertainty.decisionVoi).toBe('not_computed')
+    expect(build(highUncertainty()).uncertainty.decisionVoi).toBe('measured_non_zero')
+  })
+})
+
+describe('interventions (§14, §3B)', () => {
+  it('caps the prioritised list at three and discloses how many there were', () => {
+    const many = [1, 2, 3, 4, 5].map((n) => rec({ id: `strengthen:r${n}`, priority: n }))
+    const vm = build(openStrategicChallenge(), many)
+    expect(vm.strengthen.interventions).toHaveLength(3)
+    expect(vm.strengthen.candidateCount).toBe(5)
+    // The cap preserves the engine's order — it never re-ranks.
+    expect(vm.strengthen.interventions.map((r) => r.id)).toEqual([
+      'strengthen:r1',
+      'strengthen:r2',
+      'strengthen:r3',
+    ])
+  })
+
+  it('renders a single grounded intervention', () => {
+    const vm = build(openStrategicChallenge(), [rec({ id: 'strengthen:only' })])
+    expect(vm.strengthen.interventions.map((r) => r.id)).toEqual(['strengthen:only'])
+  })
+
+  it('renders NONE rather than manufacturing one when the engine emitted nothing', () => {
+    const vm = build(openStrategicChallenge(), [])
+    expect(vm.strengthen.interventions).toHaveLength(0)
+    expect(vm.strengthen.candidateCount).toBe(0)
+  })
+
+  it('attaches a contextual intervention to a finding BY TARGET ID, never by label', () => {
+    // The discriminating pair. First: a recommendation whose targetId matches
+    // the dominant factor attaches to that finding.
+    const matching = rec({ id: 'strengthen:dominant', targetId: 'f_leadtime' })
+    const attached = build(openStrategicChallenge(), [matching])
+    const dominant = attached.keyInsights.insights.find((i) => i.id === 'insight:dominant-factor')!
+    expect(dominant.intervention?.recommendationId).toBe('strengthen:dominant')
+
+    // Second: the SAME recommendation with a different targetId must NOT
+    // attach — even though its title, signal and label are byte-identical. A
+    // value-predicate join would still match here and this case would pass
+    // vacuously (CLAUDE.md trap 19).
+    const mismatched = rec({ id: 'strengthen:dominant', targetId: 'f_something_else' })
+    const detached = build(openStrategicChallenge(), [mismatched])
+    const dominant2 = detached.keyInsights.insights.find((i) => i.id === 'insight:dominant-factor')!
+    expect(dominant2.intervention).toBeUndefined()
+  })
+})
+
+describe('key insights (§13) — a small number, and the cap is disclosed', () => {
+  it('never exceeds four and reports the true candidate count', () => {
+    const vm = build(highUncertainty())
+    expect(vm.keyInsights.insights.length).toBeLessThanOrEqual(4)
+    expect(vm.keyInsights.candidateCount).toBeGreaterThanOrEqual(vm.keyInsights.insights.length)
+  })
+
+  it('drops an insight whose implication sentence is empty rather than rendering a bare headline', () => {
+    // A robustness verdict with no producer reason has nothing to say.
+    const vm = build(makeData({ recommendation: { robustnessVerdict: 'robust' } }))
+    expect(vm.keyInsights.insights.map((i) => i.id)).not.toContain('insight:robustness')
+  })
+})
+
+describe('staleness (§20)', () => {
+  it('marks every insight as from an earlier run, and says the MODEL changed', () => {
+    const vm = build(genuineDecision(), [], { isStale: true })
+    expect(vm.status.isStale).toBe(true)
+    expect(vm.keyInsights.insights.every((i) => i.marker === 'stale')).toBe(true)
+    // Freshness, not correctness: the copy must not call the result wrong.
+    expect(COPY.status.stale).toBe('The model has changed since this analysis ran.')
+  })
+})
+
+describe('the refuted EVPI-in-percentage-points display', () => {
+  it('is absent from every rendered row', () => {
+    const vm = build(highUncertainty())
+    expect(JSON.stringify(vm)).not.toMatch(/percentage point/i)
+    expect(JSON.stringify(vm)).not.toMatch(/evpiPp|evpi_percentage_points/)
+  })
+})

--- a/src/components/results/analysisNew/__tests__/buildAnalysisNewViewModel.spec.ts
+++ b/src/components/results/analysisNew/__tests__/buildAnalysisNewViewModel.spec.ts
@@ -18,6 +18,7 @@ import {
   genuineDecision,
   highUncertainty,
   makeData,
+  makeDriver,
   openStrategicChallenge,
 } from './analysisNewFixtures'
 
@@ -108,7 +109,7 @@ describe('robustness (§4) — display-safe verdict only', () => {
     // 'not_assessed', the producer's own stated absence, read as a measurement.
     // Turning "we did not measure this" into a verdict is the single worst
     // thing this surface could do, so it gets its own case.
-    const headlineFor = (verdict: string) =>
+    const insightFor = (verdict: string) =>
       build(
         makeData({
           recommendation: {
@@ -116,14 +117,25 @@ describe('robustness (§4) — display-safe verdict only', () => {
             robustnessVerdictReason: 'Producer reason.',
           },
         }),
-      ).keyInsights.insights.find((i) => i.id === 'insight:robustness')?.headline
+      ).keyInsights.insights.find((i) => i.id === 'insight:robustness')
+    const headlineFor = (verdict: string) => insightFor(verdict)?.headline
 
     expect(headlineFor('robust')).toBe('This result holds up under uncertainty')
     expect(headlineFor('moderate')).toBe('This result holds up, but not strongly')
     expect(headlineFor('fragile')).toBe('This result is sensitive to uncertainty')
-    // Absence renders NOTHING — not a fourth headline, and certainly not the
-    // fragile one.
-    expect(headlineFor('not_assessed')).toBeUndefined()
+
+    // ⚠⚠ ASSERT THE ROW IS ABSENT, NOT THAT ITS HEADLINE IS UNDEFINED — and the
+    // difference is the whole case. A mutant that drops the vocabulary lookup
+    // from the guard still PUSHES an insight for 'not_assessed'; its headline is
+    // merely `undefined`, so `?.headline` reads undefined either way and the
+    // weaker assertion passed on a row that would render a BLANK HEADLINE to a
+    // user. Caught by the mutation battery, not by review.
+    expect(insightFor('not_assessed')).toBeUndefined()
+    // …and the three that DO render each have a real, non-empty headline, so
+    // "absent" and "present but blank" can never be confused here again.
+    for (const v of ['robust', 'moderate', 'fragile']) {
+      expect(insightFor(v)?.headline, `${v} rendered a blank headline`).toBeTruthy()
+    }
     // …and the three that do render are genuinely distinct, so a future
     // collapse back to a binary split REDs here.
     expect(new Set([headlineFor('robust'), headlineFor('moderate'), headlineFor('fragile')]).size).toBe(3)
@@ -140,6 +152,36 @@ describe('influence basis (§16) — displayProvenance decides, not taste', () =
     // of the outcome the normalised basis does not license.
     expect(d.implication).not.toMatch(/\d+%/)
     expect(d.groundedIn).toBe('factor sensitivity, ranked within this run')
+  })
+
+  it('renders a DIRECTION only for the two members that are one — never for mixed or unknown', () => {
+    // ⚠ The producer's union is positive | negative | mixed | unknown, and the
+    // last two are NOT directions. A surface that falls back to "lowers" for
+    // them invents a direction the producer explicitly declined to resolve.
+    // This case was absent until the mutation battery found a fallback mutant
+    // surviving: nothing asserted on a mixed-direction row at all.
+    const implicationFor = (direction: string) =>
+      build(
+        makeData({
+          drivers: {
+            drivers: [
+              makeDriver({ factorKey: 'f_x', factorLabel: 'X', direction: direction as never }),
+            ],
+          },
+        }),
+      ).drivers.findings[0].implication
+
+    expect(implicationFor('positive')).toContain('raises the outcome')
+    expect(implicationFor('negative')).toContain('lowers the outcome')
+    // Neither of the two real direction verbs may appear for an unresolved one.
+    for (const undecided of ['mixed', 'unknown']) {
+      const text = implicationFor(undecided)
+      expect(text, `${undecided} was rendered as a direction`).toContain('moves the outcome')
+      expect(text).not.toContain('raises')
+      expect(text).not.toContain('lowers')
+    }
+    // An absent direction is the same case as an unresolved one.
+    expect(implicationFor(undefined as never)).toContain('moves the outcome')
   })
 
   it('states structural influence numerically ONLY on the producer influence scale', () => {

--- a/src/components/results/analysisNew/__tests__/strengthenInputsMirror.drift.spec.tsx
+++ b/src/components/results/analysisNew/__tests__/strengthenInputsMirror.drift.spec.tsx
@@ -1,0 +1,140 @@
+/**
+ * ⭐⭐ THE MIRROR DRIFT GUARD — DO NOT DELETE, DO NOT LOOSEN.
+ *
+ * `buildStrengthenInputsForAnalysisNew` is a deliberate hand-maintained mirror
+ * of the `inputs` useMemo inside `StrengthenContainer`. A hand-maintained mirror
+ * is this estate's dominant defect class (CLAUDE.md trap 12) and is permitted
+ * ONLY when it fails loud on drift. This is what makes it fail loud.
+ *
+ * ── THE MECHANISM ─────────────────────────────────────────────────────────
+ * It renders the REAL `StrengthenContainer`, intercepts the object it actually
+ * hands `buildRecommendations`, and asserts deep equality with what the mirror
+ * produces from the same sources. So the comparison is against the container's
+ * OBSERVED BEHAVIOUR, not against a copy of its source — which is the only kind
+ * of comparison that can survive the container being edited.
+ *
+ * ⚠ IF THIS GOES RED, RE-MIRROR THE CHANGE IN
+ * `buildStrengthenInputsForAnalysisNew.ts`. Do not relax the assertion, and do
+ * not delete the mirror's diverging key from the comparison — either move
+ * makes the guard agree with itself, which is worse than having no guard.
+ *
+ * ⚠ AND ITS POSITIVE CONTROL. A deep-equality assertion between two objects
+ * that were never produced passes vacuously. The first case asserts the spy was
+ * CALLED and that the captured object is non-trivial before any comparison is
+ * made (trap 13).
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render } from '@testing-library/react'
+import type { StrengthenInputs } from '../../strengthen/strengthenTypes'
+
+const captured: StrengthenInputs[] = []
+
+// Spread the real module and intercept ONE export — a hand-listed factory would
+// drop `toStrengthenPhase3Item`, which BOTH sides import.
+vi.mock('../../strengthen/buildRecommendations', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../strengthen/buildRecommendations')>()
+  return {
+    ...actual,
+    buildRecommendations: (inputs: StrengthenInputs) => {
+      captured.push(inputs)
+      return actual.buildRecommendations(inputs)
+    },
+  }
+})
+
+import { StrengthenContainer } from '../../strengthen/StrengthenContainer'
+import { buildStrengthenInputsForAnalysisNew } from '../buildStrengthenInputsForAnalysisNew'
+import { useCanvasStore } from '../../../../canvas/store'
+import { useGuidanceStore } from '../../../../canvas/stores/guidanceStore'
+import { genuineDecision, highUncertainty, makeDriver, openStrategicChallenge } from './analysisNewFixtures'
+
+const SCENARIOS = {
+  'open strategic challenge': openStrategicChallenge,
+  'genuine decision': genuineDecision,
+  'high uncertainty': highUncertainty,
+}
+
+beforeEach(() => {
+  captured.length = 0
+})
+afterEach(() => {
+  cleanup()
+})
+
+describe('the mirror matches the container it mirrors', () => {
+  for (const [name, makeScenario] of Object.entries(SCENARIOS)) {
+    it(`produces the same engine inputs as StrengthenContainer — ${name}`, () => {
+      const data = makeScenario()
+      // Give the drivers a fragile edge and a producer flag so the branches
+      // that MAP something are actually exercised — a scenario whose every
+      // optional input is absent would compare two mostly-empty objects.
+      const enriched = {
+        ...data,
+        drivers: {
+          ...data.drivers,
+          drivers: [
+            ...data.drivers.drivers,
+            makeDriver({
+              factorKey: 'f_extra',
+              factorLabel: 'Extra factor',
+              matchedNodeId: 'node_extra',
+              worthInvestigating: true,
+              confidence: 0.8,
+              isDefaultedConfidence: false,
+              rank: 9,
+            }),
+          ],
+        },
+        confidence: {
+          ...data.confidence,
+          challengeFragileEdges: [
+            {
+              edge_id: 'e_1',
+              from_id: 'f_extra',
+              from_label: 'Extra factor',
+              to_label: 'Margin',
+              switch_probability: 0.42,
+            },
+          ],
+        },
+      } as typeof data
+
+      render(<StrengthenContainer data={enriched} />)
+
+      // POSITIVE CONTROL — the comparison below means nothing if the container
+      // never ran the engine.
+      expect(captured.length, 'StrengthenContainer never called buildRecommendations').toBeGreaterThan(0)
+      const fromContainer = captured[captured.length - 1]
+      expect(
+        fromContainer.factors.length,
+        'the captured inputs carry no factors — this comparison would be near-vacuous',
+      ).toBeGreaterThan(0)
+      expect(fromContainer.fragileEdges.length).toBeGreaterThan(0)
+
+      const fromMirror = buildStrengthenInputsForAnalysisNew({
+        data: enriched,
+        guidanceItems: useGuidanceStore.getState().guidanceItems,
+        biasSignals: useCanvasStore.getState().draftCoaching?.biasSignals ?? null,
+        currentStage: useCanvasStore.getState().currentStage,
+      })
+
+      expect(fromMirror).toEqual(fromContainer)
+    })
+  }
+
+  it('the guard can actually detect a divergence', () => {
+    // ⭐ THE DISCRIMINATING HALF. Without this, "the two agree" could be true
+    // because the comparison is insensitive rather than because they agree.
+    const data = openStrategicChallenge()
+    const real = buildStrengthenInputsForAnalysisNew({
+      data,
+      guidanceItems: [],
+      biasSignals: null,
+      currentStage: null,
+    })
+    const drifted = { ...real, analysisComplete: !real.analysisComplete }
+    expect(drifted).not.toEqual(real)
+  })
+})

--- a/src/components/results/analysisNew/analysisNewCopy.ts
+++ b/src/components/results/analysisNew/analysisNewCopy.ts
@@ -1,0 +1,93 @@
+/**
+ * Analysis (New) — every user-visible string on the experimental surface, in
+ * one place, so the IA can be re-tuned without hunting through components.
+ *
+ * en-GB. Sentence case throughout: the Design System v5 guard forbids the
+ * `uppercase` utility in `src/`, and small-caps section labels are not in the
+ * panel scale. Section titles are `typography.panelHeader`.
+ *
+ * ⚠ WHAT IS *NOT* HERE, ON PURPOSE. No copy that asserts a finding. Every
+ * sentence a user reads ABOUT their situation comes from the producer, verbatim
+ * or formatted; this file holds only the furniture — section titles, disclosure
+ * affordances and the honest empty states. If a string here ever starts
+ * describing the analysis, that is the fabrication boundary being crossed.
+ */
+
+export const ANALYSIS_NEW_COPY = {
+  /** The tab's own one-line frame. Names it as an experiment, not a product. */
+  tabIntro:
+    'A second reading of the same analysis run, laid out around the reasoning. Nothing here is re-computed.',
+
+  sections: {
+    keyInsights: 'Key insights',
+    strengthen: 'Strengthen the reasoning',
+    drivers: 'Drivers and dynamics',
+    uncertainty: 'Uncertainty and gaps',
+    deeper: 'Deeper analysis and evidence',
+  },
+
+  /**
+   * Empty states. Each one states what was NOT established, never a reassuring
+   * positive. "No high-priority reasoning intervention identified yet" is a
+   * fact about this run; "Your reasoning looks solid" would be a claim nobody
+   * measured.
+   */
+  empty: {
+    keyInsights: 'No insight is grounded well enough to lead with yet.',
+    strengthen: 'No high-priority reasoning intervention identified yet.',
+    drivers: 'This run did not return factor influence.',
+    /** Used ONLY when the producer assessed evidence and found nothing. */
+    uncertaintyAssessed: 'Nothing was flagged as consequentially uncertain on this run.',
+    /** Used when the producer never assessed. Different fact, different words. */
+    uncertaintyUnassessed: 'Evidence quality was not assessed on this run.',
+  },
+
+  /** Progressive-disclosure affordances. */
+  disclosure: {
+    expand: 'Show more',
+    collapse: 'Show less',
+    inspect: 'Inspect',
+    /** Level-2 grounding prefix. Always followed by the producer signal name. */
+    groundedIn: 'Grounded in',
+    moreDrivers: (n: number) => `Show ${n} more`,
+    moreUncertainty: (n: number) => `Show ${n} more`,
+  },
+
+  markers: {
+    provisional: 'Provisional',
+    stale: 'From an earlier run',
+    notAssessed: 'Not assessed',
+  },
+
+  status: {
+    preRun: 'No analysis has run yet for this model.',
+    running: 'Analysis is running.',
+    /**
+     * ⚠ SAYS THE MODEL MOVED, NOT THAT THE RESULT IS WRONG. A stale result is
+     * the user's best available context and the Rerun control sits in the
+     * shell's footer bar. Overstating this would make the honest thing to do
+     * (keep reading) feel like an error state.
+     */
+    stale: 'The model has changed since this analysis ran.',
+  },
+
+  /**
+   * Coverage disclosure. ⚠ THE ONE SENTENCE IN THIS FILE MOST LIKELY TO DRIFT
+   * INTO A LIE. Incomplete coverage is NOT a readiness verdict and NOT a cause
+   * of any ordering — `RunAdmission` owns readiness and nothing here speaks for
+   * it. The wording states what was not covered and stops.
+   */
+  coverage: {
+    someFactorsUnassessed: 'Some factors could not be assessed for this ranking.',
+    /** Influence figures are set-relative, not a causal share of the outcome. */
+    setRelativeInfluence:
+      'Influence is relative to the other factors in this run, not a share of the outcome.',
+    referencePrefix: 'Sensitivities are measured against',
+  },
+
+  /** Whole-decision value of information. Verdict only — the units are unsafe. */
+  decisionVoi: {
+    measuredNonZero: 'Resolving the open unknowns could still change this decision.',
+    measuredZero: 'Resolving the open unknowns was measured as not changing this decision.',
+  },
+} as const

--- a/src/components/results/analysisNew/analysisNewTypes.ts
+++ b/src/components/results/analysisNew/analysisNewTypes.ts
@@ -1,0 +1,209 @@
+/**
+ * Analysis (New) — view-model types for the duplicate Analysis tab experiment.
+ *
+ * ⭐ THE ONE RULE THIS FILE EXISTS TO ENFORCE: this view model may SELECT,
+ * RANK, GROUP and FORMAT what `useResultsSectionData()` already produced. It
+ * may NOT create analytical truth. Every field below is traceable to a producer
+ * field or to an existing UI authority, and the trace is written next to it.
+ *
+ * The experiment (Paul, 27 Aug 2026) is an INFORMATION-ARCHITECTURE comparison:
+ * the existing Analysis tab is untouched, and this second surface renders THE
+ * SAME analysis run through a reasoning-led IA:
+ *
+ *   Key insights · Strengthen the reasoning · Drivers and dynamics ·
+ *   Uncertainty and gaps  (+ deeper material behind progressive disclosure)
+ *
+ * ⚠ WHY THE SECTIONS CARRY `groundedIn` STRINGS. Every row a user sees must be
+ * able to say which producer signal put it there. That is not decoration — it
+ * is the difference between this surface and a generated summary, and it is the
+ * property that makes a wrong row diagnosable rather than merely wrong.
+ */
+
+import type { Recommendation } from '../strengthen/strengthenTypes'
+
+/**
+ * How confident the SURFACE is entitled to sound — never an "AI confidence".
+ *
+ * ⚠ THERE IS NO `'confident'` MEMBER AND THAT IS DELIBERATE. The absence of a
+ * provisional marker is the confident case. Adding a positive token would
+ * invite a surface to assert soundness it was never told about, which is the
+ * fabrication class this experiment is forbidden from introducing.
+ */
+export type ProvisionalMarker =
+  /** The producer disclosed the value is provisional/auto-derived. */
+  | 'provisional'
+  /** The displayed run predates the current model (freshness, not quality). */
+  | 'stale'
+  /** The producer declined to compute or to disclose. Absence, not zero. */
+  | 'not_assessed'
+
+/** A level-3 "inspect" payload: label/value pairs, rendered verbatim. */
+export interface InspectRow {
+  label: string
+  /** Already formatted for display by the adapter. Components never compute. */
+  value: string
+}
+
+/**
+ * A contextual reasoning intervention attached to ONE finding.
+ *
+ * ⚠ Only ever populated from a Recommendation the strengthen ENGINE emitted for
+ * the same entity. It is never authored here: a client-authored "why not try…"
+ * beside a producer finding is exactly the fabricated-coaching defect the brief
+ * forbids. `recommendationId` is the join, and it is what a test binds to.
+ */
+export interface ContextualIntervention {
+  recommendationId: string
+  label: string
+  /** Present only when the engine supplied one. */
+  targetId: string | null
+}
+
+/** Shared shape for a progressively-disclosed row across all four sections. */
+export interface AnalysisNewFinding {
+  /** Stable identity. Tests bind to this, never to a value predicate. */
+  id: string
+  /** Level 1 — scan. Short, specific, no hedging adverbs. */
+  headline: string
+  /** Level 1 — one concise implication sentence. */
+  implication: string
+  /** Level 2 — expanded rationale/relationship/evidence, when there is one. */
+  detail?: string
+  /** Which producer signal put this row here. Rendered at level 2. */
+  groundedIn: string
+  marker?: ProvisionalMarker
+  /** Canvas focus target, when the producer named one. */
+  targetId?: string
+  /** Level 3 — inspect. Empty array renders no inspect affordance. */
+  inspect: InspectRow[]
+  intervention?: ContextualIntervention
+}
+
+/**
+ * Key insights — 2 to 4 of them. NOT decision-centric by construction: a
+ * comparative insight is one KIND among several and appears only when the
+ * single decision verdict entitles it.
+ */
+export interface KeyInsightsSection {
+  insights: AnalysisNewFinding[]
+  /**
+   * How many grounded candidates existed before the cap. Rendered as a plain
+   * count so the cap is disclosed rather than silent (no silent truncation).
+   */
+  candidateCount: number
+}
+
+/**
+ * The producer's DSK attestation for one intervention.
+ *
+ * ⚠ PRESENCE IS THE ATTESTATION. An intervention without a `claimId` is "not
+ * grounded", never "unknown" and never a default — which is why this whole
+ * object is absent rather than partially filled. `strength` is a closed
+ * vocabulary carried verbatim; `claimId`/`protocolId` are IDS and ride as
+ * `data-*` attributes only, never as user-facing copy.
+ *
+ * ⚠ AND WHAT THIS IS NOT: it is NOT a licence to label an intervention with a
+ * technique name the producer did not send. §15 is explicit — a recommendation
+ * is not "scientifically grounded" because it sounds like a recognised method.
+ * This carries the producer's own attestation or nothing.
+ */
+export interface ScienceGrounding {
+  claimId: string
+  protocolId?: string
+  strength?: string
+}
+
+/** Strengthen the reasoning — the prioritised interventions, 1 to 3. */
+export interface StrengthenSection {
+  /**
+   * Engine output, already filtered against the strengthen lifecycle store and
+   * capped. The engine is `buildRecommendations` — this surface runs it and
+   * renders it; it never adds a recommendation of its own.
+   */
+  interventions: Recommendation[]
+  /** Total active engine output before the cap. Disclosed, never silent. */
+  candidateCount: number
+  /**
+   * Producer DSK attestation, keyed by recommendation id. Sparse BY DESIGN: an
+   * absent key means the producer attested nothing for that intervention.
+   *
+   * ⚠ WHY THIS EXISTS AT ALL. The carrier is wire-witnessed on guidance items
+   * (`dsk_claim_id` / `dsk_protocol_id` / `evidence_strength`), but
+   * `toStrengthenPhase3Item` maps nine fields and none of these — so a
+   * genuinely grounded recommendation reached the Strengthen panel with its
+   * grounding stripped. The join is re-made HERE, in the presentation adapter,
+   * rather than by editing the shared mapper, because that mapper is on the
+   * existing Analysis tab's path and this experiment may not touch it.
+   */
+  scienceGrounding: Record<string, ScienceGrounding>
+}
+
+export interface DriversSection {
+  findings: AnalysisNewFinding[]
+  /**
+   * TRUE when the influence figures on display are SET-RELATIVE
+   * (`displayProvenance === 'normalised_elasticity'`), i.e. "largest in this
+   * set", NOT a causal share of the outcome. Drives the caveat line.
+   *
+   * ⚠ This is the "do not conflate structurally different scientific
+   * quantities" rule made mechanical: the caveat is a function of the
+   * producer's own provenance token, not of the adapter's taste.
+   */
+  influenceIsSetRelative: boolean
+  /** The option sensitivities were computed against, when disclosed. */
+  referenceOptionLabel: string | null
+  totalCount: number
+}
+
+export interface UncertaintySection {
+  findings: AnalysisNewFinding[]
+  /**
+   * Did the producer ASSESS evidence on this run at all?
+   *
+   * ⚠ THE WHOLE POINT OF CARRYING THIS. An empty gap list answers two different
+   * questions — "assessed, none found" and "never assessed" — and a surface
+   * that turns the empty list into "No evidence gaps" makes a claim only the
+   * first licenses. Sourced from `confidence.evidenceGapsAssessed`.
+   */
+  evidenceAssessed: boolean
+  /**
+   * Whole-decision value of information, as a VERDICT only. `'not_computed'`
+   * renders nothing; `'measured_zero'` is a real result and says so.
+   */
+  decisionVoi: 'not_computed' | 'measured_zero' | 'measured_non_zero'
+  totalCount: number
+}
+
+/** Level-3 material. One collapsed region, never a fifth top-level section. */
+export interface DeeperAnalysisSection {
+  groups: Array<{ title: string; rows: InspectRow[] }>
+}
+
+/**
+ * The truthful run status carried into this tab. Contextualises the content;
+ * it must never dominate the surface (§20).
+ *
+ * ⚠ `coverage` IS NOT `readiness`. `RunAdmission` remains the sole authority on
+ * whether analysis may run, and nothing here is derived from it or claims to
+ * speak for it. Uneven coverage is provenance, not a verdict on validity.
+ */
+export interface AnalysisNewStatus {
+  /** No completed analysis is being displayed. */
+  isPreRun: boolean
+  isRunning: boolean
+  /** The displayed report predates the current model. */
+  isStale: boolean
+  /** The producer disclosed the result as partial/incomplete. */
+  isProvisional: boolean
+  /** Producer-owned reason, verbatim, when there is one. Never authored here. */
+  statusNote: string | null
+}
+
+export interface AnalysisNewViewModel {
+  status: AnalysisNewStatus
+  keyInsights: KeyInsightsSection
+  strengthen: StrengthenSection
+  drivers: DriversSection
+  uncertainty: UncertaintySection
+  deeper: DeeperAnalysisSection
+}

--- a/src/components/results/analysisNew/buildAnalysisNewViewModel.ts
+++ b/src/components/results/analysisNew/buildAnalysisNewViewModel.ts
@@ -1,0 +1,571 @@
+/**
+ * Analysis (New) — THE adapter. One mapping site, so the IA can be re-tuned in
+ * one file and so no component ever reinterprets a raw analysis field.
+ *
+ * ⭐ IT SELECTS, RANKS, GROUPS AND FORMATS. IT DOES NOT COMPUTE.
+ * Every value it emits is either (a) a producer field carried verbatim,
+ * (b) a producer field formatted for display, or (c) a selection among producer
+ * fields. There is no arithmetic here that constitutes a finding, and no
+ * sentence about the user's situation that the producer did not supply.
+ *
+ * ── THE SEMANTIC RULES THIS FILE IS ANSWERABLE FOR ──────────────────────────
+ *  1. LEADER ENTITLEMENT. Nothing may name or presuppose a leading option
+ *     unless `recommendation.verdict.hasLeadingOption === true`. A completed
+ *     analysis is not an entitlement. Comparative copy is "currently scores
+ *     higher", never "wins".
+ *  2. INFLUENCE IS NOT A CAUSAL SHARE. `displayProvenance` decides: only
+ *     `'influence_score'` is an absolute producer scale; `'normalised_elasticity'`
+ *     means "largest in this set" and must carry the caveat.
+ *  3. ROBUSTNESS. The display-safe verdict is `robustnessVerdict` (+ its
+ *     producer-authored reason, rendered VERBATIM). `robustnessLevel` is
+ *     structured data and never drives the headline.
+ *  4. ABSENCE IS NOT ZERO. A null confidence suppresses the sentence; it never
+ *     prints 0. `evidenceGapsAssessed` separates "assessed, none found" from
+ *     "never assessed".
+ *  5. COVERAGE IS NOT READINESS. Nothing here reads or speaks for
+ *     `RunAdmission`. Incomplete coverage is disclosed as provenance.
+ *  6. NO EVPI IN PERCENTAGE POINTS, EVER. `evpi_percentage_points` is refuted
+ *     upstream (tests/contracts/no-evpi-display.contract.test.ts). Whole-
+ *     decision VOI crosses this boundary as a VERDICT only, never a number.
+ */
+
+import type { Recommendation } from '../strengthen/strengthenTypes'
+import type {
+  ConditionalWinner,
+  DriverItem,
+  EvidenceGapItem,
+  UncertaintyItem,
+} from '../types'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import { ANALYSIS_NEW_COPY as COPY } from './analysisNewCopy'
+import type {
+  AnalysisNewFinding,
+  AnalysisNewStatus,
+  AnalysisNewViewModel,
+  ContextualIntervention,
+  InspectRow,
+  ScienceGrounding,
+} from './analysisNewTypes'
+
+/** §2 of the brief: "a very small number of high-value insights". */
+const KEY_INSIGHT_CAP = 4
+/** §2: "1–3 prioritised reasoning interventions". */
+const STRENGTHEN_CAP = 3
+/** Level-1 rows before "Show more". */
+const DRIVER_PREVIEW = 3
+const UNCERTAINTY_PREVIEW = 3
+
+export interface AnalysisNewViewModelInputs {
+  data: ResultsSectionDataReturn
+  /** Engine output, already lifecycle-filtered by the hook. */
+  recommendations: Recommendation[]
+  /** Total active engine output BEFORE the cap, for honest disclosure. */
+  recommendationCandidateCount: number
+  isPreRun: boolean
+  isRunning: boolean
+  /** The displayed report predates the current model (freshness only). */
+  isStale: boolean
+  /** Monte Carlo sample count, when the producer disclosed one. */
+  nSamples?: number
+  /** Deterministic seed, when disclosed. */
+  seedUsed?: number | string
+  /** Response hash — the run identity both tabs share. */
+  responseHash?: string
+  /**
+   * Producer DSK attestation keyed by recommendation id, joined by the hook.
+   * Sparse: an absent key means the producer attested nothing. Never defaulted.
+   */
+  scienceGrounding?: Record<string, ScienceGrounding>
+}
+
+// ── formatting helpers (display only — none of these decide anything) ────────
+
+const pct = (v: number): string => `${Math.round(v * 100)}%`
+
+/** Absence-safe percentage. `null`/`undefined` yields null, NEVER "0%". */
+const pctOrNull = (v: number | null | undefined): string | null =>
+  typeof v === 'number' && Number.isFinite(v) ? pct(v) : null
+
+/** A 0-100 confidence, absence-safe. Rule 4: absence suppresses, never zeroes. */
+const conf100OrNull = (v: number | null | undefined): string | null =>
+  typeof v === 'number' && Number.isFinite(v) ? `${Math.round(v)}%` : null
+
+const rows = (...maybe: Array<InspectRow | null>): InspectRow[] =>
+  maybe.filter((r): r is InspectRow => r !== null)
+
+const row = (label: string, value: string | null | undefined): InspectRow | null =>
+  value == null || value === '' ? null : { label, value }
+
+/**
+ * Prefer the producer's humanised text over its raw one.
+ *
+ * ⚠ ORDER MATTERS AND IS NOT ARBITRARY: `displayText` is the data layer's
+ * pre-sanitised render-safe string (it has already passed the internal-token
+ * guard), `userMessage` is PLoT's humanised copy, `message` is the raw code-ish
+ * fallback. Reaching past a sanitised string to a raw one is how internal
+ * tokens reach a user.
+ */
+const humanised = (u: UncertaintyItem): string => u.displayText || u.userMessage || u.message
+
+/**
+ * Join an engine recommendation to a finding, by TARGET IDENTITY.
+ *
+ * ⚠ BINDS BY ID, NEVER BY A VALUE PREDICATE (CLAUDE.md trap 19). An earlier
+ * shape matched on label text, and two factors sharing a label would each have
+ * claimed the other's intervention. `targetId` is the join or there is none.
+ */
+function interventionFor(
+  recommendations: Recommendation[],
+  targetId: string | undefined,
+): ContextualIntervention | undefined {
+  if (!targetId) return undefined
+  const rec = recommendations.find((r) => r.targetId === targetId)
+  if (!rec) return undefined
+  return { recommendationId: rec.id, label: rec.action.label, targetId: rec.targetId }
+}
+
+// ── KEY INSIGHTS ────────────────────────────────────────────────────────────
+
+/**
+ * Candidate insights, most-consequential first.
+ *
+ * ⚠ THE ORDER OF THE PUSHES IS THE PRIORITY LADDER, and it is deliberately NOT
+ * decision-first. A robustness verdict, a strategic tension and a concentration
+ * risk all outrank "which option scores higher", because a decision may not
+ * exist in the scenario at all — and when it does not, a decision-first ladder
+ * produces an empty section for a perfectly well-analysed problem.
+ */
+function buildKeyInsights(
+  data: ResultsSectionDataReturn,
+  recommendations: Recommendation[],
+  isStale: boolean,
+): { insights: AnalysisNewFinding[]; candidateCount: number } {
+  const rec = data.recommendation
+  const conf = data.confidence
+  const out: AnalysisNewFinding[] = []
+  const staleMarker = isStale ? ('stale' as const) : undefined
+
+  // 1. The producer's own executive statement, when it sent one. Verbatim.
+  //    This is M1 coaching — deterministic, not LLM-generated.
+  if (rec.coachingDecisionStatement || rec.coachingHeadline) {
+    out.push({
+      id: 'insight:executive-summary',
+      headline: rec.coachingHeadline || 'What this run found',
+      implication: rec.coachingDecisionStatement || rec.coachingParagraph || '',
+      detail: rec.coachingKeyQualifier || undefined,
+      groundedIn: 'the analysis executive summary',
+      marker: staleMarker,
+      inspect: rows(
+        row('Action implication', rec.coachingActionImplication),
+        row('Readiness', rec.coachingReadiness),
+      ),
+    })
+  }
+
+  // 2. Robustness — the display-safe verdict only, with the producer's own
+  //    reason rendered verbatim. Rule 3.
+  //
+  // ⚠⚠ THE VOCABULARY HAS FOUR MEMBERS AND A BINARY SPLIT OVER IT IS A
+  // FABRICATION. An earlier draft here read `=== 'robust' ? "holds up" :
+  // "is sensitive"`, which is correct for exactly one of the four:
+  //   · 'moderate'     → rendered as "sensitive", overstating fragility;
+  //   · 'not_assessed' → the producer's own STATED ABSENCE ("robustness not
+  //     computed"), rendered as a claim that the result IS sensitive.
+  // The last one is the worst thing this surface could do: turn "we did not
+  // measure this" into a measurement. `not_assessed` therefore produces NO
+  // insight at all — absence is not a verdict (CLAUDE.md trap 22: the defect
+  // lives in the BREADTH of a predicate, not in the case you had in mind).
+  const ROBUSTNESS_HEADLINE: Record<string, string> = {
+    robust: 'This result holds up under uncertainty',
+    moderate: 'This result holds up, but not strongly',
+    fragile: 'This result is sensitive to uncertainty',
+  }
+  if (rec.robustnessVerdict && ROBUSTNESS_HEADLINE[rec.robustnessVerdict]) {
+    out.push({
+      id: 'insight:robustness',
+      headline: ROBUSTNESS_HEADLINE[rec.robustnessVerdict],
+      // The producer authors this sentence. The UI never authors robustness prose.
+      implication: rec.robustnessVerdictReason ?? '',
+      groundedIn: 'the robustness verdict from the simulation',
+      marker: staleMarker,
+      inspect: rows(
+        row('Ranking stability', pctOrNull(conf.rankingStability)),
+        row('Structured level', rec.robustnessLevel),
+      ),
+    })
+  }
+
+  // 3. Strategic tension: the leading option DEPENDS on a factor's value.
+  //    A genuine "it depends" finding, and the most reasoning-shaped thing the
+  //    producer emits. Neutral arm when the winner identity was withheld.
+  const cw: ConditionalWinner | undefined = conf.conditionalWinners?.[0]
+  if (cw) {
+    const high = cw.high_bucket?.winner_label
+    const low = cw.low_bucket?.winner_label
+    const namesBoth = Boolean(high && low && high !== low)
+    out.push({
+      id: `insight:conditional-winner:${cw.factor_id}`,
+      headline: `The answer turns on ${cw.factor_label}`,
+      implication: namesBoth
+        ? `Above ${cw.split_value}${cw.split_unit ? ` ${cw.split_unit}` : ''}, ${high} scores higher; below it, ${low} does.`
+        : `The preferred direction changes around ${cw.split_value}${cw.split_unit ? ` ${cw.split_unit}` : ''}.`,
+      groundedIn: 'the conditional-winner split from the simulation',
+      marker: staleMarker,
+      targetId: cw.factor_id,
+      inspect: rows(row('Split value', String(cw.split_value)), row('Factor', cw.factor_label)),
+      intervention: interventionFor(recommendations, cw.factor_id),
+    })
+  }
+
+  // 4. Concentration: one factor carries most of the influence. A structural
+  //    finding about the MODEL, not about a decision.
+  if (rec.dominantFactorLabel) {
+    out.push({
+      id: 'insight:dominant-factor',
+      headline: `${rec.dominantFactorLabel} dominates the model`,
+      implication:
+        'One factor carries most of the influence here, so the conclusion largely rests on it being right.',
+      groundedIn: 'the influence concentration check',
+      marker: staleMarker,
+      targetId: rec.dominantFactorId,
+      inspect: [],
+      intervention: interventionFor(recommendations, rec.dominantFactorId),
+    })
+  }
+
+  // 5. The relationship most able to change the answer.
+  const hinge = conf.m1CoachingTopFragileEdge ?? conf.topFragileEdge
+  if (hinge && typeof hinge.switchProbability === 'number') {
+    out.push({
+      id: 'insight:hinge',
+      headline: `${hinge.fromLabel} is the hinge`,
+      implication: `Its effect on ${hinge.toLabel} is the relationship most able to change the outcome.`,
+      groundedIn: 'the fragile-relationship analysis',
+      marker: staleMarker,
+      targetId: hinge.fromId,
+      inspect: rows(row('Chance the result flips', pctOrNull(hinge.switchProbability))),
+      intervention: interventionFor(recommendations, hinge.fromId),
+    })
+  }
+
+  // 6. COMPARATIVE — LAST, and only when the single verdict entitles it.
+  //    Rule 1. "Currently scores higher", never "wins".
+  const leader = rec.recommendedOption
+  if (rec.verdict?.hasLeadingOption === true && leader && !rec.isSingleOption) {
+    const winPct = pctOrNull(leader.winProbability ?? rec.winProbability)
+    out.push({
+      id: 'insight:comparative',
+      headline: `${leader.label} currently scores higher`,
+      implication: winPct
+        ? `It comes out ahead in ${winPct} of simulated futures.`
+        : 'It comes out ahead across the simulated futures.',
+      detail: rec.nearTie ? 'The top options are close enough that this ordering is not settled.' : undefined,
+      groundedIn: 'the option comparison',
+      marker: staleMarker,
+      targetId: leader.id,
+      inspect: rows(
+        row('Win probability', winPct),
+        row('Determined by', rec.determinedBy),
+        row('Recommendation stability', pctOrNull(rec.recommendationStability)),
+      ),
+      intervention: interventionFor(recommendations, leader.id),
+    })
+  }
+
+  // Insights with no implication sentence say nothing — drop rather than
+  // render a headline with an empty body.
+  const usable = out.filter((i) => i.implication.trim().length > 0 || i.detail)
+  return { insights: usable.slice(0, KEY_INSIGHT_CAP), candidateCount: usable.length }
+}
+
+// ── DRIVERS AND DYNAMICS ────────────────────────────────────────────────────
+
+function driverFinding(
+  d: DriverItem,
+  setRelative: boolean,
+  recommendations: Recommendation[],
+): AnalysisNewFinding {
+  const target = d.matchedNodeId ?? d.factorKey
+  const influence = d.displayInfluence ?? d.influenceScore ?? d.normalisedInfluence
+  // ⚠ THE PRODUCER'S DOMAIN IS `positive | negative | mixed | unknown`, and the
+  // last two are NOT a direction. `'moves'` is the honest verb for them: a
+  // factor whose direction the producer declined to resolve must not be
+  // rendered as raising or lowering anything. (An earlier draft compared
+  // against `'increase'`/`'decrease'` — tokens that do not exist in this union
+  // — so every row silently fell through to the neutral arm and the two real
+  // directions were never rendered at all. The typecheck gate caught it.)
+  const directionWord =
+    d.direction === 'positive' ? 'raises' : d.direction === 'negative' ? 'lowers' : 'moves'
+
+  return {
+    id: `driver:${d.factorKey}`,
+    headline: d.factorLabel,
+    // ⚠ Rule 2. Under a set-relative basis this says "among the strongest in
+    // this run" — a RANK claim. It never says "drives N% of the outcome",
+    // which would be an absolute causal share the basis does not license.
+    implication: setRelative
+      ? `Among the strongest influences in this run; ${directionWord} the outcome.`
+      : `Structural influence ${pct(influence)}; ${directionWord} the outcome.`,
+    detail:
+      d.fragileEdgeInfo?.switchProbability != null
+        ? `This relationship is one the result is sensitive to.`
+        : undefined,
+    groundedIn: setRelative
+      ? 'factor sensitivity, ranked within this run'
+      : 'the producer influence score',
+    // A defaulted confidence is a placeholder, not a measurement — say so
+    // rather than rendering it as evidence.
+    marker: d.isDefaultedConfidence ? 'not_assessed' : undefined,
+    targetId: d.canFocus ? target : undefined,
+    inspect: rows(
+      row('Influence', pctOrNull(influence)),
+      row('Rank', d.influenceRank != null ? String(d.influenceRank) : String(d.rank)),
+      row('Basis', d.displayProvenance === 'influence_score' ? 'producer influence score' : 'ranked within this run'),
+      // Absence-safe: a defaulted or absent confidence prints nothing.
+      row('Confidence', d.isDefaultedConfidence ? null : pctOrNull(d.confidence)),
+      row('Attribution stability', d.attributionStability),
+      row('Chance the result flips', pctOrNull(d.fragileEdgeInfo?.switchProbability)),
+    ),
+    intervention: interventionFor(recommendations, target),
+  }
+}
+
+function buildDrivers(
+  data: ResultsSectionDataReturn,
+  recommendations: Recommendation[],
+): AnalysisNewViewModel['drivers'] {
+  const drivers = data.drivers.drivers ?? []
+  // Rule 2: the basis is the PRODUCER's token, not the adapter's taste. Any
+  // row on a set-relative basis makes the whole list set-relative — mixing
+  // bases in one list is the defect the token exists to prevent.
+  const influenceIsSetRelative =
+    drivers.length > 0 && drivers.some((d) => d.displayProvenance !== 'influence_score')
+
+  const findings = drivers
+    .filter((d) => d.zeroReason == null)
+    .map((d) => driverFinding(d, influenceIsSetRelative, recommendations))
+
+  return {
+    findings,
+    influenceIsSetRelative,
+    referenceOptionLabel: data.sensitivityReference?.optionLabel ?? null,
+    totalCount: findings.length,
+  }
+}
+
+// ── UNCERTAINTY AND GAPS ────────────────────────────────────────────────────
+
+function evidenceGapFinding(
+  g: EvidenceGapItem,
+  recommendations: Recommendation[],
+): AnalysisNewFinding {
+  const target = g.targetNodeId ?? g.factorId
+  return {
+    id: `gap:${g.factorId}`,
+    headline: `${g.factorLabel} is weakly evidenced`,
+    // Producer-authored suggestion, verbatim.
+    implication: g.suggestion,
+    groundedIn: 'the evidence-gap assessment',
+    // Rule 4: a null confidence is "we were not told", not "zero".
+    marker: g.confidence == null ? 'not_assessed' : undefined,
+    targetId: target,
+    inspect: rows(
+      row('Confidence', conf100OrNull(g.confidence)),
+      // ⛔ evpi_percentage_points is never rendered — refuted upstream.
+      row('Expected value of perfect information', g.evpi != null ? String(g.evpi) : null),
+    ),
+    intervention: interventionFor(recommendations, target),
+  }
+}
+
+function buildUncertainty(
+  data: ResultsSectionDataReturn,
+  recommendations: Recommendation[],
+): AnalysisNewViewModel['uncertainty'] {
+  const conf = data.confidence
+  const findings: AnalysisNewFinding[] = []
+
+  // 1. Consequential uncertainties first — these carry a threshold or an
+  //    E-value, i.e. they are quantified, not merely noted.
+  for (const u of conf.uncertainties ?? []) {
+    const text = humanised(u)
+    if (!text) continue
+    findings.push({
+      id: `uncertainty:${u.code}`,
+      headline: u.threshold ? `${u.threshold.variable} could tip the result` : text.slice(0, 80),
+      implication: u.suggestion || text,
+      // Same union as the drivers' direction. `mixed`/`unknown` get the
+      // direction-free phrasing rather than a guessed one.
+      detail: u.threshold
+        ? `The ordering changes around ${u.threshold.value}${
+            u.threshold.direction === 'positive'
+              ? ' — above it, the ordering differs'
+              : u.threshold.direction === 'negative'
+                ? ' — below it, the ordering differs'
+                : ''
+          }.`
+        : undefined,
+      groundedIn: 'the sensitivity and critique analysis',
+      marker: u.factorConfidence == null ? undefined : undefined,
+      targetId: u.affectedNodes?.[0],
+      inspect: rows(
+        row('Severity', u.severity),
+        row('E-value', u.eValue != null ? String(u.eValue) : null),
+        row('Factor confidence', pctOrNull(u.factorConfidence)),
+      ),
+      intervention: interventionFor(recommendations, u.affectedNodes?.[0]),
+    })
+  }
+
+  // 2. Evidence gaps, in the producer's own emission order (PLoT already
+  //    selected and ordered these — no client-side re-rank).
+  for (const g of conf.evidenceGaps ?? []) findings.push(evidenceGapFinding(g, recommendations))
+
+  // 3. Producer-owned assumptions from the ledger.
+  for (const a of conf.assumptions ?? []) {
+    findings.push({
+      id: `assumption:${a.target ?? a.message.slice(0, 40)}`,
+      headline: a.target ? `Assumption about ${a.target}` : 'Assumption in the model',
+      implication: a.message,
+      groundedIn: 'the assumption ledger',
+      targetId: a.target,
+      inspect: rows(row('Severity', a.severity)),
+      intervention: interventionFor(recommendations, a.target),
+    })
+  }
+
+  // 4. Model-gap warnings the producer raised about its own inference.
+  for (const w of conf.inferenceWarnings ?? []) {
+    const message = (w as { message?: string; description?: string }).message
+      ?? (w as { description?: string }).description
+    if (!message) continue
+    findings.push({
+      id: `inference-warning:${(w as { code?: string }).code ?? message.slice(0, 32)}`,
+      headline: 'The model has a gap the analysis had to work around',
+      implication: message,
+      groundedIn: 'an inference warning from the engine',
+      inspect: [],
+    })
+  }
+
+  return {
+    findings,
+    // Rule 4 — the load-bearing distinction for this section's empty state.
+    evidenceAssessed: conf.evidenceGapsAssessed === true,
+    decisionVoi: data.decisionVoi,
+    totalCount: findings.length,
+  }
+}
+
+// ── DEEPER ANALYSIS (level 3) ───────────────────────────────────────────────
+
+function buildDeeper(inputs: AnalysisNewViewModelInputs): AnalysisNewViewModel['deeper'] {
+  const { data } = inputs
+  const conf = data.confidence
+  const groups: AnalysisNewViewModel['deeper']['groups'] = []
+
+  const run = rows(
+    row('Run identity', inputs.responseHash),
+    row('Simulations', inputs.nSamples != null ? String(inputs.nSamples) : null),
+    row('Seed', inputs.seedUsed != null ? String(inputs.seedUsed) : null),
+    row('Analysis status', data.recommendation.analysisStatus),
+    row('Drivers status', data.drivers.driversStatus),
+    row('Robustness status', conf.robustnessStatus),
+  )
+  if (run.length) groups.push({ title: 'This run', rows: run })
+
+  // ⚠ COVERAGE, NOT READINESS (rule 5). These rows say what the run did and did
+  // not cover. None of them is a statement about whether analysis may run.
+  const coverage = rows(
+    row('Result completeness', data.completeness.status),
+    row(
+      'Fields the producer did not supply',
+      data.completeness.missing.length ? data.completeness.missing.join(', ') : null,
+    ),
+    row(
+      'Evidence coverage',
+      conf.evidenceCoverage
+        ? `${conf.evidenceCoverage.backedByData} backed by data, ${conf.evidenceCoverage.needsValidation} need validation`
+        : null,
+    ),
+    row('Factors ranked for information value', data.voiRanking ? String(data.voiRanking.resolved.length) : null),
+    row(
+      'Some factors unassessed',
+      data.voiRanking?.someFactorsUnassessed ? 'yes' : null,
+    ),
+    row('Relationships hidden below the display threshold', conf.filteredFragileEdges ? String(conf.filteredFragileEdges.filteredCount) : null),
+    row('Zero-impact factors hidden', data.drivers.hiddenZeroImpactCount ? String(data.drivers.hiddenZeroImpactCount) : null),
+  )
+  if (coverage.length) groups.push({ title: 'What this run covered', rows: coverage })
+
+  const provenance = rows(
+    row(
+      'Sensitivities measured against',
+      data.sensitivityReference?.optionLabel ?? null,
+    ),
+    // Only disclosed when the producer says it was applied AND provisional —
+    // the same gate the existing surfaces use.
+    row(
+      'Automatic noise applied',
+      data.autoNoiseProvenance?.applied && data.autoNoiseProvenance?.isProvisional ? 'yes, provisional' : null,
+    ),
+    row('Per-factor attribution withheld', data.attributionSuppression === 'not_attested' ? null : String(data.attributionSuppression ?? '')),
+  )
+  if (provenance.length) groups.push({ title: 'Provenance', rows: provenance })
+
+  // Decision-quality prompts carry DSK grounding ONLY when the producer
+  // attested a claim id. Presence IS the attestation — never defaulted.
+  const dsk = (conf.m2DecisionQualityPrompts ?? [])
+    .filter((p) => p.dskClaimId)
+    .map((p) => ({ label: p.principle, value: `${p.question} (${p.dskClaimId})` }))
+  if (dsk.length) groups.push({ title: 'Grounded decision-quality prompts', rows: dsk })
+
+  return { groups }
+}
+
+// ── STATUS ──────────────────────────────────────────────────────────────────
+
+function buildStatus(inputs: AnalysisNewViewModelInputs): AnalysisNewStatus {
+  const { data } = inputs
+  const status = data.recommendation.analysisStatus
+  return {
+    isPreRun: inputs.isPreRun,
+    isRunning: inputs.isRunning,
+    isStale: inputs.isStale,
+    // 'partial' is the producer's own word for an incomplete result. The
+    // completeness verdict is the second, independent source.
+    isProvisional: status === 'partial' || data.completeness.status === 'partial',
+    // Producer-owned, verbatim. Never authored here.
+    statusNote: data.recommendation.statusReason ?? null,
+  }
+}
+
+// ── THE ADAPTER ─────────────────────────────────────────────────────────────
+
+export function buildAnalysisNewViewModel(
+  inputs: AnalysisNewViewModelInputs,
+): AnalysisNewViewModel {
+  const { data, recommendations, recommendationCandidateCount, isStale } = inputs
+
+  return {
+    status: buildStatus(inputs),
+    keyInsights: buildKeyInsights(data, recommendations, isStale),
+    strengthen: {
+      interventions: recommendations.slice(0, STRENGTHEN_CAP),
+      candidateCount: recommendationCandidateCount,
+      scienceGrounding: inputs.scienceGrounding ?? {},
+    },
+    drivers: buildDrivers(data, recommendations),
+    uncertainty: buildUncertainty(data, recommendations),
+    deeper: buildDeeper(inputs),
+  }
+}
+
+export const ANALYSIS_NEW_LIMITS = {
+  KEY_INSIGHT_CAP,
+  STRENGTHEN_CAP,
+  DRIVER_PREVIEW,
+  UNCERTAINTY_PREVIEW,
+} as const
+
+export { COPY as ANALYSIS_NEW_VIEW_COPY }

--- a/src/components/results/analysisNew/buildAnalysisNewViewModel.ts
+++ b/src/components/results/analysisNew/buildAnalysisNewViewModel.ts
@@ -27,6 +27,13 @@
  *  6. NO EVPI IN PERCENTAGE POINTS, EVER. `evpi_percentage_points` is refuted
  *     upstream (tests/contracts/no-evpi-display.contract.test.ts). Whole-
  *     decision VOI crosses this boundary as a VERDICT only, never a number.
+ *  7. NO WITHHELD-FIELD READS. `recommendation_stability` and
+ *     `ranking_stability` are never read here. PLoT withholds the first (ISL
+ *     derives it as the leader's win probability RELABELLED — "zero independent
+ *     information") and never emitted the second. Rendering either produces a
+ *     fabricated SECOND statistic beside the honest one.
+ *     `__tests__/withheldFieldReadBan.spec.ts` enforces this estate-wide and
+ *     caught exactly that here before it shipped.
  */
 
 import type { Recommendation } from '../strengthen/strengthenTypes'
@@ -188,10 +195,9 @@ function buildKeyInsights(
       implication: rec.robustnessVerdictReason ?? '',
       groundedIn: 'the robustness verdict from the simulation',
       marker: staleMarker,
-      inspect: rows(
-        row('Ranking stability', pctOrNull(conf.rankingStability)),
-        row('Structured level', rec.robustnessLevel),
-      ),
+      // ⛔ `ranking_stability` IS NOT RENDERED — see the withheld-field note on
+      // the comparative insight below. PLoT never emitted it at all.
+      inspect: rows(row('Structured level', rec.robustnessLevel)),
     })
   }
 
@@ -263,11 +269,23 @@ function buildKeyInsights(
       groundedIn: 'the option comparison',
       marker: staleMarker,
       targetId: leader.id,
-      inspect: rows(
-        row('Win probability', winPct),
-        row('Determined by', rec.determinedBy),
-        row('Recommendation stability', pctOrNull(rec.recommendationStability)),
-      ),
+      // ⛔⛔ NEITHER `recommendation_stability` NOR `ranking_stability` IS
+      // RENDERED ANYWHERE ON THIS SURFACE, AND THIS IS NOT AN OVERSIGHT.
+      //
+      // PLoT deliberately WITHHOLDS `robustness.recommendation_stability`: ISL
+      // derives it as `option_wins[winner] / n_samples` — the leader's win
+      // probability RELABELLED, carrying (the producer's words) "zero
+      // independent information". `ranking_stability` was never emitted at all.
+      //
+      // An earlier draft of this list printed BOTH `Win probability` and
+      // `Recommendation stability` — the SAME quantity twice, once honestly and
+      // once under a name implying an independent robustness measurement. That
+      // is a fabricated second statistic, and it is exactly what
+      // `withheldFieldReadBan.spec.ts` exists to stop; it caught this before
+      // the surface shipped. A hydrated pre-withdrawal payload can still carry
+      // a legacy value, so reading the field at all is the hazard, not just
+      // rendering a fresh one.
+      inspect: rows(row('Win probability', winPct), row('Determined by', rec.determinedBy)),
       intervention: interventionFor(recommendations, leader.id),
     })
   }

--- a/src/components/results/analysisNew/buildStrengthenInputsForAnalysisNew.ts
+++ b/src/components/results/analysisNew/buildStrengthenInputsForAnalysisNew.ts
@@ -1,0 +1,98 @@
+/**
+ * Analysis (New) — engine inputs for the "Strengthen the reasoning" section.
+ *
+ * ⭐⭐ READ THIS BEFORE CHANGING ANYTHING HERE.
+ *
+ * This function is a DELIBERATE MIRROR of the `inputs` useMemo inside
+ * `StrengthenContainer` (`../strengthen/StrengthenContainer.tsx`). It exists so
+ * the experimental tab can run the SAME grounded engine (`buildRecommendations`)
+ * WITHOUT mounting `StrengthenContainer`, because that container is also a
+ * WRITER: it calls `useStrengthenStore().reconcile(...)` on every completed
+ * analysis. Mounting a second writer for a presentation experiment would give
+ * the lifecycle store two owners — and "never let two lanes independently solve
+ * the same shared-state problem" is a standing rule here, not a preference.
+ *
+ * So this surface is READ-ONLY: it runs the engine to get today's grounded
+ * recommendation set, and reads the store only to honour what the user already
+ * dismissed or addressed. It never writes.
+ *
+ * ⚠ A HAND-MAINTAINED MIRROR IS THIS ESTATE'S DOMINANT DEFECT (CLAUDE.md trap
+ * 12), AND THIS FILE IS ONE. It is permitted only because it FAILS LOUD:
+ * `__tests__/strengthenInputsMirror.drift.spec.tsx` renders the real
+ * `StrengthenContainer` against a fixture, captures the object it actually
+ * hands `buildRecommendations`, and asserts deep equality with this function's
+ * output. If the container's mapping changes and this one does not, that spec
+ * goes RED and names the diverging key. Do not delete that spec, and do not
+ * "fix" a failure by loosening it — re-mirror the change here.
+ *
+ * The alternative — extracting the container's useMemo into a shared helper —
+ * was rejected for THIS experiment only: the brief's hard constraint is that no
+ * edit may alter the existing Analysis tab, and a behaviour-preserving
+ * extraction is still an edit to a file that tab renders. When the experiment
+ * concludes, extract and delete this file.
+ */
+
+import { resolveFactorConfidenceDisplay } from '../driverConfidenceDisplayPolicy'
+import { adaptivePriorityFromStage } from '../strengthen/StrengthenContainer'
+import { toStrengthenPhase3Item } from '../strengthen/buildRecommendations'
+import type { StrengthenInputs } from '../strengthen/strengthenTypes'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import type { GuidanceItem } from '../../../canvas/stores/guidanceStore'
+import type { ScenarioStage } from '../../../types/scenario'
+
+export interface StrengthenInputSources {
+  data: ResultsSectionDataReturn
+  guidanceItems: GuidanceItem[]
+  /** CEE draft-coaching bias signals. Producer-owned; never locally derived. */
+  biasSignals: Array<{ type: string }> | null
+  currentStage: ScenarioStage | null
+}
+
+export function buildStrengthenInputsForAnalysisNew({
+  data,
+  guidanceItems,
+  biasSignals,
+  currentStage,
+}: StrengthenInputSources): StrengthenInputs {
+  const fragile = (data.confidence.challengeFragileEdges ?? []) as Array<Record<string, unknown>>
+  return {
+    goalThreshold: data.recommendation.goalThreshold ?? null,
+    analysisComplete: data.recommendation.analysisStatus === 'computed',
+    // The OWNED leader entitlement, quoted from the single verdict and never
+    // re-derived. A completed analysis is not an entitlement to name a leader.
+    hasLeadingOption: data.recommendation.verdict?.hasLeadingOption,
+    flipThresholds: data.recommendation.flipThresholds ?? null,
+    fragileEdges: fragile
+      .filter((fe) => typeof fe.switch_probability === 'number')
+      .map((fe) => ({
+        edgeId: String(fe.edge_id ?? `${fe.from_id ?? fe.from_label}->${fe.to_label}`),
+        factorLabel: String(fe.from_label ?? 'this factor'),
+        switchProbability: Number(fe.switch_probability),
+        alternativeWinnerLabel:
+          typeof fe.alternative_winner_label === 'string' ? fe.alternative_winner_label : undefined,
+      })),
+    factors: data.drivers.drivers.map((d) => ({
+      factorId: d.matchedNodeId ?? d.factorKey,
+      label: d.factorLabel,
+      // The engine ranks on the SAME display value the bars show.
+      influence: d.displayInfluence ?? d.influenceScore,
+      // Resolved through THE policy module — the engine never sees the raw
+      // producer number.
+      confidenceDisplay: resolveFactorConfidenceDisplay({
+        confidence: d.confidence,
+        isDefaulted: d.isDefaultedConfidence,
+        confidenceProvenance: d.confidenceProvenance,
+      }),
+      worthInvestigating: d.worthInvestigating === true,
+      canFocus: d.canFocus,
+    })),
+    robustness: {
+      status: data.confidence.robustnessStatus ?? null,
+      level: data.confidence.robustnessLevel ?? null,
+    },
+    // Producer-owned bias findings only — never local option counting.
+    biasFindingTypes: (biasSignals ?? []).map((b) => b.type),
+    adaptivePriority: adaptivePriorityFromStage(currentStage),
+    phase3Items: guidanceItems.map(toStrengthenPhase3Item),
+  }
+}

--- a/src/components/results/analysisNew/sections/AnalysisNewSection.tsx
+++ b/src/components/results/analysisNew/sections/AnalysisNewSection.tsx
@@ -1,0 +1,104 @@
+/**
+ * Analysis (New) — the generic section shell used by Key insights, Drivers and
+ * dynamics, and Uncertainty and gaps.
+ *
+ * Deliberately RESTRAINED (§10): a heading, an optional caveat line, hairline-
+ * separated rows, and a "Show more" when the list is longer than its preview.
+ * No card, no border, no nested container. The only section with a stronger
+ * visual treatment is Strengthen the reasoning, and it earns it by being the
+ * thing the experiment is testing.
+ *
+ * ⚠ THE "SHOW MORE" COUNT IS DERIVED FROM THE ACTUAL LIST, NOT PASSED IN. A
+ * hand-passed count is a mirror, and a truncation that misreports how much it
+ * hid reads as "you have seen everything" when you have not.
+ */
+
+import { useState } from 'react'
+import { typography } from '../../../../styles/typography'
+import { ANALYSIS_NEW_COPY as COPY } from '../analysisNewCopy'
+import { DisclosureRow } from '../DisclosureRow'
+import type { AnalysisNewFinding } from '../analysisNewTypes'
+
+export interface AnalysisNewSectionProps {
+  title: string
+  findings: AnalysisNewFinding[]
+  /** How many rows before "Show more". Absent = show all. */
+  preview?: number
+  /**
+   * Rendered under the heading when the section's data carries a caveat the
+   * user must read to interpret it correctly (e.g. set-relative influence).
+   */
+  caveat?: string | null
+  /**
+   * What to say when there is nothing. Absent = render the heading and nothing
+   * else, which is the right answer when an empty message would add no
+   * comprehension (§19).
+   */
+  emptyMessage?: string | null
+  onFocusTarget?: (targetId: string) => void
+  onRunIntervention?: (recommendationId: string) => void
+  testId: string
+}
+
+export function AnalysisNewSection({
+  title,
+  findings,
+  preview,
+  caveat,
+  emptyMessage,
+  onFocusTarget,
+  onRunIntervention,
+  testId,
+}: AnalysisNewSectionProps) {
+  const [expanded, setExpanded] = useState(false)
+  const limit = preview ?? findings.length
+  const visible = expanded ? findings : findings.slice(0, limit)
+  const hidden = findings.length - visible.length
+
+  return (
+    <section className="space-y-1" data-testid={testId} aria-labelledby={`${testId}-heading`}>
+      <h3 id={`${testId}-heading`} className={`${typography.panelHeader} text-text-header`}>
+        {title}
+      </h3>
+
+      {caveat ? (
+        <p className={`${typography.panelMeta} text-text-light`} data-testid={`${testId}-caveat`}>
+          {caveat}
+        </p>
+      ) : null}
+
+      {findings.length === 0 ? (
+        emptyMessage ? (
+          <p className={`${typography.panelBody} text-text-light`} data-testid={`${testId}-empty`}>
+            {emptyMessage}
+          </p>
+        ) : null
+      ) : (
+        <>
+          <div className="mt-1">
+            {visible.map((f) => (
+              <DisclosureRow
+                key={f.id}
+                finding={f}
+                onFocusTarget={onFocusTarget}
+                onRunIntervention={onRunIntervention}
+                testIdPrefix={testId}
+              />
+            ))}
+          </div>
+          {hidden > 0 || expanded ? (
+            <button
+              type="button"
+              onClick={() => setExpanded((v) => !v)}
+              aria-expanded={expanded}
+              className={`${typography.panelMeta} text-info underline rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+              data-testid={`${testId}-show-more`}
+            >
+              {expanded ? COPY.disclosure.collapse : COPY.disclosure.moreDrivers(hidden)}
+            </button>
+          ) : null}
+        </>
+      )}
+    </section>
+  )
+}

--- a/src/components/results/analysisNew/sections/DeeperAnalysis.tsx
+++ b/src/components/results/analysisNew/sections/DeeperAnalysis.tsx
@@ -1,0 +1,71 @@
+/**
+ * Analysis (New) — "Deeper analysis and evidence" (level 3).
+ *
+ * ONE collapsed region, never a fifth top-level IA section (§18). Everything
+ * technical lands here: run identity, what the run covered, provenance, and the
+ * grounded decision-quality prompts.
+ *
+ * ⚠ THE COVERAGE GROUP IS THE ONE MOST LIKELY TO BE MISREAD, AND THE ADAPTER
+ * ALREADY GUARDS IT: those rows describe what this run did and did not cover.
+ * They are NOT a readiness verdict. `RunAdmission` remains the sole authority
+ * on whether analysis may run, and nothing on this surface reads it or speaks
+ * for it. Uneven coverage is provenance; it does not make a result invalid, and
+ * it is never offered as the cause of an ordering.
+ */
+
+import { useState } from 'react'
+import { ChevronDown, ChevronRight } from 'lucide-react'
+import { typography } from '../../../../styles/typography'
+import { ANALYSIS_NEW_COPY as COPY } from '../analysisNewCopy'
+import type { DeeperAnalysisSection } from '../analysisNewTypes'
+
+export interface DeeperAnalysisProps {
+  deeper: DeeperAnalysisSection
+  testId?: string
+}
+
+export function DeeperAnalysis({ deeper, testId = 'analysis-new-deeper' }: DeeperAnalysisProps) {
+  const [open, setOpen] = useState(false)
+
+  // Nothing to inspect renders nothing at all — an empty expander is an
+  // affordance that lies about having content behind it.
+  if (deeper.groups.length === 0) return null
+
+  return (
+    <section data-testid={testId}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={open ? `${testId}-region` : undefined}
+        className={`${typography.panelBody} text-text-light flex items-center gap-1.5 rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+        data-testid={`${testId}-toggle`}
+      >
+        {open ? (
+          <ChevronDown className="w-3.5 h-3.5" aria-hidden="true" />
+        ) : (
+          <ChevronRight className="w-3.5 h-3.5" aria-hidden="true" />
+        )}
+        {COPY.sections.deeper}
+      </button>
+
+      {open ? (
+        <div id={`${testId}-region`} className="mt-2 space-y-3 pl-5">
+          {deeper.groups.map((group) => (
+            <div key={group.title} data-testid={`${testId}-group`}>
+              <h4 className={`${typography.panelMeta} text-text-header`}>{group.title}</h4>
+              <dl className="mt-1 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
+                {group.rows.map((r) => (
+                  <div key={r.label} className="contents">
+                    <dt className={`${typography.panelMeta} text-text-light`}>{r.label}</dt>
+                    <dd className={`${typography.panelMeta} text-text-body break-words`}>{r.value}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/src/components/results/analysisNew/sections/StrengthenTheReasoning.tsx
+++ b/src/components/results/analysisNew/sections/StrengthenTheReasoning.tsx
@@ -1,0 +1,187 @@
+/**
+ * Analysis (New) — "Strengthen the reasoning".
+ *
+ * ⭐ THIS IS THE SECTION THE EXPERIMENT EXISTS TO TEST. It is second from the
+ * top and it is the only section given a stronger visual treatment, because the
+ * claim under test is that Olumi does not merely analyse a situation — it tells
+ * a team how to improve the reasoning itself. In the existing Analysis tab the
+ * same material sits roughly eleventh, below the option comparison.
+ *
+ * ⚠⚠ NOTHING HERE IS AUTHORED. Every row is a `Recommendation` emitted by
+ * `buildRecommendations` — the existing, producer-grounded engine — and every
+ * field rendered below is the engine's own: `title` (what), `signal` + `whyNow`
+ * (why it fired), `tryThis` (the one practical instruction), `sourceLine` (the
+ * named grounding, honest about producer-vs-UI basis). If this component ever
+ * starts composing a sentence about the user's reasoning, the experiment has
+ * become the fabrication it was built to avoid.
+ *
+ * ── ON THE ACTION ROUTE, STATED PLAINLY ─────────────────────────────────────
+ * The engine's `RecAction.kind` spans five routes ('inline-edit', 'ai-dialogue',
+ * 'canvas-focus', 'rerun', 'open-modal'), and `StrengthenContainer` owns the
+ * dispatch machinery for all of them — including store writes and a degrade
+ * path. This experimental surface deliberately offers only the two routes that
+ * MUTATE NOTHING:
+ *
+ *   · "Show on canvas"  → `focusModelTarget` (existing, fail-closed helper)
+ *   · the primary CTA   → `openAskOlumi` PREFILLED (existing drawer; the user
+ *                          reads and sends, this surface never auto-sends)
+ *
+ * Everything else is presented as guidance, which the brief explicitly permits
+ * ("it may be presented as guidance rather than inventing a new backend
+ * behaviour"). The reason is not caution for its own sake: a presentation
+ * experiment that also becomes a second dispatch authority would let the two
+ * tabs diverge in what they DID as well as what they showed, and the comparison
+ * would no longer be about information architecture.
+ */
+
+import { typography } from '../../../../styles/typography'
+import { openAskOlumi } from '../../coaching/askOlumiStore'
+import { focusModelTarget } from '../../../../canvas/utils/focusHelpers'
+import { ANALYSIS_NEW_COPY as COPY } from '../analysisNewCopy'
+import type { Recommendation } from '../../strengthen/strengthenTypes'
+import type { ScienceGrounding } from '../analysisNewTypes'
+
+export interface StrengthenTheReasoningProps {
+  interventions: Recommendation[]
+  /**
+   * Producer DSK attestation keyed by recommendation id. SPARSE BY DESIGN —
+   * an absent key means the producer attested nothing for that intervention,
+   * and the row then carries no grounding badge at all.
+   */
+  scienceGrounding?: Record<string, ScienceGrounding>
+  testId?: string
+}
+
+/**
+ * Human-readable strength, from the producer's CLOSED vocabulary.
+ *
+ * ⚠ ANYTHING OUTSIDE THE VOCABULARY RENDERS NOTHING. A pass-through would let
+ * an unrecognised producer token become user-facing copy, which is precisely
+ * how a fabricated-sounding scientific label gets on screen (§15).
+ */
+const STRENGTH_LABEL: Record<string, string> = {
+  strong: 'Strong evidence',
+  moderate: 'Moderate evidence',
+  limited: 'Limited evidence',
+  emerging: 'Emerging evidence',
+}
+
+export function StrengthenTheReasoning({
+  interventions,
+  scienceGrounding = {},
+  testId = 'analysis-new-strengthen',
+}: StrengthenTheReasoningProps) {
+  return (
+    <section className="space-y-2" data-testid={testId} aria-labelledby={`${testId}-heading`}>
+      <h3 id={`${testId}-heading`} className={`${typography.panelHeader} text-text-header`}>
+        {COPY.sections.strengthen}
+      </h3>
+
+      {interventions.length === 0 ? (
+        // ⚠ STATES WHAT WAS NOT FOUND, NOT THAT NOTHING IS WRONG. "Your
+        // reasoning looks solid" would be a claim nobody measured.
+        <p className={`${typography.panelBody} text-text-light`} data-testid={`${testId}-empty`}>
+          {COPY.empty.strengthen}
+        </p>
+      ) : (
+        <ul className="space-y-2 list-none p-0 m-0">
+          {interventions.map((rec) => (
+            <li
+              key={rec.id}
+              // The one stronger container on the surface. A single hairline
+              // border and a tinted panel — still not a card inside a card.
+              className="rounded-lg border border-info/30 bg-panel px-3 py-2.5 space-y-1.5"
+              data-testid={`${testId}-item`}
+              data-recommendation-id={rec.id}
+            >
+              {/* WHAT — the engine's own title. */}
+              <p className={`${typography.panelHeader} text-text-header`}>{rec.title}</p>
+
+              {/* WHY — the signal that fired, then why it matters now. */}
+              <p className={`${typography.panelBody} text-text-body`} data-testid={`${testId}-why`}>
+                {rec.signal}
+                {rec.whyNow ? ` ${rec.whyNow}` : ''}
+              </p>
+
+              {/* DO IT — the one practical instruction. */}
+              {rec.tryThis ? (
+                <p className={`${typography.panelBody} text-text-body`} data-testid={`${testId}-try`}>
+                  {rec.tryThis}
+                </p>
+              ) : null}
+
+              <div className="flex flex-wrap items-center gap-3 pt-0.5">
+                <button
+                  type="button"
+                  onClick={() =>
+                    openAskOlumi({
+                      // The drawer's context line and prefilled draft are the
+                      // ENGINE's strings, so what the user sends is what the
+                      // engine recommended — not a paraphrase of it.
+                      context: rec.whyNow || rec.signal,
+                      draft: rec.action.prompt ?? rec.tryThis,
+                      label: rec.action.label,
+                      ...(rec.targetId ? { targetId: rec.targetId } : {}),
+                      ...(rec.action.parameters ? { parameters: rec.action.parameters } : {}),
+                    })
+                  }
+                  className={`${typography.panelBody} text-info underline rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+                  data-testid={`${testId}-action`}
+                >
+                  {rec.action.label} →
+                </button>
+
+                {rec.targetId ? (
+                  <button
+                    type="button"
+                    onClick={() => focusModelTarget(rec.targetId!)}
+                    className={`${typography.panelMeta} text-text-light underline rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+                    data-testid={`${testId}-focus`}
+                  >
+                    Show on canvas
+                  </button>
+                ) : null}
+              </div>
+
+              {/* The named grounding source, verbatim from the engine. This is
+                  what makes the row auditable rather than merely plausible. */}
+              {rec.sourceLine ? (
+                <p
+                  className={`${typography.panelMeta} text-text-light`}
+                  data-testid={`${testId}-source`}
+                >
+                  {rec.sourceLine}
+                </p>
+              ) : null}
+
+              {/* ⭐ SCIENCE GROUNDING (§15) — rendered ONLY when the producer
+                  attested a DSK claim for THIS recommendation. Presence is the
+                  attestation; there is no default and no inferred strength.
+                  The claim/protocol IDS ride as `data-*` attributes and are
+                  never user-facing copy — an id is provenance for an auditor,
+                  not a sentence for a reader. An unrecognised strength token
+                  renders nothing rather than being passed through. */}
+              {scienceGrounding[rec.id] ? (
+                <p
+                  className={`${typography.panelMeta} text-text-light`}
+                  data-testid={`${testId}-science-grounding`}
+                  data-dsk-claim-id={scienceGrounding[rec.id].claimId}
+                  {...(scienceGrounding[rec.id].protocolId
+                    ? { 'data-dsk-protocol-id': scienceGrounding[rec.id].protocolId }
+                    : {})}
+                >
+                  Grounded in the decision-science knowledge base
+                  {scienceGrounding[rec.id].strength &&
+                  STRENGTH_LABEL[scienceGrounding[rec.id].strength!]
+                    ? ` · ${STRENGTH_LABEL[scienceGrounding[rec.id].strength!]}`
+                    : ''}
+                  .
+                </p>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  )
+}

--- a/src/components/results/analysisNew/sections/StrengthenTheReasoning.tsx
+++ b/src/components/results/analysisNew/sections/StrengthenTheReasoning.tsx
@@ -4,8 +4,17 @@
  * ⭐ THIS IS THE SECTION THE EXPERIMENT EXISTS TO TEST. It is second from the
  * top and it is the only section given a stronger visual treatment, because the
  * claim under test is that Olumi does not merely analyse a situation — it tells
- * a team how to improve the reasoning itself. In the existing Analysis tab the
- * same material sits roughly eleventh, below the option comparison.
+ * a team how to improve the reasoning itself.
+ *
+ * ⚠ THE COMPARISON, STATED PRECISELY RATHER THAN RHETORICALLY. Derived from
+ * `ResultsBody.tsx` at this tip, the existing Analysis tab's named sections run:
+ * Decision brief · Analysis (hero) · Key question · What I was given ·
+ * **Strengthen your model** · Options comparison · Drivers · Tornado · Your next
+ * steps · Advanced · Adjustments. So the same material is FIFTH of eleven — and
+ * it also sits below the warning strips and status furniture the dock renders
+ * above `ResultsBody`. Here it is SECOND. That placement delta is the
+ * experiment; an earlier draft of this comment said "roughly eleventh", which
+ * was a guess dressed as a measurement.
  *
  * ⚠⚠ NOTHING HERE IS AUTHORED. Every row is a `Recommendation` emitted by
  * `buildRecommendations` — the existing, producer-grounded engine — and every

--- a/src/components/results/analysisNew/useAnalysisNewViewModel.ts
+++ b/src/components/results/analysisNew/useAnalysisNewViewModel.ts
@@ -1,0 +1,127 @@
+/**
+ * Analysis (New) — the store-aware hook that assembles the view model.
+ *
+ * ⭐⭐ THIS HOOK IS READ-ONLY, AND THAT IS THE LOAD-BEARING PROPERTY OF THE
+ * WHOLE EXPERIMENT. It performs NO writes: no store mutation, no fetch, no
+ * dispatch, no reconcile. Switching to the Analysis (New) tab must not re-run
+ * analysis, create a second result, change canonical state, change readiness or
+ * change staleness — otherwise the two tabs are not a presentation comparison,
+ * they are an A/B test on different data, and Paul's comparison is void.
+ *
+ * ⚠ IT DOES NOT CALL `useResultsSectionData()` EITHER. The analysis data
+ * arrives as a PROP, so the new tab renders the SAME instance `OutputsDock`
+ * already hands `ResultsBody` — one data authority for both surfaces, exactly
+ * as the 'Alt view' comparison tab did (PR #673). Calling the hook again here
+ * would be a second derivation of the same thing and would silently reopen the
+ * "are they even looking at the same run?" question this experiment exists to
+ * close.
+ */
+
+import { useMemo } from 'react'
+import { useCanvasStore } from '../../../canvas/store'
+import { deriveGuidanceDskProvenance, useGuidanceStore } from '../../../canvas/stores/guidanceStore'
+import { useStrengthenStore } from '../../../canvas/stores/strengthenStore'
+import { buildRecommendations } from '../strengthen/buildRecommendations'
+import type { Recommendation } from '../strengthen/strengthenTypes'
+import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import { buildStrengthenInputsForAnalysisNew } from './buildStrengthenInputsForAnalysisNew'
+import { buildAnalysisNewViewModel } from './buildAnalysisNewViewModel'
+import type { AnalysisNewViewModel } from './analysisNewTypes'
+
+/**
+ * Lifecycle statuses that REMOVE a recommendation from the live list.
+ *
+ * Read-only reuse of the shared strengthen store: if the user dismissed or
+ * completed something on the existing Analysis tab, it must not reappear here.
+ * The two surfaces disagreeing about what is still outstanding would be a worse
+ * defect than the new tab showing nothing.
+ */
+const RETIRED_STATUSES = new Set(['dismissed', 'addressed'])
+
+export interface UseAnalysisNewViewModelArgs {
+  /** THE SAME instance OutputsDock hands ResultsBody. Never re-derived. */
+  data: ResultsSectionDataReturn
+  isPreRun: boolean
+  isRunning: boolean
+  isStale: boolean
+  nSamples?: number
+  seedUsed?: number | string
+  responseHash?: string
+}
+
+export function useAnalysisNewViewModel(args: UseAnalysisNewViewModelArgs): AnalysisNewViewModel {
+  const { data, isPreRun, isRunning, isStale, nSamples, seedUsed, responseHash } = args
+
+  // ── reads only ────────────────────────────────────────────────────────────
+  const currentStage = useCanvasStore((s) => s.currentStage)
+  const biasSignals = useCanvasStore((s) => s.draftCoaching?.biasSignals ?? null)
+  const guidanceItems = useGuidanceStore((s) => s.guidanceItems)
+  const strengthenRecords = useStrengthenStore((s) => s.records)
+
+  const recommendations: Recommendation[] = useMemo(() => {
+    const inputs = buildStrengthenInputsForAnalysisNew({
+      data,
+      guidanceItems,
+      biasSignals,
+      currentStage,
+    })
+    // The engine is the authority on what a grounded intervention is. This
+    // surface runs it and renders it; it never adds one of its own, and it
+    // never relaxes one of the engine's gates.
+    return buildRecommendations(inputs).filter((rec) => {
+      const record = strengthenRecords[rec.id]
+      return !record || !RETIRED_STATUSES.has(record.status)
+    })
+  }, [data, guidanceItems, biasSignals, currentStage, strengthenRecords])
+
+  /**
+   * Re-join the producer's DSK attestation onto the engine's phase-3
+   * recommendations.
+   *
+   * ⚠ THE JOIN KEY IS DERIVED FROM THE ENGINE'S OWN ID SHAPE, not guessed:
+   * `buildRecommendations` mints producer-guidance rows as
+   * `strengthen:phase3:${item.item_id}`. Nothing else in this file may invent a
+   * key, and a recommendation the engine minted from its OWN deterministic
+   * triggers has no guidance item behind it and therefore gets no grounding —
+   * which is correct, not a gap to paper over.
+   *
+   * ⚠ ID-GATED AS A UNIT. `deriveGuidanceDskProvenance` returns undefined
+   * unless the producer sent a non-empty `dsk_claim_id`; absence means "not
+   * grounded", never a default. This hook adds no key in that case.
+   */
+  const scienceGrounding = useMemo(() => {
+    const out: Record<string, { claimId: string; protocolId?: string; strength?: string }> = {}
+    for (const item of guidanceItems) {
+      const provenance = deriveGuidanceDskProvenance(item)
+      if (provenance) out[`strengthen:phase3:${item.item_id}`] = provenance
+    }
+    return out
+  }, [guidanceItems])
+
+  return useMemo(
+    () =>
+      buildAnalysisNewViewModel({
+        data,
+        recommendations,
+        recommendationCandidateCount: recommendations.length,
+        isPreRun,
+        isRunning,
+        isStale,
+        nSamples,
+        seedUsed,
+        responseHash,
+        scienceGrounding,
+      }),
+    [
+      data,
+      recommendations,
+      isPreRun,
+      isRunning,
+      isStale,
+      nSamples,
+      seedUsed,
+      responseHash,
+      scienceGrounding,
+    ],
+  )
+}

--- a/src/stores/uiStore.ts
+++ b/src/stores/uiStore.ts
@@ -17,7 +17,17 @@ import { create } from 'zustand'
  * `'altview'` (the TEMPORARY V7 comparison tab) was RETIRED with the
  * V7-vs-Current adjudication and is deliberately not a member.
  */
-export type OutputTab = 'results' | 'compare' | 'diagnostics' | 'journey' | 'olumi'
+/**
+ * The dock tab ids.
+ *
+ * `'analysisNew'` is the TEMPORARY Analysis (New) comparison surface (Paul,
+ * 27 Aug 2026): a second, separate Analysis tab rendering the SAME analysis run
+ * through a reasoning-led information architecture, so the two can be compared
+ * directly on one scenario. `'results'` (Analysis) is unchanged and remains the
+ * default. Retires when the comparison is decided — see
+ * `components/results/analysisNew/AnalysisNewTabBody.tsx`.
+ */
+export type OutputTab = 'results' | 'analysisNew' | 'compare' | 'diagnostics' | 'journey' | 'olumi'
 
 /**
  * Right-panel modes. Only one right-side panel can be open at a time.

--- a/tests/ci-guards/shell-conformance.spec.ts
+++ b/tests/ci-guards/shell-conformance.spec.ts
@@ -767,6 +767,34 @@ describe('the shell contract itself holds together', () => {
     }
   })
 
+  it('every PRESENTED surface has a body render arm in the shell host', () => {
+    // ⭐ THE MISSING HALF OF THE FOOTER GUARD ABOVE, AND THE MORE IMPORTANT ONE.
+    // A surface can be declared `presentedAsTab: true`, type-check cleanly, get
+    // its tab painted in the strip — and render an EMPTY BODY, because nothing
+    // ties the declaration to a `effectiveActiveTab === '<id>'` arm in the host.
+    // That is the Journey defect exactly: a tab that opens onto nothing, the
+    // product advertising an action that terminates in nothing. It was
+    // unguarded until 27 Aug 2026, when adding a fourth presented surface made
+    // the omission cheap to close.
+    //
+    // Deliberately a SOURCE-TEXT scan of the host, not a render: this asserts
+    // the ARM EXISTS for every presented id, which no mounted test can do
+    // without driving every surface.
+    const dock = readFileSync(path.join(REPO, SHELL_HOST), 'utf8')
+    const presented = presentedSurfaces().map(s => s.id)
+    // Positive control: the scan must be able to SEE an arm it is looking for,
+    // or every assertion below passes on a file it failed to read (trap 13).
+    expect(dock.length, 'the shell host read as empty').toBeGreaterThan(1000)
+    expect(presented.length).toBeGreaterThan(1)
+    for (const id of presented) {
+      expect(
+        dock,
+        `surface '${id}' is presented as a tab but the shell host has no ` +
+          `\`effectiveActiveTab === '${id}'\` body arm — it would open onto nothing`,
+      ).toContain(`effectiveActiveTab === '${id}'`)
+    }
+  })
+
   it('the shell renders the footer bar OUTSIDE the flag-gated stack', () => {
     // Hosting it inside the aiPanelV2 block would make the Model tab's only
     // re-run control vanish on rollback — a worse defect than the one fixed.


### PR DESCRIPTION
**An experiment for you to look at, not a change to Analysis.** A second, separate
`Analysis (New)` tab sits beside the existing `Analysis` tab and renders **the same
analysis run** through a reasoning-led information architecture. The existing tab is
untouched. Merging is your call — this is built to be compared, not to replace anything.

---

## How to compare

Switch between the two tabs on one scenario after a run. Same data, same run, two layouts.

⚠ **Compare it on `staging`, not on a deploy preview.** `VITE_FEATURE_STRENGTHEN_PANEL`
lives in `[context.staging.environment]` (`netlify.toml:90`) and has no default in
`flags.ts`, so on any non-staging build the **old** tab loses its "Strengthen your model"
section while the new tab keeps its equivalent. That would make the new IA look like it
*added* reasoning enhancement when both tabs have it on staging. It is a flag-posture
artefact, not an IA difference. (`aiPanelV2` is unaffected — it has `defaultValue: true`.)

---

## CURRENT ANALYSIS — what it prioritises

Named sections in `ResultsBody.tsx`, in render order:

> Decision brief · Analysis (hero) · Key question · What I was given ·
> **Strengthen your model** · Options comparison · Drivers · Tornado ·
> Your next steps · Advanced · Adjustments

…plus warning strips, validation, degraded-state banners and the decision-overview card
that the dock renders above `ResultsBody`.

It leads with **the decision and the hero result**. Reasoning enhancement is fifth of
eleven, below the brief, the hero, the key question and "What I was given". Structure is
broadly **decision-centric**: options comparison is a first-class block, drivers and
tornado are behind accordions.

## ANALYSIS (NEW) — what it prioritises

> Key insights · **Strengthen the reasoning** · Drivers and dynamics · Uncertainty and gaps
> · *(Deeper analysis and evidence — collapsed)*

It leads with **what to notice** and then **how to improve the reasoning** — second, not
fifth. It is deliberately **not** decision-centric: the key-insight ladder is robustness →
strategic tension ("the answer turns on X") → concentration risk → the hinge relationship
→ *and only then* the comparative one, which appears **only** when
`verdict.hasLeadingOption === true`. An open strategic challenge with no decision still
produces insights rather than an empty section.

Three levels: scan → understand (rationale, grounding, the row's own intervention) →
inspect (provenance, numbers, method). Nothing technical on the first screen.

---

## SAME UNDERLYING DATA? — **Yes**, and here is the evidence

- The new body receives the **same `resultsSectionData` instance** `OutputsDock` hands
  `ResultsBody`, plus the same sample/seed/hash reads, the same focus handler and the same
  freshness derivation — one expression list, not a re-derivation
  (`OutputsDock.tsx`, `analysisNew` branch).
- It calls **no analysis hook**, issues **no request**, and **writes to no store**.
- Pinned by test: across a round trip `Analysis → Analysis (New) → Analysis`, **zero**
  fetches, and `results` / `nodes` / `edges` / `analysisStateV1` are **referentially
  identical** (deep equality would have waved a re-derivation through).
- Staleness and the Rerun control are the **shell's**, via `footerBar: 'reanalyse'` — the
  same `handleRunAnalysis` the Model tab uses. No second run authority, no second
  staleness owner.
- "Strengthen the reasoning" runs the **existing `buildRecommendations` engine** and is
  read-only: `StrengthenContainer` remains the sole writer of the strengthen lifecycle
  store, and the new tab honours what you already dismissed or addressed, so the two tabs
  cannot disagree about what is outstanding.

**Existing tab unchanged**, proved discriminatingly rather than by "the new tab exists":
its rendered testid sequence *and* its text come back byte-identical after a full round
trip through the new tab, behind a positive control that fails if the captured tree is
trivial.

---

## KNOWN DATA GAPS — only the ones that stop the new IA saying something important

| Desired element | Required data | Current gap | Owner |
|---|---|---|---|
| A **method label** on an intervention ("this is a premortem") | `GuidanceItem.signal_code` | Wire-carried, but dropped at `toStrengthenPhase3Item` (9 fields mapped, not this one). That mapper is on the **old tab's** path, so this experiment may not edit it. | UI |
| **Science provenance** on interventions | `dsk_claim_id` / `dsk_protocol_id` / `evidence_strength` | Same boundary — **closed here**, re-joined in this adapter by the engine's own id shape. Presence is the attestation; ids ride as `data-*`, never as copy. | *(done)* |
| **Cross-run contradictions** ("this run disagrees with the last") | `AnalysisStateV1.contradictions` | Wire exists; **zero product readers**. Not surfaced here — and `[]` would not mean "consistent". | UI |
| **Evidence freshness** ("last evidenced 90 days ago") | `ReportV1.evidence_freshness` | Parsed and stored, no renderer found. *Plausible, not confirmed* — no full manifest run. | UI |
| **Causal validation** (confounders, adjustment sets) | `PLoTEnrichment.causal_validation` | Typed, gated ON, no Analysis renderer found. The one field that could carry genuine causal semantics — deliberately left alone rather than half-rendered. | UI |
| **Authorship** ("who asserted this") | `authored_by` | Collab-only; **nothing on the analysis-output path**. | CEE + schemas |
| A **direct model-edit** from this tab | an enabled `CANONICAL_EDIT_AUTHORITY` | 17 of 21 authorities are `'disabled'`. No edit route built — actions are non-mutating only. | CEE |

**Panel width (§11), as a limitation rather than a fix.** The dock's 416px outer width is
fixed by the workspace shell and asserted at every viewport by the visual harness. Varying
it per surface would change the *existing* tab's container, so it is not done. The
narrower, calmer treatment is scoped to this tab's **inner content measure**.

---

## Three defects the gates caught in my own work, now fixed

- ⭐ **I was reading two fields PLoT withholds.** `withheldFieldReadBan.spec.ts` caught
  `recommendation_stability` and `ranking_stability` in the new adapter. PLoT withholds the
  first — ISL derives it as the leader's win probability **relabelled**, carrying (the
  producer's words) *"zero independent information"* — and never emitted the second. My
  comparative insight printed **`Win probability` and `Recommendation stability` in the same
  list**: the same quantity twice, the second time under a name implying an independent
  robustness measurement. That is a fabricated second statistic, on a surface whose entire
  premise is not fabricating confidence. Both reads removed; the honest row stays, pinned.
- `RobustnessDisplayVerdict` has **four** members and my first draft split them binary — so
  `moderate` read as "sensitive", and `not_assessed` (the producer's own *stated absence*)
  read as a measurement. Turning "we did not measure this" into a verdict is the worst
  thing this surface could do. Absence now renders nothing.
- The driver direction union is `positive|negative|mixed|unknown`; the draft compared
  against `'increase'`/`'decrease'`, so both real directions were silently dead.

Two further gaps were found by the **mutation battery, not by review**: an assertion that
could not tell "no robustness row" from "a row with a blank headline", and no coverage at
all for a mixed/unknown direction being rendered as a direction. Both closed.

## Two unrelated broken alarms closed in passing

- `shell-conformance` gains **"every PRESENTED surface has a body render arm"** — the
  missing half of the `footerBar` guard. A surface could be presented, type-clean, and open
  onto **nothing** (the Journey defect). Mutant-verified.
- `e2e/visual/shellLayout` has asserted a hardcoded **4** tabs against a strip of **3** ever
  since Compare left on 18 Aug — and this change would have made it pass again *for the
  wrong reason*. It now derives from the recorded budget.

---

## Verification

- `pnpm typecheck` (what the required check runs): **PASSED** — coverage + ratchet at
  **exactly baseline** (556 files / 2251 errors). No new errors, no baseline regeneration.
- DS v5 drift (enforcing, inside the required `tsc` job): **no net-new**.
- `eslint` on every touched file: **0 errors** (4 pre-existing warnings in `OutputsDock`,
  none added).
- **67 new tests** across 5 spec files. `tests/ci-guards` + all `canvas/components/__tests__`:
  **190 files / 2175 passed, 0 failed**.
- **Mutation battery: 16/16 bitten** — applied-checked, leading and trailing controls green,
  tree restored byte-identical from a pristine archive after every mutant. Every semantic
  rule above has a mutant that turns a *named* assertion red. (First pass scored 14/16;
  neither survivor was equivalent — both were tests that did not bite, and both are fixed.)

**Diff to shared files is additive: 84 insertions, 5 deletions — and all five deletions are
lines replaced in place** (a widened union, a widened persisted-tab validator, a re-recorded
literal). No results component, no `ResultsBody`, no shared presentation component is touched.

Five existing exact-list tab pins were updated **additively, never loosened** — an exact,
ordered list is what catches a surface silently appearing or vanishing.

### CI on `b1451d0b`

**`Staging Gate`: success** — the single required check. All four `Full Test Suite`
shards, `Full Test Suite Summary`, `TypeScript + Lint`, `Typecheck Gate Self-Test`,
`Production Build`, `Security Audit`, `CEE Contract Validation` and `Flag Deployment
Drift` all green.

`Visual Regression (advisory)` is **red — and it was already red on the staging tip
`16c55158` without this change** (control run 2026-08-26T22:06:43Z; PR #879 exists to
regenerate the stale Linux references). It is advisory and not in the required gate. This
change *does* additionally alter the tab strip, so those references will need re-blessing
once #879's regeneration lands — flagging that rather than letting it look like this
branch caused the red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
