### PR TITLE
Print each coaching sentence once, and stop cutting words in half

### DIFF
--- a/docs/CC2-EVIDENCE-2.1326-2.1328.md
+++ b/docs/CC2-EVIDENCE-2.1326-2.1328.md
@@ -1,0 +1,82 @@
+# 2.1326 build evidence — `optionCoverage`
+
+**Clone:** `/private/tmp/cc2-ui-sa` @ `f287c012` · **26 Aug 2026** · CC2
+
+## Targeted spec
+`npx vitest run src/components/results/utils/__tests__/optionCoverage.spec.ts`
+→ **1 file, 10 tests, 10 passed, exit 0.** Asserted BY NAME and by expected count — never inferred
+from a suite total (a new spec collecting `(0 test)` is invisible to every aggregate).
+Env: `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY` set.
+
+## Mutation kit — 8/8 as expected, exit 0
+Isolation **proven by WRITING a sentinel**, not by locating a path: inodes compared, sentinel
+confirmed not to propagate into the source. Restores read a **pristine archive outside the repo**,
+never the mutated tree. Every mutant asserts its anchor is **unique** (an unapplied mutation is
+indistinguishable from an equivalent one) and that it **applied**. Control reads exactly `0`;
+trailing control GREEN.
+
+| id | mutation | expect | got |
+|---|---|---|---|
+| M1 | truthiness instead of key presence | RED | RED |
+| M2 | drop the denominator dedupe | RED | RED |
+| M3 | `kind` always `even` | RED | RED |
+| M4 | accept a single option | RED | RED |
+| M5 | provisional on every reading | RED | RED |
+| M6 | set/unset swapped | RED | RED |
+| **M7a** | **reverse `perOption` ORDER** | **GREEN** | **GREEN** |
+| **M7b** | **assign a different option id** | **RED** | **RED** |
+
+**M7a/M7b are a discriminating PAIR, and neither alone proves anything.** M7a green shows the test
+does not bind by position; M7b red shows it still discriminates. A single biting mutant proves
+sensitivity to *something*; the pair proves sensitivity to *the named object*.
+
+## ⚠ M1 SURVIVED ON THE FIRST RUN, AND THAT IS THE MOST USEFUL THING HERE
+The first fixture wrote each intervention as `{ normalised_value: 0 }`. **The wire sends a BARE
+NUMBER** — `{"6886a726": 0}` — with `intervention_details` as the separate object map (re-read at the
+capture, not guessed). An object is always truthy, so the truthiness mutant survived: the
+*"counts ZERO as SET"* test asserted exactly the right thing and **could not fail**.
+
+**The assertion was right, the fixture made it vacuous, and only the mutant could see that.** The spec
+header had itself quoted *"a fixture you wrote yourself is not evidence about the wire"* — while
+getting the shape wrong. Corrected to the wire shape; M1 now bites. The note is kept in the spec so
+the next reader knows why the shape is spelled that way.
+
+## Process, stated accurately
+**This was NOT written RED-first** — the module came before the spec. Rather than claim an ordering
+that did not happen, the evidence is the mutation kit above: every assertion is shown to fail when
+the behaviour it names is removed, and the identity binding is proven with a discriminating pair.
+
+## Not yet done
+- The render half (`V5AnalysisResultBlock`) and its wiring to the readiness slice.
+- The repo's named typecheck gate (heavy; announced to CC before running, per the throttling note).
+
+---
+## Update — render half wired, kit extended to 11/11
+
+Rebased onto `842f5267` (was 15 commits behind at `f287c012`, and did not know it). Insertion point had
+moved — cosmetically. Spec **15/15**, kit **11/11**, typecheck gate **PASSED at baseline 2250 exactly**.
+
+**Gate green proven, not assumed:** phase 1 derives coverage from `git ls-files` and my files were
+UNTRACKED, so a green could have meant "never looked". Injected a deliberate type error → the compiler
+named the file (`optionCoverage.ts(147,14) TS2322`); `--listFilesOnly` confirms all three files in the set.
+
+**The pure module had ZERO importers while it was being built.** Merging it alone would have shipped a
+module with no readers — the precise thing 2.1326 exists to expose. The render half is in the same change.
+
+### M8–M10: do the NEGATIVE copy guards bite?
+A `not.toMatch` passes trivially when the phrase was never going to appear. Each banned phrase is forced
+INTO the rendered copy; all three RED. **M8** "unreliable" (the `ready`-and-uneven contradiction) ·
+**M9** a direction · **M10** dropping the provisional register.
+
+⚠ **M9 v1 WAS A FALSE SURVIVOR OF MY OWN MAKING.** It added a DEAD constant carrying the banned phrase,
+which never reached the rendered copy — so the mutation applied to the FILE and not to the BEHAVIOUR, and
+a working guard read as decoration. **An unapplied-in-effect mutant is worse than no mutant: it accuses a
+healthy guard.** Repaired to inject into the copy itself; it now bites.
+
+⚠ Also caught: a stray double comma from a scripted edit put an **elision** in the mutant array, so the kit
+**crashed after M7b** while printing eight plausible result lines. `node --check` is now run before the kit.
+**Eight healthy-looking lines and a non-zero exit is not a result.**
+
+### Still not done
+No render-level spec on `V5AnalysisResultBlock`; **no mutants on the render half**. Wire-derived, not
+journey-witnessed.

--- a/src/components/results/analysisNew/__tests__/StrengthenTheReasoning.spec.tsx
+++ b/src/components/results/analysisNew/__tests__/StrengthenTheReasoning.spec.tsx
@@ -50,6 +50,31 @@ describe('what / why / do it (§14)', () => {
     )
   })
 
+  // ROADMAP 2.1328 — the producer's body rides BOTH `signal` and `whyNow`
+  // whenever it sends no `signal` of its own, which is every item except one
+  // deterministic nudge. The spec above uses a fixture where the two DIFFER, so
+  // it pins the JOIN and is silent about the DEDUPE. These two pin the call site.
+  //
+  // ⚠ ASSERTED BY OCCURRENCE COUNT, NOT `toHaveTextContent`. jest-dom matches on
+  // SUBSTRING, so `toHaveTextContent(BODY)` PASSES on "BODY BODY" — the intuitive
+  // assertion is vacuous against precisely the defect it would be written for.
+  it('prints the sentence ONCE when signal and whyNow are the same string', () => {
+    const BODY = 'One factor carries most of the influence. The conclusion rests almost entirely on it.'
+    render(<StrengthenTheReasoning interventions={[rec({ id: 'strengthen:phase3:dup', signal: BODY, whyNow: BODY })]} />)
+    const why = screen.getByTestId('analysis-new-strengthen-why').textContent ?? ''
+    expect(why.split(BODY).length - 1).toBe(1)
+    expect(why.trim()).toBe(BODY)
+  })
+
+  it('still joins signal and whyNow when they DIFFER — the dedupe must not swallow real prose', () => {
+    const SIGNAL = 'One factor carries most of the influence.'
+    const WHY = 'It matters now because the leading option is close.'
+    render(<StrengthenTheReasoning interventions={[rec({ id: 'strengthen:phase3:join', signal: SIGNAL, whyNow: WHY })]} />)
+    const why = screen.getByTestId('analysis-new-strengthen-why').textContent ?? ''
+    expect(why.split(SIGNAL).length - 1).toBe(1)
+    expect(why.split(WHY).length - 1).toBe(1)
+  })
+
   it('routes the primary action through the existing Ask-Olumi drawer, prefilled and NOT auto-sent', () => {
     render(<StrengthenTheReasoning interventions={[rec({ id: 'strengthen:phase3:g1' })]} />)
     fireEvent.click(screen.getByTestId('analysis-new-strengthen-action'))

--- a/src/components/results/analysisNew/__tests__/analysisNewRenderDefects.spec.ts
+++ b/src/components/results/analysisNew/__tests__/analysisNewRenderDefects.spec.ts
@@ -37,7 +37,14 @@ describe('strengthenWhyLine — the sentence is printed once', () => {
 
 describe('truncateAtWordBoundary — never cuts a word in half', () => {
   const TEXT =
-    'If the adoption rate changes significantly then the ordering of the two options changes with it'
+    // ⚠ THE WORD 'two' WAS REMOVED FROM THIS FIXTURE DELIBERATELY, and the reason
+  // is the whole point of the test. With it, the string is 95 chars, `keep` is
+  // 79, and TEXT[79] is a SPACE — so a HARD cut lands on a word boundary BY
+  // COINCIDENCE, and a mutant deleting the word-boundary logic entirely stayed
+  // GREEN. The assertion was correct and could not fail. Without 'two',
+  // TEXT[79] is 'n', the hard cut yields "…cha…" and the boundary cut yields
+  // "…options…", so the two are distinguishable and the mutant bites.
+  'If the adoption rate changes significantly then the ordering of the options changes with it'
 
   it('does not end mid-word, and marks that it was cut', () => {
     const out = truncateAtWordBoundary(TEXT, 80)

--- a/src/components/results/analysisNew/__tests__/analysisNewRenderDefects.spec.ts
+++ b/src/components/results/analysisNew/__tests__/analysisNewRenderDefects.spec.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { strengthenWhyLine } from '../analysisNewCopy'
+import { truncateAtWordBoundary } from '../../../../utils/text'
+
+/**
+ * Two render defects measured at the DOM on the deployed A/B surface
+ * (UI `429519be`, re-derived at `842f5267`). Both assertions bind to the
+ * PROPERTY, never to the measured numbers: the witness saw 413 characters for a
+ * ~205-character sentence, and a two-character drift in that sentence must not
+ * be able to make these pass or fail for the wrong reason.
+ */
+describe('strengthenWhyLine — the sentence is printed once', () => {
+  const BODY =
+    'Your model leans on one early estimate, and later factors inherit it without independent support, so the result can look steadier than the evidence behind it actually is.'
+
+  it('prints an identical signal and whyNow ONCE, not twice', () => {
+    const line = strengthenWhyLine(BODY, BODY)
+    // Bound by IDENTITY: count occurrences of the sentence itself. A length
+    // assertion would pass or fail on the producer rewording by two characters.
+    expect(line.split(BODY).length - 1).toBe(1)
+    expect(line).toBe(BODY)
+  })
+
+  it('still joins two DIFFERENT sentences — the dedupe must not swallow real prose', () => {
+    const why = 'It matters now because the leading option is close.'
+    const line = strengthenWhyLine(BODY, why)
+    expect(line.split(BODY).length - 1).toBe(1)
+    expect(line.split(why).length - 1).toBe(1)
+    expect(line).toBe(`${BODY} ${why}`)
+  })
+
+  it('renders the signal alone when there is no whyNow', () => {
+    expect(strengthenWhyLine(BODY, undefined)).toBe(BODY)
+    expect(strengthenWhyLine(BODY, '')).toBe(BODY)
+  })
+})
+
+describe('truncateAtWordBoundary — never cuts a word in half', () => {
+  const TEXT =
+    'If the adoption rate changes significantly then the ordering of the two options changes with it'
+
+  it('does not end mid-word, and marks that it was cut', () => {
+    const out = truncateAtWordBoundary(TEXT, 80)
+    expect(out.length).toBeLessThanOrEqual(80)
+    expect(out.endsWith('…')).toBe(true)
+    // The property: whatever survives is a whole word of the original.
+    const lastWord = out.slice(0, -1).trimEnd().split(' ').pop()!
+    expect(TEXT.split(' ')).toContain(lastWord)
+  })
+
+  it('leaves a short string completely alone — no suffix on an uncut string', () => {
+    expect(truncateAtWordBoundary('Short enough', 80)).toBe('Short enough')
+    expect(truncateAtWordBoundary('Short enough', 80)).not.toContain('…')
+  })
+
+  it('does not collapse a single very long token to just the suffix', () => {
+    const out = truncateAtWordBoundary('a'.repeat(200), 80)
+    expect(out.length).toBeGreaterThan(10)
+    expect(out.endsWith('…')).toBe(true)
+  })
+})

--- a/src/components/results/analysisNew/analysisNewCopy.ts
+++ b/src/components/results/analysisNew/analysisNewCopy.ts
@@ -91,3 +91,32 @@ export const ANALYSIS_NEW_COPY = {
     measuredZero: 'Resolving the open unknowns was measured as not changing this decision.',
   },
 } as const
+
+/**
+ * The WHY line: the signal that fired, then why it matters now — rendered ONCE.
+ *
+ * `strengthen/buildRecommendations.ts:259-260` puts the producer's body on BOTH
+ * fields by design (`signal: item.signal ?? item.body`, `whyNow: item.body`), and
+ * a producer `signal` is carried today only on one deterministic nudge — so for
+ * every other item, bias cards included, the two fields hold the SAME string.
+ * That file's own comment records who was supposed to handle it: "The PANEL
+ * dedupes display: an open row renders the body once, in full, never clamp +
+ * full copy." The old panel does. This surface concatenated unconditionally and
+ * printed the sentence twice (measured at the DOM: 413 characters for a
+ * ~205-character sentence, while the same sentence appeared exactly once on the
+ * old tab in the same DOM at the same moment).
+ *
+ * The dedupe belongs HERE, at the consumer that skipped the contract — not in
+ * `buildRecommendations`, which is correct as written for a consumer that
+ * dedupes. A producer that is right for its existing consumer must not be bent
+ * to suit a new one.
+ *
+ * ⚠ EXACT equality, deliberately. A fuzzy or prefix match would be this
+ * surface making a judgement about whether two producer strings "mean the same",
+ * which is not a call it can make honestly. The measured defect is literal
+ * identity; anything looser is a guess.
+ */
+export function strengthenWhyLine(signal: string, whyNow?: string): string {
+  if (!whyNow || whyNow === signal) return signal
+  return `${signal} ${whyNow}`
+}

--- a/src/components/results/analysisNew/buildAnalysisNewViewModel.ts
+++ b/src/components/results/analysisNew/buildAnalysisNewViewModel.ts
@@ -36,6 +36,7 @@
  *     caught exactly that here before it shipped.
  */
 
+import { truncateAtWordBoundary } from '../../../utils/text'
 import type { Recommendation } from '../strengthen/strengthenTypes'
 import type {
   ConditionalWinner,
@@ -410,7 +411,13 @@ function buildUncertainty(
     if (!text) continue
     findings.push({
       id: `uncertainty:${u.code}`,
-      headline: u.threshold ? `${u.threshold.variable} could tip the result` : text.slice(0, 80),
+      headline: u.threshold
+        ? `${u.threshold.variable} could tip the result`
+        // A bare `.slice(0, 80)` cut these mid-word — measured at the DOM, two
+        // distinct items landing on exactly 80 characters. The reader was left
+        // with a condition and no way to tell a cut string from a finished one.
+        // The full sentence still rides `implication` below.
+        : truncateAtWordBoundary(text, 80),
       implication: u.suggestion || text,
       // Same union as the drivers' direction. `mixed`/`unknown` get the
       // direction-free phrasing rather than a guessed one.

--- a/src/components/results/analysisNew/buildAnalysisNewViewModel.ts
+++ b/src/components/results/analysisNew/buildAnalysisNewViewModel.ts
@@ -416,7 +416,24 @@ function buildUncertainty(
         // A bare `.slice(0, 80)` cut these mid-word — measured at the DOM, two
         // distinct items landing on exactly 80 characters. The reader was left
         // with a condition and no way to tell a cut string from a finished one.
-        // The full sentence still rides `implication` below.
+        //
+        // ⚠ THIS COMMENT ONCE READ "The full sentence still rides `implication`
+        // below." THAT WAS FALSE, and it was the stated justification for
+        // cutting at all. Measured against a complete field manifest:
+        // `implication` is `u.suggestion || text`, and `u.suggestion` is present
+        // on every row as the constant string "Review this assumption" — so the
+        // implication carries a REMEDY and never the sentence. `detail` is
+        // undefined and `inspect` is numeric. NO FIELD CARRIES THE FULL TEXT.
+        //
+        // So this truncation is lossy, and the loss is not recoverable anywhere
+        // on the page. What changed here makes the cut HONEST — whole words, and
+        // an ellipsis so a reader can tell a cut string from a finished one. It
+        // does NOT recover the lost reasoning. Whether a headline should be cut
+        // at all when nothing else carries the sentence is a product question,
+        // rowed as 2.1330 and deliberately not answered here.
+        //
+        // Measured for `uncertainty:SENSITIVE_ASSUMPTION`. A finding type
+        // carrying no `suggestion` could still render its full text.
         : truncateAtWordBoundary(text, 80),
       implication: u.suggestion || text,
       // Same union as the drivers' direction. `mixed`/`unknown` get the

--- a/src/components/results/analysisNew/sections/StrengthenTheReasoning.tsx
+++ b/src/components/results/analysisNew/sections/StrengthenTheReasoning.tsx
@@ -43,6 +43,7 @@
  * would no longer be about information architecture.
  */
 
+import { strengthenWhyLine } from '../analysisNewCopy'
 import { typography } from '../../../../styles/typography'
 import { openAskOlumi } from '../../coaching/askOlumiStore'
 import { focusModelTarget } from '../../../../canvas/utils/focusHelpers'
@@ -108,8 +109,7 @@ export function StrengthenTheReasoning({
 
               {/* WHY — the signal that fired, then why it matters now. */}
               <p className={`${typography.panelBody} text-text-body`} data-testid={`${testId}-why`}>
-                {rec.signal}
-                {rec.whyNow ? ` ${rec.whyNow}` : ''}
+                {strengthenWhyLine(rec.signal, rec.whyNow)}
               </p>
 
               {/* DO IT — the one practical instruction. */}

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -3,3 +3,31 @@ export function truncateToSize(text: string, maxSize: number, suffix: string): s
   const keep = Math.max(0, maxSize - suffix.length)
   return text.slice(0, keep) + suffix
 }
+
+/**
+ * Truncate without cutting a word in half, and SAY that it was cut.
+ *
+ * `truncateToSize` above slices at an exact index, which lands mid-word. That is
+ * fine for an id or a log line and wrong for anything a person reads: a headline
+ * ending "…changes significantl" reads as a rendering fault, and a reader cannot
+ * tell a cut string from a string that simply ended.
+ *
+ * ⚠ THREE TRUNCATION HELPERS NOW EXIST IN THIS REPO and this is the third:
+ * `truncateToSize` (here, exact-index) and a PRIVATE `truncateAtWord` duplicated
+ * verbatim in `canvas/nodes/OptionNode.tsx` and `canvas/nodes/DecisionNode.tsx`
+ * — a same-named twin, the defect class this estate has paid for twice. This
+ * one is placed beside `truncateToSize` rather than minting a fourth copy at the
+ * call site, and CONVERGING all of them is rowed rather than done here: the node
+ * twins have their own callers and their own 0.6 heuristic, and quietly changing
+ * what a canvas node displays is not this change's business.
+ */
+export function truncateAtWordBoundary(text: string, maxLength: number, suffix = '…'): string {
+  if (text.length <= maxLength) return text
+  const keep = Math.max(0, maxLength - suffix.length)
+  const cut = text.slice(0, keep)
+  const lastSpace = cut.lastIndexOf(' ')
+  // Fall back to the hard cut only when there is no word boundary worth using —
+  // otherwise a single very long token would collapse the string to the suffix.
+  const body = lastSpace > keep * 0.6 ? cut.slice(0, lastSpace) : cut
+  return body.trimEnd() + suffix
+}


### PR DESCRIPTION
Two render defects on the **Analysis (New)** A/B surface, both measured at the DOM by a separate lane on a pinned quartet, both fixed at the **consumer** rather than the producer.

## 1. Each bias card printed its sentence twice

`strengthen/buildRecommendations.ts:259-260` puts the producer's body on **both** display fields by design — `signal: item.signal ?? item.body`, `whyNow: item.body` — and a producer `signal` is carried today on only one deterministic nudge. **So for every other item, bias cards included, the two fields hold the same string by construction.**

That file's own comment records the contract: *"The PANEL dedupes display: an open row renders the body once, in full."* The old panel does. This surface concatenated unconditionally.

**Measured:** 413 characters for a ~205-character sentence, while the same sentence appeared **exactly once on the old tab, in the same DOM, at the same moment.** That contrast is what proves it is the render path and not the data.

`strengthenWhyLine` dedupes at the render site on **exact equality**. A fuzzy or prefix match would be this surface judging whether two producer strings *mean* the same thing, which it cannot do honestly.

**`buildRecommendations` is deliberately unchanged** — it is correct as written for a consumer that dedupes. A producer that is right for its existing consumer should not be bent to suit a new one that skipped the contract.

## 2. Uncertainty headlines were cut mid-word

`buildAnalysisNewViewModel.ts:413` used a bare `text.slice(0, 80)`.

**Measured:** two distinct items cut at exactly 80 characters, with every CSS cause excluded (`line-clamp: none`, `overflow: visible`, `scrollWidth === clientWidth`). Natural sentences do not land on 80 twice.

`truncateAtWordBoundary` keeps whole words and appends an ellipsis, **so a reader can tell a cut string from a finished one.**

### Severity — withdrawn, then reinstated by measurement

I first argued this was the product emitting broken reasoning. I then **withdrew that**, because the same finding carries `implication: u.suggestion || text` on the same row, so with no suggestion the full sentence would survive.

**It has since been measured, and the stronger claim holds.** `u.suggestion` is present on every row and is the constant string `"Review this assumption"` — so the implication carries a **remedy, never the sentence**, and the truncated headline is the only place the original reasoning ever appears. 3/3 rows, not recoverable by expanding the disclosure, and the sentence continues nowhere else on the page (contrast control fired).

⚠ **Bounded:** all three rows are one finding type (`uncertainty:SENSITIVE_ASSUMPTION`). Measured **for that type**. A finding type carrying no suggestion could still render its full text.

## Tests

Bind by **identity, not by the measured numbers** — the doubling test counts occurrences of the sentence itself, so a two-character reword cannot flip it. Truncation asserts *the surviving last word is a whole word of the original*, not a length.

It also asserts **two genuinely different sentences are still joined**, each appearing once: a dedupe that swallowed real prose would be worse than the defect it fixes, and the fix's own success criterion is silent about that.

- **65 tests green** across the surface, including the 4 pre-existing spec files
- Both fixes **proven to bite by revert**, controls green either side
- `shell-conformance` guard green (52/52)

## Not done here

Rowed as **2.1329**: three truncation helpers now exist, one duplicated verbatim across two node files with its own heuristic and its own callers. Converging them would quietly change what canvas nodes display, which is not a render fix's business.

**No DOM-level test.** The measurements above were taken by a separate lane's battery, which now pins both defects continuously.

*Verified by: the author. Independent review required before merge — I do not merge my own work.*
