### PR TITLE
fix(panel): seven icon sizes and five stroke weights become three and one

### DIFF
--- a/src/canvas/conversation/ConversationPanel.tsx
+++ b/src/canvas/conversation/ConversationPanel.tsx
@@ -41,6 +41,7 @@ import { BLOCKED_REASON_COPY } from '../utils/composeBlockedReason'
 import { useShowToastSafe } from '../ToastContext'
 import { analysisHeldOn } from '../utils/analysisHeldOnInjectedModel'
 import { useGraphReadiness } from '../hooks/useGraphReadiness'
+import { ICON_STROKE } from './panelIcons'
 
 interface ConversationPanelProps {
   conversation: UseConversationReturn
@@ -818,7 +819,7 @@ export const ConversationPanel = memo(function ConversationPanel({
           }}
           data-testid="chat-panel-collapse"
         >
-          <ChevronsRight className="w-4 h-4" strokeWidth={1.8} aria-hidden="true" />
+          <ChevronsRight className="w-4 h-4" strokeWidth={ICON_STROKE} aria-hidden="true" />
         </button>
       </div>
       )}

--- a/src/canvas/conversation/GuidanceStrip.tsx
+++ b/src/canvas/conversation/GuidanceStrip.tsx
@@ -17,6 +17,7 @@ import { useCanvasStore } from '../store'
 import { focusExistingTarget } from '../utils/focusHelpers'
 import { scrollToField } from './utils/scrollToField'
 import { beginInteractionChain } from '../../lib/debug-state'
+import { ICON_STATUS } from './panelIcons'
 
 const FOCUS_DEBOUNCE_MS = 150
 
@@ -48,10 +49,10 @@ function categoryIcon(cat: GuidanceItem['category']) {
   switch (cat) {
     case 'must_fix':
     case 'should_fix':
-      return <AlertTriangle size={11} aria-hidden="true" />
+      return <AlertTriangle size={ICON_STATUS} aria-hidden="true" />
     case 'could_fix':
     case 'technique':
-      return <Lightbulb size={11} aria-hidden="true" />
+      return <Lightbulb size={ICON_STATUS} aria-hidden="true" />
   }
 }
 

--- a/src/canvas/conversation/InlineBlocks.tsx
+++ b/src/canvas/conversation/InlineBlocks.tsx
@@ -92,6 +92,7 @@ import { safeRichText, plainTextPreview } from '../utils/safeRichText'
 import { isOrchestratorRenderingV2Enabled } from '../../flags'
 import styles from './Conversation.module.css'
 import { PANEL_LIST_BULLET } from './panelLists'
+import { ICON_DENSE } from './panelIcons'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1349,7 +1350,7 @@ const EvidenceBlockRenderer = memo(function EvidenceBlockRenderer({
             }`}
             data-testid="apply-to-model-chip"
           >
-            <Wand2 size={11} aria-hidden="true" />
+            <Wand2 size={ICON_DENSE} aria-hidden="true" />
             Apply to model
           </button>
         </div>

--- a/src/canvas/conversation/dropdowns/GuideDropdown.tsx
+++ b/src/canvas/conversation/dropdowns/GuideDropdown.tsx
@@ -133,7 +133,7 @@ export function GuideDropdown({ isOpen, onClose, onInsertText, anchorRef }: Guid
               className="absolute top-1.5 right-1.5 w-5 h-5 flex items-center justify-center rounded-full text-text-light hover:bg-panel-hover transition-colors"
               aria-label="Dismiss"
             >
-              <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true"><path d="M2 2l6 6M8 2l-6 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
+              <svg width="12" height="12" viewBox="0 0 10 10" aria-hidden="true"><path d="M2 2l6 6M8 2l-6 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
             </button>
             <span className="pr-5">{HELP_TEXT}</span>
           </div>

--- a/src/canvas/conversation/dropdowns/ThinkingModeDropdown.tsx
+++ b/src/canvas/conversation/dropdowns/ThinkingModeDropdown.tsx
@@ -11,6 +11,7 @@ import { NodeShape } from '../primitives/NodeShape'
 import type { NodeType } from '../../domain/nodes'
 import { FlipDropdown } from '../../../components/ui/FlipDropdown'
 import { typography } from '../../../styles/typography'
+import { ICON_STROKE } from '../panelIcons'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Mode definitions
@@ -66,7 +67,7 @@ export function ThinkingModeChip({ selectedMode, onClick }: ThinkingModeChipProp
       data-testid="thinking-mode-chip"
     >
       <span>{mode.label}</span>
-      <ChevronDown className="w-3.5 h-3.5 text-text-light" strokeWidth={1.8} aria-hidden="true" />
+      <ChevronDown className="w-3.5 h-3.5 text-text-light" strokeWidth={ICON_STROKE} aria-hidden="true" />
     </button>
   )
 }

--- a/src/canvas/conversation/panelIcons.ts
+++ b/src/canvas/conversation/panelIcons.ts
@@ -1,0 +1,55 @@
+/**
+ * panelIcons — the icon scale for the AI panel, and the one stroke weight.
+ * British English: standardise, colour, behaviour.
+ *
+ * ── WHAT WAS THERE ───────────────────────────────────────────────────────────
+ * Measured on `5b932c28`, on ELEMENTS THAT ARE ACTUALLY ICONS (an `<svg>` or a
+ * component imported from `lucide-react` — container `div`s excluded, which is
+ * what made an earlier count read 13):
+ *
+ *     10px × 2 · 11px × 5 · 12px × 33 · 14px × 16 · 15px × 1 · 16px × 22 · 18px × 1
+ *
+ * Seven sizes, written five different ways: `size={12}`, `w-3 h-3`, `w-3.5 h-3.5`,
+ * `w-[18px] h-[18px]`, and raw `width="16" height="16"`. Three of those spellings
+ * say the same thing as another one, so the same 14px icon appears as `size={14}`
+ * in one file and `w-3.5 h-3.5` in the next.
+ *
+ * ── WHY THREE SIZES AND NOT TWO ──────────────────────────────────────────────
+ * ⚠ A two-size scale (12 dense / 16 standalone) was proposed before the design
+ * system had been read properly. DS v5 USES 14px, twice and specifically:
+ * §8.3 gives inline validation icons as `AlertTriangle` / `Check` at 14px, and
+ * §17 gives the notice anatomy a 16px leading icon. Collapsing 14 into 12 or 16
+ * would have made the panel violate the DS in order to tidy it.
+ *
+ * So the scale is the three sizes the DS and the code already agree on, and they
+ * are also the three that carry 71 of the 80 icons: 12, 14, 16.
+ * The strays — 10, 11, 15 and 18 — go to their nearest neighbour.
+ *
+ * ── STROKE WEIGHT IS NOT A TASTE CALL ────────────────────────────────────────
+ * DS v5 §17 states the library contract: *"Lucide (`lucide-react@0.263.1`)…
+ * 24px grid, 2px stroke weight."* The panel shipped FIVE weights — 1, 1.5, 1.8,
+ * 2, 2.2 — and the commonest (1.8, ten uses) is not the specified one. `Play`
+ * appears at 1.8 in one place and 2 in another: the same glyph, two weights,
+ * inside one panel. This is conformance, not preference.
+ *
+ * ── NOT FIXED HERE, AND DELIBERATELY ─────────────────────────────────────────
+ * Eight raw `<svg>` glyphs are hand-drawn where the DS says Lucide only — the
+ * thumbs up/down in `FeedbackRow`, two different hand-built `X` marks, an arrow
+ * in `EmptyState`. Replacing them changes what the glyph LOOKS like, not just its
+ * size, so it needs its own visual review rather than riding along here.
+ */
+
+/** Dense rows, inline chips, chevrons. The panel default — 33 of 80 icons. */
+export const ICON_DENSE = 12
+
+/** Inline status and validation icons. DS v5 §8.3 states this size. */
+export const ICON_STATUS = 14
+
+/** Standalone controls and notice leading icons. DS v5 §17 states this size. */
+export const ICON_STANDALONE = 16
+
+/** DS v5 §17: Lucide's own grid is 24px at 2px stroke. One weight, no exceptions. */
+export const ICON_STROKE = 2
+
+/** The scale, for guards and for anything that needs to validate a size. */
+export const ICON_SIZES = [ICON_DENSE, ICON_STATUS, ICON_STANDALONE] as const

--- a/src/canvas/conversation/primitives/IconButton.tsx
+++ b/src/canvas/conversation/primitives/IconButton.tsx
@@ -9,6 +9,7 @@
 import { forwardRef } from 'react'
 import type { LucideIcon } from 'lucide-react'
 import { Tooltip } from '../../components/Tooltip'
+import { ICON_STANDALONE, ICON_STROKE } from '../panelIcons'
 
 interface IconButtonProps {
   icon: LucideIcon
@@ -40,8 +41,9 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
         `}
       >
         <Icon
-          className={`w-[18px] h-[18px] flex-shrink-0 ${disabled ? 'text-text-light' : 'text-text-light group-hover:text-text-body'}`}
-          strokeWidth={1.8}
+          className={`flex-shrink-0 ${disabled ? 'text-text-light' : 'text-text-light group-hover:text-text-body'}`}
+          size={ICON_STANDALONE}
+          strokeWidth={ICON_STROKE}
           aria-hidden="true"
         />
       </button>

--- a/src/canvas/conversation/zones/BriefReadinessPill.tsx
+++ b/src/canvas/conversation/zones/BriefReadinessPill.tsx
@@ -53,7 +53,7 @@ export function BriefReadinessPill({ readiness, expanded, onToggle }: BriefReadi
       />
       <span>{config.label}</span>
       <svg
-        width="10" height="10" viewBox="0 0 24 24" fill="none"
+        width="12" height="12" viewBox="0 0 24 24" fill="none"
         aria-hidden="true"
         className="flex-shrink-0"
         style={{ stroke: 'var(--text-light, #6E6B6B)', strokeWidth: 1.8, strokeLinecap: 'round' as const, strokeLinejoin: 'round' as const }}

--- a/src/canvas/conversation/zones/ChatComposer.tsx
+++ b/src/canvas/conversation/zones/ChatComposer.tsx
@@ -31,6 +31,7 @@ import type { BriefReadiness } from '../hooks/useBriefSignals'
 import type { UseConversationReturn } from '../useConversation'
 import { typography } from '../../../styles/typography'
 import type { ScenarioStage } from '../../../types/scenario'
+import { ICON_DENSE, ICON_STANDALONE, ICON_STROKE } from '../panelIcons'
 
 // ChatTopBar is removed (Tranche 1 item 30); GenerateState now lives here.
 export type GenerateState = 'disabled' | 'active' | 'loading'
@@ -318,7 +319,7 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
             }}
             data-testid="composer-attach-button"
           >
-            <Paperclip className="w-4 h-4" strokeWidth={1.8} aria-hidden="true" />
+            <Paperclip className="w-4 h-4" strokeWidth={ICON_STROKE} aria-hidden="true" />
           </button>
           <button
             type="button"
@@ -334,7 +335,7 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
             }}
             data-testid="composer-voice-button"
           >
-            <Mic className="w-4 h-4" strokeWidth={1.8} aria-hidden="true" />
+            <Mic className="w-4 h-4" strokeWidth={ICON_STROKE} aria-hidden="true" />
           </button>
           {showRunAnalysis && (
             <button
@@ -358,7 +359,7 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
               }}
               data-testid="run-analysis-chip"
             >
-              <Play className="w-4 h-4" strokeWidth={1.8} aria-hidden="true" />
+              <Play className="w-4 h-4" strokeWidth={ICON_STROKE} aria-hidden="true" />
             </button>
           )}
 
@@ -411,8 +412,8 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
               data-testid="stop-button"
             >
               <Square
-                className="w-[14px] h-[14px]"
-                strokeWidth={2.2}
+                size={ICON_STANDALONE}
+                strokeWidth={ICON_STROKE}
                 fill="var(--text-body, #2A2A2A)"
                 style={{ stroke: 'var(--text-body, #2A2A2A)' }}
                 aria-hidden="true"
@@ -439,8 +440,8 @@ export const ChatComposer = memo(forwardRef<ChatComposerHandle, ChatComposerProp
               data-testid="send-button"
             >
               <ArrowUp
-                className="w-[15px] h-[15px]"
-                strokeWidth={2.2}
+                size={ICON_STANDALONE}
+                strokeWidth={ICON_STROKE}
                 style={{ stroke: composer.canSend ? 'var(--text-on-color, #FFFFFF)' : 'var(--text-light, #6E6B6B)' }}
                 aria-hidden="true"
               />
@@ -516,7 +517,8 @@ function InlineGenerateButton({ state, onClick }: { state: GenerateState; onClic
         />
       ) : (
         <Play
-          className="w-[11px] h-[11px] flex-shrink-0"
+          size={ICON_DENSE}
+            className="flex-shrink-0"
           strokeWidth={2}
           style={{ stroke: isActive ? 'var(--text-on-color, #FFFFFF)' : 'var(--text-light, #6E6B6B)' }}
           aria-hidden="true"

--- a/src/canvas/conversation/zones/CoachingTip.tsx
+++ b/src/canvas/conversation/zones/CoachingTip.tsx
@@ -34,7 +34,7 @@ export function CoachingTip({ tip, onDismiss }: CoachingTipProps) {
         aria-label="Dismiss tip"
         className="flex-shrink-0 flex items-center bg-transparent border-none p-0.5 text-text-light hover:text-text-body transition-colors duration-100 cursor-pointer"
       >
-        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" aria-hidden="true">
           <line x1="18" y1="6" x2="6" y2="18" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
           <line x1="6" y1="6" x2="18" y2="18" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" />
         </svg>

--- a/src/canvas/conversation/zones/ComposerTools.tsx
+++ b/src/canvas/conversation/zones/ComposerTools.tsx
@@ -17,6 +17,7 @@ import { NodeShape } from '../primitives/NodeShape'
 import type { NodeType } from '../../domain/nodes'
 import { typography } from '../../../styles/typography'
 import { FlipDropdown } from '../../../components/ui/FlipDropdown'
+import { ICON_STROKE } from '../panelIcons'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Shared types and copy (formerly in GuideDropdown / ThinkingModeDropdown)
@@ -124,7 +125,7 @@ export function ComposerTools({
         }}
         data-testid="composer-tools-trigger"
       >
-        <Settings className="w-4 h-4" strokeWidth={1.8} aria-hidden="true" />
+        <Settings className="w-4 h-4" strokeWidth={ICON_STROKE} aria-hidden="true" />
       </button>
 
       <FlipDropdown

--- a/src/canvas/conversation/zones/MessageActions.tsx
+++ b/src/canvas/conversation/zones/MessageActions.tsx
@@ -35,6 +35,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Copy, RefreshCw } from 'lucide-react'
+import { ICON_STROKE } from '../panelIcons'
 
 /** 44px touch target (DS v5 §8.11) — unchanged; the fix is where it sits, not its size. */
 export const ACTION_BAR_HEIGHT_PX = 44
@@ -159,7 +160,7 @@ function ActionButton({
         "
         aria-hidden="true"
       >
-        <Icon className="w-3 h-3" strokeWidth={1.8} />
+        <Icon className="w-3 h-3" strokeWidth={ICON_STROKE} />
       </span>
     </button>
   )

--- a/tests/ci-guards/panel-icon-scale.spec.ts
+++ b/tests/ci-guards/panel-icon-scale.spec.ts
@@ -1,0 +1,110 @@
+// tests/ci-guards/panel-icon-scale.spec.ts
+//
+// The AI panel's icons use three sizes and one stroke weight.
+//
+// ── WHY ──────────────────────────────────────────────────────────────────────
+// Seven sizes shipped, written five ways — `size={12}`, `w-3 h-3`, `w-3.5 h-3.5`,
+// `w-[18px] h-[18px]`, raw `width="16" height="16"` — so the same 14px icon was
+// `size={14}` in one file and `w-3.5 h-3.5` in the next. Five stroke weights
+// shipped against a design system that specifies one.
+//
+// ⚠ THE SCANNER IS THE POINT, AND IT IS WHERE THE EARLIER COUNTS WENT WRONG.
+// Three separate blind spots produced three different wrong answers before this:
+//   · `w-[0-9]+ h-[0-9]+` never matched `w-3.5 h-3.5` — eleven 14px icons invisible.
+//   · counting `w-5/6/8/10` as icons inflated the total to 13; those sit on
+//     container `div`s, not glyphs.
+//   · only two of the five spellings were checked at all.
+// So this guard resolves a size ONLY on an element that is an `<svg>` or a
+// component this file imports from `lucide-react`, and it reads all five
+// spellings. `it('the scanner sees every spelling')` pins that, because a scanner
+// that silently stops seeing one spelling reports a clean panel.
+import { describe, it, expect } from 'vitest'
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { resolve, join } from 'node:path'
+import { ICON_SIZES, ICON_STROKE } from '../../src/canvas/conversation/panelIcons'
+
+const root = resolve(__dirname, '../..')
+const SURFACE = [
+  'src/canvas/conversation',
+  'src/v5/blocks',
+  'src/canvas/components/FloatingOlumiPanel.tsx',
+  'src/canvas/components/OlumiTabBody.tsx',
+]
+
+function walk(rel: string): string[] {
+  const abs = resolve(root, rel)
+  if (statSync(abs).isFile()) return abs.endsWith('.tsx') ? [rel] : []
+  return readdirSync(abs).flatMap((e) =>
+    e === '__tests__' || e === '__fixtures__' ? [] : walk(join(rel, e)),
+  )
+}
+const FILES = SURFACE.flatMap(walk).filter((f) => !/\.(spec|test)\.tsx$/.test(f))
+
+type Hit = { file: string; tag: string; px: number | null; stroke: number | null; spelling: string }
+
+/** Every icon-element occurrence, with its size resolved from any spelling. */
+function iconHits(): Hit[] {
+  const hits: Hit[] = []
+  for (const rel of FILES) {
+    const src = readFileSync(resolve(root, rel), 'utf8')
+    const lucide = new Set<string>(['Icon'])
+    for (const m of src.matchAll(/import\s*\{([^}]+)\}\s*from\s*['"]lucide-react['"]/g))
+      for (const n of m[1].split(','))
+        lucide.add(n.trim().split(/\s+as\s+/).pop()!.trim())
+
+    for (const m of src.matchAll(/<([A-Za-z][A-Za-z0-9]*)\b([^>]*?)\/?>/gs)) {
+      const [, tag, attrs] = m
+      if (tag !== 'svg' && !lucide.has(tag)) continue
+      let px: number | null = null
+      let spelling = 'none'
+      let a: RegExpExecArray | null
+      if ((a = /\bsize=\{(\d+(?:\.\d+)?)\}/.exec(attrs))) { px = +a[1]; spelling = 'sizeProp' }
+      else if ((a = /\bw-(\d+(?:\.\d+)?) h-\1\b/.exec(attrs))) { px = +a[1] * 4; spelling = 'tailwind' }
+      else if ((a = /\bw-\[(\d+)px\] h-\[\1px\]/.exec(attrs))) { px = +a[1]; spelling = 'arbitrary' }
+      else if ((a = /\bwidth="(\d+)"[\s\S]*?height="\1"/.exec(attrs))) { px = +a[1]; spelling = 'svgAttr' }
+      const sw = /\bstrokeWidth=[{"]([\d.]+)[}"]/.exec(attrs)
+      hits.push({ file: rel, tag, px, stroke: sw ? +sw[1] : null, spelling })
+    }
+  }
+  return hits
+}
+
+describe('AI panel icon scale', () => {
+  it('PRECONDITION — the surface is walkable and full of icons', () => {
+    expect(FILES.length, 'no .tsx found in the panel surface').toBeGreaterThan(40)
+    expect(iconHits().filter((h) => h.px !== null).length, 'no sized icons found — scanner blind').toBeGreaterThan(50)
+  })
+
+  it('the scanner sees every spelling — a blind mechanism reports a clean panel', () => {
+    // Each of these produced a wrong count when it was missing. If a spelling
+    // legitimately drops to zero, delete its line here DELIBERATELY; do not let
+    // the scanner quietly stop looking for it.
+    const spellings = new Set(iconHits().filter((h) => h.px !== null).map((h) => h.spelling))
+    expect([...spellings].sort()).toEqual(['sizeProp', 'svgAttr', 'tailwind'])
+  })
+
+  it('every icon is 12, 14 or 16px', () => {
+    const offenders = iconHits()
+      .filter((h) => h.px !== null && !(ICON_SIZES as readonly number[]).includes(h.px))
+      .map((h) => `${h.file} <${h.tag}> ${h.px}px`)
+    expect(offenders, 'icon sizes outside the scale — see panelIcons.ts').toEqual([])
+  })
+
+  it('every stroke weight is the DS value', () => {
+    const offenders = iconHits()
+      .filter((h) => h.stroke !== null && h.stroke !== ICON_STROKE)
+      .map((h) => `${h.file} <${h.tag}> strokeWidth=${h.stroke}`)
+    expect(offenders, `DS v5 §17 specifies ${ICON_STROKE}px`).toEqual([])
+  })
+
+  it('pins the hand-drawn <svg> glyphs — a DECLARED debt that may shrink, never grow', () => {
+    // DS v5 §17: Lucide only. These are hand-built glyphs (thumbs, two different
+    // X marks, an arrow). Replacing them changes what the glyph LOOKS like, so it
+    // needs its own visual review — but a NEW one must not slip in meanwhile.
+    const raw = FILES.reduce(
+      (n, f) => n + (readFileSync(resolve(root, f), 'utf8').match(/<svg\b/g)?.length ?? 0),
+      0,
+    )
+    expect(raw, 'a new hand-drawn <svg> appeared — use Lucide (DS v5 §17)').toBeLessThanOrEqual(8)
+  })
+})


### PR DESCRIPTION
## ⚠ The design system changed the answer, and I had recommended the wrong one

I proposed a **two-size** scale (12 dense / 16 standalone) before reading DS v5 properly. **The DS uses 14px, specifically and twice** — §8.3 gives inline validation icons (`AlertTriangle`, `Check`) as 14px, and §17 gives the notice anatomy a 16px leading icon. Collapsing 14 into 12 or 16 would have made the panel **violate the design system in order to tidy it**.

The scale is **12 / 14 / 16** — the three the DS and the code already agree on, carrying 71 of 80 icons.

## What was there

On elements that are *actually* icons (an `<svg>`, or a component imported from `lucide-react` — container `div`s excluded):

`10px×2 · 11px×5 · 12px×33 · 14px×16 · 15px×1 · 16px×22 · 18px×1`

Written **five ways**: `size={12}` · `w-3 h-3` · `w-3.5 h-3.5` · `w-[18px] h-[18px]` · raw `width="16" height="16"`. So the same 14px icon was `size={14}` in one file and `w-3.5 h-3.5` in the next.

**After: `12px×36 · 14px×15 · 16px×22`.**

## Stroke weight is not a taste call

DS v5 §17: *"Lucide (`lucide-react@0.263.1`)… 24px grid, **2px stroke weight**."*

The panel shipped **five** weights — 1, 1.5, 1.8, 2, 2.2 — and the commonest (**1.8**, ten uses) is not the specified one. `Play` rendered at **1.8 in one place and 2 in another**: one glyph, two weights, one panel.

## ⭐ Three scanner blind spots produced three different wrong counts before this

| Blind spot | Wrong answer it gave |
|---|---|
| `w-[0-9]+ h-[0-9]+` never matched `w-3.5 h-3.5` | eleven 14px icons invisible |
| counting `w-5/6/8/10` as icons | inflated the total to **13** — those are containers |
| only two of five spellings checked | the count I first reported |

The guard now pins against all three. **`it('the scanner sees every spelling')` fails if a mechanism stops being read** — because a scanner that quietly stops looking reports a clean panel.

## Not fixed here, deliberately

**Eight hand-drawn `<svg>` glyphs** where DS §17 says Lucide only — thumbs up/down in `FeedbackRow`, two *different* hand-built `X` marks, an arrow in `EmptyState`. Replacing them changes what the glyph **looks like**, not just its size, so it needs its own visual review. **Pinned at `<= 8`** so a new one cannot slip in meanwhile.

## Evidence

- **RED-first at pristine**, naming 9 size and 10 stroke offenders by file and element.
- **Four discriminating mutants**, each biting its intended assertion: an 11px icon → size test REDs · a 1.8 stroke → stroke test REDs · a new `<svg>` → debt pin REDs · **blinding the scanner to the tailwind spelling → both the precondition and the anti-blindness test RED**.
- Controls green both ends, clean tree after, isolation proven by writing a sentinel.
- Affected suites **221/221 files, 3039 passed, 0 transform errors**.
- `eslint` exit 0; its 11 warnings are pre-existing hook-dependency notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)