### PR TITLE
Analysis (New): 'At a glance' — a 5-to-10-second read designed natively for 320px

### DIFF
--- a/src/components/results/analysisNew/AnalysisNewTabBody.tsx
+++ b/src/components/results/analysisNew/AnalysisNewTabBody.tsx
@@ -37,6 +37,7 @@ import { ANALYSIS_NEW_COPY as COPY } from './analysisNewCopy'
 import { ANALYSIS_NEW_LIMITS } from './buildAnalysisNewViewModel'
 import { useAnalysisNewViewModel } from './useAnalysisNewViewModel'
 import { AnalysisNewSection } from './sections/AnalysisNewSection'
+import { AtAGlance } from './sections/AtAGlance'
 import { StrengthenTheReasoning } from './sections/StrengthenTheReasoning'
 import { DeeperAnalysis } from './sections/DeeperAnalysis'
 
@@ -137,6 +138,9 @@ export function AnalysisNewTabBody({
             {vm.status.statusNote}
           </p>
         ) : null}
+
+        {/* ── AT A GLANCE — the 5-to-10-second read ───────────────────────── */}
+        <AtAGlance glance={vm.atAGlance} onFocusTarget={focusTarget} />
 
         {/* ── 1. KEY INSIGHTS ─────────────────────────────────────────────── */}
         <AnalysisNewSection

--- a/src/components/results/analysisNew/AnalysisNewTabBody.tsx
+++ b/src/components/results/analysisNew/AnalysisNewTabBody.tsx
@@ -146,7 +146,17 @@ export function AnalysisNewTabBody({
         <AnalysisNewSection
           title={COPY.sections.keyInsights}
           findings={vm.keyInsights.insights}
-          emptyMessage={vm.status.isPreRun ? null : COPY.empty.keyInsights}
+          // ⚠ "No insight is grounded well enough to lead with yet" is FALSE
+          // when the run DID produce insights and the glance is simply stating
+          // them — witnessed on a real run, where the glance carried all three
+          // and this line then contradicted the surface directly above it. An
+          // empty list with a non-zero candidate count means "shown above", so
+          // the section renders nothing at all rather than a claim that is not
+          // true. The honest empty state survives for a run that genuinely
+          // produced none.
+          emptyMessage={
+            vm.status.isPreRun || vm.keyInsights.candidateCount > 0 ? null : COPY.empty.keyInsights
+          }
           onFocusTarget={focusTarget}
           onRunIntervention={runIntervention}
           testId="analysis-new-key-insights"

--- a/src/components/results/analysisNew/__tests__/AnalysisNewTabBody.spec.tsx
+++ b/src/components/results/analysisNew/__tests__/AnalysisNewTabBody.spec.tsx
@@ -80,9 +80,15 @@ describe('F · the three scenario classes (§24F)', () => {
   })
 
   it('GENUINE DECISION — comparative material appears, phrased as "currently scores higher"', () => {
+    // Stated ONCE, by "At a glance". It used to appear here AND as a key
+    // insight one viewport below — measured on a real run, all three insights
+    // were restatements of the glance.
     renderBody(genuineDecision())
-    expect(screen.getByTestId('analysis-new-key-insights')).toHaveTextContent(
+    expect(screen.getByTestId('analysis-new-glance-headline')).toHaveTextContent(
       'Raise price currently scores higher',
+    )
+    expect(screen.getByTestId('analysis-new-key-insights').textContent).not.toContain(
+      'currently scores higher',
     )
   })
 
@@ -162,10 +168,9 @@ describe('staleness contextualises without dominating (§20)', () => {
     expect(screen.getByTestId('analysis-new-status-stale')).toHaveTextContent(
       'The model has changed since this analysis ran.',
     )
-    // One line, not a banner stack: the findings are still on screen.
-    expect(
-      within(screen.getByTestId('analysis-new-key-insights')).getAllByTestId('analysis-new-key-insights-row').length,
-    ).toBeGreaterThan(0)
+    // One line, not a banner stack: the read is still on screen.
+    expect(screen.getByTestId('analysis-new-glance')).toBeInTheDocument()
+    expect(screen.getByTestId('analysis-new-glance-headline')).toBeInTheDocument()
   })
 })
 

--- a/src/components/results/analysisNew/__tests__/atAGlance.spec.tsx
+++ b/src/components/results/analysisNew/__tests__/atAGlance.spec.tsx
@@ -119,11 +119,26 @@ describe('could change if — a tipping point, gated on the honesty field', () =
 
   const ROW = { label: 'Two-month timeframe', node_id: 'n_time', current_value: 2, flip_value: 3 }
 
-  it('renders when the producer computed one', () => {
-    expect(withFlip('computed', ROW)).toEqual({
-      text: 'Two-month timeframe passes 3',
+  it('renders when the producer computed one, with its unit', () => {
+    expect(withFlip('computed', { ...ROW, unit: '%' })).toEqual({
+      text: 'Two-month timeframe passes 3%',
       targetId: 'n_time',
     })
+  })
+
+  it('pairs the flip value with the current one when the producer sent NO unit', () => {
+    // Witnessed on a real run before this was fixed: "Price increase for new
+    // customers passes 1" — a bare number on the model's own scale, which the
+    // reader cannot place. `current_value` is the reference, from the same row.
+    expect(withFlip('computed', ROW)!.text).toBe('Two-month timeframe moves from 2 to 3')
+  })
+
+  it('states the condition WITHOUT a number when neither a unit nor a baseline exists', () => {
+    // No baseline means no direction of travel — printing a lone figure would
+    // imply one the producer never supplied.
+    expect(withFlip('computed', { ...ROW, current_value: null })!.text).toBe(
+      'Two-month timeframe changes materially',
+    )
   })
 
   it('renders NOTHING when the producer could not determine a flip', () => {
@@ -174,5 +189,99 @@ describe('the whole region collapses honestly', () => {
   it('renders nothing at all when no producer supplied any of it', () => {
     const { container } = render(<AtAGlance glance={glanceOf(makeData())} />)
     expect(container.querySelector('[data-testid="analysis-new-glance"]')).toBeNull()
+  })
+})
+
+describe('one signal, one primary surface', () => {
+  const vmOf = (data: ResultsSectionDataReturn) =>
+    buildAnalysisNewViewModel({
+      data,
+      recommendations: [],
+      recommendationCandidateCount: 0,
+      isPreRun: false,
+      isRunning: false,
+      isStale: false,
+    })
+
+  it('drops the insights the glance already states', () => {
+    // Measured on a real run: all three key insights restated the glance.
+    const vm = vmOf(genuineDecision())
+    expect(vm.atAGlance.headline).toBeTruthy()
+    expect(vm.atAGlance.verdict).toBeTruthy()
+    const ids = vm.keyInsights.insights.map((i) => i.id)
+    expect(ids).not.toContain('insight:comparative')
+    expect(ids).not.toContain('insight:robustness')
+  })
+
+  it('KEEPS the comparative insight when the glance did NOT state it', () => {
+    // ⭐ THE DISCRIMINATING HALF. Suppression is keyed to what the glance
+    // actually rendered — a blanket id filter would delete this finding on
+    // exactly the runs where the list is the only place it could appear.
+    const withheld = vmOf(decisionWithLeaderWithheld())
+    expect(withheld.atAGlance.headline).toBeNull()
+    // The comparative insight is absent here for its OWN reason (no
+    // entitlement), so assert the mechanism on robustness instead: the glance
+    // has no verdict, therefore the insight survives.
+    const noVerdict = vmOf(
+      makeData({
+        recommendation: {
+          robustnessVerdict: undefined as never,
+          coachingHeadline: 'What this run found',
+          coachingDecisionStatement: 'A statement.',
+        },
+      }),
+    )
+    expect(noVerdict.atAGlance.verdict).toBeNull()
+    expect(noVerdict.keyInsights.insights.map((i) => i.id)).toContain('insight:executive-summary')
+  })
+
+  it('suppresses the hinge insight when the glance already states a condition, and still reports the RUN count', () => {
+    // The hinge is the ONE remaining dedupe path: it comes from a DIFFERENT
+    // producer than the glance condition (`topFragileEdge` vs `flipThresholds`),
+    // so both can exist on the same run and the duplicate must be removed.
+    const both = makeData({
+      recommendation: {
+        flipThresholdsStatus: 'computed' as never,
+        flipThresholds: [
+          { label: 'Timeframe', node_id: 'n_t', current_value: 2, flip_value: 3 },
+        ] as never,
+      },
+      confidence: {
+        topFragileEdge: {
+          fromId: 'f_a',
+          fromLabel: 'Timeframe',
+          toId: 'g',
+          toLabel: 'Goal',
+          alternativeWinnerLabel: 'Other',
+          switchProbability: 0.4,
+        },
+      },
+    })
+    const vm = vmOf(both)
+    expect(vm.atAGlance.condition, 'the glance must state a condition for this case to mean anything').not.toBeNull()
+    expect(vm.keyInsights.insights.map((i) => i.id)).not.toContain('insight:hinge')
+    // The count still reports what the RUN produced — a cap disclosure that
+    // shrinks silently is worse than no disclosure.
+    expect(vm.keyInsights.candidateCount).toBeGreaterThan(vm.keyInsights.insights.length)
+  })
+
+  it('KEEPS the hinge insight when the glance states NO condition', () => {
+    // The discriminating twin: without a glance condition the hinge is the only
+    // place that finding appears, and a blanket id filter would delete it.
+    const hingeOnly = makeData({
+      confidence: {
+        topFragileEdge: {
+          fromId: 'f_a',
+          fromLabel: 'Timeframe',
+          toId: 'g',
+          toLabel: 'Goal',
+          alternativeWinnerLabel: 'Other',
+          switchProbability: 0.4,
+        },
+      },
+    })
+    const vm = vmOf(hingeOnly)
+    expect(vm.atAGlance.condition).toBeNull()
+    expect(vm.keyInsights.insights.map((i) => i.id)).toContain('insight:hinge')
   })
 })

--- a/src/components/results/analysisNew/__tests__/atAGlance.spec.tsx
+++ b/src/components/results/analysisNew/__tests__/atAGlance.spec.tsx
@@ -1,0 +1,178 @@
+/**
+ * At a glance — the semantic contract of the 5-to-10-second read.
+ *
+ * These pin the claims the concept mock-ups got wrong, so a future revision
+ * that reintroduces them goes RED with a named reason rather than shipping.
+ */
+
+import '@testing-library/jest-dom/vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { buildAnalysisNewViewModel } from '../buildAnalysisNewViewModel'
+import { AtAGlance } from '../sections/AtAGlance'
+import type { ResultsSectionDataReturn } from '../../useResultsSectionData'
+import {
+  decisionWithLeaderWithheld,
+  genuineDecision,
+  highUncertainty,
+  makeData,
+  makeDriver,
+  openStrategicChallenge,
+} from './analysisNewFixtures'
+
+const glanceOf = (data: ResultsSectionDataReturn) =>
+  buildAnalysisNewViewModel({
+    data,
+    recommendations: [],
+    recommendationCandidateCount: 0,
+    isPreRun: false,
+    isRunning: false,
+    isStale: false,
+  }).atAGlance
+
+afterEach(() => cleanup())
+
+describe('the read — no UI-generated strategic conclusion', () => {
+  it('states the leader only when the single verdict entitles one', () => {
+    expect(glanceOf(genuineDecision()).headline).toBe('Raise price currently scores higher')
+  })
+
+  it('renders NO headline when the entitlement is withheld — it does not fall back to a substitute', () => {
+    // The discriminating twin. A surface that invented a synthesis to fill the
+    // space would still produce a headline here.
+    expect(glanceOf(decisionWithLeaderWithheld()).headline).toBeNull()
+  })
+
+  it('renders no headline for an open strategic challenge, but still has drivers to lead with', () => {
+    const g = glanceOf(openStrategicChallenge())
+    expect(g.headline).toBeNull()
+    expect(g.drivers.length).toBeGreaterThan(0)
+  })
+})
+
+describe('the trust qualification', () => {
+  it('maps the producer enum to one word and carries its reason VERBATIM', () => {
+    const g = glanceOf(genuineDecision())
+    expect(g.verdict).toEqual({
+      tone: 'stable',
+      label: 'Stable',
+      reason: 'The ordering held across the simulated range.',
+    })
+  })
+
+  it('renders NOTHING for not_assessed — the stated absence is not a fourth word', () => {
+    const g = glanceOf(
+      makeData({ recommendation: { robustnessVerdict: 'not_assessed' as never } }),
+    )
+    expect(g.verdict).toBeNull()
+  })
+
+  it('never composes a coverage claim of its own', () => {
+    // "Robust across MOST TESTED uncertainty" was a fraction nothing computes.
+    for (const f of [genuineDecision(), highUncertainty(), openStrategicChallenge()]) {
+      const text = JSON.stringify(glanceOf(f).verdict ?? {})
+      expect(text).not.toMatch(/most|tested uncertainty|coverage|all uncertaint/i)
+    }
+  })
+})
+
+describe('driver bars — a rank comparison, never a share of the outcome', () => {
+  it('scales to the STRONGEST driver, not to a sum', () => {
+    const data = makeData({
+      drivers: {
+        drivers: [
+          makeDriver({ factorKey: 'a', factorLabel: 'A', displayInfluence: 0.5 }),
+          makeDriver({ factorKey: 'b', factorLabel: 'B', displayInfluence: 0.25 }),
+        ],
+      },
+    })
+    const g = glanceOf(data)
+    // Top is 1.0 and the second is HALF of it. Under a share-of-sum scaling
+    // these would be 0.667 / 0.333 — the reading the percentages invited.
+    expect(g.drivers[0].fraction).toBeCloseTo(1, 5)
+    expect(g.drivers[1].fraction).toBeCloseTo(0.5, 5)
+  })
+
+  it('caps at three and flags a set-relative basis from the producer token', () => {
+    expect(glanceOf(highUncertainty()).influenceIsSetRelative).toBe(true)
+    expect(glanceOf(openStrategicChallenge()).influenceIsSetRelative).toBe(false)
+    expect(glanceOf(openStrategicChallenge()).drivers.length).toBeLessThanOrEqual(3)
+  })
+
+  it('renders no numeric influence anywhere in the glance', () => {
+    // The whole point of bars: no number appears that could be read as a share.
+    const html = render(<AtAGlance glance={glanceOf(openStrategicChallenge())} />).container.innerHTML
+    expect(html).not.toMatch(/\d+%<\/|>\s*\d+%\s*</)
+  })
+})
+
+describe('could change if — a tipping point, gated on the honesty field', () => {
+  const withFlip = (status: string | undefined, flip: unknown) =>
+    glanceOf(
+      makeData({
+        recommendation: {
+          flipThresholdsStatus: status as never,
+          flipThresholds: [flip] as never,
+        },
+      }),
+    ).condition
+
+  const ROW = { label: 'Two-month timeframe', node_id: 'n_time', current_value: 2, flip_value: 3 }
+
+  it('renders when the producer computed one', () => {
+    expect(withFlip('computed', ROW)).toEqual({
+      text: 'Two-month timeframe passes 3',
+      targetId: 'n_time',
+    })
+  })
+
+  it('renders NOTHING when the producer could not determine a flip', () => {
+    // 'unresolved'/'unavailable' are technical non-results. Turning either into
+    // a visible condition converts "we could not compute this" into a finding.
+    for (const status of ['unresolved', 'unavailable', 'all_no_effect']) {
+      expect(withFlip(status, ROW), `status ${status} must render nothing`).toBeNull()
+    }
+  })
+
+  it('renders nothing when the flip value itself is absent', () => {
+    expect(withFlip('computed', { ...ROW, flip_value: null })).toBeNull()
+  })
+
+  it('is NOT derived from the influence ranking', () => {
+    // A run with drivers but no flip thresholds must produce no condition —
+    // otherwise the top driver would be reappearing under a second name.
+    const g = glanceOf(openStrategicChallenge())
+    expect(g.drivers.length).toBeGreaterThan(0)
+    expect(g.condition).toBeNull()
+  })
+})
+
+describe('fail-closed focus, and the interaction grammar', () => {
+  it('renders an unfocusable driver as text, never as a dead control', () => {
+    const data = makeData({
+      drivers: { drivers: [makeDriver({ factorKey: 'x', factorLabel: 'X', canFocus: false })] },
+    })
+    render(<AtAGlance glance={glanceOf(data)} onFocusTarget={vi.fn()} />)
+    expect(screen.getByTestId('analysis-new-glance-driver')).toBeInTheDocument()
+    expect(screen.queryByTestId('analysis-new-glance-driver-focus')).toBeNull()
+  })
+
+  it('routes a focusable driver to the Living Model by its producer target id', () => {
+    const onFocusTarget = vi.fn()
+    const data = makeData({
+      drivers: {
+        drivers: [makeDriver({ factorKey: 'x', factorLabel: 'X', matchedNodeId: 'node_x' })],
+      },
+    })
+    render(<AtAGlance glance={glanceOf(data)} onFocusTarget={onFocusTarget} />)
+    fireEvent.click(screen.getByTestId('analysis-new-glance-driver-focus'))
+    expect(onFocusTarget).toHaveBeenCalledWith('node_x')
+  })
+})
+
+describe('the whole region collapses honestly', () => {
+  it('renders nothing at all when no producer supplied any of it', () => {
+    const { container } = render(<AtAGlance glance={glanceOf(makeData())} />)
+    expect(container.querySelector('[data-testid="analysis-new-glance"]')).toBeNull()
+  })
+})

--- a/src/components/results/analysisNew/__tests__/buildAnalysisNewViewModel.spec.ts
+++ b/src/components/results/analysisNew/__tests__/buildAnalysisNewViewModel.spec.ts
@@ -53,10 +53,11 @@ const build = (
 
 describe('leader entitlement (§13) — recommendation.verdict.hasLeadingOption', () => {
   it('names a leader ONLY when the verdict entitles it, and never says "wins"', () => {
+    // The comparative read moved to "At a glance" — it is the surface that
+    // states it now, so that is where the entitlement is asserted. The
+    // vocabulary sweep below still covers the WHOLE view model.
     const vm = build(genuineDecision())
-    const comparative = vm.keyInsights.insights.find((i) => i.id === 'insight:comparative')
-    expect(comparative, 'a genuine decision with an entitled verdict must offer the comparative insight').toBeDefined()
-    expect(comparative!.headline).toBe('Raise price currently scores higher')
+    expect(vm.atAGlance.headline).toBe('Raise price currently scores higher')
     // The forbidden vocabulary, checked across the WHOLE surface rather than
     // just this row — a leader claim leaking through another section would be
     // the same defect in a different place.
@@ -73,72 +74,49 @@ describe('leader entitlement (§13) — recommendation.verdict.hasLeadingOption'
     // leader — which is exactly the conflation the single verdict exists to
     // prevent.
     const vm = build(decisionWithLeaderWithheld())
-    expect(vm.keyInsights.insights.map((i) => i.id)).not.toContain('insight:comparative')
+    expect(vm.atAGlance.headline).toBeNull()
+    expect(vm.atAGlance.winShare, 'a win share with no entitled leader is a number about a withheld option').toBeNull()
   })
 
   it('an open strategic challenge produces insights WITHOUT any option framing', () => {
     const vm = build(openStrategicChallenge())
-    expect(vm.keyInsights.insights.length).toBeGreaterThan(0)
-    expect(vm.keyInsights.insights.map((i) => i.id)).not.toContain('insight:comparative')
-    // The section is NOT empty just because there is no decision — that is the
-    // failure mode a decision-first ladder produces.
-    expect(vm.keyInsights.insights.map((i) => i.id)).toContain('insight:robustness')
+    expect(vm.atAGlance.headline).toBeNull()
+    // The surface is NOT empty just because there is no decision — that is the
+    // failure mode a decision-first ladder produces. The glance leads with
+    // drivers, and the ladder still carries the structural findings.
+    expect(vm.atAGlance.drivers.length).toBeGreaterThan(0)
     expect(vm.keyInsights.insights.map((i) => i.id)).toContain('insight:dominant-factor')
   })
 })
 
 describe('robustness (§4) — display-safe verdict only', () => {
   it("renders the producer's own reason verbatim and never authors robustness prose", () => {
-    const vm = build(openStrategicChallenge())
-    const r = vm.keyInsights.insights.find((i) => i.id === 'insight:robustness')!
-    expect(r.implication).toBe(
+    // Robustness is stated by "At a glance" now — one surface, and it is the
+    // one that carries the producer's sentence.
+    expect(build(openStrategicChallenge()).atAGlance.verdict?.reason).toBe(
       'Small changes in supplier lead time change which direction looks better.',
     )
   })
 
-  it('omits the robustness insight entirely when no display-safe verdict arrived', () => {
-    // `robustnessLevel` alone must NOT produce a headline — it is structured
-    // data, not a display-safe verdict.
-    const vm = build(makeData({ recommendation: { robustnessLevel: 'low' } }))
-    expect(vm.keyInsights.insights.map((i) => i.id)).not.toContain('insight:robustness')
+  it('says nothing about robustness when no display-safe verdict arrived', () => {
+    // `robustnessLevel` alone must NOT produce a verdict — it is structured
+    // data, not a display-safe one.
+    expect(build(makeData({ recommendation: { robustnessLevel: 'low' } })).atAGlance.verdict).toBeNull()
   })
 
   it('covers ALL FOUR vocabulary members distinctly, and turns none of them into a claim it did not receive', () => {
-    // ⭐ THE BREADTH CASE. `RobustnessDisplayVerdict` has four members and an
-    // earlier draft split them binary — so 'moderate' read as "sensitive" and
-    // 'not_assessed', the producer's own stated absence, read as a measurement.
-    // Turning "we did not measure this" into a verdict is the single worst
-    // thing this surface could do, so it gets its own case.
-    const insightFor = (verdict: string) =>
-      build(
-        makeData({
-          recommendation: {
-            robustnessVerdict: verdict as never,
-            robustnessVerdictReason: 'Producer reason.',
-          },
-        }),
-      ).keyInsights.insights.find((i) => i.id === 'insight:robustness')
-    const headlineFor = (verdict: string) => insightFor(verdict)?.headline
+    // ⭐ THE BREADTH CASE, now against the glance's word map. Four members; a
+    // binary split made 'moderate' read as sensitive and turned 'not_assessed'
+    // — the producer's own stated absence — into a measurement.
+    const wordFor = (verdict: string) =>
+      build(makeData({ recommendation: { robustnessVerdict: verdict as never, robustnessVerdictReason: 'r' } }))
+        .atAGlance.verdict
 
-    expect(headlineFor('robust')).toBe('This result holds up under uncertainty')
-    expect(headlineFor('moderate')).toBe('This result holds up, but not strongly')
-    expect(headlineFor('fragile')).toBe('This result is sensitive to uncertainty')
-
-    // ⚠⚠ ASSERT THE ROW IS ABSENT, NOT THAT ITS HEADLINE IS UNDEFINED — and the
-    // difference is the whole case. A mutant that drops the vocabulary lookup
-    // from the guard still PUSHES an insight for 'not_assessed'; its headline is
-    // merely `undefined`, so `?.headline` reads undefined either way and the
-    // weaker assertion passed on a row that would render a BLANK HEADLINE to a
-    // user. Caught by the mutation battery, not by review.
-    expect(insightFor('not_assessed')).toBeUndefined()
-    // …and the three that DO render each have a real, non-empty headline, so
-    // "absent" and "present but blank" can never be confused here again.
-    for (const v of ['robust', 'moderate', 'fragile']) {
-      expect(insightFor(v)?.headline, `${v} rendered a blank headline`).toBeTruthy()
-    }
-    // …and the three that do render are genuinely distinct, so a future
-    // collapse back to a binary split REDs here.
-    expect(new Set([headlineFor('robust'), headlineFor('moderate'), headlineFor('fragile')]).size).toBe(3)
+    expect(wordFor('robust')?.label).toBe('Stable')
+    expect(wordFor('moderate')?.label).toBe('Mixed')
+    expect(wordFor('fragile')?.label).toBe('Sensitive')
+    expect(wordFor('not_assessed')).toBeNull()
+    expect(new Set(['robust', 'moderate', 'fragile'].map((v) => wordFor(v)!.label)).size).toBe(3)
   })
 })
 
@@ -234,7 +212,9 @@ describe('coverage is not readiness (§17)', () => {
     const vm = build(highUncertainty())
     expect(vm.uncertainty.findings.length).toBeGreaterThan(0)
     expect(vm.drivers.findings.length).toBeGreaterThan(0)
-    expect(vm.keyInsights.insights.length).toBeGreaterThan(0)
+    // The glance still has a read to give even on a fragile, partial run.
+    expect(vm.atAGlance.verdict).not.toBeNull()
+    expect(vm.atAGlance.drivers.length).toBeGreaterThan(0)
   })
 })
 
@@ -341,11 +321,9 @@ describe('withheld fields (ROADMAP 2.1273) — never read, never rendered', () =
   })
 
   it('still renders the HONEST statistic it was standing beside', () => {
-    // The discriminating half: without this, deleting the whole comparative
-    // insight would satisfy the case above and prove nothing.
-    const vm = build(genuineDecision())
-    const comparative = vm.keyInsights.insights.find((i) => i.id === 'insight:comparative')!
-    expect(comparative.inspect.map((r) => r.label)).toContain('Win probability')
+    // The discriminating half: without this, deleting the win share outright
+    // would satisfy the absence case above and prove nothing.
+    expect(build(genuineDecision()).atAGlance.winShare).toBe('Ahead in 69% of simulated futures')
   })
 })
 

--- a/src/components/results/analysisNew/analysisNewCopy.ts
+++ b/src/components/results/analysisNew/analysisNewCopy.ts
@@ -19,6 +19,7 @@ export const ANALYSIS_NEW_COPY = {
     'A second reading of the same analysis run, laid out around the reasoning. Nothing here is re-computed.',
 
   sections: {
+    atAGlance: 'At a glance',
     keyInsights: 'Key insights',
     strengthen: 'Strengthen the reasoning',
     drivers: 'Drivers and dynamics',
@@ -51,6 +52,24 @@ export const ANALYSIS_NEW_COPY = {
     groundedIn: 'Grounded in',
     moreDrivers: (n: number) => `Show ${n} more`,
     moreUncertainty: (n: number) => `Show ${n} more`,
+  },
+
+  /** At a glance. Every string here is furniture — none describes the analysis. */
+  glance: {
+    whatMattersMost: 'What matters most',
+    couldChangeIf: 'Could change if',
+    /**
+     * ⚠ THE BASIS CAPTION IS A TRUTH CLAIM, NOT A LEGEND, which is why it is
+     * visible rather than hover-only. "Relative influence" says the bars rank
+     * within THIS run; "Influence" says they sit on the producer's own scale.
+     * A reader who mistakes the first for the second reads a rank as a share.
+     */
+    basisRelative: 'Relative influence',
+    basisAbsolute: 'Influence',
+    basisRelativeExplain:
+      'Each bar is scaled against the strongest factor in this run, so the bars rank the factors against each other. They are not shares of the outcome.',
+    basisAbsoluteExplain:
+      "Each bar shows the producer's own structural influence score, scaled against the strongest factor in this run.",
   },
 
   markers: {

--- a/src/components/results/analysisNew/analysisNewTypes.ts
+++ b/src/components/results/analysisNew/analysisNewTypes.ts
@@ -201,9 +201,76 @@ export interface AnalysisNewStatus {
 
 export interface AnalysisNewViewModel {
   status: AnalysisNewStatus
+  atAGlance: AtAGlance
   keyInsights: KeyInsightsSection
   strengthen: StrengthenSection
   drivers: DriversSection
   uncertainty: UncertaintySection
   deeper: DeeperAnalysisSection
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AT A GLANCE — the 5-to-10-second strategic read
+// ═══════════════════════════════════════════════════════════════════════════
+
+/**
+ * The trust qualification, as a VISIBLE state plus a producer-authored reason.
+ *
+ * ⚠ THE SPLIT IS THE POINT. `tone`/`label` is essential analytical state and
+ * stays visible; the SCOPE of the claim ("across the simulated range") is the
+ * producer's own sentence and is rendered verbatim beneath, never composed
+ * here. An earlier concept read "Robust across most tested uncertainty" — a
+ * COVERAGE claim ("most") that nothing computes. The producer says what it
+ * tested; this surface does not summarise it.
+ */
+export interface GlanceVerdict {
+  tone: 'stable' | 'mixed' | 'sensitive'
+  /** One word, user-facing. Content-strategy rename of the producer enum. */
+  label: string
+  /** `robustness.display_verdict_reason`, VERBATIM. Absent when not sent. */
+  reason?: string
+}
+
+/** One driver row: a label, a comparable magnitude, and a focus target. */
+export interface GlanceDriver {
+  id: string
+  label: string
+  /** 0-1 against the STRONGEST driver in this run — a within-run comparison. */
+  fraction: number
+  /**
+   * Focus target, or null when the producer named none / it is not on the
+   * canvas. Null renders as text, never as a dead affordance — the
+   * fail-closed pre-gate the analysis-hero prototype already established.
+   */
+  targetId: string | null
+}
+
+/**
+ * "Could change if" — a TIPPING POINT, a different analytical dimension from
+ * the influence ranking above it.
+ *
+ * ⚠ NEVER DERIVED FROM INFLUENCE. Influence ranks what moves the outcome;
+ * this names the value at which the ORDERING changes. Conflating them would
+ * put the same signal on screen twice under two names. Sourced from
+ * `flipThresholds` and gated on `flipThresholdsStatus`.
+ */
+export interface GlanceCondition {
+  text: string
+  targetId: string | null
+}
+
+export interface AtAGlance {
+  /** The current read. Absent when no producer licenses a synthesis. */
+  headline: string | null
+  verdict: GlanceVerdict | null
+  drivers: GlanceDriver[]
+  /**
+   * TRUE when the bars are set-relative (`normalised_elasticity`) rather than
+   * the producer's absolute influence scale. Drives the basis caption, which
+   * is a truth claim and therefore visible, not hover-only.
+   */
+  influenceIsSetRelative: boolean
+  condition: GlanceCondition | null
+  /** The single highest-priority engine recommendation, or null. */
+  primaryInterventionId: string | null
 }

--- a/src/components/results/analysisNew/analysisNewTypes.ts
+++ b/src/components/results/analysisNew/analysisNewTypes.ts
@@ -262,6 +262,12 @@ export interface GlanceCondition {
 export interface AtAGlance {
   /** The current read. Absent when no producer licenses a synthesis. */
   headline: string | null
+  /**
+   * The evidence behind the read, as a sentence. Gated on the SAME entitlement
+   * as `headline` — a win share with no entitled leader is a number about an
+   * option the producer declined to put forward.
+   */
+  winShare: string | null
   verdict: GlanceVerdict | null
   drivers: GlanceDriver[]
   /**

--- a/src/components/results/analysisNew/buildAnalysisNewViewModel.ts
+++ b/src/components/results/analysisNew/buildAnalysisNewViewModel.ts
@@ -176,37 +176,16 @@ function buildKeyInsights(
     })
   }
 
-  // 2. Robustness — the display-safe verdict only, with the producer's own
-  //    reason rendered verbatim. Rule 3.
-  //
-  // ⚠⚠ THE VOCABULARY HAS FOUR MEMBERS AND A BINARY SPLIT OVER IT IS A
-  // FABRICATION. An earlier draft here read `=== 'robust' ? "holds up" :
-  // "is sensitive"`, which is correct for exactly one of the four:
-  //   · 'moderate'     → rendered as "sensitive", overstating fragility;
-  //   · 'not_assessed' → the producer's own STATED ABSENCE ("robustness not
-  //     computed"), rendered as a claim that the result IS sensitive.
-  // The last one is the worst thing this surface could do: turn "we did not
-  // measure this" into a measurement. `not_assessed` therefore produces NO
-  // insight at all — absence is not a verdict (CLAUDE.md trap 22: the defect
-  // lives in the BREADTH of a predicate, not in the case you had in mind).
-  const ROBUSTNESS_HEADLINE: Record<string, string> = {
-    robust: 'This result holds up under uncertainty',
-    moderate: 'This result holds up, but not strongly',
-    fragile: 'This result is sensitive to uncertainty',
-  }
-  if (rec.robustnessVerdict && ROBUSTNESS_HEADLINE[rec.robustnessVerdict]) {
-    out.push({
-      id: 'insight:robustness',
-      headline: ROBUSTNESS_HEADLINE[rec.robustnessVerdict],
-      // The producer authors this sentence. The UI never authors robustness prose.
-      implication: rec.robustnessVerdictReason ?? '',
-      groundedIn: 'the robustness verdict from the simulation',
-      marker: staleMarker,
-      // ⛔ `ranking_stability` IS NOT RENDERED — see the withheld-field note on
-      // the comparative insight below. PLoT never emitted it at all.
-      inspect: rows(row('Structured level', rec.robustnessLevel)),
-    })
-  }
+  // 2. ⛔ ROBUSTNESS AND THE COMPARATIVE READ ARE NOT INSIGHTS ANY MORE.
+  //    "At a glance" renders both, under EXACTLY the conditions these branches
+  //    used to fire on — so once the glance shipped they were unreachable, and
+  //    on a real run all three key insights turned out to be restatements of
+  //    the glance one viewport above. Rather than keep two representations and
+  //    suppress one, the glance is simply the single surface: it states the
+  //    verdict WITH the producer's own reason, and the leader sentence with the
+  //    same entitlement gate. `ROBUSTNESS_HEADLINE`'s four-way mapping moved to
+  //    `VERDICT_WORD` there. Deleting these here is what keeps "one signal, one
+  //    primary surface" true in the code rather than only in a filter.
 
   // 3. Strategic tension: the leading option DEPENDS on a factor's value.
   //    A genuine "it depends" finding, and the most reasoning-shaped thing the
@@ -261,41 +240,11 @@ function buildKeyInsights(
     })
   }
 
-  // 6. COMPARATIVE — LAST, and only when the single verdict entitles it.
-  //    Rule 1. "Currently scores higher", never "wins".
-  const leader = rec.recommendedOption
-  if (rec.verdict?.hasLeadingOption === true && leader && !rec.isSingleOption) {
-    const winPct = pctOrNull(leader.winProbability ?? rec.winProbability)
-    out.push({
-      id: 'insight:comparative',
-      headline: `${leader.label} currently scores higher`,
-      implication: winPct
-        ? `It comes out ahead in ${winPct} of simulated futures.`
-        : 'It comes out ahead across the simulated futures.',
-      detail: rec.nearTie ? 'The top options are close enough that this ordering is not settled.' : undefined,
-      groundedIn: 'the option comparison',
-      marker: staleMarker,
-      targetId: leader.id,
-      // ⛔⛔ NEITHER `recommendation_stability` NOR `ranking_stability` IS
-      // RENDERED ANYWHERE ON THIS SURFACE, AND THIS IS NOT AN OVERSIGHT.
-      //
-      // PLoT deliberately WITHHOLDS `robustness.recommendation_stability`: ISL
-      // derives it as `option_wins[winner] / n_samples` — the leader's win
-      // probability RELABELLED, carrying (the producer's words) "zero
-      // independent information". `ranking_stability` was never emitted at all.
-      //
-      // An earlier draft of this list printed BOTH `Win probability` and
-      // `Recommendation stability` — the SAME quantity twice, once honestly and
-      // once under a name implying an independent robustness measurement. That
-      // is a fabricated second statistic, and it is exactly what
-      // `withheldFieldReadBan.spec.ts` exists to stop; it caught this before
-      // the surface shipped. A hydrated pre-withdrawal payload can still carry
-      // a legacy value, so reading the field at all is the hazard, not just
-      // rendering a fresh one.
-      inspect: rows(row('Win probability', winPct), row('Determined by', rec.determinedBy)),
-      intervention: interventionFor(recommendations, leader.id),
-    })
-  }
+  // 6. ⛔ THE COMPARATIVE READ IS NOT AN INSIGHT EITHER — the glance states it,
+  //    and its most informative part (the win share) now rides the glance's own
+  //    trust line rather than a duplicate card a viewport below. Nothing was
+  //    lost: `winShare` in `buildAtAGlance` is the same `winProbability`, on the
+  //    same entitlement gate, with the same "never says wins" vocabulary.
 
   // Insights with no implication sentence say nothing — drop rather than
   // render a headline with an empty body.
@@ -632,10 +581,26 @@ function glanceCondition(data: ResultsSectionDataReturn): GlanceCondition | null
     (t) => t && typeof t.flip_value === 'number' && typeof t.label === 'string' && t.label.length > 0,
   )
   if (!usable) return null
-  const unit = usable.unit ? `${usable.unit}` : ''
-  const value = unit === '%' ? `${usable.flip_value}%` : `${unit}${usable.flip_value}`
+  // ⚠ A BARE NUMBER WITH NO UNIT IS UNINTERPRETABLE, AND IT SHIPPED THAT WAY IN
+  // THE FIRST MOUNTED WITNESS: "Price increase for new customers passes 1" — one
+  // what? The producer sends `unit` only sometimes; when it does not, the value
+  // sits on the model's own scale and needs a reference point to mean anything.
+  // `current_value` is that reference and comes from the same producer row, so
+  // pairing them invents nothing. When even that is absent, the direction of
+  // travel is unknowable (Codex B3: a defaulted 0 fabricated a flip DIRECTION),
+  // so the row states the condition without a number rather than printing one
+  // the reader cannot place.
+  const unit = typeof usable.unit === 'string' ? usable.unit : ''
+  const fmt = (n: number) => (unit === '%' ? `${n}%` : `${unit}${n}`)
+  const flip = fmt(usable.flip_value as number)
+  const current = typeof usable.current_value === 'number' ? fmt(usable.current_value) : null
+  const text = unit
+    ? `${usable.label} passes ${flip}`
+    : current
+      ? `${usable.label} moves from ${current} to ${flip}`
+      : `${usable.label} changes materially`
   return {
-    text: `${usable.label} passes ${value}`,
+    text,
     targetId: typeof usable.node_id === 'string' && usable.node_id.length > 0 ? usable.node_id : null,
   }
 }
@@ -657,9 +622,14 @@ function buildAtAGlance(
       : null
 
   const word = rec.robustnessVerdict ? VERDICT_WORD[rec.robustnessVerdict] : undefined
+  // The single most informative number on the surface, and it is only licensed
+  // alongside an entitled leader — so it is gated on the SAME condition as the
+  // headline, never rendered on its own.
+  const winPct = headline ? pctOrNull(leader?.winProbability ?? rec.winProbability) : null
 
   return {
     headline,
+    winShare: winPct ? `Ahead in ${winPct} of simulated futures` : null,
     verdict: word
       ? {
           tone: word.tone,
@@ -694,17 +664,65 @@ function buildStatus(inputs: AnalysisNewViewModelInputs): AnalysisNewStatus {
   }
 }
 
+/**
+ * ⭐ ONE SIGNAL, ONE PRIMARY SURFACE.
+ *
+ * ⚠ MEASURED ON A REAL COMPLETED RUN, NOT THEORISED. With "At a glance" above
+ * it, ALL THREE key insights were restatements of what the glance had just
+ * said, roughly one viewport apart:
+ *
+ *   glance verdict   "Sensitive — small changes could flip this result"
+ *   key insight #1   "This result is sensitive to uncertainty /
+ *                     small changes could flip this result"
+ *
+ *   glance headline  "Status Quo … currently scores higher"
+ *   key insight #3   "Status Quo … currently scores higher"
+ *
+ *   glance condition "Could change if Price increase … moves from 0 to 1"
+ *   key insight #2   "Price increase for new customers is the hinge"
+ *
+ * Key insights was therefore contributing nothing — the section existed, took
+ * vertical space, and told the reader only what they had already read. The
+ * glance is the PRIMARY surface for these three, so they leave the list.
+ *
+ * ⚠ SUPPRESSION IS KEYED TO WHAT THE GLANCE ACTUALLY RENDERED, not to the
+ * insight ids alone. When the producer withholds the leader the glance shows no
+ * headline — and the comparative insight then belongs in the list, because
+ * nothing above is saying it. A blanket id filter would silently delete a
+ * finding on exactly the runs where it is the only place it appears.
+ */
+function dedupeAgainstGlance(
+  section: { insights: AnalysisNewFinding[]; candidateCount: number },
+  glance: AtAGlance,
+): { insights: AnalysisNewFinding[]; candidateCount: number } {
+  const shown = new Set<string>()
+  // Robustness and the comparative read are no longer produced as insights at
+  // all — the glance is their only surface. The hinge IS still produced, from a
+  // DIFFERENT producer than the glance condition (`topFragileEdge` vs
+  // `flipThresholds`), so it is suppressed only when the glance actually
+  // rendered a condition.
+  if (glance.condition) shown.add('insight:hinge')
+  if (shown.size === 0) return section
+  return {
+    insights: section.insights.filter((i) => !shown.has(i.id)),
+    // The candidate count still reports what the RUN produced, not what
+    // survived deduplication — the cap disclosure must not shrink silently.
+    candidateCount: section.candidateCount,
+  }
+}
+
 // ── THE ADAPTER ─────────────────────────────────────────────────────────────
 
 export function buildAnalysisNewViewModel(
   inputs: AnalysisNewViewModelInputs,
 ): AnalysisNewViewModel {
   const { data, recommendations, recommendationCandidateCount, isStale } = inputs
+  const glance = buildAtAGlance(data, recommendations)
 
   return {
     status: buildStatus(inputs),
-    atAGlance: buildAtAGlance(data, recommendations),
-    keyInsights: buildKeyInsights(data, recommendations, isStale),
+    atAGlance: glance,
+    keyInsights: dedupeAgainstGlance(buildKeyInsights(data, recommendations, isStale), glance),
     strengthen: {
       interventions: recommendations.slice(0, STRENGTHEN_CAP),
       candidateCount: recommendationCandidateCount,

--- a/src/components/results/analysisNew/buildAnalysisNewViewModel.ts
+++ b/src/components/results/analysisNew/buildAnalysisNewViewModel.ts
@@ -53,6 +53,10 @@ import type {
   ContextualIntervention,
   InspectRow,
   ScienceGrounding,
+  AtAGlance,
+  GlanceCondition,
+  GlanceDriver,
+  GlanceVerdict,
 } from './analysisNewTypes'
 
 /** §2 of the brief: "a very small number of high-value insights". */
@@ -62,6 +66,8 @@ const STRENGTHEN_CAP = 3
 /** Level-1 rows before "Show more". */
 const DRIVER_PREVIEW = 3
 const UNCERTAINTY_PREVIEW = 3
+/** Driver rows in the glance. Three is the existing `topDrivers` convention. */
+const GLANCE_DRIVER_COUNT = 3
 
 export interface AnalysisNewViewModelInputs {
   data: ResultsSectionDataReturn
@@ -565,6 +571,112 @@ function buildDeeper(inputs: AnalysisNewViewModelInputs): AnalysisNewViewModel['
   return { groups }
 }
 
+// ── AT A GLANCE ─────────────────────────────────────────────────────────────
+
+/** Producer enum → one user-facing word. Content strategy, not new truth. */
+const VERDICT_WORD: Record<string, { tone: GlanceVerdict['tone']; label: string }> = {
+  robust: { tone: 'stable', label: 'Stable' },
+  moderate: { tone: 'mixed', label: 'Mixed' },
+  fragile: { tone: 'sensitive', label: 'Sensitive' },
+  // 'not_assessed' is DELIBERATELY ABSENT — the producer's stated absence must
+  // render no chip at all, never a fourth word that reads as a measurement.
+}
+
+/** Drivers, capped, with a within-run comparable magnitude. */
+function glanceDrivers(data: ResultsSectionDataReturn): {
+  drivers: GlanceDriver[]
+  setRelative: boolean
+} {
+  const rows = (data.drivers.drivers ?? []).filter((d) => d.zeroReason == null)
+  const setRelative = rows.length > 0 && rows.some((d) => d.displayProvenance !== 'influence_score')
+  const magnitude = (d: (typeof rows)[number]) =>
+    d.displayInfluence ?? d.influenceScore ?? d.normalisedInfluence ?? 0
+  // ⚠ THE BAR IS SCALED TO THE STRONGEST DRIVER IN THIS RUN, NOT TO 1.0 AND NOT
+  // TO A SUM. Scaling to a sum would render each bar as a SHARE OF THE OUTCOME —
+  // a claim neither basis licenses, and the exact misreading the earlier
+  // "41% / 22% / 15%" concept invited (they sum to 78%, which reads as
+  // "the rest is something else"). A within-run maximum makes the bars a RANK
+  // COMPARISON, which is all either basis supports.
+  const top = Math.max(...rows.map(magnitude), 0)
+  return {
+    setRelative,
+    drivers: rows.slice(0, GLANCE_DRIVER_COUNT).map((d) => ({
+      id: d.factorKey,
+      label: d.factorLabel,
+      fraction: top > 0 ? Math.max(0.04, magnitude(d) / top) : 0,
+      // Fail-closed focus pre-gate, the pattern `analysis-hero` established:
+      // an unfocusable row yields null and renders as text, never a dead link.
+      targetId: d.canFocus ? (d.matchedNodeId ?? d.factorKey) : null,
+    })),
+  }
+}
+
+/**
+ * "Could change if" — the TIPPING POINT, from `flipThresholds`.
+ *
+ * ⚠ GATED ON `flipThresholdsStatus`, WHICH IS THE HONESTY FIELD. 'unavailable'
+ * and 'unresolved' mean the producer could not determine a flip; rendering a
+ * row anyway would convert a technical non-result into an apparent finding.
+ * 'all_no_effect' means it looked and found none — also no row.
+ *
+ * ⚠ AND IT IS NOT DERIVED FROM INFLUENCE. Influence ranks what moves the
+ * outcome; this names the value at which the ORDERING changes. They are
+ * different quantities and putting the influence leader here under a different
+ * name would be the same signal shown twice.
+ */
+function glanceCondition(data: ResultsSectionDataReturn): GlanceCondition | null {
+  const status = data.recommendation.flipThresholdsStatus
+  if (status && status !== 'computed' && status !== 'partial_no_effect') return null
+  const rows = data.recommendation.flipThresholds ?? []
+  const usable = rows.find(
+    (t) => t && typeof t.flip_value === 'number' && typeof t.label === 'string' && t.label.length > 0,
+  )
+  if (!usable) return null
+  const unit = usable.unit ? `${usable.unit}` : ''
+  const value = unit === '%' ? `${usable.flip_value}%` : `${unit}${usable.flip_value}`
+  return {
+    text: `${usable.label} passes ${value}`,
+    targetId: typeof usable.node_id === 'string' && usable.node_id.length > 0 ? usable.node_id : null,
+  }
+}
+
+function buildAtAGlance(
+  data: ResultsSectionDataReturn,
+  recommendations: Recommendation[],
+): AtAGlance {
+  const rec = data.recommendation
+  const { drivers, setRelative } = glanceDrivers(data)
+
+  // The synthesis is the LEADER SENTENCE when the single verdict entitles one,
+  // and otherwise nothing. There is no UI-generated strategic conclusion here:
+  // absent an entitlement, the glance leads with the drivers instead.
+  const leader = rec.recommendedOption
+  const headline =
+    rec.verdict?.hasLeadingOption === true && leader && !rec.isSingleOption
+      ? `${leader.label} currently scores higher`
+      : null
+
+  const word = rec.robustnessVerdict ? VERDICT_WORD[rec.robustnessVerdict] : undefined
+
+  return {
+    headline,
+    verdict: word
+      ? {
+          tone: word.tone,
+          label: word.label,
+          // The SCOPE of the claim is the producer's sentence, verbatim. This
+          // surface never composes one ("across most tested uncertainty" was a
+          // coverage claim nothing computes).
+          ...(rec.robustnessVerdictReason ? { reason: rec.robustnessVerdictReason } : {}),
+        }
+      : null,
+    drivers,
+    influenceIsSetRelative: setRelative,
+    condition: glanceCondition(data),
+    primaryInterventionId: recommendations[0]?.id ?? null,
+  }
+}
+
 // ── STATUS ──────────────────────────────────────────────────────────────────
 
 function buildStatus(inputs: AnalysisNewViewModelInputs): AnalysisNewStatus {
@@ -591,6 +703,7 @@ export function buildAnalysisNewViewModel(
 
   return {
     status: buildStatus(inputs),
+    atAGlance: buildAtAGlance(data, recommendations),
     keyInsights: buildKeyInsights(data, recommendations, isStale),
     strengthen: {
       interventions: recommendations.slice(0, STRENGTHEN_CAP),

--- a/src/components/results/analysisNew/sections/AnalysisNewSection.tsx
+++ b/src/components/results/analysisNew/sections/AnalysisNewSection.tsx
@@ -29,6 +29,8 @@ export interface AnalysisNewSectionProps {
    * user must read to interpret it correctly (e.g. set-relative influence).
    */
   caveat?: string | null
+  /** First-use explanation. Lives in the heading's title, never as a resting row. */
+  subtitle?: string
   /**
    * What to say when there is nothing. Absent = render the heading and nothing
    * else, which is the right answer when an empty message would add no
@@ -45,6 +47,7 @@ export function AnalysisNewSection({
   findings,
   preview,
   caveat,
+  subtitle,
   emptyMessage,
   onFocusTarget,
   onRunIntervention,
@@ -57,9 +60,22 @@ export function AnalysisNewSection({
 
   return (
     <section className="space-y-1" data-testid={testId} aria-labelledby={`${testId}-heading`}>
-      <h3 id={`${testId}-heading`} className={`${typography.panelHeader} text-text-header`}>
-        {title}
-      </h3>
+      {/* ⚠ THE HEADER IS THE COUNT, AND THE COUNT REPLACES THE SUBCOPY.
+          "Top findings from the analysis" / "Recommended next steps" answered a
+          first-use question permanently, on every visit, for every user — four
+          such lines cost ~64px of a ~590px panel before a single finding was
+          shown. A count is the one thing that changes per run, so it is the one
+          thing worth the row. The explanation moves to the heading's `title`. */}
+      <div className="flex items-baseline justify-between gap-2">
+        <h3 id={`${testId}-heading`} className={`${typography.panelHeader} text-text-header`} title={subtitle}>
+          {title}
+        </h3>
+        {findings.length > 0 ? (
+          <span className={`${typography.panelMeta} text-text-light shrink-0`} data-testid={`${testId}-count`}>
+            {findings.length}
+          </span>
+        ) : null}
+      </div>
 
       {caveat ? (
         <p className={`${typography.panelMeta} text-text-light`} data-testid={`${testId}-caveat`}>

--- a/src/components/results/analysisNew/sections/AtAGlance.tsx
+++ b/src/components/results/analysisNew/sections/AtAGlance.tsx
@@ -99,9 +99,17 @@ export function AtAGlance({
           ) : (
             <AlertTriangle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
           )}
+          {/* Evidence and trust share ONE line: the win share is the most
+              informative number on the surface and the verdict is how much to
+              rely on it, so they belong together and cost one row, not two. */}
+          {glance.winShare ? (
+            <span className="text-text-body" data-testid={`${testId}-win-share`}>
+              {glance.winShare} ·{' '}
+            </span>
+          ) : null}
           {glance.verdict.label}
           {glance.verdict.reason ? (
-            <span className="text-text-light truncate">— {glance.verdict.reason}</span>
+            <span className="text-text-light truncate"> — {glance.verdict.reason}</span>
           ) : null}
         </p>
       ) : null}

--- a/src/components/results/analysisNew/sections/AtAGlance.tsx
+++ b/src/components/results/analysisNew/sections/AtAGlance.tsx
@@ -1,0 +1,203 @@
+/**
+ * Analysis (New) — "At a glance": the 5-to-10-second strategic read.
+ *
+ * ⭐ DESIGNED NATIVELY FOR 320px, WHICH IS THE MEASURED CONTENT WIDTH (dock
+ * 416 → body 414 → measure 360 → 40px gutters). Measured on the mounted build
+ * at 1024 / 1440 / 1920 viewports: the dock is 416px at all three, so there is
+ * no wider state to design for and no responsive variant to serve.
+ *
+ * ── WHAT THE CONCEPT MOCK-UPS PROPOSED AND THIS DOES NOT ───────────────────
+ *  · A left-to-right `drivers → influence → outcome` diagram. Dropped. Every
+ *    driver points at the same focal object, so the topology is a star and the
+ *    arrows carry no information the labels do not — while costing roughly two
+ *    thirds of the horizontal budget.
+ *  · Percentages beside each driver (41% / 22% / 15%). Dropped. They sum to 78%
+ *    against one outcome, which reads as "share of the outcome"; neither the
+ *    producer's absolute influence scale nor a set-relative elasticity licenses
+ *    that reading. Bars scaled to the strongest driver make it a RANK
+ *    comparison, which is what both bases actually support.
+ *  · Coloured icon tiles beside each driver label. Dropped. ~40px of a 320px
+ *    row spent restating the label.
+ *  · "Biggest leverage opportunity". Dropped — no leverage producer exists.
+ *  · Per-driver "more robust / more uncertain" dots. Dropped — the candidate
+ *    fields appear in no fixture, and the one always present (`confidence`) is
+ *    a known placeholder the display policy exists to suppress.
+ *  · "72% model health". Dropped — `useModelHealth()` returns an issue LIST,
+ *    not a score. There is no percentage behind it.
+ *  · A persistent "Work through with Olumi | Show in model" footer. Dropped —
+ *    the shell already owns the footer region for this surface, and a GLOBAL
+ *    "show in model" has no object to focus.
+ *  · A primary reasoning intervention row inside the glance. Dropped, and this
+ *    one is the least obvious. "Strengthen the reasoning" renders the SAME
+ *    top-priority engine recommendation immediately below, inside the same
+ *    viewport — so the glance row would be the identical action twice, roughly
+ *    120px apart. One signal, one primary surface. The glance ends on "could
+ *    change if" and hands straight to Strengthen, which is where the action,
+ *    its grounding and its routes already live. `primaryInterventionId` stays
+ *    on the model so a future variant can host it without re-deriving.
+ *
+ * ── WHAT STAYS VISIBLE, AND WHY IT CANNOT BE HOVER-ONLY ────────────────────
+ * The verdict word and the influence BASIS are analytical state: the first is
+ * how much to rely on the read, the second is what the bars mean. Both would
+ * change a reader's interpretation, so both are visible. What sits behind
+ * disclosure is the EXPLANATION — the producer's scope sentence, and the
+ * definition of the basis. That is the split the brief asks for.
+ */
+
+import { AlertTriangle, CheckCircle, ChevronRight } from 'lucide-react'
+import { typography } from '../../../../styles/typography'
+import { ANALYSIS_NEW_COPY as COPY } from '../analysisNewCopy'
+import type { AtAGlance as AtAGlanceModel } from '../analysisNewTypes'
+
+const TONE_CLASS: Record<string, string> = {
+  stable: 'text-success',
+  mixed: 'text-warning',
+  sensitive: 'text-warning',
+}
+
+export interface AtAGlanceProps {
+  glance: AtAGlanceModel
+  onFocusTarget?: (targetId: string) => void
+  onOpenDrivers?: () => void
+  testId?: string
+}
+
+export function AtAGlance({
+  glance,
+  onFocusTarget,
+  onOpenDrivers,
+  testId = 'analysis-new-glance',
+}: AtAGlanceProps) {
+  const hasAnything =
+    glance.headline || glance.verdict || glance.drivers.length > 0 || glance.condition
+  if (!hasAnything) return null
+
+  return (
+    <section className="space-y-2" data-testid={testId} aria-label={COPY.sections.atAGlance}>
+      {/* ── THE READ ───────────────────────────────────────────────────────
+          Full width, no icon gutter. Absent when no producer licenses a
+          synthesis — the glance then leads with the drivers, which is the
+          correct behaviour for a situation that is not a decision. */}
+      {glance.headline ? (
+        <p className={`${typography.panelHeader} text-text-header`} data-testid={`${testId}-headline`}>
+          {glance.headline}
+        </p>
+      ) : null}
+
+      {/* ── THE TRUST QUALIFICATION ────────────────────────────────────────
+          One word, visible. The producer's scope sentence rides as the title
+          so it is available on focus/hover without spending a row. */}
+      {glance.verdict ? (
+        <p
+          className={`${typography.panelMeta} ${TONE_CLASS[glance.verdict.tone]} flex items-center gap-1.5`}
+          data-testid={`${testId}-verdict`}
+          data-verdict-tone={glance.verdict.tone}
+          title={glance.verdict.reason}
+        >
+          {glance.verdict.tone === 'stable' ? (
+            <CheckCircle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+          ) : (
+            <AlertTriangle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+          )}
+          {glance.verdict.label}
+          {glance.verdict.reason ? (
+            <span className="text-text-light truncate">— {glance.verdict.reason}</span>
+          ) : null}
+        </p>
+      ) : null}
+
+      {/* ── WHAT MATTERS MOST ──────────────────────────────────────────────
+          Label left, fixed-width track right. A FIXED track is what makes the
+          bars comparable at a glance; a proportional-width track would encode
+          the same number twice and read as two different quantities. */}
+      {glance.drivers.length > 0 ? (
+        <div className="pt-0.5" data-testid={`${testId}-drivers`}>
+          <div className="flex items-baseline justify-between gap-2">
+            <span className={`${typography.panelMeta} text-text-header`}>
+              {COPY.glance.whatMattersMost}
+            </span>
+            {/* The BASIS is a truth claim, so it is visible — but only when it
+                is the set-relative one, because that is the case a reader
+                could otherwise misread as an absolute share. */}
+            <span
+              className={`${typography.panelMeta} text-text-light shrink-0`}
+              title={
+                glance.influenceIsSetRelative
+                  ? COPY.glance.basisRelativeExplain
+                  : COPY.glance.basisAbsoluteExplain
+              }
+              data-testid={`${testId}-basis`}
+            >
+              {glance.influenceIsSetRelative ? COPY.glance.basisRelative : COPY.glance.basisAbsolute}
+            </span>
+          </div>
+
+          <ul className="mt-1 space-y-1 list-none p-0 m-0">
+            {glance.drivers.map((d) => {
+              const focusable = Boolean(d.targetId && onFocusTarget)
+              const Row = (
+                <>
+                  <span className="min-w-0 flex-1 truncate text-left" title={d.label}>
+                    {d.label}
+                  </span>
+                  <span
+                    className="h-1.5 w-[104px] shrink-0 rounded-full bg-panel-hover overflow-hidden"
+                    aria-hidden="true"
+                  >
+                    <span
+                      className="block h-full rounded-full bg-info"
+                      style={{ width: `${Math.round(d.fraction * 100)}%` }}
+                    />
+                  </span>
+                </>
+              )
+              return (
+                <li key={d.id} data-testid={`${testId}-driver`} data-driver-id={d.id}>
+                  {focusable ? (
+                    <button
+                      type="button"
+                      onClick={() => onFocusTarget!(d.targetId!)}
+                      className={`${typography.panelBody} text-text-body w-full flex items-center gap-2 rounded hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+                      data-testid={`${testId}-driver-focus`}
+                    >
+                      {Row}
+                    </button>
+                  ) : (
+                    // Fail-closed: no target, no affordance. Plain text beats a
+                    // control that does nothing.
+                    <span className={`${typography.panelBody} text-text-body w-full flex items-center gap-2`}>
+                      {Row}
+                    </span>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      ) : null}
+
+      {/* ── COULD CHANGE IF ────────────────────────────────────────────────
+          A tipping point, not a ranking. Present only when the producer
+          computed one. */}
+      {glance.condition ? (
+        <button
+          type="button"
+          onClick={
+            glance.condition.targetId && onFocusTarget
+              ? () => onFocusTarget(glance.condition!.targetId!)
+              : onOpenDrivers
+          }
+          className={`${typography.panelBody} text-text-body w-full flex items-start gap-1.5 text-left rounded hover:opacity-80 focus:outline-none focus-visible:ring-2 focus-visible:ring-info`}
+          data-testid={`${testId}-condition`}
+        >
+          <AlertTriangle className="w-3.5 h-3.5 mt-0.5 shrink-0 text-warning" aria-hidden="true" />
+          <span className="min-w-0 flex-1">
+            <span className="text-text-header">{COPY.glance.couldChangeIf}</span>{' '}
+            {glance.condition.text}
+          </span>
+          <ChevronRight className="w-3.5 h-3.5 mt-0.5 shrink-0 text-text-light" aria-hidden="true" />
+        </button>
+      ) : null}
+    </section>
+  )
+}


### PR DESCRIPTION
Adversarial pass over the two concept mock-ups, then the strongest defensible version. Measured first: the dock is **416px at 1024/1440/1920** — fixed, not resizable — giving **320px** usable content. The concepts render at ~1030px, so this is designed natively rather than shrunk.

## No producer, therefore absent
- **'Biggest leverage opportunity'** — swept with a contrast control: no leverage producer exists. The only hits are a Tornado caption that explicitly *disclaims* the word, and a canvas-local edge-weight sum.
- **Per-driver robust/uncertain dots** — `attribution_stability`, `flip_risk_category`, `rank_flip_rate` appear in zero fixtures; the field always present (`confidence`) is a known placeholder the display policy exists to suppress.
- **'72% model health'** — `useModelHealth()` returns an issue *list*, not a score.

## Dropped on design grounds
The drivers→outcome diagram (every driver points at the same focal object — the topology is a star and the arrows carry nothing the labels don't, for ~2/3 of the horizontal budget); the 41/22/15% figures (they sum to 78% against one outcome, which reads as a share; neither basis licenses that); icon tiles; and a primary intervention row that Strengthen renders identically ~120px below.

## What it shows, all traced
| Visible | Producer | Absent behaviour |
|---|---|---|
| Headline | `verdict.hasLeadingOption` + leader label | none — glance leads with drivers |
| Win share | `winProbability`, same gate | omitted |
| Trust word | `robustness.display_verdict` → 4-member map | `not_assessed` → **nothing** |
| Its reason | `display_verdict_reason`, verbatim | word alone |
| Bars | `displayInfluence`, scaled to the run's **max** | section omitted |
| Could change if | `flipThresholds`, gated on `flipThresholdsStatus` | **omitted** |

## Two branches deleted, not merely deduplicated
Mounted on a real run, all three key insights restated the glance ~120px above. The robustness and comparative branches fired under *exactly* the glance's conditions, so once it shipped they were unreachable. Both deleted; the comparative's win share now rides the glance trust line, so nothing was lost. The hinge insight **stays** and is suppressed only when the glance actually rendered a condition — different producers (`topFragileEdge` vs `flipThresholds`), pinned with a discriminating twin.

## Defects the mounted witness caught that ~90 tests did not
- `'… passes 1'` — a bare number on the model's own scale. Now pairs with `current_value`, or drops the number when there is no baseline.
- Key insights printed 'No insight is grounded well enough to lead with yet' while the glance above stated three. Now renders nothing.

## Verification
Typecheck gate at baseline; DS v5 no net-new (its raw-weight guard caught a redundant `font-normal`); analysisNew + ci-guards + results = 478 passing. Mounted at 320px on a genuine completed analysis, plus empty and pre-run states. Old Analysis untouched — no existing results component is modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)