### PR TITLE
fix(versions): teach the modelVersions adapter CEE's v2 list and restore

### DIFF
--- a/src/adapters/cee/__tests__/modelVersions.spec.ts
+++ b/src/adapters/cee/__tests__/modelVersions.spec.ts
@@ -2,9 +2,18 @@
  * modelVersions adapter — the UI's client for CEE's versions wiring slice.
  *
  * Server contract (olumi-assistants-service, assist.v1.scenario-versions.ts):
- *   POST /bff/cee/scenarios/{id}/versions          → model_versions_list.v1
+ *   POST /bff/cee/scenarios/{id}/versions          → model_versions_list.v2
  *   POST /bff/cee/scenarios/{id}/versions/save     → model_version_save.v1
- *   POST /bff/cee/scenarios/{id}/versions/restore  → model_version_restore.v1
+ *   POST /bff/cee/scenarios/{id}/versions/restore  → model_version_restore.v2
+ *
+ * ⚠ WHY THE v1 EXPECTATIONS IN THIS FILE CHANGED (2026-08-27). CEE bumped LIST
+ * and RESTORE to v2 in commit `4c29c5b5` (merged 26 Aug 14:52Z, an ancestor of
+ * the deployed staging tip `3c3d3d53` / `/healthz` build `3c3d3d5`). This spec
+ * previously pinned v1 acceptance as CORRECT; that expectation is now false
+ * about the deployed server, so it is changed here deliberately rather than
+ * left to fail. Every converted case keeps its ORIGINAL text in an adjacent
+ * comment so the change is auditable and nothing is silently rewritten.
+ * SAVE remains v1 on both sides and is untouched.
  *
  * What is pinned here:
  *  - the SAME transport rules as scenarioGraph.ts: literal same-origin
@@ -30,22 +39,111 @@ const USER = '0f8a1b2c-3d4e-4f50-9a6b-7c8d9e0f1a2b'
 const VERSION_A = 'aaaaaaaa-1111-4111-8111-aaaaaaaaaaaa'
 const HASH_A = 'a'.repeat(64)
 
-function wireSummary(overrides: Record<string, unknown> = {}) {
+// ─────────────────────────────────────────────────────────────────────────────
+// v2 CONTRACT — list + restore
+//
+// PROVENANCE OF EVERY FIXTURE FIELD BELOW: derived at the bytes from CEE
+// staging `3c3d3d53b5202526e09f2c770c5bcc467d83856d` (== deployed /healthz
+// build `3c3d3d5`), namely
+//   src/routes/assist.v1.scenario-versions.ts
+//     :115 MODEL_VERSIONS_LIST_SCHEMA   = "model_versions_list.v2"
+//     :118 MODEL_VERSION_RESTORE_SCHEMA = "model_version_restore.v2"
+//     :152-161 AtomicRestoreRouteResponseSchema (.strict())
+//     :169-241 summaryV2() — the row→wire mapping
+//   src/orchestrator-v5/model-management/history-v2.ts   (list + summary shapes)
+//   src/orchestrator-v5/model-management/mutation-receipt.ts  (receipt shape)
+// and cross-checked against CEE's OWN route test
+//   src/routes/__tests__/assist.v1.scenario-versions.test.ts
+//     :370 list schema · :795-822 restore, incl. the EXACT top-level key set
+//          ["analysis_state","receipt","request_id","restored","scenario_id","schema"].
+// These are the producer's bytes, not this lane's model of the producer.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ANALYSIS_HASH = 'd'.repeat(64)
+const SNAPSHOT_VERSION = 'cccccccc-3333-4333-8333-cccccccccccc'
+const RESTORED_VERSION = 'dddddddd-4444-4444-8444-dddddddddddd'
+const MUTATION_ID = 'eeeeeeee-5555-4555-8555-eeeeeeeeeeee'
+
+/** A v2 summary exactly as CEE's `summaryV2()` emits it for its default row
+ *  (actor_kind null + authored_by null ⇒ {kind:'unknown'}; creation_kind null
+ *  with no source pointer ⇒ {kind:'unknown', …}; root_version_id null ⇒
+ *  lineage {kind:'unknown'}). */
+function wireSummaryV2(overrides: Record<string, unknown> = {}) {
   return {
-    id: VERSION_A,
+    version_id: VERSION_A,
     scenario_id: SCENARIO,
-    owner_user_id: USER,
-    version_number: 4,
-    graph_identity_hash: HASH_A,
-    hash_algorithm: 'sha256',
-    identity_projection_version: 'identity.v1',
-    identity_normaliser_version: 'normaliser.v1',
-    graph_schema_version: 'graph.v1',
+    sequence: 4,
     label: 'Before pivot',
-    provenance: 'user_save',
-    restored_from_version_id: null,
     created_at: '2026-08-17T10:00:00.000Z',
+    actor: { kind: 'unknown' },
+    creation: { kind: 'unknown', mutation_id: null, source_turn_id: null },
+    lineage: { kind: 'unknown' },
+    full_hash: HASH_A,
+    analysis_affecting_hash: ANALYSIS_HASH,
     ...overrides,
+  }
+}
+
+function listBodyV2(overrides: Record<string, unknown> = {}) {
+  return {
+    schema: 'model_versions_list.v2',
+    request_id: 'req-1',
+    scenario_id: SCENARIO,
+    current_version_id: VERSION_A,
+    versions: [wireSummaryV2()],
+    next_cursor: null,
+    ...overrides,
+  }
+}
+
+const RESTORED_GRAPH_V2 = {
+  nodes: [
+    { id: 'n1', label: 'Take the job', kind: 'option' },
+    { id: 'n2', label: 'Commute time', kind: 'factor' },
+  ],
+  edges: [
+    {
+      from: 'n1',
+      to: 'n2',
+      strength: { mean: 0.4, std: 0.1 },
+      exists_probability: 0.9,
+      effect_direction: 'positive',
+    },
+  ],
+}
+
+function restoreBodyV2(receiptOverrides: Record<string, unknown> = {}) {
+  return {
+    schema: 'model_version_restore.v2',
+    scenario_id: SCENARIO,
+    restored: true,
+    receipt: {
+      schema: 'model_version_mutation_receipt.v1',
+      scenario_id: SCENARIO,
+      mutation_id: MUTATION_ID,
+      version_id: RESTORED_VERSION,
+      sequence: 4,
+      graph: RESTORED_GRAPH_V2,
+      full_hash: HASH_A,
+      hash_algorithm: 'sha256',
+      identity_projection_version: 'identity.v1',
+      identity_normaliser_version: 'normaliser.v1',
+      graph_schema_version: 'graph.v1',
+      analysis_affecting_hash: ANALYSIS_HASH,
+      actor: { kind: 'known', authored_by: 'owner' },
+      creation: { kind: 'restore', source_version_id: VERSION_A },
+      source_turn_id: null,
+      lineage: {
+        kind: 'known',
+        parent_version_id: SNAPSHOT_VERSION,
+        root_version_id: SNAPSHOT_VERSION,
+      },
+      undo_version_id: SNAPSHOT_VERSION,
+      event_id: `model_version_restored_mutation_${MUTATION_ID}`,
+      ...receiptOverrides,
+    },
+    analysis_state: null,
+    request_id: 'req-5',
   }
 }
 
@@ -77,16 +175,14 @@ describe('modelVersionsUrl', () => {
 })
 
 describe('listModelVersions', () => {
+  // CONVERTED v1 → v2. Original fixture was:
+  //   { schema: 'model_versions_list.v1', scenario_id, versions: [wireSummary()],
+  //     current_version_id: VERSION_A, request_id: 'req-1' }
+  // and it asserted `provenance: 'user_save'`. v2 has no flat `provenance`
+  // field — creation is a discriminated union — so the expectation below reads
+  // `creation.kind` instead. See the file header for why.
   it('POSTs the user id in the body and parses the list envelope', async () => {
-    fetchSpy.mockResolvedValue(
-      jsonResponse(200, {
-        schema: 'model_versions_list.v1',
-        scenario_id: SCENARIO,
-        versions: [wireSummary()],
-        current_version_id: VERSION_A,
-        request_id: 'req-1',
-      }),
-    )
+    fetchSpy.mockResolvedValue(jsonResponse(200, listBodyV2()))
 
     const result = await listModelVersions(SCENARIO, { userId: USER })
 
@@ -103,21 +199,21 @@ describe('listModelVersions', () => {
       id: VERSION_A,
       versionNumber: 4,
       label: 'Before pivot',
-      provenance: 'user_save',
+      // was `provenance: 'user_save'` under v1 — v2 spells creation as a union
+      provenance: 'unknown',
       graphIdentityHash: HASH_A,
     })
     expect(result.currentVersionId).toBe(VERSION_A)
   })
 
+  // CONVERTED v1 → v2 (label only; this case asserts the REQUEST, not the
+  // response). Original fixture carried `schema: 'model_versions_list.v1'`.
   it('never sends the guest sentinel as a user id', async () => {
     fetchSpy.mockResolvedValue(
-      jsonResponse(200, {
-        schema: 'model_versions_list.v1',
-        scenario_id: SCENARIO,
-        versions: [],
-        current_version_id: null,
-        request_id: 'req-2',
-      }),
+      jsonResponse(
+        200,
+        listBodyV2({ versions: [], current_version_id: null, request_id: 'req-2' }),
+      ),
     )
 
     await listModelVersions(SCENARIO, { userId: 'guest' })
@@ -149,14 +245,41 @@ describe('listModelVersions', () => {
     expect((await listModelVersions(SCENARIO, { userId: USER })).status).toBe('unusable')
   })
 
+  // CONVERTED v1 → v2. Original fixture was a v1 envelope carrying
+  //   `wireSummary({ version_number: 'four' })`.
+  // ⚠ LEFT AS v1 THIS CASE WOULD HAVE PASSED FOR THE WRONG REASON once the
+  // adapter went v2-only: the v1 SCHEMA GUARD would return 'unusable' before
+  // the row parser ever ran, so it would no longer test row validation at all.
+  // Re-pointed at the v2 shape with a wrong-TYPE `sequence`, which complements
+  // the missing-`sequence` case in the v2 block below.
   it('fails CLOSED on a malformed version row — never a silently shortened list', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(
+        200,
+        listBodyV2({
+          versions: [wireSummaryV2({ sequence: 'four' })],
+          current_version_id: null,
+          request_id: 'req-3',
+        }),
+      ),
+    )
+    expect((await listModelVersions(SCENARIO, { userId: USER })).status).toBe('unusable')
+  })
+
+  // THE v2-ONLY DECISION, MADE VISIBLE. There is no live v1 producer (CEE
+  // whole-repo sweep at `3c3d3d53`: zero v1 list/restore literals, no content
+  // negotiation), so v1 is refused rather than accepted "just in case" — an
+  // accepted-but-unproduced branch would be a compatibility path with no
+  // deletion condition. If this REDs, a v1 producer has appeared and the
+  // decision needs revisiting deliberately.
+  it('refuses a v1 list envelope — v2-only, by decision', async () => {
     fetchSpy.mockResolvedValue(
       jsonResponse(200, {
         schema: 'model_versions_list.v1',
         scenario_id: SCENARIO,
-        versions: [wireSummary({ version_number: 'four' })],
+        versions: [],
         current_version_id: null,
-        request_id: 'req-3',
+        request_id: 'req-legacy',
       }),
     )
     expect((await listModelVersions(SCENARIO, { userId: USER })).status).toBe('unusable')
@@ -239,31 +362,22 @@ describe('saveModelVersion', () => {
 })
 
 describe('restoreModelVersion', () => {
+  // CONVERTED v1 → v2. The original fixture was a FLAT v1 envelope:
+  //   { schema: 'model_version_restore.v1', scenario_id, restored: true,
+  //     deduped: false,
+  //     version: { version_id: 'dddddddd-…', version_number: 5,
+  //                graph_identity_hash: HASH_A, deduped: false, event_id: 'evt',
+  //                restored_from_version_id: VERSION_A },
+  //     undo_version_id: 'cccccccc-…', graph: restoredGraph,
+  //     graph_identity_hash: { value: HASH_A, projection_version: 'identity.v1' },
+  //     request_id: 'req-5' }
+  // In v2 `graph`, `version` and `undo_version_id` all moved INSIDE `receipt`
+  // and the ordinal is `sequence`, not `version_number`. This case still exists
+  // for what it uniquely pins: the REQUEST body (chosen version id, expected
+  // hash, and that a restore never sends a graph).
   it('sends the CHOSEN version id and expected hash; returns the restored graph and undo id', async () => {
-    const restoredGraph = {
-      nodes: [{ id: 'n1', label: 'Take the job', kind: 'option' }],
-      edges: [],
-    }
-    fetchSpy.mockResolvedValue(
-      jsonResponse(200, {
-        schema: 'model_version_restore.v1',
-        scenario_id: SCENARIO,
-        restored: true,
-        deduped: false,
-        version: {
-          version_id: 'dddddddd-4444-4444-8444-dddddddddddd',
-          version_number: 5,
-          graph_identity_hash: HASH_A,
-          deduped: false,
-          event_id: 'evt',
-          restored_from_version_id: VERSION_A,
-        },
-        undo_version_id: 'cccccccc-3333-4333-8333-cccccccccccc',
-        graph: restoredGraph,
-        graph_identity_hash: { value: HASH_A, projection_version: 'identity.v1' },
-        request_id: 'req-5',
-      }),
-    )
+    const restoredGraph = RESTORED_GRAPH_V2
+    fetchSpy.mockResolvedValue(jsonResponse(200, restoreBodyV2()))
 
     const result = await restoreModelVersion(SCENARIO, {
       userId: USER,
@@ -282,7 +396,9 @@ describe('restoreModelVersion', () => {
     expect(result.status).toBe('restored')
     if (result.status !== 'restored') throw new Error('unreachable')
     expect(result.graph).toEqual(restoredGraph)
-    expect(result.undoVersionId).toBe('cccccccc-3333-4333-8333-cccccccccccc')
+    expect(result.undoVersionId).toBe(SNAPSHOT_VERSION)
+    // v2 carries NO replay signal on the wire (CEE logs `replayed` but the
+    // .strict() response schema omits it), so this is false by construction.
     expect(result.deduped).toBe(false)
   })
 
@@ -324,24 +440,43 @@ describe('restoreModelVersion', () => {
     ).toBe('incomplete')
   })
 
-  it('a restore answer with restored:true but NO graph object is unusable — never applied blind', async () => {
+  // CONVERTED v1 → v2, AND RE-AIMED. Original fixture was a v1 envelope with
+  // `graph: null` at the TOP LEVEL, asserting 'unusable'. Left as-is it would
+  // have passed for the wrong reason (the v1 schema guard, not the graph
+  // check). Re-aimed at the stronger v2 property: a payload that carries a
+  // perfectly good graph at the v1 TOP-LEVEL position but has no `receipt`
+  // must still be refused — the adapter must never fall back to the old
+  // location and apply a graph the v2 contract did not put there.
+  it('a v2 restore with a top-level graph but NO receipt is unusable — never falls back to the v1 position', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(200, {
+        schema: 'model_version_restore.v2',
+        scenario_id: SCENARIO,
+        restored: true,
+        graph: RESTORED_GRAPH_V2,
+        undo_version_id: SNAPSHOT_VERSION,
+        version: { version_id: VERSION_A, version_number: 5 },
+        analysis_state: null,
+        request_id: 'req-6',
+      }),
+    )
+    expect(
+      (await restoreModelVersion(SCENARIO, { userId: USER, versionId: VERSION_A })).status,
+    ).toBe('unusable')
+  })
+
+  // The v2-only decision, restore side. See the list twin above.
+  it('refuses a v1 restore envelope — v2-only, by decision', async () => {
     fetchSpy.mockResolvedValue(
       jsonResponse(200, {
         schema: 'model_version_restore.v1',
         scenario_id: SCENARIO,
         restored: true,
         deduped: false,
-        version: {
-          version_id: VERSION_A,
-          version_number: 5,
-          graph_identity_hash: HASH_A,
-          deduped: false,
-          event_id: null,
-        },
+        version: { version_id: VERSION_A, version_number: 5 },
         undo_version_id: null,
-        graph: null,
-        graph_identity_hash: null,
-        request_id: 'req-6',
+        graph: RESTORED_GRAPH_V2,
+        request_id: 'req-legacy',
       }),
     )
     expect(
@@ -355,5 +490,144 @@ describe('restoreModelVersion', () => {
     )
     await restoreModelVersion(SCENARIO, { userId: USER, versionId: VERSION_A })
     expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('v2 fixture preconditions — the fixtures are genuinely v2-shaped', () => {
+  // WITHOUT THIS, a fixture that was secretly v1-shaped would make every test
+  // below pass for the wrong reason (CLAUDE.md: pin the precondition in-test).
+  it('the list fixture carries the v2 label and the v2-only field names', () => {
+    const body = listBodyV2()
+    expect(body.schema).toBe('model_versions_list.v2')
+    expect(body).toHaveProperty('next_cursor')
+    const row = body.versions[0] as Record<string, unknown>
+    // v2 field names present …
+    expect(typeof row.version_id).toBe('string')
+    expect(typeof row.sequence).toBe('number')
+    expect(typeof row.full_hash).toBe('string')
+    expect(row.creation).toBeTypeOf('object')
+    expect(row.lineage).toBeTypeOf('object')
+    expect(row.actor).toBeTypeOf('object')
+    // … and the v1 names GONE, so a v1 parser cannot accidentally succeed.
+    expect(row).not.toHaveProperty('id')
+    expect(row).not.toHaveProperty('version_number')
+    expect(row).not.toHaveProperty('graph_identity_hash')
+    expect(row).not.toHaveProperty('provenance')
+    expect(row).not.toHaveProperty('restored_from_version_id')
+  })
+
+  it('the restore fixture nests graph/version/undo INSIDE receipt and nowhere else', () => {
+    const body = restoreBodyV2()
+    expect(body.schema).toBe('model_version_restore.v2')
+    expect(body.receipt).toBeTypeOf('object')
+    expect(body.receipt.graph).toBeTypeOf('object')
+    expect(typeof body.receipt.version_id).toBe('string')
+    expect(typeof body.receipt.sequence).toBe('number')
+    expect(body.receipt.undo_version_id).toBe(SNAPSHOT_VERSION)
+    // The v1 TOP-LEVEL carriers must be absent — this is the whole bump.
+    expect(body).not.toHaveProperty('graph')
+    expect(body).not.toHaveProperty('version')
+    expect(body).not.toHaveProperty('undo_version_id')
+    expect(body).not.toHaveProperty('deduped')
+    // CEE pins this exact top-level key set in its own route test.
+    expect(Object.keys(body).sort()).toEqual([
+      'analysis_state',
+      'receipt',
+      'request_id',
+      'restored',
+      'scenario_id',
+      'schema',
+    ])
+  })
+})
+
+describe('listModelVersions — v2', () => {
+  it('parses a real model_versions_list.v2 envelope into ServerModelVersion rows', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, listBodyV2()))
+
+    const result = await listModelVersions(SCENARIO, { userId: USER })
+
+    expect(result.status).toBe('list')
+    if (result.status !== 'list') throw new Error('unreachable')
+    expect(result.versions).toHaveLength(1)
+    // Bound BY IDENTITY (version_id), never by a value predicate another row
+    // could satisfy.
+    expect(result.versions[0].id).toBe(VERSION_A)
+    expect(result.versions[0].versionNumber).toBe(4) // ← from `sequence`
+    expect(result.versions[0].label).toBe('Before pivot')
+    expect(result.versions[0].graphIdentityHash).toBe(HASH_A) // ← from `full_hash`
+    expect(result.versions[0].createdAt).toBe('2026-08-17T10:00:00.000Z')
+    expect(result.currentVersionId).toBe(VERSION_A)
+    expect(result.requestId).toBe('req-1')
+  })
+
+  it('carries the v2 creation vocabulary through as provenance and source id', async () => {
+    fetchSpy.mockResolvedValue(
+      jsonResponse(
+        200,
+        listBodyV2({
+          versions: [
+            wireSummaryV2({
+              creation: {
+                kind: 'restore',
+                source_version_id: SNAPSHOT_VERSION,
+                mutation_id: MUTATION_ID,
+                source_turn_id: null,
+              },
+            }),
+          ],
+        }),
+      ),
+    )
+
+    const result = await listModelVersions(SCENARIO, { userId: USER })
+    if (result.status !== 'list') throw new Error('unreachable')
+    expect(result.versions[0].provenance).toBe('restore')
+    expect(result.versions[0].restoredFromVersionId).toBe(SNAPSHOT_VERSION)
+  })
+
+  it('fails CLOSED on a v2 row missing sequence — never a silently shortened list', async () => {
+    const bad = wireSummaryV2()
+    delete (bad as Record<string, unknown>).sequence
+    fetchSpy.mockResolvedValue(jsonResponse(200, listBodyV2({ versions: [bad] })))
+    expect((await listModelVersions(SCENARIO, { userId: USER })).status).toBe('unusable')
+  })
+})
+
+describe('restoreModelVersion — v2', () => {
+  it('reads graph, version and undo id from the nested receipt', async () => {
+    fetchSpy.mockResolvedValue(jsonResponse(200, restoreBodyV2()))
+
+    const result = await restoreModelVersion(SCENARIO, {
+      userId: USER,
+      versionId: VERSION_A,
+      expectedGraphIdentityHash: HASH_A,
+    })
+
+    expect(result.status).toBe('restored')
+    if (result.status !== 'restored') throw new Error('unreachable')
+    expect(result.graph).toEqual(RESTORED_GRAPH_V2)
+    expect(result.version.versionId).toBe(RESTORED_VERSION)
+    expect(result.version.versionNumber).toBe(4) // ← from `receipt.sequence`
+    expect(result.undoVersionId).toBe(SNAPSHOT_VERSION)
+    expect(result.requestId).toBe('req-5')
+  })
+
+  it('a v2 restore whose receipt carries NO graph is unusable — never applied blind', async () => {
+    const body = restoreBodyV2()
+    ;(body.receipt as Record<string, unknown>).graph = null
+    fetchSpy.mockResolvedValue(jsonResponse(200, body))
+    expect(
+      (await restoreModelVersion(SCENARIO, { userId: USER, versionId: VERSION_A })).status,
+    ).toBe('unusable')
+  })
+
+  it('a v2 restore with NO receipt at all is unusable', async () => {
+    const body = restoreBodyV2() as Record<string, unknown>
+    delete body.receipt
+    fetchSpy.mockResolvedValue(jsonResponse(200, body))
+    expect(
+      (await restoreModelVersion(SCENARIO, { userId: USER, versionId: VERSION_A })).status,
+    ).toBe('unusable')
   })
 })

--- a/src/adapters/cee/__tests__/scenarioRoutesUserJwt.spec.ts
+++ b/src/adapters/cee/__tests__/scenarioRoutesUserJwt.spec.ts
@@ -101,7 +101,10 @@ const ROUTES: ReadonlyArray<{
   {
     name: 'listModelVersions (read)',
     fn: 'listModelVersions',
-    ok: { schema: 'model_versions_list.v1', versions: [] },
+    // v2 since CEE 4c29c5b5. This case asserts the REQUEST HEADERS, so the
+    // body only has to be a 200 — but a stale contract label here would be
+    // the next reader's false evidence about the wire.
+    ok: { schema: 'model_versions_list.v2', versions: [] },
     call: (o) => listModelVersions(SCENARIO_ID, o),
   },
   {
@@ -113,7 +116,7 @@ const ROUTES: ReadonlyArray<{
   {
     name: 'restoreModelVersion (write)',
     fn: 'restoreModelVersion',
-    ok: { schema: 'model_version_restore.v1' },
+    ok: { schema: 'model_version_restore.v2' },
     call: (o) => restoreModelVersion(SCENARIO_ID, { ...o, versionId: 'v1' }),
   },
 ]

--- a/src/adapters/cee/modelVersions.ts
+++ b/src/adapters/cee/modelVersions.ts
@@ -3,9 +3,32 @@
  *
  * Server contract: olumi-assistants-service `assist.v1.scenario-versions.ts`
  * (the Model Management wiring slice):
- *   POST /assist/v1/scenarios/{id}/versions          → model_versions_list.v1
+ *   POST /assist/v1/scenarios/{id}/versions          → model_versions_list.v2
  *   POST /assist/v1/scenarios/{id}/versions/save     → model_version_save.v1
- *   POST /assist/v1/scenarios/{id}/versions/restore  → model_version_restore.v1
+ *   POST /assist/v1/scenarios/{id}/versions/restore  → model_version_restore.v2
+ *
+ * ⚠ LIST AND RESTORE ARE v2; SAVE IS STILL v1. That is not an inconsistency to
+ * tidy — it is the server's actual posture, derived at CEE staging
+ * `3c3d3d53` (== deployed `/healthz` build `3c3d3d5`),
+ * `assist.v1.scenario-versions.ts:115-118`. Changing save would break the one
+ * leg that works.
+ *
+ * THE v2 BUMP MOVED THE SHAPE, NOT ONLY THE LABEL. On restore, the top-level
+ * `graph`, `version` and `undo_version_id` are GONE; they now live inside a
+ * nested `receipt` (`model_version_mutation_receipt.v1`), and the version
+ * ordinal is spelled `sequence` there, not `version_number`. On list, rows are
+ * `version_id`/`sequence`/`full_hash` with structured `actor`/`creation`/
+ * `lineage`, not `id`/`version_number`/`graph_identity_hash`/`provenance`.
+ *
+ * v2-ONLY, DELIBERATELY — NOT a compatibility path. A whole-repo sweep of CEE
+ * at that SHA finds ZERO `model_versions_list.v1` / `model_version_restore.v1`
+ * literals (contrast controls in the same sweep: 7 v2 literals, 2
+ * `model_version_save.v1`), and the route does no content negotiation — it
+ * sends one hardcoded discriminator per response. There is no live v1 producer
+ * for these two calls, so accepting v1 would be a branch with nothing to serve
+ * it, and this file would carry a compatibility path with no deletion
+ * condition. If a v1 producer is ever demonstrated, that is the moment to add
+ * one — with its deletion condition written beside it.
  * reached from the browser as `/bff/cee/scenarios/{id}/versions[...]`.
  *
  * THE TRANSPORT RULES ARE scenarioGraph.ts's, INHERITED IN FULL — see that
@@ -59,7 +82,21 @@ export interface ServerModelVersion {
   id: string
   versionNumber: number
   label: string | null
-  /** 'user_save' | 'commit' | 'pre_restore' | 'restore' — rendered, not branched on. */
+  /**
+   * v2 `creation.kind`: 'initial' | 'committed_mutation' | 'restore' |
+   * 'variant_creation' | 'variant_promotion' | 'unknown' — rendered, not
+   * branched on.
+   *
+   * ⚠ THE VOCABULARY CHANGED WITH v2. v1 spelled this
+   * 'user_save' | 'commit' | 'pre_restore' | 'restore' as a flat string; v2
+   * has no such field and models creation as a discriminated union. These are
+   * two different vocabularies answering two different questions, so this
+   * carries `creation.kind` VERBATIM rather than inventing a translation back
+   * to the retired v1 words. Safe to do because a sweep of `src` (excluding
+   * tests) finds NO consumer of this field or of `restoredFromVersionId`
+   * outside this adapter — nothing renders or branches on either today. Any
+   * future renderer must be written against the v2 words above.
+   */
   provenance: string | null
   restoredFromVersionId: string | null
   /** ISO timestamp from the server row. */
@@ -265,30 +302,80 @@ function sharedRefusal(
   }
 }
 
-function parseSummary(raw: unknown): ServerModelVersion | null {
+/**
+ * One `model_versions_list.v2` row → `ServerModelVersion`.
+ *
+ * Field mapping derived from CEE `history-v2.ts` (the wire schema) and
+ * `assist.v1.scenario-versions.ts:169-241` (`summaryV2()`, the row→wire map):
+ *   version_id → id · sequence → versionNumber · full_hash → graphIdentityHash
+ *   creation.kind → provenance · creation.source_version_id →
+ *   restoredFromVersionId (absent on the `initial`/`committed_mutation`/
+ *   `unknown` arms of the union, which is why it is read defensively).
+ * Returns null on anything that does not match, so the caller can fail CLOSED.
+ */
+function parseSummaryV2(raw: unknown): ServerModelVersion | null {
   if (raw === null || typeof raw !== 'object') return null
   const row = raw as Record<string, unknown>
-  const id = row.id
-  const versionNumber = row.version_number
+  const id = row.version_id
+  const versionNumber = row.sequence
   const createdAt = row.created_at
-  const hash = row.graph_identity_hash
+  const hash = row.full_hash
   if (typeof id !== 'string' || id.length === 0) return null
   if (typeof versionNumber !== 'number' || !Number.isInteger(versionNumber)) return null
   if (typeof createdAt !== 'string' || createdAt.length === 0) return null
   if (typeof hash !== 'string' || hash.length === 0) return null
+
+  const creation =
+    row.creation !== null && typeof row.creation === 'object'
+      ? (row.creation as Record<string, unknown>)
+      : null
+  const creationKind = typeof creation?.kind === 'string' ? creation.kind : null
+  const sourceVersionId =
+    typeof creation?.source_version_id === 'string' &&
+    (creation.source_version_id as string).length > 0
+      ? (creation.source_version_id as string)
+      : null
+
   return {
     id,
     versionNumber,
     label: typeof row.label === 'string' && row.label.length > 0 ? row.label : null,
-    provenance:
-      typeof row.provenance === 'string' && row.provenance.length > 0 ? row.provenance : null,
-    restoredFromVersionId:
-      typeof row.restored_from_version_id === 'string' &&
-      row.restored_from_version_id.length > 0
-        ? row.restored_from_version_id
-        : null,
+    provenance: creationKind !== null && creationKind.length > 0 ? creationKind : null,
+    restoredFromVersionId: sourceVersionId,
     createdAt,
     graphIdentityHash: hash,
+  }
+}
+
+/**
+ * `receipt` → `ServerVersionWriteOutcome`, for RESTORE v2 only.
+ *
+ * DELIBERATELY NOT `parseWriteOutcome`. That function answers "what did the
+ * v1 SAVE envelope's `version` block say?" (`version_number`); this one
+ * answers "what does the v2 restore RECEIPT say?" (`sequence`). Two questions,
+ * two readers — collapsing them into one would be the same
+ * similar-names/different-questions defect this codebase has paid for before.
+ *
+ * `deduped` is FALSE by construction: the v2 restore wire has no replay
+ * signal. CEE computes `replayed` and only LOGS it
+ * (`assist.v1.scenario-versions.ts`, restore handler); the response schema is
+ * `.strict()` and CEE's own route test pins the exact top-level key set
+ * ["analysis_state","receipt","request_id","restored","scenario_id","schema"].
+ * Reporting `false` is the honest read of a signal that is not on the wire —
+ * it is never used to CLAIM a replay happened, only to withhold the claim that
+ * one did. The caller (ServerVersionsSection) then falls through to its
+ * `changedNothing` branch, which says the server restored and invites a reload
+ * rather than asserting nothing changed. Vaguer, still true, fails safe.
+ */
+function parseReceiptWriteOutcome(raw: unknown): ServerVersionWriteOutcome | null {
+  if (raw === null || typeof raw !== 'object') return null
+  const receipt = raw as Record<string, unknown>
+  if (typeof receipt.version_id !== 'string' || receipt.version_id.length === 0) return null
+  if (typeof receipt.sequence !== 'number' || !Number.isInteger(receipt.sequence)) return null
+  return {
+    versionId: receipt.version_id,
+    versionNumber: receipt.sequence,
+    deduped: false,
   }
 }
 
@@ -318,7 +405,7 @@ export async function listModelVersions(
 
   if (body === null || typeof body !== 'object') return { status: 'unusable' }
   const b = body as Record<string, unknown>
-  if (b.schema !== 'model_versions_list.v1') {
+  if (b.schema !== 'model_versions_list.v2') {
     logger.warn('model_versions.unexpected_schema', { schema: String(b.schema) })
     return { status: 'unusable' }
   }
@@ -326,7 +413,7 @@ export async function listModelVersions(
 
   const versions: ServerModelVersion[] = []
   for (const raw of b.versions) {
-    const parsed = parseSummary(raw)
+    const parsed = parseSummaryV2(raw)
     // Fail CLOSED on a malformed row: a silently shortened history would
     // misrepresent what exists to be restored.
     if (parsed === null) {
@@ -407,14 +494,25 @@ export async function restoreModelVersion(
 
   if (body === null || typeof body !== 'object') return { status: 'unusable' }
   const b = body as Record<string, unknown>
-  if (b.schema !== 'model_version_restore.v1') return { status: 'unusable' }
+  if (b.schema !== 'model_version_restore.v2') return { status: 'unusable' }
   if (b.restored !== true) return { status: 'unusable' }
-  const version = parseWriteOutcome(b.version)
+
+  // v2 nests the mutation outcome in `receipt`. Everything the caller applies
+  // is read from THERE — never from the top level, which no longer carries it.
+  const receipt =
+    b.receipt !== null && typeof b.receipt === 'object'
+      ? (b.receipt as Record<string, unknown>)
+      : null
+  if (receipt === null) {
+    logger.warn('model_versions.restore_without_receipt_refused', { scenarioId })
+    return { status: 'unusable' }
+  }
+  const version = parseReceiptWriteOutcome(receipt)
   if (version === null) return { status: 'unusable' }
 
   // The graph is what the reconcile applies. A restore claim WITHOUT the
   // graph must never be applied blind — refuse the shape instead.
-  const graph = b.graph
+  const graph = receipt.graph
   if (graph === null || typeof graph !== 'object') {
     logger.warn('model_versions.restore_without_graph_refused', { scenarioId })
     return { status: 'unusable' }
@@ -423,11 +521,12 @@ export async function restoreModelVersion(
   return {
     status: 'restored',
     graph,
-    deduped: b.deduped === true,
+    // See `parseReceiptWriteOutcome`: v2 carries no replay signal on the wire.
+    deduped: false,
     version,
     undoVersionId:
-      typeof b.undo_version_id === 'string' && b.undo_version_id.length > 0
-        ? b.undo_version_id
+      typeof receipt.undo_version_id === 'string' && receipt.undo_version_id.length > 0
+        ? receipt.undo_version_id
         : null,
     requestId: typeof b.request_id === 'string' ? b.request_id : null,
   }


### PR DESCRIPTION
## The defect (live, user-facing, on the deployed build)

**Version history listed nothing and restore could not complete, while save still succeeded** — so a user could save versions they could then neither see nor restore.

CEE bumped LIST and RESTORE to v2 in `4c29c5b5` (26 Aug 14:52Z), an ancestor of the deployed staging tip `3c3d3d53` (`/healthz` → `build: 3c3d3d5`):

| call | CEE (deployed) | UI (staging `16c55158`) | result |
|---|---|---|---|
| list | `model_versions_list.v2` | demanded `…v1` | `unusable` |
| restore | `model_version_restore.v2` | demanded `…v1` | `unusable` |
| **save** | `model_version_save.v1` | `model_version_save.v1` | **works — untouched** |

The adapter's checks are hard equality, so both reads fell straight through to `unusable`.

This is a **REST contract bump landed without its reader** — not schema-pin skew. No pin alignment would have prevented it.

It fails closed to an honest retry state, so this is a **broken capability, not a trust defect**. The fail-closed behaviour and its copy are deliberate and are **unchanged**.

## The fix

The bump moved the **shape**, not only the label. Every field below was derived at the bytes from CEE `3c3d3d53` (`assist.v1.scenario-versions.ts`, `history-v2.ts`, `mutation-receipt.ts`) and cross-checked against **CEE's own route test**, which pins the exact top-level key set.

**restore** — `graph`, `version`, `undo_version_id` are gone from the top level and now live inside a nested `receipt`; the ordinal is `sequence`, not `version_number`.

**list** — rows are `version_id` / `sequence` / `full_hash` with structured `actor` / `creation` / `lineage`, replacing `id` / `version_number` / `graph_identity_hash` / `provenance`.

`parseReceiptWriteOutcome` is deliberately **named apart** from `parseWriteOutcome`: they answer different questions (v2 receipt `sequence` vs v1 save-envelope `version_number`). Collapsing them would be the similar-names/different-questions defect this codebase has paid for before.

## Decision: v2-only, not a compatibility path

A whole-repo sweep of CEE finds **zero** v1 list/restore literals (contrast controls in the same sweep: 7 v2, 2 `save.v1`), and the route does **no content negotiation** — one hardcoded discriminator per response. There is no live v1 producer, so a v1 branch would be a compatibility path with nothing to serve it and no deletion condition. Two tests pin the refusal, so this **REDs if a v1 producer ever appears**.

## ⚠ Contract narrowing — reported, not papered over

**v2 carries no replay signal on the restore wire.** CEE computes `replayed` and only *logs* it; the response schema is `.strict()` and CEE's own test pins the exact key set. So `deduped` is `false` by construction on the v2 path.

Consequence: on an idempotent replay the panel no longer says *"already at that version — nothing changed"*. It falls to the `changedNothing` branch — *"Restored on the server. If the canvas looks unchanged, reload the page…"* — plus a warn. **Vaguer, still true, fails safe.** No signal is invented to fill the gap.

## Evidence

**RED-first, by name** — the break reproduced before any fix:
- `listModelVersions — v2 > parses a real model_versions_list.v2 envelope…` → `expected 'unusable' to be 'list'`
- `restoreModelVersion — v2 > reads graph, version and undo id from the nested receipt` → `expected 'unusable' to be 'restored'`

**Fixture preconditions pinned in-test** — the fixtures are asserted to carry the v2 label *and* the nested `receipt`, *and* to lack the v1 field names, so they cannot pass for the wrong reason.

**Discriminating mutant pair** (throwaway worktree outside the repo root; isolation proved by *writing* a sentinel and confirming the source was unchanged; HEAD-relative restores; applied-check scoped to `src/`):

| mutant | expect | got |
|---|---|---|
| list guard v2→v1 | RED | RED (4 failed) |
| restore guard v2→v1 | RED | RED (2 failed) |
| graph read receipt→top-level | RED | RED (2 failed) |
| `receipt.sequence`→`version_number` | RED | RED (2 failed) |
| list `version_id`→`id` | RED | RED (3 failed) |
| list `full_hash`→`graph_identity_hash` | RED | RED (3 failed) |
| **save guard mutated — v2 tests only** | **GREEN** | **GREEN** |
| same mutant, full suite | RED | RED (1 failed — the save test) |

The last two are the pair: the same *kind* of mutation on a **different object** leaves the v2 seam green, and the full-suite run proves that mutation was genuinely applied and detectable. Failure counts vary across mutants — real discrimination, not a uniformly-firing blind probe.

**Collected count asserted by name**: `modelVersions.spec.ts` 13 → **23**, and 23 in every mutant run. Never inferred from a suite total.

**All seven `TypeScript + Lint` steps** run at this tip: lint, typecheck, `ci:guard:zustand`, `ci:guard:starters`, `check:vendor`, `ci:guard:schemas-version`, `ci:guard:ds:enforce` — **all rc=0**.

**Full suite, sharded 4-way as CI does**: shards 1–2 clean; shards 3–4 each carry **one pre-existing failure**, both **discharged by control** — a pristine worktree at `origin/staging` `16c55158` with these changes absent reproduces both identically (`aiPanelTranche1.spec.tsx` focus-ring, `useSensitivityRanking.plotBearer.spec.tsx` proxy path). Neither file is touched here.

## Three tests that would have passed for the wrong reason

Once the adapter went v2-only, three pre-existing tests would have kept passing via the **schema guard short-circuiting before the property under test ever ran**. All are converted, each keeping its **original text in an adjacent comment**. One is re-aimed at a stronger property: a v2 payload carrying a good graph at the old v1 top-level position but no `receipt` must still be refused — the adapter must never fall back to the old location.

## Scope

Disjoint from the in-flight PRs — **measured**, intersection = 0 (#886 `canvas/mutations` + `inspector-v2`; #887 `pre-analysis-v3/**`).

Do not merge or deploy on my account — handing back for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
