### PR TITLE
fix(domain): the prior note stops citing an authority table that no longer exists

### DIFF
--- a/src/canvas/domain/analyticalNodeFields.ts
+++ b/src/canvas/domain/analyticalNodeFields.ts
@@ -148,14 +148,20 @@ export const NODE_FIELD_REGISTRY: readonly AnalyticalFieldSpec[] = [
     //  · It called the field "user-editable in isolation on the live path ...
     //    routed live via InspectorRouter". That is now false: `InspectorRouter`
     //    wraps every panel in an unconditional `<fieldset disabled>`
-    //    (InspectorRouter.tsx:334-340) and this file's neighbour states the
-    //    authority directly — `NODE_SETTER_AUTHORITY.setPriorRange: 'disabled'`
-    //    (useInspectorMutations.ts:127).
+    //    (InspectorRouter.tsx:334-340), and that fieldset is the whole
+    //    enforcement.
+    //    ⚠ A second clause here cited `NODE_SETTER_AUTHORITY.setPriorRange:
+    //    'disabled'` (useInspectorMutations.ts:127) as a corroborating
+    //    authority. That manifest was DELETED on 26 Aug 2026 (PR #886) as an
+    //    unenforced mirror with ZERO CODE CONSUMERS — it RECORDED the verdict,
+    //    it never MADE it. The claim above is unchanged and was never resting
+    //    on it; only the citation is gone, and the line number it carried now
+    //    points at unrelated code.
     // `purposes: ['stale']` was and remains CORRECT and load-bearing: it is what
     // routes a prior change into hasAnalyticalNodeChange → the freshness verdict
     // behind "Model changed since this analysis". Nothing about the purposes
     // changes here; only the prose describing where the field goes.
-    note: "A factor's prior belief range {distribution, range_min, range_max} — analysis-affecting: it rides the V2 adapter's blocklist passthrough to PLoT (prior is deliberately NOT in V2_NODE_BLOCKLIST) and is declared on CEE's graph contract (schemas/cee-v3.ts) as the input ISL samples for external factors. NOT read by the V1 mapper, which takes `prior` only in its legacy NUMBER form. NOT user-editable today: the External-factor inspector mounts setPriorRange but InspectorRouter's unconditional disabled fieldset makes it inert, and NODE_SETTER_AUTHORITY.setPriorRange is 'disabled'. Consumers: staleness (hasAnalyticalNodeChange), V2 adapter. Persisted by hash-by-default.",
+    note: "A factor's prior belief range {distribution, range_min, range_max} — analysis-affecting: it rides the V2 adapter's blocklist passthrough to PLoT (prior is deliberately NOT in V2_NODE_BLOCKLIST) and is declared on CEE's graph contract (schemas/cee-v3.ts) as the input ISL samples for external factors. NOT read by the V1 mapper, which takes `prior` only in its legacy NUMBER form. NOT user-editable today: the External-factor inspector mounts setPriorRange but InspectorRouter's unconditional disabled fieldset makes it inert. Consumers: staleness (hasAnalyticalNodeChange), V2 adapter. Persisted by hash-by-default.",
   },
   {
     field: 'kind',


### PR DESCRIPTION
## The follow-up #886 named at its own deletion site

`useInspectorMutations.ts` records this outstanding item in the comment that replaced the deleted tables:

> *"`canvas/domain/analyticalNodeFields.ts:158` names `NODE_SETTER_AUTHORITY.setPriorRange` inside a **RUNTIME STRING LITERAL** … **a string that ships is prose the PRODUCT carries, not prose the repo carries** — this deletion converts that literal from true to false, and repairing it is a separate owned follow-up, deliberately not done here because you cannot write "the table was deleted" before it is."*

It is. This is that repair.

## Why it is not cosmetic

`NODE_FIELD_REGISTRY`'s `note:` fields are **runtime string literals**, and this file is imported by `useAutosave`, `graphChangeDiff`, `analyticalChange` and `useGraphEditEvents` — so the sentence reaches browsers. It named a symbol that **existed this morning and does not exist now**. TypeScript cannot see inside a string, so nothing would ever have gone red about it.

## What changed — two edits, both prose, zero behaviour

**1. The runtime string.** *"…makes it inert, and `NODE_SETTER_AUTHORITY.setPriorRange` is `'disabled'`."* → *"…makes it inert."*

⭐ **The claim is unchanged and never rested on the table.** `InspectorRouter`'s unconditional `<fieldset disabled>` is the whole enforcement and always was — the deleted manifest **recorded** the verdict, it never **made** it. Only the dead citation is gone.

**2. The `//` block above it** keeps the correction and its reason, and records *why* the citation went, rather than tidying the evidence away — the same disposal #886 used for the equivalent sites in `FactorExternalPanel.tsx` and `AnalysisHeroPanel.tsx`.

## Verification

Both anchors asserted **unique** before replacing (`count == 1` each; a naive `replace` that silently matched zero or two would otherwise be indistinguishable from a successful one). File sha256 confirmed changed.

```
live citation "NODE_SETTER_AUTHORITY.setPriorRange is"   0   ← the defect, gone
total NODE_SETTER_AUTHORITY mentions                     1   ← the correction record, kept
CONTROL "InspectorRouter"                                3   ← probe demonstrably sees
```

⚠ **An instrument note on myself, because it nearly cost me the premise.** My first control grepped `NODE_SETTER_FIELDS\|NODE_SETTER_AUTHORITY` **together** and returned 4 — which I could not interpret, because the two symbols have different fates: `NODE_SETTER_AUTHORITY` **was** deleted, `NODE_SETTER_FIELDS` **remains** and is a different thing. **Two questions under one name, in a probe written to check exactly that class of error.** Disambiguated before proceeding; the 4 is 2 live `FIELDS` references plus 2 comment mentions of the deleted table.

## Rowed, not built

A derived guard asserting the deleted symbols appear in **zero runtime string literals** across `src/` belongs in `inspectorAuthorityBinding.spec.tsx` — the spec #886 created for this concern. Deliberately not added here: attaching a cross-cutting source scanner to another lane's new 546-line spec inside my own one-file follow-up is scope creep, and this PR should merge fast. **The gap is real** — nothing type-checks a symbol name inside a string — so it is rowed rather than ignored.
