### PR TITLE
chore(dead-authority): delete ROBUSTNESS_LEVEL_COLOURS and SWITCH_PROBABILITY_THRESHOLD

### DIFF
--- a/src/components/results/constants.ts
+++ b/src/components/results/constants.ts
@@ -29,14 +29,6 @@ export const ROBUSTNESS_LEVEL_LABELS = {
   very_low: ROBUSTNESS_BADGE_LABELS.very_low,
 } as const
 
-/** Robustness level colors for badges */
-export const ROBUSTNESS_LEVEL_COLOURS = {
-  high: 'green',
-  medium: 'amber',
-  moderate: 'amber',
-  low: 'orange',
-  very_low: 'red',
-} as const
 
 // =============================================================================
 // Threshold Constants
@@ -50,10 +42,16 @@ export const ROBUSTNESS_LEVEL_COLOURS = {
 // insensitive, all file types. Contrast control in the same sweep:
 // `ROBUSTNESS_LEVEL_LABELS` returned 11 consumers, so the probe discriminates.
 //
-// ⚠ NOTE FOR WHOEVER PRUNES THIS FILE NEXT: `ROBUSTNESS_LEVEL_COLOURS` and
-// `SWITCH_PROBABILITY_THRESHOLD` also read ZERO consumers, but they were already
-// dead BEFORE this PR — they are not residue from this deletion and are
-// deliberately left alone here rather than absorbed into an unrelated train.
+// ⛔ ALSO REMOVED (delete-first batch 2): `ROBUSTNESS_LEVEL_COLOURS` and
+// `SWITCH_PROBABILITY_THRESHOLD`. #894 measured both as dead and deliberately left
+// them rather than absorb pre-existing drift into its evidence; this is that follow-up.
+//
+// ⚠ `SWITCH_PROBABILITY_THRESHOLD` was a DIVERGENT mirror, not a duplicate. Its comment
+// claimed "only edges with switch_probability > this value are shown" and it held 0.3,
+// while the value that actually decides is `THRESHOLDS.FRAGILE_EDGE_FILTER = 0.15`
+// (src/lib/mappers/constants.ts:23, Spec 6.3 / UI-SEM-013) — the two disagreed by 2x.
+// Wiring the local one up to "remove a duplicate" would have doubled the filter and
+// silently hidden half the fragile edges. If you need this threshold, import THRESHOLDS.
 
 /**
  * Epsilon for baseline delta display.
@@ -61,11 +59,6 @@ export const ROBUSTNESS_LEVEL_COLOURS = {
  */
 export const BASELINE_DELTA_EPSILON = 0.05
 
-/**
- * Switch probability threshold for filtering fragile edges.
- * Only edges with switch_probability > this value are shown.
- */
-export const SWITCH_PROBABILITY_THRESHOLD = 0.3
 
 // =============================================================================
 // Robustness Level Helpers


### PR DESCRIPTION
The two constants **#894 measured as dead and deliberately left alone** rather than absorb pre-existing drift into an unrelated train. This is that follow-up, with its own evidence rather than inherited evidence.

## Heads

| | SHA |
|---|---|
| Source tip swept + branch base (`staging`) | `842f5267bfcd356cfed1326977a4be3932c231dc` |
| **Deployed** (`staging--olumi.netlify.app/version.json`) | `842f5267…` — **identical**, so source and served artefact were the same thing during this measurement |
| This branch head | `94c239ccca46056463fe43bab6c2ab2705183ccf` |

## ⭐ Age gate — new, and it is the one that matters in this directory

A zero-importer module is only a corpse if it is also **old**. A module with no importers *yet* is a module being built, and this directory has incoming work (ROADMAP 2.1326).

```
git log -S'<SYMBOL>' --date=short -- src/components/results/constants.ts
```
| Symbol | Introduced | Touched since |
|---|---|---|
| `ROBUSTNESS_LEVEL_COLOURS` | **2026-01-27** (`713a2828`) | only `842f5267` (#894 adding the note) |
| `SWITCH_PROBABILITY_THRESHOLD` | **2026-01-27** (`713a2828`) | only `842f5267` (#894 adding the note) |

Seven months old, untouched but for a comment. Both pass.

**Separately checked and avoided**: `git log --diff-filter=A --since='3 days ago' -- src/components/results/utils/` returns **empty** — the incoming module has not landed. These two live in the **parent** directory (`results/constants.ts`), not `results/utils/`, and no open PR touches either path.

## Six-way revalidation, each with a contrast control in the same invocation

| # | Gate | `ROBUSTNESS_LEVEL_COLOURS` | `SWITCH_PROBABILITY_THRESHOLD` | Contrast control |
|---|---|---|---|---|
| 1 | Static imports | **0** consumers (2 raw hits: own definition + #894's note) | **0** consumers (2 raw hits: own definition + #894's note) | `ROBUSTNESS_LEVEL_LABELS` → **14 lines** |
| 2 | Dynamic imports | `import\([^)]*results/constants` → **0** | same | **722** `import(` in tree |
| 3 | String / template | whole-tree `-a` sweep incl. non-TS; case-insensitive → still **2** | → still **2** | as row 1 |
| 4 | Route registration | module has real importers, but only for **other** symbols — see below | same | — |
| 5 | Flag posture | **0** flag refs in the file | same | `isEnabled(` → **33** |
| 6 | Open PR dependencies | **0 of 18** open PRs touch `results/constants.ts` **or** `results/utils/` | same | scan enumerated every open PR via `gh pr diff --name-only` |

**Gate 4, stated precisely because my first measurement of it was wrong.** A loose grep for `from './constants'` returned "46 importers" — it was matching unrelated `constants` modules elsewhere in the tree. The precise sweep (`from '[^']*results/constants'`, plus relative imports from within `results/`) returns **exactly two** consumers of this module:
- `RecommendedNextSteps.tsx:23` → `isStableRobustnessLevel`
- `robustnessBadgeRegister.2928.spec.ts:50` → `ROBUSTNESS_LEVEL_LABELS`

Neither imports a deleted symbol. The file stays; two members leave.

## ⭐ Bundle-presence — a discriminating pair, not a bare zero

`ROBUSTNESS_LEVEL_COLOURS` sits **directly adjacent** to `ROBUSTNESS_LEVEL_LABELS` in the same file **with an identical key set**, one live and one dead. That makes a proper discrimination available rather than an unsupported absence. Crawled the deployed bundle at `842f5267`: **81 chunks / 5,998,141 bytes**.

| Literal | chunks | occ | |
|---|---|---|---|
| `very_low:"red"` | **0** | 0 | target pair |
| `moderate:"amber"` | **0** | 0 | target pair |
| `high:"green"` | **0** | 0 | target pair |
| `low:"orange"` | **0** | 0 | target pair |
| **`very_low:`** | **1** | **2** | ⭐ **the shared key — NON-ZERO** |
| `Highly sensitive` | 1 | 1 | live sibling's payload |
| `Robust` / `Sensitive` | 5 / 5 | 40 / 25 | live sibling's payload |

The probe **demonstrably sees this exact object shape** in the bundle (the shared key is present via the live sibling) and the target's value pairs are absent. That is a measured absence, not a blind one.

`SWITCH_PROBABILITY_THRESHOLD` reads 0 by name, as any minified module-level const would; its evidence rests on the import-graph read above, not on that zero. (`switch_probability` reads 50 occurrences — that is the **wire field**, a different thing, and is not evidence about the constant.)

## What each claimed to do vs what actually enforces it

**`SWITCH_PROBABILITY_THRESHOLD` was a DIVERGENT mirror, not a duplicate — this is the finding worth keeping.** Its comment claimed *"Only edges with switch_probability > this value are shown"* and it held **`0.3`**. The value that actually decides is **`THRESHOLDS.FRAGILE_EDGE_FILTER = 0.15`** (`src/lib/mappers/constants.ts:23`, *Spec Section 6.3 / UI-SEM-013*), enforced at `fragileEdgeMatch.ts:53,77,132` and `edgeIdentity.ts:46`.

The two disagreed **by 2×**, in the direction that hides data. Anyone tidying this file who noticed "two thresholds for the same thing" and wired the local one up would have **doubled the filter and silently hidden half the fragile edges** — and no test would have caught it, because nothing reads the dead one. The replacement comment in the file records this, so the next person does not re-add it.

**`ROBUSTNESS_LEVEL_COLOURS`** was a badge-colour map with no badge reading it. Its live neighbour `ROBUSTNESS_LEVEL_LABELS` is derived from the canonical register in `lib/stability.ts` (ROADMAP 2.928 (d)); the colour map was never brought into that register, which is why it drifted out of use unnoticed.

⚠ **Tailwind JIT risk checked, not assumed.** `tailwind.config.js` scans `./src/**/*.{js,ts,jsx,tsx}` for class strings, so deleting a colour map *could* remove generated CSS that another component builds dynamically. Measured: the values are bare colour words (`'green'`, `'amber'`, `'orange'`, `'red'`), **not** utility class names — Tailwind generates nothing from them. No CSS is affected.

## Proof the deletion is inert

- **Named gate `pnpm run typecheck` PASSED.** Coverage 3736/3776; ratchet **2250 against a baseline of 2250**.
- **No baseline regeneration, and that is deliberate.** These constants carried no diagnostics, so there was no shrink to bank — unlike #893, this PR touches **nothing** in `scripts/ci/`. A regeneration here would only have created a window to absorb unrelated drift.
- **Targeted suites** (`VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` exported): **2 files collected, 2 passed, 22 tests passed, 0 failed** — `robustnessBadgeRegister.2928.spec.ts` and `RecommendedNextSteps.spec.tsx`, each asserted collected non-zero **by name**. These are the two consumers of the module, so this is the whole dependent surface, not a sample.

## Scope limits

- **Noticed, not actioned**: `BASELINE_DELTA_EPSILON` exists twice — `results/constants.ts:62` and `lib/mappers/constants.ts:26`, both `0.05`. They **agree**, so it is a benign duplicate rather than a divergent one, and it is outside this batch. Flagging it rather than absorbing it, for the same reason #894 left mine.
- Sweeps covered the whole working tree (`e2e/`, `tests/`, `scripts/`, `docs/`, `netlify/`, `public/`, `supabase/`), not only `src/`. They did not reach other repos; gate 6 used the GitHub API because a filesystem sweep cannot see an unmerged branch.
