### PR TITLE
Hero badge states RANK, not the ordinal frozen on the first run

### DIFF
--- a/src/components/results/__tests__/ResultsBody.crossSurfaceOptionNumbering.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.crossSurfaceOptionNumbering.spec.tsx
@@ -1,0 +1,253 @@
+/**
+ * CROSS-SURFACE OPTION NUMBERING — hero RANK beside card IDENTITY, on ONE
+ * screen, after a re-run that flips the leader.
+ *
+ * ## THIS IS THE LOAD-BEARING HALF OF THE BADGE FIX, NOT A SIDE-ASSERTION
+ *
+ * The hero badge used to render `stableNumber ?? index` — the ordinal frozen
+ * on the FIRST run — while the list order, the leader fill and the "Highest
+ * on this view" cue all stated the CURRENT rank. Pointing the badge at
+ * `row.index` closes that. But it opens the opposite-direction harm
+ * immediately, and this estate's signature defect is exactly that trade: the
+ * same option would then read "1" in the cockpit and "Option 2" on the card
+ * below it and on its canvas node — a cross-surface disagreement bought with
+ * a fixed badge.
+ *
+ * Two harms cannot share one window, so they were given two elements:
+ *
+ *   | element                          | question it answers        | source        |
+ *   |----------------------------------|----------------------------|---------------|
+ *   | hero badge (filled for leader)   | who leads NOW?             | `row.index`   |
+ *   | hero `Option N` text             | which option IS this?      | `stableNumber`|
+ *   | card `Option N` text             | which option IS this?      | `stableNumber`|
+ *   | card colour swatch (no numeral)  | who leads NOW?             | `rank`        |
+ *
+ * The hero did not invent a convention: `OptionCards.tsx:722-738` has drawn
+ * rank as a NUMERAL-FREE colour swatch and identity as the TEXT
+ * `Option {stableNumber}` since D17, and `canvas/nodes/OptionNode.tsx` mirrors
+ * the same chip. The hero converged on it.
+ *
+ * ## WHY THIS FILE, RATHER THAN MORE CASES IN THE HERO SUITE
+ *
+ * A hero-only suite cannot see a cross-surface disagreement — both halves of
+ * the contradiction have to be mounted at once. `ResultsBody` is the only
+ * production parent of `OptionCards` and it also mounts
+ * `AnalysisHeroContainer` from the SAME `recommendation.allOptions`, so this
+ * is the surface a user loads with both numbers on it. (Same reasoning as
+ * `ResultsBody.notAnalysedMountPath.spec.tsx`, and the same trap it cites:
+ * CLAUDE.md 3b — a green component suite is not evidence about a screen.)
+ *
+ * ## WHAT IT IS WRITTEN TO CATCH
+ *
+ * A future "harmonisation" that makes the two numbers agree — from EITHER
+ * side. Pointing the badge back at `stableNumber` REDs it, and so does
+ * relabelling the card's identity chip with the rank. That is why the central
+ * assertion is an INEQUALITY between two NAMED quantities rather than two
+ * separate equalities that a single well-meaning edit could satisfy at once.
+ *
+ * ## STATE CLASS
+ *
+ * SEEDED-THEN-RERUN, one page session, no reload. `optionNumbering` has no
+ * `persist()`, so a reload clears it and the divergence disappears — which is
+ * why runs without a flip, and every reload, agreed.
+ *
+ * ## WHAT THIS FILE EXCLUDES
+ *
+ * jsdom: presence and text, never layout or visibility (CLAUDE.md trap 3). It
+ * says nothing about the canvas `OptionNode`, which reads the same
+ * `optionNumbering` map from the store but mounts on a different surface.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, cleanup, within, renderHook } from '@testing-library/react'
+import { ResultsBody } from '../ResultsBody'
+import { useResultsSectionData } from '../useResultsSectionData'
+import { useCanvasStore } from '../../../canvas/store'
+import { mapV2ResponseToReportV1 } from '../../../adapters/plot/v2/responseMapper'
+import type { V2RunResponse } from '../../../adapters/plot/v2/types'
+
+/** First-appearance order A, B, C — the order run 1 freezes ordinals in. */
+const OPTIONS = [
+  { id: 'opt_a', label: 'Hire two developers', mean: 30 },
+  { id: 'opt_b', label: 'Partner with a consultancy', mean: 24 },
+  { id: 'opt_c', label: 'Continue solo', mean: 12 },
+]
+
+/** ONLY `win_probability` moves between the runs. */
+const RUN1_WIN: Record<string, number> = { opt_a: 0.7, opt_b: 0.2, opt_c: 0.1 }
+const RUN2_WIN: Record<string, number> = { opt_a: 0.2, opt_b: 0.7, opt_c: 0.1 }
+
+function makeV2Response(win: Record<string, number>, leaderId: string): V2RunResponse {
+  return {
+    analysis_status: 'computed',
+    option_comparison_status: 'computed',
+    robustness_status: 'computed',
+    drivers_status: 'computed',
+    option_comparison: OPTIONS.map((o) => ({
+      option_id: o.id,
+      option_label: o.label,
+      confidence_interval: [o.mean - 10, o.mean + 10],
+      win_probability: win[o.id],
+      outcome: {
+        mean: o.mean, std: 5, p10: o.mean - 10, p50: o.mean, p90: o.mean + 10,
+        n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1,
+      },
+    })),
+    critiques: [],
+    drivers: [{ node_id: 'd', label: 'D', contribution: 0.5, direction: 'positive' }],
+    edge_sensitivity: [],
+    factor_sensitivity: [{ factor_id: 'f1', elasticity: 0.4, importance_rank: 1 }],
+    // A PERMITTED run: without a producer leader claim the verdict is
+    // `unknown`, designations are withheld, and BOTH surfaces suppress their
+    // ranked chrome — every assertion here would pass against a screen with
+    // no numbers on it at all.
+    robustness: {
+      // A DETERMINATE run. Without a stability number `buildResultsVM` returns
+      // `decisionState: indeterminate`, which NEUTRALISES the cards' ranked
+      // chrome — the screen would then carry no rank affordance to compare.
+      recommendation_stability: 0.9,
+      fragile_edges: [],
+      robust_edges: ['e1'],
+      near_tie: { is_tie: false, top_option_id: leaderId },
+    },
+    response_hash: 'h',
+    meta: { seed_used: '42', n_samples: 1000, detail_level: 'standard', latency_ms: 100 },
+  } as unknown as V2RunResponse
+}
+
+function seedRun(win: Record<string, number>, leaderId: string): void {
+  const report = mapV2ResponseToReportV1(makeV2Response(win, leaderId), { seed: 42 })
+  useCanvasStore.setState({
+    results: { status: 'complete', progress: 100, report } as never,
+    runMeta: {} as never,
+    nodes: OPTIONS.map((o) => ({
+      id: o.id,
+      type: 'option',
+      position: { x: 0, y: 0 },
+      data: { kind: 'option', label: o.label },
+    })) as never,
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: null,
+  } as never)
+}
+
+function driveHook(): ReturnType<typeof useResultsSectionData> {
+  const { result, unmount } = renderHook(() => useResultsSectionData())
+  const value = result.current
+  unmount()
+  return value
+}
+
+/**
+ * Run 1 (mints the ordinals through the REAL hook and the REAL PLoT V2
+ * mapper), then run 2 (flips the leader), then render the real mount path on
+ * run 2's data.
+ */
+function renderFlippedBody(): void {
+  useCanvasStore.setState({ optionNumbering: {} } as never)
+
+  seedRun(RUN1_WIN, 'opt_a')
+  driveHook()
+  const frozen = { ...useCanvasStore.getState().optionNumbering }
+  // PRECONDITION pinned in-test: these are the ordinals a real first run
+  // mints. Fabricating them as a fixture would make every assertion below a
+  // statement about my own arithmetic (CLAUDE.md trap 16-inverse).
+  expect(frozen).toEqual({ opt_a: 1, opt_b: 2, opt_c: 3 })
+
+  seedRun(RUN2_WIN, 'opt_b')
+  const data = driveHook()
+  // PRECONDITION: the re-run renumbered nothing. Append-only is the mechanism
+  // the whole defect rests on.
+  expect(useCanvasStore.getState().optionNumbering).toEqual(frozen)
+  // PRECONDITION: the leader actually flipped.
+  expect(data.recommendation.allOptions.map((o) => o.id)).toContain('opt_b')
+
+  render(
+    <ResultsBody
+      resultsSectionData={data}
+      tornadoData={{ rows: [], expectedOutcome: null }}
+      onSendMessage={() => {}}
+      expertMode={false}
+    />,
+  )
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({ optionNumbering: {} } as never)
+})
+afterEach(() => cleanup())
+
+describe('ResultsBody — hero rank and card identity, on one screen, after a flip', () => {
+  it('PRECONDITION: both ranked surfaces are mounted with their chrome on screen', () => {
+    renderFlippedBody()
+    // Without this every assertion below could pass against a screen that
+    // stopped rendering one of the two surfaces (CLAUDE.md trap 13).
+    expect(screen.getByTestId('analysis-hero-panel')).toBeInTheDocument()
+    expect(screen.getByTestId('option-cards')).toBeInTheDocument()
+    expect(screen.getByTestId('hero-option-row-1')).toBeInTheDocument()
+    expect(screen.getByTestId('option-card-opt_b')).toBeInTheDocument()
+    expect(screen.getByTestId('rank-marker-opt_b')).toBeInTheDocument()
+  })
+
+  it('the hero badge states RANK: opt_b flipped into the lead, so its badge reads 1', () => {
+    renderFlippedBody()
+    // Bound to opt_b by identity — the card carries `data-option-id`, and the
+    // hero row is the one containing that option's label. Never "the badge
+    // that reads 1".
+    const heroRow = screen.getByTestId('hero-option-row-1')
+    expect(within(heroRow).getByTestId('hero-row-label')).toHaveTextContent(
+      'Partner with a consultancy',
+    )
+    expect(within(heroRow).getByTestId('hero-row-number')).toHaveTextContent('1')
+  })
+
+  it('BOTH surfaces state the same IDENTITY for opt_b — Option 2 — in the same words', () => {
+    renderFlippedBody()
+    const heroRow = screen.getByTestId('hero-option-row-1')
+    expect(within(heroRow).getByTestId('hero-row-identity')).toHaveTextContent('Option 2')
+    // The card's identity chip is `OptionCards.tsx:732-738`, unchanged by this
+    // slice — the hero adopted ITS wording, not the other way round.
+    expect(screen.getByTestId('stable-number-opt_b')).toHaveTextContent('Option 2')
+  })
+
+  it('⭐ THE PIN: rank and identity are DIFFERENT QUANTITIES for opt_b, and stay different', () => {
+    renderFlippedBody()
+    const heroRow = screen.getByTestId('hero-option-row-1')
+    const heroRank = within(heroRow).getByTestId('hero-row-number').textContent?.trim()
+    const heroIdentity = within(heroRow).getByTestId('hero-row-identity').textContent?.trim()
+    const cardIdentity = screen.getByTestId('stable-number-opt_b').textContent?.trim()
+
+    // Identity agrees ACROSS surfaces...
+    expect(heroIdentity).toBe(cardIdentity)
+    // ...and differs from rank WITHIN the hero, deliberately, on this run.
+    expect(heroRank).toBe('1')
+    expect(heroIdentity).toBe('Option 2')
+    expect(heroIdentity).not.toBe(`Option ${heroRank}`)
+  })
+
+  it('the card states rank WITHOUT a numeral, so no numeral on the card can contradict the hero', () => {
+    renderFlippedBody()
+    // D17: `#N of M` was removed from the card; rank is a colour swatch. The
+    // ONLY numeral in the card header is the identity chip. If a rank numeral
+    // ever comes back to the card, this REDs — because it would immediately
+    // be a second number about a different question sitting next to identity.
+    const marker = screen.getByTestId('rank-marker-opt_b')
+    expect(marker.textContent?.trim()).toBe('')
+  })
+
+  it('CONTROL: the option that LOST the lead shows the mirror image (rank 2, identity Option 1)', () => {
+    renderFlippedBody()
+    // A single row could satisfy every assertion above by coincidence. opt_a
+    // moves the OTHER way — rank 1 -> 2 while identity stays Option 1 — so
+    // the two quantities are shown to move independently, not merely to
+    // differ once.
+    const secondRow = screen.getByTestId('hero-option-row-2')
+    expect(within(secondRow).getByTestId('hero-row-label')).toHaveTextContent(
+      'Hire two developers',
+    )
+    expect(within(secondRow).getByTestId('hero-row-number')).toHaveTextContent('2')
+    expect(within(secondRow).getByTestId('hero-row-identity')).toHaveTextContent('Option 1')
+    expect(screen.getByTestId('stable-number-opt_a')).toHaveTextContent('Option 1')
+  })
+})

--- a/src/components/results/__tests__/ResultsBody.notAnalysedMountPath.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.notAnalysedMountPath.spec.tsx
@@ -50,6 +50,7 @@ import { describe, it, expect, afterEach } from 'vitest'
 import { render, screen, cleanup, within } from '@testing-library/react'
 import { ResultsBody } from '../ResultsBody'
 import type { ResultsSectionDataReturn } from '../useResultsSectionData'
+import { useCanvasStore } from '../../../canvas/store'
 import type {
   ConfidenceSectionData,
   DecisionResultData,
@@ -150,7 +151,14 @@ const MIXED = [
   EXCLUDED_OPTION,
 ]
 
-afterEach(() => cleanup())
+afterEach(() => {
+  cleanup()
+  // `registerOptionNumbering` is append-only and the store is a module
+  // singleton, so a seeded test would otherwise leak its numbering into every
+  // sibling — and the leak is SILENT (siblings assert absence of ordinals,
+  // which a stale numbering map would quietly start contradicting).
+  useCanvasStore.setState({ optionNumbering: {} })
+})
 
 describe('ResultsBody — the not-analysed card on the mount path', () => {
   it('PRECONDITION: the options block is mounted and the ranked chrome is on screen', () => {
@@ -199,6 +207,46 @@ describe('ResultsBody — the not-analysed card on the mount path', () => {
     const analysedRow = document.querySelector(`[data-option-id="${ANALYSED_A}"]`)
     expect(analysedRow).not.toBeNull()
     expect(within(analysedRow as HTMLElement).getByTestId('hero-row-number')).toHaveTextContent('1')
+  })
+
+  it('NO-RANK covers the hero IDENTITY CHIP, not just the badge', () => {
+    // ⭐ THE BADGE HALF ABOVE IS NOT THE WHOLE SURFACE. `hero-row-number` is
+    // gated on `showOrdinal` (= `!designationsWithheld && row.isRanked`); the
+    // `hero-row-identity` chip beside it is a SECOND place an ordinal can
+    // appear in the same row, and it was gated on `stableNumber != null`
+    // alone. Registration covers `allOptions` — not-analysed options included
+    // — so `stableNumber` is non-null for every row and the chip rendered
+    // `Option 3` next to a card that deliberately renders no ordinal at all.
+    //
+    // This is the seventh-guard failure `NotAnalysedOptionCard`'s header
+    // predicted in prose ("every future stat row added to that card would have
+    // to remember the eighth guard") arriving on the OTHER surface, where the
+    // fork does not protect it. Pinning the chip by its own testid so a future
+    // ordinal-bearing element in this row cannot inherit the badge's pin.
+    // ⚠ THE SEED IS LOAD-BEARING AND ITS ABSENCE IS SILENT. `stableNumberFor`
+    // is all-or-nothing: with no `optionNumbering` in the store EVERY row's
+    // `stableNumber` is null, no chip renders anywhere, and an absence
+    // assertion here would pass while testing nothing. Registration in
+    // production covers `allOptions` — the excluded option included — so this
+    // seeds all three, which is what makes `Option 3` reachable on the
+    // excluded row at all. The positive control below is what proves the seed
+    // took; the first draft of this test failed on that control, not on the
+    // claim, which is how the vacuity was caught.
+    useCanvasStore.getState().registerOptionNumbering([ANALYSED_A, ANALYSED_B, EXCLUDED])
+
+    renderBody(MIXED)
+    const excludedRow = document.querySelector(`[data-option-id="${EXCLUDED}"]`)
+    expect(excludedRow).not.toBeNull()
+    expect(within(excludedRow as HTMLElement).queryByTestId('hero-row-identity')).toBeNull()
+
+    // POSITIVE CONTROL — the chip must still render for an option that WAS
+    // scored. Without this the absence above passes when the chip is deleted
+    // outright, which would silently undo the identity this PR exists to add.
+    const analysedRow = document.querySelector(`[data-option-id="${ANALYSED_A}"]`)
+    expect(analysedRow).not.toBeNull()
+    expect(
+      within(analysedRow as HTMLElement).getByTestId('hero-row-identity'),
+    ).toHaveTextContent(/^Option \d+$/)
   })
 
   it('the WinGauge draws no segment for it', () => {

--- a/src/components/results/__tests__/ResultsBody.notAnalysedMountPath.spec.tsx
+++ b/src/components/results/__tests__/ResultsBody.notAnalysedMountPath.spec.tsx
@@ -154,9 +154,14 @@ const MIXED = [
 afterEach(() => {
   cleanup()
   // `registerOptionNumbering` is append-only and the store is a module
-  // singleton, so a seeded test would otherwise leak its numbering into every
-  // sibling — and the leak is SILENT (siblings assert absence of ordinals,
-  // which a stale numbering map would quietly start contradicting).
+  // singleton, so a seeded test can leak its numbering into every sibling,
+  // and such a leak is SILENT (siblings assert absence of ordinals, which a
+  // stale numbering map would quietly start contradicting).
+  //
+  // ⚠ PROPHYLACTIC, NOT A LIVE FIX — measured: with this reset removed, NO
+  // sibling in this file currently REDs. An earlier revision of this comment
+  // read as though the leak were live. It is not; it is one seeded test away
+  // from being live, which is why the reset stays.
   useCanvasStore.setState({ optionNumbering: {} })
 })
 

--- a/src/components/results/analysis-hero/HeroOptionRow.tsx
+++ b/src/components/results/analysis-hero/HeroOptionRow.tsx
@@ -40,15 +40,32 @@ export interface HeroOptionRowProps {
   /** Layout-only outcome domain; null hides outcome bars. */
   outcomeDomain: { min: number; max: number } | null
   /**
-   * ROADMAP 1.267: whether to draw the ordinal number token.
+   * ROADMAP 1.267: whether to draw the RANK token.
    *
-   * The token reads `stableNumber ?? index`, and on a first run both are
-   * seeded from the probability order — so "1" IS `rank == 1`, an ordinal
-   * DESIGNATION rather than a measurement. On a withheld run it is omitted
-   * entirely; the row keeps its label, readout, bar and disclosure.
+   * ⚠⚠ THIS DOC CARRIED A FALSE PREMISE AND THE BADGE WAS BUILT ON IT.
+   * It used to read: *"The token reads `stableNumber ?? index`, and on a first
+   * run both are seeded from the probability order — so '1' IS `rank == 1`."*
+   * The first clause is true only of a FIRST RUN. It was written from the case
+   * in hand rather than from the spec, and on a RE-RUN THAT FLIPS THE LEADER
+   * it is false: `optionNumbering` is append-only, so `stableNumber` stays
+   * frozen at the first run's ranking while `index` re-ranks — and
+   * `stableNumber ?? index` made the FROZEN one win whenever the row set was
+   * fully registered. The new leader's badge came out filled leader-blue
+   * carrying the numeral 2.
+   *
+   * The token now reads `row.index` — the CURRENT display rank, the same
+   * quantity as the list order, the leader fill and the "Highest on this view"
+   * cue. IDENTITY did not disappear: it is rendered as TEXT (`Option N`)
+   * beside the label, the treatment `OptionCards.tsx:732-738` and
+   * `canvas/nodes/OptionNode.tsx` already use. One element, one question.
+   *
+   * On a withheld run the token is omitted entirely; the row keeps its label,
+   * readout, bar, disclosure — and its IDENTITY text, because withholding
+   * suppresses DESIGNATIONS, not identity (OptionCards gates its rank swatch
+   * on `!neutralised` and its identity chip on nothing but `stableNumber`).
    *
    * Separate from `isLeader` on purpose: `isLeader` removes the CROWN (which
-   * marks ONE row), this removes the NUMBERING (which ranks ALL of them).
+   * marks ONE row), this removes the RANK NUMBERING (which ranks ALL of them).
    * A withheld run must lose both, and one flag could not express that.
    */
   showOrdinal: boolean
@@ -219,17 +236,25 @@ export function HeroOptionRow({
 
   const rowGrid = (
     <>
-      {/* Row 1: badge · label · readout · chevron. Badge geometry follows
-          the prototype (24×24, 7px radius); leader = filled info-blue with
-          white numeral, others outlined.
+      {/* Row 1: badge · (identity + label) · readout · chevron. Badge geometry
+          follows the prototype (24×24, 7px radius); leader = filled info-blue
+          with white numeral, others outlined.
 
-          ROADMAP 1.267: on a withheld run the numeral is a DESIGNATION
-          (`stableNumber ?? index` is seeded from the probability order, so
-          "1" is `rank == 1`) and is not drawn. The 1.5rem grid cell is still
-          occupied by an empty placeholder — the row grid is
-          `grid-cols-[1.5rem_…]`, so omitting the element outright would slide
-          the label into the badge column and silently re-lay-out every row.
-          Suppress the claim, not the layout. */}
+          ⭐ THE BADGE STATES RANK, AND ONLY RANK (`row.index`).
+          It used to render `row.stableNumber ?? row.index`, which meant the
+          FROZEN first-run ordinal won on every fully-registered row set. After
+          a re-run that flipped the leader, this one 24×24 element was filled
+          leader-blue AND carried the numeral 2 — its FILL answering "who leads
+          now?" and its NUMERAL answering "who led first?", while the list
+          order and the "Highest on this view" cue both said 1. Three
+          authorities, one element. See
+          `__tests__/rerunFlipNumbering.rankCoherence.spec.tsx`.
+
+          ROADMAP 1.267: on a withheld run the RANK numeral is a DESIGNATION
+          and is not drawn. The 1.5rem grid cell is still occupied by an empty
+          placeholder — the row grid is `grid-cols-[1.5rem_…]`, so omitting the
+          element outright would slide the label into the badge column and
+          silently re-lay-out every row. Suppress the claim, not the layout. */}
       {showOrdinal ? (
         <span
           aria-hidden="true"
@@ -240,20 +265,47 @@ export function HeroOptionRow({
               : `border ${HERO_TOKEN_BORDER} bg-transparent text-text-body`
           }`}
         >
-          {row.stableNumber ?? row.index}
+          {row.index}
         </span>
       ) : (
         <span aria-hidden="true" className="h-6 w-6 flex-none" />
       )}
-      <span
-        id={labelId}
-        ref={labelRef}
-        title={row.label}
-        data-testid="hero-row-label"
-        className={`${typography.panelBody} min-w-0 break-words text-left text-text-header line-clamp-2`}
-      >
-        {row.label}
-        {isLeader && <span className="sr-only"> ({HERO_COPY.srLeader})</span>}
+      {/* IDENTITY, as TEXT — the treatment OptionCards (`:732-738`) and the
+          canvas OptionNode already use, adopted verbatim rather than invented
+          here. It is what keeps the badge fix from buying a cross-surface
+          disagreement: without it the same option would read "1" in the
+          cockpit and "Option 2" on the card below and on its canvas node.
+          Pinned on the real mount path in
+          `../../__tests__/ResultsBody.crossSurfaceOptionNumbering.spec.tsx`.
+
+          Gated ONLY on `stableNumber != null`, never on `showOrdinal`:
+          withholding suppresses DESIGNATIONS, and an option's identity is not
+          one (OptionCards gates its rank swatch on `!neutralised` and its
+          identity chip on nothing but the number). An un-analysed option keeps
+          its identity for the same reason.
+
+          `labelId`/`labelRef` stay on the LABEL span alone — the clamp
+          measurement and the detail region's accessible name must keep
+          describing the option name, not the name plus a chip. */}
+      <span className="flex min-w-0 flex-wrap items-baseline gap-x-1.5">
+        {row.stableNumber != null && (
+          <span
+            data-testid="hero-row-identity"
+            className={`${typography.panelMeta} flex-none text-text-light`}
+          >
+            Option {row.stableNumber}
+          </span>
+        )}
+        <span
+          id={labelId}
+          ref={labelRef}
+          title={row.label}
+          data-testid="hero-row-label"
+          className={`${typography.panelBody} min-w-0 break-words text-left text-text-header line-clamp-2`}
+        >
+          {row.label}
+          {isLeader && <span className="sr-only"> ({HERO_COPY.srLeader})</span>}
+        </span>
       </span>
 
       <span

--- a/src/components/results/analysis-hero/HeroOptionRow.tsx
+++ b/src/components/results/analysis-hero/HeroOptionRow.tsx
@@ -56,8 +56,15 @@ export interface HeroOptionRowProps {
    * The token now reads `row.index` — the CURRENT display rank, the same
    * quantity as the list order, the leader fill and the "Highest on this view"
    * cue. IDENTITY did not disappear: it is rendered as TEXT (`Option N`)
-   * beside the label, the treatment `OptionCards.tsx:732-738` and
-   * `canvas/nodes/OptionNode.tsx` already use. One element, one question.
+   * beside the label, the treatment `OptionCards.tsx:732-738` already uses.
+   * One element, one question.
+   *
+   *  ⚠ NOT the canvas node's glyph, though earlier revisions of these
+   * comments said so: `canvas/nodes/OptionNode.tsx:1206-1213` draws the BARE
+   * NUMERAL in a bordered box and carries `Option N` as its `aria-label`
+   * only. The two surfaces agree on the ACCESSIBLE NAME and deliberately
+   * differ in glyph (a canvas node has no room for the word). Corrected
+   * rather than deleted, because the aria agreement is the stronger property.
    *
    * On a withheld run the token is omitted entirely; the row keeps its label,
    * readout, bar, disclosure — and its IDENTITY text, because withholding
@@ -270,25 +277,44 @@ export function HeroOptionRow({
       ) : (
         <span aria-hidden="true" className="h-6 w-6 flex-none" />
       )}
-      {/* IDENTITY, as TEXT — the treatment OptionCards (`:732-738`) and the
-          canvas OptionNode already use, adopted verbatim rather than invented
+      {/* IDENTITY, as TEXT — the treatment OptionCards (`:732-738`)
+          already uses, adopted verbatim rather than invented
           here. It is what keeps the badge fix from buying a cross-surface
           disagreement: without it the same option would read "1" in the
-          cockpit and "Option 2" on the card below and on its canvas node.
+          cockpit and "Option 2" on the card below. (The canvas node draws a bare
+          `2` with `aria-label="Option 2"` — accessible-name agreement, not
+          glyph agreement; "and on its canvas node" was wrong about the glyph.)
           Pinned on the real mount path in
           `../../__tests__/ResultsBody.crossSurfaceOptionNumbering.spec.tsx`.
 
-          Gated ONLY on `stableNumber != null`, never on `showOrdinal`:
-          withholding suppresses DESIGNATIONS, and an option's identity is not
-          one (OptionCards gates its rank swatch on `!neutralised` and its
-          identity chip on nothing but the number). An un-analysed option keeps
-          its identity for the same reason.
+          ⚠ `showOrdinal` IS A CONJUNCTION OF TWO QUESTIONS AND THIS CHIP
+          ANSWERS ONLY ONE OF THEM. It is
+          `!designationsWithheld && row.isRanked` (AnalysisHeroPanel), and
+          `heroTypes.ts` states the distinction explicitly: withholding is
+          PER-RUN (*"may this run designate a leader?"*), `isRanked` is PER-ROW
+          (*"was this option scored?"*).
+
+          NOT gated on `designationsWithheld`: withholding suppresses
+          DESIGNATIONS, and an option's identity is not one — `OptionCards`
+          gates its rank swatch on `!neutralised` and its identity chip on
+          nothing but the number, and this converges on that.
+
+          GATED on `row.isRanked`: an option that took no part in the
+          comparison has no ordinal to state. `NotAnalysedOptionCard` renders
+          the same option on the same screen with *"No rank swatch and no
+          'Option N' … the gap is the point"* under Paul's NO-RANK ruling
+          (14 Aug 2026). An ungated chip here says `Option 3` beside a card
+          that deliberately says nothing — and `heroTypes.ts` names that exact
+          case as *"the case that shipped an ordinal it had no basis for"*.
+          An earlier revision of this comment said an un-analysed option keeps
+          its identity "for the same reason" as a withheld one. THAT WAS FALSE:
+          it collapsed the two questions the type doc keeps apart.
 
           `labelId`/`labelRef` stay on the LABEL span alone — the clamp
           measurement and the detail region's accessible name must keep
           describing the option name, not the name plus a chip. */}
       <span className="flex min-w-0 flex-wrap items-baseline gap-x-1.5">
-        {row.stableNumber != null && (
+        {row.stableNumber != null && row.isRanked && (
           <span
             data-testid="hero-row-identity"
             className={`${typography.panelMeta} flex-none text-text-light`}

--- a/src/components/results/analysis-hero/__tests__/content.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/content.spec.tsx
@@ -587,22 +587,82 @@ describe('AnalysisHeroPanel — content', () => {
     },
   )
 })
-describe('Wave 2: stable number badges', () => {
-  it('row badges show the identity-anchored ordinal, surviving a rank flip', () => {
+/**
+ * ⚠ REWRITTEN — THE BEHAVIOUR CHANGED ON PURPOSE, THE ASSERTIONS WERE NOT
+ * WEAKENED TO GO GREEN.
+ *
+ * The first case here used to be titled *"row badges show the identity-
+ * anchored ordinal, surviving a rank flip"* and asserted badge "2" on display
+ * row 1. It was a correct description of what the code did and a correct
+ * pin of the DEFECT: the badge is a RANK affordance (filled for the leader,
+ * and `showOrdinal`'s own doc says it "ranks ALL of them"), so pointing it at
+ * an ordinal frozen on the first run made one 24×24 element carry a fill
+ * saying "leads now" and a numeral saying "led first".
+ *
+ * The badge now states RANK. IDENTITY did not go away — it is rendered as the
+ * TEXT `Option N`, the treatment OptionCards and the canvas OptionNode already
+ * use — so the same property this block was written to protect (an option's
+ * number survives a rank flip) is still asserted below, on the element that
+ * now carries it. The re-run half is driven end-to-end through the real hook
+ * and the real PLoT V2 mapper in `rerunFlipNumbering.rankCoherence.spec.tsx`;
+ * the cross-surface half is on the mount path in
+ * `../../__tests__/ResultsBody.crossSurfaceOptionNumbering.spec.tsx`.
+ *
+ * Net: two assertions became five, and the no-numbering case gained an
+ * honest-absence assertion it never had.
+ */
+describe('Wave 2: rank badges and identity chips', () => {
+  it('the BADGE states display rank, even when a numbering map disagrees with it', () => {
     const a = makeOption({ ...OPTION_A, winProbability: 0.3 })
     const b = makeOption({ ...OPTION_B, winProbability: 0.7 })
     const model = buildHeroModel(makeHeroData({ options: [a, b] }), { opt_a: 1, opt_b: 2 })
     expect(model.kind).toBe('chart')
     renderPanel(model as HeroChartModel)
-    // First row is opt_b (display rank 1) but keeps its stable ordinal 2.
-    expect(within(screen.getByTestId('hero-option-row-1')).getByTestId('hero-row-number')).toHaveTextContent('2')
-    expect(within(screen.getByTestId('hero-option-row-2')).getByTestId('hero-row-number')).toHaveTextContent('1')
+    // First row is opt_b — display rank 1, frozen ordinal 2. The badge says 1.
+    expect(within(screen.getByTestId('hero-option-row-1')).getByTestId('hero-row-number')).toHaveTextContent('1')
+    expect(within(screen.getByTestId('hero-option-row-2')).getByTestId('hero-row-number')).toHaveTextContent('2')
   })
 
-  it('without a numbering map the badge falls back to the display rank', () => {
+  it('the IDENTITY chip carries the identity-anchored ordinal, surviving the same rank flip', () => {
+    const a = makeOption({ ...OPTION_A, winProbability: 0.3 })
+    const b = makeOption({ ...OPTION_B, winProbability: 0.7 })
+    const model = buildHeroModel(makeHeroData({ options: [a, b] }), { opt_a: 1, opt_b: 2 })
+    renderPanel(model as HeroChartModel)
+    // Same run, same rows: opt_b is displayed first and is still Option 2.
+    expect(within(screen.getByTestId('hero-option-row-1')).getByTestId('hero-row-identity')).toHaveTextContent('Option 2')
+    expect(within(screen.getByTestId('hero-option-row-2')).getByTestId('hero-row-identity')).toHaveTextContent('Option 1')
+  })
+
+  it('rank and identity are on SEPARATE elements, so neither can overwrite the other', () => {
+    const a = makeOption({ ...OPTION_A, winProbability: 0.3 })
+    const b = makeOption({ ...OPTION_B, winProbability: 0.7 })
+    const model = buildHeroModel(makeHeroData({ options: [a, b] }), { opt_a: 1, opt_b: 2 })
+    renderPanel(model as HeroChartModel)
+    const row = screen.getByTestId('hero-option-row-1')
+    expect(within(row).getByTestId('hero-row-number')).not.toBe(
+      within(row).getByTestId('hero-row-identity'),
+    )
+    expect(within(row).getByTestId('hero-row-number').textContent?.trim()).toBe('1')
+    expect(within(row).getByTestId('hero-row-identity').textContent?.trim()).toBe('Option 2')
+  })
+
+  it('without a numbering map the badge still states the display rank', () => {
     renderPanel(chartModel())
     expect(within(screen.getByTestId('hero-option-row-1')).getByTestId('hero-row-number')).toHaveTextContent('1')
     expect(within(screen.getByTestId('hero-option-row-2')).getByTestId('hero-row-number')).toHaveTextContent('2')
+  })
+
+  it('without a numbering map NO identity chip is drawn — an absent number is never fabricated', () => {
+    // NEW. `stableNumber` is null for an unregistered id precisely so display
+    // cannot mint a colliding one (analysisDisplaySelector, review S3). Since
+    // the badge now always reads rank, a chip synthesised from rank would read
+    // "Option 1" beside badge "1" and look authoritative while naming an
+    // identity nothing assigned.
+    renderPanel(chartModel())
+    expect(screen.queryAllByTestId('hero-row-identity')).toHaveLength(0)
+    // POSITIVE CONTROL — without it this passes just as happily if the rows
+    // stop rendering at all.
+    expect(screen.getAllByTestId('hero-row-number').length).toBeGreaterThan(0)
   })
 })
 describe('Wave 2 (§6.5): quick evidence pills in the summary row', () => {

--- a/src/components/results/analysis-hero/__tests__/rerunFlipNumbering.rankCoherence.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/rerunFlipNumbering.rankCoherence.spec.tsx
@@ -30,7 +30,8 @@
  *   - the badge (a RANK affordance — it is filled for the leader and its own
  *     `showOrdinal` doc says it "ranks ALL of them") carries `row.index`;
  *   - IDENTITY is rendered as TEXT, `Option N`, exactly as
- *     `OptionCards.tsx:732-738` and `canvas/nodes/OptionNode.tsx` already do.
+ *     `OptionCards.tsx:732-738` already does (the canvas node agrees on the
+ *     accessible name only — see the correction at the assertion below).
  * No third convention was invented; the hero converged on the existing one.
  *
  * ## State class
@@ -238,8 +239,15 @@ describe('hero badge after a re-run that flips the leader', () => {
     renderFlipped()
     const leaderRow = screen.getByTestId('hero-option-row-1')
     // opt_b was second on run 1, so its identity is Option 2 — permanently.
-    // Same string OptionCards.tsx:737 and OptionNode render for this id, so a
-    // reader moving between surfaces sees one identity, not two numbers.
+    // Same string OptionCards.tsx:737 renders for this id, so a reader moving
+    // between those two surfaces sees one identity, not two numbers.
+    // ⚠ NOT the canvas node's glyph, though earlier revisions of these
+    // comments said so: `canvas/nodes/OptionNode.tsx:1206-1213` draws the
+    // BARE NUMERAL in a bordered box and carries `Option N` as its
+    // `aria-label` only. The two surfaces agree on the ACCESSIBLE NAME and
+    // deliberately differ in glyph (a canvas node has no room for the word).
+    // Corrected rather than deleted, because the aria agreement is the
+    // stronger property.
     expect(within(leaderRow).getByTestId('hero-row-identity')).toHaveTextContent('Option 2')
     const secondRow = screen.getByTestId('hero-option-row-2')
     expect(within(secondRow).getByTestId('hero-row-identity')).toHaveTextContent('Option 1')

--- a/src/components/results/analysis-hero/__tests__/rerunFlipNumbering.rankCoherence.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/rerunFlipNumbering.rankCoherence.spec.tsx
@@ -1,0 +1,261 @@
+/**
+ * Hero rows × a RE-RUN that flips the leader — rank coherence, the OTHER half.
+ *
+ * ## What this file exists to catch
+ *
+ * `firstRunNumbering.rankCoherence.spec.ts` (this directory) closed the
+ * FIRST-RUN half of the option-rank-coherence contract: a production
+ * screenshot showed badge "4" above badge "3" because ordinals were seeded
+ * from an expected-value order while the rows sort by win probability. The
+ * fix aligned the registration order to the display order — which makes the
+ * two agree on run 1 and says nothing about run 2.
+ *
+ * On a RE-RUN THAT FLIPS THE LEADER they diverge again, and worse:
+ *
+ *   - `optionNumbering` is APPEND-ONLY (`canvas/store/stableOptionNumbers.ts`)
+ *     — an id keeps its first ordinal forever.
+ *   - `buildHeroModel` re-ranks `index` every run (`i + 1` over
+ *     `sortOptionsForDisplay`), and carries `stableNumber` unchanged.
+ *   - The badge used to render `stableNumber ?? index`, so `stableNumber` WON
+ *     whenever the row set was fully registered.
+ *
+ * The consequence, witnessed: after a flip the new leader's badge is filled
+ * leader-blue AND CARRIES THE NUMERAL 2. The fill and the numeral disagree
+ * inside one 24x24 element, while the list order, the "Highest on this view"
+ * cue and the leader chip all say 1.
+ *
+ * ## The ruling this file pins
+ *
+ * THREE authorities were reduced to ONE PER ELEMENT:
+ *   - the badge (a RANK affordance — it is filled for the leader and its own
+ *     `showOrdinal` doc says it "ranks ALL of them") carries `row.index`;
+ *   - IDENTITY is rendered as TEXT, `Option N`, exactly as
+ *     `OptionCards.tsx:732-738` and `canvas/nodes/OptionNode.tsx` already do.
+ * No third convention was invented; the hero converged on the existing one.
+ *
+ * ## State class
+ *
+ * SEEDED-THEN-RERUN, in ONE page session with no reload — that is the only
+ * state in which the defect is reachable, because `optionNumbering` has no
+ * `persist()` and a reload clears it. The run-1 registration is driven
+ * through the REAL hook and the REAL PLoT V2 mapper so the ordinals are the
+ * ones a user's first run actually mints, not a fixture's idea of them.
+ *
+ * ## What this file does NOT cover
+ *
+ * It renders the hero panel alone. The cross-surface half — hero rank beside
+ * OptionCards identity on ONE screen — is pinned on the real mount path in
+ * `../../__tests__/ResultsBody.crossSurfaceOptionNumbering.spec.tsx`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { render, screen, within, cleanup, renderHook } from '@testing-library/react'
+import { AnalysisHeroPanel } from '../AnalysisHeroPanel'
+import { buildHeroModel } from '../buildHeroModel'
+import type { HeroChartModel } from '../heroTypes'
+import { useResultsSectionData } from '../../useResultsSectionData'
+import { useCanvasStore } from '../../../../canvas/store'
+import { mapV2ResponseToReportV1 } from '../../../../adapters/plot/v2/responseMapper'
+import type { V2RunResponse } from '../../../../adapters/plot/v2/types'
+
+/**
+ * First-appearance order is A, B, C. Run 1 ranks them A, B, C (win
+ * probability), so the ordinals minted on run 1 are A=1, B=2, C=3 — and they
+ * are frozen there forever.
+ */
+const OPTIONS = [
+  { id: 'opt_a', label: 'Hire two developers', mean: 30 },
+  { id: 'opt_b', label: 'Partner with a consultancy', mean: 24 },
+  { id: 'opt_c', label: 'Continue solo', mean: 12 },
+]
+
+/**
+ * ONLY `win_probability` moves between the two runs. Everything else — the
+ * option set, the labels, the outcome distributions, the drivers — is
+ * byte-identical, so nothing but the ranking can explain a difference in what
+ * is rendered.
+ */
+const RUN1_WIN: Record<string, number> = { opt_a: 0.7, opt_b: 0.2, opt_c: 0.1 }
+const RUN2_WIN: Record<string, number> = { opt_a: 0.2, opt_b: 0.7, opt_c: 0.1 }
+
+function makeV2Response(win: Record<string, number>, leaderId: string): V2RunResponse {
+  return {
+    analysis_status: 'computed',
+    option_comparison_status: 'computed',
+    robustness_status: 'computed',
+    drivers_status: 'computed',
+    option_comparison: OPTIONS.map((o) => ({
+      option_id: o.id,
+      option_label: o.label,
+      confidence_interval: [o.mean - 10, o.mean + 10],
+      win_probability: win[o.id],
+      outcome: {
+        mean: o.mean, std: 5, p10: o.mean - 10, p50: o.mean, p90: o.mean + 10,
+        n_samples: 1000, n_valid_samples: 1000, validity_ratio: 1,
+      },
+    })),
+    critiques: [],
+    drivers: [{ node_id: 'd', label: 'D', contribution: 0.5, direction: 'positive' }],
+    edge_sensitivity: [],
+    factor_sensitivity: [{ factor_id: 'f1', elasticity: 0.4, importance_rank: 1 }],
+    // A PERMITTED run on both passes. Without a producer leader claim
+    // `deriveDecisionVerdict` returns `unknown`, designations are withheld,
+    // and this file would quietly become a withheld-run test that asserts
+    // nothing about a badge it no longer draws (the trap
+    // firstRunNumbering.rankCoherence.spec.ts documents at its fixture).
+    robustness: {
+      // A DETERMINATE run. Without a stability number `buildResultsVM` returns
+      // `decisionState: indeterminate`, which NEUTRALISES the cards' ranked
+      // chrome — the screen would then carry no rank affordance to compare.
+      recommendation_stability: 0.9,
+      fragile_edges: [],
+      robust_edges: ['e1'],
+      near_tie: { is_tie: false, top_option_id: leaderId },
+    },
+    response_hash: 'h',
+    meta: { seed_used: '42', n_samples: 1000, detail_level: 'standard', latency_ms: 100 },
+  } as unknown as V2RunResponse
+}
+
+/** Put a completed run on the store, exactly as a finished analysis leaves it. */
+function seedRun(win: Record<string, number>, leaderId: string): void {
+  const report = mapV2ResponseToReportV1(makeV2Response(win, leaderId), { seed: 42 })
+  useCanvasStore.setState({
+    results: { status: 'complete', progress: 100, report } as never,
+    runMeta: {} as never,
+    nodes: OPTIONS.map((o) => ({
+      id: o.id,
+      type: 'option',
+      position: { x: 0, y: 0 },
+      data: { kind: 'option', label: o.label },
+    })) as never,
+    edges: [],
+    hasCompletedFirstRun: true,
+    rawV2Response: null,
+  } as never)
+}
+
+/**
+ * Drive the REAL hook over the run currently on the store. Its registration
+ * effect is what mints/merges the ordinals, so run 1 must go through here for
+ * the run-2 assertions to be about real frozen ordinals.
+ */
+function driveHook(): ReturnType<typeof useResultsSectionData> {
+  const { result, unmount } = renderHook(() => useResultsSectionData())
+  const value = result.current
+  unmount()
+  return value
+}
+
+/** Run 1 (mints ordinals) then run 2 (flips the leader); returns run 2's model. */
+function flipAndBuild(): HeroChartModel {
+  useCanvasStore.setState({ optionNumbering: {} } as never)
+
+  seedRun(RUN1_WIN, 'opt_a')
+  driveHook()
+  const mintedOnRun1 = { ...useCanvasStore.getState().optionNumbering }
+  // PRECONDITION, asserted in-test: without these exact frozen ordinals the
+  // assertions below would pass for reasons unrelated to the defect (trap
+  // 13b — a discriminator must pin its own precondition).
+  expect(mintedOnRun1).toEqual({ opt_a: 1, opt_b: 2, opt_c: 3 })
+
+  seedRun(RUN2_WIN, 'opt_b')
+  const data = driveHook()
+  const numbering = useCanvasStore.getState().optionNumbering
+  // PRECONDITION: the re-run must NOT have renumbered anything — the whole
+  // defect depends on the ordinals being frozen at run 1.
+  expect(numbering).toEqual(mintedOnRun1)
+
+  const model = buildHeroModel(data, numbering)
+  expect(model.kind).toBe('chart')
+  const chart = model as HeroChartModel
+  // PRECONDITION: the leader really did flip — opt_b is now first.
+  expect(chart.rows.map((r) => r.id)).toEqual(['opt_b', 'opt_a', 'opt_c'])
+  expect(chart.rows[0].index).toBe(1)
+  expect(chart.rows[0].stableNumber).toBe(2)
+  return chart
+}
+
+function renderFlipped(): HeroChartModel {
+  const chart = flipAndBuild()
+  render(<AnalysisHeroPanel model={chart} rerunDisabled={false} />)
+  return chart
+}
+
+beforeEach(() => {
+  useCanvasStore.setState({ optionNumbering: {} } as never)
+})
+afterEach(() => cleanup())
+
+describe('hero badge after a re-run that flips the leader', () => {
+  it('the badge on the new leader row carries its CURRENT RANK, not the ordinal frozen on run 1', () => {
+    renderFlipped()
+    // Bound by identity to the row that flipped INTO the lead (row 1 is
+    // opt_b, asserted in flipAndBuild), never by "some badge reading 1".
+    const leaderRow = screen.getByTestId('hero-option-row-1')
+    expect(within(leaderRow).getByTestId('hero-row-number')).toHaveTextContent('1')
+  })
+
+  it('the FILLED badge’s numeral is its own row’s position (the witnessed contradiction)', () => {
+    renderFlipped()
+    // The filled badge is the leader treatment (`bg-primary`, HeroOptionRow).
+    // Before the fix it was filled leader-blue while carrying an ordinal from
+    // a different question — one 24x24 element answering two at once.
+    //
+    // ⚠ THIS ASSERTION WAS WRITTEN WRONG FIRST AND PASSED AT PRISTINE, which
+    // is why it is phrased this way. The original said "the filled badge
+    // reads 1" — but the DEFAULT lens is Goal fit, whose leader is opt_a on
+    // ROW 2, and opt_a's frozen ordinal happens to be 1. The test passed on a
+    // different object than the one it was written for (trap 19), with its
+    // positive control firing happily. Binding is now positional and derived:
+    // whichever row is filled, its numeral must equal ITS OWN position.
+    const positions = [1, 2, 3]
+    const filled = positions.filter((i) =>
+      /bg-primary/.test(
+        within(screen.getByTestId(`hero-option-row-${i}`)).getByTestId('hero-row-number')
+          .className,
+      ),
+    )
+    // POSITIVE CONTROL: exactly one row carries the leader fill. Without it
+    // the assertion below passes vacuously the moment the fill stops
+    // rendering at all.
+    expect(filled).toHaveLength(1)
+    const filledPosition = filled[0]
+    expect(
+      within(screen.getByTestId(`hero-option-row-${filledPosition}`)).getByTestId(
+        'hero-row-number',
+      ),
+    ).toHaveTextContent(String(filledPosition))
+  })
+
+  it('every badge in the list reads its display rank, top to bottom', () => {
+    renderFlipped()
+    const numerals = screen.getAllByTestId('hero-row-number').map((n) => n.textContent?.trim())
+    expect(numerals).toEqual(['1', '2', '3'])
+  })
+
+  it('IDENTITY is still on screen, as TEXT, in OptionCards’ existing wording', () => {
+    renderFlipped()
+    const leaderRow = screen.getByTestId('hero-option-row-1')
+    // opt_b was second on run 1, so its identity is Option 2 — permanently.
+    // Same string OptionCards.tsx:737 and OptionNode render for this id, so a
+    // reader moving between surfaces sees one identity, not two numbers.
+    expect(within(leaderRow).getByTestId('hero-row-identity')).toHaveTextContent('Option 2')
+    const secondRow = screen.getByTestId('hero-option-row-2')
+    expect(within(secondRow).getByTestId('hero-row-identity')).toHaveTextContent('Option 1')
+  })
+
+  it('rank and identity DISAGREE on this run, and that is the point — each is labelled', () => {
+    const chart = renderFlipped()
+    const leaderRow = screen.getByTestId('hero-option-row-1')
+    const rank = within(leaderRow).getByTestId('hero-row-number').textContent?.trim()
+    const identity = within(leaderRow).getByTestId('hero-row-identity').textContent?.trim()
+    // The two quantities are DELIBERATELY different for this option on this
+    // run. If a future "harmonisation" makes them equal, this REDs — which is
+    // the whole reason it is written as an inequality rather than as two
+    // separate equalities.
+    expect(rank).not.toEqual(identity)
+    expect(rank).toBe(String(chart.rows[0].index))
+    expect(identity).toBe(`Option ${chart.rows[0].stableNumber}`)
+  })
+})

--- a/src/components/results/analysis-hero/__tests__/rerunFlipNumbering.rankCoherence.spec.tsx
+++ b/src/components/results/analysis-hero/__tests__/rerunFlipNumbering.rankCoherence.spec.tsx
@@ -197,7 +197,16 @@ describe('hero badge after a re-run that flips the leader', () => {
     expect(within(leaderRow).getByTestId('hero-row-number')).toHaveTextContent('1')
   })
 
-  it('the FILLED badge’s numeral is its own row’s position (the witnessed contradiction)', () => {
+  it('the FILLED badge’s numeral is its own row’s position', () => {
+    // ⚠ TITLED "(the witnessed contradiction)" until measured: THIS FIXTURE
+    // DOES NOT REPRODUCE THE WITNESSED ARTEFACT. `mean` is held constant
+    // across runs, so the leader cannot flip — the filled row here is
+    // position 2 reading "1", not the leader reading "2" that was witnessed.
+    // What this case genuinely pins is the INVARIANT (whichever row is
+    // filled, its numeral is its own position), which the artefact would
+    // violate. Refixturing is rowed, not done here: `outcome.mean` decides
+    // which lenses are available and therefore which row is filled, so moving
+    // it needs its own RED-first and a full battery re-run.
     renderFlipped()
     // The filled badge is the leader treatment (`bg-primary`, HeroOptionRow).
     // Before the fix it was filled leader-blue while carrying an ordinal from
@@ -205,8 +214,12 @@ describe('hero badge after a re-run that flips the leader', () => {
     //
     // ⚠ THIS ASSERTION WAS WRITTEN WRONG FIRST AND PASSED AT PRISTINE, which
     // is why it is phrased this way. The original said "the filled badge
-    // reads 1" — but the DEFAULT lens is Goal fit, whose leader is opt_a on
-    // ROW 2, and opt_a's frozen ordinal happens to be 1. The test passed on a
+    // reads 1" — but this fixture renders on the OUTCOME lens, whose leader
+    // is opt_a on ROW 2, and opt_a's frozen ordinal happens to be 1. (An
+    // earlier revision said "Goal fit". `buildHeroModel.ts:1121` is
+    // `defaultLens: goalAvailable ? 'goal' : 'outcome'`, and this fixture
+    // supplies no goal threshold — so the general claim was right and the
+    // one about THIS fixture was wrong.) The test passed on a
     // different object than the one it was written for (trap 19), with its
     // positive control firing happily. Binding is now positional and derived:
     // whichever row is filled, its numeral must equal ITS OWN position.
@@ -262,7 +275,15 @@ describe('hero badge after a re-run that flips the leader', () => {
     // run. If a future "harmonisation" makes them equal, this REDs — which is
     // the whole reason it is written as an inequality rather than as two
     // separate equalities.
-    expect(rank).not.toEqual(identity)
+    //
+    // ⚠ THIS COMPARISON WAS A TAUTOLOGY AND THE COMMENT ABOVE CREDITED IT
+    // WITH A BINDING IT DID NOT HAVE. It read `expect(rank).not.toEqual(
+    // identity)` — comparing "1" against "Option 2", two strings that can
+    // never be equal under ANY mutation, including the harmonisation it
+    // claims to catch. Measured: under the harmonisation mutant the case
+    // fails on the NEXT line, and this one passed. Comparing like with like
+    // is what makes it bite.
+    expect(identity).not.toBe(`Option ${rank}`)
     expect(rank).toBe(String(chart.rows[0].index))
     expect(identity).toBe(`Option ${chart.rows[0].stableNumber}`)
   })


### PR DESCRIPTION
## The mechanism

After a re-run that flips the leader, the hero option badge showed the ordinal **frozen at the first run**, while everything around it showed current rank.

```
Producer   src/canvas/store/stableOptionNumbers.ts:14   append-only, ordinals NEVER recycled
Registered store.ts:4113  <- useResultsSectionData.ts:3841-3849, seeded via sortOptionsForDisplay (run 1's ranking)
Built      buildHeroModel.ts:403-404   index = i+1 (RE-RANKS every run) · stableNumber = frozen identity
Rendered   HeroOptionRow.tsx:243       {row.stableNumber ?? row.index}   <- stableNumber WON whenever all rows were registered
```

Consequence, reproduced deterministically: **the new leader's badge is filled leader-blue and carries the numeral 2.** The fill and the numeral disagree inside one 24×24 element.

Reachable only in **one page session with no reload** — `optionNumbering` has no `persist()`, so a reload clears it. That is why runs without a flip agreed.

## Three authorities, one visual element

| element | question it answered | source |
|---|---|---|
| badge numeral | *who led on the **first** run?* | `stableNumber` |
| list order + "Highest on this view" | *who leads **now**?* | `row.index` |
| badge fill + "Leading option" chip | *who leads **now**?* | `isLeader` |

The badge is a **rank affordance** — it is filled for the leader, and `showOrdinal`'s own doc says it "ranks ALL of them". It was being fed identity. **The false premise was written in the render file** (`HeroOptionRow.tsx:45-46`): *"on a first run both are seeded from the probability order — so '1' IS `rank == 1`."* True of a first run, false of every flipping re-run — written from the case in hand rather than from the spec. It is corrected in place, with the reason visible.

## The fix, and the opposite-direction harm

The badge now renders `row.index`. **The one-liner alone would trade a wrong badge for a cross-surface disagreement** — the same option reading "1" in the cockpit and "Option 2" on the card below it and on its canvas node. Two harms cannot share one window, so they were given **two elements**:

| element | question it answers | source |
|---|---|---|
| hero badge (filled for leader) | who leads **now**? | `row.index` |
| hero `Option N` **text** | which option **is** this? | `stableNumber` |
| card `Option N` text | which option **is** this? | `stableNumber` |
| card colour swatch (no numeral) | who leads **now**? | `rank` |

**No third convention was invented.** `OptionCards.tsx:722-738` has drawn rank as a numeral-free colour swatch and identity as the text `Option {stableNumber}` since D17, and `canvas/nodes/OptionNode.tsx` mirrors the same chip. The hero converged on it.

One derived detail: the identity chip is gated **only** on `stableNumber != null`, never on `showOrdinal`. Withholding suppresses **designations**, and identity is not one — OptionCards gates its rank swatch on `!neutralised` and its identity chip on nothing but the number. The hero now matches that precedent exactly.

`analysisDisplaySelector.ts:50`'s `displayIndex` models the same concept correctly and has no live call site. It was **not** consumed: `buildHeroModel` already computes `i + 1` over the same `sortOptionsForDisplay` output, so `row.index` **is** `displayIndex`. Nothing was minted.

## Which specs changed, and why

**One** existing spec pinned the behaviour that intentionally changed: `analysis-hero/__tests__/content.spec.tsx > Wave 2: stable number badges`. Its two cases became **five**:

- `row badges show the identity-anchored ordinal, surviving a rank flip` — was a correct description of the code and a correct pin of the **defect**. Split into a BADGE case (states rank) and an IDENTITY case (still asserts the number survives the flip — on the element that now carries it).
- `without a numbering map the badge falls back to the display rank` — renamed; there is no fallback any more.
- **New**: rank and identity are on separate elements; and an absent number is **never fabricated** (no chip when `stableNumber` is null) — an honest-absence assertion the block never had, with a positive control.

**Nothing was weakened to go green.** Net +3 assertions in that block, and every one of them bites (see M1–M4 below).

### ⚠ A correction to the brief's premise

The brief named `selectors/__tests__/analysisDisplaySelector.spec.ts:79-88` and `:90-110` as specs that "must change". **They must not, and they did not.** They pin the *selector*, which emits `displayIndex` and `stableNumber` correctly and is untouched by this change. Far from contradicting the fix, `:79-88` (`displayIndex 1` with `stableNumber 2`) is the **selector-level statement of exactly the distinction this PR renders**. Changing them would have destroyed the evidence the fix rests on.

Symbol sweep at my tip (`/usr/bin/grep -rl -a`, scope `src/`, `*.ts`+`*.tsx`, contrast control `displayIndex` → 2 files, non-zero): **14** files touch `stableNumber`, not the 17 the brief estimated. Of those, one spec REDed and is the one rewritten above; the whole `src/components/results` suite (274 files / 4705 tests) is green.

## Evidence

**RED-first at pristine `56059e18`**, by name, 11 tests collected across two new specs, 9 RED (the 2 green are deliberate standing guards: the mount-path precondition, and "the card carries no rank numeral"). Both specs drive the **real hook and the real PLoT V2 mapper** across two runs with **only `win_probability` moved**.

**An instrument defect caught at pristine and disclosed:** my first fill/numeral assertion said "the filled badge reads 1" and **passed at pristine** — the default lens is Goal fit, whose leader is `opt_a` on **row 2**, and `opt_a`'s frozen ordinal happens to be 1. A test written for row 1 passed on row 2 with its positive control firing happily (trap 19). Rewritten to derive the filled row's *position* and assert the numeral equals it; it then REDs.

**Mutation battery** — throwaway worktree outside the repo root, `--detach`, **isolation proven by writing a sentinel** (distinct inodes; source SHA-256 unchanged), restores from a pristine archive outside both trees, applied-check scoped to `src/`:

| mutant | applied | result |
|---|---|---|
| M0 control (cannot match) | 0 | 74/74 green |
| M1 defect on **all** rows | 1 | 9 RED |
| M2 defect on every row **except display rank 1** | 1 | 4 RED |
| M3 identity chip deleted | 1 | 7 RED |
| M4 identity chip **fed rank** (the "harmonisation") | 1 | 7 RED |
| M5 trailing control | 0 | 74/74 green |

**The discriminating pair.** `the badge on the new leader row carries its CURRENT RANK` is **RED under M1** and **GREEN under M2**, while `every badge in the list reads its display rank` REDs under both. A single biting mutant proves sensitivity to *something*; the pair proves this assertion binds to **row 1 by identity**.

**The cross-surface pin** (`ResultsBody.crossSurfaceOptionNumbering.spec.tsx`) is REDed by M3 and M4 from **opposite directions** — chip removed, and chip relabelled with rank — which is why its central assertion is an **inequality between two named quantities** rather than two equalities a single well-meaning edit could satisfy at once. It renders `ResultsBody`, the only production parent of `OptionCards` and also the host of `AnalysisHeroContainer`, so both halves of the contradiction are mounted on one screen (CLAUDE.md trap 3b — a green component suite is not evidence about a screen).

**Gates at my tip, all foreground to conclusion:** `pnpm typecheck` PASSED (3736/3776 files, ratchet 2250/2250) · `pnpm lint` PASSED (0 errors; hooks ratchet 229 = baseline) · `src/components/results` 274 files / **4705 tests** all pass · `src/components/results/analysis-hero` 38 files / **616 tests** all pass. Supabase env exported for every run, asserted non-empty, and every collected count checked **by name**.

## What this evidence EXCLUDES

- **jsdom proves presence and text, never layout or visibility** (trap 3). Nothing here says the chip is legible, unclipped, or well-placed at any width. The label's two-line clamp measurement is deliberately untouched — `labelId`/`labelRef` stay on the label span alone — but that is a structural argument, not a measurement.
- **No live witness.** This is CODE EXISTS → TESTED. Not deployed, not mounted-on-staging, not wire- or journey-witnessed. The staging witness is the flip repro: one session, no reload, run then re-run.
- **The canvas `OptionNode` was not rendered.** It reads the same `optionNumbering` map from the store and is unchanged, but no assertion in this PR mounts it.
- **The identity chip's effect on the row button's accessible name is asserted only as text presence** — no screen-reader verification.
- **`DecisionRecordModal.tsx:365`** renders a third spelling of identity, `"2. Label"`, in its chosen-option select. It is identity-framed and carries no rank affordance beside it, so it does not reproduce this defect. **Deliberately not touched** — flagged, not fixed.

## ⛔ Step 0 (asked before building): does the frozen ordinal reach the DURABLE decision record?

**No.** Settled at the bytes, three ways:

1. **The durable POST body carries no ordinal at all.** `decisionRecordCommitService.ts:127-138` sends exactly `scenario_id · chosen_option_id · chosen_option_label · confidence_0_100 · expectation_statement · [revisit_trigger_or_date] · client_commit_id`. Durable identity is the node id plus a label snapshot — and `chosen_option_label` is the **raw** label, not the ordinal-prefixed select string.
2. **`DecisionRecord.optionNumber` is `sessionStorage`-only with ZERO product readers.** Written once (`DecisionRecordModal.tsx:257`), persisted under `decisionRecord.v1` in `sessionStorage`. Complete reader manifest of the field (scope: all of `src/`, `*.ts`+`*.tsx`, `grep -a`): the type declaration, that one write, and two test references. Contrast control `optionLabel` in the same sweep returns 38 files — the instrument sees.
3. **`optionNumbering` is in no persisted or serialised payload.** No `persist()`; `store.ts:6138` explicitly resets it to `{}` on scenario hydration. Sweep of non-test `src/` intersected with `persist|serial|payload|graph_state|save|snapshot|toJSON` → zero hits.

**Severity is therefore unchanged: a display defect, in-session — not a false durable record. Scope was not changed.**

## Collision

Measured against the two live PRs on `src/components/results/` before writing: **#897** (`analysisNew/`, `src/utils/text.ts`) and **#898** (`results/utils/optionCoverage`, `v5/blocks/`). **Intersection with both is empty.** `buildRecommendations.ts` untouched. This PR changes 1 source file and 3 spec files.

---

## CI at head `2dbf906d` (polled to conclusion in-session, queried at the exact SHA)

`mergeable=MERGEABLE`, `mergeStateStatus=UNSTABLE`, `head=2dbf906d…` — matching `git ls-remote` and `gh api` independently.

**13 of 14 checks green**, including all four `Full Test Suite` shards, `Full Test Suite Summary`, `TypeScript + Lint`, `Production Build`, `Security Audit (pnpm)`, `Typecheck Gate Self-Test` and — the **only required context** on `staging`, derived via `gh api …/branches/staging/protection` — **`Staging Gate`: success**.

### The one red: `Visual Regression (advisory)` — and what it actually says

I read the job output rather than a label (CLAUDE.md trap 7b). It is not a diff:

> `No linux visual references were committed, so this run compared NOTHING.`

**Contrast control:** the same check is **already failing on pristine `staging` `56059e18`**, where every other check is green. So its red carries no information about this branch.

⚠ **But that cuts both ways, and it belongs in the exclusions:** the estate's visual instrument is in a COULD-NOT-MEASURE state, so **this PR has had no visual verification at all** — and it *does* change hero row layout by adding an element into the label column. jsdom proved the chip's presence and text; nothing has looked at it. Committing linux references is a separate, reviewable piece of work (the job says so itself) and is deliberately not bundled here.
