### PR TITLE
fix(canvas): remove dead Cmd/Ctrl+K entry from the keyboard legend

### DIFF
--- a/src/canvas/help/KeyboardLegend.tsx
+++ b/src/canvas/help/KeyboardLegend.tsx
@@ -127,7 +127,6 @@ const SHORTCUT_SECTIONS: ShortcutSection[] = [
     title: 'Workspace',
     items: [
       { keys: ['Cmd/Ctrl + D'], description: 'Toggle Documents drawer' },
-      { keys: ['Cmd/Ctrl + K'], description: 'Jump to global search or command palette' },
     ],
   },
   {

--- a/src/canvas/help/__tests__/KeyboardLegend.dom.spec.tsx
+++ b/src/canvas/help/__tests__/KeyboardLegend.dom.spec.tsx
@@ -114,3 +114,24 @@ describe('KeyboardLegend', () => {
     })
   })
 })
+
+describe('KeyboardLegend advertises only shortcuts that have a live handler', () => {
+  // Derived at staging a7e119ef: the ONLY `(metaKey||ctrlKey) && key === 'k'` handler in src/
+  // lives in canvas/palette/usePalette.ts, whose sole non-test importer is
+  // canvas/palette/CommandPalette.tsx -- a twin with zero non-test importers. The MOUNTED
+  // palette (canvas/components/CommandPalette.tsx, ReactFlowGraph.tsx:48) cannot be opened:
+  // setShowCommandPalette is referenced exactly twice and never set true. The live canvas
+  // shortcut hook (useCanvasKeyboardShortcuts.ts) binds no 'k'.
+  it('does not advertise Cmd/Ctrl + K, which no live handler implements', () => {
+    render(<KeyboardLegend isOpen={true} onClose={() => {}} />)
+
+    // Positive control, same render: Cmd/Ctrl + D IS advertised and IS live
+    // (useCanvasKeyboardShortcuts.ts -- "Toggle Documents drawer"). Without this the
+    // absence assertions below would also pass on an empty or non-rendering legend.
+    expect(screen.getByText('Cmd/Ctrl + D')).toBeInTheDocument()
+    expect(screen.getByText('Toggle Documents drawer')).toBeInTheDocument()
+
+    expect(screen.queryByText('Cmd/Ctrl + K')).not.toBeInTheDocument()
+    expect(screen.queryByText('Jump to global search or command palette')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Ruling

> "Cmd+K: derive intended live purpose for max ~20 minutes. If it merely points to dead/stale functionality, remove the legend entry; do not invent a new feature."

It points at dead functionality. **One line removed from the legend.** No command palette is implemented; neither palette twin is deleted here.

## What changed

`src/canvas/help/KeyboardLegend.tsx` — removed:

```
{ keys: ['Cmd/Ctrl + K'], description: 'Jump to global search or command palette' },
```

## Derivation (staging `a7e119ef`, fresh clone, contrast controls firing)

| Claim | Evidence |
|---|---|
| Only one `⌘K` handler in `src/` | `canvas/palette/usePalette.ts:149` — `(e.metaKey \|\| e.ctrlKey) && e.key === 'k'`. Contrast: 42 `metaKey` mentions tree-wide, so the sweep sees. |
| That handler is unreachable | `usePalette`'s only non-test importer is `canvas/palette/CommandPalette.tsx`, which itself has **zero** non-test importers. |
| The *mounted* palette cannot be opened | `canvas/components/CommandPalette.tsx` (imported `ReactFlowGraph.tsx:48`) is gated on `showCommandPalette`. `setShowCommandPalette` has exactly **two** references tree-wide — `useState(false)` at `:614` and an `onClose` setting `false` at `:2353`. **Nothing sets it `true`.** Contrast: `useCanvasStore` appears 79× in that same file. |
| The live shortcut hook binds no `k` | `useCanvasKeyboardShortcuts.ts` (mounted `ReactFlowGraph.tsx:1216`) binds `p, t, Alt+V, ⌘3, ⌘Enter, ⌘I, ⌘D, Shift+A, l, arrows, Shift+F10`. |

The legend itself **is live** — mounted at `ReactFlowGraph.tsx:2357`, opened by `?`, HelpMenu, KebabMenu, TopBar and OnboardingOverlay. So this was a user-visible false promise.

## Legend sweep — the other seven entries are all live

Double-click node/edge · `Esc` (×3) · `⌘D` (`useCanvasKeyboardShortcuts.ts:197`) · `⌘Enter` (`:175`) · `?` (`KeyboardLegend.tsx:83`). **⌘K was the only dead entry.**

## Test

New spec in `src/canvas/help/__tests__/KeyboardLegend.dom.spec.tsx`. It carries its **positive control in the same render** (`⌘D` / "Toggle Documents drawer" must be present), so the absence assertion cannot pass vacuously.

Discriminating mutant set, in a worktree outside the repo root whose isolation was proven **by writing a sentinel and asserting the write landed**:

| Mutant | Expected | Result |
|---|---|---|
| A — re-add the `⌘K` row | RED | **RED**, failing test named is this one |
| B — alter a *different* row (`⌘Enter`) | GREEN | **GREEN** — a *pre-existing* test caught it instead, proving identity binding |
| C — delete the `⌘D` control row | RED | **RED**, and it fails **on the control assertion** |

Applied-check scoped to `src/` read exactly 1 per mutant; pristine control read exactly 0; trailing control clean and green.

## Gate (derived from `staging-full-tests.yml`, step order Lint → Type check)

- `pnpm run lint` — **0 errors**; hooks ratchet exactly at baseline.
- `pnpm run typecheck` — **PASSED**, exit 0; coverage 3720/3760; ratchet 2196 = baseline.
- `src/canvas/help` + `src/canvas/onboarding` — **69 passed**. This spec collected **11** tests by name.

## Reported separately, deliberately NOT edited here

- `canvas/components/KeyboardMap.tsx` has **zero** non-test importers — a third dead component whose own doc comment also falsely claims `Cmd/Ctrl+K` opens it.
- The two palette twins are **rowed, not deleted** — deletion is a separate decision under the seven-way gate.
- The legend is *incomplete*: live `⌘I`, `⌘3`, `p`, `t`, `l`, `Shift+A`, `Alt+V` are unadvertised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)